### PR TITLE
#63 - Recommender recommondations not reset on document reset

### DIFF
--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/model/Predictions.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/model/Predictions.java
@@ -234,4 +234,8 @@ public class Predictions
     {
         return predictions;
     }
+    public void clearPredictions()
+    {
+        predictions.clear();
+    }
 }

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
@@ -202,14 +202,14 @@ public class RecommendationServiceImpl
     }
 
     @EventListener
-    public void afterAnnotationUpdate(AfterAnnotationUpdateEvent aEvent) throws Exception
+    public void afterAnnotationUpdate(AfterAnnotationUpdateEvent aEvent)
     {
         triggerTrainingAndClassification(aEvent.getDocument().getUser(),
                 aEvent.getDocument().getProject());
     }
 
     @EventListener
-    public void onDocumentOpen(DocumentOpenedEvent aEvent) throws Exception
+    public void onDocumentOpen(DocumentOpenedEvent aEvent)
     {
         triggerTrainingAndClassification(aEvent.getUser(), aEvent.getDocument().getProject());
     }

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
@@ -239,6 +239,8 @@ public class RecommendationServiceImpl
         String userName = aEvent.getDocument().getUser();
         Project project = aEvent.getDocument().getProject();
         clearPredictionsForProject(userName, project);
+        triggerTrainingAndClassification(aEvent.getDocument().getUser(),
+            aEvent.getDocument().getProject());
     }
 
     @Override


### PR DESCRIPTION
It will clear the predictions now, but with the current implementation it also clears active recommenders and trained models for other projects. Rather the activeRecommenders and trainedModels should be saved per Project.