### PR TITLE
#83 - Mention context not computed correctly

### DIFF
--- a/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/service/ConceptLinkingService.java
+++ b/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/service/ConceptLinkingService.java
@@ -215,7 +215,7 @@ public class ConceptLinkingService
             for (int i = 0; i < aMention.size(); i++) {
 
                 // is the word done? i-th word of mention contained in j-th token of sentence?
-                if (!mentionSentence.get(j).getCoveredText()
+                if (!mentionSentence.get(j).getCoveredText().toLowerCase(Locale.ENGLISH)
                     .contains(aMention.get(i))) {
                     break;
                 }


### PR DESCRIPTION
The covered text of Tokens retrieved by WebAnnoCasUtil.getSentence have not been converted to lower case. This lead to some errors, where the mention could not be found in the sentence.