### PR TITLE
#235 - Creating/deleting a statement in kb UI throws an exception

### DIFF
--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/StatementGroupPanel.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/StatementGroupPanel.java
@@ -182,7 +182,7 @@ public class StatementGroupPanel extends Panel {
         }
     }
     
-    private class ExistingStatementGroupFragment extends Fragment {
+    public class ExistingStatementGroupFragment extends Fragment {
         
         private static final long serialVersionUID = 5054250870556101031L;
         


### PR DESCRIPTION
- changed modifier of ExistingStatementGroupFragment from private to public

Making the class public solves all problems. 
However I couldn't really figure out what changes caused this bug.(It used to work with the private class)
If this solution is okay, the issue is solved. Otherwise I'll have to further investigate this. 

