### PR TITLE
#333 - NE linking recommendations without NE annotation

### DIFF
--- a/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/recommender/NamedEntityLinker.java
+++ b/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/recommender/NamedEntityLinker.java
@@ -203,8 +203,9 @@ public class NamedEntityLinker
     private boolean isNamedEntity(TokenObject token)
     {
         return nerAnnotations.stream()
-            .map(AnnotationObject::getOffset)
-            .anyMatch(t -> t.equals(token.getOffset()));
+            .map(AnnotationObject::getTokenObject)
+            .anyMatch(t -> t.getOffset().equals(token.getOffset())
+                   && t.getDocumentURI().equals(token.getDocumentURI()));
     }
 
     private List<KBHandle> readCandidates(KnowledgeBase kb, TokenObject token) {


### PR DESCRIPTION
When checking whether a token is a named entity, also take documentUri into account.