### PR TITLE
Bugfix/409 recommondations not shown

### DIFF
--- a/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/util/CasUtil.java
+++ b/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/util/CasUtil.java
@@ -519,6 +519,7 @@ public class CasUtil
                 AnnotationObject ao = new AnnotationObject(tObj, id, feature.getName(),
                     aRecommenderId);
                 ao.setLabel(annotationLabel);
+                result.add(ao);
                 id++;
             }
         }


### PR DESCRIPTION
When refactoring the `AnnotationObject`, I forgot to add some annotation objects to the respective lists when loading them.