### PR TITLE
444 - Document indexed twice

### DIFF
--- a/inception-search-mtas/src/main/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndex.java
+++ b/inception-search-mtas/src/main/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndex.java
@@ -150,7 +150,6 @@ public class MtasDocumentIndex
         }
        
         resourceDir = new File(aDir);
-        createPhysicalIndex();
         log.info("New Mtas/Lucene index instance created...");
     }
 


### PR DESCRIPTION
New physical index is not being automatically created when instantiating MtasDocumentIndex anymore