### PR TITLE
#419 - language_field_in_kb_editor_broken

### DIFF
--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/value/editor/StringLiteralValueEditor.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/value/editor/StringLiteralValueEditor.java
@@ -42,7 +42,8 @@ public class StringLiteralValueEditor
         value.add(new LambdaAjaxFormComponentUpdatingBehavior("change", t -> t.add(getParent())));
         add(value);
 
-        add(new TextField<>("language"));
+        add(new TextField<>("language")
+            .add((new LambdaAjaxFormComponentUpdatingBehavior("change", t -> t.add(getParent())))));
     }
     
     @Override


### PR DESCRIPTION
- safe language value on change

This PR, together with the changes from #51 fixes the issues when saving a language value.

The reason that the concept tree shows a node-id when the language of the default label is changed to for example 'de' , is that we only look for labels with language en or "" when we query for the root concepts. So getUiLabel won't find any label for that concept and returns the node-id. 
I don't know if and in what way we want to change that.

@naveen2507 Do you have any suggestions?