### PR TITLE
#496 - two clicks necessary to save a value in the stringeditor on kb page

### DIFF
--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/value/editor/StringLiteralValueEditor.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/value/editor/StringLiteralValueEditor.java
@@ -23,7 +23,6 @@ import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
 
-import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxFormComponentUpdatingBehavior;
 import de.tudarmstadt.ukp.inception.kb.graph.KBStatement;
 
 public class StringLiteralValueEditor

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/value/editor/StringLiteralValueEditor.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/value/editor/StringLiteralValueEditor.java
@@ -39,11 +39,9 @@ public class StringLiteralValueEditor
 
         value = new TextArea<>("value");
         value.setOutputMarkupId(true);
-        value.add(new LambdaAjaxFormComponentUpdatingBehavior("change", t -> t.add(getParent())));
         add(value);
 
-        add(new TextField<>("language")
-            .add((new LambdaAjaxFormComponentUpdatingBehavior("change", t -> t.add(getParent())))));
+        add(new TextField<>("language"));
     }
     
     @Override


### PR DESCRIPTION
- remove LambdaAjaxFormComponentUpdatingBehavior in StringEditor