### PR TITLE
#533 - changing the name of an instance adds a label to the concept

### DIFF
--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/StatementGroupPanel.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/StatementGroupPanel.java
@@ -284,11 +284,13 @@ public class StatementGroupPanel extends Panel {
         
         @OnEvent
         public void actionStatementChanged(AjaxStatementChangedEvent event) {
-            // event is not relevant if the statement in the event has a different property than the
-            // property of this statement group
-            boolean isEventForThisStatementGroup = event.getStatement()
-                    .getProperty()
-                    .equals(groupModel.getObject().getProperty());
+            // event is not relevant if the statement in the event has a different property|subject
+            // than the property|subject of this statement group
+            KBStatement statement = event.getStatement();
+            boolean isEventForThisStatementGroup =
+                statement.getProperty().equals(groupModel.getObject().getProperty())
+                    && statement.getInstance().getIdentifier()
+                    .equals(groupModel.getObject().getInstance().getIdentifier());
             if (!isEventForThisStatementGroup) {
                 return;
             }
@@ -297,13 +299,13 @@ public class StatementGroupPanel extends Panel {
                 // update the statement from the event
                 StatementGroupBean bean = groupModel.getObject();
                 bean.getStatements().remove(oldStatement);
-                bean.getStatements().add(event.getStatement());
+                bean.getStatements().add(statement);
                 groupModel.setObject(bean);
             }
             if (event.isDeleted()) {
                 // remove statement found in the event from the model
                 StatementGroupBean bean = groupModel.getObject();
-                bean.getStatements().remove(event.getStatement());
+                bean.getStatements().remove(statement);
                 groupModel.setObject(bean);
 
                 if (bean.getStatements().isEmpty()) {


### PR DESCRIPTION
- only trigger StatementChangedEvent on statement group when the instance of the statementgroup is equal to the instace of the changed statement