### PR TITLE
#543 - Unit tests fail for Hucit due to SPARQL service being unavailable

### DIFF
--- a/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplWikiDataIntegrationTest.java
+++ b/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplWikiDataIntegrationTest.java
@@ -18,7 +18,6 @@
 package de.tudarmstadt.ukp.inception.kb;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assume.assumeTrue;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -118,7 +117,7 @@ public class KnowledgeBaseServiceImplWikiDataIntegrationTest  {
         project = createProject(PROJECT_NAME);
         kb = buildKnowledgeBase(project, KB_NAME);
         String wikidataAccessUrl = PROFILES.get("wikidata").getAccess().getAccessUrl();
-        assumeTrue(testFixtures.isEndpointAvailable(wikidataAccessUrl, 5000));
+        testFixtures.assumeEndpointIsAvailable(wikidataAccessUrl, 5000);
         sut.registerKnowledgeBase(kb, sut.getRemoteConfig(wikidataAccessUrl));
 
     }

--- a/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplWikiDataIntegrationTest.java
+++ b/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplWikiDataIntegrationTest.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.inception.kb;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -116,7 +117,9 @@ public class KnowledgeBaseServiceImplWikiDataIntegrationTest  {
         sut = new KnowledgeBaseServiceImpl(temporaryFolder.getRoot(), entityManager);
         project = createProject(PROJECT_NAME);
         kb = buildKnowledgeBase(project, KB_NAME);
-        sut.registerKnowledgeBase(kb, sut.getRemoteConfig(PROFILES.get("wikidata").getAccess().getAccessUrl()));
+        String wikidataAccessUrl = PROFILES.get("wikidata").getAccess().getAccessUrl();
+        assumeTrue(testFixtures.isEndpointAvailable(wikidataAccessUrl, 5000));
+        sut.registerKnowledgeBase(kb, sut.getRemoteConfig(wikidataAccessUrl));
 
     }
 

--- a/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceRemoteTest.java
+++ b/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceRemoteTest.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.inception.kb;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -123,6 +124,7 @@ public class KnowledgeBaseServiceRemoteTest
         sut = new KnowledgeBaseServiceImpl(temporaryFolder.getRoot(), entityManager);
         project = testFixtures.createProject(PROJECT_NAME);
         kb.setProject(project);
+        assumeTrue(isRepositoryAvailable());
         if (kb.getType() == RepositoryType.LOCAL) {
             sut.registerKnowledgeBase(kb, sut.getNativeConfig());
             sut.updateKnowledgeBase(kb, sut.getKnowledgeBaseConfig(kb));
@@ -356,6 +358,15 @@ public class KnowledgeBaseServiceRemoteTest
     }
 
     // Helper
+
+    private boolean isRepositoryAvailable() {
+        KnowledgeBase kb = sutConfig.getKnowledgeBase();
+        if (kb.getType() == RepositoryType.REMOTE) {
+            return testFixtures.isEndpointAvailable(sutConfig.getDataUrl(), 5000);
+        }
+        // Assume that local KBs are always available in tests
+        return true;
+    }
 
     private void importKnowledgeBase(String resourceName) throws Exception
     {

--- a/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceRemoteTest.java
+++ b/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceRemoteTest.java
@@ -18,7 +18,6 @@
 package de.tudarmstadt.ukp.inception.kb;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assume.assumeTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -124,13 +123,13 @@ public class KnowledgeBaseServiceRemoteTest
         sut = new KnowledgeBaseServiceImpl(temporaryFolder.getRoot(), entityManager);
         project = testFixtures.createProject(PROJECT_NAME);
         kb.setProject(project);
-        assumeTrue(isRepositoryAvailable());
         if (kb.getType() == RepositoryType.LOCAL) {
             sut.registerKnowledgeBase(kb, sut.getNativeConfig());
             sut.updateKnowledgeBase(kb, sut.getKnowledgeBaseConfig(kb));
             importKnowledgeBase(sutConfig.getDataUrl());
         }
         else if (kb.getType() == RepositoryType.REMOTE) {
+            testFixtures.assumeEndpointIsAvailable(sutConfig.getDataUrl(), 5000);
             sut.registerKnowledgeBase(kb, sut.getRemoteConfig(sutConfig.getDataUrl()));
             sut.updateKnowledgeBase(kb, sut.getKnowledgeBaseConfig(kb));
         }
@@ -358,15 +357,6 @@ public class KnowledgeBaseServiceRemoteTest
     }
 
     // Helper
-
-    private boolean isRepositoryAvailable() {
-        KnowledgeBase kb = sutConfig.getKnowledgeBase();
-        if (kb.getType() == RepositoryType.REMOTE) {
-            return testFixtures.isEndpointAvailable(sutConfig.getDataUrl(), 5000);
-        }
-        // Assume that local KBs are always available in tests
-        return true;
-    }
 
     private void importKnowledgeBase(String resourceName) throws Exception
     {

--- a/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/util/TestFixtures.java
+++ b/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/util/TestFixtures.java
@@ -17,6 +17,8 @@
  */
 package de.tudarmstadt.ukp.inception.kb.util;
 
+import static org.junit.Assume.assumeTrue;
+
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
@@ -145,21 +147,26 @@ public class TestFixtures
     }
 
     /**
-     * Tries to connect to the given endpoint url
+     * Tries to connect to the given endpoint url and assumes that the connection is successful
+     * with {@link org.junit.Assume#assumeTrue(String, boolean)}
      * @param aEndpointURL the url to check
      * @param aTimeout a timeout
-     * @return returns true if no IOException is thrown when connecting to the url, false otherwise
      */
-    public boolean isEndpointAvailable(String aEndpointURL, int aTimeout) {
+    public void assumeEndpointIsAvailable(String aEndpointURL, int aTimeout) {
+        boolean isAvailable;
+        String errorMsg = aEndpointURL
+            + " is not available. Expected no exception to be thrown when trying to connect"
+            + " to the endpoint, but got:\n%s";
         try {
             URLConnection connection = new URL(aEndpointURL).openConnection();
             connection.setConnectTimeout(aTimeout);
             connection.connect();
-            return true;
+            isAvailable = true;
         }
         catch (IOException e) {
-            e.printStackTrace();
-            return false;
+            isAvailable = false;
+            errorMsg = String.format(errorMsg, e.toString());
         }
+        assumeTrue(errorMsg, isAvailable);
     }
 }

--- a/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/util/TestFixtures.java
+++ b/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/util/TestFixtures.java
@@ -17,7 +17,10 @@
  */
 package de.tudarmstadt.ukp.inception.kb.util;
 
+import java.io.IOException;
 import java.net.URI;
+import java.net.URL;
+import java.net.URLConnection;
 import java.util.ArrayList;
 
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -139,5 +142,24 @@ public class TestFixtures
         KBQualifier qualifier = new KBQualifier(kbStatement, propertyHandle,
             vf.createLiteral(value));
         return qualifier;
+    }
+
+    /**
+     * Tries to connect to the given endpoint url
+     * @param aEndpointURL the url to check
+     * @param aTimeout a timeout
+     * @return returns true if no IOException is thrown when connecting to the url, false otherwise
+     */
+    public boolean isEndpointAvailable(String aEndpointURL, int aTimeout) {
+        try {
+            URLConnection connection = new URL(aEndpointURL).openConnection();
+            connection.setConnectTimeout(aTimeout);
+            connection.connect();
+            return true;
+        }
+        catch (IOException e) {
+            e.printStackTrace();
+            return false;
+        }
     }
 }

--- a/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/util/TestFixtures.java
+++ b/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/util/TestFixtures.java
@@ -19,7 +19,6 @@ package de.tudarmstadt.ukp.inception.kb.util;
 
 import static org.junit.Assume.assumeTrue;
 
-import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
@@ -163,7 +162,7 @@ public class TestFixtures
             connection.connect();
             isAvailable = true;
         }
-        catch (IOException e) {
+        catch (Exception e) {
             isAvailable = false;
             errorMsg = String.format(errorMsg, e.toString());
         }


### PR DESCRIPTION
- assume that remote sparql endpoint is available before running tests against it