### PR TITLE
#605 - Unit tests leave dataset caches lying around in tmp

### DIFF
--- a/inception-app-webapp/pom.xml
+++ b/inception-app-webapp/pom.xml
@@ -64,12 +64,10 @@
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-recommendation</artifactId>
     </dependency>
-    <!--
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-imls-dl4j</artifactId>
     </dependency>
-    -->
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-imls-external</artifactId>
@@ -563,7 +561,7 @@
               <usedDependency>de.tudarmstadt.ukp.inception.app:inception-concept-linking</usedDependency>
               <usedDependency>de.tudarmstadt.ukp.inception.app:inception-recommendation</usedDependency>
               <usedDependency>de.tudarmstadt.ukp.inception.app:inception-imls-external</usedDependency>
-              <!-- <usedDependency>de.tudarmstadt.ukp.inception.app:inception-imls-dl4j</usedDependency> -->
+              <usedDependency>de.tudarmstadt.ukp.inception.app:inception-imls-dl4j</usedDependency>
               <!-- usedDependency>de.tudarmstadt.ukp.inception.app:inception-imls-mira</usedDependency -->
               <usedDependency>de.tudarmstadt.ukp.inception.app:inception-imls-opennlp</usedDependency>
               <usedDependency>de.tudarmstadt.ukp.inception.app:inception-imls-stringmatch</usedDependency>

--- a/inception-imls-dl4j/pom.xml
+++ b/inception-imls-dl4j/pom.xml
@@ -48,6 +48,10 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>it.unimi.dsi</groupId>

--- a/inception-imls-dl4j/pom.xml
+++ b/inception-imls-dl4j/pom.xml
@@ -35,12 +35,20 @@
       <groupId>de.tudarmstadt.ukp.clarin.webanno</groupId>
       <artifactId>webanno-model</artifactId>
     </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.clarin.webanno</groupId>
+      <artifactId>webanno-api-dao</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>
-    
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>it.unimi.dsi</groupId>
       <artifactId>fastutil</artifactId>

--- a/inception-imls-dl4j/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommender.java
+++ b/inception-imls-dl4j/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommender.java
@@ -85,15 +85,18 @@ public class DL4JSequenceRecommender
     
     private final String layerName;
     private final String featureName;
+    private final File datasetCache;
     private DL4JSequenceRecommenderTraits traits;
     private BinaryVectorizer wordVectors;
     private INDArray randUnk;
     
-    public DL4JSequenceRecommender(Recommender aRecommender, DL4JSequenceRecommenderTraits aTraits)
+    public DL4JSequenceRecommender(Recommender aRecommender, DL4JSequenceRecommenderTraits aTraits,
+            File aDatasetCache)
     {
         layerName = aRecommender.getLayer().getName();
         featureName = aRecommender.getFeature();
         traits = aTraits;
+        datasetCache = aDatasetCache;
     }
 
     @Override
@@ -128,8 +131,8 @@ public class DL4JSequenceRecommender
             // Load the embeddings. Mind that we are using a memory-mapped embedding store, so this
             // is a fast operation and also doesn't consume lots of memory. Hence we can do it for
             // each recommender instance and do not have to share it between recommenders.
-            DatasetFactory loader = new DatasetFactory(); 
-            File embeddingsFile =  loader.load("glove.6B.50d.dl4jw2v").getDataFiles()[0];
+            DatasetFactory loader = new DatasetFactory(datasetCache); 
+            File embeddingsFile = loader.load("glove.6B.50d.dl4jw2v").getDataFiles()[0];
             wordVectors = BinaryVectorizer.load(embeddingsFile);
         }
         

--- a/inception-imls-dl4j/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommenderFactory.java
+++ b/inception-imls-dl4j/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommenderFactory.java
@@ -17,9 +17,13 @@
  */
 package de.tudarmstadt.ukp.inception.recommendation.imls.dl4j.pos;
 
+import java.io.File;
+
 import org.apache.uima.cas.CAS;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
+import de.tudarmstadt.ukp.clarin.webanno.api.dao.RepositoryProperties;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
@@ -27,14 +31,21 @@ import de.tudarmstadt.ukp.inception.recommendation.api.recommender.Recommendatio
 import de.tudarmstadt.ukp.inception.recommendation.api.recommender.RecommendationEngineFactoryImplBase;
 
 @Component
+@ConditionalOnProperty(prefix = "recommenders.dl4j.token-sequence", name = "enabled", 
+        matchIfMissing = false)
 public class DL4JSequenceRecommenderFactory
     extends RecommendationEngineFactoryImplBase<Void>
 {
-
     // This is a string literal so we can rename/refactor the class without it changing its ID
-    // and without the database starting to refer to nonexisting recommendation tools.
-    public static final String ID = 
-        "de.tudarmstadt.ukp.inception.recommendation.imls.dl4j.pos.DL4JPosClassificationTool";
+    // and without the database starting to refer to non-existing recommendation tools.
+    public static final String ID = "de.tudarmstadt.ukp.inception.recommendation.imls.dl4j.pos.DL4JPosClassificationTool";
+
+    private final RepositoryProperties repositoryProperties;
+
+    public DL4JSequenceRecommenderFactory(RepositoryProperties aRepositoryProperties)
+    {
+        repositoryProperties = aRepositoryProperties;
+    }
 
     @Override
     public String getId()
@@ -54,13 +65,15 @@ public class DL4JSequenceRecommenderFactory
         if (aLayer == null || aFeature == null) {
             return false;
         }
-        
+
         return "span".equals(aLayer.getType()) && CAS.TYPE_NAME_STRING.equals(aFeature.getType());
     }
 
     @Override
-    public RecommendationEngine build(Recommender aRecommender) {
+    public RecommendationEngine build(Recommender aRecommender)
+    {
         DL4JSequenceRecommenderTraits traits = new DL4JSequenceRecommenderTraits();
-        return new DL4JSequenceRecommender(aRecommender, traits);
+        return new DL4JSequenceRecommender(aRecommender, traits,
+                new File(repositoryProperties.getPath(), "datasets"));
     }
 }

--- a/inception-imls-dl4j/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommenderProperties.java
+++ b/inception-imls-dl4j/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommenderProperties.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018
+ * Ubiquitous Knowledge Processing (UKP) Lab and FG Language Technology
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.imls.dl4j.pos;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties("recommenders.dl4j.token-sequence")
+public class DL4JSequenceRecommenderProperties
+{
+    private boolean enabled = false;
+
+    public boolean isEnabled()
+    {
+        return enabled;
+    }
+
+    public void setEnabled(boolean aEnabled)
+    {
+        enabled = aEnabled;
+    }
+}

--- a/inception-imls-dl4j/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommenderTest.java
+++ b/inception-imls-dl4j/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommenderTest.java
@@ -107,7 +107,8 @@ public class DL4JSequenceRecommenderTest
         ne.setValue("C");
         ne.addToIndexes();
         
-        DL4JSequenceRecommender sut = new DL4JSequenceRecommender(buildPosRecommender(), traits);
+        DL4JSequenceRecommender sut = new DL4JSequenceRecommender(buildPosRecommender(), traits,
+                cache);
         List<String> labels = sut.extractTokenLabels(
                 new ArrayList<>(select(jcas, Token.class)), 
                 new ArrayList<>(select(jcas, NamedEntity.class)));
@@ -143,7 +144,8 @@ public class DL4JSequenceRecommenderTest
         ne.setValue("B");
         ne.addToIndexes();
         
-        DL4JSequenceRecommender sut = new DL4JSequenceRecommender(buildPosRecommender(), traits);
+        DL4JSequenceRecommender sut = new DL4JSequenceRecommender(buildPosRecommender(), traits,
+                cache);
         List<String> labels = sut.extractTokenLabels(
                 new ArrayList<>(select(jcas, Token.class)), 
                 new ArrayList<>(select(jcas, NamedEntity.class)));
@@ -170,7 +172,8 @@ public class DL4JSequenceRecommenderTest
         ne.setValue("B");
         ne.addToIndexes();
         
-        DL4JSequenceRecommender sut = new DL4JSequenceRecommender(buildPosRecommender(), traits);
+        DL4JSequenceRecommender sut = new DL4JSequenceRecommender(buildPosRecommender(), traits,
+                cache);
         
         assertThatThrownBy(() -> sut.extractTokenLabels(
                 new ArrayList<>(select(jcas, Token.class)), 
@@ -197,7 +200,8 @@ public class DL4JSequenceRecommenderTest
         ne.setValue("B");
         ne.addToIndexes();
         
-        DL4JSequenceRecommender sut = new DL4JSequenceRecommender(buildPosRecommender(), traits);
+        DL4JSequenceRecommender sut = new DL4JSequenceRecommender(buildPosRecommender(), traits,
+                cache);
         
         assertThatThrownBy(() -> sut.extractTokenLabels(
                 new ArrayList<>(select(jcas, Token.class)), 
@@ -224,7 +228,8 @@ public class DL4JSequenceRecommenderTest
         ne.setValue("B");
         ne.addToIndexes();
         
-        DL4JSequenceRecommender sut = new DL4JSequenceRecommender(buildPosRecommender(), traits);
+        DL4JSequenceRecommender sut = new DL4JSequenceRecommender(buildPosRecommender(), traits,
+                cache);
         
         assertThatThrownBy(() -> sut.extractTokenLabels(
                 new ArrayList<>(select(jcas, Token.class)), 
@@ -236,7 +241,8 @@ public class DL4JSequenceRecommenderTest
     @Test
     public void thatPosTrainingWorks() throws Exception
     {
-        DL4JSequenceRecommender sut = new DL4JSequenceRecommender(buildPosRecommender(), traits);
+        DL4JSequenceRecommender sut = new DL4JSequenceRecommender(buildPosRecommender(), traits,
+                cache);
         JCas cas = loadPosDevelopmentData();
 
         sut.train(context, asList(cas.getCas()));
@@ -249,7 +255,8 @@ public class DL4JSequenceRecommenderTest
     @Test
     public void thatPosPredictionWorks() throws Exception
     {
-        DL4JSequenceRecommender sut = new DL4JSequenceRecommender(buildPosRecommender(), traits);
+        DL4JSequenceRecommender sut = new DL4JSequenceRecommender(buildPosRecommender(), traits,
+                cache);
         JCas cas = loadPosDevelopmentData();
         
         sut.train(context, asList(cas.getCas()));
@@ -266,7 +273,8 @@ public class DL4JSequenceRecommenderTest
     public void thatPosEvaluationWorks() throws Exception
     {
         DataSplitter splitStrategy = new PercentageBasedSplitter(0.8, 10);
-        DL4JSequenceRecommender sut = new DL4JSequenceRecommender(buildPosRecommender(), traits);
+        DL4JSequenceRecommender sut = new DL4JSequenceRecommender(buildPosRecommender(), traits,
+                cache);
         JCas cas = loadPosDevelopmentData();
 
         double score = sut.evaluate(asList(cas.getCas()), splitStrategy);
@@ -279,7 +287,8 @@ public class DL4JSequenceRecommenderTest
     @Test
     public void thatNerTrainingWorks() throws Exception
     {
-        DL4JSequenceRecommender sut = new DL4JSequenceRecommender(buildNerRecommender(), traits);
+        DL4JSequenceRecommender sut = new DL4JSequenceRecommender(buildNerRecommender(), traits,
+                cache);
         JCas cas = loadNerDevelopmentData();
 
         sut.train(context, asList(cas.getCas()));
@@ -292,7 +301,8 @@ public class DL4JSequenceRecommenderTest
     @Test
     public void thatNerPredictionWorks() throws Exception
     {
-        DL4JSequenceRecommender sut = new DL4JSequenceRecommender(buildNerRecommender(), traits);
+        DL4JSequenceRecommender sut = new DL4JSequenceRecommender(buildNerRecommender(), traits,
+                cache);
         JCas cas = loadNerDevelopmentData();
         
         sut.train(context, asList(cas.getCas()));
@@ -309,7 +319,8 @@ public class DL4JSequenceRecommenderTest
     public void thatNerEvaluationWorks() throws Exception
     {
         DataSplitter splitStrategy = new PercentageBasedSplitter(0.8, 10);
-        DL4JSequenceRecommender sut = new DL4JSequenceRecommender(buildNerRecommender(), traits);
+        DL4JSequenceRecommender sut = new DL4JSequenceRecommender(buildNerRecommender(), traits,
+                cache);
         JCas cas = loadNerDevelopmentData();
 
         double score = sut.evaluate(asList(cas.getCas()), splitStrategy);
@@ -323,7 +334,8 @@ public class DL4JSequenceRecommenderTest
     public void thatIncrementalNerEvaluationWorks() throws Exception
     {
         IncrementalSplitter splitStrategy = new IncrementalSplitter(0.8, 500, 10);
-        DL4JSequenceRecommender sut = new DL4JSequenceRecommender(buildNerRecommender(), traits);
+        DL4JSequenceRecommender sut = new DL4JSequenceRecommender(buildNerRecommender(), traits,
+                cache);
         JCas cas = loadNerDevelopmentData();
 
         int i = 0;

--- a/pom.xml
+++ b/pom.xml
@@ -247,13 +247,15 @@
       <dependency>
         <groupId>de.tudarmstadt.ukp.inception.app</groupId>
         <artifactId>inception-imls-dl4j</artifactId>
-        <version>0.5.0-SNAPSHOT</version>
+        <version>0.6.0-SNAPSHOT</version>
       </dependency>
+      <!--  
       <dependency>
         <groupId>de.tudarmstadt.ukp.inception.app</groupId>
         <artifactId>inception-imls-mira</artifactId>
-        <version>0.5.0-SNAPSHOT</version>
+        <version>0.6.0-SNAPSHOT</version>
       </dependency>
+      -->
       <dependency>
         <groupId>de.tudarmstadt.ukp.inception.app</groupId>
         <artifactId>inception-imls-stringmatch</artifactId>


### PR DESCRIPTION
- Unit tests store dataset in proper cache folder now
- During production, dataset is stored in INCEpTION home folder
- DL4J by default disabled, but can be enabled via property in settings.properties
- DL4J is part of build artifact again