### PR TITLE
#577 - Switching between projects does not hide kb details panel

### DIFF
--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/ProjectRecommendersPanel.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/ProjectRecommendersPanel.java
@@ -34,7 +34,7 @@ public class ProjectRecommendersPanel
     
     public ProjectRecommendersPanel(String aId, IModel<Project> aProject)
     {
-        super(aId);
+        super(aId, aProject);
 
         selectedRecommenderModel = Model.of();
         projectModel = aProject;
@@ -54,5 +54,12 @@ public class ProjectRecommendersPanel
             _target.add(recommenderEditorPanel);
         });
         add(recommenderListPanel);
+    }
+
+    @Override
+    protected void onModelChanged()
+    {
+        super.onModelChanged();
+        selectedRecommenderModel.setObject(null);
     }
 }

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/ProjectKnowledgeBasePanel.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/ProjectKnowledgeBasePanel.java
@@ -34,7 +34,7 @@ public class ProjectKnowledgeBasePanel
     private static final String DETAILS_PANEL_MARKUP_ID = "details";
 
     private IModel<Project> projectModel;
-    private IModel<KnowledgeBase> selectedKnowledgeBase;
+    private IModel<KnowledgeBase> selectedKnowledgeBaseModel;
     private Panel detailsPanel;
 
     public ProjectKnowledgeBasePanel(String aId, final IModel<Project> aProject)
@@ -47,13 +47,13 @@ public class ProjectKnowledgeBasePanel
         detailsPanel = new EmptyPanel(DETAILS_PANEL_MARKUP_ID);
         add(detailsPanel);
 
-        selectedKnowledgeBase = Model.of();
+        selectedKnowledgeBaseModel = Model.of();
         KnowledgeBaseListPanel listPanel = new KnowledgeBaseListPanel("list", projectModel,
-            selectedKnowledgeBase);
+            selectedKnowledgeBaseModel);
         listPanel.setChangeAction(t -> {
             addOrReplace(detailsPanel);
             detailsPanel.replaceWith(
-                new KnowledgeBaseDetailsPanel(DETAILS_PANEL_MARKUP_ID, selectedKnowledgeBase));
+                new KnowledgeBaseDetailsPanel(DETAILS_PANEL_MARKUP_ID, selectedKnowledgeBaseModel));
             t.add(this);
         });
         add(listPanel);
@@ -62,6 +62,6 @@ public class ProjectKnowledgeBasePanel
     @Override protected void onModelChanged()
     {
         super.onModelChanged();
-        selectedKnowledgeBase.setObject(null);
+        selectedKnowledgeBaseModel.setObject(null);
     }
 }

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/ProjectKnowledgeBasePanel.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/ProjectKnowledgeBasePanel.java
@@ -34,26 +34,34 @@ public class ProjectKnowledgeBasePanel
     private static final String DETAILS_PANEL_MARKUP_ID = "details";
 
     private IModel<Project> projectModel;
+    private IModel<KnowledgeBase> selectedKnowledgeBase;
     private Panel detailsPanel;
 
-    public ProjectKnowledgeBasePanel(String aId, IModel<Project> aProject)
+    public ProjectKnowledgeBasePanel(String aId, final IModel<Project> aProject)
     {
-        super(aId);
+        super(aId, aProject);
+
         setOutputMarkupId(true);
         projectModel = aProject;
 
         detailsPanel = new EmptyPanel(DETAILS_PANEL_MARKUP_ID);
         add(detailsPanel);
 
-        IModel<KnowledgeBase> kbModel = Model.of();
+        selectedKnowledgeBase = Model.of();
         KnowledgeBaseListPanel listPanel = new KnowledgeBaseListPanel("list", projectModel,
-                kbModel);
+            selectedKnowledgeBase);
         listPanel.setChangeAction(t -> {
             addOrReplace(detailsPanel);
-            detailsPanel
-                    .replaceWith(new KnowledgeBaseDetailsPanel(DETAILS_PANEL_MARKUP_ID, kbModel));
+            detailsPanel.replaceWith(
+                new KnowledgeBaseDetailsPanel(DETAILS_PANEL_MARKUP_ID, selectedKnowledgeBase));
             t.add(this);
         });
         add(listPanel);
+    }
+
+    @Override protected void onModelChanged()
+    {
+        super.onModelChanged();
+        selectedKnowledgeBase.setObject(null);
     }
 }


### PR DESCRIPTION
- set selected model object to null when project selection changes ( KbPanel and RecommendersPanel)