### PR TITLE
#631 - RDF files with relative IRIs cannot be imported

### DIFF
--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
@@ -397,7 +397,11 @@ public class KnowledgeBaseServiceImpl
 
         // Load files into the repository
         try (RepositoryConnection conn = getConnection(kb)) {
-            conn.add(is, "", format);
+            // If the RDF file contains relative URLs, then they probably start with a hash.
+            // To avoid having two hashes here, we drop the hash from the base prefix configured
+            // by the user.
+            String prefix = StringUtils.removeEnd(kb.getBasePrefix(), "#");
+            conn.add(is, prefix, format);
         }
     }
 


### PR DESCRIPTION
- Use the prefix configured in the KB to resolve relative IRIs