### PR TITLE
#635 - Exclude DL4J native binary JARs for some platforms

### DIFF
--- a/inception-imls-dl4j/pom.xml
+++ b/inception-imls-dl4j/pom.xml
@@ -245,10 +245,11 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
           <configuration>
-            <usedDependencies>
+            <ignoredDependencies>
               <!-- ND4J plugins - used via reflection -->
-              <usedDependency>org.nd4j:nd4j-native-platform</usedDependency>
-            </usedDependencies>
+              <dependency>org.nd4j:nd4j-native:*:*</dependency>
+              <dependency>org.bytedeco.javacpp-presets:*:*:*</dependency>
+            </ignoredDependencies>
           </configuration>
         </plugin>
       </plugins>

--- a/inception-imls-dl4j/pom.xml
+++ b/inception-imls-dl4j/pom.xml
@@ -15,7 +15,9 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>de.tudarmstadt.ukp.inception.app</groupId>
@@ -23,13 +25,20 @@
     <version>0.6.2-SNAPSHOT</version>
   </parent>
   <artifactId>inception-imls-dl4j</artifactId>
-  <name>INCEpTION - ML - Deeplearning4J</name>
+  <name>INCEpTION - ML - Deeplearning4J (v${dl4j.version})</name>
+  <properties>
+    <openblas.version>0.3.3</openblas.version>
+    <javacpp-presets.version>1.4.3</javacpp-presets.version>
+    <mkl.version>2019.0</mkl.version>
+    <mkl-dnn.javacpp.version>0.16-${javacpp-presets.version}</mkl-dnn.javacpp.version>
+    <nd4j.backend>nd4j-native</nd4j.backend>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-recommendation-api</artifactId>
     </dependency>
-  
+
     <dependency>
       <groupId>de.tudarmstadt.ukp.clarin.webanno</groupId>
       <artifactId>webanno-model</artifactId>
@@ -74,7 +83,7 @@
     <dependency>
       <groupId>org.deeplearning4j</groupId>
       <artifactId>deeplearning4j-utility-iterators</artifactId>
-      <version>1.0.0-beta</version>
+      <version>${dl4j.version}</version>
     </dependency>
     <dependency>
       <groupId>org.deeplearning4j</groupId>
@@ -89,11 +98,6 @@
     </dependency>
     <dependency>
       <groupId>org.nd4j</groupId>
-      <artifactId>nd4j-native-platform</artifactId>
-      <version>${dl4j.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.nd4j</groupId>
       <artifactId>nd4j-api</artifactId>
       <version>${dl4j.version}</version>
       <exclusions>
@@ -102,7 +106,89 @@
           <artifactId>lombok</artifactId>
         </exclusion>
       </exclusions>
+      </dependency>
+  
+  
+  
+  <!--  
+      <dependency>
+      <groupId>org.bytedeco.javacpp-presets</groupId>
+      <artifactId>openblas-platform</artifactId>
+      <version>${openblas.version}-${javacpp-presets.version}</version>
+      </dependency>
+-->    
+    <dependency>
+      <groupId>org.bytedeco.javacpp-presets</groupId>
+      <artifactId>openblas</artifactId>
+      <version>${openblas.version}-${javacpp-presets.version}</version>
+      <classifier>linux-x86</classifier>
     </dependency>
+    <dependency>
+      <groupId>org.bytedeco.javacpp-presets</groupId>
+      <artifactId>openblas</artifactId>
+      <version>${openblas.version}-${javacpp-presets.version}</version>
+      <classifier>linux-x86_64</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.bytedeco.javacpp-presets</groupId>
+      <artifactId>openblas</artifactId>
+      <version>${openblas.version}-${javacpp-presets.version}</version>
+      <classifier>macosx-x86_64</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.bytedeco.javacpp-presets</groupId>
+      <artifactId>openblas</artifactId>
+      <version>${openblas.version}-${javacpp-presets.version}</version>
+      <classifier>windows-x86</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.bytedeco.javacpp-presets</groupId>
+      <artifactId>openblas</artifactId>
+      <version>${openblas.version}-${javacpp-presets.version}</version>
+      <classifier>windows-x86_64</classifier>
+    </dependency>
+    
+    <!--  
+      <dependency>
+        <groupId>org.nd4j</groupId>
+        <artifactId>nd4j-native-platform</artifactId>
+        <version>${dl4j.version}</version>
+      </dependency>
+     -->
+    <dependency>
+      <groupId>org.bytedeco.javacpp-presets</groupId>
+      <artifactId>mkl-platform</artifactId>
+      <version>${mkl.version}-${javacpp-presets.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.bytedeco.javacpp-presets</groupId>
+      <artifactId>mkl-dnn-platform</artifactId>
+      <version>${mkl-dnn.javacpp.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.nd4j</groupId>
+      <artifactId>${nd4j.backend}</artifactId>
+      <version>${dl4j.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.nd4j</groupId>
+      <artifactId>${nd4j.backend}</artifactId>
+      <version>${dl4j.version}</version>
+      <classifier>linux-x86_64</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.nd4j</groupId>
+      <artifactId>${nd4j.backend}</artifactId>
+      <version>${dl4j.version}</version>
+      <classifier>macosx-x86_64</classifier>
+    </dependency>
+    <dependency>
+      <groupId>org.nd4j</groupId>
+      <artifactId>${nd4j.backend}</artifactId>
+      <version>${dl4j.version}</version>
+      <classifier>windows-x86_64</classifier>
+    </dependency>
+
     <dependency>
       <groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
       <artifactId>de.tudarmstadt.ukp.dkpro.core.api.datasets-asl</artifactId>
@@ -167,5 +253,5 @@
         </plugin>
       </plugins>
     </pluginManagement>
-  </build>  
+  </build>
 </project>

--- a/inception-imls-dl4j/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommender.java
+++ b/inception-imls-dl4j/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommender.java
@@ -428,7 +428,7 @@ public class DL4JSequenceRecommender
         
         // Predict labels
         long predictionStart = System.currentTimeMillis();
-        INDArray predicted = aClassifier.output(data.getFeatureMatrix(), false,
+        INDArray predicted = aClassifier.output(data.getFeatures(), false,
                 data.getFeaturesMaskArray(), data.getLabelsMaskArray());
         log.trace("Prediction took {}ms", System.currentTimeMillis() - predictionStart);
         

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <wicket-jquery-ui.version>${wicket.version}</wicket-jquery-ui.version>
     <lucene.version>7.3.0</lucene.version>
     <mtas.version>7.3.0.3</mtas.version>
-    <dl4j.version>1.0.0-beta</dl4j.version>
+    <dl4j.version>1.0.0-beta3</dl4j.version>
     <rdf4j.version>2.4.0</rdf4j.version>
     <inception-rdf4j.version>${rdf4j.version}</inception-rdf4j.version>
     <mockito.version>2.23.0</mockito.version>


### PR DESCRIPTION
- Upgrade to DL4J 1.0.0-beta3
- Reduce dependency footprint by including only platform-specific dependencies for OS X, Windows and Linux on x64 and x86_64 hardware