### PR TITLE
#646 - Reduce runtime of DL4J unit tests

### DIFF
--- a/inception-imls-dl4j/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommender.java
+++ b/inception-imls-dl4j/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommender.java
@@ -190,8 +190,8 @@ public class DL4JSequenceRecommender
         // Configure the neural network
         MultiLayerNetwork model = createConfiguredNetwork(traits, wordVectors.dimensions());
 
-        final int limit = Integer.MAX_VALUE;
-        final int batchSize = 250;
+        final int limit = traits.getTrainingSetSizeLimit();
+        final int batchSize = traits.getBatchSize();
 
         // First vectorizing all sentences and then passing them to the model would consume
         // huge amounts of memory. Thus, every sentence is vectorized and then immediately
@@ -366,10 +366,9 @@ public class DL4JSequenceRecommender
             Feature labelFeature = predictionType.getFeatureByBaseName("label");
     
             final int limit = Integer.MAX_VALUE;
-            final int batchSize = 250;
+            final int batchSize = traits.getBatchSize();
 
             Collection<AnnotationFS> sentences = select(aCas, sentenceType);
-            int sentCount = sentences.size();
             int sentNum = 0;
             
             Iterator<AnnotationFS> sentenceIterator = sentences.iterator();
@@ -408,7 +407,7 @@ public class DL4JSequenceRecommender
                     outcomeIdx++;
                 }
                 
-                log.trace("Predicted {} of {} sentences", sentNum, sentCount);
+                log.trace("Predicted {} of {} sentences", sentNum, sentences.size());
             }
         }
         catch (IOException e) {

--- a/inception-imls-dl4j/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommenderTraits.java
+++ b/inception-imls-dl4j/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommenderTraits.java
@@ -27,6 +27,8 @@ import org.nd4j.linalg.lossfunctions.LossFunctions.LossFunction;
 public class DL4JSequenceRecommenderTraits
 {
     // General parameters
+    private int trainingSetSizeLimit = Integer.MAX_VALUE;
+    private int batchSize = 250;
     private int maxTagsetSize = 70;
     private int maxSentenceLength = 150;
     private int nEpochs = 1;
@@ -43,6 +45,26 @@ public class DL4JSequenceRecommenderTraits
     private Activation activationL0 = Activation.SOFTSIGN;
     private Activation activationL1 = Activation.SOFTMAX;
     private LossFunction lossFunction = LossFunction.MCXENT;
+
+    public int getTrainingSetSizeLimit()
+    {
+        return trainingSetSizeLimit;
+    }
+
+    public void setTrainingSetSizeLimit(int aLimit)
+    {
+        trainingSetSizeLimit = aLimit;
+    }
+
+    public int getBatchSize()
+    {
+        return batchSize;
+    }
+
+    public void setBatchSize(int aBatchSize)
+    {
+        batchSize = aBatchSize;
+    }
 
     public int getMaxTagsetSize()
     {

--- a/inception-imls-dl4j/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommenderTest.java
+++ b/inception-imls-dl4j/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommenderTest.java
@@ -66,6 +66,8 @@ public class DL4JSequenceRecommenderTest
     public void setUp() {
         context = new RecommenderContext();
         traits = new DL4JSequenceRecommenderTraits();
+        traits.setTrainingSetSizeLimit(250);
+        traits.setBatchSize(50);
     }
 
     @Test
@@ -333,7 +335,7 @@ public class DL4JSequenceRecommenderTest
     @Test
     public void thatIncrementalNerEvaluationWorks() throws Exception
     {
-        IncrementalSplitter splitStrategy = new IncrementalSplitter(0.8, 500, 10);
+        IncrementalSplitter splitStrategy = new IncrementalSplitter(0.8, 50, 10);
         DL4JSequenceRecommender sut = new DL4JSequenceRecommender(buildNerRecommender(), traits,
                 cache);
         JCas cas = loadNerDevelopmentData();


### PR DESCRIPTION
- Introduced trait to limit the training set size and use it during testing
- Reduce increment size in incremental evaluation test
- Made the batch size a trait and reduce it in testing