### PR TITLE
#654 - IriConstants.IMPLICIT_NAMESPACES is not really a constant

### DIFF
--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/IriConstants.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/IriConstants.java
@@ -20,10 +20,7 @@ package de.tudarmstadt.ukp.inception.kb;
 
 import static java.util.Arrays.asList;
 
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -45,8 +42,8 @@ public class IriConstants
     public static final String PREFIX_LUCENE_SEARCH = "http://www.openrdf.org/contrib/lucenesail#";
 
     public static final String UKP_WIKIDATA_SPARQL_ENDPOINT = "http://knowledgebase.ukp.informatik.tu-darmstadt.de:8890/sparql";
-    public static final Set<String> IMPLICIT_NAMESPACES = new HashSet<>(Arrays.asList(RDF.NAMESPACE,
-            RDFS.NAMESPACE, XMLSchema.NAMESPACE, OWL.NAMESPACE, INCEPTION_SCHEMA_NAMESPACE));
+    public static final List<String> IMPLICIT_NAMESPACES = asList(RDF.NAMESPACE, RDFS.NAMESPACE,
+            XMLSchema.NAMESPACE, OWL.NAMESPACE, INCEPTION_SCHEMA_NAMESPACE);
 
     /**
      * http://www.wikidata.org/entity/Q35120

--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.inception.kb;
 
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static java.util.Collections.unmodifiableSet;
 
 import java.io.BufferedInputStream;
 import java.io.File;
@@ -155,11 +156,11 @@ public class KnowledgeBaseServiceImpl
         
         repoManager = RepositoryProvider.getRepositoryManager(kbRepositoriesRoot);
         log.info("Knowledge base repository path: {}", kbRepositoriesRoot);
-        implicitNamespaces = IriConstants.IMPLICIT_NAMESPACES;
+        
+        implicitNamespaces = new LinkedHashSet<>(IriConstants.IMPLICIT_NAMESPACES);
     }
     
-    public KnowledgeBaseServiceImpl(
-            RepositoryProperties aRepoProperties,
+    public KnowledgeBaseServiceImpl(RepositoryProperties aRepoProperties,
             EntityManager entityManager)
     {
         this(aRepoProperties);
@@ -1277,6 +1278,11 @@ public class KnowledgeBaseServiceImpl
             }
         }
         return false;
+    }
+    
+    public Set<String> getImplicitNamespaces()
+    {
+        return unmodifiableSet(implicitNamespaces);
     }
 
     @Override

--- a/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplIntegrationTest.java
+++ b/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplIntegrationTest.java
@@ -1606,7 +1606,7 @@ public class KnowledgeBaseServiceImplIntegrationTest  {
     }
 
     private boolean hasImplicitNamespace(KBHandle handle) {
-        return IriConstants.IMPLICIT_NAMESPACES.stream()
+        return sut.getImplicitNamespaces().stream()
             .anyMatch(ns -> handle.getIdentifier().startsWith(ns));
     }
 


### PR DESCRIPTION
- Made IriConstants.IMPLICIT_NAMESPACES a proper constant
- Let KnowledgeBaseSerivce manage an extensible set of implicit namespaces
- Use that managed set in unit tests