### PR TITLE
Bugfix/663 improve build times

### DIFF
--- a/inception-concept-linking/src/test/java/de/tudarmstadt/ukp/inception/conceptlinking/NamedEntityLinkerTest.java
+++ b/inception-concept-linking/src/test/java/de/tudarmstadt/ukp/inception/conceptlinking/NamedEntityLinkerTest.java
@@ -141,14 +141,6 @@ public class NamedEntityLinkerTest
 
         assertThat(predictions).as("Predictions have been written to CAS")
             .isNotEmpty();
-
-        System.out.println(predictions);
-    }
-
-    private List<CAS> loadAllData() throws IOException, UIMAException
-    {
-        Dataset ds = loader.load("germeval2014-de");
-        return loadData(ds, ds.getDataFiles());
     }
 
     private List<CAS> loadDevelopmentData() throws IOException, UIMAException

--- a/inception-pdf-editor/pom.xml
+++ b/inception-pdf-editor/pom.xml
@@ -24,6 +24,9 @@
   </parent>
   <name>INCEpTION - Editor - PDF</name>
   <artifactId>inception-pdf-editor</artifactId>
+  <properties>
+    <frontend.install.path>${session.executionRootDirectory}/cache/maven-frontend-plugin</frontend.install.path>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>de.tudarmstadt.ukp.clarin.webanno</groupId>
@@ -96,7 +99,6 @@
     <plugins>
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.1.0</version>
         <executions>
           <execution>
             <id>copy-pdfanno-to-target</id>
@@ -118,7 +120,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
-        <version>3.0.0</version>
         <executions>
           <execution>
             <id>add-pdfanno-resources</id>
@@ -143,7 +144,7 @@
         <version>1.6</version>
           <configuration>
             <workingDirectory>target/js/pdfanno/</workingDirectory>
-            <installDirectory>target/js/pdfanno/</installDirectory>
+            <installDirectory>${frontend.install.path}</installDirectory>
           </configuration>
         <executions>
           <execution>
@@ -200,4 +201,17 @@
       </plugins>
     </pluginManagement>
   </build>
+  <profiles>
+    <profile>
+      <id>jenkins</id>
+      <activation>
+        <property>
+          <name>JENKINS_HOME</name>
+        </property>
+      </activation>
+      <properties>
+        <frontend.install.path>${WORKSPACE}/cache/maven-frontend-plugin</frontend.install.path>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
     <assertj.version>3.11.1</assertj.version>
     <okhttp.version>3.11.0</okhttp.version>
     <maven.surefire.heap>6g</maven.surefire.heap>
+    <dkpro.core.testCachePath>${session.executionRootDirectory}/cache/dkpro-core-datasets</dkpro.core.testCachePath>
   </properties>
   <modules>
     <module>inception-build</module>
@@ -779,7 +780,15 @@
             <arguments>${arguments} -Dmaven.surefire.heap=${maven.surefire.heap} -Pdkpro-release</arguments>
           </configuration>
         </plugin>
-      
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <configuration>
+            <systemPropertyVariables>
+              <dkpro.core.testCachePath>${dkpro.core.testCachePath}</dkpro.core.testCachePath>
+            </systemPropertyVariables>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
- Removed detail prediction dumping to stdout from entity linking unit test to reduce log size (and thus log analysis time)
- Put the NodeJS installation into that cross-build cache folder
- Put the DKPro Core Dataset cache into the cross-build cache folder