### PR TITLE
#668 - Some recommender settings not preserved on export/import

### DIFF
--- a/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/RecommendationService.java
+++ b/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/RecommendationService.java
@@ -41,6 +41,9 @@ public interface RecommendationService
 {
     String SERVICE_NAME = "recommendationService";
     
+    int MAX_RECOMMENDATIONS_DEFAULT = 3; 
+    int MAX_RECOMMENDATIONS_CAP = 10; 
+    
     void createOrUpdateRecommender(Recommender aRecommender);
 
     void deleteRecommender(Recommender aRecommender);

--- a/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/Recommender.java
+++ b/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/Recommender.java
@@ -241,6 +241,8 @@ public class Recommender
         sb.append(", threshold=").append(threshold);
         sb.append(", alwaysSelected=").append(alwaysSelected);
         sb.append(", enabled=").append(enabled);
+        sb.append(", maxRecommendations=").append(maxRecommendations);
+        sb.append(", skipEvaluation=").append(skipEvaluation);
         sb.append(", traits='").append(traits).append('\'');
         sb.append('}');
         return sb.toString();

--- a/inception-recommendation-api/src/main/resources/de/tudarmstadt/ukp/inception/recommendation/model/db-changelog.xml
+++ b/inception-recommendation-api/src/main/resources/de/tudarmstadt/ukp/inception/recommendation/model/db-changelog.xml
@@ -370,4 +370,15 @@
       </column>
     </addColumn>
   </changeSet>
+  
+  <!--
+   - We had a bug that this setting was not properly initialized when importing projects that
+   - where this setting did not exist yet. For such cases, we set the value to the default here. 
+   -->
+  <changeSet author="INCEpTION Team" id="20181116-1">
+    <update tableName="recommender">
+      <column name="maxRecommendations" type="INT" valueNumeric="3"/>
+      <where>maxRecommendations = 0</where>
+    </update>
+  </changeSet>
 </databaseChangeLog>

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/exporter/ExportedRecommender.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/exporter/ExportedRecommender.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ExportedRecommender
 {
-
     @JsonProperty("name")
     private String name;
 
@@ -44,9 +43,15 @@ public class ExportedRecommender
     @JsonProperty("alwaysSelected")
     private boolean alwaysSelected;
 
+    @JsonProperty("skipEvaluation")
+    private boolean skipEvaluation;
+    
     @JsonProperty("enabled")
     private boolean enabled;
 
+    @JsonProperty("maxRecommendations")
+    private int maxRecommendations;
+    
     @JsonProperty("traits")
     private String traits;
 
@@ -118,6 +123,26 @@ public class ExportedRecommender
     public void setEnabled(boolean aEnabled)
     {
         enabled = aEnabled;
+    }
+
+    public boolean isSkipEvaluation()
+    {
+        return skipEvaluation;
+    }
+
+    public void setSkipEvaluation(boolean aSkipEvaluation)
+    {
+        skipEvaluation = aSkipEvaluation;
+    }
+
+    public int getMaxRecommendations()
+    {
+        return maxRecommendations;
+    }
+
+    public void setMaxRecommendations(int aMaxRecommendations)
+    {
+        maxRecommendations = aMaxRecommendations;
     }
 
     public String getTraits()

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/exporter/RecommenderExporter.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/exporter/RecommenderExporter.java
@@ -17,6 +17,8 @@
  */
 package de.tudarmstadt.ukp.inception.recommendation.exporter;
 
+import static de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService.MAX_RECOMMENDATIONS_CAP;
+import static de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService.MAX_RECOMMENDATIONS_DEFAULT;
 import static java.util.Arrays.asList;
 
 import java.io.File;
@@ -81,6 +83,8 @@ public class RecommenderExporter implements ProjectExporter {
             exportedRecommender.setName(recommender.getName());
             exportedRecommender.setThreshold(recommender.getThreshold());
             exportedRecommender.setTool(recommender.getTool());
+            exportedRecommender.setSkipEvaluation(recommender.isSkipEvaluation());
+            exportedRecommender.setMaxRecommendations(recommender.getMaxRecommendations());
             exportedRecommender.setTraits(recommender.getTraits());
             exportedRecommenders.add(exportedRecommender);
         }
@@ -104,8 +108,22 @@ public class RecommenderExporter implements ProjectExporter {
             recommender.setName(exportedRecommender.getName());
             recommender.setThreshold(exportedRecommender.getThreshold());
             recommender.setTool(exportedRecommender.getTool());
+            recommender.setSkipEvaluation(exportedRecommender.isSkipEvaluation());
+            recommender.setMaxRecommendations(exportedRecommender.getMaxRecommendations());
             recommender.setTraits(exportedRecommender.getTraits());
 
+            // The value for max recommendations must be between 1 and 100
+            if (recommender.getMaxRecommendations() < 1) {
+                // We had a bug for some time where during export this value was not included.
+                // For such cases, we import using the default value.
+                recommender.setMaxRecommendations(MAX_RECOMMENDATIONS_DEFAULT);
+            }
+            if (recommender.getMaxRecommendations() > MAX_RECOMMENDATIONS_CAP) {
+                // If the instance from where this was exported allowed more max recommendations
+                // than our instance, we just reset it to our max cap.
+                recommender.setMaxRecommendations(MAX_RECOMMENDATIONS_CAP);
+            }
+            
             String layerName = exportedRecommender.getLayerName();
             AnnotationLayer layer = annotationService.getLayer(layerName, aProject);
             recommender.setLayer(layer);

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/ProjectRecommendersPanel.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/ProjectRecommendersPanel.java
@@ -17,6 +17,8 @@
  */
 package de.tudarmstadt.ukp.inception.recommendation.project;
 
+import static de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService.MAX_RECOMMENDATIONS_DEFAULT;
+
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 
@@ -46,8 +48,10 @@ public class ProjectRecommendersPanel
         RecommenderListPanel recommenderListPanel = new RecommenderListPanel("recommenders",
                 projectModel, selectedRecommenderModel);
         recommenderListPanel.setCreateAction(_target -> {
+            Recommender recommender = new Recommender();
+            recommender.setMaxRecommendations(MAX_RECOMMENDATIONS_DEFAULT);
+            selectedRecommenderModel.setObject(recommender);
             recommenderEditorPanel.modelChanged();
-            selectedRecommenderModel.setObject(new Recommender());
         });
         recommenderListPanel.setChangeAction(_target -> {
             recommenderEditorPanel.modelChanged();

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderEditorPanel.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderEditorPanel.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.inception.recommendation.project;
 
 import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
+import static de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService.MAX_RECOMMENDATIONS_CAP;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -198,7 +199,7 @@ public class RecommenderEditorPanel
         
         form.add(new NumberTextField<>(MID_MAX_RECOMMENDATIONS, Integer.class)
                 .setMinimum(1)
-                .setMaximum(10)
+                .setMaximum(MAX_RECOMMENDATIONS_CAP)
                 .setStep(1)
                 .setOutputMarkupPlaceholderTag(true)
                 .add(visibleWhen(() -> toolChoice.getModel()


### PR DESCRIPTION
- Export and import the maxRecommendations and skipEvaluation settings
- Fix the database to set missing maxRecommendations to the default value (3)
- On project import, enforce the max recommendations cap
- On project import, set missing max recommendations to default value
- Updated import/export unit test to check for preservation of maxRecommendations and skipEvaluation settings
- Updated import/export unit test to check for cap enforcement and to set missing values to default