### PR TITLE
#676 - Annotations whose label is not set are considered as training data

### DIFF
--- a/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/ner/OpenNlpNerRecommender.java
+++ b/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/ner/OpenNlpNerRecommender.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.recommendation.imls.opennlp.ner;
 
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.uima.fit.util.CasUtil.getAnnotationType;
 import static org.apache.uima.fit.util.CasUtil.getType;
 import static org.apache.uima.fit.util.CasUtil.indexCovered;
@@ -231,7 +232,9 @@ public class OpenNlpNerRecommender
             int begin = idxToken.get(idxTokenOffset.get(annotation.getBegin()));
             int end = idxToken.get(idxTokenOffset.get(annotation.getEnd()));
             String label = annotation.getFeatureValueAsString(feature);
-            result[i] = new Span(begin, end + 1, label);
+            if (isNotBlank(label)) {
+                result[i] = new Span(begin, end + 1, label);
+            }
         }
         return result;
     }

--- a/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/pos/OpenNlpPosRecommender.java
+++ b/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/pos/OpenNlpPosRecommender.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.recommendation.imls.opennlp.pos;
 
+import static org.apache.commons.lang3.StringUtils.isNoneBlank;
 import static org.apache.uima.fit.util.CasUtil.getAnnotationType;
 import static org.apache.uima.fit.util.CasUtil.getType;
 import static org.apache.uima.fit.util.CasUtil.indexCovered;
@@ -272,7 +273,7 @@ public class OpenNlpPosRecommender
         }
 
         String value = annotations.get(0).getFeatureValueAsString(aFeature);
-        return value != null ? value : PAD;
+        return isNoneBlank(value) ? value : PAD;
     }
 
     @Nullable

--- a/inception-imls-stringmatch/pom.xml
+++ b/inception-imls-stringmatch/pom.xml
@@ -38,6 +38,11 @@
       <groupId>de.tudarmstadt.ukp.clarin.webanno</groupId>
       <artifactId>webanno-api</artifactId>
     </dependency>
+    
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework</groupId>

--- a/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/StringMatchingRecommender.java
+++ b/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/StringMatchingRecommender.java
@@ -19,6 +19,7 @@ package de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch;
 
 import static java.util.Arrays.asList;
 import static java.util.Comparator.comparingInt;
+import static org.apache.commons.lang3.StringUtils.isNoneBlank;
 import static org.apache.uima.fit.util.CasUtil.getAnnotationType;
 import static org.apache.uima.fit.util.CasUtil.getType;
 import static org.apache.uima.fit.util.CasUtil.select;
@@ -251,13 +252,15 @@ public class StringMatchingRecommender
     }
     
     private void learn(Trie<DictEntry> aDict, String aText, String aLabel) {
-        DictEntry entry = aDict.get(aText);
-        if (entry == null) {
-            entry = new DictEntry(aText);
-            aDict.put(aText, entry);
+        if (isNoneBlank(aLabel)) {
+            DictEntry entry = aDict.get(aText);
+            if (entry == null) {
+                entry = new DictEntry(aText);
+                aDict.put(aText, entry);
+            }
+            
+            entry.put(aLabel);
         }
-        
-        entry.put(aLabel);
     }
     
     private List<Sample> extractData(List<CAS> aCasses, String aLayerName, String aFeatureName)


### PR DESCRIPTION
- Exclude training data without label in OpenNLP NER recommender
- Exclude training data without label in String matching recommender
- In OpenNLP POS, check if a label is empty using "isNoneBlank" instead of simply using "!= null" as before. Really just a cosmetic change.