### PR TITLE
#650 - Auto Complete field doesn't show suggestion for concept linking

### DIFF
--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/config/KnowledgeBaseProperties.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/config/KnowledgeBaseProperties.java
@@ -24,8 +24,9 @@ import org.springframework.stereotype.Component;
 @ConfigurationProperties("inception.knowledge-base")
 public class KnowledgeBaseProperties
 {
+    public static final int HARD_MIN_RESULTS = 10;
+    
     private int defaultMaxResults = 1000;
-
     private int hardMaxResults = 10000;
 
     public int getDefaultMaxResults()

--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/exporter/KnowledgeBaseExporter.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/exporter/KnowledgeBaseExporter.java
@@ -55,6 +55,7 @@ import de.tudarmstadt.ukp.inception.kb.IriConstants;
 import de.tudarmstadt.ukp.inception.kb.KnowledgeBaseService;
 import de.tudarmstadt.ukp.inception.kb.RepositoryType;
 import de.tudarmstadt.ukp.inception.kb.SchemaProfile;
+import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBaseProperties;
 import de.tudarmstadt.ukp.inception.kb.model.KnowledgeBase;
 import de.tudarmstadt.ukp.inception.kb.reification.Reification;
 
@@ -74,13 +75,15 @@ public class KnowledgeBaseExporter implements ProjectExporter
     private static final RDFFormat knowledgeBaseFileExportFormat = RDFFormat.TURTLE;
 
     private final KnowledgeBaseService kbService;
+    private final KnowledgeBaseProperties kbProperties;
     private final AnnotationSchemaService schemaService;
 
     @Autowired
     public KnowledgeBaseExporter(KnowledgeBaseService aKbService,
-        AnnotationSchemaService aSchemaService)
+            KnowledgeBaseProperties aKbProperties, AnnotationSchemaService aSchemaService)
     {
         kbService = aKbService;
+        kbProperties = aKbProperties;
         schemaService = aSchemaService;
     }
 
@@ -223,6 +226,18 @@ public class KnowledgeBaseExporter implements ProjectExporter
             }
             kb.setDefaultLanguage(exportedKB.getDefaultLanguage());
             kb.setMaxResults(exportedKB.getMaxResults());
+            // If not setting, initialize with default
+            if (kb.getMaxResults() == 0) {
+                kb.setMaxResults(kbProperties.getDefaultMaxResults());
+            }
+            // Cap at local min results
+            if (kb.getMaxResults() < KnowledgeBaseProperties.HARD_MIN_RESULTS) {
+                kb.setMaxResults(KnowledgeBaseProperties.HARD_MIN_RESULTS);
+            }
+            // Cap at local max results
+            if (kb.getMaxResults() > kbProperties.getHardMaxResults()) {
+                kb.setMaxResults(kbProperties.getHardMaxResults());
+            }
             kb.setProject(aProject);
 
             // Get config and register knowledge base

--- a/inception-kb/src/main/resources/de/tudarmstadt/ukp/inception/kb/model/db-changelog.xml
+++ b/inception-kb/src/main/resources/de/tudarmstadt/ukp/inception/kb/model/db-changelog.xml
@@ -364,4 +364,15 @@
       <where>supportConceptLinking = true</where>
     </update>
   </changeSet>
+  
+  <!--
+   - We had a bug that this setting was not properly initialized when importing projects that
+   - where this setting did not exist yet. For such cases, we set the value to the default here. 
+   -->
+  <changeSet author="INCEpTION Team" id="20181120-1">
+    <update tableName="knowledgebase">
+      <column name="maxResults" type="INT" valueNumeric="1000"/>
+      <where>maxResults = 0</where>
+    </update>
+  </changeSet>
 </databaseChangeLog>

--- a/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseExporterTest.java
+++ b/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseExporterTest.java
@@ -55,6 +55,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.support.JSONUtil;
+import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBaseProperties;
 import de.tudarmstadt.ukp.inception.kb.exporter.KnowledgeBaseExporter;
 import de.tudarmstadt.ukp.inception.kb.model.KnowledgeBase;
 
@@ -94,7 +95,7 @@ public class KnowledgeBaseExporterTest
 
         when(schemaService.listAnnotationFeature(sourceProject)).thenReturn(features(sourceProject));
 
-        sut = new KnowledgeBaseExporter(kbService, schemaService);
+        sut = new KnowledgeBaseExporter(kbService, new KnowledgeBaseProperties(), schemaService);
     }
 
     @Test

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/KnowledgeBaseDetailsPanel.html
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/KnowledgeBaseDetailsPanel.html
@@ -124,7 +124,9 @@
           <label class="col-sm-3 control-label">
             <wicket:message key="kb.language" />
           </label>
-          <div wicket:id="language" class="col-sm-9"></div>
+          <div class="col-sm-9">
+            <input wicket:id="language" type="text" class="form-control"/>
+          </div>
         </div>
       </div>
       <div class="form-group row">
@@ -132,7 +134,7 @@
           <wicket:message key="kb.queryLimit" />
         </label>
         <div class="col-sm-9">
-          <input class="form-control" style="width:20%;" type="text" wicket:id="maxResults"/>
+          <input class="form-control" type="number" wicket:id="maxResults"/>
         </div>
       </div>
       <span wicket:id="iriPanel"></span>
@@ -225,13 +227,13 @@
           <wicket:message key="kb.queryLimit" />
         </label>
         <div class="form-inline col-sm-9">
-          <input type="text" wicket:id="maxResults" class="form-control"/>
-            <div class="checkbox" style="margin-left: 15px;">
-              <label wicket:for="maxQueryLimit">
-              <input type="checkbox" wicket:id="maxQueryLimit"/>
-                <i><wicket:label key="kb.details.contents.maxQueryLimit"/></i>
-              </label>
-            </div>
+          <input type="number" wicket:id="maxResults" class="form-control"/>
+          <div class="checkbox" style="margin-left: 15px;">
+            <label wicket:for="maxQueryLimit">
+            <input type="checkbox" wicket:id="maxQueryLimit"/>
+              <i><wicket:label key="kb.details.contents.maxQueryLimit"/></i>
+            </label>
+          </div>
         </div>
       </div>
       <span wicket:id="iriPanel"></span>

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/KnowledgeBaseDetailsPanel.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/KnowledgeBaseDetailsPanel.java
@@ -33,6 +33,7 @@ import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.CheckBox;
 import org.apache.wicket.markup.html.form.Form;
+import org.apache.wicket.markup.html.form.NumberTextField;
 import org.apache.wicket.markup.html.form.RequiredTextField;
 import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.markup.html.form.upload.FileUpload;
@@ -48,7 +49,6 @@ import org.apache.wicket.model.ResourceModel;
 import org.apache.wicket.model.StringResourceModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.apache.wicket.util.resource.IResourceStream;
-import org.apache.wicket.validation.validator.RangeValidator;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.repository.config.RepositoryConfigException;
@@ -460,10 +460,10 @@ public class KnowledgeBaseDetailsPanel
             wmc.add(iriPanel);
 
             wmc.add(new CheckBox("enabled", model.bind("kb.enabled"))
-                .add(LambdaBehavior.onConfigure(it -> it.setEnabled(false))));
+                    .add(LambdaBehavior.onConfigure(it -> it.setEnabled(false))));
             wmc.add(new RequiredTextField<>("maxResults",
                 model.bind("kb.maxResults"))
-                .add(LambdaBehavior.onConfigure(it -> it.setEnabled(false))));
+                    .add(LambdaBehavior.onConfigure(it -> it.setEnabled(false))));
 
         }
 
@@ -570,8 +570,7 @@ public class KnowledgeBaseDetailsPanel
             wmc.add(new KnowledgeBaseIriPanel("iriPanel", model,
                 KnowledgeBaseIriPanelMode.PROJECTSETTINGS));
             wmc.add(new CheckBox("enabled", model.bind("kb.enabled")));
-            queryLimitField = queryLimitField("maxResults",
-                model.bind("kb.maxResults"));
+            queryLimitField = queryLimitField("maxResults", model.bind("kb.maxResults"));
             wmc.add(queryLimitField);
             maxQueryLimitCheckBox = maxQueryLimitCheckbox("maxQueryLimit", Model.of(false));
             wmc.add(maxQueryLimitCheckBox);
@@ -618,10 +617,15 @@ public class KnowledgeBaseDetailsPanel
             wmc.add(textField);
         }
 
-        private CheckBox maxQueryLimitCheckbox(String id, IModel<Boolean> model) {
-            return new AjaxCheckBox(id, model) {
+        private CheckBox maxQueryLimitCheckbox(String id, IModel<Boolean> aModel)
+        {
+            return new AjaxCheckBox(id, aModel)
+            {
+                private static final long serialVersionUID = -8390353018496338400L;
+
                 @Override
-                public void onUpdate(AjaxRequestTarget aTarget) {
+                public void onUpdate(AjaxRequestTarget aTarget)
+                {
                     if (getModelObject()) {
                         queryLimitField.setModelObject(kbProperties.getHardMaxResults());
                         queryLimitField.setEnabled(false);
@@ -631,18 +635,16 @@ public class KnowledgeBaseDetailsPanel
                     }
                     aTarget.add(queryLimitField);
                 }
-
             };
         }
 
-        private TextField<Integer> queryLimitField(String id, IModel<Integer> model)
+        private NumberTextField<Integer> queryLimitField(String id, IModel<Integer> aModel)
         {
-            if (model.getObject() == 0) {
-                model.setObject(kbProperties.getDefaultMaxResults());
-            }
-            TextField<Integer> queryLimit = new RequiredTextField<Integer>(id, model);
-            queryLimit.add(RangeValidator.range(0, kbProperties.getHardMaxResults()));
+            NumberTextField<Integer> queryLimit = new NumberTextField<>(id, aModel, Integer.class);
             queryLimit.setOutputMarkupId(true);
+            queryLimit.setRequired(true);
+            queryLimit.setMinimum(KnowledgeBaseProperties.HARD_MIN_RESULTS);
+            queryLimit.setMaximum(kbProperties.getHardMaxResults());
             return queryLimit;
         }
     }

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/KnowledgeBaseDetailsPanel.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/KnowledgeBaseDetailsPanel.java
@@ -451,20 +451,17 @@ public class KnowledgeBaseDetailsPanel
                             .add(LambdaBehavior.onConfigure(it -> it.setEnabled(false)));
 
             // add disabled language field
-            wmc.add(new Label("language", kbwModel.bind("kb.defaultLanguage"))
-                .add(LambdaBehavior.onConfigure(tf -> tf.setEnabled(false))));
+            wmc.add(new TextField<>("language", kbwModel.bind("kb.defaultLanguage"))
+                    .setEnabled(false));
 
             // don't show radio group in view mode - normally we'd just disable it, but that doesn't
             // seem to work
             iriPanel.get("comboBoxWrapper:iriSchema").setVisible(false);
             wmc.add(iriPanel);
 
-            wmc.add(new CheckBox("enabled", model.bind("kb.enabled"))
-                    .add(LambdaBehavior.onConfigure(it -> it.setEnabled(false))));
-            wmc.add(new RequiredTextField<>("maxResults",
-                model.bind("kb.maxResults"))
-                    .add(LambdaBehavior.onConfigure(it -> it.setEnabled(false))));
-
+            wmc.add(new CheckBox("enabled", model.bind("kb.enabled")).setEnabled(false));
+            wmc.add(new NumberTextField<>("maxResults", model.bind("kb.maxResults"), Integer.class)
+                    .setEnabled(false));
         }
 
         @Override protected void setUpLocalKnowledgeBaseComponents(WebMarkupContainer wmc)
@@ -645,6 +642,20 @@ public class KnowledgeBaseDetailsPanel
             queryLimit.setRequired(true);
             queryLimit.setMinimum(KnowledgeBaseProperties.HARD_MIN_RESULTS);
             queryLimit.setMaximum(kbProperties.getHardMaxResults());
+            queryLimit.add(LambdaBehavior.onConfigure(it -> {
+                // If not setting, initialize with default
+                if (queryLimit.getModelObject() == null || queryLimit.getModelObject() == 0) {
+                    queryLimit.setModelObject(kbProperties.getDefaultMaxResults());
+                }
+                // Cap at local min results
+                else if (queryLimit.getModelObject() < KnowledgeBaseProperties.HARD_MIN_RESULTS) {
+                    queryLimit.setModelObject(KnowledgeBaseProperties.HARD_MIN_RESULTS);
+                }
+                // Cap at local max results
+                else if (queryLimit.getModelObject() > kbProperties.getHardMaxResults()) {
+                    queryLimit.setModelObject(kbProperties.getHardMaxResults());
+                }
+            }));
             return queryLimit;
         }
     }

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/wizard/KnowledgeBaseCreationWizard$TypeStep.html
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/wizard/KnowledgeBaseCreationWizard$TypeStep.html
@@ -37,7 +37,7 @@
         <wicket:message key="kb.queryLimit" />
       </label>
       <div class="form-inline">
-        <input type="text" wicket:id="maxResults" class="form-control"/>
+        <input type="number" wicket:id="maxResults" class="form-control"/>
           <div class="checkbox" style="margin-left: 15px;">
             <label wicket:for="maxQueryLimit">
               <input type="checkbox" wicket:id="maxQueryLimit"/>


### PR DESCRIPTION
- Introduce constant for query lower limit
- Fix maxResults = 0 in the DB on application start
- Apply maxResults caps during project import
- Set default value if maxResults = 0 on import
- Use a NumberTextField for the maxResults in the project settings instead of a RequiredTextField