### PR TITLE
#679 - Document import fails for HTML files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -658,6 +658,12 @@
 
       <dependency>
         <groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
+        <artifactId>de.tudarmstadt.ukp.dkpro.core.io.html-asl</artifactId>
+        <version>${dkpro.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
         <artifactId>de.tudarmstadt.ukp.dkpro.core-asl</artifactId>
         <version>${dkpro.version}</version>
         <type>pom</type>


### PR DESCRIPTION
- Set version of DKPro Core HTML reader explicitly because wrong version is inherited due to missing dependencyManagement entry in the DKPro Core 1.10.0 ASL POM