### PR TITLE
#694 - Some statement values are shown as empty but are not

### DIFF
--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/KBObject.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/KBObject.java
@@ -17,9 +17,11 @@
  */
 package de.tudarmstadt.ukp.inception.kb.graph;
 
-import java.io.Serializable;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.eclipse.rdf4j.model.util.URIUtil.getLocalNameIndex;
+import static org.eclipse.rdf4j.model.util.URIUtil.isValidURIReference;
 
-import org.eclipse.rdf4j.model.util.URIUtil;
+import java.io.Serializable;
 
 import de.tudarmstadt.ukp.inception.kb.model.KnowledgeBase;
 
@@ -73,11 +75,11 @@ public interface KBObject
     void setLanguage(String language);
 
     /**
-     * Returns a UI-friendly representation of this {@code KBObject}.
+     * Returns the name of the {@code KBObject} if available, otherwise return the local name of its
+     * IRI or, as a last resort, return the full identifier, e.g. if the identifier is not a valid
+     * IRI or if the local name is empty.
      * 
-     * @return the name of the {@code KBObject} if available, otherwise return the local name of its
-     *         IRI or, as a last resort, return the full identifier if the identifier is not a valid
-     *         IRI
+     * @return a UI-friendly representation of this {@code KBObject}.
      */
     default String getUiLabel() {
         String name = getName();
@@ -85,9 +87,15 @@ public interface KBObject
             return name;
         }
 
-        if (URIUtil.isValidURIReference(getIdentifier())) {
-            int localNameIndex = URIUtil.getLocalNameIndex(getIdentifier());
-            return getIdentifier().substring(localNameIndex).replace('_', ' ');
+        if (isValidURIReference(getIdentifier())) {
+            int localNameIndex = getLocalNameIndex(getIdentifier());
+            String label = getIdentifier().substring(localNameIndex).replace('_', ' ');
+            if (isNotBlank(label)) {
+                return label;
+            }
+            else {
+                return getIdentifier();
+            }
         } else {
             return getIdentifier();
         }

--- a/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/graph/KBHandleTest.java
+++ b/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/graph/KBHandleTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018
+ * Ubiquitous Knowledge Processing (UKP) Lab
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.kb.graph;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class KBHandleTest
+{
+    @Test
+    public void thatUILabelExtractsGoodLabelFromIRI()
+    {
+        assertThat(new KBHandle("http://dummy.org/ontology#"))
+                .as("IRI has anchor symbol but nothing after it")
+                .extracting(KBHandle::getUiLabel)
+                .isEqualTo("http://dummy.org/ontology#");
+        
+        assertThat(new KBHandle("http://dummy.org/ontology"))
+                .as("IRI ends in a path segment")
+                .extracting(KBHandle::getUiLabel)
+                .isEqualTo("ontology");
+
+        assertThat(new KBHandle("http://dummy.org/ontology#someConcept"))
+                .as("IRI has named anchor")
+                .extracting(KBHandle::getUiLabel)
+                .isEqualTo("someConcept");
+
+        assertThat(new KBHandle("http://dummy.org/ontology#some_Concept"))
+                .as("IRI has named anchor in snake_case")
+                .extracting(KBHandle::getUiLabel)
+                .isEqualTo("some Concept");
+    }
+}


### PR DESCRIPTION
- Use the IRI if extracting the local name as a label would result in an empty label
- Added unit tests