### PR TITLE
#715 - Support basic markdown in project description

### DIFF
--- a/inception-ui-core/pom.xml
+++ b/inception-ui-core/pom.xml
@@ -124,6 +124,11 @@
     </dependency>
     
     <dependency>
+      <groupId>com.github.rjeschke</groupId>
+      <artifactId>txtmark</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/dashlet/CurrentProjectDashlet.java
+++ b/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/dashlet/CurrentProjectDashlet.java
@@ -21,7 +21,11 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.wicket.Session;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.model.LoadableDetachableModel;
+import org.apache.wicket.spring.injection.annot.SpringBean;
 
+import com.github.rjeschke.txtmark.Processor;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.inception.ui.core.session.SessionMetaData;
 
@@ -30,18 +34,36 @@ public class CurrentProjectDashlet
 {
     private static final long serialVersionUID = 7732921923832675326L;
 
+    private @SpringBean ProjectService projectService;
+    
     public CurrentProjectDashlet(String aId)
     {
         super(aId);
         
         add(new Label("name", LoadableDetachableModel.of(this::getProjectName)));
         
-        add(new Label("description", LoadableDetachableModel.of(this::getProjectDescription)));
+        add(new Label("description", LoadableDetachableModel.of(this::getProjectDescription))
+                .setEscapeModelStrings(false));
+    }
+    
+    /**
+     * Look up project in session but get fresh info from the DB in case the session object is
+     * stale (e.g. if the title/description has changed).
+     */
+    private Project getProject()
+    {
+        Project project = Session.get().getMetaData(SessionMetaData.CURRENT_PROJECT);
+        if (project == null) {
+            return null;
+        }
+        else {
+            return projectService.getProject(project.getId());
+        }
     }
     
     private String getProjectName()
     {
-        Project project = Session.get().getMetaData(SessionMetaData.CURRENT_PROJECT);
+        Project project = getProject();
         if (project != null) {
             return project.getName();
         }
@@ -52,13 +74,13 @@ public class CurrentProjectDashlet
     
     private String getProjectDescription()
     {
-        Project project = Session.get().getMetaData(SessionMetaData.CURRENT_PROJECT);
+        Project project = getProject();
         if (project != null) {
             if (StringUtils.isBlank(project.getDescription())) {
                 return "Project has no description.";
             }
             else {
-                return project.getDescription();
+                return Processor.process(project.getDescription(), true);
             }
         }
         else {


### PR DESCRIPTION
- Process project description using txtmark (Markdown) before rendering
- Refresh project from DB instead of directly using the session object so we always display the latest description / title