### PR TITLE
#719 - Active learning sidebar triggers concurrent access error

### DIFF
--- a/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.java
+++ b/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.java
@@ -631,8 +631,8 @@ public class ActiveLearningSidebar
         
         // Update timestamp in state
         Optional<Long> diskTimestamp = documentService
-                .getAnnotationCasTimestamp(state.getDocument(), state.getUser().getUsername());
-        if (diskTimestamp.isPresent()) {
+                .getAnnotationCasTimestamp(sourceDoc, state.getUser().getUsername());
+        if (diskTimestamp.isPresent() && state.getDocument().getId() == sourceDoc.getId()) {
             state.setAnnotationDocumentTimestamp(diskTimestamp.get());
         }
 

--- a/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.java
+++ b/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.java
@@ -22,6 +22,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -629,11 +630,14 @@ public class ActiveLearningSidebar
         // Save CAS after annotation has been created
         documentService.writeAnnotationCas(jCas, annoDoc, true);
         
-        // Update timestamp in state
-        Optional<Long> diskTimestamp = documentService
-                .getAnnotationCasTimestamp(sourceDoc, state.getUser().getUsername());
-        if (diskTimestamp.isPresent() && state.getDocument().getId() == sourceDoc.getId()) {
-            state.setAnnotationDocumentTimestamp(diskTimestamp.get());
+        // If the currently displayed document is the same one where the annotation was created,
+        // then update timestamp in state to avoid concurrent modification errors
+        if (Objects.equals(state.getDocument().getId(), sourceDoc.getId())) {
+            Optional<Long> diskTimestamp = documentService.getAnnotationCasTimestamp(sourceDoc,
+                    state.getUser().getUsername());
+            if (diskTimestamp.isPresent()) {
+                state.setAnnotationDocumentTimestamp(diskTimestamp.get());
+            }
         }
 
         moveToNextRecommendation(aTarget);

--- a/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.java
+++ b/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.java
@@ -628,6 +628,13 @@ public class ActiveLearningSidebar
 
         // Save CAS after annotation has been created
         documentService.writeAnnotationCas(jCas, annoDoc, true);
+        
+        // Update timestamp in state
+        Optional<Long> diskTimestamp = documentService
+                .getAnnotationCasTimestamp(state.getDocument(), state.getUser().getUsername());
+        if (diskTimestamp.isPresent()) {
+            state.setAnnotationDocumentTimestamp(diskTimestamp.get());
+        }
 
         moveToNextRecommendation(aTarget);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -625,7 +625,7 @@
       <dependency>
         <groupId>com.h2database</groupId>
         <artifactId>h2</artifactId>
-        <version>1.3.160</version>
+        <version>1.4.197</version>
       </dependency>
       <dependency>
         <groupId>de.tudarmstadt.ukp.inception.app</groupId>


### PR DESCRIPTION
- Update the access timestamp in the annotator state when saving the CAS to avoid concurrent access warning