### PR TITLE
#731 - MTAS tests failing occasionally

### DIFF
--- a/inception-search-mtas/pom.xml
+++ b/inception-search-mtas/pom.xml
@@ -217,7 +217,12 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>3.1.3</version>
+      <scope>test</scope>
+    </dependency>
     <!-- Testing END -->
 
   </dependencies>  


### PR DESCRIPTION
- Give the async indexing more time
- Switch to use Awaility instead of hand-coded timeout checks