### PR TITLE
#758 - OpenNLP NER fails on overlapping annotations

### DIFF
--- a/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/ner/OpenNlpNerRecommender.java
+++ b/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/ner/OpenNlpNerRecommender.java
@@ -227,13 +227,21 @@ public class OpenNlpNerRecommender
         List<AnnotationFS> annotations = selectCovered(annotationType, aSentence);
         int numberOfAnnotations = annotations.size();
         List<Span> result = new ArrayList<>();
+        int maxSeen = 0;
         for (int i = 0; i < numberOfAnnotations; i++) {
             AnnotationFS annotation = annotations.get(i);
             int begin = idxToken.get(idxTokenOffset.get(annotation.getBegin()));
             int end = idxToken.get(idxTokenOffset.get(annotation.getEnd()));
             String label = annotation.getFeatureValueAsString(feature);
+            
+            if (begin < maxSeen) {
+                LOG.warn("Skipping overlapping annotation: [{}-{}, {}]", begin, end + 1, label);
+                continue;
+            }
+            
             if (isNotBlank(label)) {
                 result.add(new Span(begin, end + 1, label));
+                maxSeen = end + 1;
             }
         }
         return result.toArray(new Span[result.size()]);

--- a/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/ner/OpenNlpNerRecommender.java
+++ b/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/ner/OpenNlpNerRecommender.java
@@ -227,21 +227,25 @@ public class OpenNlpNerRecommender
         List<AnnotationFS> annotations = selectCovered(annotationType, aSentence);
         int numberOfAnnotations = annotations.size();
         List<Span> result = new ArrayList<>();
-        int maxSeen = 0;
+
+        int highestEndTokenPositionObserved = 0;
         for (int i = 0; i < numberOfAnnotations; i++) {
             AnnotationFS annotation = annotations.get(i);
             int begin = idxToken.get(idxTokenOffset.get(annotation.getBegin()));
             int end = idxToken.get(idxTokenOffset.get(annotation.getEnd()));
             String label = annotation.getFeatureValueAsString(feature);
             
-            if (begin < maxSeen) {
+            // If the begin offset of the current annotation is lower than the highest offset so far
+            // observed, then it is overlapping with some annotation that we have seen before. 
+            // Because OpenNLP NER does not support overlapping annotations, we skip it.
+            if (begin < highestEndTokenPositionObserved) {
                 LOG.debug("Skipping overlapping annotation: [{}-{}, {}]", begin, end + 1, label);
                 continue;
             }
             
             if (isNotBlank(label)) {
                 result.add(new Span(begin, end + 1, label));
-                maxSeen = end + 1;
+                highestEndTokenPositionObserved = end + 1;
             }
         }
         return result.toArray(new Span[result.size()]);

--- a/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/ner/OpenNlpNerRecommender.java
+++ b/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/ner/OpenNlpNerRecommender.java
@@ -235,7 +235,7 @@ public class OpenNlpNerRecommender
             String label = annotation.getFeatureValueAsString(feature);
             
             if (begin < maxSeen) {
-                LOG.warn("Skipping overlapping annotation: [{}-{}, {}]", begin, end + 1, label);
+                LOG.debug("Skipping overlapping annotation: [{}-{}, {}]", begin, end + 1, label);
                 continue;
             }
             

--- a/inception-imls-opennlp/src/main/resources/META-INF/asciidoc/user-guide/projects_recommendation_opennlp.adoc
+++ b/inception-imls-opennlp/src/main/resources/META-INF/asciidoc/user-guide/projects_recommendation_opennlp.adoc
@@ -31,5 +31,5 @@ with a feature value exists.
 This recommender uses the OpenNLP Name Finder to learn a sequence tagging model for multi-token
 annotations. The model generates a BIO-encoded representation of the annotations in the sentence.
 
-NOTE: If a layer contains overlapping annotations, the recommender does not fail, but it is also not
-      able to learn properly.
+NOTE: If a layer contains overlapping annotations, it considers only the first overlapping 
+      annotation and then skips all annotation until it reaches one that does not overlap with it.


### PR DESCRIPTION
- Remember the end of the last annotation and do not accept any new annotation that starts earlier than that