### PR TITLE
#761 - Option to explicitly enable PDF/HTML editor support

### DIFF
--- a/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/htmleditor/HtmlAnnotationEditorFactory.java
+++ b/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/htmleditor/HtmlAnnotationEditorFactory.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.inception.htmleditor;
 
 import org.apache.wicket.model.IModel;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.JCasProvider;
@@ -27,6 +28,8 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.action.AnnotationActionH
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
 
 @Component("htmlEditor")
+@ConditionalOnProperty(prefix = "ui.html", name = "enabled", havingValue = "true", 
+        matchIfMissing = false)
 public class HtmlAnnotationEditorFactory
     extends AnnotationEditorFactoryImplBase
 {

--- a/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/htmleditor/config/HtmlEditorProperties.java
+++ b/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/htmleditor/config/HtmlEditorProperties.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018
+ * Ubiquitous Knowledge Processing (UKP) Lab
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.tudarmstadt.ukp.inception.htmleditor.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties("ui.html")
+public class HtmlEditorProperties
+{
+    private boolean enabled = false;
+
+    public boolean isEnabled()
+    {
+        return enabled;
+    }
+
+    public void setEnabled(boolean aEnabled)
+    {
+        enabled = aEnabled;
+    }
+}

--- a/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/PdfAnnotationEditorFactory.java
+++ b/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/PdfAnnotationEditorFactory.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.inception.pdfeditor;
 
 import org.apache.wicket.model.IModel;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.JCasProvider;
@@ -27,6 +28,8 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.action.AnnotationActionH
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
 
 @Component("pdfEditor")
+@ConditionalOnProperty(prefix = "ui.pdf", name = "enabled", havingValue = "true", 
+        matchIfMissing = false)
 public class PdfAnnotationEditorFactory
     extends AnnotationEditorFactoryImplBase
 {

--- a/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/config/PdfEditorProperties.java
+++ b/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/config/PdfEditorProperties.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018
+ * Ubiquitous Knowledge Processing (UKP) Lab
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package de.tudarmstadt.ukp.inception.pdfeditor.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties("ui.pdf")
+public class PdfEditorProperties
+{
+    private boolean enabled = false;
+
+    public boolean isEnabled()
+    {
+        return enabled;
+    }
+
+    public void setEnabled(boolean aEnabled)
+    {
+        enabled = aEnabled;
+    }
+}


### PR DESCRIPTION
- Disabled PDF editor by default - can be activated by adding `ui.pdf.enabled=true` to the settings.properties file
- Disabled HTML editor by default - can be activated by adding `ui.html.enabled=true` to the settings.properties file