### PR TITLE
#746 - Creating two recommenders with same configuration throws

### DIFF
--- a/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/RecommendationService.java
+++ b/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/RecommendationService.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.inception.recommendation.api;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.apache.uima.jcas.JCas;
 
@@ -50,6 +51,10 @@ public interface RecommendationService
     
     Recommender getRecommender(long aId);
 
+    Optional<Recommender> getRecommender(Project aProject, String aName);
+
+    boolean existsRecommender(Project aProject, String aName);
+    
     List<Recommender> listRecommenders(Project aProject);
 
     List<Recommender> listRecommenders(AnnotationLayer aLayer);

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderEditorPanel.html
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderEditorPanel.html
@@ -26,18 +26,24 @@
       <div class="panel-body">
         <div class="col-sm-12 form-horizontal">
           <div class="form-group" wicket:enclosure="name">
-            <label class="col-sm-3 control-label">
-              <wicket:message key="name"/>
+            <label class="col-sm-3 control-label" wicket:for="name">
+              <wicket:label key="name"/>
             </label>
             <div class="col-sm-9">
-              <wicket:container wicket:id="name" class="form-control"/>
+              <div class="input-group">
+                <input wicket:id="name" class="form-control" type="text"/>
+                <span class="input-group-addon">
+                  <input wicket:id="autoGenerateName" type="checkbox"/>
+                  <wicket:message key="autoGenerateName"/>
+                </span>
+              </div>
             </div>
           </div>
           <div class="form-group" wicket:enclosure="enabled">
             <div class="col-sm-offset-3 col-sm-9">
               <div class="checkbox">
                 <label wicket:for="enabled">
-                  <input wicket:id="enabled" type="checkbox">
+                  <input wicket:id="enabled" type="checkbox"/>
                   <wicket:label key="enabled"/>
                 </label>
               </div>

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderEditorPanel.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderEditorPanel.java
@@ -132,8 +132,8 @@ public class RecommenderEditorPanel
         autoGenerateNameCheckBox = new CheckBox(MID_AUTO_GENERATED_NAME,
                 PropertyModel.of(this, "autoGenerateName"));
         autoGenerateNameCheckBox.add(new LambdaAjaxFormComponentUpdatingBehavior("change", t -> {
-            autoUpdateName(nameField, recommenderModel.getObject());
-            t.add(nameField, autoGenerateNameCheckBox);
+            autoUpdateName(t, nameField, recommenderModel.getObject());
+            t.add(autoGenerateNameCheckBox);
         }));
         form.add(autoGenerateNameCheckBox);
         
@@ -146,10 +146,10 @@ public class RecommenderEditorPanel
         layerChoice.add(new LambdaAjaxFormComponentUpdatingBehavior("change", t -> { 
             toolChoice.setModelObject(null);
             featureChoice.setModelObject(null);
-            autoUpdateName(nameField, recommenderModel.getObject());
+            autoUpdateName(t, nameField, recommenderModel.getObject());
             // Need to add the autoGenerateNameCheckBox here otherwise it looses its form-updating
             // behavior - no idea why
-            t.add(nameField, autoGenerateNameCheckBox, form.get(MID_TOOL), form.get(MID_FEATURE),
+            t.add(autoGenerateNameCheckBox, form.get(MID_TOOL), form.get(MID_FEATURE),
                     form.get(MID_MAX_RECOMMENDATIONS), activationContainer, traitsContainer);
         }));
         form.add(layerChoice);
@@ -165,10 +165,10 @@ public class RecommenderEditorPanel
         // The tools depend on the feature, so reload the tools when the feature is changed
         featureChoice.add(new LambdaAjaxFormComponentUpdatingBehavior("change", t -> {
             toolChoice.setModelObject(null);
-            autoUpdateName(nameField, recommenderModel.getObject());
+            autoUpdateName(t, nameField, recommenderModel.getObject());
             // Need to add the autoGenerateNameCheckBox here otherwise it looses its form-updating
             // behavior - no idea why
-            t.add(nameField, autoGenerateNameCheckBox, form.get(MID_TOOL),
+            t.add(autoGenerateNameCheckBox, form.get(MID_TOOL),
                     form.get(MID_MAX_RECOMMENDATIONS), activationContainer, traitsContainer);
         }));
         form.add(featureChoice);
@@ -207,10 +207,10 @@ public class RecommenderEditorPanel
         toolChoice.setRequired(true);
         toolChoice.setOutputMarkupId(true);
         toolChoice.add(new LambdaAjaxFormComponentUpdatingBehavior("change", t -> {
-            autoUpdateName(nameField, recommenderModel.getObject());
+            autoUpdateName(t, nameField, recommenderModel.getObject());
             // Need to add the autoGenerateNameCheckBox here otherwise it looses its form-updating
             // behavior - no idea why
-            t.add(nameField, autoGenerateNameCheckBox, form.get(MID_MAX_RECOMMENDATIONS),
+            t.add(autoGenerateNameCheckBox, form.get(MID_MAX_RECOMMENDATIONS),
                     activationContainer, traitsContainer);
         }));
         form.add(toolChoice);
@@ -273,13 +273,18 @@ public class RecommenderEditorPanel
         traitsContainer.add(new EmptyPanel(MID_TRAITS));
     }
 
-    private void autoUpdateName(TextField<String> aField, Recommender aRecommender)
+    private void autoUpdateName(AjaxRequestTarget aTarget, TextField<String> aField,
+            Recommender aRecommender)
     {
         if (!autoGenerateName || aRecommender == null) {
             return;
         }
-        
+
         aField.setModelObject(generateName(aRecommender));
+        
+        if (aTarget != null) {
+            aTarget.add(aField);
+        }
     }
     
     private String generateName(Recommender aRecommender)
@@ -326,7 +331,7 @@ public class RecommenderEditorPanel
                 Objects.equals(recommender.getName(), generateName(recommender))
         ) {
             autoGenerateNameCheckBox.setModelObject(true);
-            autoUpdateName(nameField, recommenderModel.getObject());
+            autoUpdateName(null, nameField, recommenderModel.getObject());
         }
         else {
             autoGenerateNameCheckBox.setModelObject(false);

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderEditorPanel.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderEditorPanel.java
@@ -131,8 +131,8 @@ public class RecommenderEditorPanel
         autoGenerateNameCheckBox = new CheckBox(MID_AUTO_GENERATED_NAME,
                 PropertyModel.of(this, "autoGenerateName"));
         autoGenerateNameCheckBox.add(new LambdaAjaxFormComponentUpdatingBehavior("change", t -> {
-            autoUpdateName(t, nameField, recommenderModel.getObject());
-            t.add(autoGenerateNameCheckBox);
+            autoUpdateName(nameField, recommenderModel.getObject());
+            t.add(nameField, autoGenerateNameCheckBox);
         }));
         form.add(autoGenerateNameCheckBox);
         
@@ -145,9 +145,9 @@ public class RecommenderEditorPanel
         layerChoice.add(new LambdaAjaxFormComponentUpdatingBehavior("change", t -> { 
             toolChoice.setModelObject(null);
             featureChoice.setModelObject(null);
-            autoUpdateName(t, nameField, recommenderModel.getObject());
-            t.add(form.get(MID_TOOL), form.get(MID_FEATURE), form.get(MID_MAX_RECOMMENDATIONS),
-                    activationContainer, traitsContainer);
+            autoUpdateName(nameField, recommenderModel.getObject());
+            t.add(nameField, form.get(MID_TOOL), form.get(MID_FEATURE),
+                    form.get(MID_MAX_RECOMMENDATIONS), activationContainer, traitsContainer);
         }));
         form.add(layerChoice);
         
@@ -162,9 +162,9 @@ public class RecommenderEditorPanel
         // The tools depend on the feature, so reload the tools when the feature is changed
         featureChoice.add(new LambdaAjaxFormComponentUpdatingBehavior("change", t -> {
             toolChoice.setModelObject(null);
-            autoUpdateName(t, nameField, recommenderModel.getObject());
-            t.add(form.get(MID_TOOL), form.get(MID_MAX_RECOMMENDATIONS), activationContainer,
-                    traitsContainer);
+            autoUpdateName(nameField, recommenderModel.getObject());
+            t.add(nameField, form.get(MID_TOOL), form.get(MID_MAX_RECOMMENDATIONS),
+                    activationContainer, traitsContainer);
         }));
         form.add(featureChoice);
         
@@ -202,8 +202,9 @@ public class RecommenderEditorPanel
         toolChoice.setRequired(true);
         toolChoice.setOutputMarkupId(true);
         toolChoice.add(new LambdaAjaxFormComponentUpdatingBehavior("change", t -> {
-            autoUpdateName(t, nameField, recommenderModel.getObject());
-            t.add(form.get(MID_MAX_RECOMMENDATIONS), activationContainer, traitsContainer); 
+            autoUpdateName(nameField, recommenderModel.getObject());
+            t.add(nameField, form.get(MID_MAX_RECOMMENDATIONS), activationContainer,
+                    traitsContainer);
         }));
         form.add(toolChoice);
         
@@ -264,12 +265,9 @@ public class RecommenderEditorPanel
         traitsContainer.setOutputMarkupPlaceholderTag(true);
         traitsContainer.add(new EmptyPanel(MID_TRAITS));
     }
-    
-    private void autoUpdateName(AjaxRequestTarget aTarget, TextField<String> aField,
-            Recommender aRecommender)
+
+    private void autoUpdateName(TextField<String> aField, Recommender aRecommender)
     {
-        aTarget.add(aField);
-        
         if (!autoGenerateName || aRecommender == null) {
             return;
         }
@@ -317,6 +315,7 @@ public class RecommenderEditorPanel
                 Objects.equals(recommender.getName(), generateName(recommender))
         ) {
             autoGenerateNameCheckBox.setModelObject(true);
+            autoUpdateName(nameField, recommenderModel.getObject());
         }
         else {
             autoGenerateNameCheckBox.setModelObject(false);

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderEditorPanel.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderEditorPanel.java
@@ -62,6 +62,7 @@ import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxLink;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaModelAdapter;
 import de.tudarmstadt.ukp.clarin.webanno.support.spring.ApplicationEventPublisherHolder;
+import de.tudarmstadt.ukp.clarin.webanno.support.wicket.ModelChangedVisitor;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
 import de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService;
 import de.tudarmstadt.ukp.inception.recommendation.api.RecommenderFactoryRegistry;
@@ -146,7 +147,9 @@ public class RecommenderEditorPanel
             toolChoice.setModelObject(null);
             featureChoice.setModelObject(null);
             autoUpdateName(nameField, recommenderModel.getObject());
-            t.add(nameField, form.get(MID_TOOL), form.get(MID_FEATURE),
+            // Need to add the autoGenerateNameCheckBox here otherwise it looses its form-updating
+            // behavior - no idea why
+            t.add(nameField, autoGenerateNameCheckBox, form.get(MID_TOOL), form.get(MID_FEATURE),
                     form.get(MID_MAX_RECOMMENDATIONS), activationContainer, traitsContainer);
         }));
         form.add(layerChoice);
@@ -163,8 +166,10 @@ public class RecommenderEditorPanel
         featureChoice.add(new LambdaAjaxFormComponentUpdatingBehavior("change", t -> {
             toolChoice.setModelObject(null);
             autoUpdateName(nameField, recommenderModel.getObject());
-            t.add(nameField, form.get(MID_TOOL), form.get(MID_MAX_RECOMMENDATIONS),
-                    activationContainer, traitsContainer);
+            // Need to add the autoGenerateNameCheckBox here otherwise it looses its form-updating
+            // behavior - no idea why
+            t.add(nameField, autoGenerateNameCheckBox, form.get(MID_TOOL),
+                    form.get(MID_MAX_RECOMMENDATIONS), activationContainer, traitsContainer);
         }));
         form.add(featureChoice);
         
@@ -203,8 +208,10 @@ public class RecommenderEditorPanel
         toolChoice.setOutputMarkupId(true);
         toolChoice.add(new LambdaAjaxFormComponentUpdatingBehavior("change", t -> {
             autoUpdateName(nameField, recommenderModel.getObject());
-            t.add(nameField, form.get(MID_MAX_RECOMMENDATIONS), activationContainer,
-                    traitsContainer);
+            // Need to add the autoGenerateNameCheckBox here otherwise it looses its form-updating
+            // behavior - no idea why
+            t.add(nameField, autoGenerateNameCheckBox, form.get(MID_MAX_RECOMMENDATIONS),
+                    activationContainer, traitsContainer);
         }));
         form.add(toolChoice);
         
@@ -303,6 +310,10 @@ public class RecommenderEditorPanel
     protected void onModelChanged()
     {
         super.onModelChanged();
+
+        // When field become invalid, Wicket stops re-rendering them. Thus we tell all of them that
+        // their model has changes such that they clear their validation status.
+        visitChildren(new ModelChangedVisitor(recommenderModel));
 
         // Since toolChoice uses a lambda model, it needs to be notified explicitly.
         toolChoice.modelChanged();

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderEditorPanel.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderEditorPanel.java
@@ -124,7 +124,7 @@ public class RecommenderEditorPanel
         add(form);
         
         nameField = new TextField<>(MID_NAME, String.class);
-        nameField.add(new RecommenderExistsValidator(recommenderModel));
+        nameField.add(new RecommenderExistsValidator(projectModel, recommenderModel));
         nameField.setRequired(true);
         form.add(nameField);
         
@@ -408,20 +408,23 @@ public class RecommenderEditorPanel
     {
         private static final long serialVersionUID = 8604561828541964271L;
 
-        private IModel<Recommender> recommenderModel;
+        private IModel<Recommender> recommender;
+        private IModel<Project> project;
         
-        public RecommenderExistsValidator(IModel<Recommender> aModel)
+        public RecommenderExistsValidator(IModel<Project> aProject,
+                IModel<Recommender> aRecommender)
         {
-            recommenderModel = aModel;
+            recommender = aRecommender;
+            project = aProject;
         }
         
         @Override
         public void validate(IValidatable<String> aValidatable)
         {
             String newName = aValidatable.getValue();
-            Recommender currentRecommender = recommenderModel.getObject();
+            Recommender currentRecommender = recommender.getObject();
             Optional<Recommender> recommenderWithNewName = recommendationService
-                    .getRecommender(currentRecommender.getProject(), newName);
+                    .getRecommender(project.getObject(), newName);
             // Either there should be no recommender with the new name already existing or it should
             // be the recommender we are currently editing (i.e. the name has not changed)
             if (

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderEditorPanel.properties
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderEditorPanel.properties
@@ -24,3 +24,4 @@ feature=Feature
 alwaysSelected=Always active (no evaluation)
 enabled=Enabled
 maxRecommendations=Max. recommendations
+autoGenerateName=auto-generate

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
@@ -20,6 +20,7 @@ package de.tudarmstadt.ukp.inception.recommendation.service;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 import javax.persistence.EntityManager;
@@ -188,7 +189,43 @@ public class RecommendationServiceImpl
     {
         return entityManager.find(Recommender.class, aId);
     }
+    
+    @Override
+    @Transactional
+    public boolean existsRecommender(Project aProject, String aName)
+    {
+        String query = String.join("\n",
+                "SELECT COUNT(*)",
+                "FROM Recommender ",
+                "WHERE name = :name ",
+                "AND project = :project");
 
+        long count = entityManager
+                .createQuery(query, Long.class)
+                .setParameter("name", aName)
+                .setParameter("project", aProject)
+                .getSingleResult();
+        
+        return count > 0;
+    }
+
+    @Override
+    @Transactional
+    public Optional<Recommender> getRecommender(Project aProject, String aName)
+    {
+        String query = String.join("\n",
+                "FROM Recommender ",
+                "WHERE name = :name ",
+                "AND project = :project");
+
+        return entityManager
+                .createQuery(query, Recommender.class)
+                .setParameter("name", aName)
+                .setParameter("project", aProject)
+                .getResultStream()
+                .findFirst();
+    }
+    
     @Override
     @Transactional
     public List<Recommender> listRecommenders(AnnotationLayer aLayer)

--- a/inception-recommendation/src/main/resources/META-INF/asciidoc/user-guide/projects_recommendation.adoc
+++ b/inception-recommendation/src/main/resources/META-INF/asciidoc/user-guide/projects_recommendation.adoc
@@ -1,5 +1,6 @@
 [[sect_projects_recommendation]]
 == Recommenders
+
 Recommenders provide annotation support by predicting potential labels.
 These can be either accepted or rejected by the user.
 The recommenders learn from this interaction to further improve the quality of predictions.
@@ -7,10 +8,13 @@ The recommenders learn from this interaction to further improve the quality of p
 After clicking on *Recommenders*, you are displayed a new pane in which you can add new recommenders
 by clicking on the button *Create*. You have to select the layer, feature and the classification tool.
 The recommenders are trained every time you create, update or delete an annotation;
-and evaluated every second time. During recommender evaluation the f-score of each recommender is calcultated,
-and recommenders with a lower f-score than their threshold will not be selected for the next training step.
-By making a tick on the checkbox next to *Always active* or leaving the threshold at 0,
-you can choose to skip f-score evaluation to ensure that the recommender runs at all times.
+and evaluated every second time. During recommender evaluation a score for each recommender is calcultated and if this score does not meet the configured threshold, the recommender will not be used.
+
+By default, the name of new recommenders are auto-generated based on the choice of layer, feature and tool. However, you can deactivate this behavior by unchecking the *auto-generate* option next to the name field.
+
+By enabling *Always active* you can choose to skip  evaluation to ensure that the recommender runs
+at all times. If this option is disabled and the score threshold is set to 0, the recommender will
+also be always executed, but internally it is still evaluated.
 
 image::recommendation2.png[align="center"]
 


### PR DESCRIPTION
- Add a proper validator for the name field which checks if a recommender by the same name already exists and provides a suitable error message in this case
- Add an option to auto-generate the recommender name to avoid forcing the user into inventing names all the time

**How to test**

* try creating new recommenders and editing existing recommenders with and without auto-generating the name
* try changing the recommender configuration with auto-generation enabled/disabled to see if/when the name is updated based on the configuration
* try creating recommenders with emtpy names and duplicate names
