### PR TITLE
#735 - Fix building on Java 11 (again)

### DIFF
--- a/inception-doc/src/main/resources/META-INF/asciidoc/common/migration.adoc
+++ b/inception-doc/src/main/resources/META-INF/asciidoc/common/migration.adoc
@@ -1,5 +1,5 @@
 // Copyright 2015
-// Ubiquitous Knowledge Processing (UKP) Lab and FG Language Technology
+// Ubiquitous Knowledge Processing (UKP) Lab
 // Technische Universität Darmstadt
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/inception-doc/src/main/resources/META-INF/asciidoc/common/systemrequirements.adoc
+++ b/inception-doc/src/main/resources/META-INF/asciidoc/common/systemrequirements.adoc
@@ -1,5 +1,5 @@
 // Copyright 2015
-// Ubiquitous Knowledge Processing (UKP) Lab and FG Language Technology
+// Ubiquitous Knowledge Processing (UKP) Lab
 // Technische Universität Darmstadt
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,7 +34,7 @@
 [cols="2*"]
 |===
 | Java Runtime Environment
-| version 8 or higher
+| version 9 or higher
 
 | Apache Tomcat
 | version 8.5 or higher (Servlet API 3.1.0)

--- a/pom.xml
+++ b/pom.xml
@@ -819,6 +819,25 @@
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-maven</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireJavaVersion>
+                  <version>[9.0,)</version>
+                </requireJavaVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>


### PR DESCRIPTION
**What's in the PR**
- Enforce minimum Java version 9 using maven enforcer plugin
- Updated system requirements
- Fixed some license headers

**How to test manually**
* Build using Maven on the command line on a Java 9 or higher

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
