### PR TITLE
#692 - PDF module makes use of SNAPSHOT library

### DIFF
--- a/inception-pdf-editor/pom.xml
+++ b/inception-pdf-editor/pom.xml
@@ -104,9 +104,9 @@
     </dependency>
 
     <dependency>
-        <groupId>paperai</groupId>
-        <artifactId>pdfextract</artifactId>
-        <version>0.3.2-SNAPSHOT</version>
+      <groupId>de.tudarmstadt.ukp.inception.pdfextract</groupId>
+      <artifactId>pdfextract</artifactId>
+      <version>0.3.2.1</version>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
**What's in the PR**
- Depend on INCEpTION pdfextract fork version 0.3.2.1

**How to test manually**
* Nothing to test really - just make sure the build works (i.e. Maven can access the artifact published to the UKP OSS repo)

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
