### PR TITLE
#813 - Error page when root concept does not exist in KB

### DIFF
--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
@@ -909,7 +909,9 @@ public class KnowledgeBaseServiceImpl
 
         if (!aKB.getRootConcepts().isEmpty()) {
             for (IRI conceptIRI : aKB.getRootConcepts()) {
-                KBConcept concept = readConcept(aKB, conceptIRI.stringValue(),aAll).get();
+                KBConcept concept = readConcept(aKB, conceptIRI.stringValue(), aAll)
+                        .orElseThrow(() -> new QueryEvaluationException("Concept not found: " + 
+                                conceptIRI));
                 KBHandle conceptHandle = new KBHandle(concept.getIdentifier(), concept.getName(),
                         concept.getDescription());
                 resultList.add(conceptHandle);


### PR DESCRIPTION
**What's in the PR**
* If the optional concept is not present, throw a proper exception which is handled by client code and causes a the error to be shown as a feedback message
* Closes #813

**How to test manually**
1. Create a new local KB
2. Add a root concept which is in the KB
3. Clear the KB
4. Try opening the KB in the KB page

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation