### PR TITLE
#815 - Sub-properties not taken into account for getStatementGroupComparator()

### DIFF
--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/ConceptInfoPanel.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/ConceptInfoPanel.java
@@ -89,12 +89,13 @@ public class ConceptInfoPanel extends AbstractInfoPanel<KBConcept> {
         return StatementDetailPreference.ALL;
     }
 
-    @Override
-    protected Comparator<StatementGroupBean> getStatementGroupComparator() {
+    @Override protected Comparator<StatementGroupBean> getStatementGroupComparator()
+    {
         return new ImportantStatementComparator(sgb -> {
             KnowledgeBase kb = kbModel.getObject();
             String identifier = sgb.getProperty().getIdentifier();
-            return kbService.isBaseProperty(identifier, kb);
+            return kbService.isBaseProperty(identifier, kb)
+                || kbService.isSubpropertyLabel(kb, identifier);
         });
     }
 }

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/ConceptInfoPanel.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/ConceptInfoPanel.java
@@ -92,11 +92,9 @@ public class ConceptInfoPanel extends AbstractInfoPanel<KBConcept> {
     @Override
     protected Comparator<StatementGroupBean> getStatementGroupComparator()
     {
-        return new ImportantStatementComparator(sgb -> {
-            KnowledgeBase kb = kbModel.getObject();
-            String identifier = sgb.getProperty().getIdentifier();
-            return kbService.isBaseProperty(identifier, kb)
-                || kbService.isSubpropertyLabel(kb, identifier);
-        });
+        return new ImportantStatementComparator<>(
+            sgb -> sgb.getProperty().getIdentifier(),
+            identifier -> kbService.isBaseProperty(identifier, kbModel.getObject())
+                    || kbService.isSubpropertyLabel(kbModel.getObject(), identifier));
     }
 }

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/ConceptInfoPanel.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/ConceptInfoPanel.java
@@ -89,7 +89,8 @@ public class ConceptInfoPanel extends AbstractInfoPanel<KBConcept> {
         return StatementDetailPreference.ALL;
     }
 
-    @Override protected Comparator<StatementGroupBean> getStatementGroupComparator()
+    @Override
+    protected Comparator<StatementGroupBean> getStatementGroupComparator()
     {
         return new ImportantStatementComparator(sgb -> {
             KnowledgeBase kb = kbModel.getObject();

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/ImportantStatementComparator.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/ImportantStatementComparator.java
@@ -20,6 +20,9 @@ package de.tudarmstadt.ukp.inception.ui.kb;
 import java.util.Comparator;
 import java.util.function.Function;
 
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+
 import de.tudarmstadt.ukp.inception.kb.graph.KBHandle;
 import de.tudarmstadt.ukp.inception.ui.kb.stmt.StatementGroupBean;
 
@@ -27,33 +30,33 @@ import de.tudarmstadt.ukp.inception.ui.kb.stmt.StatementGroupBean;
  * Comparator which sorts specifiable "important" {@link KBHandle}s to the front. As a secondary
  * criterion, {@link KBHandle}s are sorted in lexical order by their UI label.
  */
-public class ImportantStatementComparator implements Comparator<StatementGroupBean> {
+public class ImportantStatementComparator<T>
+    implements Comparator<StatementGroupBean>
+{
+    private final Function<StatementGroupBean, T> keyExtractor;
+    private final Function<T, Boolean> important;
+    private final LoadingCache<T, Integer> cache;
 
-    private Function<StatementGroupBean, Boolean> important;
-
-    public ImportantStatementComparator(Function<StatementGroupBean, Boolean> important) {
-        this.important = important;
+    public ImportantStatementComparator(Function<StatementGroupBean, T> aKeyExtractor,
+            Function<T, Boolean> aImportant)
+    {
+        keyExtractor = aKeyExtractor;
+        important = aImportant;
+        cache = Caffeine.newBuilder().build(key -> important.apply(key) ? 0 : 1);
     }
 
     @Override
-    public int compare(StatementGroupBean h1, StatementGroupBean h2) {
-        int h1Importance = important.apply(h1) ? 0 : 1;
-        int h2Importance = important.apply(h2) ? 0 : 1;
+    public int compare(StatementGroupBean aGroup1, StatementGroupBean aGroup2)
+    {
+        int h1Importance = cache.get(keyExtractor.apply(aGroup1));
+        int h2Importance = cache.get(keyExtractor.apply(aGroup2));
 
         if (h1Importance == h2Importance) {
-            return h1.getProperty().getUiLabel().compareToIgnoreCase(h2.getProperty().getUiLabel());
-        } else {
+            return aGroup1.getProperty().getUiLabel()
+                    .compareToIgnoreCase(aGroup2.getProperty().getUiLabel());
+        }
+        else {
             return Integer.compare(h1Importance, h2Importance);
         }
-    }
-
-    public Function<StatementGroupBean, Boolean> getImportant()
-    {
-        return important;
-    }
-
-    public void setImportant(Function<StatementGroupBean, Boolean> aImportant)
-    {
-        this.important = aImportant;
     }
 }

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/InstanceInfoPanel.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/InstanceInfoPanel.java
@@ -94,7 +94,8 @@ public class InstanceInfoPanel extends AbstractInfoPanel<KBInstance> {
         return new ImportantStatementComparator(sgb -> {
             KnowledgeBase kb = kbModel.getObject();
             String identifier = sgb.getProperty().getIdentifier();
-            return kbService.isBaseProperty(identifier, kb);
+            return kbService.isBaseProperty(identifier, kb)
+                || kbService.isSubpropertyLabel(kb, identifier);
         });
     }
 }

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/InstanceInfoPanel.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/InstanceInfoPanel.java
@@ -90,12 +90,11 @@ public class InstanceInfoPanel extends AbstractInfoPanel<KBInstance> {
     }
 
     @Override
-    protected Comparator<StatementGroupBean> getStatementGroupComparator() {
-        return new ImportantStatementComparator(sgb -> {
-            KnowledgeBase kb = kbModel.getObject();
-            String identifier = sgb.getProperty().getIdentifier();
-            return kbService.isBaseProperty(identifier, kb)
-                || kbService.isSubpropertyLabel(kb, identifier);
-        });
+    protected Comparator<StatementGroupBean> getStatementGroupComparator()
+    {
+        return new ImportantStatementComparator<>(
+            sgb -> sgb.getProperty().getIdentifier(),
+            identifier -> kbService.isBaseProperty(identifier, kbModel.getObject())
+                    || kbService.isSubpropertyLabel(kbModel.getObject(), identifier));
     }
 }

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/PropertyPanel.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/PropertyPanel.java
@@ -96,8 +96,12 @@ public class PropertyPanel extends Panel {
 
         @Override
         protected Comparator<StatementGroupBean> getStatementGroupComparator() {
-            return new ImportantStatementComparator(
-                sgb -> IMPORTANT_PROPERTY_URIS.contains(sgb.getProperty().getIdentifier()));
+            return new ImportantStatementComparator(sgb -> {
+                String identifier = sgb.getProperty().getIdentifier();
+                return IMPORTANT_PROPERTY_URIS.contains(identifier)
+                    || kbService.isBaseProperty(identifier, kbModel.getObject())
+                    || kbService.isSubpropertyLabel(kbModel.getObject(), identifier);
+            });
         }
         
         @Override

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/PropertyPanel.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/PropertyPanel.java
@@ -95,13 +95,13 @@ public class PropertyPanel extends Panel {
         }
 
         @Override
-        protected Comparator<StatementGroupBean> getStatementGroupComparator() {
-            return new ImportantStatementComparator(sgb -> {
-                String identifier = sgb.getProperty().getIdentifier();
-                return IMPORTANT_PROPERTY_URIS.contains(identifier)
-                    || kbService.isBaseProperty(identifier, kbModel.getObject())
-                    || kbService.isSubpropertyLabel(kbModel.getObject(), identifier);
-            });
+        protected Comparator<StatementGroupBean> getStatementGroupComparator()
+        {
+            return new ImportantStatementComparator<>(
+                sgb -> sgb.getProperty().getIdentifier(),
+                identifier -> IMPORTANT_PROPERTY_URIS.contains(identifier)
+                        || kbService.isBaseProperty(identifier, kbModel.getObject())
+                        || kbService.isSubpropertyLabel(kbModel.getObject(), identifier));
         }
         
         @Override


### PR DESCRIPTION
**What's in the PR**
* subproperty labels are taken into account by the statementgroup comarator of Concept-/Instance-/Property-InfoPanel
- check if the property is a subproperty
- prefer baseProperties in the PropertyPanel

**How to test manually**
* check if subproperty labels appear at the top of the statement group 
 (base properties/domain/range can be above)

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
