### PR TITLE
#348 - deleting features

### DIFF
--- a/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/recommender/NamedEntityLinker.java
+++ b/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/recommender/NamedEntityLinker.java
@@ -42,7 +42,6 @@ import org.apache.uima.jcas.JCas;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupport;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRegistry;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
@@ -72,7 +71,6 @@ public class NamedEntityLinker
     
     private KnowledgeBaseService kbService;
     private ConceptLinkingServiceImpl clService;
-    private AnnotationSchemaService annoService;
     private FeatureSupportRegistry fsRegistry;
     private ConceptFeatureTraits featureTraits;
 
@@ -81,14 +79,12 @@ public class NamedEntityLinker
 
     public NamedEntityLinker(Recommender aRecommender, NamedEntityLinkerTraits aTraits,
             KnowledgeBaseService aKbService, ConceptLinkingServiceImpl aClService,
-            AnnotationSchemaService aAnnoService, FeatureSupportRegistry aFsRegistry,
-            ConceptFeatureTraits aFeatureTraits)
+            FeatureSupportRegistry aFsRegistry, ConceptFeatureTraits aFeatureTraits)
     {
         recommender = aRecommender;
         traits = aTraits;
         kbService = aKbService;
         clService = aClService;
-        annoService = aAnnoService;
         fsRegistry = aFsRegistry;
         featureTraits = aFeatureTraits;
     }
@@ -107,7 +103,7 @@ public class NamedEntityLinker
     {
         Type tokenType = org.apache.uima.fit.util.CasUtil
             .getType(aCasList.get(0), recommender.getLayer().getName());
-        Feature feature = tokenType.getFeatureByBaseName(recommender.getFeature());
+        Feature feature = tokenType.getFeatureByBaseName(recommender.getFeature().getName());
 
         Collection<ImmutablePair<String, Collection<AnnotationFS>>> nameSamples = new HashSet<>();
         for (CAS cas : aCasList) {
@@ -198,8 +194,7 @@ public class NamedEntityLinker
     {
         List<KBHandle> handles = new ArrayList<>();
 
-        AnnotationFeature feat = annoService
-            .getFeature(recommender.getFeature(), recommender.getLayer());
+        AnnotationFeature feat = recommender.getFeature();
         FeatureSupport<ConceptFeatureTraits> fs = fsRegistry.getFeatureSupport(feat);
         ConceptFeatureTraits conceptFeatureTraits = fs.readTraits(feat);
 

--- a/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/recommender/NamedEntityLinkerFactory.java
+++ b/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/recommender/NamedEntityLinkerFactory.java
@@ -27,7 +27,6 @@ import org.apache.wicket.model.IModel;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupport;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRegistry;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
@@ -52,7 +51,6 @@ public class NamedEntityLinkerFactory
 
     private @Autowired KnowledgeBaseService kbService;
     private @Autowired ConceptLinkingServiceImpl clService;
-    private @Autowired AnnotationSchemaService annoService;
     private @Autowired FeatureSupportRegistry fsRegistry;
 
     @Override
@@ -66,13 +64,12 @@ public class NamedEntityLinkerFactory
     {
         NamedEntityLinkerTraits traits = readTraits(aRecommender);
         
-        AnnotationFeature feature = annoService.getFeature(aRecommender.getFeature(),
-                aRecommender.getLayer());
+        AnnotationFeature feature = aRecommender.getFeature();
         FeatureSupport<ConceptFeatureTraits> fs = fsRegistry.getFeatureSupport(feature);
         ConceptFeatureTraits featureTraits = fs.readTraits(feature);
         
-        return new NamedEntityLinker(aRecommender, traits, kbService, clService, annoService,
-                fsRegistry, featureTraits);
+        return new NamedEntityLinker(aRecommender, traits, kbService, clService, fsRegistry,
+                featureTraits);
     }
 
     @Override

--- a/inception-concept-linking/src/test/java/de/tudarmstadt/ukp/inception/conceptlinking/NamedEntityLinkerTest.java
+++ b/inception-concept-linking/src/test/java/de/tudarmstadt/ukp/inception/conceptlinking/NamedEntityLinkerTest.java
@@ -43,7 +43,6 @@ import org.apache.uima.jcas.JCas;
 import org.junit.Before;
 import org.junit.Test;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupport;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRegistry;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
@@ -85,8 +84,7 @@ public class NamedEntityLinkerTest
     {
         NamedEntityLinker sut = new NamedEntityLinker(recommender, new NamedEntityLinkerTraits(),
                 mock(KnowledgeBaseService.class), mock(ConceptLinkingServiceImpl.class),
-                mock(AnnotationSchemaService.class), mock(FeatureSupportRegistry.class),
-                new ConceptFeatureTraits());
+                mock(FeatureSupportRegistry.class), new ConceptFeatureTraits());
 
         List<CAS> casList = loadDevelopmentData();
 
@@ -120,18 +118,13 @@ public class NamedEntityLinkerTest
         when(clService.disambiguate(any(), anyString(), any(ConceptFeatureValueType.class),
                 anyString(), anyString(), anyInt(), any())).thenReturn(mockResult);
 
-        AnnotationSchemaService annoSchemaService = mock(AnnotationSchemaService.class);
-        AnnotationFeature mockAnnoFeature = mock(AnnotationFeature.class);
-        when(annoSchemaService.getFeature(recommender.getFeature(), recommender.getLayer()))
-            .thenReturn(mockAnnoFeature);
-
         FeatureSupportRegistry fsRegistry = mock(FeatureSupportRegistry.class);
         FeatureSupport fs = mock(FeatureSupport.class);
-        when(fsRegistry.getFeatureSupport(mockAnnoFeature)).thenReturn(fs);
-        when(fs.readTraits(mockAnnoFeature)).thenReturn(new ConceptFeatureTraits());
+        when(fsRegistry.getFeatureSupport(recommender.getFeature())).thenReturn(fs);
+        when(fs.readTraits(recommender.getFeature())).thenReturn(new ConceptFeatureTraits());
 
         NamedEntityLinker sut = new NamedEntityLinker(recommender, new NamedEntityLinkerTraits(),
-                kbService, clService, annoSchemaService, fsRegistry, new ConceptFeatureTraits());
+                kbService, clService, fsRegistry, new ConceptFeatureTraits());
 
         List<CAS> casList = loadDevelopmentData();
         CAS cas = casList.get(0);
@@ -175,9 +168,12 @@ public class NamedEntityLinkerTest
         AnnotationLayer layer = new AnnotationLayer();
         layer.setName(NamedEntity.class.getName());
 
+        AnnotationFeature feature = new AnnotationFeature();
+        feature.setName("identifier");
+        
         Recommender recommender = new Recommender();
         recommender.setLayer(layer);
-        recommender.setFeature("identifier");
+        recommender.setFeature(feature);
         recommender.setMaxRecommendations(3);
 
         return recommender;

--- a/inception-imls-dl4j/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommender.java
+++ b/inception-imls-dl4j/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommender.java
@@ -94,7 +94,7 @@ public class DL4JSequenceRecommender
             File aDatasetCache)
     {
         layerName = aRecommender.getLayer().getName();
-        featureName = aRecommender.getFeature();
+        featureName = aRecommender.getFeature().getName();
         traits = aTraits;
         datasetCache = aDatasetCache;
     }

--- a/inception-imls-dl4j/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommenderTest.java
+++ b/inception-imls-dl4j/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommenderTest.java
@@ -38,6 +38,7 @@ import org.apache.uima.jcas.JCas;
 import org.junit.Before;
 import org.junit.Test;
 
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.dkpro.core.api.datasets.Dataset;
 import de.tudarmstadt.ukp.dkpro.core.api.datasets.DatasetFactory;
@@ -389,9 +390,12 @@ public class DL4JSequenceRecommenderTest
         AnnotationLayer layer = new AnnotationLayer();
         layer.setName(POS.class.getName());
 
+        AnnotationFeature feature = new AnnotationFeature();
+        feature.setName("PosValue");
+        
         Recommender recommender = new Recommender();
         recommender.setLayer(layer);
-        recommender.setFeature("PosValue");
+        recommender.setFeature(feature);
 
         return recommender;
     }
@@ -401,9 +405,12 @@ public class DL4JSequenceRecommenderTest
         AnnotationLayer layer = new AnnotationLayer();
         layer.setName(NamedEntity.class.getName());
 
+        AnnotationFeature feature = new AnnotationFeature();
+        feature.setName("value");
+
         Recommender recommender = new Recommender();
         recommender.setLayer(layer);
-        recommender.setFeature("value");
+        recommender.setFeature(feature);
 
         return recommender;
     }

--- a/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommender.java
+++ b/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommender.java
@@ -229,7 +229,7 @@ public class ExternalRecommender
         AnnotationLayer layer =  recommender.getLayer();
         return new Metadata(
             layer.getName(),
-            recommender.getFeature(),
+            recommender.getFeature().getName(),
             casMetadata.getProjectId(),
             layer.getAnchoringMode().getId(),
             layer.isCrossSentence()
@@ -294,7 +294,7 @@ public class ExternalRecommender
     @Override
     public String getPredictedFeature()
     {
-        return recommender.getFeature();
+        return recommender.getFeature().getName();
     }
     
     @Override

--- a/inception-imls-external/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderIntegrationTest.java
+++ b/inception-imls-external/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderIntegrationTest.java
@@ -23,6 +23,7 @@ import static org.apache.uima.fit.factory.CollectionReaderFactory.createReader;
 import static org.apache.uima.fit.factory.TypeSystemDescriptionFactory.createTypeSystemDescription;
 import static org.apache.uima.fit.util.CasUtil.getType;
 import static org.apache.uima.util.CasCreationUtils.mergeTypeSystems;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import java.io.File;
@@ -46,6 +47,7 @@ import org.junit.Test;
 import de.tudarmstadt.ukp.clarin.webanno.api.dao.CasMetadataUtils;
 import de.tudarmstadt.ukp.clarin.webanno.api.type.CASMetadata;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.dkpro.core.api.datasets.Dataset;
 import de.tudarmstadt.ukp.dkpro.core.api.datasets.DatasetFactory;
@@ -138,7 +140,7 @@ public class ExternalRecommenderIntegrationTest
         assertThat(request.getMetadata()).hasNoNullFieldsOrProperties()
             .hasFieldOrPropertyWithValue("projectId", PROJECT_ID)
             .hasFieldOrPropertyWithValue("layer", recommender.getLayer().getName())
-            .hasFieldOrPropertyWithValue("feature", recommender.getFeature())
+            .hasFieldOrPropertyWithValue("feature", recommender.getFeature().getName())
             .hasFieldOrPropertyWithValue("crossSentence", CROSS_SENTENCE)
             .hasFieldOrPropertyWithValue("anchoringMode", ANCHORING_MODE.getId());
 
@@ -164,7 +166,7 @@ public class ExternalRecommenderIntegrationTest
         assertThat(request.getMetadata()).hasNoNullFieldsOrProperties()
             .hasFieldOrPropertyWithValue("projectId", PROJECT_ID)
             .hasFieldOrPropertyWithValue("layer", recommender.getLayer().getName())
-            .hasFieldOrPropertyWithValue("feature", recommender.getFeature())
+            .hasFieldOrPropertyWithValue("feature", recommender.getFeature().getName())
             .hasFieldOrPropertyWithValue("crossSentence", CROSS_SENTENCE)
             .hasFieldOrPropertyWithValue("anchoringMode", ANCHORING_MODE.getId());
         assertThat(request.getDocument())
@@ -235,9 +237,12 @@ public class ExternalRecommenderIntegrationTest
         layer.setCrossSentence(CROSS_SENTENCE);
         layer.setAnchoringMode(ANCHORING_MODE);
 
+        AnnotationFeature feature = new AnnotationFeature();
+        feature.setName("value");
+        
         Recommender recommender = new Recommender();
         recommender.setLayer(layer);
-        recommender.setFeature("value");
+        recommender.setFeature(feature);
         recommender.setMaxRecommendations(3);
         
         return recommender;

--- a/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/doccat/OpenNlpDoccatRecommender.java
+++ b/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/doccat/OpenNlpDoccatRecommender.java
@@ -74,7 +74,7 @@ public class OpenNlpDoccatRecommender
             OpenNlpDoccatRecommenderTraits aTraits)
     {
         layerName = aRecommender.getLayer().getName();
-        featureName = aRecommender.getFeature();
+        featureName = aRecommender.getFeature().getName();
         maxRecommendations = aRecommender.getMaxRecommendations();
 
         traits = aTraits;

--- a/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/ner/OpenNlpNerRecommender.java
+++ b/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/ner/OpenNlpNerRecommender.java
@@ -74,7 +74,7 @@ public class OpenNlpNerRecommender
     public OpenNlpNerRecommender(Recommender aRecommender, OpenNlpNerRecommenderTraits aTraits)
     {
         layerName = aRecommender.getLayer().getName();
-        featureName = aRecommender.getFeature();
+        featureName = aRecommender.getFeature().getName();
         maxRecommendations = aRecommender.getMaxRecommendations();
         
         traits = aTraits;

--- a/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/pos/OpenNlpPosRecommender.java
+++ b/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/pos/OpenNlpPosRecommender.java
@@ -76,7 +76,7 @@ public class OpenNlpPosRecommender
     public OpenNlpPosRecommender(Recommender aRecommender, OpenNlpPosRecommenderTraits aTraits)
     {
         layerName = aRecommender.getLayer().getName();
-        featureName = aRecommender.getFeature();
+        featureName = aRecommender.getFeature().getName();
         maxRecommendations = aRecommender.getMaxRecommendations();
         
         traits = aTraits;

--- a/inception-imls-opennlp/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/doccat/OpenNlpDoccatRecommenderTest.java
+++ b/inception-imls-opennlp/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/doccat/OpenNlpDoccatRecommenderTest.java
@@ -43,6 +43,7 @@ import org.apache.uima.jcas.JCas;
 import org.junit.Before;
 import org.junit.Test;
 
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.dkpro.core.api.datasets.Dataset;
 import de.tudarmstadt.ukp.dkpro.core.api.datasets.DatasetFactory;
@@ -177,10 +178,13 @@ public class OpenNlpDoccatRecommenderTest
     {
         AnnotationLayer layer = new AnnotationLayer();
         layer.setName(NamedEntity.class.getName());
+        
+        AnnotationFeature feature = new AnnotationFeature();
+        feature.setName("value");
 
         Recommender recommender = new Recommender();
         recommender.setLayer(layer);
-        recommender.setFeature("value");
+        recommender.setFeature(feature);
 
         return recommender;
     }

--- a/inception-imls-opennlp/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/ner/OpenNlpNerRecommenderTest.java
+++ b/inception-imls-opennlp/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/ner/OpenNlpNerRecommenderTest.java
@@ -36,6 +36,7 @@ import org.apache.uima.jcas.JCas;
 import org.junit.Before;
 import org.junit.Test;
 
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.dkpro.core.api.datasets.Dataset;
 import de.tudarmstadt.ukp.dkpro.core.api.datasets.DatasetFactory;
@@ -168,9 +169,12 @@ public class OpenNlpNerRecommenderTest
         AnnotationLayer layer = new AnnotationLayer();
         layer.setName(NamedEntity.class.getName());
 
+        AnnotationFeature feature = new AnnotationFeature();
+        feature.setName("value");
+        
         Recommender recommender = new Recommender();
         recommender.setLayer(layer);
-        recommender.setFeature("value");
+        recommender.setFeature(feature);
 
         return recommender;
     }

--- a/inception-imls-opennlp/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/pos/OpenNlpPosRecommenderTest.java
+++ b/inception-imls-opennlp/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/pos/OpenNlpPosRecommenderTest.java
@@ -36,6 +36,7 @@ import org.apache.uima.jcas.JCas;
 import org.junit.Before;
 import org.junit.Test;
 
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.dkpro.core.api.datasets.Dataset;
 import de.tudarmstadt.ukp.dkpro.core.api.datasets.DatasetFactory;
@@ -160,9 +161,12 @@ public class OpenNlpPosRecommenderTest
         AnnotationLayer layer = new AnnotationLayer();
         layer.setName(POS.class.getName());
 
+        AnnotationFeature feature = new AnnotationFeature();
+        feature.setName("PosValue");
+        
         Recommender recommender = new Recommender();
         recommender.setLayer(layer);
-        recommender.setFeature("PosValue");
+        recommender.setFeature(feature);
         recommender.setMaxRecommendations(3);
 
         return recommender;

--- a/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/StringMatchingRecommender.java
+++ b/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/StringMatchingRecommender.java
@@ -66,7 +66,7 @@ public class StringMatchingRecommender
             StringMatchingRecommenderTraits aTraits)
     {
         layerName = aRecommender.getLayer().getName();
-        featureName = aRecommender.getFeature();
+        featureName = aRecommender.getFeature().getName();
         maxRecommendations = aRecommender.getMaxRecommendations();
         traits = aTraits;
     }

--- a/inception-imls-stringmatch/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/StringMatchingRecommenderTest.java
+++ b/inception-imls-stringmatch/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/StringMatchingRecommenderTest.java
@@ -36,6 +36,7 @@ import org.apache.uima.jcas.JCas;
 import org.junit.Before;
 import org.junit.Test;
 
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.dkpro.core.api.datasets.Dataset;
 import de.tudarmstadt.ukp.dkpro.core.api.datasets.DatasetFactory;
@@ -175,9 +176,12 @@ public class StringMatchingRecommenderTest
         AnnotationLayer layer = new AnnotationLayer();
         layer.setName(NamedEntity.class.getName());
 
+        AnnotationFeature feature = new AnnotationFeature();
+        feature.setName("value");
+
         Recommender recommender = new Recommender();
         recommender.setLayer(layer);
-        recommender.setFeature("value");
+        recommender.setFeature(feature);
         recommender.setMaxRecommendations(3);
 
         return recommender;

--- a/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/LearningRecord.java
+++ b/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/LearningRecord.java
@@ -31,6 +31,8 @@ import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.hibernate.annotations.Type;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
@@ -49,14 +51,17 @@ public class LearningRecord
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @ManyToOne
     @JoinColumn(name = "document")
     private SourceDocument sourceDocument;
 
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @ManyToOne
     @JoinColumn(name = "layer")
     private AnnotationLayer layer;
 
+    @OnDelete(action = OnDeleteAction.CASCADE)
     @ManyToOne
     @JoinColumn(name = "annotationFeature")
     private AnnotationFeature annotationFeature;

--- a/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/Recommender.java
+++ b/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/Recommender.java
@@ -41,6 +41,7 @@ import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 
@@ -66,7 +67,10 @@ public class Recommender
     @JoinColumn(name = "layer", nullable = false)
     private AnnotationLayer layer;
     
-    private String feature;
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @ManyToOne
+    @JoinColumn(name = "feature", nullable = false)
+    private AnnotationFeature feature;
     
     private String name;
     
@@ -148,12 +152,12 @@ public class Recommender
         layer = aLayer;
     }
     
-    public String getFeature()
+    public AnnotationFeature getFeature()
     {
         return feature;
     }
 
-    public void setFeature(String aFeature)
+    public void setFeature(AnnotationFeature aFeature)
     {
         feature = aFeature;
     }

--- a/inception-recommendation-api/src/main/resources/de/tudarmstadt/ukp/inception/recommendation/model/db-changelog.xml
+++ b/inception-recommendation-api/src/main/resources/de/tudarmstadt/ukp/inception/recommendation/model/db-changelog.xml
@@ -395,4 +395,35 @@
       </column>
     </createTable>
   </changeSet>
+  
+  <changeSet author="INCEpTION Team" id="20190104-1">
+    <delete tableName="recommender">
+      <where>feature IS NULL</where>
+    </delete>
+    <addColumn tableName="recommender">
+      <column name="featuremigration" type="BIGINT">
+        <constraints nullable="false" />
+      </column>
+    </addColumn>
+    <sql>
+      UPDATE recommender rec
+      SET rec.featuremigration = (SELECT feat.id
+        FROM annotation_feature feat
+        WHERE rec.feature = feat.name AND rec.layer = feat.annotation_type)
+    </sql>
+    <renameColumn tableName="recommender"
+        newColumnName="deprecatedfeaturename"
+        oldColumnName="feature"
+        columnDataType="VARCHAR(255)"/>
+    <renameColumn tableName="recommender"
+        newColumnName="feature"
+        oldColumnName="featuremigration"
+        columnDataType="BIGINT"/>
+    <addForeignKeyConstraint
+        baseColumnNames="feature"
+        baseTableName="recommender" constraintName="FK_annotationFeature_recommender"
+        deferrable="false" initiallyDeferred="false" onDelete="CASCADE"
+        onUpdate="CASCADE" referencedColumnNames="id"
+        referencedTableName="annotation_feature" />
+  </changeSet>
 </databaseChangeLog>

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/RecommendationEditorExtension.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/RecommendationEditorExtension.java
@@ -218,7 +218,7 @@ public class RecommendationEditorExtension
         AnnotationSuggestion suggestion = oPrediction.get();
         Recommender recommender = recommendationService.getRecommender(aVID.getId());
         AnnotationLayer layer = annotationService.getLayer(aVID.getLayerId());
-        AnnotationFeature feature = annotationService.getFeature(recommender.getFeature(), layer);
+        AnnotationFeature feature = recommender.getFeature();
 
         // Hide the suggestion. This is faster than having to recalculate the visibility status for
         // the entire document or even for the part visible on screen.

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/exporter/RecommenderExporter.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/exporter/RecommenderExporter.java
@@ -37,6 +37,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExportRequest;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExporter;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectImportRequest;
 import de.tudarmstadt.ukp.clarin.webanno.export.model.ExportedProject;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService;
@@ -80,7 +81,7 @@ public class RecommenderExporter implements ProjectExporter {
         for (Recommender recommender : recommendationService.listRecommenders(project)) {
             ExportedRecommender exportedRecommender = new ExportedRecommender();
             exportedRecommender.setAlwaysSelected(recommender.isAlwaysSelected());
-            exportedRecommender.setFeature(recommender.getFeature());
+            exportedRecommender.setFeature(recommender.getFeature().getName());
             exportedRecommender.setEnabled(recommender.isEnabled());
             exportedRecommender.setLayerName(recommender.getLayer().getName());
             exportedRecommender.setName(recommender.getName());
@@ -108,7 +109,6 @@ public class RecommenderExporter implements ProjectExporter {
         for (ExportedRecommender exportedRecommender : recommenders) {
             Recommender recommender = new Recommender();
             recommender.setAlwaysSelected(exportedRecommender.isAlwaysSelected());
-            recommender.setFeature(exportedRecommender.getFeature());
             recommender.setEnabled(exportedRecommender.isEnabled());
             recommender.setName(exportedRecommender.getName());
             recommender.setThreshold(exportedRecommender.getThreshold());
@@ -134,6 +134,10 @@ public class RecommenderExporter implements ProjectExporter {
             String layerName = exportedRecommender.getLayerName();
             AnnotationLayer layer = annotationService.getLayer(layerName, aProject);
             recommender.setLayer(layer);
+
+            String featureName = exportedRecommender.getFeature();
+            AnnotationFeature feature = annotationService.getFeature(featureName, layer);
+            recommender.setFeature(feature);
 
             recommender.setProject(aProject);
             recommendationService.createOrUpdateRecommender(recommender);

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/log/RecommenderEvaluationResultEventAdapter.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/log/RecommenderEvaluationResultEventAdapter.java
@@ -72,7 +72,7 @@ public class RecommenderEvaluationResultEventAdapter
             details.duration = aEvent.getDuration();
             details.threshold = aEvent.getRecommender().getThreshold();
             details.layer = aEvent.getRecommender().getLayer().getName();
-            details.feature = aEvent.getRecommender().getFeature();
+            details.feature = aEvent.getRecommender().getFeature().getName();
             details.tool = aEvent.getRecommender().getTool();
 
             return JSONUtil.toJsonString(details);

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/scheduling/tasks/PredictionTask.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/scheduling/tasks/PredictionTask.java
@@ -242,7 +242,7 @@ public class PredictionTask
             String label = annotationFS.getFeatureValueAsString(predictedFeature);
             double score = aScoreFeature.map(f -> FSUtil.getFeature(annotationFS, f, Double.class))
                     .orElse(NO_SCORE);
-            String featurename = aRecommender.getFeature();
+            String featurename = aRecommender.getFeature().getName();
             String name = aRecommender.getName();
 
             AnnotationSuggestion ao = new AnnotationSuggestion(id, aRecommender.getId(), name,

--- a/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/exporter/RecommenderExporterTest.java
+++ b/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/exporter/RecommenderExporterTest.java
@@ -24,6 +24,8 @@ import static de.tudarmstadt.ukp.inception.recommendation.api.RecommendationServ
 import static de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService.MAX_RECOMMENDATIONS_DEFAULT;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -46,6 +48,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExportRequest;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectImportRequest;
 import de.tudarmstadt.ukp.clarin.webanno.export.model.ExportedProject;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService;
@@ -73,6 +76,14 @@ public class RecommenderExporterTest
         project.setMode(WebAnnoConst.PROJECT_TYPE_ANNOTATION);
         
         when(annotationService.getLayer(layer.getName(), project)).thenReturn(layer);
+        when(annotationService.getFeature(eq("Feature 1"), any(AnnotationLayer.class)))
+                .thenReturn(buildFeature("1"));
+        when(annotationService.getFeature(eq("Feature 2"), any(AnnotationLayer.class)))
+                .thenReturn(buildFeature("2"));
+        when(annotationService.getFeature(eq("Feature 3"), any(AnnotationLayer.class)))
+                .thenReturn(buildFeature("3"));
+        when(annotationService.getFeature(eq("Feature 4"), any(AnnotationLayer.class)))
+                .thenReturn(buildFeature("4"));
 
         sut = new RecommenderExporter(annotationService, recommendationService);
     }
@@ -191,10 +202,19 @@ public class RecommenderExporterTest
         return asList(recommender1, recommender2, recommender3, recommender4);
     }
 
+    private AnnotationFeature buildFeature(String id)
+    {
+        AnnotationFeature feature = new AnnotationFeature();
+        feature.setName("Feature " + id);
+        return feature;
+    }
+    
     private Recommender buildRecommender(String id)
     {
+        AnnotationFeature feature = buildFeature(id);
+        
         Recommender recommender = new Recommender();
-        recommender.setFeature("Feature " + id);
+        recommender.setFeature(feature);
         recommender.setName("Recommender " + id);
         recommender.setTool("Tool " + id);
         recommender.setTraits("Traits " + id);


### PR DESCRIPTION
**What's in the PR**
- Refactored DB so that "feature" field of the Recommender becomes a foreign key reference to the AnnotationFeature table
- Placed a cascade-on-delete constraint which deletes the recommender when the corresponding feature is deleted
- The DB refactoring intentionally does not delete the deprecated column - this column should be dropped by a separate changeset in a later version/revision

**How to test manually**
* Create a custom span layer with a custom string feature
* Create a recommender for that that feature
* Delete the feature
* Check if the recommender is still there

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
