### PR TITLE
#841 - Use BootstrapSelect instead of DropDownChoice

### DIFF
--- a/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.html
+++ b/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.html
@@ -33,7 +33,7 @@
           <div class="panel-body">
             <div class="form-group form-horizontal">
               <div class="input-group">
-                <select class="form-control flex-content" wicket:id="selectLayer"></select>
+                <select class="form-control flex-content" wicket:id="selectLayer" data-container="body"></select>
                 <span class="input-group-btn">
                   <a wicket:id="startSession" class="btn btn-default">
                     <i class="fa fa-play" aria-hidden="true"></i>

--- a/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.java
+++ b/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.java
@@ -65,7 +65,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wicketstuff.event.annotation.OnEvent;
 
-import de.agilecoders.wicket.extensions.markup.html.bootstrap.form.select.BootstrapSelect;
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
 import de.tudarmstadt.ukp.clarin.webanno.api.JCasProvider;
@@ -91,6 +90,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.Tag;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
+import de.tudarmstadt.ukp.clarin.webanno.support.bootstrap.select.BootstrapSelect;
 import de.tudarmstadt.ukp.clarin.webanno.support.dialog.ConfirmationDialog;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxButton;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxLink;

--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/yaml/KnowledgeBaseProfile.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/yaml/KnowledgeBaseProfile.java
@@ -28,10 +28,10 @@ import java.util.Map;
 import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
 import de.tudarmstadt.ukp.inception.kb.RepositoryType;
 
 public class KnowledgeBaseProfile implements Serializable

--- a/inception-recommendation-api/src/test/java/de/tudarmstadt/ukp/inception/recommendation/api/model/PredictionGroupTest.java
+++ b/inception-recommendation-api/src/test/java/de/tudarmstadt/ukp/inception/recommendation/api/model/PredictionGroupTest.java
@@ -24,8 +24,6 @@ import java.util.Map;
 
 import org.junit.Test;
 
-import de.tudarmstadt.ukp.inception.recommendation.api.model.AnnotationSuggestion;
-import de.tudarmstadt.ukp.inception.recommendation.api.model.SuggestionGroup;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.SuggestionGroup.Delta;
 
 public class PredictionGroupTest

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderEditorPanel.html
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderEditorPanel.html
@@ -54,7 +54,7 @@
               <wicket:label key="layer"/>
             </label>
             <div class="col-sm-9">
-              <select wicket:id="layer" class="form-control"></select>
+              <select wicket:id="layer" class="form-control" data-container="body"></select>
             </div>
           </div>
           <div class="form-group" wicket:enclosure="feature">
@@ -62,7 +62,7 @@
               <wicket:label key="feature"/>
             </label>
             <div class="col-sm-9">
-              <select wicket:id="feature" class="form-control"></select>
+              <select wicket:id="feature" class="form-control" data-container="body"></select>
             </div>
           </div>
           <div class="form-group" wicket:enclosure="tool">
@@ -70,7 +70,7 @@
               <wicket:label key="tool"/>
             </label>
             <div class="col-sm-9">
-              <select wicket:id="tool" class="form-control"></select>
+              <select wicket:id="tool" class="form-control" data-container="body"></select>
             </div>
           </div>
           <div class="form-group" wicket:id="activationContainer">

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderEditorPanel.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderEditorPanel.java
@@ -63,6 +63,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
+import de.tudarmstadt.ukp.clarin.webanno.support.bootstrap.select.BootstrapSelect;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxFormComponentUpdatingBehavior;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxFormSubmittingBehavior;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxLink;
@@ -150,7 +151,7 @@ public class RecommenderEditorPanel
         
         form.add(new CheckBox(MID_ENABLED));
         
-        layerChoice = new DropDownChoice<>(MID_LAYER,this::listLayers);
+        layerChoice = new BootstrapSelect<>(MID_LAYER,this::listLayers);
         layerChoice.setChoiceRenderer(new ChoiceRenderer<>("uiName"));
         layerChoice.setRequired(true);
         // The features and tools depend on the layer, so reload them when the layer is changed
@@ -165,7 +166,7 @@ public class RecommenderEditorPanel
         }));
         form.add(layerChoice);
         
-        featureChoice = new DropDownChoice<>(MID_FEATURE, this::listFeatures);
+        featureChoice = new BootstrapSelect<>(MID_FEATURE, this::listFeatures);
         featureChoice.setChoiceRenderer(new ChoiceRenderer<>("uiName"));
         featureChoice.setRequired(true);
         featureChoice.setOutputMarkupId(true);
@@ -193,7 +194,7 @@ public class RecommenderEditorPanel
             }, 
             (v) -> recommenderModel.getObject().setTool(v != null ? v.getKey() : null));
         
-        toolChoice = new DropDownChoice<Pair<String, String>>(MID_TOOL, toolModel, this::listTools)
+        toolChoice = new BootstrapSelect<Pair<String, String>>(MID_TOOL, toolModel, this::listTools)
         {
             private static final long serialVersionUID = -1869081847783375166L;
 

--- a/inception-search-mtas/src/test/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasUimaParserLuceneTest.java
+++ b/inception-search-mtas/src/test/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasUimaParserLuceneTest.java
@@ -63,7 +63,6 @@ import org.junit.Test;
 import de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
-import de.tudarmstadt.ukp.inception.search.index.mtas.MtasUimaParser;
 import mtas.analysis.token.MtasTokenString;
 import mtas.analysis.util.MtasTokenizerFactory;
 import mtas.codec.MtasCodec;

--- a/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/SearchPage.html
+++ b/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/SearchPage.html
@@ -42,7 +42,7 @@
             <span class="input-group-addon">
               <i class="fa fa-database"></i>
             </span>
-            <select wicket:id="repositoryCombo" class="form-control" ></select>
+            <select wicket:id="repositoryCombo" class="form-control" data-container="body"></select>
           </span>
         </form>
         <form wicket:id="searchForm" class="flex-content">

--- a/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/SearchPage.java
+++ b/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/SearchPage.java
@@ -59,7 +59,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wicketstuff.annotation.mount.MountPath;
 
-import de.agilecoders.wicket.extensions.markup.html.bootstrap.form.select.BootstrapSelect;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
 import de.tudarmstadt.ukp.clarin.webanno.api.ImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
@@ -67,6 +66,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
+import de.tudarmstadt.ukp.clarin.webanno.support.bootstrap.select.BootstrapSelect;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxFormComponentUpdatingBehavior;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxLink;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxSubmitLink;

--- a/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/project/DocumentRepositoryEditorPanel.html
+++ b/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/project/DocumentRepositoryEditorPanel.html
@@ -38,7 +38,7 @@
               <wicket:label key="type"/>
             </label>
             <div class="col-sm-10">
-              <select wicket:id="type" class="form-control"></select>
+              <select wicket:id="type" class="form-control" data-container="body"></select>
             </div>
           </div>
           <div wicket:id="propertiesContainer">

--- a/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/project/DocumentRepositoryEditorPanel.java
+++ b/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/project/DocumentRepositoryEditorPanel.java
@@ -39,6 +39,7 @@ import org.apache.wicket.spring.injection.annot.SpringBean;
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
+import de.tudarmstadt.ukp.clarin.webanno.support.bootstrap.select.BootstrapSelect;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxFormSubmittingBehavior;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxLink;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaModelAdapter;
@@ -94,7 +95,7 @@ public class DocumentRepositoryEditorPanel
                     .findFirst().orElse(null);
         }, (v) -> repositoryModel.getObject().setType(v.getKey()));
 
-        typeChoice = new DropDownChoice<Pair<String, String>>("type", typeModel, this::listTypes)
+        typeChoice = new BootstrapSelect<Pair<String, String>>("type", typeModel, this::listTypes)
         {
             private static final long serialVersionUID = -1869081847783375166L;
 

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/KnowledgeBasePanel.html
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/KnowledgeBasePanel.html
@@ -24,7 +24,7 @@
       <!-- knowledge base selector -->
       <div wicket:enclosure="knowledgebases" class="flex-v-container">
         <div class="form-group">
-          <select wicket:id="knowledgebases" class="form-control input-lg"></select>
+          <select wicket:id="knowledgebases" class="form-control input-lg" data-container="body"></select>
         </div>
       </div>
       <div class="flex-content flex-v-container flex-65" wicket:id="concepts"></div>

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/KnowledgeBasePanel.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/KnowledgeBasePanel.java
@@ -38,6 +38,7 @@ import org.slf4j.LoggerFactory;
 import org.wicketstuff.event.annotation.OnEvent;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.support.bootstrap.select.BootstrapSelect;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxFormComponentUpdatingBehavior;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaModel;
 import de.tudarmstadt.ukp.inception.kb.KnowledgeBaseService;
@@ -100,7 +101,7 @@ public class KnowledgeBasePanel
         kbModel = aKbModel;
         
         // add the selector for the knowledge bases
-        DropDownChoice<KnowledgeBase> ddc = new DropDownChoice<KnowledgeBase>("knowledgebases",
+        DropDownChoice<KnowledgeBase> ddc = new BootstrapSelect<KnowledgeBase>("knowledgebases",
                 LambdaModel.of(() -> kbService.getEnabledKnowledgeBases(aProjectModel.getObject())))
         {
 

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureTraitsEditor.html
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureTraitsEditor.html
@@ -24,7 +24,7 @@
         <wicket:label key="allowedValueType"/>
       </label>
       <div class="col-sm-8">
-        <select wicket:id="allowedValueType" class="form-control"></select>
+        <select wicket:id="allowedValueType" class="form-control" data-container="body"></select>
       </div>
     </div>
     <div class="form-group" wicket:enclosure="knowledgeBase">
@@ -32,7 +32,7 @@
         <wicket:label key="knowledgeBase"/>
       </label>
       <div class="col-sm-8">
-        <select wicket:id="knowledgeBase" class="form-control"></select>
+        <select wicket:id="knowledgeBase" class="form-control" data-container="body"></select>
       </div>
     </div>
     <div class="form-group" wicket:enclosure="scope">
@@ -40,7 +40,7 @@
         <wicket:label key="scope"/>
       </label>
       <div class="col-sm-8">
-        <select wicket:id="scope" class="form-control"></select>
+        <select wicket:id="scope" class="form-control" data-container="body"></select>
       </div>
     </div>
   </form>

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureTraitsEditor.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureTraitsEditor.java
@@ -23,7 +23,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.CompoundPropertyModel;
@@ -35,6 +34,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRegistry;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.support.bootstrap.select.BootstrapSelect;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxFormComponentUpdatingBehavior;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaChoiceRenderer;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaModel;
@@ -94,21 +94,21 @@ public class ConceptFeatureTraitsEditor
         };
         
         form.add(
-                new DropDownChoice<>(MID_SCOPE, 
+                new BootstrapSelect<>(MID_SCOPE, 
                         LambdaModel.of(this::listConcepts),
                         new LambdaChoiceRenderer<>(KBHandle::getUiLabel))
                 .setNullValid(true)
                 .setOutputMarkupPlaceholderTag(true));
 
         form.add(
-                new DropDownChoice<>(MID_KNOWLEDGE_BASE, 
+                new BootstrapSelect<>(MID_KNOWLEDGE_BASE, 
                         LambdaModel.of(this::listKnowledgeBases), 
                         new LambdaChoiceRenderer<>(KnowledgeBase::getName))
                 .setNullValid(true)
                 .add(new LambdaAjaxFormComponentUpdatingBehavior("change", target ->
                         target.add(form.get(MID_SCOPE)))));
         form.add(
-            new DropDownChoice<>(MID_ALLOWED_VALUE_TYPE, LambdaModel.of(this::listAllowedTypes)));
+            new BootstrapSelect<>(MID_ALLOWED_VALUE_TYPE, LambdaModel.of(this::listAllowedTypes)));
 
         add(form);
     }

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/PropertyFeatureEditor.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/PropertyFeatureEditor.java
@@ -37,6 +37,7 @@ import com.googlecode.wicket.jquery.core.JQueryBehavior;
 import com.googlecode.wicket.jquery.core.renderer.TextRenderer;
 import com.googlecode.wicket.jquery.core.template.IJQueryTemplate;
 import com.googlecode.wicket.kendo.ui.form.autocomplete.AutoCompleteTextField;
+
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.action.AnnotationActionHandler;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRegistry;

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/QualifierFeatureEditor.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/QualifierFeatureEditor.java
@@ -57,6 +57,7 @@ import com.googlecode.wicket.jquery.core.JQueryBehavior;
 import com.googlecode.wicket.jquery.core.renderer.TextRenderer;
 import com.googlecode.wicket.jquery.core.template.IJQueryTemplate;
 import com.googlecode.wicket.kendo.ui.form.autocomplete.AutoCompleteTextField;
+
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.action.AnnotationActionHandler;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.AnnotationException;

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/AccessSettingsPanel.html
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/AccessSettingsPanel.html
@@ -31,7 +31,7 @@
         <wicket:message key="kb.wizard.steps.type.type"/>
       </label>
       <div class="col-sm-9">
-        <select wicket:id="type"></select>
+        <select wicket:id="type" data-size="5"></select>
       </div>
     </div>
     <div class="form-group row" wicket:enclosure="writeprotection">

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/AccessSettingsPanel.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/AccessSettingsPanel.java
@@ -25,7 +25,7 @@ import org.apache.wicket.markup.html.form.EnumChoiceRenderer;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.CompoundPropertyModel;
 
-import de.agilecoders.wicket.extensions.markup.html.bootstrap.form.select.BootstrapSelect;
+import de.tudarmstadt.ukp.clarin.webanno.support.bootstrap.select.BootstrapSelect;
 import de.tudarmstadt.ukp.inception.kb.RepositoryType;
 
 public class AccessSettingsPanel

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/GeneralSettingsPanel.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/GeneralSettingsPanel.java
@@ -31,6 +31,7 @@ import org.apache.wicket.validation.IValidator;
 import org.apache.wicket.validation.ValidationError;
 
 import com.googlecode.wicket.kendo.ui.form.combobox.ComboBox;
+
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxFormComponentUpdatingBehavior;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaModelAdapter;

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/KnowledgeBaseIriPanel.html
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/KnowledgeBaseIriPanel.html
@@ -32,7 +32,7 @@
         <wicket:message key="kb.reification"/>
       </label>
       <div class="col-sm-9">
-        <select wicket:id="reification" class=""></select>
+        <select wicket:id="reification" data-size="5"></select>
       </div>
     </div>
     <div wicket:id="comboBoxWrapper">
@@ -41,7 +41,7 @@
           <wicket:message key="kb.iri.iriSchema"/>
         </label>
         <div class="col-sm-9">
-          <select wicket:id="iriSchema" class=""></select>
+          <select wicket:id="iriSchema" data-size="5"></select>
         </div>
       </div>
 

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/KnowledgeBaseIriPanel.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/KnowledgeBaseIriPanel.java
@@ -34,7 +34,7 @@ import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 
 import com.googlecode.wicket.kendo.ui.form.combobox.ComboBox;
 
-import de.agilecoders.wicket.extensions.markup.html.bootstrap.form.select.BootstrapSelect;
+import de.tudarmstadt.ukp.clarin.webanno.support.bootstrap.select.BootstrapSelect;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxFormComponentUpdatingBehavior;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaModelAdapter;

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/QuerySettingsPanel.html
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/QuerySettingsPanel.html
@@ -50,7 +50,7 @@
         <wicket:label key="kb.iri.fullTextSearchIri"/>
       </label>
       <div class="col-sm-9">
-        <select wicket:id="fullTextSearchIri" class="form-control"/>
+        <select wicket:id="fullTextSearchIri" class="form-control" data-size="5"/>
       </div>
     </div>
   </div>

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/QuerySettingsPanel.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/QuerySettingsPanel.java
@@ -30,7 +30,7 @@ import org.apache.wicket.model.Model;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.eclipse.rdf4j.model.IRI;
 
-import de.agilecoders.wicket.extensions.markup.html.bootstrap.form.select.BootstrapSelect;
+import de.tudarmstadt.ukp.clarin.webanno.support.bootstrap.select.BootstrapSelect;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior;
 import de.tudarmstadt.ukp.inception.kb.IriConstants;
 import de.tudarmstadt.ukp.inception.kb.KnowledgeBaseService;

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/QualifierEditor.html
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/QualifierEditor.html
@@ -26,8 +26,7 @@
 <wicket:fragment wicket:id="editMode">
     <form wicket:id="form" class="form-inline">
         <label class="control-label">Qualifier</label>
-        <select wicket:id="kbProperty" class="form-control flex-content"
-            style="width:80px"></select>
+        <select wicket:id="kbProperty" class="form-control flex-content" style="width:80px" data-container="body"></select>
         <input type="text" wicket:id="language" class="form-control" size="6"
             wicket:message="placeholder:qualifier.language.placeholder"></input>
         <textarea wicket:id="value" rows="1" cols="12" class="form-control hfill"

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/QualifierEditor.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/QualifierEditor.java
@@ -36,6 +36,7 @@ import org.apache.wicket.model.Model;
 import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 
+import de.tudarmstadt.ukp.clarin.webanno.support.bootstrap.select.BootstrapSelect;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxButton;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxLink;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior;
@@ -114,7 +115,7 @@ public class QualifierEditor
             IModel<KBQualifier> compoundModel = CompoundPropertyModel.of(aQualifier);
 
             Form<KBQualifier> form = new Form<>("form", compoundModel);
-            DropDownChoice<KBHandle> type = new DropDownChoice<>("kbProperty");
+            DropDownChoice<KBHandle> type = new BootstrapSelect<>("kbProperty");
             type.setChoiceRenderer(new ChoiceRenderer<>("uiLabel"));
             type.setChoices(kbService.listProperties(kbModel.getObject(), false));
             type.setRequired(true);

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/StatementGroupPanel.html
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/StatementGroupPanel.html
@@ -25,7 +25,7 @@
   <wicket:fragment wicket:id="newStatementGroup">
     <form wicket:id="form" class="statement-group flex-h-container">
       <div class="flex-25 flex-h-container">
-        <select wicket:id="property" class="form-control flex-content"></select>
+        <select wicket:id="property" class="form-control flex-content" data-container="body"></select>
         <div class="statement-editor-button-row">
           <ul>
             <li><a wicket:id="create" wicket:message="title:statement.save" class="btn-link"><i class="fa fa-check" aria-hidden="true"></i></a>

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/StatementGroupPanel.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/StatementGroupPanel.java
@@ -54,6 +54,7 @@ import org.wicketstuff.event.annotation.OnEvent;
 import com.googlecode.wicket.jquery.core.Options;
 import com.googlecode.wicket.kendo.ui.widget.tooltip.TooltipBehavior;
 
+import de.tudarmstadt.ukp.clarin.webanno.support.bootstrap.select.BootstrapSelect;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxButton;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxLink;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaModel;
@@ -130,7 +131,7 @@ public class StatementGroupPanel extends Panel {
             IModel<KBHandle> property = Model.of();
             
             Form<KBHandle> form = new Form<>("form", property);
-            DropDownChoice<KBHandle> type = new DropDownChoice<>("property");
+            DropDownChoice<KBHandle> type = new BootstrapSelect<>("property");
             type.setModel(property);
             type.setChoiceRenderer(new ChoiceRenderer<>("uiLabel"));            
             type.setChoices(getUnusedProperties());

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/editor/StatementEditor.html
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/editor/StatementEditor.html
@@ -46,7 +46,7 @@
   <wicket:fragment wicket:id="editMode">
     <form wicket:id="form" class="form-inline">
       <div class="flex-h-container flex-gutter flex-only-internal-gutter">
-        <select wicket:id=valueType class="form-control"></select>
+        <select wicket:id=valueType class="form-control" data-container="body"></select>
         <div class="flex-content flex-h-container flex-gutter flex-only-internal-gutter" wicket:id="value"></div>
         <div class="pull-right statement-editor-button-row">
           <ul>

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/editor/StatementEditor.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/editor/StatementEditor.java
@@ -47,6 +47,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wicketstuff.event.annotation.OnEvent;
 
+import de.tudarmstadt.ukp.clarin.webanno.support.bootstrap.select.BootstrapSelect;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxButton;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxFormComponentUpdatingBehavior;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxLink;
@@ -352,7 +353,7 @@ public class StatementEditor extends Panel
                         .readKBIdentifier(kbModel.getObject().getProject(), rangeValue);
                 valueTypes = valueTypeRegistry.getRangeTypes(rangeValue, rangeKBHandle);
             }
-            valueType = new DropDownChoice<>("valueType", valueTypes);
+            valueType = new BootstrapSelect<>("valueType", valueTypes);
             valueType.setChoiceRenderer(new ChoiceRenderer<>("uiName"));
             valueType.setModel(Model.of(
                     valueTypeRegistry.getValueType(aStatement.getObject(), property.getObject())));

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/value/NumericLiteralValueSupport.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/value/NumericLiteralValueSupport.java
@@ -37,7 +37,6 @@ import java.util.Optional;
 
 import org.apache.wicket.model.IModel;
 import org.cyberborean.rdfbeans.datatype.DefaultDatatypeMapper;
-
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.XMLSchema;

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/value/StringLiteralValueSupport.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/value/StringLiteralValueSupport.java
@@ -24,7 +24,6 @@ import java.util.Optional;
 
 import org.apache.wicket.model.IModel;
 import org.cyberborean.rdfbeans.datatype.DefaultDatatypeMapper;
-
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
 import org.springframework.stereotype.Component;


### PR DESCRIPTION
**What's in the PR**
- Switch from DropDownChoice to BootstrapSelect
- Switch to a more recent version of Bootstrap-Select which supports defining the container element (as included in webanno-support)
- Explicitly configure the container element for the select dropdowns to allow the dropdown to escape the container of the select element

**How to test manually**
* Open different parts of the UI and check whether dropdown menus work according to expectation

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
