### PR TITLE
#860 - Tasks are added even if same kind is already in queue

### DIFF
--- a/inception-app-webapp/src/main/resources/application.properties
+++ b/inception-app-webapp/src/main/resources/application.properties
@@ -10,8 +10,8 @@ backup.keep.time=0
 backup.interval=0
 backup.keep.number=0
 
-scheduler.threads=8
-scheduler.queuesize=200
+scheduler.threads=4
+scheduler.queuesize=100
 
 debug.casDoctor.checks=
 debug.casDoctor.repairs=

--- a/inception-app-webapp/src/main/resources/application.properties
+++ b/inception-app-webapp/src/main/resources/application.properties
@@ -10,6 +10,9 @@ backup.keep.time=0
 backup.interval=0
 backup.keep.number=0
 
+scheduler.threads=8
+scheduler.queuesize=200
+
 debug.casDoctor.checks=
 debug.casDoctor.repairs=
 debug.casDoctor.fatal=false

--- a/inception-app-webapp/src/main/resources/application.properties
+++ b/inception-app-webapp/src/main/resources/application.properties
@@ -10,9 +10,6 @@ backup.keep.time=0
 backup.interval=0
 backup.keep.number=0
 
-scheduler.threads=4
-scheduler.queuesize=100
-
 debug.casDoctor.checks=
 debug.casDoctor.repairs=
 debug.casDoctor.fatal=false

--- a/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide.adoc
+++ b/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide.adoc
@@ -79,3 +79,7 @@ include::{include-dir}settings_knowledgebase.adoc[leveloffset=+1]
 
 include::{include-dir}settings_recommendation.adoc[leveloffset=+1]
 
+include::{include-dir}settings_scheduler.adoc[leveloffset=+1]
+
+
+

--- a/inception-kb/pom.xml
+++ b/inception-kb/pom.xml
@@ -149,6 +149,10 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
@@ -208,10 +212,6 @@
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/inception-scheduling/pom.xml
+++ b/inception-scheduling/pom.xml
@@ -44,6 +44,14 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/inception-scheduling/src/main/java/de/tudarmstadt/ukp/inception/scheduling/SchedulingService.java
+++ b/inception-scheduling/src/main/java/de/tudarmstadt/ukp/inception/scheduling/SchedulingService.java
@@ -26,10 +26,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
+
+import de.tudarmstadt.ukp.inception.scheduling.config.SchedulingProperties;
 
 @Component
 public class SchedulingService
@@ -43,12 +44,11 @@ public class SchedulingService
     private final List<Task> runningTasks;
 
     @Autowired
-    public SchedulingService(ApplicationContext aApplicationContext,
-                             @Value("${scheduler.threads:4}") int numberOfThreads,
-                             @Value("${scheduler.queuesize:100}") int queueSize)
+    public SchedulingService(ApplicationContext aApplicationContext, SchedulingProperties aConfig)
     {
         applicationContext = aApplicationContext;
-        executor = new InspectableThreadPoolExecutor(numberOfThreads, queueSize,
+        executor = new InspectableThreadPoolExecutor(
+                aConfig.getNumberOfThreads(), aConfig.getQueueSize(),
                 this::beforeExecute, this::afterExecute);
         runningTasks = Collections.synchronizedList(new ArrayList<>());
     }

--- a/inception-scheduling/src/main/java/de/tudarmstadt/ukp/inception/scheduling/SchedulingService.java
+++ b/inception-scheduling/src/main/java/de/tudarmstadt/ukp/inception/scheduling/SchedulingService.java
@@ -87,6 +87,11 @@ public class SchedulingService
 
     public void enqueue(Task aTask)
     {
+        if (getScheduledTasks().contains(aTask)) {
+            log.debug("Task already in queue: {}", aTask);
+            return;
+        }
+
         // This autowires the task fields manually.
         AutowireCapableBeanFactory factory = applicationContext.getAutowireCapableBeanFactory();
         factory.autowireBean(aTask);

--- a/inception-scheduling/src/main/java/de/tudarmstadt/ukp/inception/scheduling/SchedulingService.java
+++ b/inception-scheduling/src/main/java/de/tudarmstadt/ukp/inception/scheduling/SchedulingService.java
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Component;
@@ -36,19 +37,18 @@ public class SchedulingService
 {
     private static final Logger log = LoggerFactory.getLogger(SchedulingService.class);
 
-    private static final int NUMBER_OF_THREADS = 4;
-    private static final int QUEUE_SIZE = 100;
-
     private final ApplicationContext applicationContext;
     private final ThreadPoolExecutor executor;
 
     private final List<Task> runningTasks;
 
     @Autowired
-    public SchedulingService(ApplicationContext aApplicationContext)
+    public SchedulingService(ApplicationContext aApplicationContext,
+                             @Value("${scheduler.threads:4}") int numberOfThreads,
+                             @Value("${scheduler.queuesize:100}") int queueSize)
     {
         applicationContext = aApplicationContext;
-        executor = new InspectableThreadPoolExecutor(NUMBER_OF_THREADS, QUEUE_SIZE,
+        executor = new InspectableThreadPoolExecutor(numberOfThreads, queueSize,
                 this::beforeExecute, this::afterExecute);
         runningTasks = Collections.synchronizedList(new ArrayList<>());
     }

--- a/inception-scheduling/src/main/java/de/tudarmstadt/ukp/inception/scheduling/config/SchedulingProperties.java
+++ b/inception-scheduling/src/main/java/de/tudarmstadt/ukp/inception/scheduling/config/SchedulingProperties.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019
+ * Ubiquitous Knowledge Processing (UKP) Lab
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.scheduling.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties("inception.scheduling")
+public class SchedulingProperties
+{
+    private int numberOfThreads = 4;
+    private int queueSize = 100;
+
+    public int getNumberOfThreads()
+    {
+        return numberOfThreads;
+    }
+
+    public void setNumberOfThreads(int aNumberOfThreads)
+    {
+        numberOfThreads = aNumberOfThreads;
+    }
+
+    public int getQueueSize()
+    {
+        return queueSize;
+    }
+
+    public void setQueueSize(int aQueueSize)
+    {
+        queueSize = queueSize;
+    }
+}

--- a/inception-scheduling/src/main/resources/META-INF/asciidoc/admin-guide/settings_scheduler.adoc
+++ b/inception-scheduling/src/main/resources/META-INF/asciidoc/admin-guide/settings_scheduler.adoc
@@ -1,0 +1,51 @@
+// Copyright 2019
+// Ubiquitous Knowledge Processing (UKP) Lab
+// Technische Universität Darmstadt
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+[[sect_settings_scheduler]]
+=== Scheduler Settings
+
+This section describes the global settings related to the scheduler.
+
+.Number of threads
+This parameter determines the number of threads the scheduler uses. It should be less than hardware
+threads available on the machine that runs INCEpTION. The higher the number, the more tasks can be
+run in parallel.
+
+.Queue size
+This parameter determines the maximum number of tasks that can be waiting in the scheduler queue. If
+the queue is full, then no new tasks can be scheduled until running tasks are completed.
+
+If no value for the parameter is specified, its default value is used. The default value is shown as
+an example of how the parameter can be configured below:
+
+.Scheduler settings overview
+[cols="4*", options="header"]
+|===
+| Setting
+| Description
+| Default
+| Example
+
+| inception.scheduler.numberOfThreads
+| Number of threads that run tasks
+| 4
+| 8
+
+| inception.scheduler.queueSize
+| Maximum number of tasks waiting for execution
+| 100
+| 200
+|===

--- a/inception-scheduling/src/test/java/de/tudarmstadt/ukp/inception/scheduling/SchedulingServiceTest.java
+++ b/inception-scheduling/src/test/java/de/tudarmstadt/ukp/inception/scheduling/SchedulingServiceTest.java
@@ -36,6 +36,7 @@ import org.springframework.context.ApplicationContext;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
+import de.tudarmstadt.ukp.inception.scheduling.config.SchedulingProperties;
 
 public class SchedulingServiceTest {
 
@@ -53,7 +54,7 @@ public class SchedulingServiceTest {
         when(mockContext.getAutowireCapableBeanFactory())
                 .thenReturn(mock(AutowireCapableBeanFactory.class));
 
-        sut = new SchedulingService(mockContext, 4, 100);
+        sut = new SchedulingService(mockContext, new SchedulingProperties());
     }
 
     @After
@@ -76,7 +77,7 @@ public class SchedulingServiceTest {
         }
 
         // Wait until the threads have actually been started
-        await().atMost(1, SECONDS).until(() -> Thread.activeCount() >= 3);
+        await().atMost(5, SECONDS).until(() -> Thread.activeCount() >= 3);
 
         assertThat(sut.getRunningTasks()).as("All enqueued tasks should be running")
                 .isEqualTo(tasks);

--- a/inception-scheduling/src/test/java/de/tudarmstadt/ukp/inception/scheduling/SchedulingServiceTest.java
+++ b/inception-scheduling/src/test/java/de/tudarmstadt/ukp/inception/scheduling/SchedulingServiceTest.java
@@ -53,7 +53,7 @@ public class SchedulingServiceTest {
         when(mockContext.getAutowireCapableBeanFactory())
                 .thenReturn(mock(AutowireCapableBeanFactory.class));
 
-        sut = new SchedulingService(mockContext);
+        sut = new SchedulingService(mockContext, 4, 100);
     }
 
     @After


### PR DESCRIPTION
**What's in the PR**
- Do not enqueue tasks if task of the same kind is already queued
- Add Spring configuration for scheduler properties

**How to test manually**
0. Maybe reduce the value for `scheduler.threads` to 1 or 2
1. Create a project with a slow running recommender
2. Annotate things very quickly
3. Look in the log whether you see `Task already in queue`

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
