### PR TITLE
#859 - Rejection recommendations needs another action to take effect in UI

### DIFF
--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/RecommendationEditorExtension.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/RecommendationEditorExtension.java
@@ -228,6 +228,9 @@ public class RecommendationEditorExtension
         learningRecordService.logRecord(document, aState.getUser().getUsername(),
                 suggestion, layer, feature, REJECTED, MAIN_EDITOR);
 
+        // Trigger a re-rendering of the document
+        aActionHandler.actionSelect(aTarget, aJCas);
+        
         // Send an application event that the suggestion has been rejected
         applicationEventPublisher.publishEvent(
                 new RecommendationRejectedEvent(this, document, aState.getUser().getUsername(),


### PR DESCRIPTION
**What's in the PR**
* - Use actionSelect() to trigger a re-rendering of the document. Unfortunately, there is presently no better way to do this from within an annotation editor extension.
* Closes #859

**How to test manually**
* Reject an annotation

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
