### PR TITLE
#872 - Improve performance of concept tree for local KBs

### DIFF
--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
@@ -1060,7 +1060,18 @@ public class KnowledgeBaseServiceImpl
     @Override
     public boolean hasChildConcepts(KnowledgeBase aKB, String aParentIdentifier, boolean aAll)
     {
-        return !listChildConcepts(aKB, aParentIdentifier, aAll, 1).isEmpty();
+        return read(aKB, (conn) -> {
+            String QUERY = SPARQLQueryStore.hasChildConcepts(aKB);
+            ValueFactory vf = SimpleValueFactory.getInstance();
+            TupleQuery tupleQuery = conn.prepareTupleQuery(QueryLanguage.SPARQL, QUERY);
+            tupleQuery.setBinding("oPARENT", vf.createIRI(aParentIdentifier));
+            tupleQuery.setBinding("pTYPE", aKB.getTypeIri());
+            tupleQuery.setBinding("oCLASS", aKB.getClassIri());
+            tupleQuery.setBinding("pSUBCLASS", aKB.getSubclassIri());
+            tupleQuery.setIncludeInferred(false);
+
+            return !evaluateListQuery(aKB, tupleQuery, aAll, "s").isEmpty();
+        });
     }
 
     @Override

--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/SPARQLQueryStore.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/SPARQLQueryStore.java
@@ -178,7 +178,27 @@ public final class SPARQLQueryStore
                 , "} GROUP BY ?s"
                 , "LIMIT " + aKB.getMaxResults());
     }
-    
+
+    /** 
+     * Query to check if a concept has child concepts. It returns the ID of the first child concept
+     * if it exists. 
+     */
+    public static final String hasChildConcepts(KnowledgeBase aKB)
+    {
+        return String.join("\n"
+                , SPARQL_PREFIX
+                , "SELECT ?s WHERE { "
+                , "  {"
+                , "    ?s ?pSUBCLASS ?oPARENT ." 
+                , "  } UNION { "
+                , "    ?s ?pTYPE ?oCLASS ."
+                , "    ?s owl:intersectionOf ?list . "
+                , "    FILTER EXISTS { ?list rdf:rest*/rdf:first ?oPARENT }"
+                , "  }"
+                , "}"
+                , "LIMIT 1");
+    }
+
     /** 
      * Query to read concept from a knowledge base.
      */


### PR DESCRIPTION
**What's in the PR**
- Leaner query for "hasChildConcept" which avoids loading all children (limit 1) and looking up all the labels for the children since the return value of the method is a boolean anyway

**How to test manually**
* ...

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
