### PR TITLE
#874 - Not removing recommendations when stacked entities are allowed

### DIFF
--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/PredictionTask.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/PredictionTask.java
@@ -36,6 +36,8 @@ import java.util.TreeMap;
 
 import javax.persistence.NoResultException;
 
+import org.apache.commons.collections4.MultiValuedMap;
+import org.apache.commons.collections4.multimap.ArrayListValuedHashMap;
 import org.apache.uima.UIMAException;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.Feature;
@@ -307,14 +309,20 @@ public class PredictionTask
         for (AnnotationFeature feature : aAnnotationService.listAnnotationFeature(aLayer)) {
             Feature feat = type.getFeatureByBaseName(feature.getName());
             
-            // Reduce the annotations to the once which have a non-null feature value
-            Map<Offset, AnnotationFS> annotations = new TreeMap<>(
-                    comparingInt(Offset::getBegin).thenComparingInt(Offset::getEnd));
+            // Reduce the annotations to the once which have a non-null feature value. We need to
+            // use a multi-valued map here because there may be multiple annotations at a
+            // given position.
+            MultiValuedMap<Offset, AnnotationFS> annotations = new ArrayListValuedHashMap<>();
             annotationsInWindow.stream()
                     .filter(fs -> fs.getFeatureValueAsString(feat) != null)
                     .forEach(fs -> annotations.put(new Offset(fs.getBegin(), fs.getEnd()), fs));
-            
-            // Reduce the suggestions to the ones for the given feature
+            // We need to constructed a sorted list of the keys for the OverlapIterator below
+            List<Offset> sortedAnnotationKeys = new ArrayList<>(annotations.keySet());
+            sortedAnnotationKeys
+                    .sort(comparingInt(Offset::getBegin).thenComparingInt(Offset::getEnd));
+
+            // Reduce the suggestions to the ones for the given feature. We can use the tree here
+            // since we only have a single SuggestionGroup for every position
             Map<Offset, SuggestionGroup> suggestions = new TreeMap<>(
                     comparingInt(Offset::getBegin).thenComparingInt(Offset::getEnd));
             suggestionsInWindow.stream()
@@ -326,19 +334,29 @@ public class PredictionTask
                 continue;
             }
             
-            // This iterator gives us pairs of annotations and suggestions 
-            OverlapIterator oi = new OverlapIterator(
-                    new ArrayList<>(suggestions.keySet()),
-                    new ArrayList<>(annotations.keySet()));
+            // This iterator gives us pairs of annotations and suggestions. Note that bot lists must
+            // be sorted in the same way. The suggestion offsets are sorted because they are the
+            // keys in a TreeSet - and the annotation offsets are sorted in the same way manually
+            OverlapIterator oi = new OverlapIterator(new ArrayList<>(suggestions.keySet()),
+                    sortedAnnotationKeys);
             
             // Bulk-hide any groups that overlap with existing annotations on the current layer
             // and for the current feature
             while (oi.hasNext()) {
                 if (oi.getA().overlaps(oi.getB())) {
-                    // Fetch the current suggestion
+                    // Fetch the current suggestion and annotation
                     SuggestionGroup group = suggestions.get(oi.getA());
-                    group.forEach(suggestion -> suggestion.hide(FLAG_OVERLAP));
-                    // Do not want to process the group again since it is already hidden
+                    for (AnnotationFS annotation : annotations.get(oi.getB())) {
+                        String label = annotation.getFeatureValueAsString(feat);
+                        for (AnnotationSuggestion suggestion : group) {
+                            if (!aLayer.isAllowStacking() || label.equals(suggestion.getLabel())) {
+                                suggestion.hide(FLAG_OVERLAP);
+                            }
+                        }
+                    }
+                    
+                    // Do not want to process the group again since the relevant annotations are
+                    // already hidden
                     oi.ignoraA();
                 }
                 oi.step();


### PR DESCRIPTION
**What's in the PR**
- When stacking is enabled, only hide recommendations that have the same labels as already existing annotations overlapping with the suggestion. Alternative labels are still suggested.

**How to test manually**
* enable stacking on the named entity layer
* create a string matching recommender on the value feature
* add annotations to a document such that some of the annotations have a different value but annotate the same word

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
