### PR TITLE
#877 - Recommendations not generated when opening a document

### DIFF
--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/SelectionTask.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/SelectionTask.java
@@ -173,7 +173,7 @@ public class SelectionTask
             recommendationService.setActiveRecommenders(user, layer, activeRecommenders);
         }
 
-        schedulingService.enqueue(new PredictionTask(user, getProject()));
+        schedulingService.enqueue(new TrainingTask(user, getProject()));
     }
 
     private List<CAS> readCasses(Project aProject, String aUserName)


### PR DESCRIPTION
**What's in the PR**
* Start TrainingTask instead of PredictionTask


**How to test manually**
1. Configure a project with a recommender (string matching is sufficient, do not enable "always active")
2. Create a few annotations such that the recommender generates suggestions
3. Restart application
4. Open the document again
5. See that there are annotations

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
