### PR TITLE
#620 - Exclude PDFAnno UI

### DIFF
--- a/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/config/PdfEditorProperties.java
+++ b/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/config/PdfEditorProperties.java
@@ -27,6 +27,8 @@ public class PdfEditorProperties
 {
     private boolean enabled = false;
 
+    private boolean debug = false;
+
     public boolean isEnabled()
     {
         return enabled;
@@ -35,5 +37,15 @@ public class PdfEditorProperties
     public void setEnabled(boolean aEnabled)
     {
         enabled = aEnabled;
+    }
+
+    public boolean isDebug()
+    {
+        return debug;
+    }
+
+    public void setDebug(boolean aDebug)
+    {
+        this.debug = aDebug;
     }
 }

--- a/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/pdfanno/PdfAnnoPanel.java
+++ b/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/pdfanno/PdfAnnoPanel.java
@@ -42,6 +42,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.support.JSONUtil;
 import de.tudarmstadt.ukp.inception.pdfeditor.PdfAnnotationEditor;
+import de.tudarmstadt.ukp.inception.pdfeditor.config.PdfEditorProperties;
 import de.tudarmstadt.ukp.inception.pdfeditor.pdfanno.model.PdfAnnoModel;
 import paperai.pdfextract.PDFExtractor;
 
@@ -51,6 +52,8 @@ public class PdfAnnoPanel
     private static final long serialVersionUID = 4202869513273132875L;
 
     private @SpringBean DocumentService documentService;
+
+    private @SpringBean PdfEditorProperties pdfEditorProperties;
 
     private AbstractAjaxBehavior pdfProvider;
 
@@ -179,8 +182,10 @@ public class PdfAnnoPanel
             {
                 checkComponentTag(aTag, "iframe");
 
+                String indexFile = pdfEditorProperties.isDebug() ? "index-debug.html" : "index.html";
+
                 String viewerUrl = RequestCycle.get().getUrlRenderer()
-                        .renderFullUrl(Url.parse("resources/pdfanno/index.html"));
+                        .renderFullUrl(Url.parse("resources/pdfanno/" + indexFile));
 
                 String pdfUrl = getPage().getRequestCycle().getUrlRenderer()
                         .renderFullUrl(Url.parse(pdfProvider.getCallbackUrl()));

--- a/inception-pdf-editor/src/main/js/pdfanno/src/index-debug.html
+++ b/inception-pdf-editor/src/main/js/pdfanno/src/index-debug.html
@@ -47,12 +47,8 @@ See https://github.com/adobe-type-tools/cmap-resources
 </head>
 
 <body>
-<!-- BEGIN PDFANNO EXTENSION - #620 - Exclude PDFAnno UI -->
-<!--
+
 <nav class="navbar navbar-inverse navbar-static-top">
--->
-<nav class="navbar navbar-inverse navbar-static-top" hidden>
-<!-- END PDFANNO EXTENSION -->
   <div class="container-fluid">
     <div class="navbar-header">
       <a class="navbar-brand" href="#">PDFAnno</a>
@@ -65,12 +61,9 @@ See https://github.com/adobe-type-tools/cmap-resources
 </nav>
 <div class="main">
   <div class="container-fluid">
-<!-- BEGIN PDFANNO EXTENSION - #620 - Exclude PDFAnno UI -->
-<!--
+
     <div class="row anno-ui">
--->
-    <div class="row anno-ui" hidden>
-<!-- END PDFANNO EXTENSION -->
+
       <div class="btn-group" role="group" style="display: inline-block; margin-right: 5px;">
         <a id="downloadPDFExtractButton" class="btn btn-default" href="#" title="download PDFExtract.jar">
           <i class="fa fa-download"></i> PDFExtract
@@ -138,12 +131,7 @@ See https://github.com/adobe-type-tools/cmap-resources
 
     <!-- Annotation Tools -->
     <div class="row">
-<!-- BEGIN PDFANNO EXTENSION - #620 - Exclude PDFAnno UI -->
-<!--
       <div id="tools" class="col-md-3 col-sm-3 col-xs-3" style="padding-left: 0; padding-right: 0;">
--->
-      <div id="tools" class="col-md-0 col-sm-0 col-xs-0" style="padding-left: 0; padding-right: 0;" hidden>
-<!-- END PDFANNO EXTENSION -->
         <div style="padding-left: 15px; padding-right: 15px;">
 
           <ul class="nav nav-tabs">
@@ -221,12 +209,11 @@ See https://github.com/adobe-type-tools/cmap-resources
           </div>
         </div>
       </div>
+      <div id="viewerWrapper" class="col-md-9 col-sm-9 col-xs-9" style="padding-left: 0; padding-right: 0; position: relative;">
 <!-- BEGIN PDFANNO EXTENSION - #620 - Exclude PDFAnno UI -->
 <!--
-      <div id="viewerWrapper" class="col-md-9 col-sm-9 col-xs-9" style="padding-left: 0; padding-right: 0; position: relative;">
         <div style="padding-right: 15px;">
 -->
-      <div id="viewerWrapper" class="col-md-12 col-sm-12 col-xs-12" style="padding-left: 0; padding-right: 0; position: relative;">
         <div>
 <!-- END PDFANNO EXTENSION -->
           <div id="viewerInner" class="viewer">

--- a/inception-pdf-editor/src/main/js/pdfanno/src/pdfanno.css
+++ b/inception-pdf-editor/src/main/js/pdfanno/src/pdfanno.css
@@ -75,7 +75,12 @@
 }
 
 .row.anno-ui {
+/*EGIN PDFANNO EXTENSION - #620 - Exclude PDFAnno UI*/
+/*
   padding: 0 15px 10px;
+*/
+  padding: 0 0 10px;
+/*BEGIN PDFANNO EXTENSION*/
 }
 
 /*

--- a/inception-pdf-editor/src/main/js/pdfanno/src/pdfanno.js
+++ b/inception-pdf-editor/src/main/js/pdfanno/src/pdfanno.js
@@ -1,4 +1,5 @@
 require('file-loader?name=index.html!./index.html')
+require('file-loader?name=index-debug.html!./index-debug.html')
 require('!style-loader!css-loader!./pdfanno.css')
 
 // /tab=TAB&pdf=PDFURL&anno=ANNOURL&move


### PR DESCRIPTION
**What's in the PR**
* add ui.pdf.debug config property
* PDF editor now shows only the PDF div if debug is set to false, else it shows complete PDFAnno UI

**How to test manually**
1. Set ui.pdf.debug to true or false (if not set it is false)
2. Open a PDF document in PDF editor
3. PDFAnno UI should be set when ui.pdf.debug=true, else only PDF div should be visible

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
