### PR TITLE
#879 - Selection of spans in PDF editor

### DIFF
--- a/inception-pdf-editor/src/main/js/pdfanno/src/core/src/UI/span.js
+++ b/inception-pdf-editor/src/main/js/pdfanno/src/core/src/UI/span.js
@@ -279,6 +279,7 @@ window.addEventListener('DOMContentLoaded', () => {
 // BEGIN PDFANNO EXTENSION - #838 - Creation of spans in PDF editor
     if (startPosition !== null && endPosition !== null) {
       var data = {
+        "action" : "createSpan",
         "page" : currentPage,
         "begin": startPosition,
         "end" : endPosition

--- a/inception-pdf-editor/src/main/js/pdfanno/src/core/src/annotation/container.js
+++ b/inception-pdf-editor/src/main/js/pdfanno/src/core/src/annotation/container.js
@@ -313,7 +313,7 @@ export default class AnnotationContainer {
       const objs = tomlObject[key]
       if (Array.isArray(objs)) {
         objs.forEach(obj => {
-          obj.uuid = uuid()
+          obj.uuid = obj.id || uuid()
           obj.readOnly = readOnly
 
           if (key === 'spans') {

--- a/inception-pdf-editor/src/main/js/pdfanno/src/core/src/annotation/span.js
+++ b/inception-pdf-editor/src/main/js/pdfanno/src/core/src/annotation/span.js
@@ -205,6 +205,26 @@ export default class SpanAnnotation extends AbstractAnnotation {
    */
   handleClickEvent (e) {
     super.handleClickEvent(e)
+// BEGIN PDFANNO EXTENSION - #879 - Selection of spans in PDF editor
+    if (this.selected) {
+      var data = {
+        "action": "selectSpan",
+        "id": this.uuid,
+        "page": this.page,
+        "begin": this.textRange[0],
+        "end": this.textRange[1]
+      }
+      parent.Wicket.Ajax.ajax({
+        "m": "POST",
+        "ep": data,
+        "u": window.apiUrl,
+        "sh": [],
+        "fh": [function () {
+           console.log('Something went wrong on selecting an annotation for: ' + data)
+        }]
+      });
+    }
+// END PDFANNO EXTENSION
   }
 
   export (id) {


### PR DESCRIPTION
**What's in the PR**
* on selecting spans in PDF editor the right sidebar renders correctly the span
* in PDFAnno add using provided IDs of .anno file when importing
* refactoring of PdfAnnotationEditor

**How to test manually**
1. Open a PDF document in PDF editor
2. Select a span annotation
3. on the right sidebar the annotation should be shown

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
