### PR TITLE
#825 - Split-screen external search and annotation view

### DIFF
--- a/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/sidebar/ExternalSearchAnnotationSidebar.java
+++ b/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/sidebar/ExternalSearchAnnotationSidebar.java
@@ -47,10 +47,8 @@ import org.apache.wicket.model.LoadableDetachableModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.wicketstuff.event.annotation.OnEvent;
 
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.form.select.BootstrapSelect;
@@ -73,7 +71,7 @@ import de.tudarmstadt.ukp.clarin.webanno.support.spring.ApplicationEventPublishe
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.AnnotationPage;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar.AnnotationSidebar_ImplBase;
 import de.tudarmstadt.ukp.inception.app.ui.externalsearch.ExternalResultDataProvider;
-import de.tudarmstadt.ukp.inception.app.ui.externalsearch.utils.DocumentImporterImpl;
+import de.tudarmstadt.ukp.inception.app.ui.externalsearch.utils.DocumentImporter;
 import de.tudarmstadt.ukp.inception.app.ui.externalsearch.utils.Utilities;
 import de.tudarmstadt.ukp.inception.externalsearch.ExternalSearchResult;
 import de.tudarmstadt.ukp.inception.externalsearch.ExternalSearchService;
@@ -95,7 +93,7 @@ public class ExternalSearchAnnotationSidebar
     private @SpringBean UserDao userRepository;
     private @SpringBean ImportExportService importExportService;
     private @SpringBean ApplicationEventPublisherHolder applicationEventPublisher;
-    private @SpringBean DocumentImporterImpl documentImporter;
+    private @SpringBean DocumentImporter documentImporter;
 
     private ExternalSearchUserState externalSearchUserState;
 


### PR DESCRIPTION
**What's in the PR**
- Inject DocumentImporter via interface into Wicket component instead of via implementation to avoid serialization/proxying problems

**How to test manually**
* Open annotation page and *sometimes* observe strange errors in the log about DocumentImporterImpl not implementing some methods.
* https://github.com/inception-project/inception/pull/846 also observed problems because DocumentImporterImpl was used for injection.

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation