### PR TITLE
Feature/914 gazeteer support for string matching recommender

### DIFF
--- a/inception-app-webapp/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/inception-app-webapp/src/main/resources/db/changelog/db.changelog-master.xml
@@ -30,4 +30,5 @@
   <include file="de/tudarmstadt/ukp/inception/log/model/db-changelog.xml"/>
   <include file="de/tudarmstadt/ukp/inception/search/model/db-changelog.xml"/>
   <include file="de/tudarmstadt/ukp/inception/externalsearch/model/db-changelog.xml"/>
+  <include file="de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/model/db-changelog.xml"/>
 </databaseChangeLog>

--- a/inception-imls-stringmatch/marker-wicket-module
+++ b/inception-imls-stringmatch/marker-wicket-module
@@ -1,0 +1,1 @@
+Marker file which activates the profile "wicket-module" from the parent POM.

--- a/inception-imls-stringmatch/pom.xml
+++ b/inception-imls-stringmatch/pom.xml
@@ -38,6 +38,10 @@
       <groupId>de.tudarmstadt.ukp.clarin.webanno</groupId>
       <artifactId>webanno-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.clarin.webanno</groupId>
+      <artifactId>webanno-api-dao</artifactId>
+    </dependency>
     
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -62,6 +66,11 @@
       <groupId>org.dkpro.statistics</groupId>
       <artifactId>dkpro-statistics-agreement</artifactId>
       <version>2.1.0</version>
+    </dependency>
+    
+    <dependency>
+      <groupId>de.agilecoders.wicket</groupId>
+      <artifactId>wicket-bootstrap-extensions</artifactId>
     </dependency>
 
     <!-- LOGGING DEPENDENCIES - SLF4J -->
@@ -90,6 +99,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
       <artifactId>de.tudarmstadt.ukp.dkpro.core.api.datasets-asl</artifactId>
       <scope>test</scope>
@@ -104,5 +118,64 @@
       <artifactId>de.tudarmstadt.ukp.dkpro.core.api.ner-asl</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>ch.qos.logback</groupId>
+          <artifactId>logback-classic</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-test-autoconfigure</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <configuration>
+            <usedDependencies>
+              <!-- Testing - used via reflection -->
+              <usedDependency>com.h2database:h2</usedDependency>
+              <usedDependency>org.springframework.boot:spring-boot-starter-test</usedDependency>
+              <usedDependency>org.springframework.boot:spring-boot-starter-data-jpa</usedDependency>
+            </usedDependencies>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>

--- a/inception-imls-stringmatch/pom.xml
+++ b/inception-imls-stringmatch/pom.xml
@@ -29,6 +29,10 @@
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-recommendation-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-recommendation</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>de.tudarmstadt.ukp.clarin.webanno</groupId>

--- a/inception-imls-stringmatch/pom.xml
+++ b/inception-imls-stringmatch/pom.xml
@@ -42,15 +42,35 @@
       <groupId>de.tudarmstadt.ukp.clarin.webanno</groupId>
       <artifactId>webanno-api-dao</artifactId>
     </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.clarin.webanno</groupId>
+      <artifactId>webanno-support</artifactId>
+    </dependency>
     
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-tx</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot</artifactId>
     </dependency>
     
     <dependency>
@@ -69,8 +89,29 @@
     </dependency>
     
     <dependency>
+      <groupId>org.apache.wicket</groupId>
+      <artifactId>wicket-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.wicket</groupId>
+      <artifactId>wicket-spring</artifactId>
+    </dependency>
+    <dependency>
       <groupId>de.agilecoders.wicket</groupId>
       <artifactId>wicket-bootstrap-extensions</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.danekja</groupId>
+      <artifactId>jdk-serializable-functional</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.persistence</groupId>
+      <artifactId>javax.persistence-api</artifactId>
     </dependency>
 
     <!-- LOGGING DEPENDENCIES - SLF4J -->
@@ -99,11 +140,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
       <artifactId>de.tudarmstadt.ukp.dkpro.core.api.datasets-asl</artifactId>
       <scope>test</scope>
@@ -121,11 +157,6 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-test</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/inception-imls-stringmatch/pom.xml
+++ b/inception-imls-stringmatch/pom.xml
@@ -50,6 +50,10 @@
       <groupId>de.tudarmstadt.ukp.clarin.webanno</groupId>
       <artifactId>webanno-support</artifactId>
     </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.clarin.webanno</groupId>
+      <artifactId>webanno-model-export</artifactId>
+    </dependency>
     
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -117,6 +121,10 @@
       <groupId>javax.persistence</groupId>
       <artifactId>javax.persistence-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
 
     <!-- LOGGING DEPENDENCIES - SLF4J -->
     <dependency>
@@ -136,6 +144,11 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/StringMatchingRecommender.java
+++ b/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/StringMatchingRecommender.java
@@ -18,7 +18,7 @@
 package de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch;
 
 import static java.util.Arrays.asList;
-import static java.util.Collections.emptyMap;
+import static java.util.Collections.emptyList;
 import static java.util.Comparator.comparingInt;
 import static org.apache.commons.lang3.StringUtils.isNoneBlank;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
@@ -29,10 +29,7 @@ import static org.apache.uima.fit.util.CasUtil.selectCovered;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -54,6 +51,7 @@ import de.tudarmstadt.ukp.inception.recommendation.api.recommender.Recommendatio
 import de.tudarmstadt.ukp.inception.recommendation.api.recommender.RecommenderContext;
 import de.tudarmstadt.ukp.inception.recommendation.api.recommender.RecommenderContext.Key;
 import de.tudarmstadt.ukp.inception.recommendation.api.type.PredictedSpan;
+import de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.model.GazeteerEntry;
 import de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.trie.Trie;
 import de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.trie.WhitespaceNormalizingSanitizer;
 
@@ -69,7 +67,7 @@ public class StringMatchingRecommender
     private final int maxRecommendations;
     private final StringMatchingRecommenderTraits traits;
     
-    private Map<String, String> pretrainData = emptyMap();
+    private List<GazeteerEntry> pretrainData = emptyList();
 
     public StringMatchingRecommender(Recommender aRecommender,
             StringMatchingRecommenderTraits aTraits)
@@ -80,13 +78,13 @@ public class StringMatchingRecommender
         traits = aTraits;
     }
 
-    public void pretrain(Map<String, String> aGazeteerData)
+    public void pretrain(List<GazeteerEntry> aData)
     {
-        if (aGazeteerData != null) {
-            pretrainData = new HashMap<>(aGazeteerData);
+        if (aData != null) {
+            pretrainData = aData;
         }
         else {
-            pretrainData = emptyMap();
+            pretrainData = emptyList();
         }
     }
 
@@ -101,8 +99,8 @@ public class StringMatchingRecommender
         Trie<DictEntry> dict = createTrie();
         
         // Load the pre-train data into the trie before learning from the annotated data
-        for (Entry<String, String> preTrainItem : pretrainData.entrySet()) {
-            learn(dict, preTrainItem.getKey(), preTrainItem.getValue());
+        for (GazeteerEntry entry : pretrainData) {
+            learn(dict, entry.text, entry.label);
         }
         
         // Learn from the annotated data

--- a/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/StringMatchingRecommenderFactory.java
+++ b/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/StringMatchingRecommenderFactory.java
@@ -23,7 +23,6 @@ import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.TOKENS;
 import static java.util.Arrays.asList;
 
 import java.io.IOException;
-import java.util.Map;
 
 import org.apache.uima.cas.CAS;
 import org.apache.wicket.model.IModel;
@@ -73,8 +72,7 @@ public class StringMatchingRecommenderFactory
         // Pre-load the gazeteers into the recommender
         for (Gazeteer gaz : gazeteerService.listGazeteers(aRecommender)) {
             try {
-                Map<String, String> gazeteerData = gazeteerService.readGazeteerFile(gaz);
-                recommender.pretrain(gazeteerData);
+                recommender.pretrain(gazeteerService.readGazeteerFile(gaz));
             }
             catch (IOException e) {
                 log.info("Unable to load gazeteer [{}] for recommender [{}]({}) in project [{}]({})",

--- a/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/StringMatchingRecommenderFactory.java
+++ b/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/StringMatchingRecommenderFactory.java
@@ -29,7 +29,6 @@ import org.apache.uima.cas.CAS;
 import org.apache.wicket.model.IModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
@@ -52,10 +51,9 @@ public class StringMatchingRecommenderFactory
     public static final String ID =
         "de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.StringMatchingRecommender";
 
-    private GazeteerService gazeteerService;
+    private final GazeteerService gazeteerService;
     
-    public StringMatchingRecommenderFactory(
-            @Autowired(required = false) GazeteerService aGazeteerService)
+    public StringMatchingRecommenderFactory(GazeteerService aGazeteerService)
     {
         gazeteerService = aGazeteerService;
     }
@@ -72,20 +70,18 @@ public class StringMatchingRecommenderFactory
         StringMatchingRecommenderTraits traits = new StringMatchingRecommenderTraits();
         StringMatchingRecommender recommender = new StringMatchingRecommender(aRecommender, traits);
         
-        // If there is a gazeteer service, then pre-load the gazeteers into the recommender
-        if (gazeteerService != null) {
-            for (Gazeteer gaz : gazeteerService.listGazeteers(aRecommender)) {
-                try {
-                    Map<String, String> gazeteerData = gazeteerService.readGazeteerFile(gaz);
-                    recommender.pretrain(gazeteerData);
-                }
-                catch (IOException e) {
-                    log.info("Unable to load gazeteer [{}] for recommender [{}]({}) in project [{}]({})",
-                            gaz.getName(), gaz.getRecommender().getName(),
-                            gaz.getRecommender().getId(),
-                            gaz.getRecommender().getProject().getName(),
-                            gaz.getRecommender().getProject().getId(), e);
-                }
+        // Pre-load the gazeteers into the recommender
+        for (Gazeteer gaz : gazeteerService.listGazeteers(aRecommender)) {
+            try {
+                Map<String, String> gazeteerData = gazeteerService.readGazeteerFile(gaz);
+                recommender.pretrain(gazeteerData);
+            }
+            catch (IOException e) {
+                log.info("Unable to load gazeteer [{}] for recommender [{}]({}) in project [{}]({})",
+                        gaz.getName(), gaz.getRecommender().getName(),
+                        gaz.getRecommender().getId(),
+                        gaz.getRecommender().getProject().getName(),
+                        gaz.getRecommender().getProject().getId(), e);
             }
         }
         

--- a/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/exporter/ExportedGazeteer.java
+++ b/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/exporter/ExportedGazeteer.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019
+ * Ubiquitous Knowledge Processing (UKP) Lab
+ * Technische Universität Darmstadt
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.exporter;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonPropertyOrder(alphabetic = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ExportedGazeteer
+{
+    @JsonProperty("id")
+    private long id;
+    
+    @JsonProperty("name")
+    private String name;
+
+    @JsonProperty("recommender")
+    private String recommender;
+
+    public long getId()
+    {
+        return id;
+    }
+
+    public void setId(long aId)
+    {
+        id = aId;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public void setName(String aName)
+    {
+        name = aName;
+    }
+
+    public String getRecommender()
+    {
+        return recommender;
+    }
+
+    public void setRecommender(String aRecommender)
+    {
+        recommender = aRecommender;
+    }
+}

--- a/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/exporter/GazeteerExporter.java
+++ b/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/exporter/GazeteerExporter.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2019
+ * Ubiquitous Knowledge Processing (UKP) Lab
+ * Technische Universität Darmstadt
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.exporter;
+
+import static java.util.Arrays.asList;
+
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.zip.ZipFile;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExportRequest;
+import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExporter;
+import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectImportRequest;
+import de.tudarmstadt.ukp.clarin.webanno.export.model.ExportedProject;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
+import de.tudarmstadt.ukp.inception.recommendation.exporter.RecommenderExporter;
+import de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.gazeteer.GazeteerService;
+import de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.model.Gazeteer;
+
+@Component
+public class GazeteerExporter
+    implements ProjectExporter
+{
+    private static final Logger LOG = LoggerFactory.getLogger(GazeteerExporter.class);
+
+    private static final String KEY = "gazeteers";
+    
+    private static final String GAZETEERS_FOLDER = "gazeteers";
+    
+
+    private final RecommendationService recommendationService;
+    private final GazeteerService gazeteerService;
+    
+    @Autowired
+    public GazeteerExporter(RecommendationService aRecommendationService,
+            GazeteerService aGazeteerService)
+    {
+        recommendationService = aRecommendationService;
+        gazeteerService = aGazeteerService;
+    }
+
+    @Override
+    public List<Class<? extends ProjectExporter>> getImportDependencies() {
+        return asList(RecommenderExporter.class);
+    }
+
+    @Override
+    public void exportData(ProjectExportRequest aRequest, ExportedProject aExProject, File aStage)
+        throws Exception
+    {
+        Project project = aRequest.getProject();
+        
+        List<ExportedGazeteer> exportedGazeteers = new ArrayList<>();
+        for (Recommender recommender : recommendationService.listRecommenders(project)) {
+            for (Gazeteer gazeteer : gazeteerService.listGazeteers(recommender)) {
+                ExportedGazeteer exportedGazeteer = new ExportedGazeteer();
+                exportedGazeteer.setId(gazeteer.getId());
+                exportedGazeteer.setName(gazeteer.getName());
+                exportedGazeteer.setRecommender(recommender.getName());
+                exportedGazeteers.add(exportedGazeteer);
+                
+                File targetFolder = new File(aStage, GAZETEERS_FOLDER);
+                targetFolder.mkdirs();
+                
+                Files.copy(gazeteerService.getGazeteerFile(gazeteer).toPath(),
+                        new File(targetFolder, gazeteer.getId() + ".txt").toPath());
+            }
+        }
+        
+        aExProject.setProperty(KEY, exportedGazeteers);
+        
+        LOG.info("Exported [{}] gazeteers for project [{}]", exportedGazeteers.size(),
+                project.getName());
+    }
+
+    @Override
+    public void importData(ProjectImportRequest aRequest, Project aProject,
+            ExportedProject aExProject, ZipFile aZip)
+        throws Exception
+    {
+        ExportedGazeteer[] gazeteers = aExProject.getArrayProperty(KEY, ExportedGazeteer.class);
+        
+        for (ExportedGazeteer exportedGazeteer : gazeteers) {
+            Recommender recommender = recommendationService
+                    .getRecommender(aProject, exportedGazeteer.getName()).get();
+            
+            Gazeteer gazeteer = new Gazeteer();
+            gazeteer.setName(exportedGazeteer.getName());
+            gazeteer.setRecommender(recommender);
+            gazeteerService.createOrUpdateGazeteer(gazeteer);
+            
+            try (InputStream is = aZip.getInputStream(aZip
+                    .getEntry("/" + GAZETEERS_FOLDER + "/" + exportedGazeteer.getId() + ".txt"))) {
+                gazeteerService.importGazeteerFile(gazeteer, is);
+            }
+        }
+        
+        LOG.info("Imported [{}] gazeteeres for project [{}]", gazeteers.length, aProject.getName());
+    }
+}

--- a/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/exporter/GazeteerExporter.java
+++ b/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/exporter/GazeteerExporter.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 import org.slf4j.Logger;
@@ -107,15 +108,16 @@ public class GazeteerExporter
         
         for (ExportedGazeteer exportedGazeteer : gazeteers) {
             Recommender recommender = recommendationService
-                    .getRecommender(aProject, exportedGazeteer.getName()).get();
+                    .getRecommender(aProject, exportedGazeteer.getRecommender()).get();
             
             Gazeteer gazeteer = new Gazeteer();
             gazeteer.setName(exportedGazeteer.getName());
             gazeteer.setRecommender(recommender);
             gazeteerService.createOrUpdateGazeteer(gazeteer);
             
-            try (InputStream is = aZip.getInputStream(aZip
-                    .getEntry("/" + GAZETEERS_FOLDER + "/" + exportedGazeteer.getId() + ".txt"))) {
+            ZipEntry entry = aZip
+                    .getEntry(GAZETEERS_FOLDER + "/" + exportedGazeteer.getId() + ".txt");
+            try (InputStream is = aZip.getInputStream(entry)) {
                 gazeteerService.importGazeteerFile(gazeteer, is);
             }
         }

--- a/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/gazeteer/GazeteerService.java
+++ b/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/gazeteer/GazeteerService.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2019
+ * Ubiquitous Knowledge Processing (UKP) Lab
+ * Technische Universität Darmstadt
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.gazeteer;
 
 import java.io.File;

--- a/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/gazeteer/GazeteerService.java
+++ b/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/gazeteer/GazeteerService.java
@@ -1,0 +1,44 @@
+package de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.gazeteer;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+
+import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
+import de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.model.Gazeteer;
+
+public interface GazeteerService
+{
+    /**
+     * List gazeteers for the given recommender.
+     */
+    List<Gazeteer> listGazeteers(Recommender aRecommender);
+    
+    /**
+     * Delete the given gazetter.
+     */
+    void deleteGazeteers(Gazeteer aGazeteer) throws IOException;
+    
+    /**
+     * Import the gazeteer file for the given gazeteer.
+     */
+    void importGazeteerFile(Gazeteer aGazeteer, InputStream aStream) throws IOException;
+    
+    /**
+     * Get the gazeteer file for the given gazeteer. If no file has been imported yet for the given
+     * gazeteer, the file returned by this method does not exist.
+     */
+    File getGazeteerFile(Gazeteer aSet) throws IOException;
+
+    /**
+     * Write the given gazetter to the database.
+     */
+    void createOrUpdateGazeteer(Gazeteer aGazeteer);
+
+    /**
+     * Loads the given gazetter into a map.
+     */
+    Map<String, String> readGazeteerFile(Gazeteer aGaz) throws IOException;
+}

--- a/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/gazeteer/GazeteerService.java
+++ b/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/gazeteer/GazeteerService.java
@@ -58,4 +58,6 @@ public interface GazeteerService
      * Loads the given gazetter into a map.
      */
     Map<String, String> readGazeteerFile(Gazeteer aGaz) throws IOException;
+
+    boolean existsGazeteer(Recommender aRecommender, String aName);
 }

--- a/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/gazeteer/GazeteerService.java
+++ b/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/gazeteer/GazeteerService.java
@@ -21,10 +21,10 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
-import java.util.Map;
 
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
 import de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.model.Gazeteer;
+import de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.model.GazeteerEntry;
 
 public interface GazeteerService
 {
@@ -55,9 +55,9 @@ public interface GazeteerService
     void createOrUpdateGazeteer(Gazeteer aGazeteer);
 
     /**
-     * Loads the given gazetter into a map.
+     * Loads the gazeteer.
      */
-    Map<String, String> readGazeteerFile(Gazeteer aGaz) throws IOException;
+    List<GazeteerEntry> readGazeteerFile(Gazeteer aGaz) throws IOException;
 
     boolean existsGazeteer(Recommender aRecommender, String aName);
 }

--- a/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/gazeteer/GazeteerServiceImpl.java
+++ b/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/gazeteer/GazeteerServiceImpl.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2019
+ * Ubiquitous Knowledge Processing (UKP) Lab
+ * Technische Universität Darmstadt
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.gazeteer;
 
 import static java.nio.charset.StandardCharsets.UTF_8;

--- a/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/gazeteer/GazeteerServiceImpl.java
+++ b/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/gazeteer/GazeteerServiceImpl.java
@@ -1,0 +1,173 @@
+package de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.gazeteer;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.commons.lang3.StringUtils.trimToNull;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.LineIterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.dao.RepositoryProperties;
+import de.tudarmstadt.ukp.clarin.webanno.support.logging.Logging;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
+import de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.model.Gazeteer;
+
+@Component
+public class GazeteerServiceImpl
+    implements GazeteerService
+{
+    private final Logger log = LoggerFactory.getLogger(getClass());
+    
+    @PersistenceContext
+    private EntityManager entityManager;
+    
+    private final RepositoryProperties repositoryProperties;
+    
+    @Autowired
+    public GazeteerServiceImpl(RepositoryProperties aRepositoryProperties)
+    {
+        repositoryProperties = aRepositoryProperties;
+    }    
+
+    public GazeteerServiceImpl(RepositoryProperties aRepositoryProperties,
+            EntityManager aEntityManager)
+    {
+        this(aRepositoryProperties);
+        entityManager = aEntityManager;
+    }
+    
+    @Override
+    @Transactional
+    public List<Gazeteer> listGazeteers(Recommender aRecommender)
+    {
+        String query = String.join("\n", 
+                "FROM Gazeteer",
+                "WHERE recommender = :recommender ",
+                "ORDER BY name ASC");
+        
+        return entityManager
+                .createQuery(query, Gazeteer.class)
+                .setParameter("recommender", aRecommender)
+                .getResultList();
+    }
+
+    @Override
+    @Transactional
+    public void createOrUpdateGazeteer(Gazeteer aGazeteer)
+    {
+        if (aGazeteer.getId() == null) {
+            entityManager.persist(aGazeteer);
+            
+            try (MDC.MDCCloseable closable = MDC.putCloseable(Logging.KEY_PROJECT_ID,
+                    String.valueOf(aGazeteer.getRecommender().getProject().getId()))) {
+                log.info("Created gazeteer [{}] for recommender [{}]({}) in project [{}]({})",
+                        aGazeteer.getName(), aGazeteer.getRecommender().getName(),
+                        aGazeteer.getRecommender().getId(),
+                        aGazeteer.getRecommender().getProject().getName(),
+                        aGazeteer.getRecommender().getProject().getId());
+            }
+        }
+        else {
+            entityManager.merge(aGazeteer);
+            
+            try (MDC.MDCCloseable closable = MDC.putCloseable(Logging.KEY_PROJECT_ID,
+                    String.valueOf(aGazeteer.getRecommender().getProject().getId()))) {
+                log.info("Updated gazeteer [{}] for recommender [{}]({}) in project [{}]({})",
+                        aGazeteer.getName(), aGazeteer.getRecommender().getName(),
+                        aGazeteer.getRecommender().getId(),
+                        aGazeteer.getRecommender().getProject().getName(),
+                        aGazeteer.getRecommender().getProject().getId());
+            }
+        }
+    }
+
+    @Override
+    @Transactional
+    public void importGazeteerFile(Gazeteer aGazeteer, InputStream aStream) throws IOException
+    {
+        File gazFile = getGazeteerFile(aGazeteer);
+        
+        if (!gazFile.getParentFile().exists()) {
+            gazFile.getParentFile().mkdirs();
+        }
+        
+        try (OutputStream os = new FileOutputStream(gazFile)) {
+            IOUtils.copyLarge(aStream, os);
+        }
+    }
+
+    @Override
+    public File getGazeteerFile(Gazeteer aGazeteer) throws IOException
+    {
+        return repositoryProperties.getPath().toPath()
+                .resolve("project")
+                .resolve(String.valueOf(aGazeteer.getRecommender().getProject().getId()))
+                .resolve("gazeteer")
+                .resolve(aGazeteer.getId() + ".txt")
+                .toFile();
+    }
+
+    @Override
+    @Transactional
+    public void deleteGazeteers(Gazeteer aGazeteer) throws IOException
+    {
+        entityManager.remove(
+                entityManager.contains(aGazeteer) ? aGazeteer : entityManager.merge(aGazeteer));
+        
+        File gaz = getGazeteerFile(aGazeteer);
+        if (gaz.exists()) {
+            gaz.delete();
+        }
+        
+        try (MDC.MDCCloseable closable = MDC.putCloseable(Logging.KEY_PROJECT_ID,
+                String.valueOf(aGazeteer.getRecommender().getProject().getId()))) {
+            log.info("Removed gazeteer [{}] from recommender [{}]({}) in project [{}]({})",
+                    aGazeteer.getName(), aGazeteer.getRecommender().getName(),
+                    aGazeteer.getRecommender().getId(),
+                    aGazeteer.getRecommender().getProject().getName(),
+                    aGazeteer.getRecommender().getProject().getId());
+        }
+    }
+    
+    @Override
+    public Map<String, String> readGazeteerFile(Gazeteer aGaz) throws IOException
+    {
+        File file = getGazeteerFile(aGaz);
+        
+        Map<String, String> data = new HashMap<>();
+        
+        try (InputStream is = new FileInputStream(file)) {
+            LineIterator i = IOUtils.lineIterator(is, UTF_8);
+            while (i.hasNext()) {
+                String[] line = i.nextLine().split("\t", 2);
+                if (line.length == 2) {
+                    String label = trimToNull(line[0]);
+                    String text = trimToNull(line[1]);
+                    if (label != null && text != null) {
+                        data.put(text, label);
+                    }
+                }
+            }
+        }
+        
+        return data;
+    }
+}

--- a/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/gazeteer/GazeteerServiceImpl.java
+++ b/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/gazeteer/GazeteerServiceImpl.java
@@ -35,6 +35,7 @@ import javax.persistence.PersistenceContext;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.LineIterator;
+import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -186,5 +187,25 @@ public class GazeteerServiceImpl
         }
         
         return data;
+    }
+    
+    @Override
+    @Transactional
+    public boolean existsGazeteer(Recommender aRecommender, String aName)
+    {
+        Validate.notNull(aRecommender, "Recommender must be specified");
+        Validate.notNull(aName, "Gazeteer name must be specified");
+        
+        String query = 
+                "SELECT COUNT(*) " +
+                "FROM Gazeteer " + 
+                "WHERE recommender = :recommender AND name = :name";
+        
+        long count = entityManager.createQuery(query, Long.class)
+            .setParameter("recommender", aRecommender)
+            .setParameter("name", aName)
+            .getSingleResult();
+
+        return count > 0;
     }
 }

--- a/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/model/Gazeteer.java
+++ b/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/model/Gazeteer.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2019
+ * Ubiquitous Knowledge Processing (UKP) Lab
+ * Technische Universität Darmstadt
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.model;
 
 import java.io.Serializable;

--- a/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/model/Gazeteer.java
+++ b/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/model/Gazeteer.java
@@ -1,0 +1,99 @@
+package de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.model;
+
+import java.io.Serializable;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
+
+@Entity
+@Table(name = "gazeteer", 
+        uniqueConstraints = { @UniqueConstraint(columnNames = { "name", "recommender" }) })
+public class Gazeteer
+    implements Serializable
+{
+    private static final long serialVersionUID = 7310223920449064425L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @ManyToOne
+    @JoinColumn(name = "recommender")
+    private Recommender recommender;
+
+    public Gazeteer()
+    {
+        // Required for JPA
+    }
+    
+    public Gazeteer(String aName, Recommender aRecommender)
+    {
+        name = aName;
+        recommender = aRecommender;
+    }
+
+    public Long getId()
+    {
+        return id;
+    }
+
+    public void setId(Long aId)
+    {
+        id = aId;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public void setName(String aName)
+    {
+        name = aName;
+    }
+
+    public Recommender getRecommender()
+    {
+        return recommender;
+    }
+
+    public void setRecommender(Recommender aRecommender)
+    {
+        recommender = aRecommender;
+    }
+
+    @Override
+    public boolean equals(final Object other)
+    {
+        if (!(other instanceof Gazeteer)) {
+            return false;
+        }
+        Gazeteer castOther = (Gazeteer) other;
+        return new EqualsBuilder().append(name, castOther.name)
+                .append(recommender, castOther.recommender).isEquals();
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return new HashCodeBuilder().append(name).append(recommender).toHashCode();
+    }
+}

--- a/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/model/GazeteerEntry.java
+++ b/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/model/GazeteerEntry.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019
+ * Ubiquitous Knowledge Processing (UKP) Lab
+ * Technische Universität Darmstadt
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.model;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+public class GazeteerEntry
+{
+    public final String text;
+    public final String label;
+    
+    public GazeteerEntry(String aText, String aLabel)
+    {
+        super();
+        text = aText;
+        label = aLabel;
+    }
+
+    @Override
+    public boolean equals(final Object other)
+    {
+        if (!(other instanceof GazeteerEntry)) {
+            return false;
+        }
+        GazeteerEntry castOther = (GazeteerEntry) other;
+        return new EqualsBuilder().append(text, castOther.text).append(label, castOther.label)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return new HashCodeBuilder().append(text).append(label).toHashCode();
+    }
+
+    @Override
+    public String toString()
+    {
+        return new ToStringBuilder(this).append("text", text).append("label", label).toString();
+    }
+}

--- a/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/settings/StringMatchingRecommenderTraitsEditor.html
+++ b/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/settings/StringMatchingRecommenderTraitsEditor.html
@@ -1,0 +1,52 @@
+<!--
+#Copyright 2019
+#Ubiquitous Knowledge Processing (UKP) Lab
+#Technische Universität Darmstadt
+#
+#Licensed under the Apache License, Version 2.0 (the "License");
+#you may not use this file except in compliance with the License.
+#You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+#Unless required by applicable law or agreed to in writing, software
+#distributed under the License is distributed on an "AS IS" BASIS,
+#WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#See the License for the specific language governing permissions and
+#limitations under the License.
+-->
+<html xmlns:wicket="http://wicket.apache.org">
+<body>
+  <wicket:panel>
+    <div class="col-sm-12 form-horizontal">
+      <div class="form-group">
+        <label class="col-sm-3 control-label">
+          <wicket:message key="gazeteers"/>
+        </label>
+        <div class="col-sm-9 flex-v-container flex-gutter flex-only-internal-gutter">
+          <div class="flex-h-container">
+            <input type="file" wicket:id="upload" multiple="multiple"/>
+          </div>
+          
+          <div class="flex-h-container">
+            <div wicket:id="gazeteers" class="flex-content list-group">
+              <!-- <div wicket:id="gazeteers" class="flex-content list-group"> -->
+              <div wicket:id="gazeteer" class="input-group">
+                <span wicket:id="name" class="form-control"/>
+                <span class="input-group-btn">
+                  <button wicket:id="download" type="button" class="btn btn-default">
+                    <i class="fa fa-download" aria-hidden="true"></i>
+                  </button>
+                  <button wicket:id="delete" type="button" class="btn btn-danger">
+                    <i class="fa fa-trash" aria-hidden="true"></i>
+                  </button>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>  
+  </wicket:panel>
+</body>
+</html>

--- a/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/settings/StringMatchingRecommenderTraitsEditor.html
+++ b/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/settings/StringMatchingRecommenderTraitsEditor.html
@@ -19,7 +19,14 @@
 <body>
   <wicket:panel>
     <div class="col-sm-12 form-horizontal">
-      <div class="form-group">
+      <wicket:remove>
+        <!-- 
+          NOTE: The enclosure needs to be defined on the upload field. Defining it on the
+          gazeteers field does not work properly. I.e. when uploading a file or when removing
+          a gazeteer, the upload field/and are not re-rendered.
+         -->
+      </wicket:remove>
+      <div class="form-group" wicket:enclosure="upload">
         <label class="col-sm-3 control-label">
           <wicket:message key="gazeteers"/>
         </label>

--- a/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/settings/StringMatchingRecommenderTraitsEditor.java
+++ b/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/settings/StringMatchingRecommenderTraitsEditor.java
@@ -90,7 +90,6 @@ public class StringMatchingRecommenderTraitsEditor
                 actionUploadGazeteer(aTarget);
             }
         };
-        uploadField.setOutputMarkupPlaceholderTag(true);
         uploadField.add(visibleWhen(() -> aRecommender.getObject() != null
                 && aRecommender.getObject().getId() != null));
         add(uploadField);

--- a/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/settings/StringMatchingRecommenderTraitsEditor.java
+++ b/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/settings/StringMatchingRecommenderTraitsEditor.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2019
+ * Ubiquitous Knowledge Processing (UKP) Lab
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.settings;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.wicket.WicketRuntimeException;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.feedback.IFeedback;
+import org.apache.wicket.markup.html.WebMarkupContainer;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.form.upload.FileUpload;
+import org.apache.wicket.markup.html.link.DownloadLink;
+import org.apache.wicket.markup.html.list.ListItem;
+import org.apache.wicket.markup.html.list.ListView;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.LoadableDetachableModel;
+import org.apache.wicket.model.util.ListModel;
+import org.apache.wicket.spring.injection.annot.SpringBean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import de.agilecoders.wicket.extensions.markup.html.bootstrap.form.fileinput.BootstrapFileInput;
+import de.agilecoders.wicket.extensions.markup.html.bootstrap.form.fileinput.FileInputConfig;
+import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxLink;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
+import de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.gazeteer.GazeteerService;
+import de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.model.Gazeteer;
+
+public class StringMatchingRecommenderTraitsEditor
+    extends Panel
+{
+    private static final Logger LOG = LoggerFactory
+            .getLogger(StringMatchingRecommenderTraitsEditor.class);
+    
+    private static final long serialVersionUID = 1677442652521110324L;
+
+    private @SpringBean GazeteerService gazeteerService;
+    
+    private GazeteerList gazeteers;
+    private BootstrapFileInput uploadField;
+
+    public StringMatchingRecommenderTraitsEditor(String aId, IModel<Recommender> aRecommender)
+    {
+        super(aId, aRecommender);
+
+        gazeteers = new GazeteerList("gazeteers", LoadableDetachableModel.of(this::listGazeteers));
+        add(gazeteers);
+        
+        
+        FileInputConfig config = new FileInputConfig();
+        config.initialCaption("Import gazeteers ...");
+        config.allowedFileExtensions(asList("txt"));
+        config.showPreview(false);
+        config.showUpload(true);
+        config.removeIcon("<i class=\"fa fa-remove\"></i>");
+        config.uploadIcon("<i class=\"fa fa-upload\"></i>");
+        config.browseIcon("<i class=\"fa fa-folder-open\"></i>");
+        uploadField = new BootstrapFileInput("upload", new ListModel<>(), config) {
+            private static final long serialVersionUID = -7072183979425490246L;
+
+            @Override
+            protected void onSubmit(AjaxRequestTarget aTarget)
+            {
+                actionUploadGazeteer(aTarget);
+            }
+        };
+        
+        add(uploadField);
+    }
+
+//    private void actionViewGazeteer(AjaxRequestTarget aTarget, Gazeteer aGazeteer)
+//    {
+//        
+//    }
+    
+    private void actionDeleteGazeteer(AjaxRequestTarget aTarget, Gazeteer aGazeteer)
+        throws IOException
+    {
+        gazeteerService.deleteGazeteers(aGazeteer);
+        
+        gazeteers.getDefaultModel().detach();
+        aTarget.add(gazeteers);
+    }
+    
+//    private void actionRenameGazeteer(AjaxRequestTarget aTarget, Gazeteer aGazeteer)
+//    {
+//        
+//    }
+
+    private void actionUploadGazeteer(AjaxRequestTarget aTarget)
+    {
+        for (FileUpload importedGazeteer : uploadField.getModelObject()) {
+            Gazeteer gazeteer = new Gazeteer();
+            gazeteer.setName(importedGazeteer.getClientFileName());
+            gazeteer.setRecommender(getModelObject());
+            
+            try (InputStream is = importedGazeteer.getInputStream()) {
+                gazeteerService.createOrUpdateGazeteer(gazeteer);
+                gazeteerService.importGazeteerFile(gazeteer, is);
+            }
+            catch (Exception e) {
+                aTarget.addChildren(getPage(), IFeedback.class);
+                error("Error importing gazeteer: " + ExceptionUtils.getRootCauseMessage(e));
+                LOG.error("Error importing gazeteer", e);
+            }
+        }
+        
+        gazeteers.getDefaultModel().detach();
+        aTarget.add(gazeteers);
+    }
+    
+    public Recommender getModelObject()
+    {
+        return (Recommender) getDefaultModelObject();
+    }
+
+    private List<Gazeteer> listGazeteers()
+    {
+        Recommender recommender = getModelObject();
+
+        if (recommender != null) {
+            return gazeteerService.listGazeteers(recommender);
+        }
+        else {
+            return emptyList();
+        }
+    }
+    
+    public class GazeteerList extends WebMarkupContainer
+    {
+        private static final long serialVersionUID = -2049981253344229438L;
+        
+        private ListView<Gazeteer> gazeteerList;
+        
+        public GazeteerList(String aId, IModel<? extends List<Gazeteer>> aChoices)
+        {
+            super(aId, aChoices);
+            
+            setOutputMarkupPlaceholderTag(true);
+            
+            gazeteerList = new ListView<Gazeteer>("gazeteer", aChoices) {
+                private static final long serialVersionUID = 2827701590781214260L;
+
+                @Override
+                protected void populateItem(ListItem<Gazeteer> aItem)
+                {
+                    Gazeteer gazeteer = aItem.getModelObject();
+                    
+                    aItem.add(new Label("name", aItem.getModelObject().getName()));
+
+//                    aItem.add(new LambdaAjaxLink("view",
+//                        _target -> actionViewGazeteer(_target, gazeteer)));
+//
+//                    aItem.add(new LambdaAjaxLink("rename",
+//                        _target -> actionRenameGazeteer(_target, gazeteer)));
+
+                    aItem.add(new LambdaAjaxLink("delete",
+                        _target -> actionDeleteGazeteer(_target, gazeteer)));
+
+                    aItem.add(new DownloadLink("download",
+                            LoadableDetachableModel.of(() -> getGazeteerFile(gazeteer)),
+                            gazeteer.getName()));
+                }
+            };
+            add(gazeteerList);
+        }
+        
+        private File getGazeteerFile(Gazeteer aGazeteer)
+        {
+            try {
+                return gazeteerService.getGazeteerFile(aGazeteer);
+            }
+            catch (IOException e) {
+                throw new WicketRuntimeException(e);
+            }
+        }
+    }
+}

--- a/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/settings/StringMatchingRecommenderTraitsEditor.java
+++ b/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/settings/StringMatchingRecommenderTraitsEditor.java
@@ -73,7 +73,6 @@ public class StringMatchingRecommenderTraitsEditor
                 && aRecommender.getObject().getId() != null));
         add(gazeteers);
         
-        
         FileInputConfig config = new FileInputConfig();
         config.initialCaption("Import gazeteers ...");
         config.allowedFileExtensions(asList("txt"));
@@ -91,16 +90,12 @@ public class StringMatchingRecommenderTraitsEditor
                 actionUploadGazeteer(aTarget);
             }
         };
+        uploadField.setOutputMarkupPlaceholderTag(true);
         uploadField.add(visibleWhen(() -> aRecommender.getObject() != null
                 && aRecommender.getObject().getId() != null));
         add(uploadField);
     }
 
-//    private void actionViewGazeteer(AjaxRequestTarget aTarget, Gazeteer aGazeteer)
-//    {
-//        
-//    }
-    
     private void actionDeleteGazeteer(AjaxRequestTarget aTarget, Gazeteer aGazeteer)
         throws IOException
     {
@@ -110,11 +105,6 @@ public class StringMatchingRecommenderTraitsEditor
         aTarget.add(gazeteers);
     }
     
-//    private void actionRenameGazeteer(AjaxRequestTarget aTarget, Gazeteer aGazeteer)
-//    {
-//        
-//    }
-
     private void actionUploadGazeteer(AjaxRequestTarget aTarget)
     {
         for (FileUpload importedGazeteer : uploadField.getModelObject()) {
@@ -175,12 +165,6 @@ public class StringMatchingRecommenderTraitsEditor
                     Gazeteer gazeteer = aItem.getModelObject();
                     
                     aItem.add(new Label("name", aItem.getModelObject().getName()));
-
-//                    aItem.add(new LambdaAjaxLink("view",
-//                        _target -> actionViewGazeteer(_target, gazeteer)));
-//
-//                    aItem.add(new LambdaAjaxLink("rename",
-//                        _target -> actionRenameGazeteer(_target, gazeteer)));
 
                     aItem.add(new LambdaAjaxLink("delete",
                         _target -> actionDeleteGazeteer(_target, gazeteer)));

--- a/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/settings/StringMatchingRecommenderTraitsEditor.java
+++ b/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/settings/StringMatchingRecommenderTraitsEditor.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.settings;
 
+import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 
@@ -68,6 +69,8 @@ public class StringMatchingRecommenderTraitsEditor
         super(aId, aRecommender);
 
         gazeteers = new GazeteerList("gazeteers", LoadableDetachableModel.of(this::listGazeteers));
+        gazeteers.add(visibleWhen(() -> aRecommender.getObject() != null
+                && aRecommender.getObject().getId() != null));
         add(gazeteers);
         
         
@@ -88,7 +91,8 @@ public class StringMatchingRecommenderTraitsEditor
                 actionUploadGazeteer(aTarget);
             }
         };
-        
+        uploadField.add(visibleWhen(() -> aRecommender.getObject() != null
+                && aRecommender.getObject().getId() != null));
         add(uploadField);
     }
 
@@ -142,7 +146,7 @@ public class StringMatchingRecommenderTraitsEditor
     {
         Recommender recommender = getModelObject();
 
-        if (recommender != null) {
+        if (recommender != null && recommender.getId() != null) {
             return gazeteerService.listGazeteers(recommender);
         }
         else {

--- a/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/settings/StringMatchingRecommenderTraitsEditor.properties
+++ b/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/settings/StringMatchingRecommenderTraitsEditor.properties
@@ -1,0 +1,16 @@
+# Copyright 2019
+# Ubiquitous Knowledge Processing (UKP) Lab
+# Technische Universität Darmstadt
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+gazeteers=Gazeteers

--- a/inception-imls-stringmatch/src/main/resources/META-INF/asciidoc/user-guide/projects_recommendation_string.adoc
+++ b/inception-imls-stringmatch/src/main/resources/META-INF/asciidoc/user-guide/projects_recommendation_string.adoc
@@ -32,19 +32,16 @@ internally represented as strings (e.g. concept features).
 === Gazeteers
 
 It is possible to pre-load gazeteers into string matching recommenders. A gazeteer is a simple text
-file where each line consists of a label and a text separated by a tab character. The order of 
-items in the gazeteer does not matter. Suggestions are generated considering the longest match.
+file where each line consists of a text and a label separated by a tab character. The order of 
+items in the gazeteer does not matter. Suggestions are generated considering the longest match. Comment lines start with a `#`. Empty lines are ignored.
 
 .Gazeteer example
 ----
-PER	Obama
-PER	Barack Obama
-LOC	Illinois
-ORG	Illinois State Senate
-LOC	Hawaii
-LOC	Indonesia
+# This is a comment
+Obama	PER
+Barack Obama	PER
+Illinois	LOC
+Illinois State Senate	ORG	
+Hawaii	LOC	
+Indonesia	LOC
 ----
-
-NOTE: It is possible to add comments lines such as `# This file contains named entities` because lines 
-      not containing a tab character are not considered. The `#` at the beginning of the line has no special
-      meaning! This may change in future versions of {product-name}.

--- a/inception-imls-stringmatch/src/main/resources/META-INF/asciidoc/user-guide/projects_recommendation_string.adoc
+++ b/inception-imls-stringmatch/src/main/resources/META-INF/asciidoc/user-guide/projects_recommendation_string.adoc
@@ -28,3 +28,23 @@ twice as _PER_ and once as _OTH_, than the score for _PER_ is 0.66 and the score
 The recommender can be used for span layers that anchor to single or multiple tokens and where
 cross-sentence annotations are not allowed. It can be used for string features or features which get
 internally represented as strings (e.g. concept features).
+
+=== Gazeteers
+
+It is possible to pre-load gazeteers into string matching recommenders. A gazeteer is a simple text
+file where each line consists of a label and a text separated by a tab character. The order of 
+items in the gazeteer does not matter. Suggestions are generated considering the longest match.
+
+.Gazeteer example
+----
+PER	Obama
+PER	Barack Obama
+LOC	Illinois
+ORG	Illinois State Senate
+LOC	Hawaii
+LOC	Indonesia
+----
+
+NOTE: It is possible to add comments lines such as `# This file contains named entities` because lines 
+      not containing a tab character are not considered. The `#` at the beginning of the line has no special
+      meaning! This may change in future versions of {product-name}.

--- a/inception-imls-stringmatch/src/main/resources/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/model/db-changelog.xml
+++ b/inception-imls-stringmatch/src/main/resources/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/model/db-changelog.xml
@@ -1,0 +1,31 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="
+    http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd 
+    http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+  <changeSet author="INCEpTION Team" id="20190203-01">
+    <createTable tableName="gazeteer">
+      <column autoIncrement="true" name="id" type="BIGINT">
+        <constraints primaryKey="true" />
+      </column>
+      <column name="name" type="VARCHAR(255)">
+        <constraints nullable="false" />
+      </column>
+      <column name="recommender" type="BIGINT">
+        <constraints nullable="false" />
+      </column>
+    </createTable>
+    <addUniqueConstraint tableName="gazeteer" columnNames="recommender, name"
+      constraintName="UK_gaz_rec_name" />
+    <createIndex indexName="FK_gaz_rec" tableName="gazeteer">
+      <column name="recommender" />
+    </createIndex>
+    <addForeignKeyConstraint constraintName="FK_gaz_rec"
+      baseTableName="gazeteer" baseColumnNames="recommender"
+      referencedTableName="recommender" referencedColumnNames="id"
+      deferrable="false" initiallyDeferred="false" 
+      onDelete="CASCADE" onUpdate="CASCADE"/>
+  </changeSet>
+</databaseChangeLog>

--- a/inception-imls-stringmatch/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/exporter/GazeteerExporterTest.java
+++ b/inception-imls-stringmatch/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/exporter/GazeteerExporterTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2018
+ * Ubiquitous Knowledge Processing (UKP) Lab
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.exporter;
+
+import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.SPAN_TYPE;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.TOKENS;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.io.File;
+import java.util.List;
+import java.util.Optional;
+import java.util.zip.ZipFile;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.uima.cas.CAS;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst;
+import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExportRequest;
+import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectImportRequest;
+import de.tudarmstadt.ukp.clarin.webanno.export.model.ExportedProject;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
+import de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.gazeteer.GazeteerService;
+import de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.model.Gazeteer;
+
+public class GazeteerExporterTest
+{
+    private @Mock GazeteerService gazeteerService;
+    private @Mock RecommendationService recommendationService;
+
+    private Project sourceProject;
+    private AnnotationLayer sourceLayer;
+    private AnnotationFeature sourceFeature;
+    private Recommender sourceRecommender;
+    
+    private Project targetProject;
+    private AnnotationLayer targetLayer;
+    private AnnotationFeature targetFeature;
+    private Recommender targetRecommender;
+
+    public @Rule TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private GazeteerExporter sut;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        initMocks(this);
+
+        sourceProject = new Project();
+        sourceProject.setId(1l);
+        sourceProject.setName("Test Project");
+        sourceProject.setMode(WebAnnoConst.PROJECT_TYPE_ANNOTATION);
+
+        sourceLayer = new AnnotationLayer("span", "span", SPAN_TYPE, sourceProject, false, TOKENS);
+        sourceFeature = new AnnotationFeature(sourceProject, sourceLayer, "value", "value",
+                CAS.TYPE_NAME_STRING);
+        sourceRecommender = new Recommender("rec1", sourceLayer);
+        sourceRecommender.setFeature(sourceFeature);
+        
+        targetProject = new Project();
+        targetProject.setId(2l);
+        targetProject.setName("Test Project");
+        targetProject.setMode(WebAnnoConst.PROJECT_TYPE_ANNOTATION);
+
+        targetLayer = new AnnotationLayer("span", "span", SPAN_TYPE, sourceProject, false, TOKENS);
+        targetFeature = new AnnotationFeature(sourceProject, targetLayer, "value", "value",
+                CAS.TYPE_NAME_STRING);
+        targetRecommender = new Recommender("rec1", targetLayer);
+        targetRecommender.setFeature(targetFeature);
+        
+        when(gazeteerService.listGazeteers(sourceRecommender)).thenReturn(gazeteers());
+        
+        when(gazeteerService.getGazeteerFile(Mockito.any())).thenAnswer(invocation -> {
+            Gazeteer gaz = invocation.getArgument(0);
+            File gazFile = temporaryFolder.newFile(gaz.getId() + ".txt");
+            String data = "John\tVAL" + gaz.getId();
+            FileUtils.writeStringToFile(gazFile, data, UTF_8);
+            return gazFile;
+        });
+
+        when(recommendationService.listRecommenders(sourceProject))
+                .thenReturn(asList(sourceRecommender));
+        
+        when(recommendationService.getRecommender(any(), any()))
+                .thenReturn(Optional.of(targetRecommender));
+
+        sut = new GazeteerExporter(recommendationService, gazeteerService);
+    }
+
+    @Test
+    public void thatExportingWorks() throws Exception
+    {
+        // Export the project
+        ProjectExportRequest exportRequest = new ProjectExportRequest();
+        exportRequest.setProject(sourceProject);
+        ExportedProject exportedProject = new ExportedProject();
+        sut.exportData(exportRequest, exportedProject, temporaryFolder.getRoot());
+
+        // Import the project again
+        ArgumentCaptor<Gazeteer> gazeteerCaptor = ArgumentCaptor.forClass(Gazeteer.class);
+        doNothing().when(gazeteerService).createOrUpdateGazeteer(gazeteerCaptor.capture());
+
+        ArgumentCaptor<Gazeteer> gazeteerFileCaptor = ArgumentCaptor.forClass(Gazeteer.class);
+        doNothing().when(gazeteerService).importGazeteerFile(gazeteerFileCaptor.capture(), any());
+
+        ProjectImportRequest importRequest = new ProjectImportRequest(true);
+        ZipFile zipFile = mock(ZipFile.class);
+
+        sut.importData(importRequest, targetProject, exportedProject, zipFile);
+
+        assertThat(gazeteerCaptor.getAllValues())
+                .usingElementComparatorIgnoringFields("id", "project")
+                .containsExactlyInAnyOrderElementsOf(gazeteers());
+        
+        assertThat(gazeteerFileCaptor.getAllValues())
+                .usingElementComparatorIgnoringFields("id", "project")
+                .containsExactlyInAnyOrderElementsOf(gazeteers());
+    }
+
+    private List<Gazeteer> gazeteers() throws Exception
+    {
+        Gazeteer gaz1 = new Gazeteer("gaz1", sourceRecommender);
+        gaz1.setId(1l);
+
+        Gazeteer gaz2 = new Gazeteer("gaz2", sourceRecommender);
+        gaz2.setId(2l);
+
+        return asList(gaz1, gaz2);
+    }
+}

--- a/inception-imls-stringmatch/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/gazeteer/GazeteerServiceImplTest.java
+++ b/inception-imls-stringmatch/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/gazeteer/GazeteerServiceImplTest.java
@@ -23,10 +23,12 @@ import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.TOKENS;
 import static org.apache.uima.cas.CAS.TYPE_NAME_STRING;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.contentOf;
+import static org.assertj.core.api.Assertions.entry;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.util.Map;
 
 import javax.persistence.EntityManager;
 
@@ -155,6 +157,11 @@ public class GazeteerServiceImplTest
         assertThat(gazFile.exists()).isTrue();
         assertThat(contentOf(sut.getGazeteerFile(gaz)))
                 .isEqualToNormalizingNewlines(contentOf(input));
+     
+        // Check that imported file matches the expectations
+        Map<String, String> data = sut.readGazeteerFile(gaz);
+        assertThat(data).contains(entry("John", "PER"), entry("London", "LOC"),
+                entry("ACME", "ORG"));
         
         // Check that gazeteer file has been deleted along with the entity
         sut.deleteGazeteers(gaz);

--- a/inception-imls-stringmatch/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/gazeteer/GazeteerServiceImplTest.java
+++ b/inception-imls-stringmatch/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/gazeteer/GazeteerServiceImplTest.java
@@ -116,6 +116,12 @@ public class GazeteerServiceImplTest
         Gazeteer gaz1 = new Gazeteer("gaz1", rec1);
         sut.createOrUpdateGazeteer(gaz1);
 
+        assertThat(gaz1.getId())
+                .describedAs("After saving the gazetter to the DB, the ID should be set")
+                .isNotNull();
+        assertThat(sut.existsGazeteer(gaz1.getRecommender(), gaz1.getName()))
+                .describedAs("Gazeteers can be found using existsGazeteer")
+                .isTrue();
         assertThat(sut.listGazeteers(rec1))
                 .describedAs("All gazeteers that have been created are returned by listGazeteers")
                 .containsExactly(gaz1);
@@ -124,12 +130,12 @@ public class GazeteerServiceImplTest
         Gazeteer gaz2 = new Gazeteer("gaz2", rec1);
         sut.createOrUpdateGazeteer(gaz2);
 
-        assertThat(gaz1.getId())
-                .describedAs("After saving the gazetter to the DB, the ID should be set")
-                .isNotNull();
         assertThat(gaz2.getId())
                 .describedAs("After saving the gazetter to the DB, the ID should be set")
                 .isNotNull();
+        assertThat(sut.existsGazeteer(gaz2.getRecommender(), gaz2.getName()))
+                .describedAs("Gazeteers can be found using existsGazeteer")
+                .isTrue();
         assertThat(sut.listGazeteers(rec1))
                 .describedAs("All gazeteers that have been created are returned by listGazeteers")
                 .containsExactly(gaz1, gaz2);

--- a/inception-imls-stringmatch/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/gazeteer/GazeteerServiceImplTest.java
+++ b/inception-imls-stringmatch/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/gazeteer/GazeteerServiceImplTest.java
@@ -1,0 +1,159 @@
+package de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.gazeteer;
+
+import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.PROJECT_TYPE_ANNOTATION;
+import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.SPAN_TYPE;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.TOKENS;
+import static org.apache.uima.cas.CAS.TYPE_NAME_STRING;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.contentOf;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStream;
+
+import javax.persistence.EntityManager;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.dao.RepositoryProperties;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
+import de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.model.Gazeteer;
+
+@RunWith(SpringRunner.class) 
+@DataJpaTest
+@Transactional
+@EntityScan(
+        basePackages = {
+            "de.tudarmstadt.ukp.inception",
+            "de.tudarmstadt.ukp.clarin.webanno.model"
+})
+public class GazeteerServiceImplTest
+{
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Autowired
+    private TestEntityManager testEntityManager;
+
+    private GazeteerServiceImpl sut;
+
+    private Project project;
+    private AnnotationLayer spanLayer;
+    private AnnotationFeature spanFeat1;
+    private Recommender rec1;
+    
+    @Before
+    public void setup()
+    {
+        EntityManager em = testEntityManager.getEntityManager();
+        
+        RepositoryProperties repoProps = new RepositoryProperties();
+        repoProps.setPath(temporaryFolder.getRoot());
+        
+        sut = new GazeteerServiceImpl(repoProps, em);
+        
+        project = new Project();
+        project.setName("test");
+        project.setMode(PROJECT_TYPE_ANNOTATION);
+        em.persist(project);
+        
+        spanLayer = new AnnotationLayer("span", "span", SPAN_TYPE, project, false, TOKENS);
+        em.persist(spanLayer);
+
+        spanFeat1 = new AnnotationFeature(project, spanLayer, "feat1", "feat1", TYPE_NAME_STRING);
+        em.persist(spanFeat1);
+        
+        rec1 = new Recommender("rec1", spanLayer);
+        rec1.setFeature(spanFeat1);
+        em.persist(rec1);
+    }
+
+    @Test
+    public void thatCreateListAndDeleteGazeteerWorks() throws Exception
+    {
+        // Add first gazeteer
+        Gazeteer gaz1 = new Gazeteer("gaz1", rec1);
+        sut.createOrUpdateGazeteer(gaz1);
+
+        assertThat(sut.listGazeteers(rec1)).containsExactly(gaz1);
+
+        // Add second gazeteer
+        Gazeteer gaz2 = new Gazeteer("gaz2", rec1);
+        sut.createOrUpdateGazeteer(gaz2);
+
+        assertThat(gaz1.getId()).isNotNull();
+        assertThat(gaz2.getId()).isNotNull();
+        assertThat(sut.listGazeteers(rec1)).containsExactly(gaz1, gaz2);
+        
+        // Remove first gazeteer
+        sut.deleteGazeteers(gaz1);
+        
+        assertThat(sut.listGazeteers(rec1)).containsExactly(gaz2);
+    }
+    
+    @Test
+    public void thatUpdatingGazeteerWorks() throws Exception
+    {
+        Gazeteer gaz = new Gazeteer("foo", rec1);
+        sut.createOrUpdateGazeteer(gaz);
+
+        assertThat(sut.listGazeteers(rec1)).extracting(Gazeteer::getName).containsExactly("foo");
+        
+        gaz.setName("bar");
+        sut.createOrUpdateGazeteer(gaz);
+        
+        assertThat(sut.listGazeteers(rec1)).extracting(Gazeteer::getName).containsExactly("bar");
+    }
+    
+    @Test
+    public void thatImportGazeteerWorks() throws Exception
+    {
+        Gazeteer gaz = new Gazeteer("gaz", rec1);
+        sut.createOrUpdateGazeteer(gaz);
+        
+        File input = new File("src/test/resources/gazeteers/gaz1.txt");
+        
+        // Check that import works
+        try (InputStream is = new FileInputStream(input)) {
+            sut.importGazeteerFile(gaz, is);
+        }
+        
+        File gazFile = sut.getGazeteerFile(gaz);
+        assertThat(gazFile.exists()).isTrue();
+        assertThat(contentOf(sut.getGazeteerFile(gaz)))
+                .isEqualToNormalizingNewlines(contentOf(input));
+        
+        // Check that gazeteer file has been deleted along with the entity
+        sut.deleteGazeteers(gaz);
+        
+        assertThat(gazFile.exists()).isFalse();
+    }
+    
+    @After
+    public void tearDown() throws Exception
+    {
+        testEntityManager.clear();
+    }
+    
+    @SpringBootConfiguration
+    @EnableAutoConfiguration 
+    public static class SpringConfig {
+        
+    }
+}

--- a/inception-imls-stringmatch/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/gazeteer/GazeteerServiceImplTest.java
+++ b/inception-imls-stringmatch/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/gazeteer/GazeteerServiceImplTest.java
@@ -59,8 +59,8 @@ import de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.model.Gazete
 @Transactional
 @EntityScan(
         basePackages = {
-            "de.tudarmstadt.ukp.inception",
-            "de.tudarmstadt.ukp.clarin.webanno.model"
+                "de.tudarmstadt.ukp.inception",
+                "de.tudarmstadt.ukp.clarin.webanno.model"
 })
 public class GazeteerServiceImplTest
 {
@@ -102,6 +102,12 @@ public class GazeteerServiceImplTest
         rec1.setFeature(spanFeat1);
         em.persist(rec1);
     }
+    
+    @After
+    public void tearDown() throws Exception
+    {
+        testEntityManager.clear();
+    }
 
     @Test
     public void thatCreateListAndDeleteGazeteerWorks() throws Exception
@@ -110,20 +116,30 @@ public class GazeteerServiceImplTest
         Gazeteer gaz1 = new Gazeteer("gaz1", rec1);
         sut.createOrUpdateGazeteer(gaz1);
 
-        assertThat(sut.listGazeteers(rec1)).containsExactly(gaz1);
+        assertThat(sut.listGazeteers(rec1))
+                .describedAs("All gazeteers that have been created are returned by listGazeteers")
+                .containsExactly(gaz1);
 
         // Add second gazeteer
         Gazeteer gaz2 = new Gazeteer("gaz2", rec1);
         sut.createOrUpdateGazeteer(gaz2);
 
-        assertThat(gaz1.getId()).isNotNull();
-        assertThat(gaz2.getId()).isNotNull();
-        assertThat(sut.listGazeteers(rec1)).containsExactly(gaz1, gaz2);
+        assertThat(gaz1.getId())
+                .describedAs("After saving the gazetter to the DB, the ID should be set")
+                .isNotNull();
+        assertThat(gaz2.getId())
+                .describedAs("After saving the gazetter to the DB, the ID should be set")
+                .isNotNull();
+        assertThat(sut.listGazeteers(rec1))
+                .describedAs("All gazeteers that have been created are returned by listGazeteers")
+                .containsExactly(gaz1, gaz2);
         
         // Remove first gazeteer
         sut.deleteGazeteers(gaz1);
         
-        assertThat(sut.listGazeteers(rec1)).containsExactly(gaz2);
+        assertThat(sut.listGazeteers(rec1))
+                .describedAs("A deleted gazeteer no longer returned by listGazeteers")
+                .containsExactly(gaz2);
     }
     
     @Test
@@ -132,12 +148,18 @@ public class GazeteerServiceImplTest
         Gazeteer gaz = new Gazeteer("foo", rec1);
         sut.createOrUpdateGazeteer(gaz);
 
-        assertThat(sut.listGazeteers(rec1)).extracting(Gazeteer::getName).containsExactly("foo");
+        assertThat(sut.listGazeteers(rec1))
+                .describedAs("Name of the gazeteer has the initial value")
+                .extracting(Gazeteer::getName)
+                .containsExactly("foo");
         
         gaz.setName("bar");
         sut.createOrUpdateGazeteer(gaz);
         
-        assertThat(sut.listGazeteers(rec1)).extracting(Gazeteer::getName).containsExactly("bar");
+        assertThat(sut.listGazeteers(rec1))
+                .describedAs("Name of the gazeteer has the updated value")
+                .extracting(Gazeteer::getName)
+                .containsExactly("bar");
     }
     
     @Test
@@ -154,30 +176,29 @@ public class GazeteerServiceImplTest
         }
         
         File gazFile = sut.getGazeteerFile(gaz);
-        assertThat(gazFile.exists()).isTrue();
+        assertThat(gazFile.exists())
+                .describedAs("Gazeteer data has been imported")
+                .isTrue();
         assertThat(contentOf(sut.getGazeteerFile(gaz)))
                 .isEqualToNormalizingNewlines(contentOf(input));
      
         // Check that imported file matches the expectations
         Map<String, String> data = sut.readGazeteerFile(gaz);
-        assertThat(data).contains(entry("John", "PER"), entry("London", "LOC"),
-                entry("ACME", "ORG"));
+        assertThat(data)
+                .describedAs("Gazeteer data file content can be read")
+                .contains(entry("John", "PER"), entry("London", "LOC"), entry("ACME", "ORG"));
         
         // Check that gazeteer file has been deleted along with the entity
         sut.deleteGazeteers(gaz);
         
-        assertThat(gazFile.exists()).isFalse();
-    }
-    
-    @After
-    public void tearDown() throws Exception
-    {
-        testEntityManager.clear();
+        assertThat(gazFile.exists())
+                .describedAs("Gazeteer data has been deleted")
+                .isFalse();
     }
     
     @SpringBootConfiguration
     @EnableAutoConfiguration 
     public static class SpringConfig {
-        
+        // No content
     }
 }

--- a/inception-imls-stringmatch/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/gazeteer/GazeteerServiceImplTest.java
+++ b/inception-imls-stringmatch/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/gazeteer/GazeteerServiceImplTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2019
+ * Ubiquitous Knowledge Processing (UKP) Lab
+ * Technische Universität Darmstadt
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.gazeteer;
 
 import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.PROJECT_TYPE_ANNOTATION;

--- a/inception-imls-stringmatch/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/trie/TrieTest.java
+++ b/inception-imls-stringmatch/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/trie/TrieTest.java
@@ -49,8 +49,9 @@ public class TrieTest
             i++;
         }
 
-        assertThat(sut.keys()).containsExactlyInAnyOrderElementsOf(keys);
         assertThat(sut.size()).isEqualTo(keys.size());
+        assertThat(sut.keys()).containsExactlyInAnyOrderElementsOf(keys);
+        assertThat(sut.keyIterator()).containsExactlyInAnyOrderElementsOf(keys);
         
         for (String key : keys) {
             assertThat(sut.getNode(key)).isNotNull();

--- a/inception-imls-stringmatch/src/test/resources/gazeteers/gaz1.txt
+++ b/inception-imls-stringmatch/src/test/resources/gazeteers/gaz1.txt
@@ -1,1 +1,3 @@
 PER	John
+LOC	London
+ORG	ACME

--- a/inception-imls-stringmatch/src/test/resources/gazeteers/gaz1.txt
+++ b/inception-imls-stringmatch/src/test/resources/gazeteers/gaz1.txt
@@ -1,3 +1,5 @@
-PER	John
-LOC	London
-ORG	ACME
+# This is a comment
+John	PER
+London	LOC
+London	GPE
+ACME	ORG

--- a/inception-imls-stringmatch/src/test/resources/gazeteers/gaz1.txt
+++ b/inception-imls-stringmatch/src/test/resources/gazeteers/gaz1.txt
@@ -1,0 +1,1 @@
+PER	John

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderEditorPanel.html
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderEditorPanel.html
@@ -23,7 +23,7 @@
       <div class="panel-heading">
         <h3 class="panel-title"><wicket:message key="details"/></h3>
       </div>
-      <div class="panel-body">
+      <div class="scrolling panel-body">
         <div class="col-sm-12 form-horizontal">
           <div class="form-group" wicket:enclosure="name">
             <label class="col-sm-3 control-label" wicket:for="name">

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderEditorPanel.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderEditorPanel.java
@@ -323,8 +323,7 @@ public class RecommenderEditorPanel
 
         form.add(new LambdaAjaxLink(MID_DELETE, this::actionDelete)
                 .onConfigure(_this -> _this.setVisible(form.getModelObject().getId() != null)));
-        form.add(new LambdaAjaxLink(MID_CANCEL, this::actionCancel)
-                .onConfigure(_this -> _this.setVisible(form.getModelObject().getId() == null)));
+        form.add(new LambdaAjaxLink(MID_CANCEL, this::actionCancel));
 
         form.add(traitsContainer = new WebMarkupContainer(MID_TRAITS_CONTAINER));
         traitsContainer.setOutputMarkupPlaceholderTag(true);
@@ -390,6 +389,7 @@ public class RecommenderEditorPanel
         ) {
             autoGenerateNameCheckBox.setModelObject(true);
             autoUpdateName(null, nameField, recommenderModel.getObject());
+            statesForTraining.setObject(getAllPossibleDocumentStates());
         }
         else {
             autoGenerateNameCheckBox.setModelObject(false);
@@ -449,10 +449,10 @@ public class RecommenderEditorPanel
 
         recommendationService.createOrUpdateRecommender(recommender);
 
-        // Reset selection after saving
-        recommenderModel.setObject(null);
-        statesForTraining.setObject(getAllPossibleDocumentStates());
-
+        // Not clearing the selection / editor panel here because saving the recommender may
+        // cause additional UI elements to appear (e.g. options to upload pre-trained models
+        // which cannot be uploaded/saved before the recommender has been persisted).
+        
         // Reload whole page because master panel also needs to be reloaded.
         aTarget.add(getPage());
     }

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/TrainingTask.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/TrainingTask.java
@@ -125,7 +125,6 @@ public class TrainingTask
                 RecommenderContext context = recommendationService.getContext(user, recommender);
                 RecommendationEngineFactory factory = recommendationService
                     .getRecommenderFactory(recommender);
-                RecommendationEngine recommendationEngine = factory.build(recommender);
 
                 try {
                     List<CAS> cassesForTraining = casses.get()
@@ -139,11 +138,13 @@ public class TrainingTask
                             user.getUsername(), recommender.getName(), cassesForTraining.size(),
                             casses.get().size());
 
+                    RecommendationEngine recommendationEngine = factory.build(recommender);
                     recommendationEngine.train(context, cassesForTraining);
+                    
                     log.info("[{}][{}]: Training complete ({} ms)", user.getUsername(),
                             recommender.getName(), (System.currentTimeMillis() - startTime));
                 }
-                catch (Exception e) {
+                catch (Throwable e) {
                     log.info("[{}][{}]: Training failed ({} ms)", user.getUsername(),
                             recommender.getName(), (System.currentTimeMillis() - startTime), e);
                 }

--- a/inception-support/marker-wicket-module
+++ b/inception-support/marker-wicket-module
@@ -1,0 +1,1 @@
+Marker file which activates the profile "wicket-module" from the parent POM.

--- a/inception-support/pom.xml
+++ b/inception-support/pom.xml
@@ -46,6 +46,11 @@
       <artifactId>wicket-util</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.googlecode.wicket-jquery-ui</groupId>
+      <artifactId>wicket-jquery-ui</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
     </dependency>

--- a/inception-support/pom.xml
+++ b/inception-support/pom.xml
@@ -45,10 +45,6 @@
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-util</artifactId>
     </dependency>
-    <dependency>
-      <groupId>com.googlecode.wicket-jquery-ui</groupId>
-      <artifactId>wicket-jquery-ui</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>org.springframework</groupId>


### PR DESCRIPTION
**What's in the PR**
- [x] Add ability to imported / download gazeteers to the String recommender traits UI
- [x] Created a new DB table to manage gazeteers
- [x] Implemented unit tests for the new GazeteerService
- [x] Added documentation on gazeteers
- [x] Allow RecommenderEditorPanel to scroll its content to allow for large traits editors
- [x] Expanded scope of the try/catch clauses in PredictionTask and TrainingTask to cover any exceptions that might be thrown during recommender initialization
- [x] Handle importing two Gazeteers by the same name
- [x] Handle Gazeteer containing multiple labels for the same text
- [x] Remove `setOutputMarkupPlaceholder` on `upload` field 
- [x] Support Gazeteers in project export/import

**How to test manually**
* Create a project with a string recommender
* Import a text
* Create a simple gazeteer file containing label/word pairs separated by tabs for some of the words (or multi-words) in the text
* Import the gazeteer into the string recommender via the recommender traits panel
* Go to the annotations screen and observe suggestions
* Delete gazeteer (to see that this also works)
* Export/re-import a project with Gazeteers and see if they are still there and work in the re-imported project

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [x] PR updates documentation