### PR TITLE
#922 - External recommender fails training when giving no casses

### DIFF
--- a/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.java
+++ b/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.java
@@ -1061,8 +1061,8 @@ public class ActiveLearningSidebar
             // Update visibility in case the annotation where the feature was set overlaps with 
             // any suggestions that need to be hidden now.
             PredictionTask.calculateVisibility(learningRecordService, annotationService,
-                    getAnnotationPage().getEditorCas(), state.getUser().getUsername(), aLayer,
-                    alState.getSuggestions(), state.getWindowBeginOffset(),
+                    getAnnotationPage().getEditorCas().getCas(), state.getUser().getUsername(),
+                    aLayer, alState.getSuggestions(), state.getWindowBeginOffset(),
                     state.getWindowEndOffset());
     
             // Update the suggestion in the AL sidebar, but do not jump or touch the right

--- a/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommender.java
+++ b/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommender.java
@@ -302,4 +302,10 @@ public class ExternalRecommender
     {
         return Optional.empty();
     }
+    
+    @Override
+    public boolean requiresTraining()
+    {
+        return traits.isTrainable();
+    }
 }

--- a/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderTraits.java
+++ b/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderTraits.java
@@ -25,6 +25,7 @@ public class ExternalRecommenderTraits
     private static final long serialVersionUID = -3109239605741337123L;
 
     private String remoteUrl;
+    private boolean trainable;
 
     public String getRemoteUrl()
     {
@@ -34,5 +35,15 @@ public class ExternalRecommenderTraits
     public void setRemoteUrl(String aRemoteUrl)
     {
         remoteUrl = aRemoteUrl;
+    }
+
+    public boolean isTrainable()
+    {
+        return trainable;
+    }
+
+    public void setTrainable(boolean aTrainable)
+    {
+        trainable = aTrainable;
     }
 }

--- a/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderTraitsEditor.html
+++ b/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderTraitsEditor.html
@@ -31,6 +31,16 @@
         </div>
       </div>
     </div>
+    <div class="form-group" wicket:enclosure="trainable">
+      <div class="col-sm-offset-3 col-sm-9">
+        <div class="checkbox">
+          <label wicket:for="trainable">
+            <input wicket:id="trainable" type="checkbox"/>
+            <wicket:label key="trainable"/>
+          </label>
+        </div>
+      </div>  
+    </div>
   </form>
 </wicket:panel>
 </html>

--- a/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderTraitsEditor.java
+++ b/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderTraitsEditor.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.recommendation.imls.external;
 
+import org.apache.wicket.markup.html.form.CheckBox;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.markup.html.panel.Panel;
@@ -62,6 +63,9 @@ public class ExternalRecommenderTraitsEditor
         remoteUrl.setRequired(true);
         remoteUrl.add(new UrlValidator());
         form.add(remoteUrl);
+
+        CheckBox trainable = new CheckBox("trainable");
+        form.add(trainable);
 
         add(form);
     }

--- a/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderTraitsEditor.properties
+++ b/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderTraitsEditor.properties
@@ -15,3 +15,4 @@
 # limitations under the License.
 
 remoteUrl=Remote URL
+trainable=Trainable

--- a/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/recommender/RecommendationEngine.java
+++ b/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/recommender/RecommendationEngine.java
@@ -83,4 +83,15 @@ public interface RecommendationEngine {
     {
         return Optional.of("score");
     }
+    
+    /**
+     * Whether or not this engine supports training. If training is not supported, the call to
+     * {@link #train} should be skipped and {@link #predict} should be called immediately. Note
+     * that the engine cannot expect a model to be present in the {@link RecommenderContext} if
+     * training is skipped - this is meant only for engines that use pre-trained models.
+     */
+    default boolean requiresTraining()
+    {
+        return true;
+    }
 }

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/render/RecommendationSpanRenderer.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/render/RecommendationSpanRenderer.java
@@ -111,8 +111,9 @@ public class RecommendationSpanRenderer
         String color = aColoringStrategy.getColor(null, null);
         String bratTypeName = TypeUtil.getUiTypeName(typeAdapter);
 
-        PredictionTask.calculateVisibility(learningRecordService, aAnnotationService, aJcas,
-                aState.getUser().getUsername(), layer, groups, windowBegin, windowEnd);
+        PredictionTask.calculateVisibility(learningRecordService, aAnnotationService,
+                aJcas.getCas(), aState.getUser().getUsername(), layer, groups, windowBegin,
+                windowEnd);
 
         Preferences pref = recommendationService.getPreferences(aState.getUser(),
                 layer.getProject());

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/PredictionTask.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/PredictionTask.java
@@ -40,13 +40,19 @@ import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.multimap.ArrayListValuedHashMap;
 import org.apache.uima.UIMAException;
 import org.apache.uima.cas.CAS;
+import org.apache.uima.cas.CASException;
 import org.apache.uima.cas.Feature;
 import org.apache.uima.cas.Type;
+import org.apache.uima.cas.admin.CASMgr;
+import org.apache.uima.cas.impl.CASCompleteSerializer;
+import org.apache.uima.cas.impl.Serialization;
 import org.apache.uima.cas.text.AnnotationFS;
 import org.apache.uima.fit.util.CasUtil;
 import org.apache.uima.fit.util.FSUtil;
 import org.apache.uima.fit.util.JCasUtil;
-import org.apache.uima.jcas.JCas;
+import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
+import org.apache.uima.util.CasCreationUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -104,8 +110,11 @@ public class PredictionTask
         Predictions model = new Predictions(project, getUser());
         List<SourceDocument> documents = documentService.listSourceDocuments(project);
 
+        log.info("[{}]: Starting prediction...", user.getUsername());
+        long startTime = System.currentTimeMillis();
         nextDocument: for (SourceDocument document : documents) {
-            Optional<JCas> jCas = Optional.empty();
+            Optional<CAS> originalCas = Optional.empty();
+            Optional<CAS> predictionCas = Optional.empty();
             nextLayer: for (AnnotationLayer layer : annoService.listAnnotationLayer(project)) {
                 if (!layer.isEnabled()) {
                     continue nextLayer;
@@ -115,6 +124,7 @@ public class PredictionTask
                     .getActiveRecommenders(user, layer);
 
                 nextRecommender: for (Recommender r : recommenders) {
+                    
                     // Make sure we have the latest recommender config from the DB - the one from
                     // the active recommenders list may be outdated
                     Recommender recommender;
@@ -150,10 +160,10 @@ public class PredictionTask
                     // We lazily load the CAS only at this point because that allows us to skip
                     // loading the CAS entirely if there is no enabled layer or recommender.
                     // If the CAS cannot be loaded, then we skip to the next document.
-                    if (!jCas.isPresent()) {
+                    if (!originalCas.isPresent()) {
                         try {
-                            jCas = Optional.of(documentService.readAnnotationCas(document,
-                                    user.getUsername()));
+                            originalCas = Optional.of(documentService.readAnnotationCas(document,
+                                    user.getUsername()).getCas());
                         }
                         catch (IOException e) {
                             log.error("Cannot read annotation CAS for user [{}] of document "
@@ -163,7 +173,7 @@ public class PredictionTask
                             continue nextDocument;
                         }
                         try {
-                            annoService.upgradeCasIfRequired(jCas.get().getCas(), document,
+                            annoService.upgradeCasIfRequired(originalCas.get(), document,
                                     user.getUsername());
                         }
                         catch (UIMAException | IOException e) {
@@ -173,10 +183,20 @@ public class PredictionTask
                                     project.getName(), project.getId(), e);
                             continue nextDocument;
                         }
+                        try {
+                            predictionCas = Optional.of(cloneCAS(originalCas.get()));
+                        }
+                        catch (UIMAException e) {
+                            log.error("Cannot clone annotation CAS for user [{}] of document "
+                                    + "[{}]({}) in project [{}]({}) - skipping document",
+                                    user.getUsername(), document.getName(), document.getId(),
+                                    project.getName(), project.getId(), e);
+                            continue nextDocument;
+                        }
                     }
                     
                     try {
-                        recommendationEngine.predict(ctx, jCas.get().getCas());
+                        recommendationEngine.predict(ctx, predictionCas.get());
                     }
                     catch (Throwable e) {
                         log.error("Error applying recommender [{}]({}) for user [{}] to document "
@@ -190,7 +210,7 @@ public class PredictionTask
                     String predictedTypeName = recommendationEngine.getPredictedType();
                     String predictedFeatureName = recommendationEngine.getPredictedFeature();
                     Optional<String> scoreFeatureName = recommendationEngine.getScoreFeature();
-                    Type predictionType = getAnnotationType(jCas.get().getCas(), predictedTypeName);
+                    Type predictionType = getAnnotationType(predictionCas.get(), predictedTypeName);
                     Feature labelFeature = predictionType
                             .getFeatureByBaseName(predictedFeatureName);
                     Optional<Feature> scoreFeature = scoreFeatureName
@@ -199,26 +219,43 @@ public class PredictionTask
                     // Extract the suggestions from the data which the recommender has written into
                     // the CAS
                     List<AnnotationSuggestion> predictions = extractSuggestions(user,
-                            jCas.get().getCas(), predictionType, labelFeature, scoreFeature,
+                            predictionCas.get(), predictionType, labelFeature, scoreFeature,
                             document, recommender);
                     
-                    // Calculate the visbility of the suggestions
+                    // Calculate the visbility of the suggestions. This happens via the original
+                    // CAS which contains only the manually created annotations and *not* the
+                    // suggestions.
                     Collection<SuggestionGroup> groups = SuggestionGroup.group(predictions);
-                    calculateVisibility(learningRecordService, annoService, jCas.get(),
+                    calculateVisibility(learningRecordService, annoService, originalCas.get(),
                             getUser().getUsername(), layer, groups, 0,
-                            jCas.get().getDocumentText().length());
+                            originalCas.get().getDocumentText().length());
                     
                     model.putPredictions(layer.getId(), predictions);
 
                     // In order to just extract the annotations for a single recommender, each
                     // recommender undoes the changes applied in `recommendationEngine.predict`
 
-                    removePredictions(jCas.get().getCas(), predictionType);
+                    removePredictions(predictionCas.get(), predictionType);
                 }
             }
         }
+        log.info("[{}]: Prediction complete ({} ms)", user.getUsername(),
+                (System.currentTimeMillis() - startTime));
 
         recommendationService.putIncomingPredictions(getUser(), project, model);
+    }
+    
+    private CAS cloneCAS(CAS aCAS) throws ResourceInitializationException, CASException
+    {
+        CAS clone = CasCreationUtils.createCas((TypeSystemDescription) null, null, null);
+        
+        CASCompleteSerializer ser = Serialization.serializeCASComplete((CASMgr) aCAS);
+        Serialization.deserializeCASComplete(ser, (CASMgr) clone);
+        
+        // Make sure JCas is properly initialized too
+        clone.getJCas();
+        
+        return clone;
     }
 
     private List<AnnotationSuggestion> extractSuggestions(User aUser, CAS aCas, Type predictionType,
@@ -281,13 +318,13 @@ public class PredictionTask
      * Goes through all AnnotationObjects and determines the visibility of each one
      */
     public static void calculateVisibility(LearningRecordService aLearningRecordService,
-            AnnotationSchemaService aAnnotationService, JCas aJcas, String aUser,
+            AnnotationSchemaService aAnnotationService, CAS aCas, String aUser,
             AnnotationLayer aLayer, Collection<SuggestionGroup> aRecommendations, int aWindowBegin,
             int aWindowEnd)
     {
         // Collect all annotations of the given layer within the view window
-        Type type = CasUtil.getType(aJcas.getCas(), aLayer.getName());
-        List<AnnotationFS> annotationsInWindow = select(aJcas.getCas(), type).stream()
+        Type type = CasUtil.getType(aCas, aLayer.getName());
+        List<AnnotationFS> annotationsInWindow = select(aCas, type).stream()
                 .filter(fs -> aWindowBegin <= fs.getBegin() && fs.getEnd() <= aWindowEnd)
                 .collect(toList());
         

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/TrainingTask.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/TrainingTask.java
@@ -125,7 +125,6 @@ public class TrainingTask
                 RecommenderContext context = recommendationService.getContext(user, recommender);
                 RecommendationEngineFactory factory = recommendationService
                     .getRecommenderFactory(recommender);
-                RecommendationEngine recommendationEngine = factory.build(recommender);
 
                 try {
                     List<CAS> cassesForTraining = casses.get()
@@ -135,13 +134,22 @@ public class TrainingTask
                             .filter(e -> containsTargetAnnotation(recommender, e.cas))
                             .map(e -> e.cas)
                             .collect(Collectors.toList());
-                    log.info("[{}][{}]: Training model on [{}] out of [{}] documents ...",
-                            user.getUsername(), recommender.getName(), cassesForTraining.size(),
-                            casses.get().size());
 
-                    recommendationEngine.train(context, cassesForTraining);
-                    log.info("[{}][{}]: Training complete ({} ms)", user.getUsername(),
-                            recommender.getName(), (System.currentTimeMillis() - startTime));
+                    if (!cassesForTraining.isEmpty()) {
+                        log.info("[{}][{}]: Training model on [{}] out of [{}] documents ...",
+                                user.getUsername(), recommender.getName(), cassesForTraining.size(),
+                                casses.get().size());
+                        
+                        RecommendationEngine recommendationEngine = factory.build(recommender);
+                        recommendationEngine.train(context, cassesForTraining);
+                        
+                        log.info("[{}][{}]: Training complete ({} ms)", user.getUsername(),
+                                recommender.getName(), (System.currentTimeMillis() - startTime));
+                    }
+                    else {
+                        log.info("[{}][{}]: There are annotations available to train on",
+                                user.getUsername(), recommender.getName());
+                    }
                 }
                 catch (Exception e) {
                     log.info("[{}][{}]: Training failed ({} ms)", user.getUsername(),

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/TrainingTask.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/TrainingTask.java
@@ -127,6 +127,17 @@ public class TrainingTask
                     .getRecommenderFactory(recommender);
 
                 try {
+                    RecommendationEngine recommendationEngine = factory.build(recommender);
+                    
+                    // If the engine does not require/support training, then we mark the context
+                    // as ready for prediction and skip the training step
+                    if (!recommendationEngine.requiresTraining()) {
+                        log.info("[{}][{}]: Engine does not require training",
+                                user.getUsername(), recommender.getName());
+                        context.markAsReadyForPrediction();
+                        continue;
+                    }
+                    
                     List<CAS> cassesForTraining = casses.get()
                             .stream()
                             .filter(e -> !recommender.getStatesIgnoredForTraining()
@@ -140,7 +151,6 @@ public class TrainingTask
                                 user.getUsername(), recommender.getName(), cassesForTraining.size(),
                                 casses.get().size());
                         
-                        RecommendationEngine recommendationEngine = factory.build(recommender);
                         recommendationEngine.train(context, cassesForTraining);
                         
                         log.info("[{}][{}]: Training complete ({} ms)", user.getUsername(),


### PR DESCRIPTION
**What's in the PR**
- Skip training if there is no data to train on and provide a proper log message
- Construct the recommender within the try/catch block to allow catching problems that occur in the recommender construction

**How to test manually**
* Try using an external recommender on unannotated documents

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
