### PR TITLE
#928 - Remember layer default setting missing in application.properties

### DIFF
--- a/inception-app-webapp/src/main/resources/application.properties
+++ b/inception-app-webapp/src/main/resources/application.properties
@@ -18,6 +18,7 @@ debug.casDoctor.forceReleaseBehavior=false
 ui.brat.sentences.number=5
 ui.brat.singleClickSelection=true
 ui.brat.autoScroll=false
+ui.brat.rememberLayer=true
 
 # ===================================================================
 # Spring Boot Properties


### PR DESCRIPTION
**What's in the PR**
- Add default setting for remember layer turning it ON

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
