### PR TITLE
#931 - Training/prediction runs twice when document is opened

### DIFF
--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
@@ -298,17 +298,16 @@ public class RecommendationServiceImpl
         return settings;
     }
 
+    /**
+     * This is called whenever a document is opened (because of the implicit CAS upgrade and saving
+     * of the CAS that happens when a document is opened) as well as when any updates to annotations
+     * are made. Therefore, we do not need an extra event listener for {@link DocumentOpenedEvent}
+     */
     @EventListener
     public void afterAnnotationUpdate(AfterAnnotationUpdateEvent aEvent)
     {
         triggerTrainingAndClassification(aEvent.getDocument().getUser(),
                 aEvent.getDocument().getProject());
-    }
-
-    @EventListener
-    public void onDocumentOpen(DocumentOpenedEvent aEvent)
-    {
-        triggerTrainingAndClassification(aEvent.getUser(), aEvent.getDocument().getProject());
     }
 
     @EventListener


### PR DESCRIPTION
**What's in the PR**
- Remove scheduling of prediction cycle on DocumentOpened event because when opening a document, also an AfterAnnotationUpdateEvent is generated and we already react to that

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
