### PR TITLE
#936 - maven-enforcer-plugin enforces wrong Java version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -873,7 +873,7 @@
             <configuration>
               <rules>
                 <requireJavaVersion>
-                  <version>[9.0,)</version>
+                  <version>[1.8.0,)</version>
                 </requireJavaVersion>
               </rules>
             </configuration>


### PR DESCRIPTION
**What's in the PR**
* Setting the version maven enforces to `1.8`

**How to test manually**
* Build INCEpTION on the command line

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
