### PR TITLE
#939 - PDF editor loads wrong PDF

### DIFF
--- a/inception-pdf-editor/src/main/js/pdfanno/src/page/pdf/PDFAnnoPage.js
+++ b/inception-pdf-editor/src/main/js/pdfanno/src/page/pdf/PDFAnnoPage.js
@@ -583,7 +583,14 @@ export default class PDFAnnoPage {
    * @memberof PDFAnnoPage
    */
   loadPdf (url) {
+// BEGIN INCEpTION EXTENSION - #939 - PDF editor loads wrong PDF
+/*
     return fetch(url, {
+*/
+    // add noise to the query parameters so caching is prevented
+    var antiCacheUrl= url + "&time=" + new Date().getTime();
+    return fetch(antiCacheUrl, {
+// END INCEpTION EXTENSION
       method : 'GET',
       mode   : 'cors'
     }).then(response => {
@@ -611,7 +618,14 @@ export default class PDFAnnoPage {
    * @memberof PDFAnnoPage
    */
   loadPdftxt (url) {
+// BEGIN INCEpTION EXTENSION - #939 - PDF editor loads wrong PDF
+/*
     return fetch(url, {
+*/
+    // add noise to the query parameters so caching is prevented
+    var antiCacheUrl= url + "&time=" + new Date().getTime();
+    return fetch(antiCacheUrl, {
+// END INCEpTION EXTENSION
       method : 'GET',
       mode   : 'cors'
     }).then(response => {


### PR DESCRIPTION
**What's in the PR**
* remove caching on GET request for PDF file and pdftxt which fixes loading wrong PDF files

**How to test manually**
* open a PDF file
* restart INCEpTION
* open another PDF file

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
