### PR TITLE
#277 - Import/export external search settings when importing/exporting project

### DIFF
--- a/inception-external-search-core/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/config/ExternalSearchAutoConfiguration.java
+++ b/inception-external-search-core/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/config/ExternalSearchAutoConfiguration.java
@@ -30,6 +30,7 @@ import de.tudarmstadt.ukp.inception.externalsearch.ExternalSearchProviderRegistr
 import de.tudarmstadt.ukp.inception.externalsearch.ExternalSearchProviderRegistryImpl;
 import de.tudarmstadt.ukp.inception.externalsearch.ExternalSearchService;
 import de.tudarmstadt.ukp.inception.externalsearch.ExternalSearchServiceImpl;
+import de.tudarmstadt.ukp.inception.externalsearch.exporter.DocumentRepositoryExporter;
 
 /**
  * Provides all back-end Spring beans for the external search functionality.
@@ -50,5 +51,12 @@ public class ExternalSearchAutoConfiguration
             @Lazy @Autowired(required = false) List<ExternalSearchProviderFactory> aProviders)
     {
         return new ExternalSearchProviderRegistryImpl(aProviders);
+    }
+    
+    @Bean
+    public DocumentRepositoryExporter documentRepositoryExporter(
+            @Autowired ExternalSearchService aSearchService)
+    {
+        return new DocumentRepositoryExporter(aSearchService);
     }
 }

--- a/inception-external-search-core/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/exporter/DocumentRepositoryExporter.java
+++ b/inception-external-search-core/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/exporter/DocumentRepositoryExporter.java
@@ -25,7 +25,6 @@ import java.util.zip.ZipFile;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExportRequest;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExporter;
@@ -33,12 +32,19 @@ import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectImportRequest;
 import de.tudarmstadt.ukp.clarin.webanno.export.model.ExportedProject;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.inception.externalsearch.ExternalSearchService;
+import de.tudarmstadt.ukp.inception.externalsearch.config.ExternalSearchAutoConfiguration;
 import de.tudarmstadt.ukp.inception.externalsearch.model.DocumentRepository;
 import de.tudarmstadt.ukp.inception.log.exporter.LoggedEventExporter;
 
-@Component
-public class DocumentRepositoryExporter implements ProjectExporter {
-    
+/**
+ * <p>
+ * This class is exposed as a Spring Component via
+ * {@link ExternalSearchAutoConfiguration#documentRepositoryExporter(ExternalSearchService)}.
+ * </p>
+ */
+public class DocumentRepositoryExporter
+    implements ProjectExporter
+{
     private static final String KEY = "external_search";
     private static final Logger LOG = LoggerFactory.getLogger(LoggedEventExporter.class);
     
@@ -73,7 +79,7 @@ public class DocumentRepositoryExporter implements ProjectExporter {
     
     @Override
     public void importData(ProjectImportRequest aRequest, Project aProject,
-                           ExportedProject aExProject, ZipFile aZip)
+            ExportedProject aExProject, ZipFile aZip)
     {
         ExportedDocumentRepository[] exportedDocumentRepositories = aExProject
                 .getArrayProperty(KEY, ExportedDocumentRepository.class);


### PR DESCRIPTION
**What's in the PR**
- Instantiate exporter component via auto-configuration and only if external search is at all enabled

**How to test manually**
* Start up INCEpTION without external search being enabled (default configuration)

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
