### PR TITLE
#966 - Annotations not starting/ending at Token boundaries cause OpenNlpNerRecommender to crash

### DIFF
--- a/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/ner/OpenNlpNerRecommender.java
+++ b/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/ner/OpenNlpNerRecommender.java
@@ -244,6 +244,7 @@ public class OpenNlpNerRecommender
             if (beginToken == null || endToken == null) {
                 LOG.warn("Skipping annotation not starting/ending at token boundaries: [{}-{}, {}]",
                         annotation.getBegin(), annotation.getEnd(), label);
+                continue;
             }
             
             int begin = idxToken.get(beginToken);


### PR DESCRIPTION
**What's in the PR**
- Forgot to actually skip processing the annotation before the NPE happens...

**How to test manually**
* See issue...

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
