### PR TITLE
#1027 - Remove unused read() methods from KBObject subclasses

### DIFF
--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/KBConcept.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/KBConcept.java
@@ -17,17 +17,14 @@
  */
 package de.tudarmstadt.ukp.inception.kb.graph;
 
-import static de.tudarmstadt.ukp.inception.kb.graph.RdfUtils.readFirst;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
-import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
@@ -229,48 +226,6 @@ public class KBConcept
         */
     }
     
-    public static KBConcept read(RepositoryConnection aConn, Resource aSubject, KnowledgeBase kb)
-    {
-        KBConcept kbConcept = new KBConcept();
-        kbConcept.setIdentifier(aSubject.stringValue());
-        kbConcept.setKB(kb);
-
-        readFirst(aConn, aSubject, kb.getLabelIri(), null, kb.getDefaultLanguage(), kb)
-            .ifPresent((stmt) -> {
-                kbConcept.setName(stmt.getObject().stringValue());
-                kbConcept.originalStatements.add(stmt);
-                if (stmt.getObject() instanceof Literal) {
-                    Literal literal = (Literal) stmt.getObject();
-                    Optional<String> language = literal.getLanguage();
-                    language.ifPresent(kbConcept::setLanguage);
-                }
-            });
-
-        readFirst(aConn, aSubject, kb.getDescriptionIri(), null, kb.getDefaultLanguage(), kb)
-            .ifPresent((stmt) -> {
-                kbConcept.setDescription(stmt.getObject().stringValue());
-                kbConcept.originalStatements.add(stmt);
-                if (stmt.getObject() instanceof Literal) {
-                    Literal literal = (Literal) stmt.getObject();
-                    Optional<String> language = literal.getLanguage();
-                    language.ifPresent(kbConcept::setLanguage);
-                }
-            });
-
-        /* Commented out until the functionality which uses them is actually implemented
-        readFirst(aConn, aStmt.getSubject(), CLOSED, null).ifPresent((stmt) -> {
-            kbConcept.setClosed(((Literal) stmt.getObject()).booleanValue());
-            kbConcept.originalStatements.add(stmt);
-        });
-        readFirst(aConn, aStmt.getSubject(), ABSTRACT, null).ifPresent((stmt) -> {
-            kbConcept.setAbstract(((Literal) stmt.getObject()).booleanValue());
-            kbConcept.originalStatements.add(stmt);
-        });
-        */
-
-        return kbConcept;
-    }
-
     @Override
     public String toString()
     {

--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/KBInstance.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/KBInstance.java
@@ -17,14 +17,12 @@
  */
 package de.tudarmstadt.ukp.inception.kb.graph;
 
-import static de.tudarmstadt.ukp.inception.kb.graph.RdfUtils.readFirst;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.eclipse.rdf4j.model.IRI;
@@ -175,40 +173,6 @@ public class KBInstance
             originalStatements.add(descStmt);
             aConn.add(descStmt);
         }
-    }
-
-    public static KBInstance read(RepositoryConnection aConn, Statement aStmt, KnowledgeBase aKb)
-    {
-        KBInstance kbInst = new KBInstance();
-        kbInst.setType(URI.create(aStmt.getObject().stringValue()));
-        kbInst.setIdentifier(aStmt.getSubject().stringValue());
-        kbInst.setKB(aKb);
-        kbInst.originalStatements.add(aStmt);
-
-        readFirst(aConn, aStmt.getSubject(), aKb.getLabelIri(), null, aKb.getDefaultLanguage(), aKb)
-            .ifPresent((stmt) -> {
-                kbInst.setName(stmt.getObject().stringValue());
-                kbInst.originalStatements.add(stmt);
-                if (stmt.getObject() instanceof Literal) {
-                    Literal literal = (Literal) stmt.getObject();
-                    Optional<String> language = literal.getLanguage();
-                    language.ifPresent(kbInst::setLanguage);
-                }
-            });
-
-        readFirst(aConn, aStmt.getSubject(), aKb.getDescriptionIri(), null, 
-                aKb.getDefaultLanguage(), aKb)
-            .ifPresent((stmt) -> {
-                kbInst.setDescription(stmt.getObject().stringValue());
-                kbInst.originalStatements.add(stmt);
-                if (stmt.getObject() instanceof Literal) {
-                    Literal literal = (Literal) stmt.getObject();
-                    Optional<String> language = literal.getLanguage();
-                    language.ifPresent(kbInst::setLanguage);
-                }
-            });
-
-        return kbInst;
     }
 
     @Override

--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/KBProperty.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/KBProperty.java
@@ -17,13 +17,11 @@
  */
 package de.tudarmstadt.ukp.inception.kb.graph;
 
-import static de.tudarmstadt.ukp.inception.kb.graph.RdfUtils.readFirst;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
@@ -213,50 +211,6 @@ public class KBProperty
             originalStatements.add(rangeStmt);
             aConn.add(rangeStmt);
         }
-    }
-
-    public static KBProperty read(RepositoryConnection aConn, Statement aStmt, KnowledgeBase kb)
-    {
-        KBProperty kbProp = new KBProperty();
-        kbProp.setIdentifier(aStmt.getSubject().stringValue());
-        kbProp.setKB(kb);
-        kbProp.originalStatements.add(aStmt);
-
-        readFirst(aConn, aStmt.getSubject(), kb.getPropertyLabelIri(), null, 
-                kb.getDefaultLanguage(), kb)
-            .ifPresent((stmt) -> {
-                kbProp.setName(stmt.getObject().stringValue());
-                kbProp.originalStatements.add(stmt);
-                if (stmt.getObject() instanceof Literal) {
-                    Literal literal = (Literal) stmt.getObject();
-                    Optional<String> language = literal.getLanguage();
-                    language.ifPresent(kbProp::setLanguage);
-                }
-            });
-
-        readFirst(aConn, aStmt.getSubject(), kb.getPropertyDescriptionIri(), null, 
-                kb.getDefaultLanguage(), kb)
-            .ifPresent((stmt) -> {
-                kbProp.setDescription(stmt.getObject().stringValue());
-                kbProp.originalStatements.add(stmt);
-                if (stmt.getObject() instanceof Literal) {
-                    Literal literal = (Literal) stmt.getObject();
-                    Optional<String> language = literal.getLanguage();
-                    language.ifPresent(kbProp::setLanguage);
-                }
-            });
-
-        readFirst(aConn, aStmt.getSubject(), RDFS.RANGE, null, kb).ifPresent((stmt) -> {
-            kbProp.setRange(stmt.getObject().stringValue());
-            kbProp.originalStatements.add(stmt);
-        });
-
-        readFirst(aConn, aStmt.getSubject(), RDFS.DOMAIN, null, kb).ifPresent((stmt) -> {
-            kbProp.setDomain(stmt.getObject().stringValue());
-            kbProp.originalStatements.add(stmt);
-        });
-
-        return kbProp;
     }
 
     @Override

--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/RdfUtils.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/RdfUtils.java
@@ -43,10 +43,10 @@ import de.tudarmstadt.ukp.inception.kb.model.KnowledgeBase;
 public class RdfUtils
 {
     public static Optional<Statement> readFirst(RepositoryConnection conn, Resource subj, IRI pred,
-            Value obj, String language, KnowledgeBase aKB)
+            Value obj, KnowledgeBase aKB)
     {
-        try (RepositoryResult<Statement> results =
-            getStatementsSparql(conn, subj, pred, obj, false, language, aKB)) {
+        try (RepositoryResult<Statement> results = getStatementsSparql(conn, subj, pred, obj, false,
+                null, aKB)) {
             if (results.hasNext()) {
                 return Optional.of(results.next());
             }
@@ -54,12 +54,6 @@ public class RdfUtils
                 return Optional.empty();
             }
         }
-    }
-
-    public static Optional<Statement> readFirst(RepositoryConnection conn, Resource subj, IRI pred,
-        Value obj, KnowledgeBase aKB)
-    {
-        return readFirst(conn, subj, pred, obj, null, aKB);
     }
 
     public static RepositoryResult<Statement> getStatementsSparql(RepositoryConnection conn,


### PR DESCRIPTION
**What's in the PR**
- Removing unused code
- Inline a method in RdfUtils which was only used internally in RdfUtils after the code has been removed

**How to test manually**
* There is no need to test anything. If it still compiles, it should be good.

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
