### PR TITLE
#958 - KB instance not properly filtered when annotating

### DIFF
--- a/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/service/ConceptLinkingServiceImpl.java
+++ b/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/service/ConceptLinkingServiceImpl.java
@@ -170,11 +170,17 @@ public class ConceptLinkingServiceImpl
                     .stream()
                     .filter(Objects::nonNull)
                     .toArray(String[]::new);
-            List<KBHandle> exactMatches =  newQueryBuilder(aValueType, aKB)
-                    .withLabelMatchingExactlyAnyOf(exactLabels)
+            SPARQLQueryPrimaryConditions exactBuilder = newQueryBuilder(aValueType, aKB)
+                    .withLabelMatchingExactlyAnyOf(exactLabels);
+            
+            if (aConceptScope != null) {
+                exactBuilder.childrenOf(aConceptScope);
+            }
+            
+            List<KBHandle> exactMatches = exactBuilder
                     .retrieveLabel()
                     .retrieveDescription()
-                    .asHandles((RepositoryConnection) conn, true);
+                    .asHandles(conn, true);
 
             log.debug("Found [{}] candidates exactly matching {}",
                     exactMatches.size(), asList(exactLabels));
@@ -185,11 +191,17 @@ public class ConceptLinkingServiceImpl
             if (aQuery != null && aQuery.length() > threshold) {
                 // Collect matches starting with the query - this is the main driver for the
                 // auto-complete functionality
-                List<KBHandle> startingWithMatches = newQueryBuilder(aValueType, aKB)
-                        .withLabelStartingWith(aQuery)
+                SPARQLQueryPrimaryConditions startingWithBuilder = newQueryBuilder(aValueType, aKB)
+                        .withLabelStartingWith(aQuery);
+                
+                if (aConceptScope != null) {
+                    startingWithBuilder.childrenOf(aConceptScope);
+                }
+                
+                List<KBHandle> startingWithMatches = startingWithBuilder
                         .retrieveLabel()
                         .retrieveDescription()
-                        .asHandles((RepositoryConnection) conn, true);
+                        .asHandles(conn, true);
                 
                 log.debug("Found [{}] candidates starting with [{}]]",
                         startingWithMatches.size(), aQuery);            
@@ -204,11 +216,17 @@ public class ConceptLinkingServiceImpl
                     .stream()
                     .filter(Objects::nonNull)
                     .toArray(String[]::new);
-            List<KBHandle> containingMatches = newQueryBuilder(aValueType, aKB)
-                    .withLabelContainingAnyOf(containingLabels)
+            SPARQLQueryPrimaryConditions containingBuilder = newQueryBuilder(aValueType, aKB)
+                    .withLabelContainingAnyOf(containingLabels);
+            
+            if (aConceptScope != null) {
+                containingBuilder.childrenOf(aConceptScope);
+            }
+            
+            List<KBHandle> containingMatches = containingBuilder
                     .retrieveLabel()
                     .retrieveDescription()
-                    .asHandles((RepositoryConnection) conn, true);
+                    .asHandles(conn, true);
             
             log.debug("Found [{}] candidates using containing {}",
                     containingMatches.size(), asList(containingLabels));

--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
@@ -312,9 +312,28 @@ public class SPARQLQueryBuilder
         protected GraphPattern childrenPattern(KnowledgeBase aKB, Iri aContext)
         {
             Iri subClassProperty = Rdf.iri(aKB.getSubclassIri().toString());
+            Iri typeOfProperty = Rdf.iri(aKB.getTypeIri().toString());
                         
             switch (this) {
+            case ITEM: {
+                List<GraphPattern> classPatterns = new ArrayList<>();
+                classPatterns.add(
+                        VAR_SUBJECT.has(() -> subClassProperty.getQueryString(), aContext));
+                classPatterns.add(VAR_SUBJECT.has(typeOfProperty, aContext));
+                if (OWL.CLASS.equals(aKB.getClassIri())) {
+                    classPatterns.add(VAR_SUBJECT.has(
+                            Path.of(OWL_INTERSECTIONOF, zeroOrMore(RDF_REST), RDF_FIRST),
+                            aContext));
+                }
+                
+                return GraphPatterns.union(classPatterns.stream().toArray(GraphPattern[]::new));
+            }
+            case INSTANCE: {
+                return VAR_SUBJECT.has(typeOfProperty, aContext);
+            }
             case CLASS: {
+                // Follow the subclass property and also take into account owl:intersectionOf if
+                // using OWL classes
                 List<GraphPattern> classPatterns = new ArrayList<>();
                 classPatterns.add(VAR_SUBJECT.has(subClassProperty, aContext));
                 if (OWL.CLASS.equals(aKB.getClassIri())) {

--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryPrimaryConditions.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryPrimaryConditions.java
@@ -73,14 +73,18 @@ public interface SPARQLQueryPrimaryConditions
     SPARQLQueryPrimaryConditions ancestorsOf(String aItemIri);
 
     /**
-     * Limits results to descendants of the given class.
+     * Limits results to descendants of the given class. Descendants of a class include its
+     * subclasses and instances (of subclasses). Depending on which kind if items the query is built
+     * for, either one of them or both are returned.
      * 
      * @return the builder (fluent API)
      */
     SPARQLQueryPrimaryConditions descendantsOf(String aClassIri);
 
     /**
-     * Limits results to children of the given class.
+     * Limits results to children of the given class. Children of a class are its subclasses and
+     * instances. Depending on which kind if items the query is built for, either one of them or
+     * both are returned.
      * 
      * @return the builder (fluent API)
      */

--- a/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderTest.java
+++ b/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderTest.java
@@ -516,6 +516,36 @@ public class SPARQLQueryBuilderTest
     }
 
     @Test
+    public void thatInstanceQueryLimitedToChildrenDoesNotReturnOutOfScopeResults() throws Exception
+    {
+        importDataFromString(RDFFormat.TURTLE, TURTLE_PREFIX, DATA_CLASS_RDFS_HIERARCHY);
+    
+        List<KBHandle> results = asHandles(rdf4jLocalRepo, SPARQLQueryBuilder
+                .forInstances(kb)
+                .childrenOf("http://example.org/#subclass1"));
+        
+        assertThat(results).isNotEmpty();
+        assertThat(results)
+                .extracting(KBHandle::getIdentifier)
+                .containsExactlyInAnyOrder("http://example.org/#1-instance-1");
+    }
+
+    @Test
+    public void thatItemQueryLimitedToChildrenDoesNotReturnOutOfScopeResults() throws Exception
+    {
+        importDataFromString(RDFFormat.TURTLE, TURTLE_PREFIX, DATA_CLASS_RDFS_HIERARCHY);
+    
+        List<KBHandle> results = asHandles(rdf4jLocalRepo, SPARQLQueryBuilder
+                .forItems(kb)
+                .childrenOf("http://example.org/#subclass1"));
+        
+        assertThat(results).isNotEmpty();
+        assertThat(results)
+                .extracting(KBHandle::getIdentifier)
+                .containsExactlyInAnyOrder("http://example.org/#1-instance-1", 
+                        "http://example.org/#subclass1-1");
+    }
+    @Test
     public void thatInstanceQueryLimitedToDescendantsDoesNotReturnOutOfScopeResults()
         throws Exception
     {


### PR DESCRIPTION
**What's in the PR**
- Actually consider scope when generating candidates
- Allow using the children axis not only for class queries, but also for instance and item queries
- Added additional tests for the children axis

**How to test manually**
* Create remote KB connecting to `http://nlp.dainst.org:8888/sparql` (OWL mapping)
* Edit the `identifier` feature of the `NamedEntity` layer, limit it to the KB just created, allow only instance and limit to `work` (`org/efrbroo/F1_Work`) - check the IRI appearing in the feature list because there are probably at least two items called `work` in the KB.
* Annotate a word as named entity
* Enter `Liba` into the identifier field
* Only items starting with the IRI `http://purl.org/hucit/kb/works/` should appear (cf. issue #958 for screenshot showing non-works being listed)

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
