### PR TITLE
#1056 - Knob color in PDF editor

### DIFF
--- a/inception-pdf-editor/src/main/js/pdfanno/src/core/src/render/renderKnob.js
+++ b/inception-pdf-editor/src/main/js/pdfanno/src/core/src/render/renderKnob.js
@@ -12,8 +12,13 @@ export const DEFAULT_RADIUS = 7
 /*
 export function renderKnob ({ x, y, readOnly }) {
 */
+// BEGIN INCEpTION EXTENSION - #1056 - Knob color in PDF editor
+/*
 export function renderKnob ({ x, y, readOnly, text}) {
-// END INCEpTION EXTENSION
+*/
+export function renderKnob ({ x, y, readOnly, text, color}) {
+// END INCEpTION EXTENSION - #1056
+// END INCEpTION EXTENSION - #981
 
   // Adjust the position.
   [x, y] = adjustPoint(x, (y - (DEFAULT_RADIUS + 2)), DEFAULT_RADIUS)
@@ -34,7 +39,13 @@ export function renderKnob ({ x, y, readOnly, text}) {
     top    : `${y}px`,
     left   : `${x}px`,
     width  : DEFAULT_RADIUS + 'px',
+// BEGIN INCEpTION EXTENSION - #1056 - Knob color in PDF editor
+/*
     height : DEFAULT_RADIUS + 'px'
+*/
+    height : DEFAULT_RADIUS + 'px',
+    backgroundColor : color
+// END INCEpTION EXTENSION - #1056
   })
 }
 

--- a/inception-pdf-editor/src/main/js/pdfanno/src/core/src/render/renderSpan.js
+++ b/inception-pdf-editor/src/main/js/pdfanno/src/core/src/render/renderSpan.js
@@ -61,8 +61,14 @@ export function renderSpan (a) {
       readOnly
 */
       readOnly,
+// BEGIN INCEpTION EXTENSION - #1056 - Knob color in PDF editor
+/*
       text : a.text
-// END INCEpTION EXTENSION
+*/
+      text : a.text,
+      color : a.color
+// END INCEpTION EXTENSION - #1056
+// END INCEpTION EXTENSION - #981
     }))
   }
 


### PR DESCRIPTION
**What's in the PR**
* make knob color for span annotations the layer color instead of blue

**How to test manually**
* Open a PDF in PDF editor
* if no is present create a span annotation
* see color of span annotation knob

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
