### PR TITLE
#1079 - Reduce build times

### DIFF
--- a/inception-imls-dl4j/pom.xml
+++ b/inception-imls-dl4j/pom.xml
@@ -104,9 +104,12 @@
           <artifactId>lombok</artifactId>
         </exclusion>
       </exclusions>
-      </dependency>
-  
-  
+     </dependency>
+    <dependency>
+      <groupId>org.nd4j</groupId>
+      <artifactId>nd4j-native-api</artifactId>
+      <version>${dl4j.version}</version>
+    </dependency>
   
   <!--  
       <dependency>

--- a/inception-imls-dl4j/pom.xml
+++ b/inception-imls-dl4j/pom.xml
@@ -105,11 +105,13 @@
         </exclusion>
       </exclusions>
      </dependency>
-    <dependency>
-      <groupId>org.nd4j</groupId>
-      <artifactId>nd4j-native-api</artifactId>
-      <version>${dl4j.version}</version>
-    </dependency>
+     <!--  
+     <dependency>
+       <groupId>org.nd4j</groupId>
+       <artifactId>nd4j-native-api</artifactId>
+       <version>${dl4j.version}</version>
+     </dependency>
+     -->
   
   <!--  
       <dependency>

--- a/inception-imls-dl4j/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommender.java
+++ b/inception-imls-dl4j/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommender.java
@@ -366,7 +366,7 @@ public class DL4JSequenceRecommender
             Feature confidenceFeature = predictionType.getFeatureByBaseName("score");
             Feature labelFeature = predictionType.getFeatureByBaseName("label");
     
-            final int limit = Integer.MAX_VALUE;
+            final int limit = traits.getPredictionLimit();
             final int batchSize = traits.getBatchSize();
 
             Collection<AnnotationFS> sentences = select(aCas, sentenceType);

--- a/inception-imls-dl4j/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommenderTraits.java
+++ b/inception-imls-dl4j/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommenderTraits.java
@@ -28,6 +28,7 @@ public class DL4JSequenceRecommenderTraits
 {
     // General parameters
     private int trainingSetSizeLimit = Integer.MAX_VALUE;
+    private int predictionLimit = Integer.MAX_VALUE;
     private int batchSize = 250;
     private int maxTagsetSize = 70;
     private int maxSentenceLength = 150;
@@ -54,6 +55,16 @@ public class DL4JSequenceRecommenderTraits
     public void setTrainingSetSizeLimit(int aLimit)
     {
         trainingSetSizeLimit = aLimit;
+    }
+    
+    public int getPredictionLimit()
+    {
+        return predictionLimit;
+    }
+
+    public void setPredictionLimit(int aPredictionLimit)
+    {
+        predictionLimit = aPredictionLimit;
     }
 
     public int getBatchSize()

--- a/inception-imls-dl4j/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommenderTest.java
+++ b/inception-imls-dl4j/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommenderTest.java
@@ -37,6 +37,10 @@ import org.apache.uima.fit.util.JCasUtil;
 import org.apache.uima.jcas.JCas;
 import org.junit.Before;
 import org.junit.Test;
+import org.nd4j.linalg.factory.Nd4j;
+import org.nd4j.nativeblas.NativeOps;
+import org.nd4j.nativeblas.NativeOpsHolder;
+import org.nd4j.nativeblas.Nd4jBlas;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
@@ -64,7 +68,15 @@ public class DL4JSequenceRecommenderTest
     private DL4JSequenceRecommenderTraits traits;
 
     @Before
-    public void setUp() {
+    public void setUp()
+    {
+        Nd4jBlas nd4jBlas = (Nd4jBlas) Nd4j.factory().blas();
+        nd4jBlas.setMaxThreads(2);
+
+        NativeOpsHolder instance = NativeOpsHolder.getInstance();
+        NativeOps deviceNativeOps = instance.getDeviceNativeOps();
+        deviceNativeOps.setOmpNumThreads(2);
+
         context = new RecommenderContext();
         traits = new DL4JSequenceRecommenderTraits();
         traits.setTrainingSetSizeLimit(250);

--- a/inception-imls-dl4j/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommenderTest.java
+++ b/inception-imls-dl4j/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommenderTest.java
@@ -37,10 +37,6 @@ import org.apache.uima.fit.util.JCasUtil;
 import org.apache.uima.jcas.JCas;
 import org.junit.Before;
 import org.junit.Test;
-import org.nd4j.linalg.factory.Nd4j;
-import org.nd4j.nativeblas.NativeOps;
-import org.nd4j.nativeblas.NativeOpsHolder;
-import org.nd4j.nativeblas.Nd4jBlas;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
@@ -70,16 +66,19 @@ public class DL4JSequenceRecommenderTest
     @Before
     public void setUp()
     {
-        Nd4jBlas nd4jBlas = (Nd4jBlas) Nd4j.factory().blas();
-        nd4jBlas.setMaxThreads(2);
+        // By default, ND4J will use a value equal to the number of physical CPU cores (not logical
+        // cores) as this will give optimal performance
+        // Nd4jBlas nd4jBlas = (Nd4jBlas) Nd4j.factory().blas();
+        // nd4jBlas.setMaxThreads(2);
 
-        NativeOpsHolder instance = NativeOpsHolder.getInstance();
-        NativeOps deviceNativeOps = instance.getDeviceNativeOps();
-        deviceNativeOps.setOmpNumThreads(2);
+        // NativeOpsHolder instance = NativeOpsHolder.getInstance();
+        // NativeOps deviceNativeOps = instance.getDeviceNativeOps();
+        // deviceNativeOps.setOmpNumThreads(2);
 
         context = new RecommenderContext();
         traits = new DL4JSequenceRecommenderTraits();
         traits.setTrainingSetSizeLimit(250);
+        traits.setPredictionLimit(250);
         traits.setBatchSize(50);
     }
 

--- a/inception-imls-dl4j/src/test/resources/log4j2.xml
+++ b/inception-imls-dl4j/src/test/resources/log4j2.xml
@@ -7,6 +7,7 @@
   </Appenders>
 
   <Loggers>
+    <Logger name="org.nd4j" level="INFO"/>
     <Logger name="org.deeplearning4j.optimize.listeners" level="INFO"/>
     <Logger name="de.tudarmstadt.ukp.inception.recommendation" level="TRACE"/>
     <Root level="ERROR">

--- a/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/doccat/OpenNlpDoccatRecommender.java
+++ b/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/doccat/OpenNlpDoccatRecommender.java
@@ -116,7 +116,13 @@ public class OpenNlpDoccatRecommender
         Feature confidenceFeature = predictionType.getFeatureByBaseName("score");
         Feature labelFeature = predictionType.getFeatureByBaseName("label");
 
+        int predictionCount = 0;
         for (AnnotationFS sentence : select(aCas, sentenceType)) {
+            if (predictionCount >= traits.getPredictionLimit()) {
+                break;
+            }
+            predictionCount++;
+            
             List<AnnotationFS> tokenAnnotations = selectCovered(tokenType, sentence);
             String[] tokens = tokenAnnotations.stream()
                 .map(AnnotationFS::getCoveredText)
@@ -191,12 +197,12 @@ public class OpenNlpDoccatRecommender
     private List<DocumentSample> extractSamples(List<CAS> aCasses)
     {
         List<DocumentSample> samples = new ArrayList<>();
-        for (CAS cas : aCasses) {
+        casses: for (CAS cas : aCasses) {
             Type sentenceType = getType(cas, Sentence.class);
             Type tokenType = getType(cas, Token.class);
 
-            Map<AnnotationFS, Collection<AnnotationFS>> sentences =
-                indexCovered(cas, sentenceType, tokenType);
+            Map<AnnotationFS, Collection<AnnotationFS>> sentences = indexCovered(
+                    cas, sentenceType, tokenType);
             for (Entry<AnnotationFS, Collection<AnnotationFS>> e : sentences.entrySet()) {
                 AnnotationFS sentence = e.getKey();
                 Collection<AnnotationFS> tokens = e.getValue();
@@ -208,6 +214,10 @@ public class OpenNlpDoccatRecommender
                 Feature feature = annotationType.getFeatureByBaseName(featureName);
                 
                 for (AnnotationFS annotation : selectCovered(annotationType, sentence)) {
+                    if (samples.size() >= traits.getTrainingSetSizeLimit()) {
+                        break casses;
+                    }
+                    
                     String label = annotation.getFeatureValueAsString(feature);
                     DocumentSample nameSample = new DocumentSample(
                             label != null ? label : NO_CATEGORY, tokenTexts);
@@ -217,6 +227,7 @@ public class OpenNlpDoccatRecommender
                 }
             }
         }
+        
         return samples;
     }
 

--- a/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/doccat/OpenNlpDoccatRecommenderTraits.java
+++ b/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/doccat/OpenNlpDoccatRecommenderTraits.java
@@ -26,7 +26,10 @@ public class OpenNlpDoccatRecommenderTraits
     implements Serializable
 {
     private static final long serialVersionUID = 220089332064652542L;
-    
+
+    private int trainingSetSizeLimit = Integer.MAX_VALUE;
+    private int predictionLimit = Integer.MAX_VALUE;
+
     private int iterations = 100;
     private int cutoff = 5;
     private int numThreads = 1;
@@ -59,6 +62,26 @@ public class OpenNlpDoccatRecommenderTraits
     public void setNumThreads(int aNumThreads)
     {
         numThreads = aNumThreads;
+    }
+
+    public int getTrainingSetSizeLimit()
+    {
+        return trainingSetSizeLimit;
+    }
+
+    public void setTrainingSetSizeLimit(int aTrainingSetSizeLimit)
+    {
+        trainingSetSizeLimit = aTrainingSetSizeLimit;
+    }
+
+    public int getPredictionLimit()
+    {
+        return predictionLimit;
+    }
+
+    public void setPredictionLimit(int aPredictionLimit)
+    {
+        predictionLimit = aPredictionLimit;
     }
 
     public TrainingParameters getParameters()

--- a/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/doccat/OpenNlpDoccatRecommenderTraits.java
+++ b/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/doccat/OpenNlpDoccatRecommenderTraits.java
@@ -29,6 +29,7 @@ public class OpenNlpDoccatRecommenderTraits
     
     private int iterations = 100;
     private int cutoff = 5;
+    private int numThreads = 1;
 
     public int getIterations()
     {
@@ -50,12 +51,23 @@ public class OpenNlpDoccatRecommenderTraits
         cutoff = aCutoff;
     }
     
+    public int getNumThreads()
+    {
+        return numThreads;
+    }
+
+    public void setNumThreads(int aNumThreads)
+    {
+        numThreads = aNumThreads;
+    }
+
     public TrainingParameters getParameters()
     {
         TrainingParameters parameters = TrainingParameters.defaultParams();
         parameters.put(AbstractTrainer.VERBOSE_PARAM, false);
         parameters.put(TrainingParameters.ITERATIONS_PARAM, iterations);
         parameters.put(TrainingParameters.CUTOFF_PARAM, cutoff);
+        parameters.put(TrainingParameters.THREADS_PARAM, numThreads);
         return parameters;
     }
 }

--- a/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/ner/OpenNlpNerRecommenderTraits.java
+++ b/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/ner/OpenNlpNerRecommenderTraits.java
@@ -17,14 +17,33 @@
  */
 package de.tudarmstadt.ukp.inception.recommendation.imls.opennlp.ner;
 
+import java.io.Serializable;
+
 import opennlp.tools.ml.AbstractTrainer;
 import opennlp.tools.util.TrainingParameters;
 
-public class OpenNlpNerRecommenderTraits {
+public class OpenNlpNerRecommenderTraits
+    implements Serializable
+{
+    private static final long serialVersionUID = 7717316701623340670L;
 
-    public TrainingParameters getParameters() {
+    private int numThreads = 1;
+
+    public int getNumThreads()
+    {
+        return numThreads;
+    }
+
+    public void setNumThreads(int aNumThreads)
+    {
+        numThreads = aNumThreads;
+    }
+
+    public TrainingParameters getParameters()
+    {
         TrainingParameters parameters = TrainingParameters.defaultParams();
         parameters.put(AbstractTrainer.VERBOSE_PARAM, "false");
+        parameters.put(TrainingParameters.THREADS_PARAM, numThreads);
         return parameters;
     }
 }

--- a/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/ner/OpenNlpNerRecommenderTraits.java
+++ b/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/ner/OpenNlpNerRecommenderTraits.java
@@ -27,6 +27,9 @@ public class OpenNlpNerRecommenderTraits
 {
     private static final long serialVersionUID = 7717316701623340670L;
 
+    private int trainingSetSizeLimit = Integer.MAX_VALUE;
+    private int predictionLimit = Integer.MAX_VALUE;
+    
     private int numThreads = 1;
 
     public int getNumThreads()
@@ -37,6 +40,26 @@ public class OpenNlpNerRecommenderTraits
     public void setNumThreads(int aNumThreads)
     {
         numThreads = aNumThreads;
+    }
+
+    public int getTrainingSetSizeLimit()
+    {
+        return trainingSetSizeLimit;
+    }
+
+    public void setTrainingSetSizeLimit(int aTrainingSetSizeLimit)
+    {
+        trainingSetSizeLimit = aTrainingSetSizeLimit;
+    }
+
+    public int getPredictionLimit()
+    {
+        return predictionLimit;
+    }
+
+    public void setPredictionLimit(int aPredictionLimit)
+    {
+        predictionLimit = aPredictionLimit;
     }
 
     public TrainingParameters getParameters()

--- a/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/pos/OpenNlpPosRecommender.java
+++ b/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/pos/OpenNlpPosRecommender.java
@@ -120,7 +120,13 @@ public class OpenNlpPosRecommender
         Feature confidenceFeature = predictionType.getFeatureByBaseName("score");
         Feature labelFeature = predictionType.getFeatureByBaseName("label");
 
+        int predictionCount = 0;
         for (AnnotationFS sentence : select(aCas, sentenceType)) {
+            if (predictionCount >= traits.getPredictionLimit()) {
+                break;
+            }
+            predictionCount++;
+            
             List<AnnotationFS> tokenAnnotations = selectCovered(tokenType, sentence);
             String[] tokens = tokenAnnotations.stream()
                 .map(AnnotationFS::getCoveredText)
@@ -223,13 +229,18 @@ public class OpenNlpPosRecommender
     private List<POSSample> extractPosSamples(List<CAS> aCasses)
     {
         List<POSSample> posSamples = new ArrayList<>();
-        for (CAS cas : aCasses) {
+        
+        casses: for (CAS cas : aCasses) {
             Type sentenceType = getType(cas, Sentence.class);
             Type tokenType = getType(cas, Token.class);
 
-            Map<AnnotationFS, Collection<AnnotationFS>> sentences =
-                indexCovered(cas, sentenceType, tokenType);
+            Map<AnnotationFS, Collection<AnnotationFS>> sentences = indexCovered(
+                    cas, sentenceType, tokenType);
             for (Map.Entry<AnnotationFS, Collection<AnnotationFS>> e : sentences.entrySet()) {
+                if (posSamples.size() >= traits.getTrainingSetSizeLimit()) {
+                    break casses;
+                }
+                
                 AnnotationFS sentence = e.getKey();
 
                 Collection<AnnotationFS> tokens = e.getValue();

--- a/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/pos/OpenNlpPosRecommenderTraits.java
+++ b/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/pos/OpenNlpPosRecommenderTraits.java
@@ -27,10 +27,24 @@ public class OpenNlpPosRecommenderTraits
 {
     private static final long serialVersionUID = -4514466471370195077L;
 
+    private int numThreads = 1;
+
+    public int getNumThreads()
+    {
+        return numThreads;
+    }
+
+    public void setNumThreads(int aNumThreads)
+    {
+        numThreads = aNumThreads;
+    }
+
+    
     public TrainingParameters getParameters()
     {
         TrainingParameters parameters = TrainingParameters.defaultParams();
         parameters.put(AbstractTrainer.VERBOSE_PARAM, "false");
+        parameters.put(TrainingParameters.THREADS_PARAM, numThreads);
         return parameters;
     }
 }

--- a/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/pos/OpenNlpPosRecommenderTraits.java
+++ b/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/pos/OpenNlpPosRecommenderTraits.java
@@ -27,6 +27,9 @@ public class OpenNlpPosRecommenderTraits
 {
     private static final long serialVersionUID = -4514466471370195077L;
 
+    private int trainingSetSizeLimit = Integer.MAX_VALUE;
+    private int predictionLimit = Integer.MAX_VALUE;
+    
     private int numThreads = 1;
 
     public int getNumThreads()
@@ -38,8 +41,27 @@ public class OpenNlpPosRecommenderTraits
     {
         numThreads = aNumThreads;
     }
-
     
+    public int getTrainingSetSizeLimit()
+    {
+        return trainingSetSizeLimit;
+    }
+
+    public void setTrainingSetSizeLimit(int aTrainingSetSizeLimit)
+    {
+        trainingSetSizeLimit = aTrainingSetSizeLimit;
+    }
+
+    public int getPredictionLimit()
+    {
+        return predictionLimit;
+    }
+
+    public void setPredictionLimit(int aPredictionLimit)
+    {
+        predictionLimit = aPredictionLimit;
+    }
+
     public TrainingParameters getParameters()
     {
         TrainingParameters parameters = TrainingParameters.defaultParams();

--- a/inception-imls-opennlp/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/doccat/OpenNlpDoccatRecommenderTest.java
+++ b/inception-imls-opennlp/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/doccat/OpenNlpDoccatRecommenderTest.java
@@ -20,6 +20,7 @@ package de.tudarmstadt.ukp.inception.recommendation.imls.opennlp.doccat;
 import static java.util.Arrays.asList;
 import static org.apache.uima.fit.factory.AnalysisEngineFactory.createEngine;
 import static org.apache.uima.fit.factory.CollectionReaderFactory.createReader;
+import static org.apache.uima.fit.util.JCasUtil.select;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.BufferedInputStream;
@@ -27,6 +28,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -38,7 +40,6 @@ import org.apache.uima.cas.CAS;
 import org.apache.uima.collection.CollectionException;
 import org.apache.uima.collection.CollectionReader;
 import org.apache.uima.fit.factory.JCasFactory;
-import org.apache.uima.fit.util.JCasUtil;
 import org.apache.uima.jcas.JCas;
 import org.junit.Before;
 import org.junit.Test;
@@ -76,13 +77,15 @@ public class OpenNlpDoccatRecommenderTest
         recommender = buildRecommender();
         traits = new OpenNlpDoccatRecommenderTraits();
         traits.setNumThreads(2);
+        traits.setTrainingSetSizeLimit(250);
+        traits.setPredictionLimit(250);
     }
 
     @Test
     public void thatTrainingWorks() throws Exception
     {
         OpenNlpDoccatRecommender sut = new OpenNlpDoccatRecommender(recommender, traits);
-        List<CAS> casList = loadDevelopmentData();
+        List<CAS> casList = loadArxivData();
 
         sut.train(context, casList);
 
@@ -95,7 +98,7 @@ public class OpenNlpDoccatRecommenderTest
     public void thatPredictionWorks() throws Exception
     {
         OpenNlpDoccatRecommender sut = new OpenNlpDoccatRecommender(recommender, traits);
-        List<CAS> casList = loadDevelopmentData();
+        List<CAS> casList = loadArxivData();
         
         CAS cas = casList.get(0);
         
@@ -103,7 +106,7 @@ public class OpenNlpDoccatRecommenderTest
 
         sut.predict(context, cas);
 
-        Collection<PredictedSpan> predictions = JCasUtil.select(cas.getJCas(), PredictedSpan.class);
+        Collection<PredictedSpan> predictions = select(cas.getJCas(), PredictedSpan.class);
 
         assertThat(predictions).as("Predictions have been written to CAS")
             .isNotEmpty();
@@ -114,7 +117,7 @@ public class OpenNlpDoccatRecommenderTest
     {
         DataSplitter splitStrategy = new PercentageBasedSplitter(0.8, 10);
         OpenNlpDoccatRecommender sut = new OpenNlpDoccatRecommender(recommender, traits);
-        List<CAS> casList = loadDevelopmentData();
+        List<CAS> casList = loadArxivData();
 
         double score = sut.evaluate(casList, splitStrategy).getDefaultScore();
 
@@ -128,7 +131,7 @@ public class OpenNlpDoccatRecommenderTest
     {
         IncrementalSplitter splitStrategy = new IncrementalSplitter(0.8, 250, 10);
         OpenNlpDoccatRecommender sut = new OpenNlpDoccatRecommender(recommender, traits);
-        List<CAS> casList = loadAllData();
+        List<CAS> casList = loadArxivData();
 
         int i = 0;
         while (splitStrategy.hasNext() && i < 3) {
@@ -144,16 +147,12 @@ public class OpenNlpDoccatRecommenderTest
         }
     }
 
-    private List<CAS> loadAllData() throws IOException, UIMAException
+    private List<CAS> loadArxivData() throws IOException, UIMAException
     {
         Dataset ds = loader.load("sentence-classification-en");
-        return loadData(ds, ds.getDataFiles());
-    }
-
-    private List<CAS> loadDevelopmentData() throws IOException, UIMAException
-    {
-        Dataset ds = loader.load("sentence-classification-en");
-        return loadData(ds, ds.getDefaultSplit().getDevelopmentFiles());
+        return loadData(ds, Arrays.stream(ds.getDataFiles())
+                .filter(file -> file.getName().contains("arxiv"))
+                .toArray(File[]::new));
     }
 
     private List<CAS> loadData(Dataset ds, File ... files) throws UIMAException, IOException

--- a/inception-imls-opennlp/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/doccat/OpenNlpDoccatRecommenderTest.java
+++ b/inception-imls-opennlp/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/doccat/OpenNlpDoccatRecommenderTest.java
@@ -75,6 +75,7 @@ public class OpenNlpDoccatRecommenderTest
         context = new RecommenderContext();
         recommender = buildRecommender();
         traits = new OpenNlpDoccatRecommenderTraits();
+        traits.setNumThreads(2);
     }
 
     @Test

--- a/inception-imls-opennlp/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/ner/OpenNlpNerRecommenderTest.java
+++ b/inception-imls-opennlp/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/ner/OpenNlpNerRecommenderTest.java
@@ -66,6 +66,8 @@ public class OpenNlpNerRecommenderTest
         recommender = buildRecommender();
         traits = new OpenNlpNerRecommenderTraits();
         traits.setNumThreads(2);
+        traits.setTrainingSetSizeLimit(250);
+        traits.setPredictionLimit(250);
     }
 
     @Test

--- a/inception-imls-opennlp/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/ner/OpenNlpNerRecommenderTest.java
+++ b/inception-imls-opennlp/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/ner/OpenNlpNerRecommenderTest.java
@@ -65,6 +65,7 @@ public class OpenNlpNerRecommenderTest
         context = new RecommenderContext();
         recommender = buildRecommender();
         traits = new OpenNlpNerRecommenderTraits();
+        traits.setNumThreads(2);
     }
 
     @Test

--- a/inception-imls-opennlp/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/pos/OpenNlpPosRecommenderTest.java
+++ b/inception-imls-opennlp/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/pos/OpenNlpPosRecommenderTest.java
@@ -65,6 +65,7 @@ public class OpenNlpPosRecommenderTest
         context = new RecommenderContext();
         recommender = buildRecommender();
         traits = new OpenNlpPosRecommenderTraits();
+        traits.setNumThreads(2);
     }
 
     @Test

--- a/inception-imls-opennlp/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/pos/OpenNlpPosRecommenderTest.java
+++ b/inception-imls-opennlp/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/pos/OpenNlpPosRecommenderTest.java
@@ -66,6 +66,8 @@ public class OpenNlpPosRecommenderTest
         recommender = buildRecommender();
         traits = new OpenNlpPosRecommenderTraits();
         traits.setNumThreads(2);
+        traits.setTrainingSetSizeLimit(250);
+        traits.setPredictionLimit(250);
     }
 
     @Test


### PR DESCRIPTION
**What's in the PR**
- enable multi-threading for OpenNLP recommenders during test runs
- Introduce the ability to limit the training and prediction size to DL4J and OpenNLP recommenders
- Limit training size and prediction size in tests to 250 units

**How to test manually**
* This is about automatic builds/testing - no need to test manually

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
