### PR TITLE
#988 Make max. results configurable for ElasticSearch repos

### DIFF
--- a/inception-external-search-elastic/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/elastic/traits/ElasticSearchProviderTraitsEditor.html
+++ b/inception-external-search-elastic/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/elastic/traits/ElasticSearchProviderTraitsEditor.html
@@ -58,7 +58,7 @@
             <wicket:message key="resultSize"/>
           </label>
           <div class="col-sm-10">
-            <input wicket:id="resultSize" type="number" min="1" max="25000" class="form-control"/>
+            <input wicket:id="resultSize" type="number" class="form-control"/>
           </div>
         </div>
         <div class="form-group" wicket:enclosure="randomOrder">

--- a/inception-external-search-elastic/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/elastic/traits/ElasticSearchProviderTraitsEditor.html
+++ b/inception-external-search-elastic/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/elastic/traits/ElasticSearchProviderTraitsEditor.html
@@ -53,6 +53,14 @@
             <input wicket:id="objectType" type="text" class="form-control"/>
           </div>
         </div>
+        <div class="form-group" wicket:enclosure="resultSize">
+          <label class="col-sm-2 control-label">
+            <wicket:message key="resultSize"/>
+          </label>
+          <div class="col-sm-10">
+            <input wicket:id="resultSize" type="number" min="1" max="25000" class="form-control"/>
+          </div>
+        </div>
         <div class="form-group" wicket:enclosure="randomOrder">
           <div class="col-sm-offset-2 col-sm-10">
             <div class="checkbox">

--- a/inception-external-search-elastic/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/elastic/traits/ElasticSearchProviderTraitsEditor.java
+++ b/inception-external-search-elastic/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/elastic/traits/ElasticSearchProviderTraitsEditor.java
@@ -85,9 +85,9 @@ public class ElasticSearchProviderTraitsEditor
         form.add(objectType);
     
         NumberTextField<Integer> resultSize =
-                new NumberTextField<Integer>("resultSize", Integer.class);
+                new NumberTextField<>("resultSize", Integer.class);
         resultSize.setMinimum(1);
-        resultSize.setMaximum(25000);
+        resultSize.setMaximum(10000);
         resultSize.setRequired(true);
         form.add(resultSize);
 

--- a/inception-external-search-elastic/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/elastic/traits/ElasticSearchProviderTraitsEditor.java
+++ b/inception-external-search-elastic/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/elastic/traits/ElasticSearchProviderTraitsEditor.java
@@ -83,6 +83,13 @@ public class ElasticSearchProviderTraitsEditor
         TextField<String> objectType = new TextField<>("objectType");
         objectType.setRequired(true);
         form.add(objectType);
+    
+        NumberTextField<Integer> resultSize =
+                new NumberTextField<Integer>("resultSize", Integer.class);
+        resultSize.setMinimum(1);
+        resultSize.setMaximum(25000);
+        resultSize.setRequired(true);
+        form.add(resultSize);
 
         NumberTextField<Integer> seed = new NumberTextField<Integer>("seed", Integer.class);
         seed.setMinimum(0);

--- a/inception-external-search-elastic/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/elastic/traits/ElasticSearchProviderTraitsEditor.java
+++ b/inception-external-search-elastic/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/elastic/traits/ElasticSearchProviderTraitsEditor.java
@@ -28,6 +28,7 @@ import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
+import org.apache.wicket.model.ResourceModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.apache.wicket.validation.validator.UrlValidator;
 
@@ -95,7 +96,7 @@ public class ElasticSearchProviderTraitsEditor
         seed.setMinimum(0);
         seed.setMaximum(Integer.MAX_VALUE);
         seed.add(visibleWhen(() -> properties.isRandomOrder()));
-        seed.add(new AttributeModifier("title", getString("seedTooltip")));
+        seed.add(new AttributeModifier("title", new ResourceModel("seedTooltip")));
         seed.setOutputMarkupPlaceholderTag(true);
         seed.setRequired(true);
         form.add(seed);

--- a/inception-external-search-elastic/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/elastic/traits/ElasticSearchProviderTraitsEditor.properties
+++ b/inception-external-search-elastic/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/elastic/traits/ElasticSearchProviderTraitsEditor.properties
@@ -18,6 +18,7 @@ remoteUrl=Remote URL
 indexName=Index Name
 searchPath=Search Path
 objectType=Object Type
+resultSize=Result Size
 randomOrder=Random Ordering
 seed=Random seed
 seedTooltip=The random seed used to compute the reproducible random scores when Random Ordering is selected.

--- a/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/project/DocumentRepositoryEditorPanel.java
+++ b/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/project/DocumentRepositoryEditorPanel.java
@@ -25,6 +25,7 @@ import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.form.AjaxFormComponentUpdatingBehavior;
 import org.apache.wicket.ajax.markup.html.form.AjaxButton;
+import org.apache.wicket.feedback.IFeedback;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.form.ChoiceRenderer;
 import org.apache.wicket.markup.html.form.DropDownChoice;
@@ -136,9 +137,15 @@ public class DocumentRepositoryEditorPanel
             private static final long serialVersionUID = -3902555252753037183L;
 
             @Override
-            protected void onAfterSubmit(AjaxRequestTarget target)
+            protected void onAfterSubmit(AjaxRequestTarget aTarget)
             {
-                actionSave(target);
+                actionSave(aTarget);
+            };
+            
+            @Override
+            protected void onError(AjaxRequestTarget aTarget)
+            {
+                aTarget.addChildren(getPage(), IFeedback.class);
             };
         });
         form.add(new LambdaAjaxLink("delete", this::actionDelete)
@@ -182,11 +189,14 @@ public class DocumentRepositoryEditorPanel
         documentRepository.setProject(projectModel.getObject());
         externalSearchService.createOrUpdateDocumentRepository(documentRepository);
 
+        success("Document repository settings saved");
+        
         // causes deselection after saving
         repositoryModel.setObject(null);
 
         // Reload whole page because master panel also needs to be reloaded.
-        aTarget.add(getPage());
+        aTarget.add(findParent(ProjectDocumentRepositoriesPanel.class));
+        aTarget.addChildren(getPage(), IFeedback.class);
     }
 
     private void actionDelete(AjaxRequestTarget aTarget)

--- a/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/project/ProjectDocumentRepositoriesPanel.java
+++ b/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/project/ProjectDocumentRepositoriesPanel.java
@@ -36,6 +36,8 @@ public class ProjectDocumentRepositoriesPanel
     {
         super(aId);
 
+        setOutputMarkupId(true);
+        
         selectedDocumentRepository = Model.of();
         projectModel = aProject;
 


### PR DESCRIPTION
**What's in the PR**
* Max. number of returned results for external search is now configurable in the repository traits. The hard-coded upper limit is 25000.
* Min. number is also hard-coded at 1.
* resolves #988 

**How to test manually**
* Enter "Document Repositories" tab in project settings
* Specify result size (play around and try illegal numbers)
* Execute external search query and observe whether number of returned results matches the specified result size

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
