### PR TITLE
#1101 Evaluating DL4J as NER recommender only predicts NO-LABEL

### DIFF
--- a/inception-imls-dl4j/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommender.java
+++ b/inception-imls-dl4j/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommender.java
@@ -262,25 +262,25 @@ public class DL4JSequenceRecommender
                 }
     
                 featureVec.put(new INDArrayIndex[] { point(sampleIdx), all(), point(t) }, vector);
-                
+                featureMask.putScalar(new int[] { sampleIdx, t }, 1.0);
 
                 // FIXME: exclude padding labels from training
                 // compare instances to avoid collision with possible no_label user label
                 if (labels == null || labels.get(t) == NO_LABEL) {
                     labelMask.putScalar(new int[] { sampleIdx, t }, 0.0);
-                    featureMask.putScalar(new int[] { sampleIdx, t }, 0.0);
                 }
                 else {
                     labelMask.putScalar(new int[] { sampleIdx, t }, 1.0);
-                    featureMask.putScalar(new int[] { sampleIdx, t }, 1.0);
                 }
 
-                if (aIncludeLabels) {
+                if (aIncludeLabels && labels != null) {
                     String label = labels.get(t);
-                    if (!aTagset.containsKey(label)) {
-                        aTagset.put(label, aTagset.size());
+                    if (label != NO_LABEL) {
+                        if (!aTagset.containsKey(label)) {
+                            aTagset.put(label, aTagset.size());
+                        }
+                        labelVec.putScalar(sampleIdx, aTagset.get(label), t, 1.0);
                     }
-                    labelVec.putScalar(sampleIdx, aTagset.get(label), t, 1.0);
                 }
             }
             

--- a/inception-imls-dl4j/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommender.java
+++ b/inception-imls-dl4j/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommender.java
@@ -262,9 +262,19 @@ public class DL4JSequenceRecommender
                 }
     
                 featureVec.put(new INDArrayIndex[] { point(sampleIdx), all(), point(t) }, vector);
-                featureMask.putScalar(new int[] { sampleIdx, t }, 1.0);
-                labelMask.putScalar(new int[] { sampleIdx, t }, 1.0);
-    
+                
+
+                // FIXME: exclude padding labels from training
+                // compare instances to avoid collision with possible no_label user label
+                if (labels == null || labels.get(t) == NO_LABEL) {
+                    labelMask.putScalar(new int[] { sampleIdx, t }, 0.0);
+                    featureMask.putScalar(new int[] { sampleIdx, t }, 0.0);
+                }
+                else {
+                    labelMask.putScalar(new int[] { sampleIdx, t }, 1.0);
+                    featureMask.putScalar(new int[] { sampleIdx, t }, 1.0);
+                }
+
                 if (aIncludeLabels) {
                     String label = labels.get(t);
                     if (!aTagset.containsKey(label)) {

--- a/inception-imls-dl4j/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommender.java
+++ b/inception-imls-dl4j/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommender.java
@@ -274,9 +274,7 @@ public class DL4JSequenceRecommender
                     String label = labels.get(t);
                     // do not add padding label no_label as predictable label
                     if (label != NO_LABEL) {
-                        if (!aTagset.containsKey(label)) {
-                            aTagset.put(label, aTagset.size());
-                        }
+                        aTagset.computeIfAbsent(label, key -> aTagset.size());
                         labelVec.putScalar(sampleIdx, aTagset.get(label), t, 1.0);
                     }
                 }

--- a/inception-imls-dl4j/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommender.java
+++ b/inception-imls-dl4j/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommender.java
@@ -264,17 +264,15 @@ public class DL4JSequenceRecommender
                 featureVec.put(new INDArrayIndex[] { point(sampleIdx), all(), point(t) }, vector);
                 featureMask.putScalar(new int[] { sampleIdx, t }, 1.0);
 
-                // FIXME: exclude padding labels from training
+                // exclude padding labels from training
                 // compare instances to avoid collision with possible no_label user label
-                if (labels == null || labels.get(t) == NO_LABEL) {
-                    labelMask.putScalar(new int[] { sampleIdx, t }, 0.0);
-                }
-                else {
+                if (labels != null && labels.get(t) != NO_LABEL) {
                     labelMask.putScalar(new int[] { sampleIdx, t }, 1.0);
                 }
 
                 if (aIncludeLabels && labels != null) {
                     String label = labels.get(t);
+                    // do not add padding label no_label as predictable label
                     if (label != NO_LABEL) {
                         if (!aTagset.containsKey(label)) {
                             aTagset.put(label, aTagset.size());

--- a/inception-imls-dl4j/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommenderTest.java
+++ b/inception-imls-dl4j/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommenderTest.java
@@ -278,7 +278,7 @@ public class DL4JSequenceRecommenderTest
                 predictions.size());
         
         assertThat(predictions).as("There are predictions other than *No_Label*")
-        .anyMatch(l -> !l.getLabel().equals(DL4JSequenceRecommender.NO_LABEL));
+            .anyMatch(l -> !l.getLabel().equals(DL4JSequenceRecommender.NO_LABEL));
     }
 
     @Test
@@ -333,7 +333,7 @@ public class DL4JSequenceRecommenderTest
                 predictions.size());
         
         assertThat(predictions).as("There are predictions other than *No_Label*")
-        .anyMatch(l -> !l.getLabel().equals(DL4JSequenceRecommender.NO_LABEL));
+            .anyMatch(l -> !l.getLabel().equals(DL4JSequenceRecommender.NO_LABEL));
     }
 
     @Test

--- a/inception-imls-dl4j/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommenderTest.java
+++ b/inception-imls-dl4j/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommenderTest.java
@@ -334,6 +334,29 @@ public class DL4JSequenceRecommenderTest
     }
 
     @Test
+    public void thatNerPredictionProducesNonPaddingLabels() throws Exception
+    {
+        DL4JSequenceRecommender sut = new DL4JSequenceRecommender(buildNerRecommender(), traits,
+                cache);
+        JCas cas = loadNerDevelopmentData();
+
+        sut.train(context, asList(cas.getCas()));
+
+        sut.predict(context, cas.getCas());
+
+        Collection<PredictedSpan> predictions = JCasUtil.select(cas, PredictedSpan.class);
+
+        long numWithLabel = predictions.stream()
+                .filter(p -> !p.getLabel().equals(DL4JSequenceRecommender.NO_LABEL)).count();
+
+        System.out.printf("Predicted %d labels not no_label out of %d.%n", numWithLabel,
+                predictions.size());
+
+        assertThat(predictions).as("There are predictions other than *No_Label*")
+                .anyMatch(l -> !l.getLabel().equals(DL4JSequenceRecommender.NO_LABEL));
+    }
+
+    @Test
     public void thatIncrementalNerEvaluationWorks() throws Exception
     {
         IncrementalSplitter splitStrategy = new IncrementalSplitter(0.8, 50, 10);

--- a/inception-imls-dl4j/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommenderTest.java
+++ b/inception-imls-dl4j/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommenderTest.java
@@ -270,6 +270,15 @@ public class DL4JSequenceRecommenderTest
 
         assertThat(predictions).as("Predictions have been written to CAS")
             .isNotEmpty();
+        
+        // check how many labels are not padding labels
+        long numWithLabel = predictions.stream()
+                .filter(p -> !p.getLabel().equals(DL4JSequenceRecommender.NO_LABEL)).count();
+        System.out.printf("Predicted %d labels not no_label out of %d.%n", numWithLabel,
+                predictions.size());
+        
+        assertThat(predictions).as("There are predictions other than *No_Label*")
+        .anyMatch(l -> !l.getLabel().equals(DL4JSequenceRecommender.NO_LABEL));
     }
 
     @Test
@@ -316,6 +325,15 @@ public class DL4JSequenceRecommenderTest
 
         assertThat(predictions).as("Predictions have been written to CAS")
             .isNotEmpty();
+        
+        // check how many labels are not padding labels
+        long numWithLabel = predictions.stream()
+                .filter(p -> !p.getLabel().equals(DL4JSequenceRecommender.NO_LABEL)).count();
+        System.out.printf("Predicted %d labels not no_label out of %d.%n", numWithLabel,
+                predictions.size());
+        
+        assertThat(predictions).as("There are predictions other than *No_Label*")
+        .anyMatch(l -> !l.getLabel().equals(DL4JSequenceRecommender.NO_LABEL));
     }
 
     @Test
@@ -331,29 +349,6 @@ public class DL4JSequenceRecommenderTest
         System.out.printf("Score: %f%n", score);
         
         assertThat(score).isBetween(0.0, 1.0);
-    }
-
-    @Test
-    public void thatNerPredictionProducesNonPaddingLabels() throws Exception
-    {
-        DL4JSequenceRecommender sut = new DL4JSequenceRecommender(buildNerRecommender(), traits,
-                cache);
-        JCas cas = loadNerDevelopmentData();
-
-        sut.train(context, asList(cas.getCas()));
-
-        sut.predict(context, cas.getCas());
-
-        Collection<PredictedSpan> predictions = JCasUtil.select(cas, PredictedSpan.class);
-
-        long numWithLabel = predictions.stream()
-                .filter(p -> !p.getLabel().equals(DL4JSequenceRecommender.NO_LABEL)).count();
-
-        System.out.printf("Predicted %d labels not no_label out of %d.%n", numWithLabel,
-                predictions.size());
-
-        assertThat(predictions).as("There are predictions other than *No_Label*")
-                .anyMatch(l -> !l.getLabel().equals(DL4JSequenceRecommender.NO_LABEL));
     }
 
     @Test


### PR DESCRIPTION
**What's in the PR**
The sequences in the DL4j recommender are padded with NO_LABEL if no annotation exists yet for a token. This e.g. happens during the NER evaluation test. In this case, the predictions for this test are only NO_LABEL.

**How to test manually**
* not applicable

**Automatic testing**
* [X] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
