### PR TITLE
#1095 - Creating a statement with KB resource and empty value throws

### DIFF
--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/editor/StatementEditor.html
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/editor/StatementEditor.html
@@ -46,7 +46,9 @@
   <wicket:fragment wicket:id="editMode">
     <form wicket:id="form" class="form-inline">
       <div class="flex-h-container flex-gutter flex-only-internal-gutter">
+        <div style="width: 140px;">
         <select wicket:id=valueType class="form-control" data-container="body"></select>
+        </div>
         <div class="flex-content flex-h-container flex-gutter flex-only-internal-gutter" wicket:id="value"></div>
         <div class="pull-right statement-editor-button-row">
           <ul>

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/editor/StatementEditor.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/editor/StatementEditor.java
@@ -153,6 +153,13 @@ public class StatementEditor extends Panel
     private void actionSave(AjaxRequestTarget aTarget, Form<KBStatement> aForm)
     {
         KBStatement modifiedStatement = aForm.getModelObject();
+
+        if (modifiedStatement.getValue() == null) {
+            error("The value of statement cannot be empty");
+            aTarget.addChildren(getPage(), IFeedback.class);
+            return;
+        }
+
         try {
             // persist the modified statement and replace the original, unchanged model
             KBStatement oldStatement = statement.getObject();

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/value/IriValueSupport.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/value/IriValueSupport.java
@@ -58,7 +58,7 @@ public class IriValueSupport
     public List<ValueType> getSupportedValueTypes()
     {
         return asList(
-            new ValueType(XMLSchema.ANYURI.stringValue(), "KB Resource", valueTypeSupportId));
+            new ValueType(XMLSchema.ANYURI.stringValue(), "Resource", valueTypeSupportId));
     }
 
     @Override

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/value/NumericLiteralValueSupport.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/value/NumericLiteralValueSupport.java
@@ -77,7 +77,7 @@ public class NumericLiteralValueSupport
     @Override
     public List<ValueType> getSupportedValueTypes()
     {
-        return asList(new ValueType(XMLSchema.DOUBLE.stringValue(), "Numeric", valueTypeSupportId));
+        return asList(new ValueType(XMLSchema.DOUBLE.stringValue(), "Number", valueTypeSupportId));
     }
     
     @Override

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/value/StringLiteralValueSupport.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/value/StringLiteralValueSupport.java
@@ -58,7 +58,7 @@ public class StringLiteralValueSupport
     @Override
     public List<ValueType> getSupportedValueTypes()
     {
-        return asList(new ValueType(XMLSchema.STRING.stringValue(), "String Resource",
+        return asList(new ValueType(XMLSchema.STRING.stringValue(), "String",
                 valueTypeSupportId));
     }
     

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/value/editor/IRIValueEditor.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/value/editor/IRIValueEditor.java
@@ -124,6 +124,7 @@ public class IRIValueEditor
         };
         value.setOutputMarkupId(true);
         value.add(new LambdaAjaxFormComponentUpdatingBehavior("change", t -> t.add(getParent())));
+        value.setRequired(true);
         add(value);
     }
 

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/value/editor/StringLiteralValueEditor.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/value/editor/StringLiteralValueEditor.java
@@ -38,6 +38,7 @@ public class StringLiteralValueEditor
 
         value = new TextArea<>("value");
         value.setOutputMarkupId(true);
+        value.setRequired(true);
         add(value);
 
         add(new TextField<>("language"));


### PR DESCRIPTION
**What's in the PR**
- Require value when saving a string or IRI statement to avoid NPE - display message if value is missing
- Explicitly check again on actionCreate in case the form validator was somehow bypassed - display message if value is missing
- Improved layout of statement editor
- Changed names of value types (now: String, Resource, Number, Boolean)

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
