### PR TITLE
# 542 recommender layer anchor mismatch

### DIFF
--- a/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/RecommendationService.java
+++ b/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/RecommendationService.java
@@ -112,4 +112,6 @@ public interface RecommendationService
         throws AnnotationException;
     
     Boolean showLearningCurveDiagram();
+
+    List<Recommender> listAllEnabledRecommenders(Project aProject, AnnotationLayer aLayer);
 }

--- a/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/RecommendationService.java
+++ b/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/RecommendationService.java
@@ -60,7 +60,7 @@ public interface RecommendationService
 
     List<Recommender> listRecommenders(AnnotationLayer aLayer);
     
-    List<Recommender> getEnabledRecommenders(Long aRecommenderId);
+    Optional<Recommender> getEnabledRecommender(long aRecommenderId);
     
     List<Recommender> listEnabledRecommenders(Project aProject);
 
@@ -113,5 +113,5 @@ public interface RecommendationService
     
     Boolean showLearningCurveDiagram();
 
-    List<Recommender> listAllEnabledRecommenders(Project aProject, AnnotationLayer aLayer);
+    List<Recommender> listEnabledRecommenders(AnnotationLayer aLayer);
 }

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderEditorPanel.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderEditorPanel.java
@@ -51,12 +51,11 @@ import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.PropertyModel;
+import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.apache.wicket.validation.IValidatable;
 import org.apache.wicket.validation.IValidator;
 import org.apache.wicket.validation.ValidationError;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst;
@@ -84,7 +83,6 @@ public class RecommenderEditorPanel
     extends Panel
 {
     private static final long serialVersionUID = -5278078988218713188L;
-    private final Logger log = LoggerFactory.getLogger(getClass());
 
     private static final String MID_CANCEL = "cancel";
     private static final String MID_DELETE = "delete";
@@ -196,7 +194,7 @@ public class RecommenderEditorPanel
                 return factory != null ? Pair.of(factory.getId(), factory.getName()) : null;
             }, 
             (v) -> recommenderModel.getObject().setTool(v != null ? v.getKey() : null));
-        
+
         toolChoice = new BootstrapSelect<Pair<String, String>>(MID_TOOL, toolModel, this::listTools)
         {
             private static final long serialVersionUID = -1869081847783375166L;
@@ -204,22 +202,13 @@ public class RecommenderEditorPanel
             @Override
             protected void onModelChanged()
             {
+                checkRecommenderLayerMatch(toolModel);
                 // If the feature type has changed, we need to set up a new traits editor
                 Component newTraits;
                 if (form.getModelObject() != null && getModelObject() != null) {
                     RecommendationEngineFactory factory = recommenderRegistry
                             .getFactory(getModelObject().getKey());
                     newTraits = factory.createTraitsEditor(MID_TRAITS, form.getModel());
-                    
-                    Recommender recommender = recommenderModel.getObject();
-                    // check if recommender and layer still match
-                    if (!factory.accepts(recommender.getLayer(), recommender.getFeature())) {
-                        //FIXME error does not show
-                        log.info("[{}][{}]: Recommender configured with invalid layer or feature "
-                                + "- skipping recommender", recommender.getName());
-                        error(String.format("The recommender %s is configured for an invalid layer."
-                                , recommender.getName()));
-                    }
                 }
                 else {
                     newTraits = new EmptyPanel(MID_TRAITS);
@@ -228,6 +217,7 @@ public class RecommenderEditorPanel
                 traitsContainer.addOrReplace(newTraits);
             }
         };
+        
         // TODO: For a deprecated recommender, show itself in the tool dropdown but unselectable
         toolChoice.setChoiceRenderer(new ChoiceRenderer<>("value"));
         toolChoice.setRequired(true);
@@ -288,7 +278,6 @@ public class RecommenderEditorPanel
                 actionSave(target);
             }
         });
-
 
         // We need to invert the states in documentStates, as the recommender stores the
         // ones to ignore, not the ones to consider
@@ -354,6 +343,26 @@ public class RecommenderEditorPanel
         
         if (aTarget != null) {
             aTarget.add(aField);
+        }
+    }
+    
+    /**
+     * Check if the selected recommender still accepts the configured layer and feature.
+     * If not show an error message.
+     */
+    private void checkRecommenderLayerMatch(IModel<Pair<String, String>> aToolModel)
+    {
+        Recommender recommender = recommenderModel.getObject();
+        // check if recommender and layer still match
+        RecommendationEngineFactory factory = recommenderRegistry
+                .getFactory(aToolModel.getObject().getKey());
+        if (!factory.accepts(recommender.getLayer(), recommender.getFeature())) {
+            error(String.format("Recommender %s configured with invalid layer or feature.",
+                    recommender.getName()));
+            Optional<AjaxRequestTarget> target = RequestCycle.get().find(AjaxRequestTarget.class);
+            if (target.isPresent()) {
+                target.get().addChildren(getPage(), IFeedback.class);
+            }
         }
     }
     
@@ -524,4 +533,5 @@ public class RecommenderEditorPanel
             }
         }
     }
+
 }

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderEditorPanel.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderEditorPanel.java
@@ -352,16 +352,19 @@ public class RecommenderEditorPanel
      */
     private void checkRecommenderLayerMatch(IModel<Pair<String, String>> aToolModel)
     {
-        Recommender recommender = recommenderModel.getObject();
-        // check if recommender and layer still match
-        RecommendationEngineFactory factory = recommenderRegistry
-                .getFactory(aToolModel.getObject().getKey());
-        if (!factory.accepts(recommender.getLayer(), recommender.getFeature())) {
-            error(String.format("Recommender %s configured with invalid layer or feature.",
-                    recommender.getName()));
-            Optional<AjaxRequestTarget> target = RequestCycle.get().find(AjaxRequestTarget.class);
-            if (target.isPresent()) {
-                target.get().addChildren(getPage(), IFeedback.class);
+        if (recommenderModel.getObject() != null && aToolModel.getObject() != null) {
+            Recommender recommender = recommenderModel.getObject();
+            // check if recommender and layer still match
+            RecommendationEngineFactory factory = recommenderRegistry
+                    .getFactory(aToolModel.getObject().getKey());
+            if (!factory.accepts(recommender.getLayer(), recommender.getFeature())) {
+                error(String.format("Recommender %s configured with invalid layer or feature.",
+                        recommender.getName()));
+                Optional<AjaxRequestTarget> target = RequestCycle.get()
+                        .find(AjaxRequestTarget.class);
+                if (target.isPresent()) {
+                    target.get().addChildren(getPage(), IFeedback.class);
+                }
             }
         }
     }

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderEditorPanel.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderEditorPanel.java
@@ -347,12 +347,15 @@ public class RecommenderEditorPanel
     }
     
     /**
-     * Check if the selected recommender still accepts the configured layer and feature.
-     * If not show an error message.
+     * Check if the selected recommender still accepts the configured layer and feature. If not show
+     * an error message.
      */
     private void checkRecommenderLayerMatch(IModel<Pair<String, String>> aToolModel)
     {
-        if (recommenderModel.getObject() != null && aToolModel.getObject() != null) {
+        if (recommenderModel.getObject() == null || aToolModel.getObject() == null) {
+            return;
+        }
+        else {
             Recommender recommender = recommenderModel.getObject();
             // check if recommender and layer still match
             RecommendationEngineFactory factory = recommenderRegistry

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderEditorPanel.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderEditorPanel.java
@@ -55,6 +55,8 @@ import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.apache.wicket.validation.IValidatable;
 import org.apache.wicket.validation.IValidator;
 import org.apache.wicket.validation.ValidationError;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst;
@@ -82,6 +84,7 @@ public class RecommenderEditorPanel
     extends Panel
 {
     private static final long serialVersionUID = -5278078988218713188L;
+    private final Logger log = LoggerFactory.getLogger(getClass());
 
     private static final String MID_CANCEL = "cancel";
     private static final String MID_DELETE = "delete";
@@ -207,6 +210,16 @@ public class RecommenderEditorPanel
                     RecommendationEngineFactory factory = recommenderRegistry
                             .getFactory(getModelObject().getKey());
                     newTraits = factory.createTraitsEditor(MID_TRAITS, form.getModel());
+                    
+                    Recommender recommender = recommenderModel.getObject();
+                    // check if recommender and layer still match
+                    if (!factory.accepts(recommender.getLayer(), recommender.getFeature())) {
+                        //FIXME error does not show
+                        log.info("[{}][{}]: Recommender configured with invalid layer or feature "
+                                + "- skipping recommender", recommender.getName());
+                        error(String.format("The recommender %s is configured for an invalid layer."
+                                , recommender.getName()));
+                    }
                 }
                 else {
                     newTraits = new EmptyPanel(MID_TRAITS);

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderEditorPanel.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderEditorPanel.java
@@ -355,19 +355,17 @@ public class RecommenderEditorPanel
         if (recommenderModel.getObject() == null || aToolModel.getObject() == null) {
             return;
         }
-        else {
-            Recommender recommender = recommenderModel.getObject();
-            // check if recommender and layer still match
-            RecommendationEngineFactory factory = recommenderRegistry
-                    .getFactory(aToolModel.getObject().getKey());
-            if (!factory.accepts(recommender.getLayer(), recommender.getFeature())) {
-                error(String.format("Recommender %s configured with invalid layer or feature.",
-                        recommender.getName()));
-                Optional<AjaxRequestTarget> target = RequestCycle.get()
-                        .find(AjaxRequestTarget.class);
-                if (target.isPresent()) {
-                    target.get().addChildren(getPage(), IFeedback.class);
-                }
+        
+        Recommender recommender = recommenderModel.getObject();
+        // check if recommender and layer still match
+        RecommendationEngineFactory factory = recommenderRegistry
+                .getFactory(aToolModel.getObject().getKey());
+        if (!factory.accepts(recommender.getLayer(), recommender.getFeature())) {
+            error(String.format("Recommender %s configured with invalid layer or feature.",
+                    recommender.getName()));
+            Optional<AjaxRequestTarget> target = RequestCycle.get().find(AjaxRequestTarget.class);
+            if (target.isPresent()) {
+                target.get().addChildren(getPage(), IFeedback.class);
             }
         }
     }
@@ -378,14 +376,10 @@ public class RecommenderEditorPanel
                 || aRecommender.getTool() == null) {
             return null;
         }
-        else {
-            RecommendationEngineFactory factory = recommenderRegistry
-                    .getFactory(aRecommender.getTool());
-            return String.format(Locale.US, "[%s@%s] %s",
-                    aRecommender.getLayer().getUiName(),
-                    aRecommender.getFeature().getUiName(), 
-                    factory.getName());
-        }
+        RecommendationEngineFactory factory = recommenderRegistry
+                .getFactory(aRecommender.getTool());
+        return String.format(Locale.US, "[%s@%s] %s", aRecommender.getLayer().getUiName(),
+                aRecommender.getFeature().getUiName(), factory.getName());
     }
     
     @Override
@@ -465,9 +459,7 @@ public class RecommenderEditorPanel
                 .map(f -> Pair.of(f.getId(), f.getName()))
                 .collect(Collectors.toList());
         }
-        else {
-            return Collections.emptyList();
-        }
+        return Collections.emptyList();
     }
 
     private void actionSave(AjaxRequestTarget aTarget)

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
@@ -260,7 +260,7 @@ public class RecommendationServiceImpl
     
     @Override
     @Transactional
-    public List<Recommender> getEnabledRecommenders(Long aRecommenderId)
+    public Optional<Recommender> getEnabledRecommender(long aRecommenderId)
     {
         String query = String.join("\n",
                 "FROM Recommender WHERE ",
@@ -270,33 +270,37 @@ public class RecommendationServiceImpl
         return entityManager.createQuery(query, Recommender.class)
                 .setParameter("id", aRecommenderId)
                 .setParameter("enabled", true)
-                .getResultList();
+                .getResultStream()
+                .findFirst();
     }
     
     @Override
     @Transactional
-    public List<Recommender> listAllEnabledRecommenders(Project aProject, AnnotationLayer aLayer)
+    public List<Recommender> listEnabledRecommenders(AnnotationLayer aLayer)
     {
         String query = String.join("\n",
                 "FROM Recommender WHERE ",
                 "project = :project AND",
                 "layer = :layer AND",
-                "enabled = :enabled");
+                "enabled = :enabled",
+                "ORDER BY name ASC" );
 
         return entityManager.createQuery(query, Recommender.class)
-                .setParameter("project", aProject)
+                .setParameter("project", aLayer.getProject())
                 .setParameter("layer", aLayer)
                 .setParameter("enabled", true)
                 .getResultList();
     }
     
     @Override
+    @Transactional
     public List<Recommender> listEnabledRecommenders(Project aProject)
     {
         String query = String.join("\n",
-                "FROM Recommender WHERE ",
-                "project = :project AND ",
-                "enabled = :enabled" );
+                "FROM Recommender WHERE",
+                "project = :project AND",
+                "enabled = :enabled",
+                "ORDER BY name ASC" );
 
         return entityManager.createQuery(query, Recommender.class)
                 .setParameter("project", aProject)
@@ -308,11 +312,14 @@ public class RecommendationServiceImpl
     @Transactional
     public List<Recommender> listRecommenders(AnnotationLayer aLayer)
     {
-        List<Recommender> settings = entityManager
-                .createQuery("FROM Recommender WHERE layer = :layer ORDER BY name ASC",
-                        Recommender.class)
-                .setParameter("layer", aLayer).getResultList();
-        return settings;
+        String query = String.join("\n",
+                "FROM Recommender WHERE ",
+                "layer = :layer",
+                "ORDER BY name ASC" );
+        
+        return entityManager.createQuery(query, Recommender.class)
+                .setParameter("layer", aLayer)
+                .getResultList();
     }
 
     /**

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
@@ -274,6 +274,23 @@ public class RecommendationServiceImpl
     }
     
     @Override
+    @Transactional
+    public List<Recommender> listAllEnabledRecommenders(Project aProject, AnnotationLayer aLayer)
+    {
+        String query = String.join("\n",
+                "FROM Recommender WHERE ",
+                "project = :project AND",
+                "layer = :layer AND",
+                "enabled = :enabled");
+
+        return entityManager.createQuery(query, Recommender.class)
+                .setParameter("project", aProject)
+                .setParameter("layer", aLayer)
+                .setParameter("enabled", true)
+                .getResultList();
+    }
+    
+    @Override
     public List<Recommender> listEnabledRecommenders(Project aProject)
     {
         String query = String.join("\n",

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/LearningCurveChartPanel.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/LearningCurveChartPanel.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -227,10 +228,16 @@ public class LearningCurveChartPanel
             try {
                 Details detail = fromJsonString(Details.class, detailJson);
 
+                // If the log is inconsistent and we do not have an ID for some reason, then we
+                // have to skip it
+                if (detail.recommenderId == null) {
+                    continue;
+                }
+                
                 //do not include the scores from disabled recommenders
-                List<Recommender> recommenderIfActive = recommendationService
-                        .getEnabledRecommenders(detail.recommenderId);
-                if (recommenderIfActive.isEmpty()) {
+                Optional<Recommender> recommenderIfActive = recommendationService
+                        .getEnabledRecommender(detail.recommenderId);
+                if (recommenderIfActive.isPresent()) {
                     continue;
                 }
 
@@ -240,7 +247,7 @@ public class LearningCurveChartPanel
                 }
                 
                 //recommenderIfActive only has one member
-                recommenderScoreMap.put(recommenderIfActive.get(0).getName(), detail.score);
+                recommenderScoreMap.put(recommenderIfActive.get().getName(), detail.score);
             }
             catch (IOException e) {
                 log.error("Invalid logged Event detail. Skipping record with logged event id: "

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommendationSidebar.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommendationSidebar.java
@@ -93,8 +93,7 @@ public class RecommendationSidebar
             if (!layer.isEnabled()) {
                 continue;
             }
-            for (Recommender recommender : recommendationService.listAllEnabledRecommenders(project,
-                    layer)) {
+            for (Recommender recommender : recommendationService.listEnabledRecommenders(layer)) {
                 RecommendationEngineFactory<?> factory = recommendationService
                         .getRecommenderFactory(recommender);
                 if (!factory.accepts(recommender.getLayer(), recommender.getFeature())) {

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/PredictionTask.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/PredictionTask.java
@@ -160,7 +160,6 @@ public class PredictionTask
                     if (!factory.accepts(recommender.getLayer(), recommender.getFeature())) {
                         log.info("[{}][{}]: Recommender configured with invalid layer or feature "
                                 + "- skipping recommender", user.getUsername(), r.getName());
-                        // TODO: inform user
                         continue nextRecommender;
                     }
                     

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/PredictionTask.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/PredictionTask.java
@@ -154,6 +154,16 @@ public class PredictionTask
 
                     RecommendationEngineFactory<?> factory = recommendationService
                             .getRecommenderFactory(recommender);
+                    
+                    // Check that configured layer and feature are accepted 
+                    // by this type of recommender
+                    if (!factory.accepts(recommender.getLayer(), recommender.getFeature())) {
+                        log.info("[{}][{}]: Recommender configured with invalid layer or feature "
+                                + "- skipping recommender", user.getUsername(), r.getName());
+                        // TODO: inform user
+                        continue nextRecommender;
+                    }
+                    
 
                     // We lazily load the CAS only at this point because that allows us to skip
                     // loading the CAS entirely if there is no enabled layer or recommender.

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/SelectionTask.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/SelectionTask.java
@@ -126,6 +126,14 @@ public class SelectionTask
                     long start = System.currentTimeMillis();
                     RecommendationEngineFactory factory = recommendationService
                         .getRecommenderFactory(recommender);
+                    
+                    if (!factory.accepts(recommender.getLayer(), recommender.getFeature())) {
+                        log.info("[{}][{}]: Recommender configured with invalid layer or feature "
+                                + "- skipping recommender", user.getUsername(), r.getName());
+                        // TODO: inform user
+                        continue;
+                    }
+                    
                     RecommendationEngine recommendationEngine = factory.build(recommender);
 
                     if (recommender.isAlwaysSelected()) {

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/SelectionTask.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/SelectionTask.java
@@ -130,7 +130,6 @@ public class SelectionTask
                     if (!factory.accepts(recommender.getLayer(), recommender.getFeature())) {
                         log.info("[{}][{}]: Recommender configured with invalid layer or feature "
                                 + "- skipping recommender", user.getUsername(), r.getName());
-                        // TODO: inform user
                         continue;
                     }
                     

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/TrainingTask.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/TrainingTask.java
@@ -125,6 +125,13 @@ public class TrainingTask
                 RecommenderContext context = recommendationService.getContext(user, recommender);
                 RecommendationEngineFactory factory = recommendationService
                     .getRecommenderFactory(recommender);
+                
+                if (!factory.accepts(recommender.getLayer(), recommender.getFeature())) {
+                    log.info("[{}][{}]: Recommender configured with invalid layer or feature "
+                            + "- skipping recommender", user.getUsername(), r.getName());
+                    // TODO: inform user
+                    continue;
+                }
 
                 try {
                     RecommendationEngine recommendationEngine = factory.build(recommender);

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/TrainingTask.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/TrainingTask.java
@@ -129,7 +129,6 @@ public class TrainingTask
                 if (!factory.accepts(recommender.getLayer(), recommender.getFeature())) {
                     log.info("[{}][{}]: Recommender configured with invalid layer or feature "
                             + "- skipping recommender", user.getUsername(), r.getName());
-                    // TODO: inform user
                     continue;
                 }
 

--- a/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImplIntegrationTest.java
+++ b/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImplIntegrationTest.java
@@ -64,6 +64,7 @@ public class RecommendationServiceImplIntegrationTest
         sut = new RecommendationServiceImpl(testEntityManager.getEntityManager());
         project = createProject(PROJECT_NAME);
         layer = createAnnotationLayer();
+        layer.setProject(project);
         feature = createAnnotationFeature(layer, "strFeat");
     }
 

--- a/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImplIntegrationTest.java
+++ b/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImplIntegrationTest.java
@@ -21,6 +21,7 @@ package de.tudarmstadt.ukp.inception.recommendation.service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.apache.uima.cas.CAS;
 import org.junit.After;
@@ -85,11 +86,12 @@ public class RecommendationServiceImplIntegrationTest
 
         sut.createOrUpdateRecommender(rec);
 
-        List<Recommender> enabledRecommenders = sut.listAllEnabledRecommenders(rec.getProject(),
-                rec.getLayer());
+        List<Recommender> enabledRecommenders = sut.listEnabledRecommenders(rec.getLayer());
 
-        assertThat(enabledRecommenders).as("Check that the previously created recommender is found")
-                .hasSize(1).contains(rec);
+        assertThat(enabledRecommenders)
+        .as("Check that the previously created recommender is found")
+                .hasSize(1)
+                .contains(rec);
     }
     
     @Test
@@ -100,10 +102,12 @@ public class RecommendationServiceImplIntegrationTest
 
         sut.createOrUpdateRecommender(rec);
 
-        List<Recommender> enabledRecommenders = sut.getEnabledRecommenders(rec.getId());
+        Optional<Recommender> enabledRecommenders = sut.getEnabledRecommender(rec.getId());
 
-        assertThat(enabledRecommenders).as("Check that only the previously created recommender is found")
-                .hasSize(1).contains(rec);
+        assertThat(enabledRecommenders)
+                .as("Check that only the previously created recommender is found")
+                .isPresent()
+                .contains(rec);
     }
 
     @Test
@@ -114,7 +118,7 @@ public class RecommendationServiceImplIntegrationTest
 
         sut.createOrUpdateRecommender(rec);
 
-        List<Recommender> enabledRecommenders = sut.getEnabledRecommenders(rec.getId());
+        Optional<Recommender> enabledRecommenders = sut.getEnabledRecommender(rec.getId());
 
         assertThat(enabledRecommenders).as("Check that no recommender is found").isEmpty();;
     }
@@ -127,10 +131,12 @@ public class RecommendationServiceImplIntegrationTest
 
         sut.createOrUpdateRecommender(rec);
 
-        Long otherId = 9999L;
-        List<Recommender> enabledRecommenders = sut.getEnabledRecommenders(otherId );
+        long otherId = 9999L;
+        Optional<Recommender> enabledRecommenders = sut.getEnabledRecommender(otherId );
 
-        assertThat(enabledRecommenders).as("Check that no recommender is found").isEmpty();;
+        assertThat(enabledRecommenders)
+                .as("Check that no recommender is found")
+                .isEmpty();;
     }
 
     private Recommender buildRecommender(Project aProject, AnnotationFeature aFeature)

--- a/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImplIntegrationTest.java
+++ b/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImplIntegrationTest.java
@@ -78,6 +78,21 @@ public class RecommendationServiceImplIntegrationTest
     }
     
     @Test
+    public void listRecommenders_WithOneEnabledRecommender_ShouldReturnStoredRecommender()
+    {
+        rec = buildRecommender(project, feature);
+        rec.setEnabled(true);
+
+        sut.createOrUpdateRecommender(rec);
+
+        List<Recommender> enabledRecommenders = sut.listAllEnabledRecommenders(rec.getProject(),
+                rec.getLayer());
+
+        assertThat(enabledRecommenders).as("Check that the previously created recommender is found")
+                .hasSize(1).contains(rec);
+    }
+    
+    @Test
     public void getRecommenders_WithOneEnabledRecommender_ShouldReturnStoredRecommender()
     {
         rec = buildRecommender(project, feature);


### PR DESCRIPTION
**What's in the PR**
The anchoring mode (e.g. lock-to-token) can be changed by the user even after a layer has been created. Recommenders usually do not work for all modes - only for certain ones. This means that the layer configuration can become inconsistent with the configured recommenders.

- When a recommender job is run (train/evaluate/predict) the scheduler must check if the recommender still accepts the layer configuration - if not, display an error to the user and skip the recommender
- On the recommender tab in the project settings warnings should be shown if recommenders
are inconsistent with the configuration of the layer they are defined on

**How to test manually**
* Create a layer with a given anchoring mode
* Create a recommender that supports this mode
* Change the anchoring mode of the layer to something the recommender does not support
* Go to the project settings Recommender tab, an error message should be shown
* Go to the annotation page and open the recommender sidebar, an error message should be shown

**Automatic testing**
* [x] PR includes unit tests

