### PR TITLE
#1119 - Images jump back to top after new annotation tag

### DIFF
--- a/inception-image/src/main/java/de/tudarmstadt/ukp/inception/image/sidebar/ImageSidebar.html
+++ b/inception-image/src/main/java/de/tudarmstadt/ukp/inception/image/sidebar/ImageSidebar.html
@@ -17,18 +17,29 @@
  - limitations under the License.
 -->
 <html xmlns:wicket="http://wicket.apache.org">
+<wicket:head>
+  <style>
+    .showOnHover {
+      opacity: 0.1;
+    }
+    
+    .showOnHover:hover {
+      opacity: 1;
+    } 
+  </style>
+</wicket:head>
 <wicket:panel>
   <div class="flex-content flex-v-container flex-gutter flex-only-internal-gutter">
     <div class="panel panel-default panel-flex flex-content">
       <div class="panel-heading">
         <h3 class="panel-title">Images</h3>
       </div>
-      <div class="panel-body flex-v-container">
-        <div wicket:id="mainContainer" class="scrolling flex-content flex-v-container flex-gutter">
+      <div class="scrolling panel-body flex-v-container">
+        <div wicket:id="mainContainer" class="flex-content flex-v-container flex-gutter">
           <wicket:container wicket:id="images">
             <div style="position: relative;">
               <img wicket:id="image" class="img-thumbnail img-responsive"/>
-              <div style="position: absolute; top: 5px; right: 5px;">
+              <div style="position: absolute; top: 5px; right: 5px;" class="showOnHover">
                 <a wicket:id="open" target="_blank" class="btn btn-xs btn-default">
                   <i class="fa fa-external-link" aria-hidden="true"></i>
                 </a>


### PR DESCRIPTION
**What's in the PR**
- Move the "scrolling" class one element up in the hierarchy to avoid the list jumping back to the beginning when it is updated
- Show the "open in new window" button translucently unless mouse hovers over it

**How to test manually**
* Add many annotations with image features linking to some images such that the image sidebar starts showing a scroll bar
* scroll a bit down in the sidebar
* select annotations or add/remove annotations and observe that the scroll position does not change
* check that the "open in new window" button in the top-right of every image in the sidebar is translucent unless you move the mouse over it

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
