### PR TITLE
#1089 - PDF Editor Viewport undefined

### DIFF
--- a/inception-pdf-editor/src/main/js/pdfanno/src/page/textLayer.js
+++ b/inception-pdf-editor/src/main/js/pdfanno/src/page/textLayer.js
@@ -163,6 +163,19 @@ function withinMargin (x, base, margin) {
   return (base - margin) <= x && x <= (base + margin)
 }
 
+/**
+ * Returns the scaling factor of the PDF. If the PDF has not been drawn yet, a factor of 1 is
+ * assumed.
+ */
 function scale () {
-  return window.PDFView.pdfViewer.getPageView(0).viewport.scale
+// BEGIN INCEpTION EXTENSION - #1089 - PDF Editor Viewport undefined
+/*
+  return window.PDFView.pdfViewer.getPageView(0).viewport.scale;
+*/
+  if (window.PDFView.pdfViewer.getPageView(0) === undefined) {
+    return 1;
+  } else {
+    return window.PDFView.pdfViewer.getPageView(0).viewport.scale;
+  }
+// END INCEpTION EXTENSION - #1089 - PDF Editor Viewport undefined
 }

--- a/inception-pdf-editor/src/main/js/pdfanno/src/pdfanno.js
+++ b/inception-pdf-editor/src/main/js/pdfanno/src/pdfanno.js
@@ -215,8 +215,14 @@ async function displayViewer () {
     const renderTimeout = 500
     window.pagechangeEventCounter = 0
     window.pageRender = 1;
-    getAnnotations()
 
+// BEGIN INCEpTION EXTENSION - #1089 - PDF Editor Viewport undefined
+    let initAnnotations = function(e) {
+      getAnnotations()
+      document.removeEventListener('pagerendered', initAnnotations)
+    }
+    document.addEventListener('pagerendered', initAnnotations)
+// END INCEpTION EXTENSION - #1089
     document.addEventListener('pagechange', function(e) {
       pagechangeEventCounter++
       if (e.pageNumber !== window.pageRender) {
@@ -230,7 +236,7 @@ async function displayViewer () {
         }, renderTimeout)
       }
     })
-// END INCEpTION EXTENSION
+// END INCEpTION EXTENSION - #802
 
   } catch (err) {
 

--- a/inception-pdf-editor/src/main/js/pdfanno/src/pdfanno.js
+++ b/inception-pdf-editor/src/main/js/pdfanno/src/pdfanno.js
@@ -220,8 +220,11 @@ async function displayViewer () {
     getAnnotations()
 */
     let initAnnotations = function(e) {
-      getAnnotations()
-      document.removeEventListener('pagerendered', initAnnotations)
+      try {
+        getAnnotations()
+      } finally {
+        document.removeEventListener('pagerendered', initAnnotations)
+      }
     }
     document.addEventListener('pagerendered', initAnnotations)
 // END INCEpTION EXTENSION - #1089

--- a/inception-pdf-editor/src/main/js/pdfanno/src/pdfanno.js
+++ b/inception-pdf-editor/src/main/js/pdfanno/src/pdfanno.js
@@ -215,8 +215,10 @@ async function displayViewer () {
     const renderTimeout = 500
     window.pagechangeEventCounter = 0
     window.pageRender = 1;
-
 // BEGIN INCEpTION EXTENSION - #1089 - PDF Editor Viewport undefined
+/*
+    getAnnotations()
+*/
     let initAnnotations = function(e) {
       getAnnotations()
       document.removeEventListener('pagerendered', initAnnotations)


### PR DESCRIPTION
**What's in the PR**
- Avoid accessing the first rendered page if it has not been rendered yet

**How to test manually**
* Basically open and PDF - for me the error described in the issue happened *always* when opening a PDF document after coming from the dashboard page

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
