### PR TITLE
#1128 Make default_field configurable for ElasticSearch queries

### DIFF
--- a/inception-external-search-elastic/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/elastic/ElasticSearchProvider.java
+++ b/inception-external-search-elastic/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/elastic/ElasticSearchProvider.java
@@ -132,11 +132,13 @@ public class ElasticSearchProvider
 
                 // There are highlights, set them in the result
                 List<ExternalSearchHighlight> highlights = new ArrayList<>();
-                for (String highlight : hit.getHighlight().getDoctext()) {
-                    Optional<ExternalSearchHighlight> exHighlight = HighlightUtils
-                            .parseHighlight(highlight, originalText);
+                if (hit.getHighlight().getDoctext() != null) {
+                    for (String highlight : hit.getHighlight().getDoctext()) {
+                        Optional<ExternalSearchHighlight> exHighlight = HighlightUtils
+                                .parseHighlight(highlight, originalText);
                     
-                    exHighlight.ifPresent(highlights::add);
+                        exHighlight.ifPresent(highlights::add);
+                    }
                 }
                 result.setHighlights(highlights);
             }
@@ -155,7 +157,7 @@ public class ElasticSearchProvider
         bodyNode.put("size", aTraits.getResultSize());
 
         ObjectNode queryString = mapper.createObjectNode();
-        queryString.put("default_field", "doc.text");
+        queryString.put("default_field", aTraits.getDefaultField());
         queryString.put("query", aQuery);
         
         ObjectNode queryBody = mapper.createObjectNode();
@@ -182,7 +184,7 @@ public class ElasticSearchProvider
         ObjectNode highlightNode = mapper.createObjectNode();
         ObjectNode emptyNode = mapper.createObjectNode();
         highlightNode.putPOJO("fields", mapper.createObjectNode()
-            .putPOJO("doc.text", emptyNode));
+            .putPOJO(aTraits.getDefaultField(), emptyNode));
         bodyNode.putPOJO("highlight", highlightNode);
 
         // Render JSON to string

--- a/inception-external-search-elastic/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/elastic/traits/ElasticSearchProviderTraits.java
+++ b/inception-external-search-elastic/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/elastic/traits/ElasticSearchProviderTraits.java
@@ -34,6 +34,8 @@ public class ElasticSearchProviderTraits
     
     private String objectType = "texts";
     
+    private String defaultField = "doc.text";
+    
     /**
      *  Number of results retrieved from the server
      */
@@ -81,6 +83,16 @@ public class ElasticSearchProviderTraits
     public void setObjectType(String aObjectType)
     {
         objectType = aObjectType;
+    }
+    
+    public String getDefaultField()
+    {
+        return defaultField;
+    }
+    
+    public void setDefaultField(String aDefaultField)
+    {
+        defaultField = aDefaultField;
     }
 
     public int getResultSize()

--- a/inception-external-search-elastic/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/elastic/traits/ElasticSearchProviderTraitsEditor.html
+++ b/inception-external-search-elastic/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/elastic/traits/ElasticSearchProviderTraitsEditor.html
@@ -53,6 +53,14 @@
             <input wicket:id="objectType" type="text" class="form-control"/>
           </div>
         </div>
+        <div class="form-group" wicket:enclosure="defaultField">
+          <label class="col-sm-2 control-label">
+            <wicket:message key="defaultField"/>
+          </label>
+          <div class="col-sm-10">
+            <input wicket:id="defaultField" type="text" class="form-control"/>
+          </div>
+        </div>
         <div class="form-group" wicket:enclosure="resultSize">
           <label class="col-sm-2 control-label">
             <wicket:message key="resultSize"/>

--- a/inception-external-search-elastic/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/elastic/traits/ElasticSearchProviderTraitsEditor.java
+++ b/inception-external-search-elastic/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/elastic/traits/ElasticSearchProviderTraitsEditor.java
@@ -85,6 +85,10 @@ public class ElasticSearchProviderTraitsEditor
         objectType.setRequired(true);
         form.add(objectType);
     
+        TextField<String> defaultField = new TextField<>("defaultField");
+        objectType.setRequired(true);
+        form.add(defaultField);
+    
         NumberTextField<Integer> resultSize =
                 new NumberTextField<>("resultSize", Integer.class);
         resultSize.setMinimum(1);

--- a/inception-external-search-elastic/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/elastic/traits/ElasticSearchProviderTraitsEditor.properties
+++ b/inception-external-search-elastic/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/elastic/traits/ElasticSearchProviderTraitsEditor.properties
@@ -18,6 +18,7 @@ remoteUrl=Remote URL
 indexName=Index Name
 searchPath=Search Path
 objectType=Object Type
+defaultField=Field
 resultSize=Result Size
 randomOrder=Random Ordering
 seed=Random seed


### PR DESCRIPTION
**What's in the PR**
* make the default_field configurable for ElasticSearch queries
* resolves #1128

**How to test manually**
* configure the "Field" trait in the document repository traits for the gigaword document repository to `metadata.id`
* execute search query `NYT_ENG_20000114.0283`
* exactly one result should be returned

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
