### PR TITLE
#1137 Learning curve is not shown on annotation page

### DIFF
--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/LearningCurveChartPanel.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/LearningCurveChartPanel.java
@@ -237,7 +237,7 @@ public class LearningCurveChartPanel
                 //do not include the scores from disabled recommenders
                 Optional<Recommender> recommenderIfActive = recommendationService
                         .getEnabledRecommender(detail.recommenderId);
-                if (recommenderIfActive.isPresent()) {
+                if (!recommenderIfActive.isPresent()) {
                     continue;
                 }
 


### PR DESCRIPTION
**What's in the PR**
* Learning curve is shown when enabled.

**How to test manually**
* Enable the display of the learning curve in the projects.settings
* Configure and enable a recommender.
* Annotate.
* Open the recommender sidebar to show the learning curve.

**Automatic testing**
* not applicable
