### PR TITLE
#1178 - Allow OpenNLP POS tagger for concept features

### DIFF
--- a/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/ner/OpenNlpNerRecommenderFactory.java
+++ b/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/ner/OpenNlpNerRecommenderFactory.java
@@ -71,7 +71,7 @@ public class OpenNlpNerRecommenderFactory
         
         return (asList(SINGLE_TOKEN, TOKENS).contains(aLayer.getAnchoringMode()))
                 && !aLayer.isCrossSentence() && SPAN_TYPE.equals(aLayer.getType())
-                && CAS.TYPE_NAME_STRING.equals(aFeature.getType()) || aFeature.isVirtualFeature();
+                && (CAS.TYPE_NAME_STRING.equals(aFeature.getType()) || aFeature.isVirtualFeature());
     }
 
     @Override

--- a/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/pos/OpenNlpPosRecommenderFactory.java
+++ b/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/pos/OpenNlpPosRecommenderFactory.java
@@ -64,7 +64,7 @@ public class OpenNlpPosRecommenderFactory
         }
         
         return SINGLE_TOKEN.equals(aLayer.getAnchoringMode()) && SPAN_TYPE.equals(aLayer.getType())
-                && CAS.TYPE_NAME_STRING.equals(aFeature.getType());
+                && (CAS.TYPE_NAME_STRING.equals(aFeature.getType()) || aFeature.isVirtualFeature());
     }
 
     @Override


### PR DESCRIPTION
**What's in the PR**
- Allow concept features for the OpenNLP pos tagger
- Formatting

**How to test manually**
* Set up a local KB from the "OLiA - Penn Treebank tagset (morphosyntax)"
* Set up a custom layer with single-token granularity and a concept feature
* Set up OpenNLP POS recommender for that layer/feature

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation