### PR TITLE
#1201 - Support reading TEI format

### DIFF
--- a/inception-app-webapp/pom.xml
+++ b/inception-app-webapp/pom.xml
@@ -177,6 +177,10 @@
       <groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
       <artifactId>de.tudarmstadt.ukp.dkpro.core.io.lif-asl</artifactId>
     </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.dkpro.core</groupId>
+      <artifactId>de.tudarmstadt.ukp.dkpro.core.io.tei-asl</artifactId>
+    </dependency>
 
     <!-- WEBANNO DEPENDENCIES -->
     <dependency>

--- a/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/formats/TeiFormatSupport.java
+++ b/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/formats/TeiFormatSupport.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019
+ * Ubiquitous Knowledge Processing (UKP) Lab
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.formats;
+
+import static org.apache.uima.fit.factory.AnalysisEngineFactory.createEngineDescription;
+import static org.apache.uima.fit.factory.CollectionReaderFactory.createReaderDescription;
+
+import org.apache.uima.analysis_engine.AnalysisEngineDescription;
+import org.apache.uima.cas.CAS;
+import org.apache.uima.collection.CollectionReaderDescription;
+import org.apache.uima.resource.ResourceInitializationException;
+import org.springframework.stereotype.Component;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.dkpro.core.io.tei.TeiReader;
+import de.tudarmstadt.ukp.dkpro.core.io.tei.TeiWriter;
+
+@Component
+public class TeiFormatSupport
+    implements FormatSupport
+{
+    public static final String ID = "dkpro-core-tei";
+    public static final String NAME = "TEI";
+    
+    @Override
+    public String getId()
+    {
+        return ID;
+    }
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public boolean isReadable()
+    {
+        return true;
+    }
+
+    @Override
+    public CollectionReaderDescription getReaderDescription() throws ResourceInitializationException
+    {
+        return createReaderDescription(TeiReader.class);
+    }
+    
+    @Override
+    public AnalysisEngineDescription getWriterDescription(Project aProject, CAS aCAS)
+        throws ResourceInitializationException
+    {
+        return createEngineDescription(TeiWriter.class);
+    }
+}


### PR DESCRIPTION
**What's in the PR**
- Added TeiFormatSupport integrating the DKPro Core TEI reader/writer
- Added dependency on DKPro Core TEI module

**How to test manually**
* Import a TEI file, e.g. http://www.perseus.tufts.edu/hopper/dltext?doc=Perseus%3Atext%3A1999.03.0025
* View the file
* Export it again - mind that it is not expected that all data from the original file will be present in the export!

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation