### PR TITLE
#1219 - Description tooltips not showing for feature labels

### DIFF
--- a/inception-image/src/main/java/de/tudarmstadt/ukp/inception/image/feature/ImageFeatureEditor.html
+++ b/inception-image/src/main/java/de/tudarmstadt/ukp/inception/image/feature/ImageFeatureEditor.html
@@ -20,7 +20,7 @@
 <wicket:panel>
   <div class="form-group" wicket:enclosure="value">
     <label wicket:for="value" class="col-sm-3 control-label">
-      <wicket:container wicket:id="feature"/>
+      <span wicket:id="feature"/>
     </label>
     <div class="col-sm-9">
       <div>

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureEditor.html
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureEditor.html
@@ -20,7 +20,7 @@
 <wicket:panel>
   <div class="form-group" wicket:enclosure="value">
     <label wicket:for="value" class="col-sm-3 control-label">
-      <wicket:container wicket:id="feature"/>
+      <span wicket:id="feature"/>
       <span wicket:id="disabledKBWarning"></span>
       <span wicket:id="iriInfoBadge"/>
     </label>


### PR DESCRIPTION
**What's in the PR**
- Change feature label HTML code such that a span is used instead of a wicket:container as no style/JS can be attached to the latter

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation