### PR TITLE
Fix random search for java api

### DIFF
--- a/inception-external-search-elastic/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/elastic/ElasticSearchProvider.java
+++ b/inception-external-search-elastic/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/elastic/ElasticSearchProvider.java
@@ -87,7 +87,7 @@ public class ElasticSearchProvider
             SearchRequest searchRequest = new SearchRequest(indexName);
             SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
             RandomScoreFunctionBuilder randomFunc = ScoreFunctionBuilders.randomFunction();
-            randomFunc.seed(37);
+            randomFunc.seed(aTraits.getSeed());
             if (aTraits.isRandomOrder()) {
                 searchSourceBuilder.query(QueryBuilders.functionScoreQuery(
                         QueryBuilders.constantScoreQuery(

--- a/inception-external-search-elastic/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/elastic/ElasticSearchProvider.java
+++ b/inception-external-search-elastic/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/elastic/ElasticSearchProvider.java
@@ -35,6 +35,7 @@ import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.common.text.Text;
 import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.functionscore.RandomScoreFunctionBuilder;
 import org.elasticsearch.index.query.functionscore.ScoreFunctionBuilders;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
@@ -85,12 +86,14 @@ public class ElasticSearchProvider
     
             SearchRequest searchRequest = new SearchRequest(indexName);
             SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+            RandomScoreFunctionBuilder randomFunc = ScoreFunctionBuilders.randomFunction();
+            randomFunc.seed(37);
             if (aTraits.isRandomOrder()) {
                 searchSourceBuilder.query(QueryBuilders.functionScoreQuery(
                         QueryBuilders.constantScoreQuery(
                             QueryBuilders.termQuery(aTraits.getDefaultField(), aQuery)
                         ).boost(1.0f),
-                        ScoreFunctionBuilders.randomFunction()));
+                        randomFunc));
             }
             else {
                 searchSourceBuilder.query(QueryBuilders.termQuery(

--- a/inception-external-search-elastic/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/elastic/ElasticSearchProvider.java
+++ b/inception-external-search-elastic/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/elastic/ElasticSearchProvider.java
@@ -87,7 +87,9 @@ public class ElasticSearchProvider
             SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
             if (aTraits.isRandomOrder()) {
                 searchSourceBuilder.query(QueryBuilders.functionScoreQuery(
-                        QueryBuilders.termQuery(aTraits.getDefaultField(), aQuery),
+                        QueryBuilders.constantScoreQuery(
+                            QueryBuilders.termQuery(aTraits.getDefaultField(), aQuery)
+                        ).boost(1.0f),
                         ScoreFunctionBuilders.randomFunction()));
             }
             else {


### PR DESCRIPTION
Related:
* inception-project/inception/pull/1181
* isi-vista/curated-training-annotator/issues/16
* inception-project/inception/issues/987

**What's in the PR**
* Fixed bug in `ElasticSearchProvider.java` where the term match score overshadows the random noise for randomly ordering search results

**How to test manually**
* In previous version with random order enabled, if you search a term, then more relevant results still show first. Now, results are really random

**Automatic testing**
* [ ] PR includes unit tests -- nope

**Documentation**
* [ ] PR updates documentation -- nope

**Remaining Problems**
* **Seeding is not working.** In one session, if you search the same term twice, then you will get results in a different order.
