### PR TITLE
#1215 Write recommender evaluation scores to event log

### DIFF
--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/event/RecommenderEvaluationResultEvent.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/event/RecommenderEvaluationResultEvent.java
@@ -19,6 +19,7 @@ package de.tudarmstadt.ukp.inception.recommendation.event;
 
 import org.springframework.context.ApplicationEvent;
 
+import de.tudarmstadt.ukp.inception.recommendation.api.evaluation.EvaluationResult;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
 
 public class RecommenderEvaluationResultEvent extends ApplicationEvent
@@ -27,18 +28,18 @@ public class RecommenderEvaluationResultEvent extends ApplicationEvent
     
     private final Recommender recommender;
     private final String user;
-    private final double score;
+    private final EvaluationResult evalResul;
     private final long duration;
     private final boolean active;
     
     public RecommenderEvaluationResultEvent(Object aSource, Recommender aRecommender, String aUser,
-            double aScore, long aDuration, boolean aActive)
+            EvaluationResult aResult, long aDuration, boolean aActive)
     {
         super(aSource);
 
         recommender = aRecommender;
         user = aUser;
-        score = aScore;
+        evalResul = aResult;
         duration = aDuration;
         active = aActive;
     }
@@ -53,9 +54,9 @@ public class RecommenderEvaluationResultEvent extends ApplicationEvent
         return recommender;
     }
     
-    public double getScore()
+    public EvaluationResult getResult()
     {
-        return score;
+        return evalResul;
     }
     
     public long getDuration()

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/event/RecommenderEvaluationResultEvent.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/event/RecommenderEvaluationResultEvent.java
@@ -28,7 +28,7 @@ public class RecommenderEvaluationResultEvent extends ApplicationEvent
     
     private final Recommender recommender;
     private final String user;
-    private final EvaluationResult evalResul;
+    private final EvaluationResult evalResult;
     private final long duration;
     private final boolean active;
     
@@ -39,7 +39,7 @@ public class RecommenderEvaluationResultEvent extends ApplicationEvent
 
         recommender = aRecommender;
         user = aUser;
-        evalResul = aResult;
+        evalResult = aResult;
         duration = aDuration;
         active = aActive;
     }
@@ -56,7 +56,7 @@ public class RecommenderEvaluationResultEvent extends ApplicationEvent
     
     public EvaluationResult getResult()
     {
-        return evalResul;
+        return evalResult;
     }
     
     public long getDuration()

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/log/RecommenderEvaluationResultEventAdapter.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/log/RecommenderEvaluationResultEventAdapter.java
@@ -67,13 +67,18 @@ public class RecommenderEvaluationResultEventAdapter
             Details details = new Details();
 
             details.recommenderId = aEvent.getRecommender().getId();
+            
             EvaluationResult result = aEvent.getResult();
             details.accuracy = result.computeAccuracyScore();
             details.f1 = result.computeF1Score();
             details.precision = result.computePrecisionScore();
             details.recall = result.computeRecallScore();
-            details.active = aEvent.isActive();
+            
+            
+            details.trainSetSize = result.getTrainingSetSize();
+            details.testSetSize = result.getTestSetSize();
 
+            details.active = aEvent.isActive();
             details.duration = aEvent.getDuration();
             details.threshold = aEvent.getRecommender().getThreshold();
             details.layer = aEvent.getRecommender().getLayer().getName();
@@ -107,5 +112,9 @@ public class RecommenderEvaluationResultEventAdapter
         public double f1;
         public double precision;
         public double recall;
+        
+        // Used data
+        public int trainSetSize;
+        public int testSetSize;
     }
 }

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/log/RecommenderEvaluationResultEventAdapter.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/log/RecommenderEvaluationResultEventAdapter.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import de.tudarmstadt.ukp.clarin.webanno.support.JSONUtil;
 import de.tudarmstadt.ukp.inception.log.adapter.EventLoggingAdapter;
+import de.tudarmstadt.ukp.inception.recommendation.api.evaluation.EvaluationResult;
 import de.tudarmstadt.ukp.inception.recommendation.event.RecommenderEvaluationResultEvent;
 
 @Component
@@ -66,7 +67,11 @@ public class RecommenderEvaluationResultEventAdapter
             Details details = new Details();
 
             details.recommenderId = aEvent.getRecommender().getId();
-            details.score = aEvent.getScore();
+            EvaluationResult result = aEvent.getResult();
+            details.accuracy = result.computeAccuracyScore();
+            details.f1 = result.computeF1Score();
+            details.precision = result.computePrecisionScore();
+            details.recall = result.computeRecallScore();
             details.active = aEvent.isActive();
 
             details.duration = aEvent.getDuration();
@@ -98,6 +103,9 @@ public class RecommenderEvaluationResultEventAdapter
 
         // Evaluation results
         public boolean active;
-        public double score;
+        public double accuracy;
+        public double f1;
+        public double precision;
+        public double recall;
     }
 }

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/LearningCurveChartPanel.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/LearningCurveChartPanel.java
@@ -188,12 +188,12 @@ public class LearningCurveChartPanel
                 }
 
                 // sometimes score values NaN. Can result into error while rendering the graph on UI
-                if (!Double.isFinite(detail.score)) {
+                if (!Double.isFinite(detail.f1)) {
                     continue;
                 }
                 
                 //recommenderIfActive only has one member
-                recommenderScoreMap.put(recommenderIfActive.get().getName(), detail.score);
+                recommenderScoreMap.put(recommenderIfActive.get().getName(), detail.f1);
             }
             catch (IOException e) {
                 LOG.error("Invalid logged Event detail. Skipping record with logged event id: "

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/SelectionTask.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/SelectionTask.java
@@ -39,6 +39,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService;
 import de.tudarmstadt.ukp.inception.recommendation.api.evaluation.DataSplitter;
+import de.tudarmstadt.ukp.inception.recommendation.api.evaluation.EvaluationResult;
 import de.tudarmstadt.ukp.inception.recommendation.api.evaluation.PercentageBasedSplitter;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
 import de.tudarmstadt.ukp.inception.recommendation.api.recommender.RecommendationEngine;
@@ -149,9 +150,8 @@ public class SelectionTask
                     log.info("[{}][{}]: Evaluating...", userName, recommenderName);
 
                     DataSplitter splitter = new PercentageBasedSplitter(0.8, 10);
-                    // set F1-score as default score for threshold
-                    double score = recommendationEngine.evaluate(casses.get(), splitter)
-                            .computeF1Score();
+                    EvaluationResult result = recommendationEngine.evaluate(casses.get(), splitter);
+                    double score = result.computeF1Score();
 
                     Double threshold = recommender.getThreshold();
                     boolean activated;
@@ -170,7 +170,7 @@ public class SelectionTask
                     }
 
                     appEventPublisher.publishEvent(new RecommenderEvaluationResultEvent(this,
-                            recommender, user.getUsername(), score,
+                            recommender, user.getUsername(), result,
                             System.currentTimeMillis() - start, activated));
                 }
                 catch (Throwable e) {


### PR DESCRIPTION
After having now implemented more than one score for the recommender I want to add them to the Details field of the LoggedEvent. This will allow us to retrieve and show different metrics in the learning curve on the annotation page (see #1103).

**What's in the PR**
Store the EvaluationResult object from the evaluation that is done in the SelectionTask in the RecommenderEvaluationResultEvent and then put the respective scores in the details json in the RecommenderEvaluationResultEventAdapter.

**How to test manually**
* Add recommender to your project
* Annotate and check that learning curve is still drawn accurately
