### PR TITLE
#1240 - Allow adding external JARs to the standalone application

### DIFF
--- a/inception-app-webapp/pom.xml
+++ b/inception-app-webapp/pom.xml
@@ -827,17 +827,24 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-maven-plugin</artifactId>
             <version>${spring.boot.version}</version>
-            <configuration>
-              <executable>true</executable>
-              <layout>ZIP</layout> <!-- To use the PropertiesLauncher -->
-            </configuration>
             <executions>
               <execution>
                 <goals>
                   <goal>repackage</goal>
                 </goals>
+                <configuration>
+                  <executable>true</executable>
+                  <layoutFactory implementation="de.tudarmstadt.ukp.inception.bootloader.PluginEnabledWarLayoutFactory"/>
+                </configuration>
               </execution>
             </executions>
+            <dependencies>
+              <dependency>
+                <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+                <artifactId>inception-boot-loader</artifactId>
+                <version>0.10.0-SNAPSHOT</version>
+              </dependency>
+            </dependencies>
           </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>

--- a/inception-boot-loader/LICENSE.txt
+++ b/inception-boot-loader/LICENSE.txt
@@ -1,0 +1,268 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+=== brat ===
+
+Copyright (C) 2010-2012 The brat contributors, all rights reserved.             
+                                                                                
+Permission is hereby granted, free of charge, to any person obtaining a copy of 
+this software and associated documentation files (the "Software"), to deal in   
+the Software without restriction, including without limitation the rights to    
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies   
+of the Software, and to permit persons to whom the Software is furnished to do  
+so, subject to the following conditions:                                        
+                                                                                
+The above copyright notice and this permission notice shall be included in all  
+copies or substantial portions of the Software.                                 
+                                                                                
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR      
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,        
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE     
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER          
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,   
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE   
+SOFTWARE.                                                                       
+
+=== JQuery SVG ===
+
+Copyright 2007 - 2014 Keith Wood                                                                 
+                                                                                                 
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software    
+and associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,        
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is    
+furnished to do so, subject to the following conditions:                                         
+                                                                                                 
+The above copyright notice and this permission notice shall be included in all copies or         
+substantial portions of the Software.                                                            
+                                                                                                 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND           
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,     
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,   
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.          
+
+=== JQuery JSON ===
+ 
+Copyright 2009-2011 Brantley Harris                                         
+Copyright 2010–2014 Timo Tijhof                                             
+                                                                            
+Permission is hereby granted, free of charge, to any person obtaining       
+a copy of this software and associated documentation files (the             
+"Software"), to deal in the Software without restriction, including         
+without limitation the rights to use, copy, modify, merge, publish,         
+distribute, sublicense, and/or sell copies of the Software, and to          
+permit persons to whom the Software is furnished to do so, subject to       
+the following conditions:                                                   
+                                                                            
+The above copyright notice and this permission notice shall be              
+included in all copies or substantial portions of the Software.             
+                                                                            
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,             
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF          
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND                       
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE      
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION      
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION       
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.   
+          

--- a/inception-boot-loader/pom.xml
+++ b/inception-boot-loader/pom.xml
@@ -1,0 +1,40 @@
+<!--
+  Copyright 2019
+  Ubiquitous Knowledge Processing (UKP) Lab
+  Technische Universität Darmstadt
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+    <artifactId>inception-app</artifactId>
+    <version>0.10.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>inception-boot-loader</artifactId>
+  <name>INCEpTION - Boot loader</name>
+  <packaging>jar</packaging>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-loader</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-loader-tools</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/inception-boot-loader/src/main/java/de/tudarmstadt/ukp/inception/bootloader/PluginEnabledWarLauncher.java
+++ b/inception-boot-loader/src/main/java/de/tudarmstadt/ukp/inception/bootloader/PluginEnabledWarLauncher.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2019
+ * Ubiquitous Knowledge Processing (UKP) Lab
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.bootloader;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.boot.loader.PropertiesLauncher;
+import org.springframework.boot.loader.archive.Archive;
+import org.springframework.boot.loader.archive.JarFileArchive;
+
+public class PluginEnabledWarLauncher
+    extends PropertiesLauncher
+{
+    private static final String DEBUG = "loader.debug";
+
+    private static final String WEB_INF = "WEB-INF/";
+
+    private static final String WEB_INF_CLASSES = WEB_INF + "classes/";
+
+    private static final String WEB_INF_LIB = WEB_INF + "lib/";
+
+    private static final String WEB_INF_LIB_PROVIDED = WEB_INF + "lib-provided/";
+
+    private final Archive archive;
+
+    public PluginEnabledWarLauncher()
+    {
+        try {
+            archive = createArchive();
+        }
+        catch (Exception ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    @Override
+    protected List<Archive> getClassPathArchives() throws Exception
+    {
+        List<Archive> archives = new ArrayList<>(archive.getNestedArchives(this::isNestedArchive));
+        
+        Path pluginPath = Paths.get(getApplicationHome() + "/plugins");
+        
+        
+        if (Files.exists(pluginPath)) {
+            debug("Scanning for plugins in [" + pluginPath + "]");
+            
+            for (Path jar : Files.newDirectoryStream(pluginPath, "*.jar")) {
+                debug("Adding plugin JAR: [" + jar + "]");
+                archives.add(new JarFileArchive(jar.toFile()));
+            }
+        }
+        
+        return archives;
+    }
+
+    protected boolean isNestedArchive(Archive.Entry entry)
+    {
+        if (entry.isDirectory()) {
+            return entry.getName().equals(WEB_INF_CLASSES);
+        }
+        else {
+            return entry.getName().startsWith(WEB_INF_LIB)
+                    || entry.getName().startsWith(WEB_INF_LIB_PROVIDED);
+        }
+    }
+
+    private void debug(String message)
+    {
+        if (Boolean.getBoolean(DEBUG)) {
+            System.out.println(message);
+        }
+    }
+
+    /**
+     * Locate the settings file and return its location.
+     * 
+     * @return the location of the settings file or {@code null} if none could be found.
+     */
+    public static String getApplicationHome()
+    {
+        String appHome = System.getProperty("inception.home");
+        String userHome = System.getProperty("user.home");
+
+        if (appHome != null) {
+            return appHome;
+        }
+        else {
+            return userHome + "/" + ".inception";
+        }
+    }
+    
+    public static void main(String[] args) throws Exception
+    {
+        new PluginEnabledWarLauncher().launch(args);
+    }
+}

--- a/inception-boot-loader/src/main/java/de/tudarmstadt/ukp/inception/bootloader/PluginEnabledWarLayoutFactory.java
+++ b/inception-boot-loader/src/main/java/de/tudarmstadt/ukp/inception/bootloader/PluginEnabledWarLayoutFactory.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2019
+ * Ubiquitous Knowledge Processing (UKP) Lab
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.bootloader;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.springframework.boot.loader.tools.CustomLoaderLayout;
+import org.springframework.boot.loader.tools.Layout;
+import org.springframework.boot.loader.tools.LayoutFactory;
+import org.springframework.boot.loader.tools.Layouts.War;
+import org.springframework.boot.loader.tools.LibraryScope;
+import org.springframework.boot.loader.tools.LoaderClassesWriter;
+
+public class PluginEnabledWarLayoutFactory
+    implements LayoutFactory
+{
+    @Override
+    public Layout getLayout(File aSource)
+    {
+        if (!aSource.getName().endsWith(".war")) {
+            throw new IllegalArgumentException("Only WAR archives are supported for this layout");
+        }
+
+        return new PluginEnabledWar();
+    }
+
+    public static class PluginEnabledWar
+        extends War
+        implements CustomLoaderLayout
+    {
+        @Override
+        public String getLauncherClassName()
+        {
+            return "de.tudarmstadt.ukp.inception.bootloader.PluginEnabledWarLauncher";
+        }
+        
+        @Override
+        public String getLibraryDestination(String aLibraryName, LibraryScope aScope)
+        {
+            if (aLibraryName.startsWith("inception-boot-loader-")) {
+                // Boot loader classes go to the root of the JAR
+                return "";
+            }
+            
+            return super.getLibraryDestination(aLibraryName, aScope);
+        }
+
+        @Override
+        public void writeLoadedClasses(LoaderClassesWriter aWriter) throws IOException
+        {
+            // Package the default Spring Boot loader classes
+            aWriter.writeLoaderClasses();
+            
+            // Package our own custom launcher class
+            String classResourceName = "de/tudarmstadt/ukp/inception/bootloader/PluginEnabledWarLauncher.class";
+            try (InputStream is = getClass().getResourceAsStream("/" + classResourceName)) {
+                aWriter.writeEntry(classResourceName, is);
+            }
+        }
+    }
+}

--- a/inception-example-imls-data-majority/pom.xml
+++ b/inception-example-imls-data-majority/pom.xml
@@ -94,11 +94,6 @@
     </dependency>
     <dependency>
       <groupId>org.dkpro.core</groupId>
-      <artifactId>dkpro-core-api-datasets-asl</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.dkpro.core</groupId>
       <artifactId>dkpro-core-testing-asl</artifactId>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
   </properties>
   <modules>
     <module>inception-build</module>
+    <module>inception-boot-loader</module>
     <module>inception-app-webapp</module>
     <module>inception-ui-search</module>
     <module>inception-search-core</module>


### PR DESCRIPTION
**What's in the PR**
- Implemented a custom launcher for the standalone JAR which checks for a "plugins" folder under the INCEpTION home directory and adds any JARs found there to the classpath.

**How to test manually**
* Build the standalone JAR
* Build the JAR for the `inception-example-imls-data-majority` module
* Copy the `inception-example-imls-data-majority` JAR to `.inception/plugins` (or adjust if you use a different home folder for INCEpTION)
* Start up with `-Dloader.debug`
* Check if the `inception-example-imls-data-majority` JAR is detected during startup as a plugin JAR, that the recommender it provides is available and that it works

NOTE: if a plugin requires any JARs which are not yet part of INCEpTION, it won't work. The launcher does not yet support "fat plugin JARs", i.e. plugins with nested JARs.

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
