### PR TITLE
#1238 Cannot open pages from last activities

### DIFF
--- a/inception-support/pom.xml
+++ b/inception-support/pom.xml
@@ -50,5 +50,17 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.clarin.webanno</groupId>
+      <artifactId>webanno-model</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.clarin.webanno</groupId>
+      <artifactId>webanno-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.wicket</groupId>
+      <artifactId>wicket-request</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/ui/LinkProvider.java
+++ b/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/ui/LinkProvider.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019
+ * Ubiquitous Knowledge Processing (UKP) Lab
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.support.ui;
+import org.apache.wicket.markup.html.WebPage;
+import org.apache.wicket.markup.html.link.ExternalLink;
+import org.apache.wicket.request.cycle.RequestCycle;
+import org.apache.wicket.request.mapper.parameter.PageParameters;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+
+public class LinkProvider
+{
+
+    /**
+     * Create an external link to a page which opens a document, codes the url as
+     * aPageClass?params#!p=projectId&d=docId
+     */
+    public static ExternalLink createDocumentPageLink(DocumentService aDocService, Project aProject,
+            String aDocId, String aId, String aLinkLabel, Class<? extends WebPage> aPageClass)
+    {
+        long docId = -1;
+        if (aDocService.existsSourceDocument(aProject, aDocId)) {
+            docId = aDocService.getSourceDocument(aProject, aDocId).getId();
+        }
+        
+        return createDocumentPageLink(aProject, docId, aId, aLinkLabel, aPageClass);
+    }
+    
+    public static ExternalLink createDocumentPageLink(Project aProject, long aDocId, String aId,
+            String aLinkLabel, Class<? extends WebPage> aPageClass)
+    {
+        String url = "";
+        if (aDocId >= 0) {
+            url = String.format("%s#!p=%d&d=%d",
+                    RequestCycle.get().urlFor(aPageClass, new PageParameters()), aProject.getId(),
+                    aDocId);
+        }
+        if (aLinkLabel == null) {
+            new ExternalLink(aId, url);
+        }
+        
+        return new ExternalLink(aId, url, aLinkLabel);
+        
+    }
+
+    public static ExternalLink createDocumentPageLink(DocumentService aDocService, Project aProject,
+            String aDocumentId, String aId, Class<? extends WebPage> aClass)
+    {
+        return createDocumentPageLink(aDocService, aProject, aDocumentId, aId, null, aClass);
+    }
+    
+    public static ExternalLink createDocumentPageLink(Project aProject,
+            long aDocumentId, String aId, Class<? extends WebPage> aClass)
+    {
+        return createDocumentPageLink(aProject, aDocumentId, aId, null, aClass);
+    }
+
+}

--- a/inception-ui-core/pom.xml
+++ b/inception-ui-core/pom.xml
@@ -160,6 +160,10 @@
       <groupId>javax.persistence</groupId>
       <artifactId>javax.persistence-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-support</artifactId>
+    </dependency>
   </dependencies>
   
   <build>

--- a/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/dashlet/ActivitiesDashlet.html
+++ b/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/dashlet/ActivitiesDashlet.html
@@ -23,9 +23,7 @@
       <h3><wicket:message key="activitiesHeading"/></h3>
       <ul class="scrolling flex-content flex-v-container flex-gutter">
         <li wicket:id="activity">
-          <a wicket:id="eventLink">
-            <span wicket:id="eventName"></span>
-          </a>
+          <a wicket:id="eventLink"></a>
         </li>
       </ul>
     </div>

--- a/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/SearchPage.java
+++ b/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/SearchPage.java
@@ -40,7 +40,6 @@ import org.apache.wicket.markup.html.form.ChoiceRenderer;
 import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.form.TextField;
-import org.apache.wicket.markup.html.link.ExternalLink;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.markup.repeater.Item;
 import org.apache.wicket.model.CompoundPropertyModel;
@@ -69,6 +68,7 @@ import de.tudarmstadt.ukp.inception.externalsearch.ExternalSearchResult;
 import de.tudarmstadt.ukp.inception.externalsearch.ExternalSearchService;
 import de.tudarmstadt.ukp.inception.externalsearch.event.ExternalSearchQueryEvent;
 import de.tudarmstadt.ukp.inception.externalsearch.model.DocumentRepository;
+import de.tudarmstadt.ukp.inception.support.ui.LinkProvider;
 import de.tudarmstadt.ukp.inception.ui.core.session.SessionMetaData;
 
 @MountPath("/search.html")
@@ -253,16 +253,10 @@ public class SearchPage extends ApplicationPageBase
             add(new LambdaAjaxLink("importLink", _target -> actionImportDocument(_target, result))
                     .add(visibleWhen(() -> !existsSourceDocument)));
             
-            String url = "";
-            if (existsSourceDocument) {
-                long docId = documentService.getSourceDocument(project, result.getDocumentId())
-                        .getId();
-                url = String.format("%s#!p=%d&d=%d",
-                        getRequestCycle().urlFor(AnnotationPage.class, new PageParameters()),
-                        project.getId(), docId);
-            }
-            add(new ExternalLink("openLink", url).add(
-                    visibleWhen(() -> existsSourceDocument)));
+            add(LinkProvider
+                    .createDocumentPageLink(documentService, project, result.getDocumentId(),
+                            "openLink", AnnotationPage.class)
+                    .add(visibleWhen(() -> existsSourceDocument)));
         }
     }
 }


### PR DESCRIPTION
After accessing a last activity via the link in the project dashboard, one can no longer open another document via the Open menu item on the annotation or curation page.

**What's in the PR**
* Implemented a provider for external links with manually built url
* Using this in SearchPage and LastActivitiesDashlet

**How to test manually**
* Annotate or curate two documents
* Open one via the last activities link on the project dashboard page
* Try to open the other.
* Configure a document repository
* Search it on the search page
* Make sure that imported documents can still be opened via the Open link.
