### PR TITLE
#628 Improve performance of loading results from external search

### DIFF
--- a/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/sidebar/ExternalSearchAnnotationSidebar.java
+++ b/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/sidebar/ExternalSearchAnnotationSidebar.java
@@ -225,10 +225,8 @@ public class ExternalSearchAnnotationSidebar
     {
         ExternalSearchUserState searchState = searchStateModel.getObject();
         try {
-            String documentText = externalSearchService.getDocumentText(
-                    searchState.getSelectedResult().getRepository(),
-                    searchState.getSelectedResult().getCollectionId(),
-                    searchState.getSelectedResult().getDocumentId());
+            String documentText = getCasProvider().get().getDocumentText();
+            
             for (ExternalSearchHighlight highlight :
                     searchState.getSelectedResult().getHighlights()) {
                 


### PR DESCRIPTION
**What's in the PR**
* query does not return source document information (e.g. text)
* therefore ExternalSearchResult does not store text anymore
* ExternalSearchProvider.getDocumentText() is used to get the text through a separate request
* resolves #628 

**How to test manually**
* search for documents in an external search repository (should be faster hopefully)

**Automatic testing**
* [X] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
