### PR TITLE
#1260 Adapt DocumentOpenedEventAdapter to Webanno Change

### DIFF
--- a/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/DocumentOpenedEventAdapter.java
+++ b/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/DocumentOpenedEventAdapter.java
@@ -17,9 +17,6 @@
  */
 package de.tudarmstadt.ukp.inception.log.adapter;
 
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.event.DocumentOpenedEvent;
@@ -28,7 +25,6 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.event.DocumentOpenedEven
 public class DocumentOpenedEventAdapter
     implements EventLoggingAdapter<DocumentOpenedEvent>
 {
-    private final Logger log = LoggerFactory.getLogger(getClass());
     
     @Override
     public boolean accepts(Object aEvent)

--- a/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/DocumentOpenedEventAdapter.java
+++ b/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/DocumentOpenedEventAdapter.java
@@ -17,15 +17,12 @@
  */
 package de.tudarmstadt.ukp.inception.log.adapter;
 
-import java.io.IOException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.event.DocumentOpenedEvent;
-import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
-import de.tudarmstadt.ukp.clarin.webanno.support.JSONUtil;
 
 @Component
 public class DocumentOpenedEventAdapter
@@ -52,21 +49,6 @@ public class DocumentOpenedEventAdapter
     }
 
     @Override
-    public String getDetails(DocumentOpenedEvent aEvent)
-    {
-        DocumentOpenedDetails details = new DocumentOpenedDetails(aEvent.getAnnotator(),
-                aEvent.getUser(), aEvent.getDocument());
-        try {
-            String json = JSONUtil.toJsonString(details); 
-            return json;
-        }
-        catch (IOException e) {
-            log.error("Unable to log event [{}]", aEvent, e);
-            return "<ERROR>";
-        }
-    }
-
-    @Override
     public String getUser(DocumentOpenedEvent aEvent)
     {
         return aEvent.getUser();
@@ -76,33 +58,5 @@ public class DocumentOpenedEventAdapter
     public String getAnnotator(DocumentOpenedEvent aEvent)
     {
         return aEvent.getAnnotator();
-    }
-
-    private class DocumentOpenedDetails
-    {
-        private final String annotator;
-        private final String opener;
-        private final String docName;
-        
-        public DocumentOpenedDetails(String aAnnotator, String aOpener, SourceDocument aDoc) {
-            annotator = aAnnotator;
-            opener = aOpener;
-            docName = aDoc.getName();
-        }
-
-        public String getAnnotator()
-        {
-            return annotator;
-        }
-
-        public String getOpener()
-        {
-            return opener;
-        }
-
-        public String getDocName()
-        {
-            return docName;
-        }
     }
 }

--- a/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/DocumentOpenedEventAdapter.java
+++ b/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/DocumentOpenedEventAdapter.java
@@ -17,14 +17,22 @@
  */
 package de.tudarmstadt.ukp.inception.log.adapter;
 
+import java.io.IOException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.event.DocumentOpenedEvent;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.clarin.webanno.support.JSONUtil;
 
 @Component
 public class DocumentOpenedEventAdapter
     implements EventLoggingAdapter<DocumentOpenedEvent>
 {
+    private final Logger log = LoggerFactory.getLogger(getClass());
+    
     @Override
     public boolean accepts(Object aEvent)
     {
@@ -41,5 +49,60 @@ public class DocumentOpenedEventAdapter
     public long getProject(DocumentOpenedEvent aEvent)
     {
         return aEvent.getDocument().getProject().getId();
+    }
+
+    @Override
+    public String getDetails(DocumentOpenedEvent aEvent)
+    {
+        DocumentOpenedDetails details = new DocumentOpenedDetails(aEvent.getAnnotator(),
+                aEvent.getUser(), aEvent.getDocument());
+        try {
+            String json = JSONUtil.toJsonString(details); 
+            return json;
+        }
+        catch (IOException e) {
+            log.error("Unable to log event [{}]", aEvent, e);
+            return "<ERROR>";
+        }
+    }
+
+    @Override
+    public String getUser(DocumentOpenedEvent aEvent)
+    {
+        return aEvent.getUser();
+    }
+
+    @Override
+    public String getAnnotator(DocumentOpenedEvent aEvent)
+    {
+        return aEvent.getAnnotator();
+    }
+
+    private class DocumentOpenedDetails
+    {
+        private final String annotator;
+        private final String opener;
+        private final String docName;
+        
+        public DocumentOpenedDetails(String aAnnotator, String aOpener, SourceDocument aDoc) {
+            annotator = aAnnotator;
+            opener = aOpener;
+            docName = aDoc.getName();
+        }
+
+        public String getAnnotator()
+        {
+            return annotator;
+        }
+
+        public String getOpener()
+        {
+            return opener;
+        }
+
+        public String getDocName()
+        {
+            return docName;
+        }
     }
 }


### PR DESCRIPTION
Webanno added a new field to the DocumentOpenedEvent to account for events where a different user opened the document than the original annotator. The adapter will need to be changed to log the correct users involved.

**What's in the PR**
* changed DocumentOpenedAdapter to report user and annotator of opened event

Additional context
Due to a change in Webanno webanno/webanno#1329

**How to test manually**
* Open documents for annotation as the logged in user and for another user
* check the database for logged events related to these actions
