### PR TITLE
#790 - DB accesses during in-project search slow down process

### DIFF
--- a/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchQueryRequest.java
+++ b/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchQueryRequest.java
@@ -23,11 +23,12 @@ import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 
 public class SearchQueryRequest
 {
     private final Project project;
-    private final String username;
+    private final User user;
     private final String query;
 
     private final SourceDocument limitedToDocument;
@@ -35,24 +36,24 @@ public class SearchQueryRequest
     private final AnnotationLayer annoationLayer;
     private final AnnotationFeature annotationFeature;
 
-    public SearchQueryRequest(Project aProject, String aUsername, String aQuery)
+    public SearchQueryRequest(Project aProject, User aUser, String aQuery)
     {
-        this(aProject, aUsername, aQuery, null);
+        this(aProject, aUser, aQuery, null);
     }
 
-    public SearchQueryRequest(Project aProject, String aUsername, String aQuery,
+    public SearchQueryRequest(Project aProject, User aUser, String aQuery,
             SourceDocument aLimitedToDocument)
     {
-        this(aProject, aUsername, aQuery, aLimitedToDocument, null, null);
+        this(aProject, aUser, aQuery, aLimitedToDocument, null, null);
     }
 
-    public SearchQueryRequest(Project aProject, String aUsername, String aQuery,
+    public SearchQueryRequest(Project aProject, User aUser, String aQuery,
         SourceDocument aLimitedToDocument, AnnotationLayer aAnnotationLayer,
         AnnotationFeature aAnnotationFeature)
     {
         super();
         project = aProject;
-        username = aUsername;
+        user = aUser;
         query = aQuery;
         limitedToDocument = aLimitedToDocument;
         annoationLayer = aAnnotationLayer;
@@ -64,9 +65,9 @@ public class SearchQueryRequest
         return project;
     }
 
-    public String getUsername()
+    public User getUser()
     {
-        return username;
+        return user;
     }
 
     public String getQuery()

--- a/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchServiceImpl.java
+++ b/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchServiceImpl.java
@@ -383,7 +383,7 @@ public class SearchServiceImpl
                 log.debug("Running query: [{}]", aQuery);
 
                 results = index.getPhysicalIndex().executeQuery(
-                    new SearchQueryRequest(aProject, aUser.getUsername(), aQuery, aDocument,
+                    new SearchQueryRequest(aProject, aUser, aQuery, aDocument,
                         aAnnotationLayer, aAnnotationFeature));
             }
 


### PR DESCRIPTION
**What's in the PR**
* bugfix for #790 
* make a DB query for all SourceDocuments that have an AnnotationDocuments once before iteration over all the documents of a span
* change SearchQueryRequest to save the User instead of just the Username

**How to test manually**
* make queries in the search sidebar, see if it still works and if possible test if it is faster then before for large projects 

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
