### PR TITLE
#1300 - Disabled training states reset when re-opening recommender

### DIFF
--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderEditorPanel.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderEditorPanel.java
@@ -405,17 +405,22 @@ public class RecommenderEditorPanel
 
         // Since toolChoice uses a lambda model, it needs to be notified explicitly.
         toolChoice.modelChanged();
-        
+
+        Recommender recommender = recommenderModel.getObject();
+
+        // New recommenders should run on all states
+        if (recommender.getId() == null) {
+            statesForTraining.setObject(getAllPossibleDocumentStates());
+        }
+
         // For new recommenders, default to auto-generation of name, for existing recommenders,
         // do not auto-generate name unless asked to
-        Recommender recommender = recommenderModel.getObject();
         if (
                 recommender.getId() == null || 
                 Objects.equals(recommender.getName(), generateName(recommender))
         ) {
             autoGenerateNameCheckBox.setModelObject(true);
             autoUpdateName(null, nameField, recommenderModel.getObject());
-            statesForTraining.setObject(getAllPossibleDocumentStates());
         }
         else {
             autoGenerateNameCheckBox.setModelObject(false);


### PR DESCRIPTION
**What's in the PR**
- Initialize training states only when creating a new recommender

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
