### PR TITLE
Bugfix/1302 unable to use string matching recommender only with gazeteer

### DIFF
--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/TrainingTask.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/TrainingTask.java
@@ -151,20 +151,14 @@ public class TrainingTask
                             .map(e -> e.cas)
                             .collect(Collectors.toList());
 
-                    if (!cassesForTraining.isEmpty()) {
-                        log.info("[{}][{}]: Training model on [{}] out of [{}] documents ...",
-                                user.getUsername(), recommender.getName(), cassesForTraining.size(),
-                                casses.get().size());
-                        
-                        recommendationEngine.train(context, cassesForTraining);
-                        
-                        log.info("[{}][{}]: Training complete ({} ms)", user.getUsername(),
-                                recommender.getName(), (System.currentTimeMillis() - startTime));
-                    }
-                    else {
-                        log.info("[{}][{}]: There are annotations available to train on",
-                                user.getUsername(), recommender.getName());
-                    }
+                    log.info("[{}][{}]: Training model on [{}] out of [{}] documents ...",
+                            user.getUsername(), recommender.getName(), cassesForTraining.size(),
+                            casses.get().size());
+                    
+                    recommendationEngine.train(context, cassesForTraining);
+                    
+                    log.info("[{}][{}]: Training complete ({} ms)", user.getUsername(),
+                            recommender.getName(), (System.currentTimeMillis() - startTime));
                 }
                 catch (Throwable e) {
                     log.info("[{}][{}]: Training failed ({} ms)", user.getUsername(),


### PR DESCRIPTION
**What's in the PR**
- Don't skip training even if no CASes are selected for training - this is necessary to give thhe recommender a chance to pre-train itself

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
