### PR TITLE
#1273 - Explicit recommender training capabilities

### DIFF
--- a/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/StringMatchingRecommenderFactory.java
+++ b/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/StringMatchingRecommenderFactory.java
@@ -22,12 +22,8 @@ import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.SINGLE_TOKEN
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.TOKENS;
 import static java.util.Arrays.asList;
 
-import java.io.IOException;
-
 import org.apache.uima.cas.CAS;
 import org.apache.wicket.model.IModel;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
@@ -37,15 +33,12 @@ import de.tudarmstadt.ukp.inception.recommendation.api.recommender.Recommendatio
 import de.tudarmstadt.ukp.inception.recommendation.api.recommender.RecommendationEngineFactoryImplBase;
 import de.tudarmstadt.ukp.inception.recommendation.api.recommender.RecommenderContext;
 import de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.gazeteer.GazeteerService;
-import de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.model.Gazeteer;
 import de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.settings.StringMatchingRecommenderTraitsEditor;
 
 @Component
 public class StringMatchingRecommenderFactory
     extends RecommendationEngineFactoryImplBase<StringMatchingRecommenderTraits>
 {
-    private final Logger log = LoggerFactory.getLogger(getClass());
-    
     // This is a string literal so we can rename/refactor the class without it changing its ID
     // and without the database starting to refer to non-existing recommendation tools.
     public static final String ID =
@@ -68,23 +61,7 @@ public class StringMatchingRecommenderFactory
     public RecommendationEngine build(Recommender aRecommender, RecommenderContext aContext)
     {
         StringMatchingRecommenderTraits traits = new StringMatchingRecommenderTraits();
-        StringMatchingRecommender recommender = new StringMatchingRecommender(aRecommender, traits);
-        
-        // Pre-load the gazeteers into the recommender
-        for (Gazeteer gaz : gazeteerService.listGazeteers(aRecommender)) {
-            try {
-                recommender.pretrain(gazeteerService.readGazeteerFile(gaz), aContext);
-            }
-            catch (IOException e) {
-                log.info("Unable to load gazeteer [{}] for recommender [{}]({}) in project [{}]({})",
-                        gaz.getName(), gaz.getRecommender().getName(),
-                        gaz.getRecommender().getId(),
-                        gaz.getRecommender().getProject().getName(),
-                        gaz.getRecommender().getProject().getId(), e);
-            }
-        }
-        
-        return recommender;
+        return new StringMatchingRecommender(aRecommender, traits, gazeteerService);
     }
 
     @Override


### PR DESCRIPTION
**What's in the PR**
- Close and post recommender context for recommenders where training is not supported
- Do not close and post recommender context if training is required by no CASes are available for training
- Fix handling of gazeteer in StringMatchingRecommender

**How to test manually**
1. Create a string matching recommender
2. Upload a gazeteer
3. Make an annotation on the predicted layer
4. See how the gazeteer is now used to make predictions
5. Disable all the training states on the gazeteer
6. Log out and log back in again (to clear the recommender state)
7. Go to the annotation page again and see that nothing is recommended anymore

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation