### PR TITLE
#1327 - Untrainable external recommender thinks it cannot predict

### DIFF
--- a/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommender.java
+++ b/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommender.java
@@ -85,7 +85,11 @@ public class ExternalRecommender
     @Override
     public boolean isReadyForPrediction(RecommenderContext aContext)
     {
-        return aContext.get(KEY_TRAINING_COMPLETE).orElse(false);
+        if (traits.isTrainable()) {
+            return aContext.get(KEY_TRAINING_COMPLETE).orElse(false);
+        } else {
+            return true;
+        }
     }
     
     @Override


### PR DESCRIPTION
**What's in the PR**
- External recommender is always ready to predict if it is not trainable

**How to test manually**
* Create an external recommender and see if you get recommendations

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
