### PR TITLE
#1342 - Training run scheduled whenever a CAS is saved even if there were no changes

### DIFF
--- a/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/AfterCasWrittenEventAdapter.java
+++ b/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/AfterCasWrittenEventAdapter.java
@@ -19,32 +19,32 @@ package de.tudarmstadt.ukp.inception.log.adapter;
 
 import org.springframework.stereotype.Component;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.event.AfterAnnotationUpdateEvent;
+import de.tudarmstadt.ukp.clarin.webanno.api.event.AfterCasWrittenEvent;
 
 @Component
-public class AfterAnnotationUpdateEventAdapter
-    implements EventLoggingAdapter<AfterAnnotationUpdateEvent>
+public class AfterCasWrittenEventAdapter
+    implements EventLoggingAdapter<AfterCasWrittenEvent>
 {
     @Override
     public boolean accepts(Object aEvent)
     {
-        return aEvent instanceof AfterAnnotationUpdateEvent;
+        return aEvent instanceof AfterCasWrittenEvent;
     }
     
     @Override
-    public long getDocument(AfterAnnotationUpdateEvent aEvent)
+    public long getDocument(AfterCasWrittenEvent aEvent)
     {
         return aEvent.getDocument().getDocument().getId();
     }
     
     @Override
-    public long getProject(AfterAnnotationUpdateEvent aEvent)
+    public long getProject(AfterCasWrittenEvent aEvent)
     {
         return aEvent.getDocument().getProject().getId();
     }
     
     @Override
-    public String getAnnotator(AfterAnnotationUpdateEvent aEvent)
+    public String getAnnotator(AfterCasWrittenEvent aEvent)
     {
         return aEvent.getDocument().getUser();
     }

--- a/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/RelationEventAdapter.java
+++ b/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/RelationEventAdapter.java
@@ -23,23 +23,24 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.event.RelationUpdateEvent;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.event.RelationEvent;
 import de.tudarmstadt.ukp.clarin.webanno.support.JSONUtil;
 import de.tudarmstadt.ukp.inception.log.model.AnnotationDetails;
 
 @Component
-public class RelationUpdateEventAdapter implements EventLoggingAdapter<RelationUpdateEvent>
+public class RelationEventAdapter
+    implements EventLoggingAdapter<RelationEvent>
 {
     private final Logger log = LoggerFactory.getLogger(getClass());
 
     @Override
     public boolean accepts(Object aEvent)
     {
-        return aEvent instanceof RelationUpdateEvent;
+        return aEvent instanceof RelationEvent;
     }
 
     @Override
-    public String getDetails(RelationUpdateEvent aEvent)
+    public String getDetails(RelationEvent aEvent)
     {
         try {
             AnnotationDetails details = new AnnotationDetails(aEvent.getTargetAnnotation());
@@ -52,19 +53,19 @@ public class RelationUpdateEventAdapter implements EventLoggingAdapter<RelationU
     }
 
     @Override
-    public long getDocument(RelationUpdateEvent aEvent)
+    public long getDocument(RelationEvent aEvent)
     {
         return aEvent.getDocument().getId();
     }
 
     @Override
-    public String getAnnotator(RelationUpdateEvent aEvent)
+    public String getAnnotator(RelationEvent aEvent)
     {
         return aEvent.getUser();
     }
 
     @Override
-    public long getProject(RelationUpdateEvent aEvent)
+    public long getProject(RelationEvent aEvent)
     {
         return aEvent.getDocument().getProject().getId();
     }

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/PredictionTask.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/PredictionTask.java
@@ -56,7 +56,8 @@ public class PredictionTask
         Project project = getProject();
         List<SourceDocument> docs = documentService.listSourceDocuments(project);
 
-        log.info("[{}]: Starting prediction...", user.getUsername());
+        log.debug("[{}]: Starting prediction for user [{}] in project [{}] triggered by [{}]...",
+                user, project, getTrigger());
         long startTime = System.currentTimeMillis();
 
         Predictions predictions = recommendationService.computePredictions(user, project, docs);

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/TrainingTask.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/TrainingTask.java
@@ -78,7 +78,8 @@ public class TrainingTask
         Project project = getProject();
         User user = getUser();
 
-        log.debug("Running training task for user [{}] in project [{}]",  user, project);
+        log.debug("[{}]: Starting training for user [{}] in project [{}] triggered by [{}]...",
+                user, project, getTrigger());
 
         // Read the CASes only when they are accessed the first time. This allows us to skip reading
         // the CASes in case that no layer / recommender is available or if no recommender requires

--- a/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchServiceImpl.java
+++ b/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchServiceImpl.java
@@ -41,7 +41,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
-import de.tudarmstadt.ukp.clarin.webanno.api.event.AfterAnnotationUpdateEvent;
+import de.tudarmstadt.ukp.clarin.webanno.api.event.AfterCasWrittenEvent;
 import de.tudarmstadt.ukp.clarin.webanno.api.event.AfterDocumentCreatedEvent;
 import de.tudarmstadt.ukp.clarin.webanno.api.event.BeforeDocumentRemovedEvent;
 import de.tudarmstadt.ukp.clarin.webanno.api.event.BeforeProjectRemovedEvent;
@@ -306,7 +306,7 @@ public class SearchServiceImpl
 
     @TransactionalEventListener(fallbackExecution = true)
     @Transactional
-    public void afterAnnotationUpdate(AfterAnnotationUpdateEvent aEvent) throws Exception
+    public void afterAnnotationUpdate(AfterCasWrittenEvent aEvent) throws Exception
     {
         log.trace("Starting afterAnnotationUpdate");
 


### PR DESCRIPTION
**What's in the PR**
- Adjust to changes in upstream API
- Listen to DocumentOpened and Annotation events to trigger recommendations
- Don't trigger training run when a recommender is deleted - this can wait until the next time annodations are edited / documents are opened
- Don't trigger training run when a recommender was deleted, removing its predictions from the context is sufficient
- Use RecommendationStateKey instead of a Pair for the trainingTaskCounter as well
- Clear recommendation state for all users of a project when a new document is added or when a document is removed

**How to test manually**
* Switch between documents and check that no training run is triggered
* Open a document and/or make a change and see that a training run is triggered

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation