### PR TITLE
#950 - Add LAPPS Grid external recommender support

### DIFF
--- a/inception-doc/src/main/resources/META-INF/asciidoc/user-guide.adoc
+++ b/inception-doc/src/main/resources/META-INF/asciidoc/user-guide.adoc
@@ -135,6 +135,8 @@ include::{include-dir}projects_recommendation_conceptlinker.adoc[leveloffset=+2]
 
 include::{include-dir}projects_recommendation_external.adoc[leveloffset=+2]
 
+include::{include-dir}projects_recommendation_lappsgrid.adoc[leveloffset=+2]
+
 include::{include-dir}projects_tagsets.adoc[leveloffset=+2]
 
 include::{include-dir}projects_export.adoc[leveloffset=+2]

--- a/inception-imls-lapps/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/lapps/LappsGridRecommenderFactory.java
+++ b/inception-imls-lapps/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/lapps/LappsGridRecommenderFactory.java
@@ -38,7 +38,7 @@ import de.tudarmstadt.ukp.inception.recommendation.imls.lapps.traits.LappsGridRe
 
 @Component
 @ConditionalOnProperty(prefix = "recommenders.lappsgrid", name = "enabled",
-        matchIfMissing = false)
+        matchIfMissing = true)
 public class LappsGridRecommenderFactory
     extends RecommendationEngineFactoryImplBase<LappsGridRecommenderTraits>
 {

--- a/inception-imls-lapps/src/main/resources/META-INF/asciidoc/user-guide/projects_recommendation_lappsgrid.adoc
+++ b/inception-imls-lapps/src/main/resources/META-INF/asciidoc/user-guide/projects_recommendation_lappsgrid.adoc
@@ -1,4 +1,4 @@
-// Copyright 2018
+// Copyright 2019
 // Ubiquitous Knowledge Processing (UKP) Lab
 // Technische Universität Darmstadt
 // 
@@ -14,8 +14,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-== External Recommender
+== LAPPS Grid
 
-This recommender allows to use external web-services to generate predictions. For details on the
-protocol used in the communication with the external services, please refer to the developer
-documentation.
+This recommender allows to use LAPPS Grid web-services to generate predictions. Only services
+taking the inputs are supported:
+
+.Inputs
+* Text
+* Tokens
+* Sentences
+
+Furthermore, the services must produce annotations on one of the following built-in layers:
+
+.Outputs
+* Part-of-speech
+* Lemma
+* Named entity
+
+The recommender comes with a list of pre-configured services that can be conveniently chosen from.
+However, note that these services use versioned URLs and as LAPPS Grid evolves, these the services
+might be upgrade and become available under different URLs. 

--- a/inception-imls-opennlp/src/main/resources/META-INF/asciidoc/user-guide/projects_recommendation_opennlp.adoc
+++ b/inception-imls-opennlp/src/main/resources/META-INF/asciidoc/user-guide/projects_recommendation_opennlp.adoc
@@ -1,5 +1,5 @@
 // Copyright 2018
-// Ubiquitous Knowledge Processing (UKP) Lab and FG Language Technology
+// Ubiquitous Knowledge Processing (UKP) Lab
 // Technische Universität Darmstadt
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/inception-imls-stringmatch/src/main/resources/META-INF/asciidoc/user-guide/projects_recommendation_string.adoc
+++ b/inception-imls-stringmatch/src/main/resources/META-INF/asciidoc/user-guide/projects_recommendation_string.adoc
@@ -1,5 +1,5 @@
 // Copyright 2018
-// Ubiquitous Knowledge Processing (UKP) Lab and FG Language Technology
+// Ubiquitous Knowledge Processing (UKP) Lab
 // Technische Universität Darmstadt
 // 
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
**What's in the PR**
- Added rudimentary documentation
- Always enable LAPPS recommender (but leave setting to allow turning it off)
- Fixed some copyright headers

**How to test manually**
* Have a look at the documentation
* Start INCEpTION and check if the LAPPS recommender is enabled by default (remove the `recommenders.lappsgrid.enabled=true` line from the `settings.properties` before if it is there)

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation