### PR TITLE
#1316 - Sidebar drop down does not scroll down

### DIFF
--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/MetricSelectDropDownPanel.html
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/MetricSelectDropDownPanel.html
@@ -20,7 +20,7 @@
 <body>
 	<wicket:panel>
 		<div id="demo-panel"
-			style="display: inline-block; z-index: 1; position: absolute; margin-top: 5px;">
+			style="display: inline-block; margin-top: 5px;">
 			<select style="width: 0px; margin-right: 5px;" wicket:id="select"></select><span
 				style="width: 10px"></span><span class="fa fa-chevron-circle-right"
 				wicket:id="link"></span>


### PR DESCRIPTION
- bug fix. The drop scrolls with the chart. 

**What's in the PR**
* On the recommendation sidebar, the dropdown for the evaluation-metric change place when scrolling down. This means it sticks to the chart when the chart scrolls up.

**How to test manually**

* Configure several recommenders for the project.
* Go to the annotation page, open the recommendation sidebar.
* Scroll down
* the metric dropdown should also scroll with 
