### PR TITLE
#1335 - Recommendationservice performance

### DIFF
--- a/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/RecommendationService.java
+++ b/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/RecommendationService.java
@@ -134,4 +134,8 @@ public interface RecommendationService
             Collection<SuggestionGroup> aRecommendations, int aWindowBegin, int aWindowEnd);
 
     List<Recommender> listEnabledRecommenders(AnnotationLayer aLayer);
+
+    void clearState(String aUsername);
+
+    void triggerTrainingAndClassification(String aUser, Project aProject, String aEventName);
 }

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
@@ -30,10 +30,12 @@ import static org.apache.uima.fit.util.CasUtil.select;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -61,6 +63,9 @@ import org.apache.uima.resource.metadata.FeatureDescription;
 import org.apache.uima.resource.metadata.TypeDescription;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.apache.uima.util.CasCreationUtils;
+import org.apache.wicket.MetaDataKey;
+import org.apache.wicket.request.cycle.IRequestCycleListener;
+import org.apache.wicket.request.cycle.RequestCycle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -75,10 +80,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
+import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.adapter.SpanAdapter;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.event.AnnotationEvent;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.event.DocumentOpenedEvent;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.AnnotationException;
+import de.tudarmstadt.ukp.clarin.webanno.api.event.AfterCasWrittenEvent;
 import de.tudarmstadt.ukp.clarin.webanno.api.event.AfterDocumentCreatedEvent;
 import de.tudarmstadt.ukp.clarin.webanno.api.event.AfterDocumentResetEvent;
 import de.tudarmstadt.ukp.clarin.webanno.api.event.BeforeDocumentRemovedEvent;
@@ -131,15 +138,34 @@ public class RecommendationServiceImpl
     private final AnnotationSchemaService annoService;
     private final DocumentService documentService;
     private final LearningRecordService learningRecordService;
+    private final ProjectService projectService;
     
     private final ConcurrentMap<RecommendationStateKey, AtomicInteger> trainingTaskCounter;
     private final ConcurrentMap<RecommendationStateKey, RecommendationState> states;
+    
+    private IRequestCycleListener triggerTraingRunListener;
+
+    /*
+     * Marks user/projects to which annotations were added during this request. 
+     */
+    @SuppressWarnings("serial")
+    private static final MetaDataKey<Set<RecommendationStateKey>> DIRTIES = 
+            new MetaDataKey<Set<RecommendationStateKey>>() {};
+
+    /*
+     * Marks for which CASes have been saved during this request (probably the ones to which
+     * annotations have been added above).
+     */
+    @SuppressWarnings("serial")
+    private static final MetaDataKey<Set<RecommendationStateKey>> COMMITTED = 
+            new MetaDataKey<Set<RecommendationStateKey>>() {};
 
     @Autowired
     public RecommendationServiceImpl(SessionRegistry aSessionRegistry, UserDao aUserRepository,
             RecommenderFactoryRegistry aRecommenderFactoryRegistry,
             SchedulingService aSchedulingService, AnnotationSchemaService aAnnoService,
-            DocumentService aDocumentService, LearningRecordService aLearningRecordService)
+            DocumentService aDocumentService, LearningRecordService aLearningRecordService,
+            ProjectService aProjectService)
     {
         sessionRegistry = aSessionRegistry;
         userRepository = aUserRepository;
@@ -148,6 +174,7 @@ public class RecommendationServiceImpl
         annoService = aAnnoService;
         documentService = aDocumentService;
         learningRecordService = aLearningRecordService;
+        projectService = aProjectService;
         
         trainingTaskCounter = new ConcurrentHashMap<>();
         states = new ConcurrentHashMap<>();
@@ -160,14 +187,14 @@ public class RecommendationServiceImpl
             EntityManager aEntityManager)
     {
         this(aSessionRegistry, aUserRepository, aRecommenderFactoryRegistry, aSchedulingService,
-                aAnnoService, aDocumentService, aLearningRecordService);
+                aAnnoService, aDocumentService, aLearningRecordService, (ProjectService) null);
         
         entityManager = aEntityManager;
     }
 
     public RecommendationServiceImpl(EntityManager aEntityManager)
     {
-        this(null, null, null, null, null, null, null);
+        this(null, null, null, null, null, null, null, (ProjectService) null);
 
         entityManager = aEntityManager;
     }
@@ -388,12 +415,54 @@ public class RecommendationServiceImpl
         }
     }
 
+    /* 
+     * There can be multiple annotation changes in a single user request. Thus, we do not
+     * trigger a training on every action but rather mark the project/user as dirty and trigger
+     * the training only when we get a CAS-written event on a dirty project/user.
+     */
     @EventListener
     public void onAnnotation(AnnotationEvent aEvent)
     {
-        // Whenever annotations are changed, we trigger a new training and classification run
-        triggerTrainingAndClassification(aEvent.getUser(),
-                aEvent.getDocument().getProject(), "AnnotationEvent");
+        RequestCycle requestCycle = RequestCycle.get();
+        
+        if (requestCycle == null) {
+            return;
+        }
+        
+        Set<RecommendationStateKey> dirties = requestCycle.getMetaData(DIRTIES);
+        if (dirties == null) {
+            dirties = new HashSet<>();
+            requestCycle.setMetaData(DIRTIES, dirties);
+        }
+        
+        dirties.add(
+                new RecommendationStateKey(aEvent.getUser(), aEvent.getDocument().getProject()));
+    }
+    
+    /*
+     * We only want to schedule training runs as a reaction to the user performing an action. We
+     * don't need to keep training all the time if the user isn't even going to look at the results.
+     * Thus, we make use of the Wicket RequestCycle here.
+     */
+    @EventListener
+    public void onAfterCasWritten(AfterCasWrittenEvent aEvent)
+    {
+        RequestCycle requestCycle = RequestCycle.get();
+        
+        if (requestCycle == null) {
+            return;
+        }
+        
+        Set<RecommendationStateKey> committed = requestCycle.getMetaData(COMMITTED);
+        if (committed == null) {
+            committed = new HashSet<>();
+            requestCycle.setMetaData(COMMITTED, committed);
+        }
+        
+        committed.add(new RecommendationStateKey(aEvent.getDocument().getUser(),
+                aEvent.getDocument().getProject()));        
+        
+        requestCycle.getListeners().add(triggerTrainingTaskListener());
     }
 
     @EventListener
@@ -444,7 +513,7 @@ public class RecommendationServiceImpl
     
     @EventListener
     @Order(Ordered.HIGHEST_PRECEDENCE)
-    public void onApplicationEvent(SessionDestroyedEvent event)
+    public void onSessionDestroyed(SessionDestroyedEvent event)
     {
         SessionInformation info = sessionRegistry.getSessionInformation(event.getId());
         // Could be an anonymous session without information.
@@ -1089,7 +1158,7 @@ public class RecommendationServiceImpl
                 TypeDescription td = tsd.getType(layer.getName());
 
                 if (td == null) {
-                    log.debug("Could not monkey patch type [{}]", layer.getName());
+                    log.trace("Could not monkey patch type [{}]", layer.getName());
                     continue;
                 }
 
@@ -1110,5 +1179,43 @@ public class RecommendationServiceImpl
         }
 
         return aTargetCas;
+    }
+    
+    private synchronized IRequestCycleListener triggerTrainingTaskListener()
+    {
+        if (triggerTraingRunListener == null) {
+            triggerTraingRunListener = new IRequestCycleListener()
+            {
+                @Override
+                public void onEndRequest(RequestCycle cycle)
+                {
+                    Set<RecommendationStateKey> dirties = cycle.getMetaData(DIRTIES);
+                    Set<RecommendationStateKey> committed = cycle.getMetaData(COMMITTED);
+                    
+                    if (dirties == null || committed == null) {
+                        return;
+                    }
+
+                    for (RecommendationStateKey committedKey : committed) {
+                        if (!dirties.contains(committedKey)) {
+                            // Committed but not dirty, so nothing to do.
+                            continue;
+                        }
+                        
+                        Project project = projectService.getProject(committedKey.getProjectId());
+                        if (project == null) {
+                            // Concurrent action has deleted project, so we can ignore this
+                            continue;
+                        }
+                        
+                        triggerTrainingAndClassification(
+                                committedKey.getUser(), project, 
+                                "Committed dirty CAS at end of request");
+                    }
+                };
+            };
+        }
+        
+        return triggerTraingRunListener;
     }
 }

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommendationSidebar.html
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommendationSidebar.html
@@ -53,7 +53,8 @@
             </div>
           </div>
           <div class="panel-footer text-right">
-            <input wicket:id="save" type="submit" class="btn btn-primary"  wicket:message="value:apply"/>
+            <input wicket:id="retrain" type="button" class="btn btn-default" wicket:message="value:retrain"/>
+            <input wicket:id="save" type="submit" class="btn btn-primary" wicket:message="value:apply"/>
           </div>
         </form>
         <div wicket:id="learningCurve" ></div>

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommendationSidebar.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommendationSidebar.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.form.CheckBox;
 import org.apache.wicket.markup.html.form.Form;
@@ -42,6 +43,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.rendering.event.RenderAn
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxButton;
+import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxLink;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaModelAdapter;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.AnnotationPage;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar.AnnotationSidebar_ImplBase;
@@ -91,6 +93,8 @@ public class RecommendationSidebar
 
         form.add(new CheckBox("showAllPredictions"));
 
+        form.add(new LambdaAjaxLink("retrain", this::actionRetrain));
+
         form.add(new LambdaAjaxButton<>("save", (_target, _form) -> 
                 aAnnotationPage.actionRefreshDocument(_target)));
 
@@ -125,6 +129,14 @@ public class RecommendationSidebar
         aEvent.getRequestHandler().add(warning);
     }
 
+    private void actionRetrain(AjaxRequestTarget aTarget)
+    {
+        AnnotatorState state = getModelObject();
+        recommendationService.clearState(state.getUser().getUsername());
+        recommendationService.triggerTrainingAndClassification(state.getUser().getUsername(),
+                state.getProject(), "User request via sidebar");
+    }
+    
     private List<String> findMismatchedRecommenders()
     {
         List<String> mismatchedRecommenderNames = new ArrayList<>();

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommendationSidebar.properties
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommendationSidebar.properties
@@ -19,3 +19,4 @@ maxSuggestions=Max. suggestions
 showAll=Show all
 learningCurve=Learning curve
 mismatch=Recommender and Layer are mismatched for {0}.
+retrain=Retrain

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/PredictionTask.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/PredictionTask.java
@@ -56,13 +56,14 @@ public class PredictionTask
         Project project = getProject();
         List<SourceDocument> docs = documentService.listSourceDocuments(project);
 
-        log.debug("[{}]: Starting prediction for user [{}] in project [{}] triggered by [{}]...",
-                user, project, getTrigger());
+        log.debug("[{}][{}]: Starting prediction for project [{}] triggered by [{}]...", getId(),
+                user.getUsername(), project, getTrigger());
+        
         long startTime = System.currentTimeMillis();
 
         Predictions predictions = recommendationService.computePredictions(user, project, docs);
         
-        log.debug("[{}]: Prediction complete ({} ms)", user.getUsername(),
+        log.debug("[{}][{}]: Prediction complete ({} ms)", getId(), user.getUsername(),
                 (System.currentTimeMillis() - startTime));
 
         recommendationService.putIncomingPredictions(user, project, predictions);

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/TrainingTask.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/TrainingTask.java
@@ -163,7 +163,7 @@ public class TrainingTask
                             .stream()
                             .filter(e -> !recommender.getStatesIgnoredForTraining()
                                     .contains(e.state))
-                            .filter(e -> containsTargetAnnotation(recommender, e.cas))
+                            .filter(e -> containsTargetTypeAndFeature(recommender, e.cas))
                             .map(e -> e.cas)
                             .collect(Collectors.toList());
 
@@ -219,9 +219,24 @@ public class TrainingTask
         return casses;
     }
 
-    private boolean containsTargetAnnotation(Recommender aRecommender, CAS aCas)
+    private boolean containsTargetTypeAndFeature(Recommender aRecommender, CAS aCas)
     {
-        Type type = CasUtil.getType(aCas, aRecommender.getLayer().getName());
+        Type type;
+        try {
+            type = CasUtil.getType(aCas, aRecommender.getLayer().getName());
+        }
+        catch (IllegalArgumentException e ) {
+            // If the CAS does not contain the target type at all, then it cannot contain any
+            // annotations of that type.
+            return false;
+        }
+        
+        if (type.getFeatureByBaseName(aRecommender.getFeature().getName()) == null) {
+            // If the CAS does not contain the target feature, then there won't be any training
+            // data.
+            return false;            
+        }
+        
         return CasUtil.iterator(aCas, type).hasNext();
     }
 

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/TrainingTask.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/TrainingTask.java
@@ -78,8 +78,8 @@ public class TrainingTask
         Project project = getProject();
         User user = getUser();
 
-        log.debug("[{}]: Starting training for user [{}] in project [{}] triggered by [{}]...",
-                user, project, getTrigger());
+        log.debug("[{}][{}]: Starting training for project [{}] triggered by [{}]...",
+                getId(), user.getUsername(),project, getTrigger());
 
         // Read the CASes only when they are accessed the first time. This allows us to skip reading
         // the CASes in case that no layer / recommender is available or if no recommender requires
@@ -103,8 +103,8 @@ public class TrainingTask
                     .getActiveRecommenders(user, layer);
     
             if (recommenders.isEmpty()) {
-                log.debug("[{}][{}]: No active recommenders, skipping training.",
-                        user.getUsername(), layer.getUiName());
+                log.debug("[{}][{}][{}]: No active recommenders, skipping training.",
+                        getId(), user.getUsername(), layer.getUiName());
                 continue;
             }
             
@@ -116,14 +116,14 @@ public class TrainingTask
                     recommender = recommendationService.getRecommender(r.getRecommender().getId());
                 }
                 catch (NoResultException e) {
-                    log.info("[{}][{}]: Recommender no longer available... skipping",
-                            user.getUsername(), r.getRecommender().getName());
+                    log.info("[{}][{}][{}]: Recommender no longer available... skipping",
+                            getId(), user.getUsername(), r.getRecommender().getName());
                     continue;
                 }
                 
                 if (!recommender.isEnabled()) {
-                    log.debug("[{}][{}]: Disabled - skipping", user.getUsername(),
-                            r.getRecommender().getName());
+                    log.debug("[{}][{}][{}]: Disabled - skipping", user.getUsername(),
+                            getId(), r.getRecommender().getName());
                     continue;
                 }
                 
@@ -134,9 +134,9 @@ public class TrainingTask
                             .getRecommenderFactory(recommender);
 
                     if (!factory.accepts(recommender.getLayer(), recommender.getFeature())) {
-                        log.info("[{}][{}]: Recommender configured with invalid layer or feature "
+                        log.info("[{}][{}][{}]: Recommender configured with invalid layer or feature "
                                         + "- skipping recommender",
-                                user.getUsername(), r.getRecommender().getName());
+                                getId(), user.getUsername(), r.getRecommender().getName());
                         continue;
                     }
                     
@@ -152,8 +152,8 @@ public class TrainingTask
                     
                     // If engine does not support training, mark engine ready and skip to prediction
                     if (capability == TRAINING_NOT_SUPPORTED) {
-                        log.info("[{}][{}]: Engine does not support training",
-                                user.getUsername(), recommender.getName());
+                        log.info("[{}][{}][{}]: Engine does not support training",
+                                getId(), user.getUsername(), recommender.getName());
                         ctx.close();
                         recommendationService.putContext(user, recommender, ctx);
                         continue;
@@ -170,32 +170,34 @@ public class TrainingTask
                     // If no data for training is available, but the engine requires training, 
                     // do not mark as ready
                     if (cassesForTraining.isEmpty() && capability == TRAINING_REQUIRED) {
-                        log.info("[{}][{}]: There are no annotations available to train on",
-                                user.getUsername(), recommender.getName());
+                        log.info("[{}][{}][{}]: There are no annotations available to train on",
+                                getId(), user.getUsername(), recommender.getName());
                         continue;
                     }
                     
-                    log.info("[{}][{}]: Training model on [{}] out of [{}] documents ...",
-                            user.getUsername(), recommender.getName(), cassesForTraining.size(),
-                            casses.get().size());
+                    log.info("[{}][{}][{}]: Training model on [{}] out of [{}] documents ...",
+                            getId(), user.getUsername(), recommender.getName(),
+                            cassesForTraining.size(), casses.get().size());
                     
                     recommendationEngine.train(ctx, cassesForTraining);
                     
-                    log.info("[{}][{}]: Training complete ({} ms)", user.getUsername(),
-                            recommender.getName(), (System.currentTimeMillis() - startTime));
+                    log.info("[{}][{}][{}]: Training complete ({} ms)", getId(),
+                            user.getUsername(), recommender.getName(),
+                            (System.currentTimeMillis() - startTime));
                     
                     ctx.close();
                     recommendationService.putContext(user, recommender, ctx);
                 }
                 catch (Throwable e) {
-                    log.info("[{}][{}]: Training failed ({} ms)", user.getUsername(),
-                            recommender.getName(), (System.currentTimeMillis() - startTime), e);
+                    log.info("[{}][{}][{}]: Training failed ({} ms)", getId(),
+                            user.getUsername(), recommender.getName(),
+                            (System.currentTimeMillis() - startTime), e);
                 }
             }
         }
 
         schedulingService.enqueue(new PredictionTask(user, getProject(),
-                        "TrainingTask after training was finished"));
+                        String.format("TrainingTask %s complete", getId())));
     }
 
     private List<TrainingDocument> readCasses(Project aProject, User aUser)

--- a/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/VisibilityCalculationTests.java
+++ b/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/VisibilityCalculationTests.java
@@ -26,6 +26,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import javax.persistence.EntityManager;
+
 import org.apache.uima.cas.CAS;
 import org.apache.uima.fit.factory.JCasFactory;
 import org.apache.uima.jcas.JCas;
@@ -90,7 +92,7 @@ public class VisibilityCalculationTests
         when(annoService.listAnnotationFeature(layer)).thenReturn(featureList);
         
         sut = new RecommendationServiceImpl(null, null, null, null, annoService, null,
-                recordService, null);
+                recordService, (EntityManager) null);
     }
 
     @Test

--- a/inception-scheduling/src/main/java/de/tudarmstadt/ukp/inception/scheduling/Task.java
+++ b/inception-scheduling/src/main/java/de/tudarmstadt/ukp/inception/scheduling/Task.java
@@ -20,6 +20,7 @@ package de.tudarmstadt.ukp.inception.scheduling;
 import static org.apache.commons.lang3.Validate.notNull;
 
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
@@ -27,9 +28,12 @@ import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 public abstract class Task
     implements Runnable
 {
+    private final static AtomicInteger nextId = new AtomicInteger(1);
+    
     private final User user;
     private final Project project;
     private final String trigger;
+    private final int id;
 
     public Task(User aUser, Project aProject, String aTrigger)
     {
@@ -40,6 +44,7 @@ public abstract class Task
         user = aUser;
         project = aProject;
         trigger = aTrigger;
+        id = nextId.getAndIncrement();
     }
 
     public User getUser()
@@ -61,6 +66,11 @@ public abstract class Task
     {
         return getClass().getSimpleName();
     }
+    
+    public int getId()
+    {
+        return id;
+    }
 
     @Override
     public String toString() {
@@ -75,8 +85,12 @@ public abstract class Task
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         Task task = (Task) o;
         return user.equals(task.user) && project.equals(task.project);
     }


### PR DESCRIPTION
**What's in the PR**
- Remove call to upgrade "original" CAS
- Changed TrainingTask "containsTargetAnnotation" to be able to deal with the case where the target type and/or feature are not defined in a CAS yet
- Changed RecommendationServiceImpl "calculateVisibility" to be able to deal with the case where the target type and/or feature are not defined in a CAS yet
- Added button to the recommender sidebar to explicitly trigger a retraining

**How to test manually**
* Assume a project with multiple documents
* Create a new span layer with a new string feature
* Define some recommender on that string feature (best a StringMatchingRecommender)
* Open the first document in the annotation page (meaning the first document is upgraded to the new type system, but the other documents are still on the old type system)
* Make some annotation using the span layer with the recommender
* See if predictions come up

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
