### PR TITLE
#1349 - Delete project endpoint fails with python's requests library

### DIFF
--- a/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/menubar/MenuBarEventAdapter.java
+++ b/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/menubar/MenuBarEventAdapter.java
@@ -33,8 +33,8 @@ public class MenuBarEventAdapter
     @EventListener
     public void onProjectDeleted(BeforeProjectRemovedEvent aEvent)
     {
-        Session session = Session.get();
-        if (session != null) {
+        if (Session.exists()) {
+            Session session = Session.get();
             // If the currently selected project is deleted, clear it from the session.
             Project project = session.getMetaData(SessionMetaData.CURRENT_PROJECT);
             if (project != null && Objects.equals(aEvent.getProject().getId(), project.getId())) {


### PR DESCRIPTION
**What's in the PR**
- Check if session exists before trying to get it to avoid exception when project is deleted via remote API

**How to test manually**
* See python script in issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
