### PR TITLE
#1082 - Editor loads files of wrong format

### DIFF
--- a/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/PdfAnnotationEditor.java
+++ b/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/PdfAnnotationEditor.java
@@ -97,10 +97,11 @@ public class PdfAnnotationEditor
             AnnotationActionHandler aActionHandler, CasProvider aCasProvider)
     {
         super(aId, aModel, aActionHandler, aCasProvider);
-        if (aModel.getObject().getDocument().getFormat().equals(PdfFormatSupport.ID)) {
+        String format = aModel.getObject().getDocument().getFormat(); 
+        if (format.equals(PdfFormatSupport.ID)) {
             add(new PdfAnnoPanel(VIS, aModel, this));
         } else {
-            add(new WrongFileFormatPanel(VIS));
+            add(new WrongFileFormatPanel(VIS, format));
         }
     }
 

--- a/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/PdfAnnotationEditor.java
+++ b/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/PdfAnnotationEditor.java
@@ -80,6 +80,8 @@ public class PdfAnnotationEditor
     private static final String SELECT_RELATION = "selectRelation";
     private static final String DELETE_RECOMMENDATION = "deleteRecommendation";
     private static final String GET_ANNOTATIONS = "getAnnotations";
+    
+    private static final String VIS = "vis";
 
     private PdfExtractFile pdfExtractFile;
     private DocumentModel documentModel;
@@ -95,8 +97,11 @@ public class PdfAnnotationEditor
             AnnotationActionHandler aActionHandler, CasProvider aCasProvider)
     {
         super(aId, aModel, aActionHandler, aCasProvider);
-
-        add(new PdfAnnoPanel("vis", aModel, this));
+        if (aModel.getObject().getDocument().getFormat().equals(PdfFormatSupport.ID)) {
+            add(new PdfAnnoPanel(VIS, aModel, this));
+        } else {
+            add(new WrongFileFormatPanel(VIS));
+        }
     }
 
     @Override

--- a/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/WrongFileFormatPanel.html
+++ b/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/WrongFileFormatPanel.html
@@ -1,0 +1,28 @@
+<!--
+ - Copyright 2019
+ - Ubiquitous Knowledge Processing (UKP) Lab
+ - Technische Universität Darmstadt
+ - 
+ - Licensed under the Apache License, Version 2.0 (the "License");
+ - you may not use this file except in compliance with the License.
+ - You may obtain a copy of the License at
+ -  
+ - http://www.apache.org/licenses/LICENSE-2.0
+ - 
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the License is distributed on an "AS IS" BASIS,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the License for the specific language governing permissions and
+ - limitations under the License.
+-->
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:wicket="http://wicket.apache.org/dtds.data/wicket-xhtml1.4-strict.dtd">
+<body>
+<wicket:panel>
+    <h1 class="col-xs-10 col-xs-offset-1" style="text-align: center;">
+        The opened file was not imported as PDF document and cannot be opened by the PDF editor.
+        Please use another editor.
+    </h1>
+</wicket:panel>
+</body>
+</html>

--- a/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/WrongFileFormatPanel.html
+++ b/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/WrongFileFormatPanel.html
@@ -19,13 +19,13 @@
       xmlns:wicket="http://wicket.apache.org/dtds.data/wicket-xhtml1.4-strict.dtd">
 <body>
 <wicket:panel>
-    <!--    <h1 class="col-xs-10 col-xs-offset-1" style="text-align: center;">-->
-    <h1 class="col-xs-offset-1 col-xs-10" style="text-align: center;">
-        <p>The opened file was not imported with the PDF format.</p>
-        <p>It cannot be opened by the PDF editor.</p>
-        <p>The following file format was used: <label wicket:id="format"></label></p>
-        <p>Please use another editor or reimport with the correct format.</p>
-    </h1>
+  <div class="flex-content" style="display: flex; align-items: center; justify-content: center;">
+    <div class="alert alert-danger">
+      <h4 class="text-center">Incompatible file format</h4>
+      <p>The original document is not a PDF file, but a <b wicket:id="format"></b> file.</p>
+      <p>Switch to another editor via the <b>Settings</b> dialog accessible from the action bar above.</p>
+    </div>
+  </div>
 </wicket:panel>
 </body>
 </html>

--- a/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/WrongFileFormatPanel.html
+++ b/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/WrongFileFormatPanel.html
@@ -19,9 +19,12 @@
       xmlns:wicket="http://wicket.apache.org/dtds.data/wicket-xhtml1.4-strict.dtd">
 <body>
 <wicket:panel>
-    <h1 class="col-xs-10 col-xs-offset-1" style="text-align: center;">
-        The opened file was not imported as PDF document and cannot be opened by the PDF editor.
-        Please use another editor.
+    <!--    <h1 class="col-xs-10 col-xs-offset-1" style="text-align: center;">-->
+    <h1 class="col-xs-offset-1 col-xs-10" style="text-align: center;">
+        <p>The opened file was not imported with the PDF format.</p>
+        <p>It cannot be opened by the PDF editor.</p>
+        <p>The following file format was used: <label wicket:id="format"></label></p>
+        <p>Please use another editor or reimport with the correct format.</p>
     </h1>
 </wicket:panel>
 </body>

--- a/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/WrongFileFormatPanel.java
+++ b/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/WrongFileFormatPanel.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019
+ * Ubiquitous Knowledge Processing (UKP) Lab
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.pdfeditor;
+
+import org.apache.wicket.markup.html.panel.Panel;
+
+public class WrongFileFormatPanel
+    extends Panel
+{
+    public WrongFileFormatPanel(String id) {
+        super(id);
+    }
+}

--- a/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/WrongFileFormatPanel.java
+++ b/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/WrongFileFormatPanel.java
@@ -17,12 +17,14 @@
  */
 package de.tudarmstadt.ukp.inception.pdfeditor;
 
+import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.panel.Panel;
 
 public class WrongFileFormatPanel
     extends Panel
 {
-    public WrongFileFormatPanel(String id) {
+    public WrongFileFormatPanel(String id, String format) {
         super(id);
+        add(new Label("format", format));
     }
 }


### PR DESCRIPTION
**What's in the PR**
- add output of file format if it does not match PDF in the PDF editor
- add check for document format and display a message if format is PDF instead of showing the editor for PDF editor

**How to test manually**
* Open a non-pdf document in the PDF editor and see message that the format is wrong.
* Open a pdf document in the PDF editor and see the PDF editor as usual.

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
