### PR TITLE
#1356 - Importing of large event logs too slow

### DIFF
--- a/inception-log/pom.xml
+++ b/inception-log/pom.xml
@@ -118,6 +118,11 @@
       <artifactId>javax.persistence-api</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
+
     <!-- Testing -->
 
     <dependency>

--- a/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/EventRepositoryImpl.java
+++ b/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/EventRepositoryImpl.java
@@ -56,10 +56,13 @@ public class EventRepositoryImpl
     @Transactional
     public void create(LoggedEvent... aEvents)
     {
+        long start = System.currentTimeMillis();
         for (LoggedEvent event : aEvents) {
             log.trace("{}", event);
             entityManager.persist(event);
         }
+        long duration = System.currentTimeMillis() - start;
+        log.debug("... {} events stored ... ({}ms)", aEvents.length, duration);
     }
 
     @Override


### PR DESCRIPTION
**What's in the PR**
- Increase batch size for persisting events
- Added a cache for looking up source documents to avoid having to look up the documents from the DB on every event
- Fixed bug that batch was not cleared after persisting

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
