### PR TITLE
#1370 - Indexing crashes if document contains illegal XML character

### DIFF
--- a/inception-search-mtas/src/main/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasUimaParser.java
+++ b/inception-search-mtas/src/main/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasUimaParser.java
@@ -245,11 +245,11 @@ public class MtasUimaParser
         }
         
         Pair<AnnotationFS, Integer> endToken;
-        if (tokenEndIndex.ceilingEntry(aAnnotation.getEnd() - 1) == null) {
+        if (tokenEndIndex.ceilingEntry(aAnnotation.getEnd()) == null) {
             endToken = tokenEndIndex.lastEntry().getValue();
         }
         else {
-            endToken = tokenEndIndex.ceilingEntry(aAnnotation.getEnd() - 1).getValue();
+            endToken = tokenEndIndex.ceilingEntry(aAnnotation.getEnd()).getValue();
         }
         return new Range(beginToken.getValue(), endToken.getValue(), beginToken.getKey().getBegin(),
                 endToken.getKey().getEnd());

--- a/inception-search-mtas/src/main/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasUimaParser.java
+++ b/inception-search-mtas/src/main/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasUimaParser.java
@@ -17,11 +17,18 @@
  */
 package de.tudarmstadt.ukp.inception.search.index.mtas;
 
+import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.getAddr;
 import static de.tudarmstadt.ukp.inception.search.FeatureIndexingSupport.SPECIAL_SEP;
+import static de.tudarmstadt.ukp.inception.search.index.mtas.MtasUtils.charsToBytes;
 import static de.tudarmstadt.ukp.inception.search.index.mtas.MtasUtils.encodeFSAddress;
+import static org.apache.commons.io.IOUtils.toCharArray;
+import static org.apache.uima.fit.util.CasUtil.getType;
+import static org.apache.uima.fit.util.CasUtil.select;
+import static org.apache.uima.fit.util.CasUtil.selectAll;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.Reader;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -33,16 +40,14 @@ import java.util.Optional;
 import java.util.TreeMap;
 
 import org.apache.commons.collections4.MultiValuedMap;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.uima.UIMAException;
-import org.apache.uima.cas.impl.XmiCasDeserializer;
+import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.text.AnnotationFS;
-import org.apache.uima.fit.factory.JCasFactory;
 import org.apache.uima.fit.util.FSUtil;
-import org.apache.uima.fit.util.JCasUtil;
-import org.apache.uima.jcas.JCas;
-import org.apache.uima.jcas.tcas.Annotation;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
+import org.apache.uima.util.CasCreationUtils;
+import org.apache.uima.util.CasIOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,7 +60,6 @@ import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
 import de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.adapter.RelationAdapter;
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
@@ -103,8 +107,8 @@ public class MtasUimaParser
     private Map<String, AnnotationLayer> layers;
     private Map<String, List<AnnotationFeature>> layerFeatures;
 
-    private NavigableMap<Integer, Pair<Token, Integer>> tokenBeginIndex;
-    private NavigableMap<Integer, Pair<Token, Integer>> tokenEndIndex;
+    private NavigableMap<Integer, Pair<AnnotationFS, Integer>> tokenBeginIndex;
+    private NavigableMap<Integer, Pair<AnnotationFS, Integer>> tokenEndIndex;
 
     public MtasUimaParser(MtasConfiguration config)
     {
@@ -166,9 +170,9 @@ public class MtasUimaParser
         long start = System.currentTimeMillis();
         log.debug("Starting creation of token collection");
 
-        JCas jcas;
+        CAS cas;
         try {
-            jcas = readCas(aReader);
+            cas = readCas(aReader);
         }
         catch (Exception e) {
             log.error("Unable to decode CAS", e);
@@ -176,7 +180,7 @@ public class MtasUimaParser
         }
 
         try {
-            createTokenCollection(jcas);
+            createTokenCollection(cas);
             log.debug("Created token collection in {} ms", (System.currentTimeMillis() - start));
             return tokenCollection;
         }
@@ -186,20 +190,18 @@ public class MtasUimaParser
         }
     }
     
-    private JCas readCas(Reader reader) throws UIMAException, IOException, SAXException
+    private CAS readCas(Reader aReader) throws UIMAException, IOException, SAXException
     {
-        JCas jcas = JCasFactory
-                .createJCas(annotationSchemaService.getFullProjectTypeSystem(project));
+        CAS cas = CasCreationUtils.createCas((TypeSystemDescription) null, null, null);
 
-        String xmi = IOUtils.toString(reader);
-
-        // Get the annotations from the XMI are back in the CAS.
-        XmiCasDeserializer.deserialize(new ByteArrayInputStream(xmi.getBytes()), jcas.getCas());
-
-        return jcas;
+        try (InputStream in = new ByteArrayInputStream(charsToBytes(toCharArray(aReader)))) {
+            CasIOUtils.load(in, cas);
+        }
+        
+        return cas;
     }
 
-    public MtasTokenCollection createTokenCollection(JCas aJCas)
+    public MtasTokenCollection createTokenCollection(CAS aJCas)
     {
         // Initialize state
         tokenCollection = new MtasTokenCollection();
@@ -210,14 +212,14 @@ public class MtasUimaParser
         // tokens based on their offsets.
         tokenBeginIndex = new TreeMap<>();
         tokenEndIndex = new TreeMap<>();
-        for (Token token : JCasUtil.select(aJCas, Token.class)) {
+        for (AnnotationFS token : select(aJCas, getType(aJCas, Token.class))) {
             tokenBeginIndex.put(token.getBegin(), Pair.of(token, tokenNum));
             tokenEndIndex.put(token.getEnd(), Pair.of(token, tokenNum));
             tokenNum++;
         }
         
         // Loop over the annotations
-        for (Annotation annotation : JCasUtil.select(aJCas, Annotation.class)) {
+        for (AnnotationFS annotation : selectAll(aJCas)) {
             // MTAS cannot index zero-width annotations, so we skip them here.
             if (annotation.getBegin() == annotation.getEnd()) {
                 continue;
@@ -234,7 +236,7 @@ public class MtasUimaParser
         // 1) if the first token starts after the first char. For example, when there's
         // a space or line break in the beginning of the document.
         // 2) if the last token ends before the last char. Same as above.
-        Pair<Token, Integer> beginToken;
+        Pair<AnnotationFS, Integer> beginToken;
         if (tokenBeginIndex.floorEntry(aAnnotation.getBegin()) == null) {
             beginToken = tokenBeginIndex.firstEntry().getValue();
         }
@@ -242,7 +244,7 @@ public class MtasUimaParser
             beginToken = tokenBeginIndex.floorEntry(aAnnotation.getBegin()).getValue();
         }
         
-        Pair<Token, Integer> endToken;
+        Pair<AnnotationFS, Integer> endToken;
         if (tokenEndIndex.ceilingEntry(aAnnotation.getEnd() - 1) == null) {
             endToken = tokenEndIndex.lastEntry().getValue();
         }
@@ -257,7 +259,7 @@ public class MtasUimaParser
             int aMtasId)
     {
         int mtasId = aMtasId;
-        int fsAddress = WebAnnoCasUtil.getAddr(aAnnotation);
+        int fsAddress = getAddr(aAnnotation);
         if (aAnnotation.getEnd() - aAnnotation.getBegin() > OVERSIZED_ANNOTATION_LIMIT) {
             log.trace("Skipping indexing of very long annotation: {} {} characters at [{}-{}]",
                     aAnnotation.getType().getName(), aAnnotation.getEnd() - aAnnotation.getBegin(),

--- a/inception-search-mtas/src/main/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasUtils.java
+++ b/inception-search-mtas/src/main/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasUtils.java
@@ -63,4 +63,43 @@ public final class MtasUtils
         buffer.flip();
         return buffer.getInt();
     }
+    
+    public static char[] bytesToChars(byte[] aBytes)
+    {
+        // Reserve sufficient space of the length and the char-encoded byte array
+        char[] chars = new char[2 + (aBytes.length / 2) + (aBytes.length % 2)];
+
+        // Encode the length of the byte array
+        chars[0] = (char) ((aBytes.length & 0xFFFF0000) >> 16);
+        chars[1] = (char) (aBytes.length & 0x0000FFFF);
+        
+        // Encode the byte array into the char array
+        for (int i = 0; i < aBytes.length; i++) {
+            if (i % 2 == 0) {
+                chars[2 + (i / 2)] |= (char) (aBytes[i] << 8);
+            }
+            else {
+                chars[2 + (i / 2)] |= (char) (aBytes[i] & 0x00FF);
+            }
+        }
+        
+        return chars;
+    }
+    
+    public static byte[] charsToBytes(char[] aChars)
+    {
+        int len = ((int) aChars[0] << 16) | aChars[1];
+        byte[] bytes = new byte[len];
+        
+        for (int i = 0; i < len; i++) {
+            if (i % 2 == 0) {
+                bytes[i] = (byte) (aChars[2 + (i / 2)] >>> 8);
+            }
+            else {
+                bytes[i] = (byte) (aChars[2 + (i / 2)] & 0x00FF);
+            }
+        }
+        
+        return bytes;
+    }
 }

--- a/inception-search-mtas/src/test/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndexTest.java
+++ b/inception-search-mtas/src/test/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndexTest.java
@@ -121,7 +121,6 @@ import de.tudarmstadt.ukp.inception.search.scheduling.IndexScheduler;
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 @DataJpaTest
 @Transactional(propagation = Propagation.NEVER)
-
 public class MtasDocumentIndexTest
 {
     private @Autowired UserDao userRepository;

--- a/inception-search-mtas/src/test/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasUimaParserTest.java
+++ b/inception-search-mtas/src/test/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasUimaParserTest.java
@@ -105,7 +105,7 @@ public class MtasUimaParserTest
         
         MtasUimaParser sut = new MtasUimaParser(project, annotationSchemaService,
                 featureIndexingSupportRegistry);
-        MtasTokenCollection tc = sut.createTokenCollection(jcas);
+        MtasTokenCollection tc = sut.createTokenCollection(jcas.getCas());
         
         MtasUtils.print(tc);
         
@@ -155,7 +155,7 @@ public class MtasUimaParserTest
         
         MtasUimaParser sut = new MtasUimaParser(project, annotationSchemaService,
                 featureIndexingSupportRegistry);
-        MtasTokenCollection tc = sut.createTokenCollection(jcas);
+        MtasTokenCollection tc = sut.createTokenCollection(jcas.getCas());
         
         MtasUtils.print(tc);
         
@@ -195,7 +195,7 @@ public class MtasUimaParserTest
         
         MtasUimaParser sut = new MtasUimaParser(project, annotationSchemaService,
                 featureIndexingSupportRegistry);
-        MtasTokenCollection tc = sut.createTokenCollection(jcas);
+        MtasTokenCollection tc = sut.createTokenCollection(jcas.getCas());
         
         MtasUtils.print(tc);
         
@@ -281,7 +281,7 @@ public class MtasUimaParserTest
         
         MtasUimaParser sut = new MtasUimaParser(project, annotationSchemaService,
                 featureIndexingSupportRegistry);
-        MtasTokenCollection tc = sut.createTokenCollection(jcas);
+        MtasTokenCollection tc = sut.createTokenCollection(jcas.getCas());
         
         MtasUtils.print(tc);
         

--- a/inception-search-mtas/src/test/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasUtilsTest.java
+++ b/inception-search-mtas/src/test/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasUtilsTest.java
@@ -22,7 +22,7 @@ import static de.tudarmstadt.ukp.inception.search.index.mtas.MtasUtils.charsToBy
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
+import java.util.Random;
 
 import org.junit.Test;
 
@@ -42,7 +42,9 @@ public class MtasUtilsTest
     public void bytesToCharsRoundtripRandom() throws NoSuchAlgorithmException
     {
         byte[] input = new byte[65535];
-        SecureRandom.getInstanceStrong().nextBytes(input);
+        
+        Random rnd = new Random();
+        rnd.nextBytes(input);
 
         byte[] output = charsToBytes(bytesToChars(input));
 

--- a/inception-search-mtas/src/test/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasUtilsTest.java
+++ b/inception-search-mtas/src/test/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasUtilsTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019
+ * Ubiquitous Knowledge Processing (UKP) Lab
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.search.index.mtas;
+
+import static de.tudarmstadt.ukp.inception.search.index.mtas.MtasUtils.bytesToChars;
+import static de.tudarmstadt.ukp.inception.search.index.mtas.MtasUtils.charsToBytes;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+
+import org.junit.Test;
+
+public class MtasUtilsTest
+{
+    @Test
+    public void bytesToCharsRoundtripFixed() throws NoSuchAlgorithmException
+    {
+        byte[] input = new byte[] { 0x01, 0x02, (byte) 0xFE, (byte) 0xFF };
+
+        byte[] output = charsToBytes(bytesToChars(input));
+
+        assertThat(output).isEqualTo(input);
+    }
+
+    @Test
+    public void bytesToCharsRoundtripRandom() throws NoSuchAlgorithmException
+    {
+        byte[] input = new byte[65535];
+        SecureRandom.getInstanceStrong().nextBytes(input);
+
+        byte[] output = charsToBytes(bytesToChars(input));
+
+        assertThat(output).isEqualTo(input);
+    }
+}

--- a/inception-search-mtas/src/test/resources/log4j2.xml
+++ b/inception-search-mtas/src/test/resources/log4j2.xml
@@ -10,6 +10,7 @@
     <Logger name="mtas" level="INFO"/>
     <Logger name="de.tudarmstadt.ukp.inception.search" level="INFO"/>
     <Logger name="de.tudarmstadt.ukp.clarin.webanno.api.dao.DocumentServiceImpl" level="INFO"/>
+<!--     <Logger name="de.tudarmstadt.ukp.inception.search.index.mtas.MtasUimaParser" level="TRACE"/> -->
     <Root level="WARN">
       <AppenderRef ref="ConsoleAppender" />
     </Root>

--- a/inception-ui-kb/src/test/java/de/tudarmstadt/ukp/inception/ui/kb/search/ConceptFeatureIndexingSupportTest.java
+++ b/inception-ui-kb/src/test/java/de/tudarmstadt/ukp/inception/ui/kb/search/ConceptFeatureIndexingSupportTest.java
@@ -146,7 +146,7 @@ public class ConceptFeatureIndexingSupportTest
 
         MtasUimaParser sut = new MtasUimaParser(project, annotationSchemaService,
                 featureIndexingSupportRegistry);
-        MtasTokenCollection tc = sut.createTokenCollection(jcas);
+        MtasTokenCollection tc = sut.createTokenCollection(jcas.getCas());
         MtasUtils.print(tc);
         
         List<MtasToken> tokens = new ArrayList<>();


### PR DESCRIPTION
**What's in the PR**
- Serialize CAS using a binary serialization
- Encode bytes into characters at the binary level to channel the serialized CAS into the MTAS core
- Use CAS instead of JCas in MtasUimaParser

**How to test manually**
* See issue description

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
