### PR TITLE
#1373 - Invalid Conll-U export of text reference (not on the same line)

### DIFF
--- a/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/formats/ConllUFormatSupport.java
+++ b/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/formats/ConllUFormatSupport.java
@@ -25,10 +25,10 @@ import org.apache.uima.cas.CAS;
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
 import org.dkpro.core.io.conll.ConllUReader;
-import org.dkpro.core.io.conll.ConllUWriter;
 import org.springframework.stereotype.Component;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.conll.ConllUWriter;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 
 @Component
@@ -72,6 +72,8 @@ public class ConllUFormatSupport
     public AnalysisEngineDescription getWriterDescription(Project aProject, CAS aCAS)
         throws ResourceInitializationException
     {
+        // TODO: The backported ConllUWriter should be removed again when DKPro Core 1.11.2 or
+        // higher is released with the appropriate fix for the line breaks within sentences
         return createEngineDescription(ConllUWriter.class);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     </repository>
   </distributionManagement>
   <properties>
-    <webanno.version>3.6.0-beta-13</webanno.version>
+    <webanno.version>3.6.0-beta-14</webanno.version>
     <uima.version>2.10.4</uima.version>
     <dkpro.version>1.11.1</dkpro.version>
     <spring.version>5.1.9.RELEASE</spring.version>


### PR DESCRIPTION
**What's in the PR**
- Switch to WebAnno 3.6.0-beta-14 which has a patched CoNLL-U writer backported from DKPro Core

**How to test manually**
* Export a text with line breaks to CoNLL-U

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
