### PR TITLE
#1382 - Scoped a concept feature may not generate any candidates

### DIFF
--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
@@ -189,6 +189,8 @@ public class SPARQLQueryBuilder
     
     private boolean includeInferred = true;
     
+    private boolean forceDisableFTS = false;
+    
     /**
      * This flag controls whether we attempt to drop duplicate labels and descriptions on the
      * side of the SPARQL server (true) or whether we try retrieving all labels and descriptions
@@ -603,6 +605,8 @@ public class SPARQLQueryBuilder
     @Override
     public SPARQLQueryPrimaryConditions withIdentifier(String... aIdentifiers)
     {
+        forceDisableFTS = true;
+        
         addPattern(PRIMARY, new ValuesPattern(VAR_SUBJECT,
                 Arrays.stream(aIdentifiers).map(Rdf::iri).toArray(RdfValue[]::new)));
         
@@ -612,6 +616,8 @@ public class SPARQLQueryBuilder
     @Override
     public SPARQLQueryPrimaryConditions matchingDomain(String aIdentifier)
     {
+        forceDisableFTS = true;
+        
         // The original code considered owl:unionOf in the domain defintion... we do not do this
         // at the moment, but to see how it was before and potentially restore that behavior, we
         // keep a copy of the old query here.
@@ -654,7 +660,7 @@ public class SPARQLQueryBuilder
             return this;
         }
         
-        IRI ftsMode = kb.getFullTextSearchIri();
+        IRI ftsMode = forceDisableFTS ? FTS_NONE : kb.getFullTextSearchIri();
         
         if (FTS_LUCENE.equals(ftsMode)) {
             addPattern(PRIMARY, withLabelMatchingExactlyAnyOf_RDF4J_FTS(aValues));
@@ -810,7 +816,7 @@ public class SPARQLQueryBuilder
             return this;
         }
         
-        IRI ftsMode = kb.getFullTextSearchIri();
+        IRI ftsMode = forceDisableFTS ? FTS_NONE : kb.getFullTextSearchIri();
         
         if (FTS_LUCENE.equals(ftsMode)) {
             addPattern(PRIMARY, withLabelContainingAnyOf_RDF4J_FTS(aValues));
@@ -963,7 +969,7 @@ public class SPARQLQueryBuilder
         }
         
         
-        IRI ftsMode = kb.getFullTextSearchIri();
+        IRI ftsMode = forceDisableFTS ? FTS_NONE : kb.getFullTextSearchIri();
         
         if (FTS_LUCENE.equals(ftsMode)) {
             addPattern(PRIMARY, withLabelStartingWith_RDF4J_FTS(aPrefixQuery));
@@ -1250,6 +1256,8 @@ public class SPARQLQueryBuilder
     @Override
     public SPARQLQueryPrimaryConditions roots()
     {
+        forceDisableFTS = true;
+        
         addPattern(PRIMARY, mode.rootsPattern(kb));
         
         return this;
@@ -1258,6 +1266,8 @@ public class SPARQLQueryBuilder
     @Override
     public SPARQLQueryPrimaryConditions ancestorsOf(String aItemIri)
     {
+        forceDisableFTS = true;
+        
         Iri contextIri = iri(aItemIri);
         
         addPattern(PRIMARY, mode.ancestorsPattern(kb, contextIri));
@@ -1268,6 +1278,8 @@ public class SPARQLQueryBuilder
     @Override
     public SPARQLQueryPrimaryConditions descendantsOf(String aClassIri)
     {
+        forceDisableFTS = true;
+        
         Iri contextIri = iri(aClassIri);
         
         addPattern(PRIMARY, mode.descendentsPattern(kb, contextIri));
@@ -1278,6 +1290,8 @@ public class SPARQLQueryBuilder
     @Override
     public SPARQLQueryPrimaryConditions childrenOf(String aClassIri)
     {
+        forceDisableFTS = true;
+        
         Iri contextIri = iri(aClassIri);
         
         addPattern(PRIMARY, mode.childrenPattern(kb, contextIri));
@@ -1288,6 +1302,8 @@ public class SPARQLQueryBuilder
     @Override
     public SPARQLQueryPrimaryConditions parentsOf(String aClassIri)
     {
+        forceDisableFTS = true;
+        
         Iri contextIri = iri(aClassIri);
         
         addPattern(PRIMARY, mode.parentsPattern(kb, contextIri));

--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryPrimaryConditions.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryPrimaryConditions.java
@@ -17,11 +17,30 @@
  */
 package de.tudarmstadt.ukp.inception.kb.querybuilder;
 
+/**
+ * When working with queries using any of {@link #roots()}, @link #withIdentifier(String)}, @link
+ * #childrenOf(String)}, {@link #descendantsOf(String)}, {@link #parentsOf(String)} or
+ * {@link #ancestorsOf(String)}}, the FTS is internally disabled. These methods must be called
+ * <b>before</b> any label-restricting methods like {@link #withLabelStartingWith(String)} This is
+ * because the FTS part of the query pre-filters the potential candidates, but the FTS may not
+ * return all candidates. Let's consider a large KB (e.g. Wikidata) and a query for <i>all humans
+ * named Amanda in the Star Trek universe</i> (there is a category for <i>humans in the Star Trek
+ * universe</i> in Wikidata). First the FTS would try to retrieve all entities named <i>Amanda</i>,
+ * but it does not really return all, just the top 50 (which is what Wikidata seems to be hard-coded
+ * to despite the documentation for <i>wikidata:limit</i> saying otherwise). None of these Amandas,
+ * however, is part of the Star Trek universe, so the final result of the query is empty. Here, the
+ * FTS restricts too much and too early. For such cases, we should rely on the scope sufficiently
+ * limiting the returned results such that the regex-based filtering does not get too slow.
+ */
 public interface SPARQLQueryPrimaryConditions
     extends SPARQLQuery, SPARQLQueryOptionalElements
 {
     /**
      * Find the item with the given identifiers.
+     * <p>
+     * <b>NOTE:</b> this method implicitly disables FTS for the query and must be called before
+     * {@link #withLabelStartingWith(String)} or any other label-matching methods. Failure to do so
+     * may result in queries returning fewer than expected results (in the worst case, no results).
      * 
      * @param aIdentifiers
      *            the item identifiers.
@@ -61,12 +80,20 @@ public interface SPARQLQueryPrimaryConditions
 
     /**
      * Match all the roots of the class hierarchy.
+     * <p>
+     * <b>NOTE:</b> this method implicitly disables FTS for the query and must be called before
+     * {@link #withLabelStartingWith(String)} or any other label-matching methods. Failure to do so
+     * may result in queries returning fewer than expected results (in the worst case, no results).
      */
     SPARQLQueryPrimaryConditions roots();
 
     /**
      * Limits results to ancestors of the given item. If the item is an instance, its classes are
      * considered to be its parents. If the item is a class, then the superclasses are the parents.
+     * <p>
+     * <b>NOTE:</b> this method implicitly disables FTS for the query and must be called before
+     * {@link #withLabelStartingWith(String)} or any other label-matching methods. Failure to do so
+     * may result in queries returning fewer than expected results (in the worst case, no results).
      * 
      * @return the builder (fluent API)
      */
@@ -76,6 +103,10 @@ public interface SPARQLQueryPrimaryConditions
      * Limits results to descendants of the given class. Descendants of a class include its
      * subclasses and instances (of subclasses). Depending on which kind if items the query is built
      * for, either one of them or both are returned.
+     * <p>
+     * <b>NOTE:</b> this method implicitly disables FTS for the query and must be called before
+     * {@link #withLabelStartingWith(String)} or any other label-matching methods. Failure to do so
+     * may result in queries returning fewer than expected results (in the worst case, no results).
      * 
      * @return the builder (fluent API)
      */
@@ -85,6 +116,10 @@ public interface SPARQLQueryPrimaryConditions
      * Limits results to children of the given class. Children of a class are its subclasses and
      * instances. Depending on which kind if items the query is built for, either one of them or
      * both are returned.
+     * <p>
+     * <b>NOTE:</b> this method implicitly disables FTS for the query and must be called before
+     * {@link #withLabelStartingWith(String)} or any other label-matching methods. Failure to do so
+     * may result in queries returning fewer than expected results (in the worst case, no results).
      * 
      * @return the builder (fluent API)
      */
@@ -92,6 +127,10 @@ public interface SPARQLQueryPrimaryConditions
 
     /**
      * Limits results to parents of the given class.
+     * <p>
+     * <b>NOTE:</b> this method implicitly disables FTS for the query and must be called before
+     * {@link #withLabelStartingWith(String)} or any other label-matching methods. Failure to do so
+     * may result in queries returning fewer than expected results (in the worst case, no results).
      * 
      * @return the builder (fluent API)
      */
@@ -101,6 +140,10 @@ public interface SPARQLQueryPrimaryConditions
      * Limits results to properties with the given domain or without any domain. Considers the
      * inheritance hierarchy, so if A has a property x and B is a subclass of A, then B also has
      * the property x.
+     * <p>
+     * <b>NOTE:</b> this method implicitly disables FTS for the query and must be called before
+     * {@link #withLabelStartingWith(String)} or any other label-matching methods. Failure to do so
+     * may result in queries returning fewer than expected results (in the worst case, no results).
      * 
      * @return the builder (fluent API)
      */

--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/WikidataEntitySearchService.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/WikidataEntitySearchService.java
@@ -71,7 +71,7 @@ public class WikidataEntitySearchService implements GraphPattern
         patterns = new ArrayList<>();
         patterns.add(BD_SERVICE_PARAM.has(WIKIBASE_API, literalOf("EntitySearch")));
         patterns.add(BD_SERVICE_PARAM.has(WIKIBASE_ENDPOINT, literalOf("www.wikidata.org")));
-        patterns.add(BD_SERVICE_PARAM.has(WIKIBASE_LIMIT, literalOf(50)));
+        patterns.add(BD_SERVICE_PARAM.has(WIKIBASE_LIMIT, literalOf("once")));
         patterns.add(BD_SERVICE_PARAM.has(MWAPI_SEARCH, literalOf(aQuery)));
         patterns.add(BD_SERVICE_PARAM.has(MWAPI_LANGUAGE, literalOf(aLanguage)));
         patterns.add(aSubject.has(WIKIBASE_API_OUTPUT_ITEM, MWAPI_ITEM));

--- a/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderTest.java
+++ b/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderTest.java
@@ -619,6 +619,35 @@ public class SPARQLQueryBuilderTest
                 .containsExactlyInAnyOrder("http://example.org/#subclass1-1");
     }
 
+    /**
+     * This query tries to find all <i>humans in the Star Trek universe</i> 
+     * ({@code http://www.wikidata.org/entity/Q924827}) who are named <i>Amanda</i>. It tests
+     * whether the call to {@link SPARQLQueryBuilder#childrenOf(String)} disables the FTS. If the
+     * FTS is not disabled, then no result would be returned because there are so many Amandas in
+     * Wikidata that the popular ones returned by the FTS do not include any from the Star Trek
+     * universe.
+     */
+    @Test
+    public void thatClassQueryLimitedToChildrenDoesNotReturnOutOfScopeResults_Wikidata() throws Exception
+    {
+        assertIsReachable(wikidata);
+        
+        kb.setType(REMOTE);
+        kb.setFullTextSearchIri(IriConstants.FTS_WIKIDATA);
+        initWikidataMapping();
+    
+        List<KBHandle> results = asHandles(wikidata, SPARQLQueryBuilder
+                .forInstances(kb)
+                .childrenOf("http://www.wikidata.org/entity/Q924827")
+                .withLabelStartingWith("Amanda")
+                .retrieveLabel());
+        
+        assertThat(results).isNotEmpty();
+        assertThat(results)
+                .extracting(KBHandle::getIdentifier)
+                .containsExactlyInAnyOrder("http://www.wikidata.org/entity/Q1412447");
+    }
+
     @Test
     public void thatClassQueryLimitedToDescendantsDoesNotReturnOutOfScopeResults() throws Exception
     {


### PR DESCRIPTION
**What's in the PR**
- Disable FTS if a scoping function is called on the SPARQLQueryBuilder to ensure that the FTS doesn't take candidates away too early
- Added a test and JavaDoc documentation

**How to test manually**
* See issue description

**Automatic testing**
* x ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
