### PR TITLE
#1384 - Scoping a concept feature should also return descendants

### DIFF
--- a/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/service/ConceptLinkingServiceImpl.java
+++ b/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/service/ConceptLinkingServiceImpl.java
@@ -176,7 +176,7 @@ public class ConceptLinkingServiceImpl
                             .withIdentifier(aQuery);
                     
                     if (aConceptScope != null) {
-                        iriMatchBuilder.childrenOf(aConceptScope);
+                        iriMatchBuilder.descendantsOf(aConceptScope);
                     }
                     
                     List<KBHandle> exactMatches = iriMatchBuilder
@@ -195,7 +195,7 @@ public class ConceptLinkingServiceImpl
             
             if (aConceptScope != null) {
                 // Scope-limiting must always happen before label matching!
-                exactBuilder.childrenOf(aConceptScope);
+                exactBuilder.descendantsOf(aConceptScope);
             }
             
             // Collect exact matches - although exact matches are theoretically contained in the
@@ -224,7 +224,7 @@ public class ConceptLinkingServiceImpl
                 
                 if (aConceptScope != null) {
                     // Scope-limiting must always happen before label matching!
-                    startingWithBuilder.childrenOf(aConceptScope);
+                    startingWithBuilder.descendantsOf(aConceptScope);
                 }
                 
                 // Collect matches starting with the query - this is the main driver for the
@@ -248,7 +248,7 @@ public class ConceptLinkingServiceImpl
 
             if (aConceptScope != null) {
                 // Scope-limiting must always happen before label matching!
-                containingBuilder.childrenOf(aConceptScope);
+                containingBuilder.descendantsOf(aConceptScope);
             }
             
             String[] containingLabels = asList(

--- a/inception-doc/src/main/resources/META-INF/asciidoc/user-guide.adoc
+++ b/inception-doc/src/main/resources/META-INF/asciidoc/user-guide.adoc
@@ -77,6 +77,8 @@ include::{include-dir}annotation_create-annotations_link-features.adoc[leveloffs
 
 include::{include-dir}annotation_create-annotations_image-features.adoc[leveloffset=+3]
 
+include::{include-dir}annotation_create-annotations_concept-features.adoc[leveloffset=+3]
+
 include::{include-dir}annotation_settings.adoc[leveloffset=+2]
 
 include::{include-dir}annotation_export.adoc[leveloffset=+2]

--- a/inception-ui-kb/src/main/resources/META-INF/asciidoc/user-guide/annotation_create-annotations_concept-features.adoc
+++ b/inception-ui-kb/src/main/resources/META-INF/asciidoc/user-guide/annotation_create-annotations_concept-features.adoc
@@ -1,0 +1,4 @@
+= Concept features
+
+Concept features are shown as an auto-complete field. Typing into the field triggers a query against
+the knowledge base and displays candidates in a dropdown list.

--- a/inception-ui-kb/src/main/resources/META-INF/asciidoc/user-guide/knowledge_base.adoc
+++ b/inception-ui-kb/src/main/resources/META-INF/asciidoc/user-guide/knowledge_base.adoc
@@ -52,4 +52,8 @@ image::kb5.png[align="center"]
 
 When creating a new annotation with this feature, then the user is offered a dropdown with possible entities from the knowledge base. This dropdown is then limited to only concepts or features or both when selecting the respective filter in the feature configuration.
 
+The *scope* setting allows to limit linking candidates to a subtree of the knowledge base. 
 
+NOTE: Selecting scope means that full-text search cannot be used. This means that queries may become
+      very slow if the scope covers a large number concepts or instances. Therefore, it is best not to choose
+      too broad scopes.


### PR DESCRIPTION
**What's in the PR**
- Also return descendants
- Document new behavior

**How to test manually**
* Create an empty local KB
* Add a root concept
* Add a child and a child-child concept
* Add instances to the root, child and child-child concepts
* Configure Named Entity to be scoped to the child concept
* Try linking on the annotation page and make sure you can only reach instances from the child and child-child concept

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
