### PR TITLE
#1388 Should not show recommendations for others

### DIFF
--- a/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderGenericTest.java
+++ b/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderGenericTest.java
@@ -179,7 +179,7 @@ public class SPARQLQueryBuilderGenericTest
                         SPARQLQueryBuilder
                                 .forClasses(kb)
                                 .parentsOf(_child)
-                                .limit(3)
+                                .limit(5)
                                 .asHandles(conn, true)
                                 .stream()
                                 .map(KBHandle::getIdentifier)

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/RecommendationEditorExtension.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/RecommendationEditorExtension.java
@@ -251,7 +251,7 @@ public class RecommendationEditorExtension
                        int aWindowBeginOffset, int aWindowEndOffset)
     {
         // do not show predictions during curation or when viewing others' work
-        if (aState.getMode().equals(Mode.CURATION) || 
+        if (!aState.getMode().equals(Mode.ANNOTATION) || 
                 !aState.getUser().equals(userRegistry.getCurrentUser())) {
             return;
         }

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/RecommendationEditorExtension.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/RecommendationEditorExtension.java
@@ -53,7 +53,9 @@ import de.tudarmstadt.ukp.clarin.webanno.brat.message.DoActionResponse;
 import de.tudarmstadt.ukp.clarin.webanno.brat.message.SpanAnnotationResponse;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.Mode;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.inception.recommendation.api.LearningRecordService;
 import de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.AnnotationSuggestion;
@@ -90,13 +92,15 @@ public class RecommendationEditorExtension
     private final ApplicationEventPublisher applicationEventPublisher;
     private final FeatureSupportRegistry fsRegistry;
     private final DocumentService documentService;
+    private final UserDao userRegistry;
 
     @Autowired
     public RecommendationEditorExtension(AnnotationSchemaService aAnnotationService,
             RecommendationService aRecommendationService,
             LearningRecordService aLearningRecordService,
             ApplicationEventPublisher aApplicationEventPublisher,
-            FeatureSupportRegistry aFsRegistry, DocumentService aDocumentService)
+            FeatureSupportRegistry aFsRegistry, DocumentService aDocumentService, 
+            UserDao aUserRegistry)
     {
         annotationService = aAnnotationService;
         recommendationService = aRecommendationService;
@@ -104,6 +108,7 @@ public class RecommendationEditorExtension
         applicationEventPublisher = aApplicationEventPublisher;
         fsRegistry = aFsRegistry;
         documentService = aDocumentService;
+        userRegistry = aUserRegistry;
     }
 
     @Override
@@ -245,6 +250,12 @@ public class RecommendationEditorExtension
     public void render(CAS aCas, AnnotatorState aState, VDocument aVDoc,
                        int aWindowBeginOffset, int aWindowEndOffset)
     {
+        // do not show predictions during curation or when viewing others' work
+        if (aState.getMode().equals(Mode.CURATION) || 
+                !aState.getUser().equals(userRegistry.getCurrentUser())) {
+            return;
+        }
+        
         // We activate new suggestions during rendering. For one, we don't have a push mechanism
         // at the moment. For another, even if we had it, it would be quite annoying to the user
         // if the UI kept updating itself without any the user expecting an update. The user does

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
@@ -494,7 +494,7 @@ public class RecommendationServiceImpl
     {
         User user = userRepository.get(aUser);
         
-        // do not trigger training during curation or when viewing others' work
+        // do not trigger training during when viewing others' work
         if (!user.equals(userRepository.getCurrentUser())) {
             return;
         }

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
@@ -493,6 +493,11 @@ public class RecommendationServiceImpl
     public void triggerTrainingAndClassification(String aUser, Project aProject, String aEventName)
     {
         User user = userRepository.get(aUser);
+        
+        // do not trigger training during curation or when viewing others' work
+        if (!user.equals(userRepository.getCurrentUser())) {
+            return;
+        }
 
         // Update the task count
         AtomicInteger count = trainingTaskCounter.computeIfAbsent(

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommendationSidebar.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommendationSidebar.java
@@ -41,7 +41,6 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.action.AnnotationActionH
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.rendering.event.RenderAnnotationsEvent;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
-import de.tudarmstadt.ukp.clarin.webanno.model.Mode;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxButton;
@@ -117,15 +116,9 @@ public class RecommendationSidebar
         // using onConfigure as last state in lifecycle to configure visibility
         super.onConfigure();
         configureMismatched();
-        AnnotatorState state = getModelObject();
-        if (state.getMode().equals(Mode.CURATION) 
-                || !state.getUser().equals(userRepository.getCurrentUser())) {
-            form.setEnabled(false);
-            recommenderInfos.setEnabled(false);
-            return;
-        }
-        form.setEnabled(true);
-        recommenderInfos.setEnabled(true);
+        boolean enabled = getModelObject().getUser().equals(userRepository.getCurrentUser());
+        form.setEnabled(enabled);
+        recommenderInfos.setEnabled(enabled);
     }
 
     protected void configureMismatched()

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommendationSidebar.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommendationSidebar.java
@@ -122,7 +122,10 @@ public class RecommendationSidebar
                 || !state.getUser().equals(userRepository.getCurrentUser())) {
             form.setEnabled(false);
             recommenderInfos.setEnabled(false);
+            return;
         }
+        form.setEnabled(true);
+        recommenderInfos.setEnabled(true);
     }
 
     protected void configureMismatched()


### PR DESCRIPTION
**What's in the PR**
If a user is viewing others' documents (as admin or for curation):
- disable recommendation sidebar forms
- do not show predictions
- do not trigger training

Closes #1388, #1377

**How to test manually**
For #1388 
* Configure recommenders for your project
* Get some suggestions for a user
* Log in as an admin user
* Open a document of the other user
* Make sure that no recommendations are shown and the recommendation sidebar is disabled

For #1377 
* Switch to curation page after annotating with recommendations
* Make sure that no recommendations are shown on the curation page
