### PR TITLE
#1397 - annotation propagation changes the status of already finished documents

### DIFF
--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
@@ -435,8 +435,7 @@ public class RecommendationServiceImpl
             requestCycle.setMetaData(DIRTIES, dirties);
         }
         
-        dirties.add(
-                new RecommendationStateKey(aEvent.getUser(), aEvent.getDocument().getProject()));
+        dirties.add(new RecommendationStateKey(aEvent.getUser(), aEvent.getProject()));
     }
     
     /*

--- a/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchResult.java
+++ b/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchResult.java
@@ -25,9 +25,6 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 public class SearchResult
     implements Serializable
 {
-    /**
-     * 
-     */
     private static final long serialVersionUID = 2698492628701213714L;
 
     private int tokenStart = -1;
@@ -39,10 +36,16 @@ public class SearchResult
     private String rightContext;
     private long documentId;
     private String documentTitle;
+    private boolean readOnly;
 
     // only used in the ui to simplify the selection of search results for annotation
     private boolean isSelectedForAnnotation = true;
 
+    public SearchResult()
+    {
+        // Nothing to do here
+    }
+    
     public int getTokenStart()
     {
         return tokenStart;
@@ -141,6 +144,20 @@ public class SearchResult
     public void setSelectedForAnnotation(boolean selectedForAnnotation)
     {
         isSelectedForAnnotation = selectedForAnnotation;
+    }
+    
+    /**
+     * Indicates whether the document to which this result applies cannot be modified by the user
+     * who issued the query.
+     */
+    public boolean isReadOnly()
+    {
+        return readOnly;
+    }
+
+    public void setReadOnly(boolean aReadOnly)
+    {
+        readOnly = aReadOnly;
     }
 
     @Override

--- a/inception-search-core/src/main/resources/META-INF/asciidoc/user-guide/search-core.adoc
+++ b/inception-search-core/src/main/resources/META-INF/asciidoc/user-guide/search-core.adoc
@@ -38,7 +38,8 @@ results.
 This means that annotations will be created/deleted at the token offsets of the selected search
 results.
 Search results can be selected via the checkbox on the left. Per default all search
-results are selected.
+results are selected. If a result originates from a document which the user has already marked as
+*finished*, there is no checkbox since such documents cannot be modified anyway.
 
 The currently selected annotation in the annotation editor serves as template for the annotations
 that are to be created/deleted. Note that selecting an annotation first is necessary for

--- a/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchAnnotationSidebar.java
+++ b/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchAnnotationSidebar.java
@@ -32,7 +32,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -69,6 +68,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.CasProvider;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.action.AnnotationActionHandler;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.adapter.SpanAdapter;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.event.BulkAnnotationEvent;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.AnnotationException;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.FeatureState;
@@ -76,6 +76,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.VID;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.rendering.event.RenderAnnotationsEvent;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.rendering.model.VMarker;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.rendering.model.VTextMarker;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
@@ -261,6 +262,8 @@ public class SearchAnnotationSidebar
 
         layerChoice.add(new AjaxFormComponentUpdatingBehavior("change")
         {
+            private static final long serialVersionUID = -6095969211884063787L;
+
             @Override protected void onUpdate(AjaxRequestTarget aTarget)
             {
                 //update the choices for the feature selection dropdown
@@ -297,7 +300,8 @@ public class SearchAnnotationSidebar
         return selectAllCheckBox;
     }
 
-    private void actionSearch(AjaxRequestTarget aTarget, Form<Void> aForm) {
+    private void actionSearch(AjaxRequestTarget aTarget, Form<Void> aForm)
+    {
         selectedResult = null;
         groupedSearchResults.detach();
         aTarget.add(mainContainer);
@@ -368,6 +372,7 @@ public class SearchAnnotationSidebar
             AnnotationLayer layer = getModelObject().getSelectedAnnotationLayer();
             try {
                 SpanAdapter adapter = (SpanAdapter) annotationService.getAdapter(layer);
+                adapter.silenceEvents();
                 
                 // Group the results by document such that we can process one CAS at a time
                 Map<Long, List<SearchResult>> resultsByDocument = groupedSearchResults.getObject()
@@ -377,11 +382,25 @@ public class SearchAnnotationSidebar
                         .flatMap(group -> group.getResults().stream())
                         .collect(groupingBy(SearchResult::getDocumentId));
                 
+                BulkOperationResult bulkResult = new BulkOperationResult();
+                
                 AnnotatorState state = getModelObject();
                 for (Entry<Long, List<SearchResult>> resultsGroup : resultsByDocument.entrySet()) {
                     long documentId = resultsGroup.getKey();
                     SourceDocument sourceDoc = documentService
                             .getSourceDocument(state.getProject().getId(), documentId);
+
+                    AnnotationDocument annoDoc = documentService
+                            .createOrGetAnnotationDocument(sourceDoc, currentUser);
+                    
+                    switch (annoDoc.getState()) {
+                    case FINISHED: // fall-through
+                    case IGNORE:
+                        // Skip processing any documents which are finished or ignored
+                        continue;
+                    default:
+                        // Do nothing
+                    }
                     
                     // Load annotated document
                     CAS cas = documentService.readAnnotationCas(sourceDoc,
@@ -389,14 +408,36 @@ public class SearchAnnotationSidebar
 
                     // Apply bulk operations to all hits from this document
                     for (SearchResult result : resultsGroup.getValue()) {
-                        if (result.isSelectedForAnnotation()) {
-                            aConsumer.apply(sourceDoc, cas, adapter, result);
+                        if (result.isReadOnly() || !result.isSelectedForAnnotation()) {
+                            continue;
                         }
+                        
+                        aConsumer.apply(sourceDoc, cas, adapter, result, bulkResult);
                     }
 
                     // Persist annotated document
                     writeJCasAndUpdateTimeStamp(sourceDoc, cas);
                 }
+                
+                if (bulkResult.created > 0) {
+                    success("Created annotations: " + bulkResult.created);
+                }
+                if (bulkResult.updated > 0) {
+                    success("Updated annotations: " + bulkResult.updated);
+                }
+                if (bulkResult.deleted > 0) {
+                    success("Deleted annotations: " + bulkResult.deleted);
+                }
+                if (bulkResult.conflict > 0) {
+                    warn("Annotations skipped due to conflicts: " + bulkResult.conflict);
+                }
+                
+                if (bulkResult.created == 0 && bulkResult.updated == 0 && bulkResult.deleted == 0) {
+                    info("No changes");
+                }
+                
+                applicationEventPublisher.get().publishEvent(new BulkAnnotationEvent(this,
+                        getModelObject().getProject(), currentUser.getUsername(), layer));
             }
             catch (ClassCastException e) {
                 error("Can only create SPAN annotations for search results.");
@@ -407,11 +448,12 @@ public class SearchAnnotationSidebar
                 LOG.error("Unable to apply action to search results: ", e);
             }
         }
+        
         getAnnotationPage().actionRefreshDocument(aTarget);
     }
 
     private void createAnnotationAtSearchResult(SourceDocument aDocument, CAS aCas,
-            SpanAdapter aAdapter, SearchResult aSearchResult)
+            SpanAdapter aAdapter, SearchResult aSearchResult, BulkOperationResult aBulkResult)
         throws AnnotationException
     {
         AnnotatorState state = getModelObject();
@@ -432,10 +474,19 @@ public class SearchAnnotationSidebar
 
         // create a new annotation if not already there or if stacking is enabled and the
         // new annotation has different features than the existing one
-        if (annoFS == null || !featureValuesMatchCurrentState(annoFS) && !overrideExisting) {
-            annoFS = aAdapter
-                .add(aDocument, currentUser.getUsername(), aCas, aSearchResult.getOffsetStart(),
-                    aSearchResult.getOffsetEnd());
+        if (annoFS == null || (!overrideExisting && !featureValuesMatchCurrentState(annoFS))) {
+            try {
+                annoFS = aAdapter
+                    .add(aDocument, currentUser.getUsername(), aCas, aSearchResult.getOffsetStart(),
+                        aSearchResult.getOffsetEnd());
+                aBulkResult.created++;
+            }
+            catch (AnnotationException e) {
+                aBulkResult.conflict++;
+            }
+        }
+        else {
+            aBulkResult.updated++;
         }
 
         // set values for all features according to current state
@@ -451,7 +502,7 @@ public class SearchAnnotationSidebar
     }
 
     private void deleteAnnotationAtSearchResult(SourceDocument aDocument, CAS aCas,
-            SpanAdapter aAdapter, SearchResult aSearchResult)
+            SpanAdapter aAdapter, SearchResult aSearchResult, BulkOperationResult aBulkResult)
     {
         Type type = CasUtil.getAnnotationType(aCas, aAdapter.getAnnotationTypeName());
         AnnotationFS annoFS = selectAt(aCas, type, aSearchResult.getOffsetStart(),
@@ -461,31 +512,23 @@ public class SearchAnnotationSidebar
                 && deleteOptions.getObject().isDeleteOnlyMatchingFeatureValues()) {
             return;
         }
+        
         aAdapter.delete(aDocument, currentUser.getUsername(), aCas, new VID(annoFS));
+        aBulkResult.deleted++;
     }
 
-    private void writeJCasAndUpdateTimeStamp(SourceDocument aSourceDoc, CAS aJCas)
+    private void writeJCasAndUpdateTimeStamp(SourceDocument aSourceDoc, CAS aCas)
         throws IOException
     {
-        if (!documentService.existsAnnotationDocument(aSourceDoc, currentUser)) {
-            documentService.createOrGetAnnotationDocument(aSourceDoc, currentUser);
-        }
-        documentService.writeAnnotationCas(aJCas, aSourceDoc, currentUser, true);
-
-        updateTimestamp(aSourceDoc);
-    }
-
-    private void updateTimestamp(SourceDocument aModifiedDocument) throws IOException
-    {
-        // If the currently displayed document is the same one where the annotation was created,
-        // then update timestamp in state to avoid concurrent modification errors
         AnnotatorState state = getModelObject();
-        if (Objects.equals(state.getDocument().getId(), aModifiedDocument.getId())) {
-            Optional<Long> diskTimestamp = documentService
-                .getAnnotationCasTimestamp(aModifiedDocument, currentUser.getUsername());
-            if (diskTimestamp.isPresent()) {
-                state.setAnnotationDocumentTimestamp(diskTimestamp.get());
-            }
+
+        if (Objects.equals(state.getDocument().getId(), aSourceDoc.getId())) {
+            // Updating the currently open document is done through the page in order to notify the
+            // mechanism to detect concurrent modifications.
+            getAnnotationPage().writeEditorCas(aCas);
+        }
+        else {
+            documentService.writeAnnotationCas(aCas, aSourceDoc, currentUser, true);
         }
     }
 
@@ -546,6 +589,7 @@ public class SearchAnnotationSidebar
                 {
                     Project currentProject = SearchAnnotationSidebar.this.getModel().getObject()
                             .getProject();
+                    SearchResult result = aItem.getModelObject();
                     
                     LambdaAjaxLink lambdaAjaxLink = new LambdaAjaxLink("showSelectedDocument",
                         t -> {
@@ -559,8 +603,10 @@ public class SearchAnnotationSidebar
                     aItem.add(lambdaAjaxLink);
 
                     AjaxCheckBox selected = new AjaxCheckBox("selected",
-                        Model.of(aItem.getModelObject().isSelectedForAnnotation()))
+                        Model.of(result.isSelectedForAnnotation()))
                     {
+                        private static final long serialVersionUID = -6955396602403459129L;
+
                         @Override
                         protected void onUpdate(AjaxRequestTarget target)
                         {
@@ -574,6 +620,7 @@ public class SearchAnnotationSidebar
                             }
                         }
                     };
+                    selected.setVisible(!result.isReadOnly());
                     aItem.add(selected);
 
                     String sentence = new String();
@@ -595,7 +642,16 @@ public class SearchAnnotationSidebar
     @FunctionalInterface
     private interface Operation
     {
-        void apply(SourceDocument aSourceDoc, CAS aCas, SpanAdapter aAdapter, SearchResult aResult)
+        void apply(SourceDocument aSourceDoc, CAS aCas, SpanAdapter aAdapter, SearchResult aResult,
+                BulkOperationResult aBulkResult)
             throws AnnotationException;
+    }
+    
+    private class BulkOperationResult
+    {
+        public int created = 0;
+        public int deleted = 0;
+        public int updated = 0;
+        public int conflict = 0;
     }
 }


### PR DESCRIPTION
**What's in the PR**
- Search results in finished documents can no longer be selected
- Do not show results from ignored documents
- Additional safeguards to not apply changes to finished documents
- Feedback messages for bulk operations
- Create BulkAnnotationEvent instead of generating an event for every added/changed/deleted annotation

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
