### PR TITLE
Bugfix/1427 string literals should not be duplicated

### DIFF
--- a/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplWikiDataIntegrationTest.java
+++ b/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplWikiDataIntegrationTest.java
@@ -249,7 +249,7 @@ public class KnowledgeBaseServiceImplWikiDataIntegrationTest  {
         PROFILES = KnowledgeBaseProfile.readKnowledgeBaseProfiles();
         KnowledgeBase kb_wikidata_direct = new KnowledgeBase();
         kb_wikidata_direct.setProject(project);
-        kb_wikidata_direct.setName("Wikidata (official/direct mapping)");
+        kb_wikidata_direct.setName(KB_NAME);
         kb_wikidata_direct.setType(PROFILES.get("wikidata").getType());
         kb_wikidata_direct.applyMapping(PROFILES.get("wikidata").getMapping());
         kb_wikidata_direct.applyRootConcepts(PROFILES.get("wikidata"));

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderEditorPanel.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderEditorPanel.java
@@ -138,7 +138,7 @@ public class RecommenderEditorPanel
         form.add(nameField);
         
         autoGenerateNameCheckBox = new CheckBox(MID_AUTO_GENERATED_NAME,
-                PropertyModel.of(this, "autoGenerateName"));
+                PropertyModel.of(this, MID_AUTO_GENERATED_NAME));
         autoGenerateNameCheckBox.add(new LambdaAjaxFormComponentUpdatingBehavior("change", t -> {
             autoUpdateName(t, nameField, recommenderModel.getObject());
             t.add(autoGenerateNameCheckBox);

--- a/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/VisibilityCalculationTests.java
+++ b/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/VisibilityCalculationTests.java
@@ -88,7 +88,7 @@ public class VisibilityCalculationTests
         project.setMode(WebAnnoConst.PROJECT_TYPE_ANNOTATION);
 
         List<AnnotationFeature> featureList = new ArrayList<AnnotationFeature>();
-        featureList.add(new AnnotationFeature("value", "uima.cas.String"));
+        featureList.add(new AnnotationFeature(FEATURE, "uima.cas.String"));
         when(annoService.listAnnotationFeature(layer)).thenReturn(featureList);
         
         sut = new RecommendationServiceImpl(null, null, null, null, annoService, null,

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/AbstractInfoPanel.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/AbstractInfoPanel.java
@@ -171,7 +171,7 @@ public abstract class AbstractInfoPanel<T extends KBObject> extends Panel {
             Label identifier = new Label("idtext"); 
             TooltipBehavior tip = new TooltipBehavior();
             tip.setOption("autoHide", false);
-            tip.setOption("content",
+            tip.setOption(CONTENT_MARKUP_ID,
                     Options.asString((compoundModel.bind("identifier").getObject())));
             tip.setOption("showOn", Options.asString("click"));
             identifier.add(tip);


### PR DESCRIPTION
Duplicated string literals make the process of refactoring error-prone, since you must be sure to update all occurrences. On the other hand, constants can be referenced from many places, but only need to be updated in a single place.