### PR TITLE
#1453 - Document metadata panel shows disabled layers

### DIFF
--- a/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationSelectionPanel.java
+++ b/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationSelectionPanel.java
@@ -254,12 +254,7 @@ public class DocumentMetadataAnnotationSelectionPanel extends Panel
         }
         
         List<AnnotationListItem> items = new ArrayList<>();
-        for (AnnotationLayer layer : listMetadataLayers()) {
-            if (!DocumentMetadataLayerSupport.TYPE.equals(layer.getType())
-                || !layer.isEnabled()) {
-                continue;
-            }
-            
+        for (AnnotationLayer layer : listMetadataLayers()) {            
             List<AnnotationFeature> features = annotationService.listAnnotationFeature(layer);
             TypeAdapter adapter = annotationService.getAdapter(layer);
             Renderer renderer = layerSupportRegistry.getLayerSupport(layer).getRenderer(layer);

--- a/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationSelectionPanel.java
+++ b/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationSelectionPanel.java
@@ -237,7 +237,8 @@ public class DocumentMetadataAnnotationSelectionPanel extends Panel
     private List<AnnotationLayer> listMetadataLayers()
     {
         return annotationService.listAnnotationLayer(getModelObject()).stream()
-                .filter(layer -> DocumentMetadataLayerSupport.TYPE.equals(layer.getType())).
+                .filter(layer -> DocumentMetadataLayerSupport.TYPE.equals(layer.getType())
+                        && layer.isEnabled()).
                 collect(Collectors.toList());
     }
     
@@ -254,7 +255,8 @@ public class DocumentMetadataAnnotationSelectionPanel extends Panel
         
         List<AnnotationListItem> items = new ArrayList<>();
         for (AnnotationLayer layer : listMetadataLayers()) {
-            if (!DocumentMetadataLayerSupport.TYPE.equals(layer.getType())) {
+            if (!DocumentMetadataLayerSupport.TYPE.equals(layer.getType())
+                || !layer.isEnabled()) {
                 continue;
             }
             


### PR DESCRIPTION
**What's in the PR**
- fix handling for disabled layers for document metadata panel

**How to test manually**
1. Have a disabled document annotation layer
2. Open Document Metadata Panel
3. Click dropdown to select a layer
4. Disabled layer should'nt show up

Also already created annotatios in afterwards disabled layers should not show up anymore

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
