### PR TITLE
#1090 - Crash when changing PDF document

### DIFF
--- a/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/PdfAnnotationEditor.java
+++ b/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/PdfAnnotationEditor.java
@@ -178,6 +178,13 @@ public class PdfAnnotationEditor
     public void createSpanAnnotation(
         AjaxRequestTarget aTarget, IRequestParameters aParams, CAS aCas)
     {
+        if (pdfExtractFile == null && documentModel == null) {
+            // in this case the user probably changed the document and accidentally
+            // marked text in the old document. so do not create any annotation here.
+            handleError("Unable to create span annotation: " 
+                + "Did you accidentally marked text when switching documents?", aTarget);
+            return;
+        }
         try
         {
             Offset offset = new Offset(aParams);


### PR DESCRIPTION
**What's in the PR**
- catch if pdfExtractFile and documentModel are null when creating span annotations in the PDF editor

**How to test manually**
1. Open a PDF document in PDF editor
2. Open the `Open` dialog to change the document
3. Select a document in the dialog
4. You need to be quick so make the selection by pressing enter and immediately select some text in the old document
5. There no should be an error warning instead of a NPE which lead to a complete crash

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
