### PR TITLE
#1465 - Annotation linking after double click not working

### DIFF
--- a/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/PdfAnnotationEditor.java
+++ b/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/PdfAnnotationEditor.java
@@ -59,7 +59,6 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.AnnotationExce
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.Selection;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.VID;
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.rendering.model.VDocument;
 import de.tudarmstadt.ukp.inception.pdfeditor.pdfanno.PdfAnnoPanel;
 import de.tudarmstadt.ukp.inception.pdfeditor.pdfanno.model.DocumentModel;

--- a/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/PdfAnnotationEditor.java
+++ b/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/PdfAnnotationEditor.java
@@ -59,6 +59,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.AnnotationExce
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.Selection;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.VID;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.rendering.model.VDocument;
 import de.tudarmstadt.ukp.inception.pdfeditor.pdfanno.PdfAnnoPanel;
 import de.tudarmstadt.ukp.inception.pdfeditor.pdfanno.model.DocumentModel;
@@ -327,6 +328,7 @@ public class PdfAnnotationEditor
         try {
             VID paramId = VID.parseOptional(aParams.getParameterValue("id").toString());
             if (paramId.isSynthetic()) {
+                getModelObject().clearArmedSlot();
                 Offset offset = new Offset(aParams);
                 Offset docOffset =
                     PdfAnnoRenderer.convertToDocumentOffset(offset, documentModel, pdfExtractFile);
@@ -377,7 +379,8 @@ public class PdfAnnotationEditor
             // Doing anything but selecting or creating a span annotation when a
             // slot is armed will unarm it
             if (getModelObject().isSlotArmed()
-                && !(action.equals(SELECT_SPAN) || action.equals(CREATE_SPAN))) {
+                && !(action.equals(SELECT_SPAN) || action.equals(CREATE_SPAN)
+                   || action.equals(DELETE_RECOMMENDATION))) {
                 getModelObject().clearArmedSlot();
             }
 

--- a/inception-pdf-editor/src/main/js/pdfanno/src/core/src/annotation/abstract.js
+++ b/inception-pdf-editor/src/main/js/pdfanno/src/core/src/annotation/abstract.js
@@ -97,24 +97,16 @@ export default class AbstractAnnotation extends EventEmitter {
    * Handle a click event.
    */
   handleClickEvent (e) {
-    this.toggleSelect()
+    if (!this.selected) {
+      this.toggleSelect()
+    }
 
     if (this.type !== 'textbox') {
-
       if (this.selected) {
-
         // TODO Use common function.
         let event = document.createEvent('CustomEvent')
         event.initCustomEvent('annotationSelected', true, true, this)
         window.dispatchEvent(event)
-
-      } else {
-
-        // TODO Use common function.
-        let event = document.createEvent('CustomEvent')
-        event.initCustomEvent('annotationDeselected', true, true, this)
-        window.dispatchEvent(event)
-
       }
     }
   }

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <uima.version>3.1.0</uima.version>
     <log4j.version>2.12.1</log4j.version>
 
-    <webanno.version>4.0.0-beta-2</webanno.version>
+    <webanno.version>4.0.0-SNAPSHOT</webanno.version>
     <lucene.version>7.3.1</lucene.version>
     <elasticsearch.version>6.3.0</elasticsearch.version>
     <mtas.version>7.3.0.3</mtas.version>


### PR DESCRIPTION
**What's in the PR**
- disable clearing armed slot when double clicking non-recommendation span annotations
- disable deselecting annotations in PDF editor in the PDF panel via annotation knobs

**How to test manually**
1. Arm a slot of a link feature
2. Double click a non-recommendation span annotation
3. Single click a non-recommendation span annotation to link it

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
