### PR TITLE
#1467 - Attempting to create recommender with traits fails

### DIFF
--- a/inception-recommendation-api/marker-wicket-module
+++ b/inception-recommendation-api/marker-wicket-module
@@ -1,0 +1,1 @@
+Marker file which activates the profile "wicket-module" from the parent POM.


### PR DESCRIPTION
**What's in the PR**
- There is a Wicket HTML template now in the recommender-api module (DefaultTrainableRecommenderTraitsEditor.html), so it must be marked as a Wicket module otherwise this file is missing from the JAR/WAR.

**How to test manually**
* Build on the command line
* Run JAR on the command line
* Try creating a trainable recommender (e.g. String Matching Recommender)

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
