### PR TITLE
feature/#1117 export recommender model 

### DIFF
--- a/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/recommender/RecommendationEngine.java
+++ b/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/recommender/RecommendationEngine.java
@@ -22,6 +22,9 @@ import static de.tudarmstadt.ukp.inception.recommendation.api.RecommendationServ
 import static de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService.FEATURE_NAME_SCORE_SUFFIX;
 import static org.apache.uima.fit.util.CasUtil.getType;
 
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
 import java.util.List;
 
 import org.apache.uima.cas.CAS;
@@ -151,5 +154,14 @@ public abstract class RecommendationEngine
     protected Feature getIsPredictionFeature(CAS aCas)
     {
         return getPredictedType(aCas).getFeatureByBaseName(FEATURE_NAME_IS_PREDICTION);
+    }
+    
+    /**
+     * Method supporting export the recommender object
+     */
+    public void export(String path) throws IOException{
+        ObjectOutputStream objos= new ObjectOutputStream(new FileOutputStream(path));
+        objos.writeObject(this);
+        objos.close();
     }
 }

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommenderInfoPanel.html
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommenderInfoPanel.html
@@ -60,6 +60,9 @@
             </div>
           </div>
           <div class="row text-right">
+            <input wicket:id="download" type="button" class="btn btn-xs btn-success" value="Download"/>
+          </div>
+          <div class="row text-right">
             <input wicket:id="acceptAll" type="button" class="btn btn-xs btn-success" value="Accept all"/>
           </div>
         </li>

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommenderInfoPanel.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommenderInfoPanel.java
@@ -91,6 +91,9 @@ public class RecommenderInfoPanel
                 item.add(new Label("name", recommender.getName()));
                 item.add(new Label("state", evalResult.isPresent() ? "active" : "off"));
 
+                item.add(new LambdaAjaxLink("download", _target -> 
+                actionAcceptAll(_target, recommender)));
+                
                 item.add(new LambdaAjaxLink("acceptAll", _target -> 
                         actionAcceptAll(_target, recommender)));
                 


### PR DESCRIPTION
**What's in the PR**
Offer an option in the recommender sidebar where the user can select a recommender and press a button to download the current recommender model.

Now we only change the UI that add the button of exporting the recommender model. But we have 3 question.
1. what the recommender model format should I export
2. Now I only can get the recommender which the user has, but we don't know how to find the data of recommender. Is it in the model object or recommender context?
