### PR TITLE
#1480 - External recommender crashes if there are no CASes

### DIFF
--- a/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommender.java
+++ b/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommender.java
@@ -18,7 +18,7 @@
 package de.tudarmstadt.ukp.inception.recommendation.imls.external;
 
 import static de.tudarmstadt.ukp.inception.recommendation.api.recommender.RecommendationEngineCapability.TRAINING_NOT_SUPPORTED;
-import static de.tudarmstadt.ukp.inception.recommendation.api.recommender.RecommendationEngineCapability.TRAINING_SUPPORTED;
+import static de.tudarmstadt.ukp.inception.recommendation.api.recommender.RecommendationEngineCapability.TRAINING_REQUIRED;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -299,7 +299,10 @@ public class ExternalRecommender
     public RecommendationEngineCapability getTrainingCapability() 
     {
         if (traits.isTrainable()) {
-            return TRAINING_SUPPORTED;
+            // 
+            // return TRAINING_SUPPORTED;
+            // We need to get at least one training CAS because we need to extract the type system
+            return TRAINING_REQUIRED;
         } else {
             return TRAINING_NOT_SUPPORTED;
         }

--- a/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderFactory.java
+++ b/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderFactory.java
@@ -17,13 +17,15 @@
  */
 package de.tudarmstadt.ukp.inception.recommendation.imls.external;
 
+import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.SPAN_TYPE;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.SENTENCES;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.SINGLE_TOKEN;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.TOKENS;
 import static java.util.Arrays.asList;
 
 import org.apache.wicket.model.IModel;
 import org.springframework.stereotype.Component;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst;
-import de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
@@ -64,9 +66,9 @@ public class ExternalRecommenderFactory
             return false;
         }
 
-        return asList(AnchoringMode.SINGLE_TOKEN, AnchoringMode.TOKENS, AnchoringMode.SENTENCES)
+        return asList(SINGLE_TOKEN, TOKENS, SENTENCES)
                 .contains(aLayer.getAnchoringMode()) &&
-                WebAnnoConst.SPAN_TYPE.equals(aLayer.getType());
+                SPAN_TYPE.equals(aLayer.getType());
     }
 
     @Override


### PR DESCRIPTION
**What's in the PR**
- An external trainable recommender should be TRAINING_REQUIRED instead of TRAINING_SUPPORTED since we need some (training) CAS to get the type system from...

**How to test manually**
* See issue

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
