### PR TITLE
feature/994-Restrict-URLs-for-image-features

### DIFF
--- a/inception-image/src/main/java/de/tudarmstadt/ukp/inception/image/feature/ImageFeatureTraitsEditor.properties
+++ b/inception-image/src/main/java/de/tudarmstadt/ukp/inception/image/feature/ImageFeatureTraitsEditor.properties
@@ -13,3 +13,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+regex="Matching URLs against a suitable regex"


### PR DESCRIPTION
**What's in the PR**
*  To ensure the security and prevent future errores is necessary to control the input URL from external images given by the user. Therefore we are going to check the protocol of the image URL , if this URL has the correct format and to verify that the server connected to is a controlled one. For this purpose we are going to make use of regular expressions to validate the URL inputs.


**How to test manually**
* Settings -> new Layer -> new Fact -> Feature -> URL image. After we redirect to any project and click into annotation there we create a new annotation and add a layer fact, in the we insert the Url and it can be debugged.

**Automatic testing**
* Not applies

**Documentation**
* Not applies