### PR TITLE
#1486 - Document Annotation change does not affect armed slot

### DIFF
--- a/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationDetailPanel.java
+++ b/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationDetailPanel.java
@@ -413,6 +413,7 @@ public class DocumentMetadataAnnotationDetailPanel extends Panel
     
     public void toggleVisibility()
     {
+        state.clearArmedSlot();
         setVisible(!isVisible());
     }
     


### PR DESCRIPTION
**What's in the PR**
- add clearing state when toggeling DocumentMetadataAnnotationDetailPanel


**How to test manually**
1. Arm a slot in a document annotation
2. Open another document annotation without disarming the slot
3. Reopen the previous document annotation
4. `Add` button should appear instead of `Del`

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
