### PR TITLE
#1490 - Adapt changes for Choice Components from WebAnno

### DIFF
--- a/inception-image/src/main/java/de/tudarmstadt/ukp/inception/image/feature/ImageFeatureEditor.java
+++ b/inception-image/src/main/java/de/tudarmstadt/ukp/inception/image/feature/ImageFeatureEditor.java
@@ -19,10 +19,10 @@ package de.tudarmstadt.ukp.inception.image.feature;
 
 import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
 
-import org.apache.wicket.Component;
 import org.apache.wicket.MarkupContainer;
 import org.apache.wicket.ajax.form.OnChangeAjaxBehavior;
 import org.apache.wicket.markup.html.form.AbstractTextComponent;
+import org.apache.wicket.markup.html.form.FormComponent;
 import org.apache.wicket.markup.html.image.ExternalImage;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
@@ -87,7 +87,7 @@ public class ImageFeatureEditor
     }
 
     @Override
-    public Component getFocusComponent()
+    public FormComponent getFocusComponent()
     {
         return field;
     }

--- a/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationDetailPanel.java
+++ b/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationDetailPanel.java
@@ -20,6 +20,7 @@ package de.tudarmstadt.ukp.inception.ui.core.docanno.sidebar;
 import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.selectAnnotationByAddr;
 import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.selectFsByAddr;
 import static java.util.Collections.emptyList;
+import static org.apache.wicket.util.time.Duration.milliseconds;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -37,16 +38,21 @@ import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.attributes.AjaxCallListener;
 import org.apache.wicket.ajax.attributes.AjaxRequestAttributes;
 import org.apache.wicket.ajax.attributes.ThrottlingSettings;
+import org.apache.wicket.ajax.form.AjaxFormChoiceComponentUpdatingBehavior;
 import org.apache.wicket.ajax.form.AjaxFormComponentUpdatingBehavior;
 import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.feedback.IFeedback;
+import org.apache.wicket.markup.html.form.CheckBoxMultipleChoice;
+import org.apache.wicket.markup.html.form.CheckGroup;
+import org.apache.wicket.markup.html.form.FormComponent;
+import org.apache.wicket.markup.html.form.RadioChoice;
+import org.apache.wicket.markup.html.form.RadioGroup;
 import org.apache.wicket.markup.html.list.ListItem;
 import org.apache.wicket.markup.html.list.ListView;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.LoadableDetachableModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
-import org.apache.wicket.util.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wicketstuff.event.annotation.OnEvent;
@@ -255,46 +261,78 @@ public class DocumentMetadataAnnotationDetailPanel extends Panel
     
     private void addAnnotateActionBehavior(final FeatureEditor aFrag)
     {
-        aFrag.getFocusComponent().add(new AjaxFormComponentUpdatingBehavior("change")
-        {
-            private static final long serialVersionUID = 5179816588460867471L;
-
-            @Override
-            protected void updateAjaxAttributes(AjaxRequestAttributes aAttributes)
+        FormComponent focusComponent = aFrag.getFocusComponent();
+        
+        if (
+            (focusComponent instanceof RadioChoice) ||
+                (focusComponent instanceof CheckBoxMultipleChoice) ||
+                (focusComponent instanceof RadioGroup) ||
+                (focusComponent instanceof CheckGroup)
+        ) {
+            focusComponent.add(new AjaxFormChoiceComponentUpdatingBehavior()
             {
-                super.updateAjaxAttributes(aAttributes);
-                // When focus is on a feature editor and the user selects a new annotation,
-                // there is a race condition between the saving the value of the feature
-                // editor and the loading of the new annotation. Delay the feature editor
-                // save to give preference to loading the new annotation.
-                aAttributes.setThrottlingSettings(new ThrottlingSettings(getMarkupId(),
-                    Duration.milliseconds(250), true));
-                aAttributes.getAjaxCallListeners().add(new AjaxCallListener()
+                private static final long serialVersionUID = -5058365578109385064L;
+                
+                @Override
+                protected void updateAjaxAttributes(AjaxRequestAttributes aAttributes)
                 {
-                    private static final long serialVersionUID = 1L;
-
-                    @Override
-                    public CharSequence getPrecondition(Component aComponent)
-                    {
-                        // If the panel refreshes because the user selects a new annotation,
-                        // the annotation editor panel is updated for the new annotation
-                        // first (before saving values) because of the delay set above. When
-                        // the delay is over, we can no longer save the value because the
-                        // old component is no longer there. We use the markup id of the
-                        // editor fragments to check if the old component is still there
-                        // (i.e. if the user has just tabbed to a new field) or if the old
-                        // component is gone (i.e. the user selected/created another
-                        // annotation). If the old component is no longer there, we abort
-                        // the delayed save action.
-                        return "return $('#" + aFrag.getMarkupId() + "').length > 0;";
-                    }
-                });
-            }
-
-            @Override
-            protected void onUpdate(AjaxRequestTarget aTarget)
+                    super.updateAjaxAttributes(aAttributes);
+                    addDelay(aFrag, aAttributes, 300);
+                }
+                
+                @Override
+                protected void onUpdate(AjaxRequestTarget aTarget)
+                {
+                    actionAnnotate(aTarget);
+                }
+            });
+        }
+        else {
+            focusComponent.add(new AjaxFormComponentUpdatingBehavior("change")
             {
-                actionAnnotate(aTarget);
+                private static final long serialVersionUID = -8944946839865527412L;
+                
+                @Override
+                protected void updateAjaxAttributes(AjaxRequestAttributes aAttributes)
+                {
+                    super.updateAjaxAttributes(aAttributes);
+                    addDelay(aFrag, aAttributes, 250);
+                }
+                
+                @Override
+                protected void onUpdate(AjaxRequestTarget aTarget)
+                {
+                    actionAnnotate(aTarget);
+                }
+            });
+        }
+    }
+    
+    private void addDelay(FeatureEditor aFrag, AjaxRequestAttributes aAttributes, int aDelay)
+    {
+        // When focus is on a feature editor and the user selects a new annotation,
+        // there is a race condition between the saving the value of the feature
+        // editor and the loading of the new annotation. Delay the feature editor
+        // save to give preference to loading the new annotation.
+        aAttributes.setThrottlingSettings(new ThrottlingSettings(milliseconds(aDelay), true));
+        aAttributes.getAjaxCallListeners().add(new AjaxCallListener()
+        {
+            private static final long serialVersionUID = 3157811089824093324L;
+            
+            @Override
+            public CharSequence getPrecondition(Component aComponent)
+            {
+                // If the panel refreshes because the user selects a new annotation,
+                // the annotation editor panel is updated for the new annotation
+                // first (before saving values) because of the delay set above. When
+                // the delay is over, we can no longer save the value because the
+                // old component is no longer there. We use the markup id of the
+                // editor fragments to check if the old component is still there
+                // (i.e. if the user has just tabbed to a new field) or if the old
+                // component is gone (i.e. the user selected/created another
+                // annotation). If the old component is no longer there, we abort
+                // the delayed save action.
+                return "return $('#" + aFrag.getMarkupId() + "').length > 0;";
             }
         });
     }

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureEditor.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureEditor.java
@@ -28,11 +28,11 @@ import java.util.List;
 import java.util.Optional;
 
 import org.apache.uima.cas.CAS;
-import org.apache.wicket.Component;
 import org.apache.wicket.MarkupContainer;
 import org.apache.wicket.core.request.handler.IPartialPageRequestHandler;
 import org.apache.wicket.feedback.IFeedback;
 import org.apache.wicket.markup.head.IHeaderResponse;
+import org.apache.wicket.markup.html.form.FormComponent;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.LoadableDetachableModel;
@@ -66,7 +66,7 @@ public class ConceptFeatureEditor
     
     private static final long serialVersionUID = 7763348613632105600L;
 
-    private Component focusComponent;
+    private FormComponent focusComponent;
     private IriInfoBadge iriBadge;
 
     private @SpringBean KnowledgeBaseService kbService;
@@ -154,7 +154,7 @@ public class ConceptFeatureEditor
     }
 
     @Override
-    public Component getFocusComponent()
+    public FormComponent getFocusComponent()
     {
         return focusComponent;
     }

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/PropertyFeatureEditor.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/PropertyFeatureEditor.java
@@ -24,10 +24,10 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.uima.cas.CAS;
-import org.apache.wicket.Component;
 import org.apache.wicket.MarkupContainer;
 import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.form.FormComponent;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
@@ -64,7 +64,7 @@ public class PropertyFeatureEditor
 {
     private static final long serialVersionUID = -4649541419448384970L;
     private static final Logger LOG = LoggerFactory.getLogger(PropertyFeatureEditor.class);
-    private Component focusComponent;
+    private FormComponent focusComponent;
     private IModel<AnnotatorState> stateModel;
     private AnnotationActionHandler actionHandler;
     private Project project;
@@ -160,7 +160,7 @@ public class PropertyFeatureEditor
     }
 
     @Override
-    public Component getFocusComponent()
+    public FormComponent getFocusComponent()
     {
         return focusComponent;
     }

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/QualifierFeatureEditor.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/QualifierFeatureEditor.java
@@ -41,6 +41,7 @@ import org.apache.wicket.feedback.IFeedback;
 import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.form.FormComponent;
 import org.apache.wicket.markup.repeater.Item;
 import org.apache.wicket.markup.repeater.RefreshingView;
 import org.apache.wicket.markup.repeater.util.ModelIteratorAdapter;
@@ -95,7 +96,7 @@ public class QualifierFeatureEditor
     private @SpringBean KnowledgeBaseService kbService;
 
     private WebMarkupContainer content;
-    private Component focusComponent;
+    private FormComponent focusComponent;
     private AnnotationActionHandler actionHandler;
     private IModel<AnnotatorState> stateModel;
     private Project project;
@@ -452,7 +453,7 @@ public class QualifierFeatureEditor
     }
 
     @Override
-    public Component getFocusComponent()
+    public FormComponent getFocusComponent()
     {
         return focusComponent;
     }

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/SubjectObjectFeatureEditor.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/SubjectObjectFeatureEditor.java
@@ -39,6 +39,7 @@ import org.apache.wicket.feedback.IFeedback;
 import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.form.FormComponent;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
@@ -91,7 +92,7 @@ public class SubjectObjectFeatureEditor
     private @SpringBean KnowledgeBaseService kbService;
 
     private WebMarkupContainer content;
-    private Component focusComponent;
+    private FormComponent focusComponent;
     private AnnotationActionHandler actionHandler;
     private IModel<AnnotatorState> stateModel;
     private Project project;
@@ -238,7 +239,7 @@ public class SubjectObjectFeatureEditor
     }
 
     @Override
-    public Component getFocusComponent()
+    public FormComponent getFocusComponent()
     {
         return focusComponent;
     }


### PR DESCRIPTION
**What's in the PR**
- adapt feature editors to new method signature for getFocusComponent
- adapt document metadata panel to choice component handling changes from annotation panel

**How to test manually**
1. Have a string feature in a document annotation
2. Have a rating feature in a document annotation
3. Edit the string feature text
4. Click on a value of the rating feature
5. String feature changes should be saved

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
