### PR TITLE
#1505 - PDF (PDFAnno) Editor not shows up in Settings

### DIFF
--- a/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/PdfAnnotationEditorFactory.java
+++ b/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/PdfAnnotationEditorFactory.java
@@ -29,7 +29,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
 
 @Component("pdfEditor")
 @ConditionalOnProperty(prefix = "ui.pdf", name = "enabled", havingValue = "true", 
-        matchIfMissing = false)
+        matchIfMissing = true)
 public class PdfAnnotationEditorFactory
     extends AnnotationEditorFactoryImplBase
 {


### PR DESCRIPTION
**What's in the PR**
- Enable PDF UI support by default - it is already in the documentation, not having it enabled is a bit confusing, in particular since the documentation does not say how to enable it.

**How to test manually**
* Remove the `ui.pdf.enabled=true` from the `settings.properties`
* Restart
* Import a PDF file
* Open the file in the annotation view
* Try switching to the PDF editor mode

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
