### PR TITLE
#1508 - Support character-level external recommenders

### DIFF
--- a/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderFactory.java
+++ b/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderFactory.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.inception.recommendation.imls.external;
 
 import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.SPAN_TYPE;
+
 import org.apache.wicket.model.IModel;
 import org.springframework.stereotype.Component;
 

--- a/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderFactory.java
+++ b/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderFactory.java
@@ -18,11 +18,6 @@
 package de.tudarmstadt.ukp.inception.recommendation.imls.external;
 
 import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.SPAN_TYPE;
-import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.SENTENCES;
-import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.SINGLE_TOKEN;
-import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.TOKENS;
-import static java.util.Arrays.asList;
-
 import org.apache.wicket.model.IModel;
 import org.springframework.stereotype.Component;
 
@@ -66,9 +61,7 @@ public class ExternalRecommenderFactory
             return false;
         }
 
-        return asList(SINGLE_TOKEN, TOKENS, SENTENCES)
-                .contains(aLayer.getAnchoringMode()) &&
-                SPAN_TYPE.equals(aLayer.getType());
+        return SPAN_TYPE.equals(aLayer.getType());
     }
 
     @Override

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
@@ -1215,6 +1215,8 @@ public class RecommendationServiceImpl
                     // This can happen if a recommender uses different token boundaries (e.g. if a
                     // remote service performs its own tokenization). We might be smart here by
                     // looking for overlapping tokens instead of contained tokens.
+                    log.trace("Discarding suggestion because no covering token was found: {}",
+                            annotationFS);
                     continue;
                 }
                 
@@ -1223,6 +1225,8 @@ public class RecommendationServiceImpl
                 
                 if (!firstToken.equals(lastToken)) {
                     // We only want to accept single-token suggestions
+                    log.trace("Discarding suggestion because only single-token suggestions are "
+                            + "accepted: {}", annotationFS);
                     continue;
                 }
                 
@@ -1236,6 +1240,8 @@ public class RecommendationServiceImpl
                     // This can happen if a recommender uses different token boundaries (e.g. if a
                     // remote service performs its own tokenization). We might be smart here by
                     // looking for overlapping tokens instead of contained tokens.
+                    log.trace("Discarding suggestion because no covering tokens were found: {}",
+                            annotationFS);
                     continue;
                 }
                 
@@ -1249,6 +1255,8 @@ public class RecommendationServiceImpl
                     // This can happen if a recommender uses different token boundaries (e.g. if a
                     // remote service performs its own tokenization). We might be smart here by
                     // looking for overlapping sentences instead of contained sentences.
+                    log.trace("Discarding suggestion because no covering sentences were found: {}",
+                            annotationFS);
                     continue;
                 }
                 


### PR DESCRIPTION
**What's in the PR**
- Adjusted suggestion extraction for the different anchoring modes
- Allow configuring external recommenders for all anchoring modes

**How to test manually**
* Try the usual recommenders on different levels of granularity
* Try using an external recommender on the character-level granularity

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
