### PR TITLE
#1539 - String-based recommender on layers with character-level granularity

### DIFF
--- a/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/StringMatchingRecommenderFactory.java
+++ b/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/StringMatchingRecommenderFactory.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch;
 
 import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.SPAN_TYPE;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.CHARACTERS;
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.SINGLE_TOKEN;
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.TOKENS;
 import static java.util.Arrays.asList;
@@ -76,8 +77,10 @@ public class StringMatchingRecommenderFactory
             return false;
         }
 
-        return (asList(SINGLE_TOKEN, TOKENS).contains(aLayer.getAnchoringMode()))
-            && !aLayer.isCrossSentence() && SPAN_TYPE.equals(aLayer.getType())
+        // We exclude sentence level for the moment for no better reason than that would probably
+        // generate quite large dictionaries...
+        return (asList(CHARACTERS, SINGLE_TOKEN, TOKENS).contains(aLayer.getAnchoringMode()))
+            && SPAN_TYPE.equals(aLayer.getType())
             && (CAS.TYPE_NAME_STRING.equals(aFeature.getType()) || aFeature.isVirtualFeature());
     }
     

--- a/inception-imls-stringmatch/src/main/resources/META-INF/asciidoc/user-guide/projects_recommendation_string.adoc
+++ b/inception-imls-stringmatch/src/main/resources/META-INF/asciidoc/user-guide/projects_recommendation_string.adoc
@@ -45,3 +45,13 @@ Illinois State Senate	ORG
 Hawaii	LOC	
 Indonesia	LOC
 ----
+
+=== Character-level layers
+
+For layers which are configured to have a character-level annotation granularity, the string 
+matching recommender will still try to match only at the beginning of tokens. However, it will not
+require that the end of a match also ends at a token boundary. This helps e.g. in situations where
+punctuation is not correctly detected as being a separate token.
+
+NOTE: For layers with character-level granularity or layers which allow cross-sentence annotations,
+      the evaluation scores of the recommender may not be exact.


### PR DESCRIPTION
**What's in the PR**
- Allow using the string matching recommender on layers with character granularity and document behavior on these
- Allow using the string matching recommender on layers which allow cross-sentence annotations

**How to test manually**
* Create a text file with contents like this:
```
blah blah blah
blah blah blah
blah blah blah
```
* Import the file as "Plain text (one sentence per line)"
* Configure a span layer with character granularity and allowing cross sentence. Mind the layer must have one string feature
* Configure a string matching recommender for that string feature
* Annotate using this layer on the annotation page and check how recommendations behave

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [x] PR updates documentation
