### PR TITLE
#1517 - Description of KB items is cut in the concept editor

### DIFF
--- a/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/app/css/inception.css
+++ b/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/app/css/inception.css
@@ -34,6 +34,21 @@
   font-weight: bolder;
 }
 
+.k-item .item-title .badge {
+  font-size: 8px;
+/*  background-color: #eeeeee; */
+}
+
+.k-list-container > .k-footer {
+  background-color: #eeeeee;
+  border-top: 1px solid #bbb;
+  padding: 3px 10px;
+}
+
+.k-item .item-rank {
+  font-weight: lighter;
+}
+
 .k-item .item-identifier {
   font-size: 85%;
   line-height: normal; 

--- a/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/service/ConceptLinkingServiceImpl.java
+++ b/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/service/ConceptLinkingServiceImpl.java
@@ -346,6 +346,12 @@ public class ConceptLinkingServiceImpl
                 })
                 .limit(properties.getCandidateDisplayLimit())
                 .collect(Collectors.toList());
+        
+        int rank = 1;
+        for (KBHandle handle : results) {
+            handle.setRank(rank);
+            rank++;
+        }
          
         log.debug("Ranked [{}] candidates for mention [{}] and query [{}] in [{}] ms",
                  results.size(), aMention, aQuery, currentTimeMillis() - startTime);

--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/KBHandle.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/KBHandle.java
@@ -39,6 +39,8 @@ public class KBHandle
     private KnowledgeBase kb;
     private String language;
     
+    private int rank;
+    private double score;
     private String debugInfo;
     
     // domain and range for cases in which the KBHandle represents a property
@@ -114,11 +116,13 @@ public class KBHandle
         range = aRange;
     }
 
+    @Override
     public String getDescription()
     {
         return description;
     }
 
+    @Override
     public void setDescription(String aDescription)
     {
         description = aDescription;
@@ -180,6 +184,26 @@ public class KBHandle
     public String getDebugInfo()
     {
         return debugInfo;
+    }
+    
+    public int getRank()
+    {
+        return rank;
+    }
+
+    public void setRank(int aRank)
+    {
+        rank = aRank;
+    }
+
+    public double getScore()
+    {
+        return score;
+    }
+
+    public void setScore(double aScore)
+    {
+        score = aScore;
     }
 
     public static KBHandle of(KBObject aObject)

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/KnowledgeBaseItemAutoCompleteField.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/KnowledgeBaseItemAutoCompleteField.java
@@ -82,24 +82,29 @@ public class KnowledgeBaseItemAutoCompleteField
     {
         super.onConfigure(behavior);
         
-        // Use one-third of the browser width but not less than 300 pixels. This is better than 
-        // using the Kendo auto-sizing feature because that sometimes doesn't get the width right.
-        // See: https://github.com/inception-project/inception/issues/1517
-        behavior.setOption("open", String.join(" ",
-                "function(e) {",
-                "  e.sender.list.width(Math.max($(window).width()*0.3,300));",
-                "}"));
-        behavior.setOption("height", "Math.max($(window).height()*0.5,200)");
         behavior.setOption("ignoreCase", false);
         behavior.setOption("delay", 500);
         behavior.setOption("animation", false);
         behavior.setOption("footerTemplate",
                 Options.asString("#: instance.dataSource.total() # items found"));
+        
+        // Try to smartly set the width and height of the dropdown
+        behavior.setOption("height", "Math.max($(window).height()*0.5,200)");
+        behavior.setOption("open", String.join(" ",
+                "function(e) {",
+                "  e.sender.list.width(Math.max($(window).width()*0.3,300));",
+                "}"));
         // Prevent scrolling action from closing the dropdown while the focus is on the input field
+        // Use one-third of the browser width but not less than 300 pixels. This is better than 
+        // using the Kendo auto-sizing feature because that sometimes doesn't get the width right.
+        // The solution we use here is a NASTY hack, but I didn't find any other way to cancel out
+        // only the closing triggered by scrolling the browser window without having other adverse
+        // side effects such as mouse clicks or enter no longer selecting and closing the dropdown.
+        // See: https://github.com/inception-project/inception/issues/1517
         behavior.setOption("close", String.join(" ",
                 "function(e) {",
-                "  if (document.activeElement == e.sender.element[0]) {", 
-                "    e.preventDefault();" + 
+                "  if (new Error().stack.toString().includes('_resize')) {", 
+                "    e.preventDefault();",
                 "  }",
                 "}"));
     }

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/KnowledgeBaseItemAutoCompleteField.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/KnowledgeBaseItemAutoCompleteField.java
@@ -85,13 +85,23 @@ public class KnowledgeBaseItemAutoCompleteField
         // Use one-third of the browser width but not less than 300 pixels. This is better than 
         // using the Kendo auto-sizing feature because that sometimes doesn't get the width right.
         // See: https://github.com/inception-project/inception/issues/1517
-        behavior.setOption("open",
-                "function(e) { $(e.sender.list).width(Math.max($(window).width()*0.3,300)); }");
+        behavior.setOption("open", String.join(" ",
+                "function(e) {",
+                "  e.sender.list.width(Math.max($(window).width()*0.3,300));",
+                "}"));
+        behavior.setOption("height", "Math.max($(window).height()*0.5,200)");
         behavior.setOption("ignoreCase", false);
         behavior.setOption("delay", 500);
         behavior.setOption("animation", false);
         behavior.setOption("footerTemplate",
                 Options.asString("#: instance.dataSource.total() # items found"));
+        // Prevent scrolling action from closing the dropdown while the focus is on the input field
+        behavior.setOption("close", String.join(" ",
+                "function(e) {",
+                "  if (document.activeElement == e.sender.element[0]) {", 
+                "    e.preventDefault();" + 
+                "  }",
+                "}"));
     }
     
     @Override

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/KnowledgeBaseItemAutoCompleteField.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/KnowledgeBaseItemAutoCompleteField.java
@@ -27,6 +27,7 @@ import org.apache.wicket.model.IModel;
 import org.danekja.java.util.function.serializable.SerializableFunction;
 
 import com.googlecode.wicket.jquery.core.JQueryBehavior;
+import com.googlecode.wicket.jquery.core.Options;
 import com.googlecode.wicket.jquery.core.renderer.ITextRenderer;
 import com.googlecode.wicket.jquery.core.renderer.TextRenderer;
 import com.googlecode.wicket.jquery.core.template.IJQueryTemplate;
@@ -80,12 +81,19 @@ public class KnowledgeBaseItemAutoCompleteField
     public void onConfigure(JQueryBehavior behavior)
     {
         super.onConfigure(behavior);
-
-        behavior.setOption("autoWidth", true);
+        
+        // Use one-third of the browser width but not less than 300 pixels. This is better than 
+        // using the Kendo auto-sizing feature because that sometimes doesn't get the width right.
+        // See: https://github.com/inception-project/inception/issues/1517
+        behavior.setOption("open",
+                "function(e) { $(e.sender.list).width(Math.max($(window).width()*0.3,300)); }");
         behavior.setOption("ignoreCase", false);
         behavior.setOption("delay", 500);
+        behavior.setOption("animation", false);
+        behavior.setOption("footerTemplate",
+                Options.asString("#: instance.dataSource.total() # items found"));
     }
-
+    
     @Override
     protected IJQueryTemplate newTemplate()
     {
@@ -97,8 +105,13 @@ public class KnowledgeBaseItemAutoCompleteField
             public String getText()
             {
                 StringBuilder sb = new StringBuilder();
-                sb.append("<div style=\"max-width: 450px\">");
+                sb.append("<div>");
                 sb.append("  <div class=\"item-title\">");
+                sb.append("  # if (data.rank) { #");
+                sb.append("  <span class=\"item-rank\">");
+                sb.append("    [${ data.rank }]");
+                sb.append("  </span>");
+                sb.append("  # } #");
                 sb.append("    ${ data.name }");
                 sb.append("  </div>");
                 sb.append("  <div class=\"item-identifier\">");
@@ -123,6 +136,7 @@ public class KnowledgeBaseItemAutoCompleteField
                 properties.add("name");
                 properties.add("identifier");
                 properties.add("description");
+                properties.add("rank");
                 if (DEVELOPMENT.equals(getApplication().getConfigurationType())) {
                     properties.add("debugInfo");
                 }


### PR DESCRIPTION
**What's in the PR**
- Disable auto-sizing the dropdown list in favor of using a fixed 30% of the screenwidth and a minimum of 300 pixels
- Use more vertical space for the dropdown if such space is available
- Added footer to concept feature editor indicating the number of items found
- Added rank information to the matching concepts
- Fixed issue that dropdown closes when the surrounding document scrolls (e.g. due to a scroll-down rubberband effect)

**How to test manually**
* Try linking some concepts and check if the dropdown appears ok

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
