### PR TITLE
#1559 - Problems if multiple entities have the same label

### DIFF
--- a/inception-layer-docmetadata/pom.xml
+++ b/inception-layer-docmetadata/pom.xml
@@ -92,10 +92,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.wicket</groupId>
-      <artifactId>wicket-util</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-spring</artifactId>
     </dependency>
     <dependency>

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureEditor.html
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureEditor.html
@@ -31,6 +31,11 @@
         </span> 
         <input style="width: 100%;" wicket:id="value" class="form-control" type="text"/>
       </div>
+      <div class="col-sm-12" style="position: relative; height: 5em;" wicket:enclosure="description">
+        <div class="form-control" style="overflow-y: auto; width: unset; word-wrap: break-word; height: 5em; position: absolute; top: 0; left: 0px; right: 0px;" readonly>
+          <span class="small" wicket:id="description"/>
+        </div>
+      </div>
       <div wicket:id="keyBindings" class="col-sm-12"/>
     </div>
   </div>

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureSupport.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureSupport.java
@@ -138,11 +138,11 @@ public class ConceptFeatureSupport
     }
 
     @Override
-    public String renderFeatureValue(AnnotationFeature aFeature, String aLabel)
+    public String renderFeatureValue(AnnotationFeature aFeature, String aIdentifier)
     {
         String renderValue = null;
-        if (aLabel != null) {
-            return labelCache.get(new Key(aFeature, aLabel)).getUiLabel();
+        if (aIdentifier != null) {
+            return labelCache.get(new Key(aFeature, aIdentifier)).getUiLabel();
         }
         return renderValue;
     }
@@ -202,7 +202,10 @@ public class ConceptFeatureSupport
     {
         if (aValue instanceof String) {
             String identifier = (String) aValue;
-            return new KBHandle(identifier, renderFeatureValue(aFeature, identifier));
+            String label = renderFeatureValue(aFeature, identifier);
+            String description = labelCache.get(new Key(aFeature, identifier)).getDescription();
+            
+            return new KBHandle(identifier, label, description);
         }
         else if (aValue instanceof KBHandle) {
             return (KBHandle) aValue;

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/KnowledgeBaseItemAutoCompleteField.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/KnowledgeBaseItemAutoCompleteField.java
@@ -21,15 +21,9 @@ import static org.apache.wicket.RuntimeConfigurationType.DEVELOPMENT;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 
 import org.apache.commons.lang3.Validate;
-import org.apache.wicket.ajax.form.AjaxFormChoiceComponentUpdatingBehavior;
 import org.apache.wicket.model.IModel;
-import org.apache.wicket.request.IRequestParameters;
-import org.apache.wicket.request.http.WebRequest;
-import org.apache.wicket.util.convert.IConverter;
-import org.apache.wicket.util.string.StringValue;
 import org.danekja.java.util.function.serializable.SerializableFunction;
 
 import com.googlecode.wicket.jquery.core.JQueryBehavior;
@@ -43,11 +37,6 @@ import de.tudarmstadt.ukp.inception.kb.graph.KBHandle;
 
 /**
  * Auto-complete field for accessing a knowledge base.
- * <p>
- * <b>NOTE:</b> This field <b>must</b> be used with a
- * {@link AjaxFormChoiceComponentUpdatingBehavior} and using
- * {@link #getIdentifierDynamicAttributeScript()} otherwise it cannot differentiate between
- * different items that have the same label!!!
  */
 public class KnowledgeBaseItemAutoCompleteField
     extends AutoCompleteTextField<KBHandle>
@@ -55,9 +44,6 @@ public class KnowledgeBaseItemAutoCompleteField
     private static final long serialVersionUID = -1276017349261462683L;
 
     private SerializableFunction<String, List<KBHandle>> choiceProvider;
-    private IConverter<KBHandle> converter;
-    private List<KBHandle> choiceCache;
-    private boolean allowChoiceCache = false;
     
     public KnowledgeBaseItemAutoCompleteField(String aId,
             SerializableFunction<String, List<KBHandle>> aChoiceProvider)
@@ -66,7 +52,6 @@ public class KnowledgeBaseItemAutoCompleteField
         
         Validate.notNull(aChoiceProvider);
         choiceProvider = aChoiceProvider;
-        converter = newConverter();
     }
 
     public KnowledgeBaseItemAutoCompleteField(String aId,
@@ -77,7 +62,6 @@ public class KnowledgeBaseItemAutoCompleteField
         
         Validate.notNull(aChoiceProvider);
         choiceProvider = aChoiceProvider;
-        converter = newConverter();
     }
 
     public KnowledgeBaseItemAutoCompleteField(String aId,
@@ -88,124 +72,14 @@ public class KnowledgeBaseItemAutoCompleteField
         
         Validate.notNull(aChoiceProvider);
         choiceProvider = aChoiceProvider;
-        converter = newConverter();
     }
     
     @Override
     protected List<KBHandle> getChoices(String aInput)
     {
-        if (!allowChoiceCache || choiceCache == null) {
-            choiceCache = choiceProvider.apply(aInput);
-        }
-        return choiceCache;
+        return choiceProvider.apply(aInput);
     }
     
-    @Override
-    public String[] getInputAsArray()
-    {
-        // If the web request includes the additional "identifier" parameter which is supposed to
-        // contain the IRI of the selected item instead of its label, then we use that as the value.
-        WebRequest request = getWebRequest();
-        IRequestParameters requestParameters = request.getRequestParameters();
-        StringValue identifier = requestParameters
-                .getParameterValue(getInputName() + ":identifier");
-        
-        if (!identifier.isEmpty()) {
-            return new String[] { identifier.toString() };
-        }
-        
-        return super.getInputAsArray();
-    }
-    
-    /**
-     * When using this input component with an {@link AjaxFormChoiceComponentUpdatingBehavior}, it
-     * is necessary to request the identifier of the selected item as an additional dynamic 
-     * attribute, otherwise no distinction can be made between two items with the same label!
-     */
-    public String getIdentifierDynamicAttributeScript()
-    {
-        return String.join(" ", 
-                "var item = $(attrs.event.target).data('kendoAutoComplete').dataItem();",
-                "if (item) {",
-                "  return [{",
-                "    'name': '" + getInputName() + ":identifier', ",
-                "    'value': $(attrs.event.target).data('kendoAutoComplete').dataItem().identifier",
-                "  }]",
-                "}",
-                "return [];");
-    }
-    
-    @Override
-    public <C> IConverter<C> getConverter(Class<C> aType)
-    {
-        if (aType != null && aType.isAssignableFrom(this.getType())) {
-            return (IConverter<C>) converter;
-        }
-        
-        return super.getConverter(aType);
-    }
-    
-    private IConverter<KBHandle> newConverter()
-    {
-        return new IConverter<KBHandle>() {
-
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public KBHandle convertToObject(String value, Locale locale)
-            {
-                if (value == null) {
-                    return null;
-                }
-                
-                if (value.equals(getModelValue())) {
-                    return getModelObject();
-                }
-                
-                // Check choices only here since fetching choices can take some time. If we already
-                // have choices from a previous query, then we use them instead of reloading all
-                // the choices. This avoids having to load the choices when opening the dropdown
-                // AND when selecting one of the items from it.
-                List<KBHandle> choices; 
-                try {
-                    allowChoiceCache = true;
-                    choices = getChoices(value);
-                }
-                finally {
-                    allowChoiceCache = false;
-                }
-                
-                if (choices.isEmpty()) {
-                    return null;
-                }
-                
-                // Check if we can find a match by the identifier. The identifier is unique while
-                // the same label may appear on multiple items
-                for (KBHandle handle : choices) {
-                    if (value.equals(handle.getIdentifier())) {
-                        return handle;
-                    }
-                }
-                
-                // Check labels if there was no match on the identifier
-                for (KBHandle handle : choices) {
-                    if (value.equals(getRenderer().getText(handle))) {
-                        return handle;
-                    }
-                }
-                
-                // If there was no match at all, return null
-                return null;
-            }
-
-            @Override
-            public String convertToString(KBHandle value, Locale locale)
-            {
-                return getRenderer().getText(value);
-            }
-        };
-    } 
-
     @Override
     public void onConfigure(JQueryBehavior behavior)
     {
@@ -229,15 +103,6 @@ public class KnowledgeBaseItemAutoCompleteField
         behavior.setOption("filtering", String.join(" ",
                 "function(e) {",
                 "  e.sender.listView.value([]);",
-                "}"));
-        
-        // We need to explicitly trigger the change event on the input element in order to trigger
-        // the Wicket AJAX update (if there is one). If we do not do this, then Kendo will "forget"
-        // to trigger a change event if the label of the newly selected item is the same as the 
-        // label of the previously selected item!!!
-        behavior.setOption("select", String.join(" ",
-                "function (e) {",
-                "  e.sender.element.trigger('change');",
                 "}"));
         
         // Prevent scrolling action from closing the dropdown while the focus is on the input field

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/KnowledgeBaseItemAutoCompleteField.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/KnowledgeBaseItemAutoCompleteField.java
@@ -21,9 +21,15 @@ import static org.apache.wicket.RuntimeConfigurationType.DEVELOPMENT;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import org.apache.commons.lang3.Validate;
+import org.apache.wicket.ajax.form.AjaxFormChoiceComponentUpdatingBehavior;
 import org.apache.wicket.model.IModel;
+import org.apache.wicket.request.IRequestParameters;
+import org.apache.wicket.request.http.WebRequest;
+import org.apache.wicket.util.convert.IConverter;
+import org.apache.wicket.util.string.StringValue;
 import org.danekja.java.util.function.serializable.SerializableFunction;
 
 import com.googlecode.wicket.jquery.core.JQueryBehavior;
@@ -35,12 +41,23 @@ import com.googlecode.wicket.kendo.ui.form.autocomplete.AutoCompleteTextField;
 
 import de.tudarmstadt.ukp.inception.kb.graph.KBHandle;
 
+/**
+ * Auto-complete field for accessing a knowledge base.
+ * <p>
+ * <b>NOTE:</b> This field <b>must</b> be used with a
+ * {@link AjaxFormChoiceComponentUpdatingBehavior} and using
+ * {@link #getIdentifierDynamicAttributeScript()} otherwise it cannot differentiate between
+ * different items that have the same label!!!
+ */
 public class KnowledgeBaseItemAutoCompleteField
     extends AutoCompleteTextField<KBHandle>
 {
     private static final long serialVersionUID = -1276017349261462683L;
 
     private SerializableFunction<String, List<KBHandle>> choiceProvider;
+    private IConverter<KBHandle> converter;
+    private List<KBHandle> choiceCache;
+    private boolean allowChoiceCache = false;
     
     public KnowledgeBaseItemAutoCompleteField(String aId,
             SerializableFunction<String, List<KBHandle>> aChoiceProvider)
@@ -49,6 +66,7 @@ public class KnowledgeBaseItemAutoCompleteField
         
         Validate.notNull(aChoiceProvider);
         choiceProvider = aChoiceProvider;
+        converter = newConverter();
     }
 
     public KnowledgeBaseItemAutoCompleteField(String aId,
@@ -59,6 +77,7 @@ public class KnowledgeBaseItemAutoCompleteField
         
         Validate.notNull(aChoiceProvider);
         choiceProvider = aChoiceProvider;
+        converter = newConverter();
     }
 
     public KnowledgeBaseItemAutoCompleteField(String aId,
@@ -69,13 +88,123 @@ public class KnowledgeBaseItemAutoCompleteField
         
         Validate.notNull(aChoiceProvider);
         choiceProvider = aChoiceProvider;
+        converter = newConverter();
     }
     
     @Override
     protected List<KBHandle> getChoices(String aInput)
     {
-        return choiceProvider.apply(aInput);
+        if (!allowChoiceCache || choiceCache == null) {
+            choiceCache = choiceProvider.apply(aInput);
+        }
+        return choiceCache;
     }
+    
+    @Override
+    public String[] getInputAsArray()
+    {
+        // If the web request includes the additional "identifier" parameter which is supposed to
+        // contain the IRI of the selected item instead of its label, then we use that as the value.
+        WebRequest request = getWebRequest();
+        IRequestParameters requestParameters = request.getRequestParameters();
+        StringValue identifier = requestParameters
+                .getParameterValue(getInputName() + ":identifier");
+        
+        if (!identifier.isEmpty()) {
+            return new String[] { identifier.toString() };
+        }
+        
+        return super.getInputAsArray();
+    }
+    
+    /**
+     * When using this input component with an {@link AjaxFormChoiceComponentUpdatingBehavior}, it
+     * is necessary to request the identifier of the selected item as an additional dynamic 
+     * attribute, otherwise no distinction can be made between two items with the same label!
+     */
+    public String getIdentifierDynamicAttributeScript()
+    {
+        return String.join(" ", 
+                "var item = $(attrs.event.target).data('kendoAutoComplete').dataItem();",
+                "if (item) {",
+                "  return [{",
+                "    'name': '" + getInputName() + ":identifier', ",
+                "    'value': $(attrs.event.target).data('kendoAutoComplete').dataItem().identifier",
+                "  }]",
+                "}",
+                "return [];");
+    }
+    
+    @Override
+    public <C> IConverter<C> getConverter(Class<C> aType)
+    {
+        if (aType != null && aType.isAssignableFrom(this.getType())) {
+            return (IConverter<C>) converter;
+        }
+        
+        return super.getConverter(aType);
+    }
+    
+    private IConverter<KBHandle> newConverter()
+    {
+        return new IConverter<KBHandle>() {
+
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public KBHandle convertToObject(String value, Locale locale)
+            {
+                if (value == null) {
+                    return null;
+                }
+                
+                if (value.equals(getModelValue())) {
+                    return getModelObject();
+                }
+                
+                // Check choices only here since fetching choices can take some time. If we already
+                // have choices from a previous query, then we use them instead of reloading all
+                // the choices. This avoids having to load the choices when opening the dropdown
+                // AND when selecting one of the items from it.
+                List<KBHandle> choices; 
+                try {
+                    allowChoiceCache = true;
+                    choices = getChoices(value);
+                }
+                finally {
+                    allowChoiceCache = false;
+                }
+                
+                if (choices.isEmpty()) {
+                    return null;
+                }
+                
+                // Check if we can find a match by the identifier. The identifier is unique while
+                // the same label may appear on multiple items
+                for (KBHandle handle : choices) {
+                    if (value.equals(handle.getIdentifier())) {
+                        return handle;
+                    }
+                }
+                
+                // Check labels if there was no match on the identifier
+                for (KBHandle handle : choices) {
+                    if (value.equals(getRenderer().getText(handle))) {
+                        return handle;
+                    }
+                }
+                
+                // If there was no match at all, return null
+                return null;
+            }
+
+            @Override
+            public String convertToString(KBHandle value, Locale locale)
+            {
+                return getRenderer().getText(value);
+            }
+        };
+    } 
 
     @Override
     public void onConfigure(JQueryBehavior behavior)
@@ -94,6 +223,23 @@ public class KnowledgeBaseItemAutoCompleteField
                 "function(e) {",
                 "  e.sender.list.width(Math.max($(window).width()*0.3,300));",
                 "}"));
+        
+        // Reset the values in the dropdown listbox to avoid that when opening the dropdown the next
+        // time ALL items with the same label as the selected item appear as selected
+        behavior.setOption("filtering", String.join(" ",
+                "function(e) {",
+                "  e.sender.listView.value([]);",
+                "}"));
+        
+        // We need to explicitly trigger the change event on the input element in order to trigger
+        // the Wicket AJAX update (if there is one). If we do not do this, then Kendo will "forget"
+        // to trigger a change event if the label of the newly selected item is the same as the 
+        // label of the previously selected item!!!
+        behavior.setOption("select", String.join(" ",
+                "function (e) {",
+                "  e.sender.element.trigger('change');",
+                "}"));
+        
         // Prevent scrolling action from closing the dropdown while the focus is on the input field
         // Use one-third of the browser width but not less than 300 pixels. This is better than 
         // using the Kendo auto-sizing feature because that sometimes doesn't get the width right.
@@ -127,7 +273,7 @@ public class KnowledgeBaseItemAutoCompleteField
                 sb.append("    [${ data.rank }]");
                 sb.append("  </span>");
                 sb.append("  # } #");
-                sb.append("    ${ data.name }");
+                sb.append("    ${ data.uiLabel }");
                 sb.append("  </div>");
                 sb.append("  <div class=\"item-identifier\">");
                 sb.append("    ${ data.identifier }");
@@ -148,7 +294,6 @@ public class KnowledgeBaseItemAutoCompleteField
             public List<String> getTextProperties()
             {
                 List<String> properties = new ArrayList<>();
-                properties.add("name");
                 properties.add("identifier");
                 properties.add("description");
                 properties.add("rank");


### PR DESCRIPTION
**What's in the PR**
- Fixes issue of items with the same label being confused by frontend and backend by using IRI as an identifier
- Improve performance of linking an entity by not fetching the choices again if we still have them from filling the dropdown
- Avoid sending redundant data to the UI
- Add area with entity description below the entity linking field

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
