### PR TITLE
#1563 - Allow configuring concept feature for properties

### DIFF
--- a/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/service/ConceptLinkingServiceImpl.java
+++ b/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/service/ConceptLinkingServiceImpl.java
@@ -139,6 +139,8 @@ public class ConceptLinkingServiceImpl
             return SPARQLQueryBuilder.forClasses(aKB);
         case INSTANCE:
             return SPARQLQueryBuilder.forInstances(aKB);
+        case PROPERTY:
+            return SPARQLQueryBuilder.forProperties(aKB);
         default:
             throw new IllegalArgumentException("Unknown item type: [" + aValueType + "]");
         }

--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/ConceptFeatureValueType.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/ConceptFeatureValueType.java
@@ -19,9 +19,10 @@ package de.tudarmstadt.ukp.inception.kb;
 
 public enum ConceptFeatureValueType
 {
-    ANY_OBJECT("<Any Concept/Instance>"), 
-    CONCEPT("Only Concepts"), 
-    INSTANCE("Only Instances");
+    ANY_OBJECT("<any concept/instance>"), 
+    CONCEPT("concepts only"), 
+    INSTANCE("instances only"),
+    PROPERTY("properties only");
 
     private final String uiLabel;
 

--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
@@ -499,6 +499,12 @@ public class SPARQLQueryBuilder
     {
         kb = aKB;
         mode = aMode;
+        
+        // The Wikidata search service we are using does not return properties, so we have to do 
+        // this the old-fashioned way...
+        if (Mode.PROPERTY.equals(mode) && FTS_WIKIDATA.equals(aKB.getFullTextSearchIri())) {
+            forceDisableFTS = true;
+        }
     }
     
     private void addPattern(Priority aPriority, GraphPattern aPattern)
@@ -675,6 +681,8 @@ public class SPARQLQueryBuilder
             addPattern(PRIMARY, withLabelMatchingExactlyAnyOf_Wikidata_FTS(aValues));
         }
         else if (FTS_NONE.equals(ftsMode) || ftsMode == null) {
+            // For exact matching, we do not make use of regexes, so we keep this as a primary
+            // condition - unlike in withLabelContainingAnyOf or withLabelStartingWith
             addPattern(PRIMARY, withLabelMatchingExactlyAnyOf_No_FTS(aValues));
         }
         else {
@@ -831,7 +839,10 @@ public class SPARQLQueryBuilder
             addPattern(PRIMARY, withLabelContainingAnyOf_Wikidata_FTS(aValues));
         }
         else if (FTS_NONE.equals(ftsMode) || ftsMode == null) {
-            addPattern(PRIMARY, withLabelContainingAnyOf_No_FTS(aValues));
+            // Label matching without FTS is slow, so we add this with low prio and hope that some
+            // other higher-prio condition exists which limites the number of candidates to a
+            // manageable level
+            addPattern(SECONDARY, withLabelContainingAnyOf_No_FTS(aValues));
         }
         else {
             throw new IllegalStateException(
@@ -968,7 +979,6 @@ public class SPARQLQueryBuilder
             return this;
         }
         
-        
         IRI ftsMode = forceDisableFTS ? FTS_NONE : kb.getFullTextSearchIri();
         
         if (FTS_LUCENE.equals(ftsMode)) {
@@ -984,7 +994,10 @@ public class SPARQLQueryBuilder
             addPattern(PRIMARY, withLabelStartingWith_Wikidata_FTS(aPrefixQuery));
         }
         else if (FTS_NONE.equals(ftsMode) || ftsMode == null) {
-            addPattern(PRIMARY, withLabelStartingWith_No_FTS(aPrefixQuery));
+            // Label matching without FTS is slow, so we add this with low prio and hope that some
+            // other higher-prio condition exists which limites the number of candidates to a
+            // manageable level
+            addPattern(SECONDARY, withLabelStartingWith_No_FTS(aPrefixQuery));
         }
         else {
             throw new IllegalStateException(
@@ -1498,7 +1511,7 @@ public class SPARQLQueryBuilder
                 GraphPatterns.and(concat(primaryPatterns.stream(), primaryRestrictions.stream())
                         .toArray(GraphPattern[]::new)).getQueryString()));
         
-        // Then add the optional elements
+        // Then add the optional or lower-prio elements 
         secondaryPatterns.stream().forEach(query::where);
         
         if (serverSideReduce) {

--- a/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderTest.java
+++ b/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderTest.java
@@ -456,7 +456,42 @@ public class SPARQLQueryBuilderTest
                 .containsExactlyInAnyOrder("http://example.org/#subproperty-1-1",
                         "http://example.org/#subproperty-1-1-1");
     }
+    
+    @Test
+    public void thatPropertyQueryListWorks_Wikidata()
+    {
+        assertIsReachable(wikidata);
+        
+        kb.setType(REMOTE);
+        kb.setFullTextSearchIri(FTS_WIKIDATA);
+        initWikidataMapping();
+        
+        List<KBHandle> results = asHandles(wikidata, SPARQLQueryBuilder
+                .forProperties(kb)
+                .limit(10));
+        
+        assertThat(results).extracting(KBHandle::getIdentifier).doesNotHaveDuplicates();
+        assertThat(results).hasSize(10);
+    }
 
+    @Test
+    public void thatPropertyQueryLabelStartingWith_Wikidata()
+    {
+        assertIsReachable(wikidata);
+        
+        kb.setType(REMOTE);
+        kb.setFullTextSearchIri(FTS_WIKIDATA);
+        initWikidataMapping();
+        
+        List<KBHandle> results = asHandles(wikidata, SPARQLQueryBuilder
+                .forProperties(kb)
+                .withLabelStartingWith("educated"));
+        
+        assertThat(results).extracting(KBHandle::getIdentifier).doesNotHaveDuplicates();
+        assertThat(results).isNotEmpty();
+        assertThat(results).extracting(KBHandle::getUiLabel)
+                .allMatch(label -> label.toLowerCase().startsWith("educated"));
+    }
     @Test
     public void thatPropertyQueryLimitedToChildrenDoesNotReturnOutOfScopeResults()
         throws Exception

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureSupport.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureSupport.java
@@ -122,7 +122,8 @@ public class ConceptFeatureSupport
     {
         // We just start with no specific scope at all (ANY) and let the user refine this via
         // the traits editor
-        return asList(new FeatureType(TYPE_ANY_OBJECT, "KB: Concept/Instance", featureSupportId));
+        return asList(new FeatureType(TYPE_ANY_OBJECT, "KB: Concept/Instance/Property",
+                featureSupportId));
     }
 
     @Override


### PR DESCRIPTION
**What's in the PR**
- Add the option for linking to properties

**How to test manually**
* Configure a KB to provide properties, e.g. Wikidata
* Configure the `identifier` property of the `Named entity` layer to link to properties
* Annotate some named entities and link them to properties (semantically doesn't make sense of course, but tests the functionality)

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
