### PR TITLE
#1565 - Some fontawesome glyphs are no longer visible

### DIFF
--- a/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/settings/StringMatchingRecommenderTraitsEditor.html
+++ b/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/settings/StringMatchingRecommenderTraitsEditor.html
@@ -42,10 +42,10 @@
                 <span wicket:id="name" class="form-control"/>
                 <span class="input-group-btn">
                   <button wicket:id="download" type="button" class="btn btn-default">
-                    <i class="fa fa-download" aria-hidden="true"></i>
+                    <i class="fas fa-download"></i>
                   </button>
                   <button wicket:id="delete" type="button" class="btn btn-danger">
-                    <i class="fa fa-trash" aria-hidden="true"></i>
+                    <i class="fas fa-trash"></i>
                   </button>
                 </span>
               </div>

--- a/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationSelectionPanel.html
+++ b/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationSelectionPanel.html
@@ -30,7 +30,7 @@
               <select class="form-control flex-content" wicket:id="layer" data-size="10"></select>
               <span class="input-group-btn">
                 <a wicket:id="create" class="btn btn-default">
-                  <i class="fa fa-plus" aria-hidden="true"></i>
+                  <i class="fas fa-plus"></i>
                 </a>
               </span>
             </div>
@@ -40,8 +40,8 @@
           <ul wicket:id="annotationsContainer" class="form-group list-group">
             <li wicket:id="annotations" class="list-group-item">
               <div wicket:id="annotation">
-                <span><i wicket:id="open" class="fa fa-plus"></i></span>
-                <span><i wicket:id="close" class="fa fa-minus"></i></span>
+                <span wicket:id="open"><i class="far fa-plus-square"></i></span>
+                <span wicket:id="close"><i class="far fa-minus-square"></i></span>
                 <span wicket:id="type" class="badge"/>
                 <span wicket:id="label" class="pull-right"/>
               </div>

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/MetricSelectDropDownPanel.html
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/MetricSelectDropDownPanel.html
@@ -22,7 +22,7 @@
     <div style="display: inline-block;">
       <select wicket:id="select" style="width: 0px;"></select>
       <span style="width: 10px"></span>
-      <span wicket:id="link" class="fa fa-chevron-circle-right"></span>
+      <span wicket:id="link" class="fas fa-chevron-circle-right"></span>
     </div>
   </wicket:panel>
 </body>

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommendationSidebar.html
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommendationSidebar.html
@@ -22,7 +22,7 @@
     <div class="flex-content panel panel-default panel-flex">
       <div class="panel-heading">
         <h3 class="panel-title"><wicket:message key="recommender"/>
-          <i wicket:id="warning" class="fa fa-warning" style="color: orange" wicket:message="value:mismatch"></i>
+          <i wicket:id="warning" class="fas fa-exclamation-triangle" style="color: orange" wicket:message="value:mismatch"></i>
         </h3>
       </div>
       <div class="scrolling panel-body">

--- a/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/projectlist/ProjectsOverviewPage.html
+++ b/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/projectlist/ProjectsOverviewPage.html
@@ -36,7 +36,7 @@
         <div style="flex-basis: 0%;">
           <div wicket:id="roleFilters" class="input-group">
             <span class="input-group-addon">
-              <i class="fa fa-filter"></i>
+              <i class="fas fa-filter"></i>
             </span>
             <span class="input-group-btn">
               <wicket:container wicket:id="roleFilter">
@@ -66,7 +66,7 @@
               <div wicket:id="actionDropdown" class="flex-h-container">
                 <div class="dropdown flex-content flex-h-container">
                   <button class="btn btn-default dropdown-toggle flex-content" type="button" data-toggle="dropdown">
-                    <span class="fa fa-ellipsis-v"></span>
+                    <i class="fas fa-ellipsis-v"></i>
                   </button>
                   <ul class="dropdown-menu pull-right" role="menu">
                     <li role="presentation"><a role="menuitem" tabindex="-1" wicket:id="leaveProject"><wicket:message key="leaveDialog.title"/></a></li>

--- a/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/menubar/MenuBar.html
+++ b/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/menubar/MenuBar.html
@@ -31,7 +31,7 @@
     </div>
 
     <p class="navbar-text navbar-left" wicket:enclosure="projectsLink">
-      <i class="fa fa-archive" aria-hidden="true"></i>
+      <i class="fas fa-archive"></i>
       <a class="navbar-link" wicket:id="projectsLink">
         <wicket:message key="projects" />
       </a>
@@ -46,7 +46,7 @@
     
     <!--  
     <p class="navbar-text">
-      <i class="fa fa-home" aria-hidden="true"></i>
+      <i class="fas fa-home"></i>
       <a class="navbar-link" href="welcome.html">Home</a>
     </p>
     -->
@@ -75,14 +75,14 @@
     </wicket:enclosure>
 
     <p class="navbar-text navbar-right" wicket:enclosure="adminLink">
-      <i class="fa fa-wrench" aria-hidden="true"></i>
+      <i class="fas fa-tools"></i>
       <a class="navbar-link" wicket:id="adminLink">
         <wicket:message key="administration" />
       </a>
     </p>
     
     <p class="navbar-text navbar-right" wicket:enclosure="helpLink">
-      <i class="fa fa-question-circle" aria-hidden="true"></i>
+      <i class="fas fa-question-circle"></i>
       <a class="navbar-link" wicket:id="helpLink"></a>
     </p>
     

--- a/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/SearchPage$ResultRowView.html
+++ b/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/SearchPage$ResultRowView.html
@@ -29,7 +29,7 @@
         </div>
       </div>
       <div class="flex-v-container">
-        <button wicket:id="importLink" class="btn btn-default"><i class="fa fa-plus" aria-hidden="true"></i> Import</button>
+        <button wicket:id="importLink" class="btn btn-default"><i class="fas fa-plus"></i> Import</button>
         <button wicket:id="openLink" class="btn btn-default">Open</button>
         <div wicket:id="importStatus" class="label label-info"/>
         <div class="text-center">

--- a/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/SearchPage.html
+++ b/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/SearchPage.html
@@ -40,7 +40,7 @@
         <div style="width: 240px;">
           <div class="input-group">
             <span class="input-group-addon">
-              <i class="fa fa-database"></i>
+              <i class="fas fa-database"></i>
             </span>
             <select wicket:id="repository" class="form-control" data-container="body"></select>
           </div>
@@ -48,7 +48,7 @@
         <div class="flex-content">
           <div class="input-group">
             <span class="input-group-addon">
-              <i class="fa fa-search"></i>
+              <i class="fas fa-search"></i>
             </span>
             <input wicket:id="query" class="form-control" type="text" />
             <div class="input-group-btn">

--- a/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/sidebar/ExternalSearchAnnotationSidebar.html
+++ b/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/sidebar/ExternalSearchAnnotationSidebar.html
@@ -28,7 +28,7 @@
           <form wicket:id="repositorySelectionForm">
             <span class="input-group">
               <span class="input-group-addon">
-                <i class="fa fa-database"></i>
+                <i class="fas fa-database"></i>
               </span>
               <select wicket:id="repositoryCombo" class="form-control" ></select>
             </span>
@@ -38,7 +38,7 @@
           <form wicket:id="searchForm" class="flex-content">
             <div class="input-group">
               <span class="input-group-addon">
-                <i class="fa fa-search"></i>
+                <i class="fas fa-search"></i>
               </span>
               <input wicket:id="queryInput" class="form-control" type="text" />
               <div class="input-group-btn">

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/AbstractInfoPanel.html
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/AbstractInfoPanel.html
@@ -29,9 +29,9 @@
        <div class="kb-object-headline-uilabel-wrapper">
          <h2 wicket:id="uiLabel"></h2>
        </div>
-       <span wicket:id="idtext" class="fa fa-info-circle"></span>
-       <button wicket:id="delete" type="button" class="btn btn-danger pull-right"><i class="fa fa-trash" aria-hidden="true"></i> <wicket:container wicket:id="label"></wicket:container></button>
-       <button wicket:id="createSubclass" type="button" class="btn btn-primary btn pull-right" style="margin-right :5px"><i class="fa fa-plus" aria-hidden="true"></i> <wicket:container wicket:id="subclassLabel"></wicket:container></button>
+       <span wicket:id="idtext" class="fas fa-info-circle"></span>
+       <button wicket:id="delete" type="button" class="btn btn-danger pull-right"><i class="fas fa-trash"></i> <wicket:container wicket:id="label"></wicket:container></button>
+       <button wicket:id="createSubclass" type="button" class="btn btn-primary btn pull-right" style="margin-right :5px"><i class="fas fa-plus"></i> <wicket:container wicket:id="subclassLabel"></wicket:container></button>
        <h5>
          <span wicket:id="typeLabel" class="label label-default pull-down"></span>
        </h5>
@@ -48,8 +48,8 @@
         <div class="input-group input-group-lg">
           <input wicket:id="name" class="flex-content form-control" />
           <div class="input-group-btn">
-            <button wicket:id="create" type="submit" class="btn btn-success"><i class="fa fa-plus" aria-hidden="true"></i> <wicket:container wicket:id="label"></wicket:container></button>
-            <button wicket:id="cancel" type="button" class="btn btn-default"><i class="fa fa-times" aria-hidden="true"></i> <wicket:container wicket:id="label"></wicket:container></button>
+            <button wicket:id="create" type="submit" class="btn btn-success"><i class="fas fa-plus"></i> <wicket:container wicket:id="label"></wicket:container></button>
+            <button wicket:id="cancel" type="button" class="btn btn-default"><i class="fas fa-times"></i> <wicket:container wicket:id="label"></wicket:container></button>
           </div>
         </div>
       </form>

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/ConceptListPanel.html
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/ConceptListPanel.html
@@ -34,7 +34,7 @@
       <select wicket:id="concepts" class="form-control list-panel"></select>
     </div>
     <div class="panel-footer text-right">
-      <button wicket:id="add" type="submit" class="btn btn-primary"><i class="fa fa-plus" aria-hidden="true"></i> <wicket:container wicket:id="label"></wicket:container></button>
+      <button wicket:id="add" type="submit" class="btn btn-primary"><i class="fas fa-plus"></i> <wicket:container wicket:id="label"></wicket:container></button>
     </div>
   </div>
 </wicket:panel>

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/ConceptTreePanel.html
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/ConceptTreePanel.html
@@ -36,7 +36,7 @@
       </div>
     </div>
     <div class="panel-footer text-right">
-      <button wicket:id="add" type="submit" class="btn btn-primary"><i class="fa fa-plus" aria-hidden="true"></i> <wicket:container wicket:id="label"></wicket:container></button>
+      <button wicket:id="add" type="submit" class="btn btn-primary"><i class="fas fa-plus"></i> <wicket:container wicket:id="label"></wicket:container></button>
     </div>
   </div>
 </wicket:panel>

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/InstanceListPanel.html
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/InstanceListPanel.html
@@ -31,7 +31,7 @@
           <wicket:container wicket:id="count"></wicket:container>
         </div>
       </div>      
-      <div class="flex-content flex-v-container" style="padding: 0px;">
+      <div class="flex-content scrolling flex-v-container" style="padding: 0px;">
         <div class="flex-v-container flex-content fit-child-snug">
           <wicket:enclosure child="noInstancesNotice">
             <div class="list-empty-notice">
@@ -42,7 +42,7 @@
         </div>
       </div>
       <div class="panel-footer text-right">
-        <button wicket:id="add" type="submit" class="btn btn-primary"><i class="fa fa-plus" aria-hidden="true"></i> <wicket:container wicket:id="label"></wicket:container></button>
+        <button wicket:id="add" type="submit" class="btn btn-primary"><i class="fas fa-plus"></i> <wicket:container wicket:id="label"></wicket:container></button>
       </div>
     </div>
   </wicket:panel>

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/IriInfoBadge.html
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/IriInfoBadge.html
@@ -19,7 +19,7 @@
 <html xmlns:wicket="http://wicket.apache.org">
 <body>
   <wicket:panel>
-    <span wicket:id="iri" class="fa fa-info-circle"></span>
+    <span wicket:id="iri" class="fas fa-info-circle"></span>
   </wicket:panel>
 </body>
 </html>

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/PropertyListPanel.html
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/PropertyListPanel.html
@@ -34,7 +34,7 @@
       <select wicket:id="properties" class="form-control list-panel"></select>
     </div>
     <div class="panel-footer text-right">
-      <button wicket:id="add" type="submit" class="btn btn-primary"><i class="fa fa-plus" aria-hidden="true"></i> <wicket:container wicket:id="label"></wicket:container></button> 
+      <button wicket:id="add" type="submit" class="btn btn-primary"><i class="fas fa-plus"></i> <wicket:container wicket:id="label"></wicket:container></button> 
     </div>            
   </div>
 </wicket:panel>

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/DisabledKBWarning.html
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/DisabledKBWarning.html
@@ -19,7 +19,7 @@
 <html lang="en" xmlns:wicket="http://www.w3.org/1999/xhtml">
 <body>
 <wicket:panel>
-    <i wicket:id="warning" class="fa fa-warning" style="color: orange";></i>
+  <i wicket:id="warning" class="fas fa-exclamation-triangle" style="color: orange";></i>
 </wicket:panel>
 </body>
 </html>

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/SubjectObjectFeatureEditor.html
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/SubjectObjectFeatureEditor.html
@@ -35,7 +35,7 @@
               <span wicket:id="label" class="form-control text-nowrap feature-editor-slot-label"></span>
               <span class="input-group-btn">
                 <button wicket:id="removeLabel" type="button" class="btn btn-default">
-                  <i class="fa fa-times" aria-hidden="true" aria-label="clear"></i>
+                  <i class="fas fa-times"></i>
                 </button>
               </span>
             </div>

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/less/inception-ui-kbp.less
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/less/inception-ui-kbp.less
@@ -57,16 +57,16 @@
 
 /* style for overall panel structure */
 div.flex-25 {
-  flex:0 1 25%
+  flex:0 0 25%
 }
 div.flex-35 {
-  flex:0 1 35%;
+  flex:0 0 35%;
 }
 div.flex-50 {
-  flex:0 1 50%;
+  flex:0 0 50%;
 }
 div.flex-65 {
-  flex:0 1 65%;
+  flex:0 0 65%;
 }
 div.knowledge-base-panel {
   padding:10px;
@@ -164,7 +164,6 @@ div.statement-editor {
 }
 div.statement-editor textarea {
   resize:vertical;
-  min-height:@input-height-base;
 }
 div.statement-editor span, div.statement-editor label {
   word-break:break-all;
@@ -175,6 +174,7 @@ div.statement-editor-button-row ul {
   cursor:default;
   margin:5px 0;
   padding-left:5px;
+  white-space: nowrap;
 }
 div.statement-editor-button-row ul li {
   display: inline-block;
@@ -185,7 +185,7 @@ div.list-empty-notice {
   display:flex;
   background-color:@panel-footer-bg;
   border-radius:5px;
-  min-height:100px;
+  min-height:20px;
 }
 div.list-empty-notice > p {
   margin:auto;

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/AccessSpecificSettingsPanel.html
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/AccessSpecificSettingsPanel.html
@@ -123,7 +123,7 @@
           <div class="flex-h-container flex-gutter flex-only-internal-gutter">
             <div wicket:id="exportButtons">
               <button wicket:id="link" type="button" class="btn btn-default"><i
-                      class="fa fa-download" aria-hidden="true"></i>
+                      class="fas fa-download" aria-hidden="true"></i>
                 <wicket:container wicket:id="label"></wicket:container>
               </button>
             </div>

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/KnowledgeBaseDetailsPanel.html
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/KnowledgeBaseDetailsPanel.html
@@ -34,11 +34,11 @@
     <div class="panel-footer">
       <div class="pull-left">
         <a wicket:id="reindex" class="btn btn-danger" href="#" role="button">
-          <!-- <i class="fa fa-trash"></i> -->
+          <!-- <i class="fas fa-trash"></i> -->
           <wicket:message key="kb.reindex"/>
         </a>
         <a wicket:id="delete" class="btn btn-danger" href="#" role="button">
-          <!-- <i class="fa fa-trash"></i> -->
+          <!-- <i class="fas fa-trash"></i> -->
           <wicket:message key="kb.delete"/>
         </a>
       </div>

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/RootConceptsPanel.html
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/RootConceptsPanel.html
@@ -37,7 +37,7 @@
               <input type="text" wicket:id="newConceptField" class="form-control"/>
               <span class="input-group-btn">
                 <a wicket:id="newExplicitConcept" class="btn btn-primary">
-                  <i class="fa fa-plus" aria-hidden="true"></i>
+                  <i class="fas fa-plus" aria-hidden="true"></i>
                 </a>
               </span>
             </div>
@@ -48,7 +48,7 @@
                 <input type="text" wicket:id="textField" class="form-control"/>
                 <span class="input-group-btn">
                   <a wicket:id="removeConcept" class="btn btn-danger">
-                    <i class="fa fa-trash" aria-hidden="true"></i>
+                    <i class="fas fa-trash" aria-hidden="true"></i>
                   </a>
                 </span>
               </div>

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/QualifierEditor.html
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/QualifierEditor.html
@@ -36,13 +36,13 @@
         <div class="pull-right statement-editor-button-row">
             <ul>
               <li><a wicket:id="create" wicket:message="title:qualifier.save" class="btn-link"><i
-                  class="fa fa-check" aria-hidden="true"></i></a>
+                  class="fas fa-check"></i></a>
               </li>
               <li><a wicket:id="cancel" wicket:message="title:cancel" class="btn-link"><i
-                  class="fa fa-times" aria-hidden="true"></i></a>
+                  class="fas fa-times"></i></a>
             </li>
                 <li><a wicket:id="delete" wicket:message="title:qualifier.delete"
-                    class="btn-link"><i class="fa fa-trash" aria-hidden="true"></i></a>
+                    class="btn-link"><i class="fas fa-trash"></i></a>
           </li>
           </ul>
         </div>
@@ -58,7 +58,7 @@
     <span wicket:id="value"></span>
     <div class="pull-right">
         <a wicket:id="edit" wicket:message="title:qualifier.edit" class="btn-link">
-            <i class="fa fa-pencil" aria-hidden="true"></i></a>
+            <i class="fas fa-edit" aria-hidden="true"></i></a>
     </div>
 </wicket:fragment>
 </body>

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/StatementGroupPanel.html
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/StatementGroupPanel.html
@@ -28,9 +28,9 @@
         <select wicket:id="property" class="form-control flex-content" data-container="body"></select>
         <div class="statement-editor-button-row">
           <ul>
-            <li><a wicket:id="create" wicket:message="title:statement.save" class="btn-link"><i class="fa fa-check" aria-hidden="true"></i></a>
+            <li><a wicket:id="create" wicket:message="title:statement.save" class="btn-link"><i class="fas fa-check"></i></a>
             </li>
-            <li><a wicket:id="cancel" wicket:message="title:cancel" class="btn-link"><i class="fa fa-times" aria-hidden="true"></i></a>
+            <li><a wicket:id="cancel" wicket:message="title:cancel" class="btn-link"><i class="fas fa-times"></i></a>
             </li>
           </ul>
         </div>
@@ -48,14 +48,14 @@
           <a wicket:id="propertyLink"><wicket:container wicket:id="property"></wicket:container></a>
         </span>
       </div>
-	  <div class="statement-group-statements-list flex-v-container flex-content">
+      <div class="statement-group-statements-list flex-v-container flex-content">
         <div wicket:id="statementListWrapper" class="flex-v-container flex-content flex-gutter flex-only-initial-gutter">
           <div wicket:id="statementList" class="statement-group-statement-wrapper">
             <div class="statement-editor" wicket:id="statement"></div>
           </div>
         </div>
         <div wicket:id="statementGroupFooter" class="statement-group-footer">
-          <button wicket:id="add" type="button" class="btn btn-link pull-right"><i class="fa fa-plus" aria-hidden="true"></i> <wicket:container wicket:id="label"></wicket:container></button>
+          <button wicket:id="add" type="button" class="btn btn-link pull-right"><i class="fas fa-plus"></i> <wicket:container wicket:id="label"></wicket:container></button>
         </div>
       </div>
     </form>

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/StatementsPanel.html
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/StatementsPanel.html
@@ -45,7 +45,7 @@
       <div class="btn-group btn-group-justified" role="group">
         <div class="btn-group" role="group">
           <button wicket:id="add" type="button" class="btn btn-primary">
-              <i class="fa fa-plus" aria-hidden="true"></i>
+              <i class="fas fa-plus"></i>
               <wicket:container wicket:id="label"></wicket:container>
           </button>
         </div>

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/editor/StatementEditor.html
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/editor/StatementEditor.html
@@ -27,8 +27,8 @@
     <wicket:container wicket:id="value"></wicket:container>
     
     <div class="pull-right">
-      <a wicket:id="makeExplicit" wicket:message="title:makeExplicit" class="btn-link"> <i class="fa fa-gavel" aria-hidden="true"></i></a>
-      <a wicket:id="edit" wicket:message="title:edit" class="btn-link"> <i class="fa fa-pencil" aria-hidden="true"></i></a>
+      <a wicket:id="makeExplicit" wicket:message="title:makeExplicit" class="btn-link"> <i class="fas fa-gavel"></i></a>
+      <a wicket:id="edit" wicket:message="title:edit" class="btn-link"> <i class="fas fa-edit"></i></a>
     </div>
     <div>
       <div wicket:id="qualifierListWrapper" class="flex-v-container flex-content">
@@ -39,7 +39,7 @@
     </div>
     <div class="pull-right" wicket:enclosure="addQualifier">
       <a wicket:id="addQualifier" class="btn-link">
-        <i class="fa fa-plus" aria-hidden="true"></i>
+        <i class="fas fa-plus" aria-hidden="true"></i>
         <wicket:container wicket:id="label"></wicket:container>
       </a>
     </div>
@@ -47,18 +47,18 @@
 
   <wicket:fragment wicket:id="editMode">
     <form wicket:id="form" class="form-inline">
-      <div class="flex-h-container flex-gutter flex-only-internal-gutter">
-        <div style="width: 140px;">
-          <select wicket:id="valueType" class="form-control" data-container="body"></select>
+      <div class="flex-h-container flex-gutter flex-only-internal-gutter" style="flex-wrap: wrap">
+        <div class="flex-h-container" style="width: 8em;">
+          <select wicket:id="valueType" class="flex-content form-control" data-container="body"></select>
         </div>
         <div class="flex-content flex-h-container flex-gutter flex-only-internal-gutter" wicket:id="value"></div>
         <div class="pull-right statement-editor-button-row">
           <ul>
-            <li><a wicket:id="save" wicket:message="title:statement.save" class="btn-link"><i class="fa fa-check" aria-hidden="true"></i></a>
+            <li><a wicket:id="save" wicket:message="title:statement.save" class="btn-link"><i class="fas fa-check"></i></a>
             </li>
-            <li><a wicket:id="cancel" wicket:message="title:cancel" class="btn-link"><i class="fa fa-times" aria-hidden="true"></i></a>
+            <li><a wicket:id="cancel" wicket:message="title:cancel" class="btn-link"><i class="fas fa-times"></i></a>
             </li>
-            <li><a wicket:id="delete" wicket:message="title:statement.delete" class="btn-link"><i class="fa fa-trash" aria-hidden="true"></i></a>
+            <li><a wicket:id="delete" wicket:message="title:statement.delete" class="btn-link"><i class="fas fa-trash"></i></a>
             </li>
           </ul>
         </div>

--- a/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchAnnotationSidebar.html
+++ b/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchAnnotationSidebar.html
@@ -32,11 +32,11 @@
               </div>
               <div class="form-group flex-h-container flex-gutter flex-only-internal-gutter">
                 <button wicket:id="search" type="submit" class="btn btn-primary flex-content">
-                  <i class="fa fa-search" aria-hidden="true"></i>
+                  <i class="fas fa-search" aria-hidden="true"></i>
                   Search
                 </button>
                 <button wicket:id="toggleOptionsVisibility" type="button" class="btn btn-default">
-                  <i class="fa fa-cog" aria-hidden="true"></i>
+                  <i class="fas fa-cog" aria-hidden="true"></i>
                 </button>
               </div>
             </div>
@@ -81,7 +81,7 @@
             </div>
             <div class="panel-footer text-right">
               <button wicket:id="reindexProject" type="button" class="btn btn-sm btn-default">
-                <i class="fa fa-refresh" aria-hidden="true"></i>
+                <i class="fas fa-sync" aria-hidden="true"></i>
                 <wicket:message key="reindex"/>
               </button>
             </div>
@@ -108,11 +108,11 @@
         <form wicket:id="annotateForm" style="margin-top: 5px">
           <div class="form-group flex-h-container flex-gutter flex-only-internal-gutter">
             <button wicket:id="annotateAllButton" type="submit" class="btn btn-primary flex-content">
-              <i class="fa fa-plus" aria-hidden="true"></i>
+              <i class="fas fa-plus" aria-hidden="true"></i>
                 Create Annotations
             </button>
             <button wicket:id="toggleCreateOptionsVisibility" type="button" class="btn btn-default">
-              <i class="fa fa-cog" aria-hidden="true"></i>
+              <i class="fas fa-cog" aria-hidden="true"></i>
             </button>
           </div>
           <form wicket:id="createOptions" class="panel-small panel panel-default panel-flex">
@@ -139,11 +139,11 @@
 
           <div class="form-group flex-h-container flex-gutter flex-only-internal-gutter">
             <button wicket:id="deleteButton" type="submit" class="btn btn-primary flex-content">
-              <i class="fa fa-trash" aria-hidden="true"></i>
+              <i class="fas fa-trash" aria-hidden="true"></i>
                 Delete Annotations
             </button>
             <button wicket:id="toggleDeleteOptionsVisibility" type="button" class="btn btn-default">
-              <i class="fa fa-cog" aria-hidden="true"></i>
+              <i class="fas fa-cog" aria-hidden="true"></i>
             </button>
           </div>
           <form wicket:id="deleteOptions" class="panel-small panel panel-default panel-flex">


### PR DESCRIPTION
**What's in the PR**
- Switch to modern fontawesome classes
- Improve the flex layout of the statement editors

**How to test manually**
* Edit KB (see issue description)
* Can also click a bit through the rest of the UI to make sure I didn't accidentally break some HTML due to missing brackets or such while upgrading the CSS classes

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
