### PR TITLE
#1567 - Cache knowledge base query results

### DIFF
--- a/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/service/ConceptLinkingServiceImpl.java
+++ b/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/service/ConceptLinkingServiceImpl.java
@@ -42,7 +42,6 @@ import org.apache.commons.lang3.Validate;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.text.AnnotationFS;
 import org.eclipse.rdf4j.common.net.ParsedIRI;
-import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
@@ -82,7 +81,7 @@ public class ConceptLinkingServiceImpl
 
     private final List<EntityRankingFeatureGenerator> featureGeneratorsProxy;
     private List<EntityRankingFeatureGenerator> featureGenerators;
-
+    
     @Autowired
     public ConceptLinkingServiceImpl(KnowledgeBaseService aKbService,
             EntityLinkingProperties aProperties,
@@ -98,7 +97,7 @@ public class ConceptLinkingServiceImpl
         featureGeneratorsProxy = aFeatureGenerators;
         repoProperties = aRepoProperties;
     }
-
+    
     @Override
     public void afterPropertiesSet() throws Exception
     {
@@ -158,112 +157,141 @@ public class ConceptLinkingServiceImpl
         long startTime = currentTimeMillis();
         Set<KBHandle> result = new HashSet<>();
         
-        try (RepositoryConnection conn = kbService.getConnection(aKB)) {
-            if (aQuery != null) {
-                ParsedIRI iri = null;
-                try {
-                    iri = new ParsedIRI(aQuery);
-                }
-                catch (URISyntaxException | NullPointerException e) {
-                    // Skip match by IRI.
-                }
-                if (iri != null && iri.isAbsolute()) {
-                    SPARQLQueryPrimaryConditions iriMatchBuilder = newQueryBuilder(aValueType, aKB)
-                            .withIdentifier(aQuery);
-                    
-                    if (aConceptScope != null) {
-                        iriMatchBuilder.descendantsOf(aConceptScope);
-                    }
-                    
-                    List<KBHandle> exactMatches = iriMatchBuilder
-                            .retrieveLabel()
-                            .retrieveDescription()
-                            .asHandles(conn, true);
-    
-                    log.debug("Found [{}] candidates exactly matching IRI {}",
-                            exactMatches.size(), asList(aQuery));
-    
-                    result.addAll(exactMatches);
-                }
+        if (aQuery != null) {
+            ParsedIRI iri = null;
+            try {
+                iri = new ParsedIRI(aQuery);
             }
-            
-            SPARQLQueryPrimaryConditions exactBuilder = newQueryBuilder(aValueType, aKB);
-            
-            if (aConceptScope != null) {
-                // Scope-limiting must always happen before label matching!
-                exactBuilder.descendantsOf(aConceptScope);
+            catch (URISyntaxException | NullPointerException e) {
+                // Skip match by IRI.
             }
-            
-            // Collect exact matches - although exact matches are theoretically contained in the
-            // set of containing matches, due to the ranking performed by the KB/FTS, we might
-            // not actually see the exact matches within the first N results. So we query for
-            // the exact matches separately to ensure we have them.
-            String[] exactLabels = asList(
-                    (aQuery != null && aQuery.length() <= threshold) ? aQuery : null, aMention)
-                    .stream()
-                    .filter(Objects::nonNull)
-                    .toArray(String[]::new);
-            exactBuilder.withLabelMatchingExactlyAnyOf(exactLabels);
-            
-            List<KBHandle> exactMatches = exactBuilder
-                    .retrieveLabel()
-                    .retrieveDescription()
-                    .asHandles(conn, true);
-
-            log.debug("Found [{}] candidates exactly matching {}",
-                    exactMatches.size(), asList(exactLabels));
-
-            result.addAll(exactMatches);
-
-            if (aQuery != null && aQuery.length() > threshold) {
-                SPARQLQueryPrimaryConditions startingWithBuilder = newQueryBuilder(aValueType, aKB);
+            if (iri != null && iri.isAbsolute()) {
+                SPARQLQueryPrimaryConditions iriMatchBuilder = newQueryBuilder(aValueType, aKB)
+                        .withIdentifier(aQuery);
                 
                 if (aConceptScope != null) {
-                    // Scope-limiting must always happen before label matching!
-                    startingWithBuilder.descendantsOf(aConceptScope);
+                    iriMatchBuilder.descendantsOf(aConceptScope);
                 }
                 
-                // Collect matches starting with the query - this is the main driver for the
-                // auto-complete functionality
-                startingWithBuilder.withLabelStartingWith(aQuery);
-                
-                List<KBHandle> startingWithMatches = startingWithBuilder
+                iriMatchBuilder
                         .retrieveLabel()
-                        .retrieveDescription()
-                        .asHandles(conn, true);
-                
-                log.debug("Found [{}] candidates starting with [{}]]",
-                        startingWithMatches.size(), aQuery);            
-                
-                result.addAll(startingWithMatches);
-            }
-            
-            
-            // Collect containing matches
-            SPARQLQueryPrimaryConditions containingBuilder = newQueryBuilder(aValueType, aKB);
+                        .retrieveDescription();
 
+                List<KBHandle> iriMatches;
+                if (aKB.isReadOnly()) {
+                    iriMatches = kbService.listHandlesCaching(aKB, iriMatchBuilder, true);
+                }
+                else {
+                    iriMatches = kbService.read(aKB, conn -> iriMatchBuilder.asHandles(conn, true));
+                }
+                
+                log.debug("Found [{}] candidates exactly matching IRI {}",
+                        iriMatches.size(), asList(aQuery));
+
+                result.addAll(iriMatches);
+            }
+        }
+        
+        SPARQLQueryPrimaryConditions exactBuilder = newQueryBuilder(aValueType, aKB);
+        
+        if (aConceptScope != null) {
+            // Scope-limiting must always happen before label matching!
+            exactBuilder.descendantsOf(aConceptScope);
+        }
+        
+        // Collect exact matches - although exact matches are theoretically contained in the
+        // set of containing matches, due to the ranking performed by the KB/FTS, we might
+        // not actually see the exact matches within the first N results. So we query for
+        // the exact matches separately to ensure we have them.
+        String[] exactLabels = asList(
+                (aQuery != null && aQuery.length() <= threshold) ? aQuery : null, aMention)
+                .stream()
+                .filter(Objects::nonNull)
+                .toArray(String[]::new);
+        exactBuilder.withLabelMatchingExactlyAnyOf(exactLabels);
+        
+        exactBuilder
+                .retrieveLabel()
+                .retrieveDescription();
+
+        List<KBHandle> exactMatches;
+        if (aKB.isReadOnly()) {
+            exactMatches = kbService.listHandlesCaching(aKB, exactBuilder, true);
+        }
+        else {
+            exactMatches = kbService.read(aKB, conn -> exactBuilder.asHandles(conn, true));
+        }
+        
+        
+        log.debug("Found [{}] candidates exactly matching {}",
+                exactMatches.size(), asList(exactLabels));
+
+        result.addAll(exactMatches);
+
+        if (aQuery != null && aQuery.length() > threshold) {
+            SPARQLQueryPrimaryConditions startingWithBuilder = newQueryBuilder(aValueType, aKB);
+            
             if (aConceptScope != null) {
                 // Scope-limiting must always happen before label matching!
-                containingBuilder.descendantsOf(aConceptScope);
+                startingWithBuilder.descendantsOf(aConceptScope);
             }
             
-            String[] containingLabels = asList(
-                    (aQuery != null && aQuery.length() > threshold) ? aQuery : null, aMention)
-                    .stream()
-                    .filter(Objects::nonNull)
-                    .toArray(String[]::new);
-            containingBuilder.withLabelContainingAnyOf(containingLabels);
+            // Collect matches starting with the query - this is the main driver for the
+            // auto-complete functionality
+            startingWithBuilder.withLabelStartingWith(aQuery);
             
-            List<KBHandle> containingMatches = containingBuilder
+            startingWithBuilder
                     .retrieveLabel()
-                    .retrieveDescription()
-                    .asHandles(conn, true);
+                    .retrieveDescription();
             
-            log.debug("Found [{}] candidates using containing {}",
-                    containingMatches.size(), asList(containingLabels));
+            List<KBHandle> startingWithMatches;
+            if (aKB.isReadOnly()) {
+                startingWithMatches = kbService.listHandlesCaching(aKB, startingWithBuilder, true);
+            }
+            else {
+                startingWithMatches = kbService.read(aKB,
+                    conn -> startingWithBuilder.asHandles(conn, true));
+            }
+                        
+            log.debug("Found [{}] candidates starting with [{}]]",
+                    startingWithMatches.size(), aQuery);            
             
-            result.addAll(containingMatches);
+            result.addAll(startingWithMatches);
         }
+        
+        
+        // Collect containing matches
+        SPARQLQueryPrimaryConditions containingBuilder = newQueryBuilder(aValueType, aKB);
+
+        if (aConceptScope != null) {
+            // Scope-limiting must always happen before label matching!
+            containingBuilder.descendantsOf(aConceptScope);
+        }
+        
+        String[] containingLabels = asList(
+                (aQuery != null && aQuery.length() > threshold) ? aQuery : null, aMention)
+                .stream()
+                .filter(Objects::nonNull)
+                .toArray(String[]::new);
+        containingBuilder.withLabelContainingAnyOf(containingLabels);
+        
+        containingBuilder
+                .retrieveLabel()
+                .retrieveDescription();
+        
+        List<KBHandle> containingMatches;
+        if (aKB.isReadOnly()) {
+            containingMatches = kbService.listHandlesCaching(aKB, containingBuilder, true);
+        }
+        else {
+            containingMatches = kbService.read(aKB,
+                conn -> containingBuilder.asHandles(conn, true));
+        }
+        
+        log.debug("Found [{}] candidates using containing {}",
+                containingMatches.size(), asList(containingLabels));
+        
+        result.addAll(containingMatches);
 
         log.debug("Generated [{}] candidates in {}ms", result.size(),
                 currentTimeMillis() - startTime);

--- a/inception-concept-linking/src/test/java/de/tudarmstadt/ukp/inception/conceptlinking/service/ConceptLinkingServiceImplTest.java
+++ b/inception-concept-linking/src/test/java/de/tudarmstadt/ukp/inception/conceptlinking/service/ConceptLinkingServiceImplTest.java
@@ -45,6 +45,8 @@ import de.tudarmstadt.ukp.inception.conceptlinking.util.TestFixtures;
 import de.tudarmstadt.ukp.inception.kb.ConceptFeatureValueType;
 import de.tudarmstadt.ukp.inception.kb.KnowledgeBaseService;
 import de.tudarmstadt.ukp.inception.kb.KnowledgeBaseServiceImpl;
+import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBaseProperties;
+import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBasePropertiesImpl;
 import de.tudarmstadt.ukp.inception.kb.graph.KBConcept;
 import de.tudarmstadt.ukp.inception.kb.graph.KBHandle;
 import de.tudarmstadt.ukp.inception.kb.model.KnowledgeBase;
@@ -74,10 +76,11 @@ public class ConceptLinkingServiceImplTest
     public void setUp() throws Exception
     {
         RepositoryProperties repoProps = new RepositoryProperties();
+        KnowledgeBaseProperties kbProperties = new KnowledgeBasePropertiesImpl();
         repoProps.setPath(temporaryFolder.getRoot());
         EntityManager entityManager = testEntityManager.getEntityManager();
         TestFixtures testFixtures = new TestFixtures(testEntityManager);
-        kbService = new KnowledgeBaseServiceImpl(repoProps, entityManager);
+        kbService = new KnowledgeBaseServiceImpl(repoProps, kbProperties, entityManager);
         sut = new ConceptLinkingServiceImpl(kbService, new EntityLinkingProperties(), repoProps,
                 emptyList());
         sut.afterPropertiesSet();

--- a/inception-kb/pom.xml
+++ b/inception-kb/pom.xml
@@ -139,6 +139,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-beans</artifactId>
     </dependency>

--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseService.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseService.java
@@ -41,6 +41,8 @@ import de.tudarmstadt.ukp.inception.kb.graph.KBProperty;
 import de.tudarmstadt.ukp.inception.kb.graph.KBQualifier;
 import de.tudarmstadt.ukp.inception.kb.graph.KBStatement;
 import de.tudarmstadt.ukp.inception.kb.model.KnowledgeBase;
+import de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQuery;
+import de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilder;
 import de.tudarmstadt.ukp.inception.kb.yaml.KnowledgeBaseProfile;
 
 public interface KnowledgeBaseService
@@ -520,4 +522,19 @@ public interface KnowledgeBaseService
      * @return whether the knowledge base with the given id is available or not
      */
     boolean isKnowledgeBaseEnabled(Project aProject, String repositoryID);
+    
+    /**
+     * Execute the given query and return the results. The service will try to cache the results for
+     * faster subsequent access.
+     * <p>
+     * <b>NOTE:</b> Do <b>NOT</b> use this method when current data from the KB is required, in 
+     * particular if it is a writable KB.
+     * 
+     * @param aQuery
+     *            a SPARQL query built using {@link SPARQLQueryBuilder}
+     * @return a list of {@link KBHandle KBHandles}
+     */
+    List<KBHandle> listHandlesCaching(KnowledgeBase aKB, SPARQLQuery aQuery, boolean aAll);
+    
+    Optional<KBHandle> fetchHandleCaching(KnowledgeBase aKB, SPARQLQuery aQuery, boolean aAll);
 }

--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
@@ -38,7 +38,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import javax.persistence.EntityManager;
@@ -147,8 +146,8 @@ public class KnowledgeBaseServiceImpl
     {
         Caffeine<QueryKey, List<KBHandle>> cacheBuilder = Caffeine.newBuilder()
                 .maximumWeight(aKBProperties.getCacheSize())
-                .expireAfterAccess(aKBProperties.getCacheExpireDelay(), TimeUnit.MINUTES)
-                .refreshAfterWrite(aKBProperties.getCacheRefreshDelay(), TimeUnit.MINUTES)
+                .expireAfterAccess(aKBProperties.getCacheExpireDelay())
+                .refreshAfterWrite(aKBProperties.getCacheRefreshDelay())
                 .weigher((QueryKey key, List<KBHandle> value) -> value.size());
         
         if (log.isTraceEnabled()) {

--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/config/KnowledgeBaseProperties.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/config/KnowledgeBaseProperties.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.kb.config;
 
+import java.time.Duration;
 
 public interface KnowledgeBaseProperties
 {
@@ -34,10 +35,10 @@ public interface KnowledgeBaseProperties
      * The time before KB items are dropped from the cache if they have not been accessed (in
      * minutes).
      */
-    int getCacheExpireDelay();
+    Duration getCacheExpireDelay();
 
     /**
      * The time before KB items are asynchronously refreshed (in minutes).
      */
-    int getCacheRefreshDelay();
+    Duration getCacheRefreshDelay();
 }

--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/config/KnowledgeBaseProperties.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/config/KnowledgeBaseProperties.java
@@ -20,12 +20,24 @@ package de.tudarmstadt.ukp.inception.kb.config;
 
 public interface KnowledgeBaseProperties
 {
-
-    public int getDefaultMaxResults();
+    int getDefaultMaxResults();
     
-    public void setDefaultMaxResults(int aDefaultMaxResults);
+    int getHardMaxResults();
 
-    public int getHardMaxResults();
+    /**
+     * The cache size in terms of KB items that are being cached. A single query may return a
+     * large number of such items.
+     */
+    long getCacheSize();
 
-    public void setHardMaxResults(int aHardMaxResults);
+    /**
+     * The time before KB items are dropped from the cache if they have not been accessed (in
+     * minutes).
+     */
+    int getCacheExpireDelay();
+
+    /**
+     * The time before KB items are asynchronously refreshed (in minutes).
+     */
+    int getCacheRefreshDelay();
 }

--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/config/KnowledgeBasePropertiesImpl.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/config/KnowledgeBasePropertiesImpl.java
@@ -22,12 +22,16 @@ import org.springframework.stereotype.Component;
 
 @Component
 @ConfigurationProperties("inception.knowledge-base")
-public class KnowledgeBasePropertiesImpl implements KnowledgeBaseProperties
+public class KnowledgeBasePropertiesImpl
+    implements KnowledgeBaseProperties
 {
     public static final int HARD_MIN_RESULTS = 10;
     
-    private int defaultMaxResults = 1000;
-    private int hardMaxResults = 10000;
+    private int defaultMaxResults = 1_000;
+    private int hardMaxResults = 10_000;
+    private long cacheSize = 100_000;
+    private int cacheExpireDelay = 15;
+    private int cacheRefreshDelay = 5;
 
     @Override
     public int getDefaultMaxResults()
@@ -35,7 +39,6 @@ public class KnowledgeBasePropertiesImpl implements KnowledgeBaseProperties
         return defaultMaxResults;
     }
 
-    @Override
     public void setDefaultMaxResults(int aDefaultMaxResults)
     {
         defaultMaxResults = aDefaultMaxResults;
@@ -47,9 +50,41 @@ public class KnowledgeBasePropertiesImpl implements KnowledgeBaseProperties
         return hardMaxResults;
     }
 
-    @Override
     public void setHardMaxResults(int aHardMaxResults)
     {
         hardMaxResults = aHardMaxResults;
+    }
+
+    @Override
+    public long getCacheSize()
+    {
+        return cacheSize;
+    }
+    
+    public void setCacheSize(long aCacheSize)
+    {
+        cacheSize = aCacheSize;
+    }
+
+    @Override
+    public int getCacheExpireDelay()
+    {
+        return cacheExpireDelay;
+    }
+    
+    public void setCacheExpireDelay(int aCacheExpireDelay)
+    {
+        cacheExpireDelay = aCacheExpireDelay;
+    }
+
+    @Override
+    public int getCacheRefreshDelay()
+    {
+        return cacheRefreshDelay;
+    }
+    
+    public void setCacheRefreshDelay(int aCacheRefreshDelay)
+    {
+        cacheRefreshDelay = aCacheRefreshDelay;
     }
 }

--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/config/KnowledgeBasePropertiesImpl.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/config/KnowledgeBasePropertiesImpl.java
@@ -17,7 +17,11 @@
  */
 package de.tudarmstadt.ukp.inception.kb.config;
 
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.convert.DurationUnit;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -30,8 +34,12 @@ public class KnowledgeBasePropertiesImpl
     private int defaultMaxResults = 1_000;
     private int hardMaxResults = 10_000;
     private long cacheSize = 100_000;
-    private int cacheExpireDelay = 15;
-    private int cacheRefreshDelay = 5;
+    
+    @DurationUnit(ChronoUnit.MINUTES)
+    private Duration cacheExpireDelay = Duration.ofMinutes(15);
+    
+    @DurationUnit(ChronoUnit.MINUTES)
+    private Duration cacheRefreshDelay = Duration.ofMinutes(5);
 
     @Override
     public int getDefaultMaxResults()
@@ -67,23 +75,23 @@ public class KnowledgeBasePropertiesImpl
     }
 
     @Override
-    public int getCacheExpireDelay()
+    public Duration getCacheExpireDelay()
     {
         return cacheExpireDelay;
     }
     
-    public void setCacheExpireDelay(int aCacheExpireDelay)
+    public void setCacheExpireDelay(Duration aCacheExpireDelay)
     {
         cacheExpireDelay = aCacheExpireDelay;
     }
 
     @Override
-    public int getCacheRefreshDelay()
+    public Duration getCacheRefreshDelay()
     {
         return cacheRefreshDelay;
     }
     
-    public void setCacheRefreshDelay(int aCacheRefreshDelay)
+    public void setCacheRefreshDelay(Duration aCacheRefreshDelay)
     {
         cacheRefreshDelay = aCacheRefreshDelay;
     }

--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
@@ -1771,4 +1771,23 @@ public class SPARQLQueryBuilder
                 .replaceAll("[\\u00AD]", "")
                 .trim();
     }
+
+    @Override
+    public boolean equals(final Object other)
+    {
+        if (!(other instanceof SPARQLQueryBuilder)) {
+            return false;
+        }
+        
+        SPARQLQueryBuilder castOther = (SPARQLQueryBuilder) other;
+        String query = selectQuery().getQueryString();
+        String otherQuery = castOther.selectQuery().getQueryString();
+        return query.equals(otherQuery);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return selectQuery().getQueryString().hashCode();
+    }
 }

--- a/inception-kb/src/main/resources/META-INF/asciidoc/admin-guide/settings_knowledgebase.adoc
+++ b/inception-kb/src/main/resources/META-INF/asciidoc/admin-guide/settings_knowledgebase.adoc
@@ -47,4 +47,19 @@ an example of how the parameter can be configured below:
 | hard limit for the maximum number of results from a query
 | 10000
 | 5000
+
+| inception.knowledge-base.cacheSize
+| number of items (classes, instances and properties) to cache
+| 100000
+| 500000
+
+| inception.knowledge-base.cacheExpireDelay
+| time before items are expunged from the cache
+| 15m
+| 1h
+
+| inception.knowledge-base.cacheRefreshDelay
+| time before items are asynchronously refreshed
+| 5m
+| 30m
 |===

--- a/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplImportExportIntegrationTest.java
+++ b/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplImportExportIntegrationTest.java
@@ -49,6 +49,8 @@ import org.springframework.transaction.annotation.Transactional;
 import de.tudarmstadt.ukp.clarin.webanno.api.RepositoryProperties;
 import de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBaseProperties;
+import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBasePropertiesImpl;
 import de.tudarmstadt.ukp.inception.kb.graph.KBConcept;
 import de.tudarmstadt.ukp.inception.kb.graph.KBInstance;
 import de.tudarmstadt.ukp.inception.kb.graph.KBObject;
@@ -88,9 +90,10 @@ public class KnowledgeBaseServiceImplImportExportIntegrationTest {
     public void setUp() {
         RepositoryProperties repoProps = new RepositoryProperties();
         repoProps.setPath(temporaryFolder.getRoot());
+        KnowledgeBaseProperties kbProperties = new KnowledgeBasePropertiesImpl();
         EntityManager entityManager = testEntityManager.getEntityManager();
         testFixtures = new TestFixtures(testEntityManager);
-        sut = new KnowledgeBaseServiceImpl(repoProps, entityManager);
+        sut = new KnowledgeBaseServiceImpl(repoProps, kbProperties, entityManager);
         project = createProject(PROJECT_NAME);
         kb = buildKnowledgeBase(project, KB_NAME);
     }

--- a/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplIntegrationTest.java
+++ b/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplIntegrationTest.java
@@ -68,6 +68,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.RepositoryProperties;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBaseProperties;
+import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBasePropertiesImpl;
 import de.tudarmstadt.ukp.inception.kb.graph.KBConcept;
 import de.tudarmstadt.ukp.inception.kb.graph.KBHandle;
 import de.tudarmstadt.ukp.inception.kb.graph.KBInstance;
@@ -127,9 +129,10 @@ public class KnowledgeBaseServiceImplIntegrationTest  {
     public void setUp() throws Exception {
         RepositoryProperties repoProps = new RepositoryProperties();
         repoProps.setPath(temporaryFolder.getRoot());
+        KnowledgeBaseProperties kbProperties = new KnowledgeBasePropertiesImpl();
         EntityManager entityManager = testEntityManager.getEntityManager();
         testFixtures = new TestFixtures(testEntityManager);
-        sut = new KnowledgeBaseServiceImpl(repoProps, entityManager);
+        sut = new KnowledgeBaseServiceImpl(repoProps, kbProperties, entityManager);
         project = createProject(PROJECT_NAME);
         kb = buildKnowledgeBase(project, KB_NAME);
     }

--- a/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplQualifierIntegrationTest.java
+++ b/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplQualifierIntegrationTest.java
@@ -45,6 +45,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.RepositoryProperties;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBaseProperties;
+import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBasePropertiesImpl;
 import de.tudarmstadt.ukp.inception.kb.graph.KBConcept;
 import de.tudarmstadt.ukp.inception.kb.graph.KBHandle;
 import de.tudarmstadt.ukp.inception.kb.graph.KBProperty;
@@ -96,9 +98,10 @@ public class KnowledgeBaseServiceImplQualifierIntegrationTest {
     {
         RepositoryProperties repoProps = new RepositoryProperties();
         repoProps.setPath(temporaryFolder.getRoot());
+        KnowledgeBaseProperties kbProperties = new KnowledgeBasePropertiesImpl();
         EntityManager entityManager = testEntityManager.getEntityManager();
         testFixtures = new TestFixtures(testEntityManager);
-        sut = new KnowledgeBaseServiceImpl(repoProps, entityManager);
+        sut = new KnowledgeBaseServiceImpl(repoProps, kbProperties, entityManager);
         project = testFixtures.createProject(PROJECT_NAME);
         kb = testFixtures.buildKnowledgeBase(project, KB_NAME, Reification.WIKIDATA);
         sut.registerKnowledgeBase(kb, sut.getNativeConfig());

--- a/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplWikiDataIntegrationTest.java
+++ b/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplWikiDataIntegrationTest.java
@@ -49,6 +49,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.RepositoryProperties;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBaseProperties;
+import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBasePropertiesImpl;
 import de.tudarmstadt.ukp.inception.kb.graph.KBConcept;
 import de.tudarmstadt.ukp.inception.kb.graph.KBHandle;
 import de.tudarmstadt.ukp.inception.kb.graph.KBInstance;
@@ -112,9 +114,10 @@ public class KnowledgeBaseServiceImplWikiDataIntegrationTest  {
     {
         RepositoryProperties repoProps = new RepositoryProperties();
         repoProps.setPath(temporaryFolder.getRoot());
+        KnowledgeBaseProperties kbProperties = new KnowledgeBasePropertiesImpl();
         EntityManager entityManager = testEntityManager.getEntityManager();
         testFixtures = new TestFixtures(testEntityManager);
-        sut = new KnowledgeBaseServiceImpl(repoProps, entityManager);
+        sut = new KnowledgeBaseServiceImpl(repoProps, kbProperties, entityManager);
         project = createProject(PROJECT_NAME);
         kb = buildKnowledgeBase(project, KB_NAME);
         String wikidataAccessUrl = PROFILES.get("wikidata").getAccess().getAccessUrl();

--- a/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceRemoteTest.java
+++ b/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceRemoteTest.java
@@ -54,6 +54,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.RepositoryProperties;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBaseProperties;
+import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBasePropertiesImpl;
 import de.tudarmstadt.ukp.inception.kb.graph.KBHandle;
 import de.tudarmstadt.ukp.inception.kb.graph.KBProperty;
 import de.tudarmstadt.ukp.inception.kb.model.KnowledgeBase;
@@ -113,9 +115,10 @@ public class KnowledgeBaseServiceRemoteTest
 
         RepositoryProperties repoProps = new RepositoryProperties();
         repoProps.setPath(temporaryFolder.getRoot());
+        KnowledgeBaseProperties kbProperties = new KnowledgeBasePropertiesImpl();
         EntityManager entityManager = testEntityManager.getEntityManager();
         testFixtures = new TestFixtures(testEntityManager);
-        sut = new KnowledgeBaseServiceImpl(repoProps, entityManager);
+        sut = new KnowledgeBaseServiceImpl(repoProps, kbProperties, entityManager);
         project = testFixtures.createProject(PROJECT_NAME);
         kb.setProject(project);
         if (kb.getType() == RepositoryType.LOCAL) {

--- a/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseSubPropertyLabelTest.java
+++ b/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseSubPropertyLabelTest.java
@@ -50,6 +50,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.RepositoryProperties;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBaseProperties;
+import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBasePropertiesImpl;
 import de.tudarmstadt.ukp.inception.kb.graph.KBHandle;
 import de.tudarmstadt.ukp.inception.kb.graph.KBInstance;
 import de.tudarmstadt.ukp.inception.kb.graph.KBProperty;
@@ -107,9 +109,10 @@ public class KnowledgeBaseSubPropertyLabelTest
     public void setUp() {
         RepositoryProperties repoProps = new RepositoryProperties();
         repoProps.setPath(temporaryFolder.getRoot());
+        KnowledgeBaseProperties kbProperties = new KnowledgeBasePropertiesImpl();
         EntityManager entityManager = testEntityManager.getEntityManager();
         testFixtures = new TestFixtures(testEntityManager);
-        sut = new KnowledgeBaseServiceImpl(repoProps, entityManager);
+        sut = new KnowledgeBaseServiceImpl(repoProps, kbProperties, entityManager);
         project = createProject(PROJECT_NAME);
     }
 

--- a/inception-search-mtas/src/test/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndexTest.java
+++ b/inception-search-mtas/src/test/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndexTest.java
@@ -98,6 +98,8 @@ import de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
 import de.tudarmstadt.ukp.inception.kb.KnowledgeBaseService;
 import de.tudarmstadt.ukp.inception.kb.KnowledgeBaseServiceImpl;
+import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBaseProperties;
+import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBasePropertiesImpl;
 import de.tudarmstadt.ukp.inception.search.FeatureIndexingSupport;
 import de.tudarmstadt.ukp.inception.search.FeatureIndexingSupportRegistry;
 import de.tudarmstadt.ukp.inception.search.FeatureIndexingSupportRegistryImpl;
@@ -584,7 +586,7 @@ public class MtasDocumentIndexTest
         @Bean
         public KnowledgeBaseService knowledgeBaseService()
         {
-            return new KnowledgeBaseServiceImpl(repositoryProperties());
+            return new KnowledgeBaseServiceImpl(repositoryProperties(), knowledgeBaseProperties());
         }
 
         @Bean
@@ -632,6 +634,12 @@ public class MtasDocumentIndexTest
         public RepositoryProperties repositoryProperties()
         {
             return new RepositoryProperties();
+        }
+
+        @Bean
+        public KnowledgeBaseProperties knowledgeBaseProperties()
+        {
+            return new KnowledgeBasePropertiesImpl();
         }
 
         @Bean

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureSupport.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureSupport.java
@@ -81,7 +81,7 @@ public class ConceptFeatureSupport
     
     private LoadingCache<Key, KBHandle> labelCache = Caffeine.newBuilder()
         .maximumSize(10_000)
-        .expireAfterWrite(1, TimeUnit.MINUTES)
+        .expireAfterWrite(10, TimeUnit.MINUTES)
         .refreshAfterWrite(1, TimeUnit.MINUTES)
         .build(key -> loadLabelValue(key));
     


### PR DESCRIPTION
**What's in the PR**
- Introduce a cache at the level of the KnowledgeBaseService which caches queries on a per-KB basis
- Invalidate caches if the configuration of the KBs of a project is changed
- Use cache for read-only KBs for most queries
- Introduce settings to configure the KB cache behavior

**How to test manually**
* Use entity linking
* Use the KB page
* To see cache usage, set the log level for the KB service to `TRACE`

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
