### PR TITLE
#1576 - External recommender should interpret 429 as busy

### DIFF
--- a/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommender.java
+++ b/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommender.java
@@ -138,9 +138,12 @@ public class ExternalRecommender
         Request request = new Request.Builder().url(url).post(body).build();
 
         try (Response response = sendRequest(request)) {
+            if (response.code() == HTTP_TOO_MANY_REQUESTS) {
+                LOG.info("External recommender is already training");
+            }
             // If the response indicates that the request was not successful,
             // then it does not make sense to go on and try to decode the XMI
-            if (!response.isSuccessful()) {
+            else if (!response.isSuccessful()) {
                 int code = response.code();
                 String responseBody = getResponseBody(response);
                 String msg = format("Request was not successful: [%d] - [%s]", code, responseBody);
@@ -170,12 +173,9 @@ public class ExternalRecommender
         Request request = new Request.Builder().url(url).post(body).build();
 
         try (Response response = sendRequest(request)) {
-            if (response.code() == HTTP_TOO_MANY_REQUESTS) {
-                LOG.info("External recommender is already training");
-            }
             // If the response indicates that the request was not successful,
             // then it does not make sense to go on and try to decode the XMI
-            else if (!response.isSuccessful()) {
+            if (!response.isSuccessful()) {
                 int code = response.code();
                 String responseBody = getResponseBody(response);
                 String msg = format("Request was not successful: [%d] - [%s]", code, responseBody);

--- a/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommender.java
+++ b/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommender.java
@@ -71,6 +71,9 @@ public class ExternalRecommender
     
     private static final Logger LOG = LoggerFactory.getLogger(ExternalRecommender.class);
     private static final MediaType JSON = MediaType.parse("application/json");
+
+    private static final int HTTP_TOO_MANY_REQUESTS = 429;
+
     private static final long CONNECT_TIMEOUT = 30;
     private static final long WRITE_TIMEOUT = 30;
     private static final long READ_TIMEOUT = 30;
@@ -167,9 +170,12 @@ public class ExternalRecommender
         Request request = new Request.Builder().url(url).post(body).build();
 
         try (Response response = sendRequest(request)) {
+            if (response.code() == HTTP_TOO_MANY_REQUESTS) {
+                LOG.info("External recommender is already training");
+            }
             // If the response indicates that the request was not successful,
             // then it does not make sense to go on and try to decode the XMI
-            if (!response.isSuccessful()) {
+            else if (!response.isSuccessful()) {
                 int code = response.code();
                 String responseBody = getResponseBody(response);
                 String msg = format("Request was not successful: [%d] - [%s]", code, responseBody);


### PR DESCRIPTION

**What's in the PR**
- Do not throw on 429

**How to test manually**
* Setup an external recommender that trains (preferably long) and see the log for errors regarding 429

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
