### PR TITLE
#1595 - KB entity not displayed in candidates' dropdown

### DIFF
--- a/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/service/ConceptLinkingServiceImpl.java
+++ b/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/service/ConceptLinkingServiceImpl.java
@@ -365,7 +365,7 @@ public class ConceptLinkingServiceImpl
         long startTime = currentTimeMillis();
         
         // Set the feature values
-        List<CandidateEntity> candidates = aCandidates.parallelStream()
+        List<CandidateEntity> candidates = aCandidates.stream()
                 .map(CandidateEntity::new)
                 .map(candidate -> initCandidate(candidate, aQuery, aMention, aCas, aBegin))
                 .map(candidate -> {
@@ -386,7 +386,6 @@ public class ConceptLinkingServiceImpl
                     handle.setDebugInfo(String.valueOf(candidate.getFeatures()));
                     return handle;
                 })
-                .limit(properties.getCandidateDisplayLimit())
                 .collect(Collectors.toList());
         
         int rank = 1;

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/KnowledgeBasePanel.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/KnowledgeBasePanel.java
@@ -20,6 +20,7 @@ package de.tudarmstadt.ukp.inception.ui.kb;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.Component;
@@ -44,6 +45,7 @@ import org.wicketstuff.event.annotation.OnEvent;
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.form.select.BootstrapSelect;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxFormComponentUpdatingBehavior;
+import de.tudarmstadt.ukp.inception.conceptlinking.config.EntityLinkingProperties;
 import de.tudarmstadt.ukp.inception.conceptlinking.service.ConceptLinkingService;
 import de.tudarmstadt.ukp.inception.kb.KnowledgeBaseService;
 import de.tudarmstadt.ukp.inception.kb.graph.KBConcept;
@@ -84,6 +86,7 @@ public class KnowledgeBasePanel
 
     private @SpringBean KnowledgeBaseService kbService;
     private @SpringBean ConceptLinkingService conceptLinkingService;
+    private @SpringBean EntityLinkingProperties entityLinkingProperties;
 
     private IModel<KnowledgeBase> kbModel;
     private Model<KBObject> selectedConceptHandle = Model.of();
@@ -173,7 +176,9 @@ public class KnowledgeBasePanel
     {
         List<KBHandle> results;
         KnowledgeBase kb = kbModel.getObject();
-        results = conceptLinkingService.searchItems(kb, aTypedString);
+        results = conceptLinkingService.searchItems(kb, aTypedString).stream()
+            .limit(entityLinkingProperties.getCandidateDisplayLimit())
+            .collect(Collectors.toList());
         return results;
     }
 

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureEditor.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureEditor.java
@@ -71,6 +71,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.keybindings.KeyBindingsP
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.FeatureState;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.inception.conceptlinking.config.EntityLinkingProperties;
 import de.tudarmstadt.ukp.inception.conceptlinking.service.ConceptLinkingService;
 import de.tudarmstadt.ukp.inception.kb.ConceptFeatureTraits;
 import de.tudarmstadt.ukp.inception.kb.KnowledgeBaseService;
@@ -95,6 +96,7 @@ public class ConceptFeatureEditor
     private @SpringBean KnowledgeBaseService kbService;
     private @SpringBean FeatureSupportRegistry featureSupportRegistry;
     private @SpringBean ConceptLinkingService clService;
+    private @SpringBean EntityLinkingProperties entityLinkingProperties;
 
     public ConceptFeatureEditor(String aId, MarkupContainer aItem, IModel<FeatureState> aModel,
             IModel<AnnotatorState> aStateModel, AnnotationActionHandler aHandler)
@@ -236,7 +238,9 @@ public class ConceptFeatureEditor
                     .collect(Collectors.toList());
         }
         
-        return choices;
+        return choices.stream()
+                .limit(entityLinkingProperties.getCandidateDisplayLimit())
+                .collect(Collectors.toList());
     }
 
     private ConceptFeatureTraits readFeatureTraits(AnnotationFeature aAnnotationFeature)


### PR DESCRIPTION
**What's in the PR**
- First rank, then filter, then limit
- Turn parallel stream into stream

**How to test manually**
* Check that Paris is in Wikidata when linking it and searching via `paris::capital`
* Check that KB editor has maximum of display limit = 100 entries

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
