### PR TITLE
#1623 - Reduce time when importing a large number of documents via the UI

### DIFF
--- a/inception-app-webapp/pom.xml
+++ b/inception-app-webapp/pom.xml
@@ -30,13 +30,6 @@
     <docker.image.name>inceptionproject/inception-snapshots</docker.image.name>
   </properties>
   <dependencies>
-  <!--  
-    <dependency>
-      <groupId>xml-apis</groupId>
-      <artifactId>xml-apis</artifactId>
-    </dependency>
-    -->
-  
     <!-- INCEPTION - CORE DEPENDENCIES -->
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
@@ -423,11 +416,6 @@
     </dependency>
 
     <dependency>
-      <groupId>commons-fileupload</groupId>
-      <artifactId>commons-fileupload</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-entitymanager</artifactId>
     </dependency>
@@ -768,7 +756,6 @@
               <usedDependency>org.springframework:spring-webmvc</usedDependency>
               <usedDependency>org.springframework:spring-expression</usedDependency>
               <!-- Spring Web MVC data conversion -->
-              <usedDependency>commons-fileupload:commons-fileupload</usedDependency>
               <usedDependency>de.tudarmstadt.ukp.inception.app:inception-recommendation</usedDependency>	
               <!-- Spring AOP
                 <usedDependency>org.springframework:spring-aop</usedDependency>

--- a/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/formats/ImsCwbFormatSupport.java
+++ b/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/formats/ImsCwbFormatSupport.java
@@ -21,6 +21,7 @@ import static org.apache.uima.fit.factory.CollectionReaderFactory.createReaderDe
 
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.imscwb.ImsCwbReader;
 import org.springframework.stereotype.Component;
 
@@ -58,7 +59,8 @@ public class ImsCwbFormatSupport
 //    }
 
     @Override
-    public CollectionReaderDescription getReaderDescription() throws ResourceInitializationException
+    public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
+        throws ResourceInitializationException
     {
         return createReaderDescription(ImsCwbReader.class);
     }

--- a/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/formats/ImsCwbFormatSupport.java
+++ b/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/formats/ImsCwbFormatSupport.java
@@ -62,7 +62,7 @@ public class ImsCwbFormatSupport
     public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
         throws ResourceInitializationException
     {
-        return createReaderDescription(ImsCwbReader.class);
+        return createReaderDescription(ImsCwbReader.class, aTSD);
     }
     
 //    @Override

--- a/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/formats/LifFormatSupport.java
+++ b/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/formats/LifFormatSupport.java
@@ -24,6 +24,7 @@ import org.apache.uima.analysis_engine.AnalysisEngineDescription;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.lif.LifReader;
 import org.dkpro.core.io.lif.LifWriter;
 import org.springframework.stereotype.Component;
@@ -63,13 +64,15 @@ public class LifFormatSupport
     }
 
     @Override
-    public CollectionReaderDescription getReaderDescription() throws ResourceInitializationException
+    public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
+        throws ResourceInitializationException
     {
         return createReaderDescription(LifReader.class);
     }
     
     @Override
-    public AnalysisEngineDescription getWriterDescription(Project aProject, CAS aCAS)
+    public AnalysisEngineDescription getWriterDescription(Project aProject,
+            TypeSystemDescription aTSD, CAS aCAS)
         throws ResourceInitializationException
     {
         return createEngineDescription(LifWriter.class);

--- a/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/formats/LifFormatSupport.java
+++ b/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/formats/LifFormatSupport.java
@@ -67,7 +67,7 @@ public class LifFormatSupport
     public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
         throws ResourceInitializationException
     {
-        return createReaderDescription(LifReader.class);
+        return createReaderDescription(LifReader.class, aTSD);
     }
     
     @Override
@@ -75,6 +75,6 @@ public class LifFormatSupport
             TypeSystemDescription aTSD, CAS aCAS)
         throws ResourceInitializationException
     {
-        return createEngineDescription(LifWriter.class);
+        return createEngineDescription(LifWriter.class, aTSD);
     }
 }

--- a/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/formats/NifFormatSupport.java
+++ b/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/formats/NifFormatSupport.java
@@ -24,6 +24,7 @@ import org.apache.uima.analysis_engine.AnalysisEngineDescription;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.nif.NifReader;
 import org.dkpro.core.io.nif.NifWriter;
 import org.springframework.stereotype.Component;
@@ -63,13 +64,15 @@ public class NifFormatSupport
     }
 
     @Override
-    public CollectionReaderDescription getReaderDescription() throws ResourceInitializationException
+    public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
+        throws ResourceInitializationException
     {
         return createReaderDescription(NifReader.class);
     }
     
     @Override
-    public AnalysisEngineDescription getWriterDescription(Project aProject, CAS aCAS)
+    public AnalysisEngineDescription getWriterDescription(Project aProject,
+            TypeSystemDescription aTSD, CAS aCAS)
         throws ResourceInitializationException
     {
         return createEngineDescription(NifWriter.class);

--- a/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/formats/NifFormatSupport.java
+++ b/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/formats/NifFormatSupport.java
@@ -67,7 +67,7 @@ public class NifFormatSupport
     public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
         throws ResourceInitializationException
     {
-        return createReaderDescription(NifReader.class);
+        return createReaderDescription(NifReader.class, aTSD);
     }
     
     @Override
@@ -75,6 +75,6 @@ public class NifFormatSupport
             TypeSystemDescription aTSD, CAS aCAS)
         throws ResourceInitializationException
     {
-        return createEngineDescription(NifWriter.class);
+        return createEngineDescription(NifWriter.class, aTSD);
     }
 }

--- a/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/formats/PerseusFormatSupport.java
+++ b/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/formats/PerseusFormatSupport.java
@@ -21,6 +21,7 @@ import static org.apache.uima.fit.factory.CollectionReaderFactory.createReaderDe
 
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.perseus.PerseusReader;
 import org.springframework.stereotype.Component;
 
@@ -58,7 +59,8 @@ public class PerseusFormatSupport
     }
 
     @Override
-    public CollectionReaderDescription getReaderDescription() throws ResourceInitializationException
+    public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
+        throws ResourceInitializationException
     {
         return createReaderDescription(PerseusReader.class);
     }

--- a/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/formats/PerseusFormatSupport.java
+++ b/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/formats/PerseusFormatSupport.java
@@ -62,6 +62,6 @@ public class PerseusFormatSupport
     public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
         throws ResourceInitializationException
     {
-        return createReaderDescription(PerseusReader.class);
+        return createReaderDescription(PerseusReader.class, aTSD);
     }
 }

--- a/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/formats/TeiFormatSupport.java
+++ b/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/formats/TeiFormatSupport.java
@@ -24,6 +24,7 @@ import org.apache.uima.analysis_engine.AnalysisEngineDescription;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.tei.TeiReader;
 import org.dkpro.core.io.tei.TeiWriter;
 import org.springframework.stereotype.Component;
@@ -63,13 +64,15 @@ public class TeiFormatSupport
     }
     
     @Override
-    public CollectionReaderDescription getReaderDescription() throws ResourceInitializationException
+    public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
+        throws ResourceInitializationException
     {
         return createReaderDescription(TeiReader.class);
     }
     
     @Override
-    public AnalysisEngineDescription getWriterDescription(Project aProject, CAS aCAS)
+    public AnalysisEngineDescription getWriterDescription(Project aProject,
+            TypeSystemDescription aTSD, CAS aCAS)
         throws ResourceInitializationException
     {
         return createEngineDescription(TeiWriter.class);

--- a/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/formats/TeiFormatSupport.java
+++ b/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/formats/TeiFormatSupport.java
@@ -67,7 +67,7 @@ public class TeiFormatSupport
     public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
         throws ResourceInitializationException
     {
-        return createReaderDescription(TeiReader.class);
+        return createReaderDescription(TeiReader.class, aTSD);
     }
     
     @Override
@@ -75,6 +75,6 @@ public class TeiFormatSupport
             TypeSystemDescription aTSD, CAS aCAS)
         throws ResourceInitializationException
     {
-        return createEngineDescription(TeiWriter.class);
+        return createEngineDescription(TeiWriter.class, aTSD);
     }
 }

--- a/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/formats/UimaInlineXmlTeiFormatSupport.java
+++ b/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/formats/UimaInlineXmlTeiFormatSupport.java
@@ -22,6 +22,7 @@ import static org.apache.uima.fit.factory.AnalysisEngineFactory.createEngineDesc
 import org.apache.uima.analysis_engine.AnalysisEngineDescription;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.xml.InlineXmlWriter;
 import org.springframework.stereotype.Component;
 
@@ -54,7 +55,8 @@ public class UimaInlineXmlTeiFormatSupport
     }
 
     @Override
-    public AnalysisEngineDescription getWriterDescription(Project aProject, CAS aCAS)
+    public AnalysisEngineDescription getWriterDescription(Project aProject,
+            TypeSystemDescription aTSD, CAS aCAS)
         throws ResourceInitializationException
     {
         return createEngineDescription(InlineXmlWriter.class);

--- a/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/formats/UimaInlineXmlTeiFormatSupport.java
+++ b/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/formats/UimaInlineXmlTeiFormatSupport.java
@@ -59,6 +59,6 @@ public class UimaInlineXmlTeiFormatSupport
             TypeSystemDescription aTSD, CAS aCAS)
         throws ResourceInitializationException
     {
-        return createEngineDescription(InlineXmlWriter.class);
+        return createEngineDescription(InlineXmlWriter.class, aTSD);
     }
 }

--- a/inception-external-search-pubannotation/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/pubannotation/format/PubAnnotationSectionsFormatSupport.java
+++ b/inception-external-search-pubannotation/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/pubannotation/format/PubAnnotationSectionsFormatSupport.java
@@ -21,6 +21,7 @@ import static org.apache.uima.fit.factory.CollectionReaderFactory.createReaderDe
 
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.springframework.stereotype.Component;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
@@ -51,7 +52,8 @@ public class PubAnnotationSectionsFormatSupport
     }
 
     @Override
-    public CollectionReaderDescription getReaderDescription() throws ResourceInitializationException
+    public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
+        throws ResourceInitializationException
     {
         return createReaderDescription(PubAnnotationSectionsReader.class);
     }

--- a/inception-external-search-pubannotation/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/pubannotation/format/PubAnnotationSectionsFormatSupport.java
+++ b/inception-external-search-pubannotation/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/pubannotation/format/PubAnnotationSectionsFormatSupport.java
@@ -55,6 +55,6 @@ public class PubAnnotationSectionsFormatSupport
     public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
         throws ResourceInitializationException
     {
-        return createReaderDescription(PubAnnotationSectionsReader.class);
+        return createReaderDescription(PubAnnotationSectionsReader.class, aTSD);
     }
 }

--- a/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/htmleditor/HtmlFormatSupport.java
+++ b/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/htmleditor/HtmlFormatSupport.java
@@ -56,6 +56,6 @@ public class HtmlFormatSupport
     public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
         throws ResourceInitializationException
     {
-        return createReaderDescription(HtmlReader.class);
+        return createReaderDescription(HtmlReader.class, aTSD);
     }
 }

--- a/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/htmleditor/HtmlFormatSupport.java
+++ b/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/htmleditor/HtmlFormatSupport.java
@@ -21,6 +21,7 @@ import static org.apache.uima.fit.factory.CollectionReaderFactory.createReaderDe
 
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.html.HtmlReader;
 import org.springframework.stereotype.Component;
 
@@ -52,7 +53,8 @@ public class HtmlFormatSupport
     }
     
     @Override
-    public CollectionReaderDescription getReaderDescription() throws ResourceInitializationException
+    public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
+        throws ResourceInitializationException
     {
         return createReaderDescription(HtmlReader.class);
     }

--- a/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/PdfFormatSupport.java
+++ b/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/PdfFormatSupport.java
@@ -56,6 +56,6 @@ public class PdfFormatSupport
     public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
         throws ResourceInitializationException
     {
-        return createReaderDescription(PdfReader.class);
+        return createReaderDescription(PdfReader.class, aTSD);
     }
 }

--- a/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/PdfFormatSupport.java
+++ b/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/PdfFormatSupport.java
@@ -21,6 +21,7 @@ import static org.apache.uima.fit.factory.CollectionReaderFactory.createReaderDe
 
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.pdf.PdfReader;
 import org.springframework.stereotype.Component;
 
@@ -52,7 +53,8 @@ public class PdfFormatSupport
     }
     
     @Override
-    public CollectionReaderDescription getReaderDescription() throws ResourceInitializationException
+    public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
+        throws ResourceInitializationException
     {
         return createReaderDescription(PdfReader.class);
     }

--- a/inception-ui-core/pom.xml
+++ b/inception-ui-core/pom.xml
@@ -165,8 +165,9 @@
       <artifactId>inception-support</artifactId>
     </dependency>
     <dependency>
-    	<groupId>javax.servlet</groupId>
-    	<artifactId>javax.servlet-api</artifactId>
+     <groupId>javax.servlet</groupId>
+     <artifactId>javax.servlet-api</artifactId>
+     <scope>provided</scope> 
     </dependency>
   </dependencies>
   

--- a/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/SearchPage.java
+++ b/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/SearchPage.java
@@ -137,6 +137,7 @@ public class SearchPage extends ApplicationPageBase
         } catch (IOException e) {
             LOG.error(e.getMessage(), e);
             error(e.getMessage() + " - " + ExceptionUtils.getRootCauseMessage(e));
+            aTarget.addChildren(getPage(), IFeedback.class);
         }
     }
 


### PR DESCRIPTION
**What's in the PR**
- Adjust to upstream changes
- Remove unnecessary dependency on commons-fileupload (Wicket needs it and draws it in transitively)
- Mark the servlet-api as provided so we don't include it in the JAR/WAR builds
- Fix issue on external search page causing feedback messages not to be displayed when an import completes/fails

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
