### PR TITLE
#1658 - Port and protocol information for external document repositories ignored

### DIFF
--- a/inception-external-search-elastic/src/main/resources/META-INF/asciidoc/user-guide/external-search-repos-elasticsearch.adoc
+++ b/inception-external-search-elastic/src/main/resources/META-INF/asciidoc/user-guide/external-search-repos-elasticsearch.adoc
@@ -6,7 +6,7 @@ Selecting the **ElasticSearch** repository type allows connecting to remote Elas
 In order to set up a connection to an ElasticSearch repository, the following information needs to
 be provided:
 
-* *Remote URL*: the URL where the ElasticSearch instance is running (e.g. `http://localhost:9200/`)
+* *Remote URL*: the URL where the ElasticSearch instance is running (e.g. `http://localhost:9200/`) 
 * *Index Name*: the name of the index within the instance (e.g. `mycorpus`)
 * *Search path*: the suffix used to access the searching endpoint (usually `_search`)
 * *Object type*: the endpoint used to download the full document text (usually `texts`)
@@ -17,6 +17,10 @@ From this information, two URLs are constructed:
 
 * the search URL: `<URL>/<index name>/<search path>`
 * the document retrieval URL as: `<URL>/<index name>/<object type>/<document id>`
+
+NOTE: From the *remote URL* field, only the protocol, hostname and port information is used. Any 
+      path information appearing after the port number is discarded and replaced by the index name and 
+      search path as outlined above.
 
 The individual documents should contain following two fields as their source:
 


### PR DESCRIPTION
**What's in the PR**
- Parse the URL and properly forward protocol, hostname and port info to the ElasticSearch client
- Centralize building of client to a single method

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
