### PR TITLE
#1715 AL sidebar is missing

### DIFF
--- a/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/config/ActiveLearningAutoConfiguration.java
+++ b/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/config/ActiveLearningAutoConfiguration.java
@@ -33,11 +33,10 @@ import de.tudarmstadt.ukp.inception.active.learning.sidebar.ActiveLearningSideba
 import de.tudarmstadt.ukp.inception.recommendation.api.LearningRecordService;
 import de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService;
 import de.tudarmstadt.ukp.inception.recommendation.config.RecommenderServiceAutoConfiguration;
-import de.tudarmstadt.ukp.inception.recommendation.sidebar.RecommendationSidebarFactory;
 
 @Configuration
 @AutoConfigureAfter(RecommenderServiceAutoConfiguration.class)
-@ConditionalOnBean(RecommendationSidebarFactory.class)
+@ConditionalOnBean(RecommendationService.class)
 @ConditionalOnProperty(
     prefix = "recommender.active-learning", 
     name = "enabled", 

--- a/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/config/ActiveLearningAutoConfiguration.java
+++ b/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/config/ActiveLearningAutoConfiguration.java
@@ -33,11 +33,11 @@ import de.tudarmstadt.ukp.inception.active.learning.sidebar.ActiveLearningSideba
 import de.tudarmstadt.ukp.inception.recommendation.api.LearningRecordService;
 import de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService;
 import de.tudarmstadt.ukp.inception.recommendation.config.RecommenderServiceAutoConfiguration;
-import de.tudarmstadt.ukp.inception.recommendation.sidebar.RecommendationSidebar;
+import de.tudarmstadt.ukp.inception.recommendation.sidebar.RecommendationSidebarFactory;
 
 @Configuration
 @AutoConfigureAfter(RecommenderServiceAutoConfiguration.class)
-@ConditionalOnBean(RecommendationSidebar.class)
+@ConditionalOnBean(RecommendationSidebarFactory.class)
 @ConditionalOnProperty(
     prefix = "recommender.active-learning", 
     name = "enabled", 

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/config/RecommenderServiceAutoConfiguration.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/config/RecommenderServiceAutoConfiguration.java
@@ -46,6 +46,7 @@ import de.tudarmstadt.ukp.inception.recommendation.log.RecommendationAcceptedEve
 import de.tudarmstadt.ukp.inception.recommendation.log.RecommendationRejectedEventAdapter;
 import de.tudarmstadt.ukp.inception.recommendation.log.RecommenderDeletedEventAdapter;
 import de.tudarmstadt.ukp.inception.recommendation.log.RecommenderEvaluationResultEventAdapter;
+import de.tudarmstadt.ukp.inception.recommendation.metrics.RecommendationMetricsImpl;
 import de.tudarmstadt.ukp.inception.recommendation.project.RecommenderProjectSettingsPanelFactory;
 import de.tudarmstadt.ukp.inception.recommendation.service.LearningRecordServiceImpl;
 import de.tudarmstadt.ukp.inception.recommendation.service.RecommendationServiceImpl;
@@ -154,5 +155,13 @@ public class RecommenderServiceAutoConfiguration
             @Lazy @Autowired(required = false) List<RecommendationEngineFactory> aExtensions)
     {
         return new RecommenderFactoryRegistryImpl(aExtensions);
+    }
+    
+    @Bean
+    @Autowired
+    @ConditionalOnProperty(prefix = "monitoring.metrics", name = "enabled", havingValue = "true")
+    public RecommendationMetricsImpl recommendationMetricsImpl(RecommendationService aRecService) {
+        return new RecommendationMetricsImpl(aRecService);
+        
     }
 }

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/metrics/RecommendationMetricsImpl.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/metrics/RecommendationMetricsImpl.java
@@ -18,16 +18,18 @@
 package de.tudarmstadt.ukp.inception.recommendation.metrics;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.jmx.export.annotation.ManagedAttribute;
 import org.springframework.jmx.export.annotation.ManagedResource;
-import org.springframework.stereotype.Service;
 
 import de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService;
 
 @ManagedResource
-@Service
-@ConditionalOnProperty(prefix = "monitoring.metrics", name = "enabled", havingValue = "true")
+/**
+ * <p>
+ * This class is exposed as a Spring Component via
+ * {@link RecommenderServiceAutoConfiguration#recommendationMetricsImpl}.
+ * </p>
+ */
 public class RecommendationMetricsImpl
     implements RecommendationMetrics
 {


### PR DESCRIPTION
Active Learning sidebar was no longer shown.

**What's in the PR**
* Fixed AL autoconfiguration to be conditional on recommendersidebar factory instead of the sidebar itself.
* Made RecommendationMetrics conditional on recommenders enabled.

**How to test manually**
* Open the annotation page and check that the AL sidebar is there
* Check e.g. with jconsole that metric on enabled recommenders is calculated
* Test with settings `recommender.enabled=false`-> neither recommendersidebar nor AL sidebar should be shown
* Test with settings `recommender.active-learning.enabled=false`-> recommendersidebar should be shown but not AL sidebar 


