### PR TITLE
#1742 CurationSidebar: error when no users are selected

### DIFF
--- a/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/CurationServiceImpl.java
+++ b/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/CurationServiceImpl.java
@@ -248,8 +248,12 @@ public class CurationServiceImpl
     private List<User> queryDBForFinishedUsers(List<User> aUsers, Project aProject, 
             SourceDocument aDocument)
     {
-        Validate.notNull(aUsers, "Users must be specified");
+        Validate.notNull(aDocument, "Document must be specified");
         Validate.notNull(aProject, "project must be specified");
+        
+        if (aUsers == null || aUsers.isEmpty()) {
+            return new ArrayList<>();
+        }
         
         String query = String.join("\n",
                 "SELECT u FROM User u, AnnotationDocument d",


### PR DESCRIPTION
**What's in the PR**
* Check that user list is not null or empty before querying database.

**How to test manually**
1. Go to Annotation Page with curation sidebar enabled in properties file `curation.sidebar.enabled=true`.
2. Click on Curationsidebar
3. No error should occur
