### PR TITLE
#1792 - Specific token spans cause SPARQL queries to fail in Fuseki

### DIFF
--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
@@ -932,8 +932,9 @@ public class SPARQLQueryBuilder
         List<GraphPattern> valuePatterns = new ArrayList<>();
         for (String value : aValues) {
             String sanitizedValue = sanitizeQueryStringForFTS(value);
+            String fuzzyQuery = convertToFuzzyMatchingQuery(sanitizedValue);
 
-            if (StringUtils.isBlank(sanitizedValue)) {
+            if (StringUtils.isBlank(sanitizedValue) || StringUtils.isBlank(fuzzyQuery)) {
                 continue;
             }
             
@@ -944,8 +945,6 @@ public class SPARQLQueryBuilder
                 String language = kb.getDefaultLanguage() != null ? kb.getDefaultLanguage() : "en";
                 sanitizedValue = sanitizedValue.toLowerCase(Locale.forLanguageTag(language));
             }
-            
-            String fuzzyQuery = convertToFuzzyMatchingQuery(sanitizedValue);
 
             valuePatterns.add(VAR_SUBJECT
                     .has(FUSEKI_QUERY, collectionOf(VAR_LABEL_PROPERTY, literalOf(fuzzyQuery)))

--- a/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/EventRepositoryImpl.java
+++ b/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/EventRepositoryImpl.java
@@ -62,7 +62,10 @@ public class EventRepositoryImpl
             entityManager.persist(event);
         }
         long duration = System.currentTimeMillis() - start;
-        log.debug("... {} events stored ... ({}ms)", aEvents.length, duration);
+
+        if (aEvents.length > 0) {
+            log.debug("... {} events stored ... ({}ms)", aEvents.length, duration);
+        }
     }
 
     @Override


### PR DESCRIPTION
**What's in the PR**
* Do not send empty FTS queries to Fueski

**How to test manually**
* Have a text with "1-1" or "vs." and try to entity link that span

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
