### PR TITLE
#1810 Dismissing recommendations no longer works

### DIFF
--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/RecommendationEditorExtension.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/RecommendationEditorExtension.java
@@ -36,6 +36,7 @@ import java.util.Optional;
 
 import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.text.AnnotationFS;
+import org.apache.wicket.Page;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.event.Broadcast;
 import org.apache.wicket.feedback.IFeedback;
@@ -54,6 +55,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.AnnotationExce
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRegistry;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.VID;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.rendering.event.SelectionChangedEvent;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.rendering.model.VDocument;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.rendering.model.VLazyDetailResult;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil;
@@ -262,7 +264,8 @@ public class RecommendationEditorExtension
                 suggestion, layer, feature, REJECTED, MAIN_EDITOR);
 
         // Trigger a re-rendering of the document
-        aActionHandler.actionSelect(aTarget);
+        Page page = aTarget.getPage();
+        page.send(page, Broadcast.BREADTH, new SelectionChangedEvent(aTarget));
         
         // Send an application event that the suggestion has been rejected
         applicationEventPublisher.publishEvent(new RecommendationRejectedEvent(this, document,
@@ -270,7 +273,7 @@ public class RecommendationEditorExtension
                 suggestion.getCoveredText(), feature, suggestion.getLabel()));
 
         // Send a UI event that the suggestion has been rejected
-        aTarget.getPage().send(aTarget.getPage(), Broadcast.BREADTH,
+        page.send(page, Broadcast.BREADTH,
                 new AjaxRecommendationRejectedEvent(aTarget, aState, recommendationVID));
     }
     


### PR DESCRIPTION
Dismissing recommendations by double-click did no longer work because the document was not re-rendered.

**What's in the PR**
* Trigger reloading differently in editor extension

**How to test manually**
* Have a recommender enabled and start annotating
* dismiss a recommendation, it should disappear immediately
