### PR TITLE
#1812 Tutorial fails on setting tabs

### DIFF
--- a/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/footer/resources/tutorial.js
+++ b/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/footer/resources/tutorial.js
@@ -402,7 +402,7 @@ function createDashboardRoutine() {
 function createOpenDocumentsRoutine(enjoyHint) {
 	var a = [
 		    {
-		    	'click .tab1' : 'Click here to add a document to the project.',
+		    	'click li:contains(Documents)' : 'Click here to add a document to the project.',
 		    	'showSkip': false
 		    }
 			];
@@ -425,7 +425,7 @@ function createAddDocumentRoutine(enjoyHint) {
 function createOpenRecommendersRoutine(enjoyHint) {
 	var a = [
 			{
-				'click .tab5' : 'Now, lets add a recommender. Click here!',
+				'click li:contains(Recommenders)' : 'Now, lets add a recommender. Click here!',
 				'showSkip': false
 		    }
 			];

--- a/inception-workload/src/main/java/de/tudarmstadt/ukp/inception/workload/settings/ProjectWorkloadSettingsPanelFactory.java
+++ b/inception-workload/src/main/java/de/tudarmstadt/ukp/inception/workload/settings/ProjectWorkloadSettingsPanelFactory.java
@@ -33,7 +33,7 @@ import de.tudarmstadt.ukp.inception.workload.extension.WorkloadManagerExtensionP
  * {@link WorkloadManagementAutoConfiguration#projectWorkloadSettingsPanelFactory}.
  * </p>
  */
-@Order(600)
+@Order(340)
 public class ProjectWorkloadSettingsPanelFactory
     implements ProjectSettingsPanelFactory
 {

--- a/inception-workload/src/main/java/de/tudarmstadt/ukp/inception/workload/settings/ProjectWorkloadSettingsPanelFactory.java
+++ b/inception-workload/src/main/java/de/tudarmstadt/ukp/inception/workload/settings/ProjectWorkloadSettingsPanelFactory.java
@@ -33,7 +33,7 @@ import de.tudarmstadt.ukp.inception.workload.extension.WorkloadManagerExtensionP
  * {@link WorkloadManagementAutoConfiguration#projectWorkloadSettingsPanelFactory}.
  * </p>
  */
-@Order(300)
+@Order(600)
 public class ProjectWorkloadSettingsPanelFactory
     implements ProjectSettingsPanelFactory
 {


### PR DESCRIPTION
Tutorial failed because of change from previous tab order of the setting tabs. Naming the recommender tab that we want to select here does not work, because they are represented as links at the time. We will have to keep identifying the correct tab by order.

**What's in the PR**
* Change back to previous tab order.

**How to test manually**
* go through the tutorial and check that everything works

