### PR TITLE
Bugfix/1825 duplicates in search

### DIFF
--- a/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/FeatureIndexingSupport.java
+++ b/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/FeatureIndexingSupport.java
@@ -47,12 +47,20 @@ public interface FeatureIndexingSupport
      *            features.
      * @param aFeature
      *            the feature from which to extract the values.
+     * @return key/value pairs as a map
      */
     MultiValuedMap<String, String> indexFeatureValue(String aFieldPrefix,
             AnnotationFS aAnnotation, String aFeaturePrefix, AnnotationFeature aFeature);
 
     /**
      * Get the name of the feature how it is used in the index
+     * @param aFieldPrefix 
+     *            the layer name
+     * @param aFeaturePrefix possible prefix to the feature name, 
+     *            currently for source and target of relation annotations
+     * @param aFeature 
+     *            the feature
+     * @return index feature name
      */
     String featureIndexName(String aFieldPrefix, String aFeaturePrefix, AnnotationFeature aFeature);
 }

--- a/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchResult.java
+++ b/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchResult.java
@@ -149,6 +149,7 @@ public class SearchResult
     /**
      * Indicates whether the document to which this result applies cannot be modified by the user
      * who issued the query.
+     * @return whether the document is read-only
      */
     public boolean isReadOnly()
     {

--- a/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchService.java
+++ b/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchService.java
@@ -34,9 +34,19 @@ public interface SearchService
         throws IOException, ExecutionException;
 
     /**
-     * Receive the search results un-grouped as a list. See
-     * {@link #query(User, Project, String, SourceDocument, AnnotationLayer, AnnotationFeature, 
+     * Receive the search results un-grouped as a list. 
+     * See{@link #query(User, Project, String, SourceDocument, AnnotationLayer, AnnotationFeature, 
      * long, long)}
+     * @param aUser
+     *            the current user
+     * @param aProject
+     *            the project to search in
+     * @param aQuery
+     *            the search query
+     * @param aDocument
+     *            limit search to this document or search in the whole project if null
+     * @throws IOException
+     * @throws ExecutionException
      */
     List<SearchResult> query(User aUser, Project aProject, String aQuery, SourceDocument aDocument)
         throws IOException, ExecutionException;
@@ -50,6 +60,8 @@ public interface SearchService
      *            the current user
      * @param aProject
      *            the project to search in
+     * @param aQuery
+     *            the search query
      * @param aDocument
      *            limit search to this document or search in the whole project if null
      * @param aAnnotationLayer
@@ -75,7 +87,10 @@ public interface SearchService
 
     /**
      * This method is only for testing. It allows waiting until the indexing process has completed
-     * before issueing a query.
+     * before issuing a query.
+     * @param aProject
+     *           the project
+     * @return whether the index is flagged as valid
      */
     boolean isIndexValid(Project aProject);
 

--- a/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchServiceImpl.java
+++ b/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchServiceImpl.java
@@ -166,6 +166,7 @@ public class SearchServiceImpl
      * 
      * @param aEvent
      *            The BeforeProjectRemovedEvent event
+     * @throws IOException
      */
     @EventListener
     public void beforeProjectRemove(BeforeProjectRemovedEvent aEvent) throws IOException

--- a/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchServiceImpl.java
+++ b/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchServiceImpl.java
@@ -311,7 +311,7 @@ public class SearchServiceImpl
             // threads to update the index concurrently. The underlying index code should hopefully
             // be thread-safe...
             try {
-                index.getPhysicalIndex().reindexDocument(aSourceDocument, aBinaryCas);
+                index.getPhysicalIndex().indexDocument(aSourceDocument, aBinaryCas);
             }
             catch (IOException e) {
                 log.error("Error indexing source document [{}]({}) in project [{}]({})",
@@ -359,7 +359,7 @@ public class SearchServiceImpl
                         "Indexing new version of annotation document [{}]({}) in project [{}]({})",
                         aAnnotationDocument.getName(), aAnnotationDocument.getId(),
                         project.getName(), project.getId());
-                index.getPhysicalIndex().reindexDocument(aAnnotationDocument, aBinaryCas);
+                index.getPhysicalIndex().indexDocument(aAnnotationDocument, aBinaryCas);
             }
             catch (IOException e) {
                 log.error("Error indexing annotation document [{}]({}) in project [{}]({})",

--- a/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/event/SearchQueryEvent.java
+++ b/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/event/SearchQueryEvent.java
@@ -79,6 +79,7 @@ public class SearchQueryEvent
     
     /**
      * Query is limited to the given document.
+     * @return the source document if it exists or empty optional
      */
     public Optional<SourceDocument> getSourceDocument()
     {

--- a/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/index/PhysicalIndex.java
+++ b/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/index/PhysicalIndex.java
@@ -51,10 +51,6 @@ public interface PhysicalIndex
 
     long numberOfQueryResults(SearchQueryRequest aSearchQueryRequest)
         throws IOException, ExecutionException;
-    
-    void indexDocument(SourceDocument aDocument, byte[] aBinaryCas) throws IOException;
-
-    void indexDocument(AnnotationDocument aDocument, byte[] aBinaryCas) throws IOException;
 
     void deindexDocument(SourceDocument aDocument) throws IOException;
 
@@ -62,7 +58,7 @@ public interface PhysicalIndex
 
     void deindexDocument(AnnotationDocument aDocument, String aTimestamp) throws IOException;
     
-    void reindexDocument(AnnotationDocument aDocument, byte[] aBinaryCas) throws IOException;
+    void indexDocument(AnnotationDocument aDocument, byte[] aBinaryCas) throws IOException;
 
     void clear() throws IOException;
     
@@ -79,5 +75,5 @@ public interface PhysicalIndex
      */
     public Optional<String> getTimestamp(long aSrcDocId, long aAnnoDocId) throws IOException;
 
-    void reindexDocument(SourceDocument aSourceDocument, byte[] aBinaryCas) throws IOException;
+    void indexDocument(SourceDocument aSourceDocument, byte[] aBinaryCas) throws IOException;
 }

--- a/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/index/PhysicalIndex.java
+++ b/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/index/PhysicalIndex.java
@@ -38,6 +38,7 @@ public interface PhysicalIndex
     /**
      * Deletes the index data, e.g. by removing the index files from disk. If necessary, the index
      * is closed before.
+     * @throws IOException
      */
     void delete() throws IOException;
 
@@ -67,10 +68,13 @@ public interface PhysicalIndex
     
     /**
      * Retrieve the timestamp of this annotation document
-     * @param aDocument
-     *          The annotation document
-     * @return
-     *          The document timestamp field value. Empty string if document is not found.
+     * 
+     * @param aSrcDocId
+     *            the source document's ID
+     * @param aAnnoDocId
+     *            the annotation document's ID
+     * @return The first found document timestamp field value. Empty string if document is not
+     *         found.
      * @throws IOException
      */
     public Optional<String> getTimestamp(long aSrcDocId, long aAnnoDocId) throws IOException;

--- a/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/index/PhysicalIndex.java
+++ b/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/index/PhysicalIndex.java
@@ -60,6 +60,8 @@ public interface PhysicalIndex
     void deindexDocument(AnnotationDocument aDocument) throws IOException;
 
     void deindexDocument(AnnotationDocument aDocument, String aTimestamp) throws IOException;
+    
+    void reindexDocument(AnnotationDocument aDocument, byte[] aBinaryCas) throws IOException;
 
     void clear() throws IOException;
     
@@ -71,5 +73,7 @@ public interface PhysicalIndex
      *          The document timestamp field value. Empty string if document is not found.
      * @throws IOException
      */
-    public Optional<String> getTimestamp(AnnotationDocument aDocument) throws IOException;
+    public Optional<String> getTimestamp(long aSrcDocId, long aAnnoDocId) throws IOException;
+
+    void reindexDocument(SourceDocument aSourceDocument, byte[] aBinaryCas) throws IOException;
 }

--- a/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/scheduling/tasks/Task.java
+++ b/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/scheduling/tasks/Task.java
@@ -121,6 +121,10 @@ public abstract class Task
     /**
      * Used to avoid scheduling duplicate tasks. Returns true if the current task is a duplicate of
      * the given task.
+     * 
+     * @param aTask
+     *            the given scheduling task
+     * @return whether the given task matches this one
      */
     public abstract boolean matches(Task aTask);
 

--- a/inception-search-mtas/src/main/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndex.java
+++ b/inception-search-mtas/src/main/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndex.java
@@ -63,8 +63,6 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.document.TextField;
-import org.apache.lucene.index.DirectoryReader;
-import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.LeafReaderContext;
@@ -81,7 +79,6 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.spans.SpanWeight;
 import org.apache.lucene.search.spans.Spans;
-import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -267,6 +264,9 @@ public class MtasDocumentIndex
         if (_indexWriter != null) {
             try {
                 _indexWriter.commit();
+                log.debug(
+                        "Executed scheduled commit to complete in project [{}]({})",
+                        project.getName(), project.getId());
             }
             catch (IOException e) {
                 log.error("Error committing changes to index for project [{}]({})",
@@ -278,11 +278,17 @@ public class MtasDocumentIndex
     @Override
     public synchronized void close()
     {
-        OPEN_INDEXES.remove(project.getId());
-
         if (schedulerService != null) {
+            log.debug("close: shutting down scheduler");
             schedulerService.shutdown();
         }
+        
+        closeIndex();
+    }
+
+    private void closeIndex()
+    {
+        OPEN_INDEXES.remove(project.getId());
 
         if (!isOpen()) {
             return;
@@ -319,13 +325,18 @@ public class MtasDocumentIndex
             return;
         }
         
-        // Cancel any existing commit
-        if (_commitFuture != null) {
-            _commitFuture.cancel(false);
+        // already scheduled commit which is not done yet, we don't need to schedule again
+        if (_commitFuture != null && !_commitFuture.isDone()) {
+            return;
         }
         
+        log.debug("Enqueuing new future to index for project [{}]({})", project.getName(),
+                project.getId());
+          
         _commitFuture = schedulerService.schedule(() -> {
             try {
+                log.debug("Executing future to index for project [{}]({})", project.getName(),
+                        project.getId());
                 if (_indexWriter != null && _indexWriter.isOpen()) {
                     _indexWriter.commit();
                     log.debug("Committed changes to index for project [{}]({})", project.getName(),
@@ -880,14 +891,13 @@ public class MtasDocumentIndex
 
         // Add document to the Lucene index
         indexWriter.addDocument(doc);
-
-        scheduleCommit();
     };
 
     @Override
     public void indexDocument(SourceDocument aDocument, byte[] aBinaryCas) throws IOException
     {
         indexDocument(aDocument.getName(), aDocument.getId(), -1, "", aBinaryCas);
+        scheduleCommit();
     };
 
     @Override
@@ -895,6 +905,7 @@ public class MtasDocumentIndex
     {
         indexDocument(aDocument.getName(), aDocument.getDocument().getId(), aDocument.getId(),
                 aDocument.getUser(), aBinaryCas);
+        scheduleCommit();
     };
 
     /**
@@ -922,7 +933,6 @@ public class MtasDocumentIndex
         IndexWriter indexWriter = getIndexWriter();
         indexWriter.deleteDocuments(new Term(FIELD_ID,
                 String.format("%d/%d", aSourceDocumentId, aAnnotationDocumentId)));
-        scheduleCommit();
     }
 
     /**
@@ -959,8 +969,6 @@ public class MtasDocumentIndex
 
         // Delete document based on the previous query
         indexWriter.deleteDocuments(booleanQuery.build());
-
-        scheduleCommit();
     }
 
     /**
@@ -973,23 +981,19 @@ public class MtasDocumentIndex
     public void deindexDocument(SourceDocument aDocument) throws IOException
     {
         deindexDocument(aDocument.getId(), -1, "");
+        scheduleCommit();
     }
 
     @Override
     public synchronized void clear() throws IOException
     {
-        // Disable the scheduler temporarily to avoid new commits getting scheduled
-        if (schedulerService != null) {
-            schedulerService.shutdown();
-        }
-        
         // Remove all data from the index
         IndexWriter indexWriter = getIndexWriter();
         indexWriter.deleteAll();
         
         // Close the index temporarily because we want the IndexWriter to be re-initialized on the
         // next access in order to pick up the current layer configuration of the project.
-        close();
+        closeIndex();
     }
     
     /**
@@ -1002,6 +1006,7 @@ public class MtasDocumentIndex
     public void deindexDocument(AnnotationDocument aDocument) throws IOException
     {
         deindexDocument(aDocument.getDocument().getId(), aDocument.getId(), aDocument.getUser());
+        scheduleCommit();
     }
 
     /**
@@ -1015,6 +1020,7 @@ public class MtasDocumentIndex
     {
         deindexDocument(aDocument.getDocument().getId(), aDocument.getId(), aDocument.getUser(),
                 aTimestamp);
+        scheduleCommit();
     }
 
     /**
@@ -1048,36 +1054,46 @@ public class MtasDocumentIndex
     }
 
     @Override
-    public Optional<String> getTimestamp(AnnotationDocument aDocument) throws IOException
+    public Optional<String> getTimestamp(long aSrcDocId, long aAnnoDocId) throws IOException
     {
         Optional<String> result = Optional.empty();
+        
+        if (aSrcDocId == -1 || aAnnoDocId == -1) {
+            return result;
+        }
 
         // Prepare index searcher for accessing index
-        Directory directory = FSDirectory.open(getIndexDir().toPath());
-        IndexReader indexReader = DirectoryReader.open(directory);
-        IndexSearcher indexSearcher = new IndexSearcher(indexReader);
+        ReferenceManager<IndexSearcher> searchManager = getSearcherManager();
+        searchManager.maybeRefresh();
+        IndexSearcher indexSearcher = searchManager.acquire();
+        try {
 
-        // Prepare query for the annotation document for this annotation document
-        Term term = new Term(FIELD_ID,
-                String.format("%d/%d", aDocument.getDocument().getId(), aDocument.getId()));
-        
-        TermQuery query = new TermQuery(term);
+            // Prepare query for the annotation document for this annotation document
+            Term term = new Term(FIELD_ID, String.format("%d/%d", aSrcDocId, aAnnoDocId));
 
-        // Do query
-        TopDocs docs = indexSearcher.search(query, 1);
+            TermQuery query = new TermQuery(term);
 
-        if (docs.scoreDocs.length > 0) {
-            // If there are results, retrieve first document, since all results should come
-            // from the same document
-            Document document = indexSearcher.doc(docs.scoreDocs[0].doc);
+            // Do query
+            TopDocs docs = indexSearcher.search(query, 1);
 
-            // Retrieve the timestamp field if it exists
-            if (document.getField(FIELD_TIMESTAMP) != null) {
-                result = Optional.ofNullable(StringUtils
-                        .trimToNull(document.getField(FIELD_TIMESTAMP).stringValue()));
+            if (docs.scoreDocs.length > 0) {
+                // If there are results, retrieve first document, since all results should come
+                // from the same document
+                Document document = indexSearcher.doc(docs.scoreDocs[0].doc);
+
+                // Retrieve the timestamp field if it exists
+                if (document.getField(FIELD_TIMESTAMP) != null) {
+                    result = Optional.ofNullable(StringUtils
+                            .trimToNull(document.getField(FIELD_TIMESTAMP).stringValue()));
+                }
             }
         }
-        
+        finally {
+            if (indexSearcher != null) {
+                searchManager.release(indexSearcher);
+                indexSearcher = null;
+            }
+        }
         return result;
     }
     
@@ -1108,5 +1124,28 @@ public class MtasDocumentIndex
     {
         T run(IndexSearcher searcher, SearchQueryRequest aRequest, MtasSpanQuery q)
             throws Exception;
+    }
+
+    @Override
+    public void reindexDocument(AnnotationDocument aDocument, byte[] aBinaryCas) throws IOException
+    {
+        long srcDocId = aDocument.getDocument().getId();
+        long annoDocId = aDocument.getId();
+        String user = aDocument.getUser();
+        
+        Optional<String> oldTimestamp = getTimestamp(srcDocId, annoDocId);
+        indexDocument(aDocument.getName(), srcDocId, annoDocId, user, aBinaryCas);
+        if (oldTimestamp.isPresent()) {
+            deindexDocument(srcDocId, annoDocId, user, oldTimestamp.get());
+        }
+        scheduleCommit();        
+    }
+
+    @Override
+    public void reindexDocument(SourceDocument aSourceDocument, byte[] aBinaryCas) 
+            throws IOException
+    {
+        deindexDocument(aSourceDocument.getId(), -1, "");
+        indexDocument(aSourceDocument, aBinaryCas);
     }
 }

--- a/inception-search-mtas/src/main/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndex.java
+++ b/inception-search-mtas/src/main/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndex.java
@@ -264,9 +264,6 @@ public class MtasDocumentIndex
         if (_indexWriter != null) {
             try {
                 _indexWriter.commit();
-                log.debug(
-                        "Executed scheduled commit to complete in project [{}]({})",
-                        project.getName(), project.getId());
             }
             catch (IOException e) {
                 log.error("Error committing changes to index for project [{}]({})",
@@ -279,7 +276,6 @@ public class MtasDocumentIndex
     public synchronized void close()
     {
         if (schedulerService != null) {
-            log.debug("close: shutting down scheduler");
             schedulerService.shutdown();
         }
         


### PR DESCRIPTION
**What's in the PR**
- deindex, index in one
- do not shutdown scheduler
- only search with searchmanager to stay up to date

**How to test manually**
* Make sure that during searches no duplicates are found
* Test a few times because before the fix the bug was still found sometimes after a few successful searches

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
