### PR TITLE
#1828 - Error in importing projects

### DIFF
--- a/inception-search-mtas/src/main/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasUtils.java
+++ b/inception-search-mtas/src/main/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasUtils.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.search.index.mtas;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
 import org.apache.commons.lang3.StringUtils;
@@ -60,7 +61,9 @@ public final class MtasUtils
     {
         ByteBuffer buffer = ByteBuffer.allocate(4).put(aBytesRef.bytes, aBytesRef.offset,
                 aBytesRef.length);
-        buffer.flip();
+        // Cast to buffer to permit code to run on Java 8.
+        // See: https://github.com/inception-project/inception/issues/1828#issuecomment-717047584
+        ((Buffer) buffer).flip();
         return buffer.getInt();
     }
     

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <log4j.version>2.13.2</log4j.version>
     <groovy.version>3.0.3</groovy.version>
 
-    <webanno.version>4.0.0-beta-16</webanno.version>
+    <webanno.version>4.0.0-SNAPSHOT</webanno.version>
     <servlet-api.version>4.0.1</servlet-api.version>
     <lucene.version>7.3.1</lucene.version>
     <elasticsearch.version>6.3.0</elasticsearch.version>


### PR DESCRIPTION
**What's in the PR**
- Add explicit type cast to avoid linking to a non-Java-8 version of the `flip()` method
- Strictly speaking, this does not fix the import issue (the import issue is fixed by an upstream fix in [WebAnno](https://github.com/webanno/webanno/issues/1795)), but it fixes the same problem in the project search.

```
2020-10-27 08:58:51 ERROR [SYSTEM] [dispatcherServlet] - Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Filter execution threw an exception] with root cause
java.lang.NoSuchMethodError: java.nio.ByteBuffer.flip()Ljava/nio/ByteBuffer;
	at de.tudarmstadt.ukp.inception.search.index.mtas.MtasUtils.decodeFSAddress(MtasUtils.java:63) ~[inception-search-mtas-0.17.0.jar!/:?]
	at de.tudarmstadt.ukp.inception.search.index.mtas.MtasDocumentIndex.lambda$featureValuesAtMatch$8(MtasDocumentIndex.java:818) ~[inception-search-mtas-0.17.0.jar!/:?]
	at java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:174) ~[?:1.8.0_252]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1382) ~[?:1.8.0_252]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482) ~[?:1.8.0_252]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472) ~[?:1.8.0_252]
	at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:150) ~[?:1.8.0_252]
	at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:173) ~[?:1.8.0_252]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:1.8.0_252]
	at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:485) ~[?:1.8.0_252]
	at de.tudarmstadt.ukp.inception.search.index.mtas.MtasDocumentIndex.featureValuesAtMatch(MtasDocumentIndex.java:819) ~[inception-search-mtas-0.17.0.jar!/:?]
	at de.tudarmstadt.ukp.inception.search.index.mtas.MtasDocumentIndex.doQuery(MtasDocumentIndex.java:752) ~[inception-search-mtas-0.17.0.jar!/:?]
	at de.tudarmstadt.ukp.inception.search.index.mtas.MtasDocumentIndex._executeQuery(MtasDocumentIndex.java:399) ~[inception-search-mtas-0.17.0.jar!/:?]
	at de.tudarmstadt.ukp.inception.search.index.mtas.MtasDocumentIndex.executeQuery(MtasDocumentIndex.java:362) ~[inception-search-mtas-0.17.0.jar!/:?]
	at de.tudarmstadt.ukp.inception.search.SearchServiceImpl.query(SearchServiceImpl.java:436) ~[inception-search-core-0.17.0.jar!/:?]
	at de.tudarmstadt.ukp.inception.search.SearchServiceImpl$$FastClassBySpringCGLIB$$d6146f50.invoke(<generated>) ~[inception-search-core-0.17.0.jar!/:?]
	at org.springframework.cglib.proxy.MethodProxy.invoke(MethodProxy.java:218) ~[spring-core-5.2.6.RELEASE.jar!/:5.2.6.RELEASE]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.invokeJoinpoint(CglibAopProxy.java:771) ~[spring-aop-5.2.6.RELEASE.jar!/:5.2.6.RELEASE]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163) ~[spring-aop-5.2.6.RELEASE.jar!/:5.2.6.RELEASE]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:749) ~[spring-aop-5.2.6.RELEASE.jar!/:5.2.6.RELEASE]
	at org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:366) ~[spring-tx-5.2.6.RELEASE.jar!/:5.2.6.RELEASE]
	at org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:118) ~[spring-tx-5.2.6.RELEASE.jar!/:5.2.6.RELEASE]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) ~[spring-aop-5.2.6.RELEASE.jar!/:5.2.6.RELEASE]
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:749) ~[spring-aop-5.2.6.RELEASE.jar!/:5.2.6.RELEASE]
	at org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:691) ~[spring-aop-5.2.6.RELEASE.jar!/:5.2.6.RELEASE]
	at de.tudarmstadt.ukp.inception.search.SearchServiceImpl$$EnhancerBySpringCGLIB$$40b16edc.query(<generated>) ~[inception-search-core-0.17.0.jar!/:?]
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_252]
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_252]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_252]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_252]
	at org.apache.wicket.proxy.LazyInitProxyFactory$JdkHandler.invoke(LazyInitProxyFactory.java:521) ~[wicket-ioc-8.8.0.jar!/:8.8.0]
	at com.sun.proxy.$Proxy231.query(Unknown Source) ~[?:?]
	at de.tudarmstadt.ukp.inception.app.ui.search.sidebar.SearchResultsProvider.iterator(SearchResultsProvider.java:87) ~[inception-ui-search-0.17.0.jar!/:?]
	at de.tudarmstadt.ukp.inception.app.ui.search.sidebar.SearchResultsProviderWrapper.getAllResults(SearchResultsProviderWrapper.java:156) ~[inception-ui-search-0.17.0.jar!/:?]
	at de.tudarmstadt.ukp.inception.app.ui.search.sidebar.SearchResultsProviderWrapper.initializeQuery(SearchResultsProviderWrapper.java:149) ~[inception-ui-search-0.17.0.jar!/:?]
	at de.tudarmstadt.ukp.inception.app.ui.search.sidebar.SearchAnnotationSidebar.executeSearchResultsGroupedQuery(SearchAnnotationSidebar.java:456) ~[inception-ui-search-0.17.0.jar!/:?]
	at de.tudarmstadt.ukp.inception.app.ui.search.sidebar.SearchAnnotationSidebar.actionSearch(SearchAnnotationSidebar.java:411) ~[inception-ui-search-0.17.0.jar!/:?]
	at de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxButton.action(LambdaAjaxButton.java:75) ~[webanno-support-4.0.0-beta-16.jar!/:?]
	at de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxButton.onSubmit(LambdaAjaxButton.java:58) ~[webanno-support-4.0.0-beta-16.jar!/:?]
```

**How to test manually**
* Compile WebAnno on Java 14
* Run on Java 8
* Annotate a lemma with a value
* Perform a sidebar search with the "grouping feature" enabled on the lemma
* java.lang.NoSuchMethodError: java.nio.ByteBuffer.flip()Ljava/nio/ByteBuffer

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
