### PR TITLE
#1852 - Default ElasticSearch document repository settings do not work

### DIFF
--- a/inception-external-search-elastic/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/elastic/traits/ElasticSearchProviderTraits.java
+++ b/inception-external-search-elastic/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/elastic/traits/ElasticSearchProviderTraits.java
@@ -32,7 +32,7 @@ public class ElasticSearchProviderTraits
     
     private String searchPath = "_search";
     
-    private String objectType = "texts";
+    private String objectType = "_doc";
     
     private String defaultField = "doc.text";
     

--- a/inception-external-search-elastic/src/main/resources/META-INF/asciidoc/user-guide/external-search-repos-elasticsearch.adoc
+++ b/inception-external-search-elastic/src/main/resources/META-INF/asciidoc/user-guide/external-search-repos-elasticsearch.adoc
@@ -40,10 +40,78 @@ when querying the document repository. The possible result sizes lie between 1 a
 If the default **Field** setting `doc.text` is used, then the JSON structure for indexed documents 
 should look as follows:
 
-```
+[source,json]
+----
 {
+  "metadata": {
+    "language": "en",
+    "source": "My favourite document collection",
+    "timestamp": "2011/11/11 11:11",
+    "uri": "http://the.internet.com/my/document/collection/document1.txt",
+    "title": "Cool Document Title"
+  },
   "doc": {
-    "text": "Here goes the document text."
+    "text": "This is a test document"
   }
 }
-```
+----
+
+== Setting up a simple ElasticSearch document repository
+
+In this example, we use link:https://www.docker.com[Docker] to get ElasticSearch and link:https://elasticvue.com[ElasticVue] up and running very quickly. Note, that the docker containers we start
+here will not save any data permanently. It is just for you to get an idea of how the setup works.
+In a productive environment, you need to use a proper installation of ElasticSearch.
+
+1. Open a terminal and run ElasticSearch as a Docker service
++
+[source,sh]
+----
+$ docker run -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" -e "http.cors.enabled=true" -e "http.cors.allow-origin=http://localhost:9090" docker.elastic.co/elasticsearch/elasticsearch-oss:7.9.3-amd64
+----
+2. Open a second terminal and run ElasticVue as a Docker service
++
+[source,sh]
+----
+$ docker run -p 9090:8080 cars10/elasticvue
+----
+3. Open a browser and access ElasticVue at `http://localhost:9090`
+4. Switch to the Indices tab in ElasticVue
+5. Create an index named "test"
+6. Switch to the REST tab in ElasticVue
+7. Set the HTTP Method to "POST" and enter `test/_doc/1` as the Path (means "create a new document with ID 1 in collection test)
+8. Put the following JSON into the request body field
++
+[source,json]
+----
+{
+  "metadata": {
+    "language": "en",
+    "source": "My favourite document collection",
+    "timestamp": "2011/11/11 11:11",
+    "uri": "http://the.internet.com/my/document/collection/document1.txt",
+    "title": "Cool Document Title"
+  },
+  "doc": {
+    "text": "This is a test document"
+  }
+}
+----
+9. Click *Run Query*
+10. Start up INCEpTION
+11. Create a new project
+12. Add a document repository with the following settings (and click save):
+* Name: `My ElasticSearch Document Repository`
+* Type: `Elastic Search`
+* Remote URL: `http://localhost:9200`
+* Index name: `test`
+* Search path: `_search`
+* Object type: `_doc`
+* Field: `doc.text`
+* Result Size: `1000`
+* Random ordering: `false`
+13. Switch to the *Dashboard* and from there to the *Search* page
+14. Select the repository `test`
+15. Enter `document` into the search field and press the *Search* button
+16. You should get result for the document you posted to the ElasticSearch index in step 8
+17. Click on *Import*
+18. The import button should change to *Open* now - click on it to open the documen in the annotation editor


### PR DESCRIPTION
**What's in the PR**
- Update default object type to "_doc"
- Added simple testing example of ElasticSearch to the documentation

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
