### PR TITLE
#1868 - Deadlock importing project with large tagset on HSQLDB

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <log4j.version>2.13.2</log4j.version>
     <groovy.version>3.0.3</groovy.version>
 
-    <webanno.version>4.0.0-beta-17</webanno.version>
+    <webanno.version>4.0.0-SNAPSHOT</webanno.version>
     <servlet-api.version>4.0.1</servlet-api.version>
     <lucene.version>7.3.1</lucene.version>
     <elasticsearch.version>6.3.0</elasticsearch.version>


### PR DESCRIPTION
**What's in the PR**
- Improve synchronization on event log to avoid empirically observed deadlock with huge tagsets on HSQLDB

**How to test manually**
* Import project with huge tagset while running with embedded DB

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
