### PR TITLE
Feature/1870 improve roundtrip times on annotation page

### DIFF
--- a/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.java
+++ b/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.java
@@ -88,8 +88,8 @@ import de.tudarmstadt.ukp.clarin.webanno.api.event.AfterDocumentResetEvent;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.model.ReorderableTag;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
-import de.tudarmstadt.ukp.clarin.webanno.model.Tag;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.clarin.webanno.support.dialog.ConfirmationDialog;
@@ -537,8 +537,8 @@ public class ActiveLearningSidebar
             feat, (Serializable) wrappedFeatureValue);
         
         // Populate the tagset moving the tags with recommended labels to the top 
-        List<Tag> tagList = annotationService.listTags(feat.getTagset());
-        List<Tag> reorderedTagList = new ArrayList<>();
+        List<ReorderableTag> tagList = annotationService.listTagsReorderable(feat.getTagset());
+        List<ReorderableTag> reorderedTagList = new ArrayList<>();
         if (tagList.size() > 0) {
             Predictions predictions = recommendationService.getPredictions(state.getUser(),
                     state.getProject());
@@ -555,7 +555,7 @@ public class ActiveLearningSidebar
                     .map(ao -> ao.getLabel())
                     .collect(Collectors.toList());
             
-            for (Tag tag : tagList) {
+            for (ReorderableTag tag : tagList) {
                 // add the tags which contain the prediction-labels to the beginning of a tagset
                 if (allRecommendationLabels.contains(tag.getName())) {
                     tag.setReordered(true);

--- a/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/htmleditor/HtmlAnnotationEditor.java
+++ b/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/htmleditor/HtmlAnnotationEditor.java
@@ -470,7 +470,7 @@ public class HtmlAnnotationEditor
 
             // Render visible (custom) layers
             Map<String[], Queue<String>> colorQueues = new HashMap<>();
-            for (AnnotationLayer layer : vdoc.getAnnotationLayers()) {
+            for (AnnotationLayer layer : state.getAllAnnotationLayers()) {
                 ColoringStrategy coloringStrategy = coloringService.getStrategy(layer,
                         state.getPreferences(), colorQueues);
                 

--- a/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationDetailPanel.java
+++ b/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationDetailPanel.java
@@ -238,7 +238,8 @@ public class DocumentMetadataAnnotationDetailPanel extends Panel
 
             FeatureState featureState = new FeatureState(vid, feature, value);
             featureStates.add(featureState);
-            featureState.tagset = annotationService.listTags(featureState.feature.getTagset());
+            featureState.tagset = annotationService
+                    .listTagsReorderable(featureState.feature.getTagset());
         }
 
         return featureStates;

--- a/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/pdfanno/render/PdfAnnoRenderer.java
+++ b/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/pdfanno/render/PdfAnnoRenderer.java
@@ -70,7 +70,7 @@ public class PdfAnnoRenderer
 
         // Render visible (custom) layers
         Map<String[], Queue<String>> colorQueues = new HashMap<>();
-        for (AnnotationLayer layer : schemaService.listAnnotationLayer(aState.getProject())) {
+        for (AnnotationLayer layer : aState.getAllAnnotationLayers()) {
             ColoringStrategy coloringStrategy = coloringService.getStrategy(layer,
                     aState.getPreferences(), colorQueues);
 

--- a/inception-pdf-editor/src/test/java/de/tudarmstadt/ukpinception/pdfeditor/pdfanno/model/PdfAnnoRendererTest.java
+++ b/inception-pdf-editor/src/test/java/de/tudarmstadt/ukpinception/pdfeditor/pdfanno/model/PdfAnnoRendererTest.java
@@ -168,6 +168,7 @@ public class PdfAnnoRendererTest
         reader.getNext(cas);
 
         AnnotatorState state = new AnnotatorStateImpl(Mode.ANNOTATION);
+        state.setAllAnnotationLayers(schemaService.listAnnotationLayer(project));
         state.setPagingStrategy(new SentenceOrientedPagingStrategy());
         state.getPreferences().setWindowSize(10);
         state.setProject(project);

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/RecommendationEditorExtension.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/RecommendationEditorExtension.java
@@ -283,7 +283,7 @@ public class RecommendationEditorExtension
     {
         // do not show predictions during curation or when viewing others' work
         if (!aState.getMode().equals(ANNOTATION) || 
-                !aState.getUser().equals(userRegistry.getCurrentUser())) {
+                !aState.getUser().getUsername().equals(userRegistry.getCurrentUsername())) {
             return;
         }
         

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/render/RecommendationRenderer.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/render/RecommendationRenderer.java
@@ -18,6 +18,9 @@
 package de.tudarmstadt.ukp.inception.recommendation.render;
 
 import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.CHAIN_TYPE;
+import static de.tudarmstadt.ukp.clarin.webanno.model.Mode.AUTOMATION;
+import static de.tudarmstadt.ukp.clarin.webanno.model.Mode.CORRECTION;
+import static de.tudarmstadt.ukp.clarin.webanno.model.Mode.CURATION;
 
 import org.apache.uima.cas.CAS;
 
@@ -29,7 +32,6 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRe
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.rendering.model.VDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
-import de.tudarmstadt.ukp.clarin.webanno.model.Mode;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
 import de.tudarmstadt.ukp.inception.recommendation.api.LearningRecordService;
@@ -62,9 +64,9 @@ public class RecommendationRenderer
             if (layer.getName().equals(Token.class.getName())
                     || layer.getName().equals(Sentence.class.getName())
                     || (layer.getType().equals(CHAIN_TYPE)
-                            && (aState.getMode().equals(Mode.AUTOMATION)
-                                    || aState.getMode().equals(Mode.CORRECTION)
-                                    || aState.getMode().equals(Mode.CURATION)))
+                            && (aState.getMode().equals(AUTOMATION)
+                                    || aState.getMode().equals(CORRECTION)
+                                    || aState.getMode().equals(CURATION)))
                     || !layer.isEnabled()) { /* Hide layer if not enabled */
                 continue;
             }

--- a/inception-search-mtas/src/test/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndexTest.java
+++ b/inception-search-mtas/src/test/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndexTest.java
@@ -593,8 +593,8 @@ public class MtasDocumentIndexTest
         public DocumentService documentService(
                 @Lazy @Autowired(required = false) List<ProjectInitializer> aInitializerProxy)
         {
-            return new DocumentServiceImpl(repositoryProperties(), userRepository(),
-                    casStorageService(), importExportService(), projectService(aInitializerProxy),
+            return new DocumentServiceImpl(repositoryProperties(), casStorageService(),
+                    importExportService(), projectService(aInitializerProxy),
                     applicationEventPublisher, entityManager);
         }
 

--- a/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchAnnotationSidebar.java
+++ b/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchAnnotationSidebar.java
@@ -297,7 +297,7 @@ public class SearchAnnotationSidebar
         super.onConfigure();
         
         setChangeAnnotationsElementsEnabled(
-                !getModelObject().isUserViewingOthersWork(userRepository.getCurrentUser()));
+                !getModelObject().isUserViewingOthersWork(userRepository.getCurrentUsername()));
     }
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <log4j.version>2.13.2</log4j.version>
     <groovy.version>3.0.3</groovy.version>
 
-    <webanno.version>4.0.0-beta-17</webanno.version>
+    <webanno.version>4.0.0-SNAPSHOT</webanno.version>
     <servlet-api.version>4.0.1</servlet-api.version>
     <lucene.version>7.3.1</lucene.version>
     <elasticsearch.version>6.3.0</elasticsearch.version>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <log4j.version>2.13.2</log4j.version>
     <groovy.version>3.0.3</groovy.version>
 
-    <webanno.version>4.0.0-SNAPSHOT</webanno.version>
+    <webanno.version>webanno-4.0.0-beta-18-SNAPSHOT</webanno.version>
     <servlet-api.version>4.0.1</servlet-api.version>
     <lucene.version>7.3.1</lucene.version>
     <elasticsearch.version>6.3.0</elasticsearch.version>


### PR DESCRIPTION
**What's in the PR**
- Using the username instead of the User object reduces database access for checking if a user is viewing another users annotations
- Store the available layers in the annotator state. If the layers change, the change in the type system will require the user to reload the annotation editor anyway, so we do not need to listen to any events for refreshing the list. Getting the layers from the state is way faster than getting them from the DB every time.
- Maintain cache of tags within a tagset which is used primarily for the feature editors and which is flushed when a tag is created or deleted.
- Remove previous hack of maintaining a transient field in the Tag entity to mark it as reordered. Instead have a proper ReorderableTag class for this.

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
