### PR TITLE
#1881 Search sidebar shows results for wrong user when viewing other …

### DIFF
--- a/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchAnnotationSidebar.java
+++ b/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchAnnotationSidebar.java
@@ -455,8 +455,9 @@ public class SearchAnnotationSidebar
             applicationEventPublisher.get().publishEvent(new SearchQueryEvent(this, project,
                     state.getUser().getUsername(), targetQuery.getObject(), limitToDocument));
             SearchOptions opt = searchOptions.getObject();
-            resultsProvider.initializeQuery(currentUser, project, targetQuery.getObject(),
-                    limitToDocument, opt.getGroupingLayer(), opt.getGroupingFeature());
+            resultsProvider.initializeQuery(getModelObject().getUser(), project,
+                    targetQuery.getObject(), limitToDocument, opt.getGroupingLayer(),
+                    opt.getGroupingFeature());
             return;
         }
         catch (Exception e) {


### PR DESCRIPTION
**What's in the PR**
* Search for annotations of the user in annotator state not the current user

**How to test manually**
* Log in as project manager
* Open a document that another user has annotated via the annotation page
* Search for the annotations that the other users has made
