### PR TITLE
#1919 - Allow excluding events from being logged

### DIFF
--- a/inception-log/pom.xml
+++ b/inception-log/pom.xml
@@ -53,6 +53,7 @@
       <groupId>de.tudarmstadt.ukp.clarin.webanno</groupId>
       <artifactId>webanno-security</artifactId>
     </dependency>
+    
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
@@ -78,9 +79,14 @@
       <artifactId>spring-boot</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
     </dependency>
+    
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
@@ -138,11 +144,6 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-autoconfigure</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/EventLoggingListener.java
+++ b/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/EventLoggingListener.java
@@ -39,13 +39,19 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.annotation.AnnotationAwareOrderComparator;
-import org.springframework.stereotype.Component;
 
 import de.tudarmstadt.ukp.inception.log.adapter.EventLoggingAdapter;
 import de.tudarmstadt.ukp.inception.log.adapter.GenericEventAdapter;
+import de.tudarmstadt.ukp.inception.log.config.EventLoggingAutoConfiguration;
+import de.tudarmstadt.ukp.inception.log.config.EventLoggingProperties;
 import de.tudarmstadt.ukp.inception.log.model.LoggedEvent;
 
-@Component
+/**
+ * <p>
+ * This class is exposed as a Spring Component via
+ * {@link EventLoggingAutoConfiguration#eventLoggingListener}.
+ * </p>
+ */
 public class EventLoggingListener
     implements DisposableBean
 {
@@ -62,14 +68,18 @@ public class EventLoggingListener
 
     private final Deque<LoggedEvent> queue;
 
+    private final EventLoggingProperties properties;
+
     private volatile boolean flushing = false;
 
     public EventLoggingListener(@Autowired EventRepository aRepo,
-            @Lazy @Autowired(required = false) List<EventLoggingAdapter<?>> aAdapters)
+            @Lazy @Autowired(required = false) List<EventLoggingAdapter<?>> aAdapters,
+            EventLoggingProperties aProperties)
     {
         repo = aRepo;
         adapterProxy = aAdapters;
         adapterCache = new HashedMap<>();
+        properties = aProperties;
 
         queue = new ConcurrentLinkedDeque<>();
 
@@ -132,6 +142,10 @@ public class EventLoggingListener
 
         if (adapter.isPresent()) {
             EventLoggingAdapter<ApplicationEvent> a = adapter.get();
+
+            if (properties.getExcludeEvents().contains(a.getEvent(aEvent))) {
+                return;
+            }
 
             LoggedEvent e = new LoggedEvent();
             e.setCreated(a.getCreated(aEvent));

--- a/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/EventRepositoryImpl.java
+++ b/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/EventRepositoryImpl.java
@@ -36,25 +36,27 @@ import javax.persistence.TypedQuery;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Component;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.inception.log.config.EventLoggingAutoConfiguration;
 import de.tudarmstadt.ukp.inception.log.model.LoggedEvent;
 
-@Component
+/**
+ * <p>
+ * This class is exposed as a Spring Component via
+ * {@link EventLoggingAutoConfiguration#eventRepository}.
+ * </p>
+ */
 public class EventRepositoryImpl
     implements EventRepository
 {
     private final Logger log = LoggerFactory.getLogger(getClass());
 
-    @PersistenceContext
-    private EntityManager entityManager;
+    private @PersistenceContext EntityManager entityManager;
 
-    public EventRepositoryImpl()
-    {
-    }
-
+    @Autowired
     public EventRepositoryImpl(EntityManager aEntityManager)
     {
         entityManager = aEntityManager;

--- a/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/TagEventAdapter.java
+++ b/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/TagEventAdapter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021
+ * Ubiquitous Knowledge Processing (UKP) Lab
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.log.adapter;
+
+import java.io.IOException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.event.TagEvent;
+import de.tudarmstadt.ukp.clarin.webanno.support.JSONUtil;
+import de.tudarmstadt.ukp.inception.log.model.TagDetails;
+
+@Component
+public class TagEventAdapter
+    implements EventLoggingAdapter<TagEvent>
+{
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    @Override
+    public boolean accepts(Object aEvent)
+    {
+        return aEvent instanceof TagEvent;
+    }
+
+    @Override
+    public long getProject(TagEvent aEvent)
+    {
+        return aEvent.getTag().getTagSet().getProject().getId();
+    }
+
+    @Override
+    public String getDetails(TagEvent aEvent)
+    {
+        try {
+            TagDetails details = new TagDetails(aEvent.getTag());
+            return JSONUtil.toJsonString(details);
+        }
+        catch (IOException e) {
+            log.error("Unable to log event [{}]", aEvent, e);
+            return "<ERROR>";
+        }
+    }
+}

--- a/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingAutoConfiguration.java
+++ b/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingAutoConfiguration.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021
+ * Ubiquitous Knowledge Processing (UKP) Lab
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.log.config;
+
+import java.util.List;
+
+import javax.persistence.EntityManager;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+
+import de.tudarmstadt.ukp.inception.log.EventLoggingListener;
+import de.tudarmstadt.ukp.inception.log.EventRepository;
+import de.tudarmstadt.ukp.inception.log.EventRepositoryImpl;
+import de.tudarmstadt.ukp.inception.log.adapter.EventLoggingAdapter;
+
+/**
+ * Provides support event logging.
+ */
+@Configuration
+@ConditionalOnProperty(prefix = "event-logging", name = "enabled", havingValue = "true", matchIfMissing = true)
+@EnableConfigurationProperties(EventLoggingPropertiesImpl.class)
+public class EventLoggingAutoConfiguration
+{
+    @Bean
+    @Autowired
+    public EventRepository eventRepository(EntityManager aEntityManager)
+    {
+        return new EventRepositoryImpl(aEntityManager);
+    }
+
+    @Bean
+    @Autowired
+    public EventLoggingListener eventLoggingListener(EventRepository aRepo,
+            @Lazy @Autowired(required = false) List<EventLoggingAdapter<?>> aAdapters,
+            EventLoggingProperties aProperties)
+    {
+        return new EventLoggingListener(aRepo, aAdapters, aProperties);
+    }
+}

--- a/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingProperties.java
+++ b/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingProperties.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2021
+ * Ubiquitous Knowledge Processing (UKP) Lab
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.log.config;
+
+import java.util.Set;
+
+public interface EventLoggingProperties
+{
+    void setEnabled(boolean aEnabled);
+
+    boolean isEnabled();
+
+    Set<String> getExcludeEvents();
+
+    /**
+     * @param aExcludeEvents
+     *            events never to be written to the event log.
+     */
+    void setExcludeEvents(Set<String> aExcludeEvents);
+}

--- a/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingPropertiesImpl.java
+++ b/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingPropertiesImpl.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021
+ * Ubiquitous Knowledge Processing (UKP) Lab
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.log.config;
+
+import java.util.Set;
+
+import org.springframework.boot.availability.AvailabilityChangeEvent;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.event.AfterCasWrittenEvent;
+
+@ConfigurationProperties("event-logging")
+public class EventLoggingPropertiesImpl
+    implements EventLoggingProperties
+{
+    private boolean enabled;
+
+    private Set<String> excludeEvents = Set.of( //
+            // Do not log this by default - hardly any information value
+            AfterCasWrittenEvent.class.getSimpleName(),
+            AvailabilityChangeEvent.class.getSimpleName());
+
+    @Override
+    public boolean isEnabled()
+    {
+        return enabled;
+    }
+
+    @Override
+    public void setEnabled(boolean aEnabled)
+    {
+        enabled = aEnabled;
+    }
+
+    @Override
+    public Set<String> getExcludeEvents()
+    {
+        return excludeEvents;
+    }
+
+    @Override
+    public void setExcludeEvents(Set<String> aExcludeEvents)
+    {
+        excludeEvents = aExcludeEvents;
+    }
+}

--- a/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/model/TagDetails.java
+++ b/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/model/TagDetails.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021
+ * Ubiquitous Knowledge Processing (UKP) Lab
+ * Technische Universität Darmstadt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.log.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.Tag;
+
+@JsonInclude(Include.NON_NULL)
+public class TagDetails
+{
+    private String tag;
+    private String tagSet;
+
+    public TagDetails()
+    {
+        // Nothing to do
+    }
+
+    public TagDetails(Tag aTag)
+    {
+        tag = aTag.getName();
+        tagSet = aTag.getTagSet().getName();
+    }
+
+    public String getTag()
+    {
+        return tag;
+    }
+
+    public void setTag(String aTag)
+    {
+        tag = aTag;
+    }
+
+    public String getTagSet()
+    {
+        return tagSet;
+    }
+
+    public void setTagSet(String aTagSet)
+    {
+        tagSet = aTagSet;
+    }
+}

--- a/inception-log/src/main/resources/META-INF/spring.factories
+++ b/inception-log/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+de.tudarmstadt.ukp.inception.log.config.EventLoggingAutoConfiguration


### PR DESCRIPTION
**What's in the PR**
- Convert logging module to auto-configuration
- Add setting for excluding events from being logged
- Exclude some events by default
- Added a proper adapter for tag events

**How to test manually**
* Add/remove tag and check event log
* Check that default-excluded events are not written to the event log but other events are

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
