### PR TITLE
#1923 - Error during log writing creates unparseable JSON

### DIFF
--- a/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/log/ActiveLearningRecommendationEventAdapter.java
+++ b/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/log/ActiveLearningRecommendationEventAdapter.java
@@ -61,30 +61,24 @@ public class ActiveLearningRecommendationEventAdapter
     }
 
     @Override
-    public String getDetails(ActiveLearningRecommendationEvent aEvent)
+    public String getDetails(ActiveLearningRecommendationEvent aEvent) throws IOException
     {
-        try {
-            ActiveLearningRecommendationDetails details = new ActiveLearningRecommendationDetails();
-            details.ann = new AnnotationDetails();
-            details.ann.setBegin(aEvent.getCurrentRecommendation().getBegin());
-            details.ann.setEnd(aEvent.getCurrentRecommendation().getEnd());
-            details.ann.setText(aEvent.getCurrentRecommendation().getCoveredText());
-            details.ann.setType(aEvent.getLayer().getName());
-            details.annotationFeature = aEvent.getAnnotationFeature();
-            details.userAction = aEvent.getAction();
-            details.currentLabel = aEvent.getCurrentRecommendation().getLabel();
-            details.confidence = aEvent.getCurrentRecommendation().getConfidence();
-            details.recommenderId = aEvent.getCurrentRecommendation().getRecommenderId();
+        ActiveLearningRecommendationDetails details = new ActiveLearningRecommendationDetails();
+        details.ann = new AnnotationDetails();
+        details.ann.setBegin(aEvent.getCurrentRecommendation().getBegin());
+        details.ann.setEnd(aEvent.getCurrentRecommendation().getEnd());
+        details.ann.setText(aEvent.getCurrentRecommendation().getCoveredText());
+        details.ann.setType(aEvent.getLayer().getName());
+        details.annotationFeature = aEvent.getAnnotationFeature();
+        details.userAction = aEvent.getAction();
+        details.currentLabel = aEvent.getCurrentRecommendation().getLabel();
+        details.confidence = aEvent.getCurrentRecommendation().getConfidence();
+        details.recommenderId = aEvent.getCurrentRecommendation().getRecommenderId();
 
-            List<String> allLabelList = aEvent.getAllRecommendations().stream()
-                    .map(ao -> ao.getLabel()).collect(Collectors.toList());
-            details.allLabels = String.join(", ", allLabelList);
-            return JSONUtil.toJsonString(details);
-        }
-        catch (IOException e) {
-            log.error("Unable to log event [{}]", aEvent, e);
-            return "<ERROR>";
-        }
+        List<String> allLabelList = aEvent.getAllRecommendations().stream().map(ao -> ao.getLabel())
+                .collect(Collectors.toList());
+        details.allLabels = String.join(", ", allLabelList);
+        return JSONUtil.toJsonString(details);
     }
 
     public static class ActiveLearningRecommendationDetails

--- a/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/log/ActiveLearningSuggestionOfferedAdapter.java
+++ b/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/log/ActiveLearningSuggestionOfferedAdapter.java
@@ -62,29 +62,23 @@ public class ActiveLearningSuggestionOfferedAdapter
     }
 
     @Override
-    public String getDetails(ActiveLearningSuggestionOfferedEvent aEvent)
+    public String getDetails(ActiveLearningSuggestionOfferedEvent aEvent) throws IOException
     {
-        try {
-            Details details = new Details();
-            details.ann = new AnnotationDetails();
-            details.ann.setBegin(aEvent.getCurrentRecommendation().getBegin());
-            details.ann.setEnd(aEvent.getCurrentRecommendation().getEnd());
-            details.ann.setText(aEvent.getCurrentRecommendation().getCoveredText());
-            details.ann.setType(aEvent.getLayer().getName());
-            details.annotationFeature = aEvent.getAnnotationFeature();
-            details.currentLabel = aEvent.getCurrentRecommendation().getLabel();
-            details.confidence = aEvent.getCurrentRecommendation().getConfidence();
-            details.recommenderId = aEvent.getCurrentRecommendation().getRecommenderId();
+        Details details = new Details();
+        details.ann = new AnnotationDetails();
+        details.ann.setBegin(aEvent.getCurrentRecommendation().getBegin());
+        details.ann.setEnd(aEvent.getCurrentRecommendation().getEnd());
+        details.ann.setText(aEvent.getCurrentRecommendation().getCoveredText());
+        details.ann.setType(aEvent.getLayer().getName());
+        details.annotationFeature = aEvent.getAnnotationFeature();
+        details.currentLabel = aEvent.getCurrentRecommendation().getLabel();
+        details.confidence = aEvent.getCurrentRecommendation().getConfidence();
+        details.recommenderId = aEvent.getCurrentRecommendation().getRecommenderId();
 
-            List<String> allLabelList = aEvent.getAllRecommendations().stream()
-                    .map(ao -> ao.getLabel()).collect(Collectors.toList());
-            details.allLabels = String.join(", ", allLabelList);
-            return JSONUtil.toJsonString(details);
-        }
-        catch (IOException e) {
-            log.error("Unable to log event [{}]", aEvent, e);
-            return "<ERROR>";
-        }
+        List<String> allLabelList = aEvent.getAllRecommendations().stream().map(ao -> ao.getLabel())
+                .collect(Collectors.toList());
+        details.allLabels = String.join(", ", allLabelList);
+        return JSONUtil.toJsonString(details);
     }
 
     public static class Details

--- a/inception-external-search-core/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/log/ExternalSearchQueryEventAdapter.java
+++ b/inception-external-search-core/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/log/ExternalSearchQueryEventAdapter.java
@@ -59,19 +59,11 @@ public class ExternalSearchQueryEventAdapter
     }
 
     @Override
-    public String getDetails(ExternalSearchQueryEvent aEvent)
+    public String getDetails(ExternalSearchQueryEvent aEvent) throws IOException
     {
-        try {
-            Details details = new Details();
-
-            details.query = aEvent.getQuery();
-
-            return JSONUtil.toJsonString(details);
-        }
-        catch (IOException e) {
-            log.error("Unable to log event [{}]", aEvent, e);
-            return "<ERROR>";
-        }
+        Details details = new Details();
+        details.query = aEvent.getQuery();
+        return JSONUtil.toJsonString(details);
     }
 
     public static class Details

--- a/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/EventLoggingListener.java
+++ b/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/EventLoggingListener.java
@@ -134,13 +134,21 @@ public class EventLoggingListener
             EventLoggingAdapter<ApplicationEvent> a = adapter.get();
 
             LoggedEvent e = new LoggedEvent();
-            e.setCreated(a.getCreated(aEvent));
-            e.setEvent(a.getEvent(aEvent));
-            e.setUser(a.getUser(aEvent));
-            e.setProject(a.getProject(aEvent));
-            e.setDocument(a.getDocument(aEvent));
-            e.setAnnotator(a.getAnnotator(aEvent));
-            e.setDetails(a.getDetails(aEvent));
+
+            try {
+                e.setCreated(a.getCreated(aEvent));
+                e.setEvent(a.getEvent(aEvent));
+                e.setUser(a.getUser(aEvent));
+                e.setProject(a.getProject(aEvent));
+                e.setDocument(a.getDocument(aEvent));
+                e.setAnnotator(a.getAnnotator(aEvent));
+                e.setDetails(a.getDetails(aEvent));
+            }
+            catch (Exception ex) {
+                log.error("Unable to log event [{}]", aEvent, ex);
+                return;
+            }
+
             // Add to the writing queue which gets flushed regularly by a timer
             queue.add(e);
 

--- a/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/AfterDocumentCreatedEventAdapter.java
+++ b/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/AfterDocumentCreatedEventAdapter.java
@@ -17,9 +17,13 @@
  */
 package de.tudarmstadt.ukp.inception.log.adapter;
 
+import java.io.IOException;
+
 import org.springframework.stereotype.Component;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.event.AfterDocumentCreatedEvent;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState;
+import de.tudarmstadt.ukp.clarin.webanno.support.JSONUtil;
 
 @Component
 public class AfterDocumentCreatedEventAdapter
@@ -41,5 +45,22 @@ public class AfterDocumentCreatedEventAdapter
     public long getProject(AfterDocumentCreatedEvent aEvent)
     {
         return aEvent.getDocument().getProject().getId();
+    }
+
+    @Override
+    public String getDetails(AfterDocumentCreatedEvent aEvent) throws IOException
+    {
+        Details details = new Details();
+        details.documentName = aEvent.getDocument().getName();
+        details.format = aEvent.getDocument().getFormat();
+        details.state = aEvent.getDocument().getState();
+        return JSONUtil.toJsonString(details);
+    }
+
+    public static class Details
+    {
+        public String documentName;
+        public String format;
+        public SourceDocumentState state;
     }
 }

--- a/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/AfterProjectCreatedEventAdapter.java
+++ b/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/AfterProjectCreatedEventAdapter.java
@@ -17,9 +17,12 @@
  */
 package de.tudarmstadt.ukp.inception.log.adapter;
 
+import java.io.IOException;
+
 import org.springframework.stereotype.Component;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.event.AfterProjectCreatedEvent;
+import de.tudarmstadt.ukp.clarin.webanno.support.JSONUtil;
 
 @Component
 public class AfterProjectCreatedEventAdapter
@@ -35,5 +38,18 @@ public class AfterProjectCreatedEventAdapter
     public long getProject(AfterProjectCreatedEvent aEvent)
     {
         return aEvent.getProject().getId();
+    }
+
+    @Override
+    public String getDetails(AfterProjectCreatedEvent aEvent) throws IOException
+    {
+        Details details = new Details();
+        details.projectName = aEvent.getProject().getName();
+        return JSONUtil.toJsonString(details);
+    }
+
+    public static class Details
+    {
+        public String projectName;
     }
 }

--- a/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/AnnotationStateChangedEventAdapter.java
+++ b/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/AnnotationStateChangedEventAdapter.java
@@ -59,17 +59,11 @@ public class AnnotationStateChangedEventAdapter
     }
 
     @Override
-    public String getDetails(AnnotationStateChangeEvent aEvent)
+    public String getDetails(AnnotationStateChangeEvent aEvent) throws IOException
     {
-        try {
-            StateChangeDetails details = new StateChangeDetails();
-            details.setState(Objects.toString(aEvent.getNewState(), null));
-            details.setPreviousState(Objects.toString(aEvent.getPreviousState(), null));
-            return JSONUtil.toJsonString(details);
-        }
-        catch (IOException e) {
-            log.error("Unable to log event [{}]", aEvent, e);
-            return "<ERROR>";
-        }
+        StateChangeDetails details = new StateChangeDetails();
+        details.setState(Objects.toString(aEvent.getNewState(), null));
+        details.setPreviousState(Objects.toString(aEvent.getPreviousState(), null));
+        return JSONUtil.toJsonString(details);
     }
 }

--- a/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/DocumentStateChangedEventAdapter.java
+++ b/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/DocumentStateChangedEventAdapter.java
@@ -53,17 +53,11 @@ public class DocumentStateChangedEventAdapter
     }
 
     @Override
-    public String getDetails(DocumentStateChangedEvent aEvent)
+    public String getDetails(DocumentStateChangedEvent aEvent) throws IOException
     {
-        try {
-            StateChangeDetails details = new StateChangeDetails();
-            details.setState(Objects.toString(aEvent.getNewState(), null));
-            details.setPreviousState(Objects.toString(aEvent.getPreviousState(), null));
-            return JSONUtil.toJsonString(details);
-        }
-        catch (IOException e) {
-            log.error("Unable to log event [{}]", aEvent, e);
-            return "<ERROR>";
-        }
+        StateChangeDetails details = new StateChangeDetails();
+        details.setState(Objects.toString(aEvent.getNewState(), null));
+        details.setPreviousState(Objects.toString(aEvent.getPreviousState(), null));
+        return JSONUtil.toJsonString(details);
     }
 }

--- a/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/EventLoggingAdapter.java
+++ b/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/EventLoggingAdapter.java
@@ -27,7 +27,7 @@ public interface EventLoggingAdapter<T>
 {
     boolean accepts(Object aEvent);
 
-    default String getDetails(T aEvent)
+    default String getDetails(T aEvent) throws Exception
     {
         return null;
     }

--- a/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/FeatureValueUpdatedEventAdapter.java
+++ b/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/FeatureValueUpdatedEventAdapter.java
@@ -58,17 +58,11 @@ public class FeatureValueUpdatedEventAdapter
     }
 
     @Override
-    public String getDetails(FeatureValueUpdatedEvent aEvent)
+    public String getDetails(FeatureValueUpdatedEvent aEvent) throws IOException
     {
-        try {
-            // FIXME This may fail for slot features... let's see.
-            FeatureChangeDetails details = new FeatureChangeDetails(aEvent.getFS(),
-                    aEvent.getNewValue(), aEvent.getOldValue());
-            return JSONUtil.toJsonString(details);
-        }
-        catch (IOException e) {
-            log.error("Unable to log event [{}]", aEvent, e);
-            return "<ERROR>";
-        }
+        // FIXME This may fail for slot features... let's see.
+        FeatureChangeDetails details = new FeatureChangeDetails(aEvent.getFS(),
+                aEvent.getNewValue(), aEvent.getOldValue());
+        return JSONUtil.toJsonString(details);
     }
 }

--- a/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/GenericEventAdapter.java
+++ b/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/GenericEventAdapter.java
@@ -34,11 +34,13 @@ public class GenericEventAdapter
     @Override
     public boolean accepts(Object aEvent)
     {
-        return aEvent instanceof ApplicationEvent && !(aEvent instanceof ApplicationContextEvent
-                || aEvent instanceof ServletRequestHandledEvent
-                || aEvent instanceof SessionCreationEvent || aEvent instanceof SessionDestroyedEvent
-                || aEvent instanceof AbstractAuthorizationEvent
-                || aEvent instanceof AbstractAuthenticationEvent
-                || aEvent instanceof WebServerInitializedEvent);
+        return aEvent instanceof ApplicationEvent && //
+                !(aEvent instanceof ApplicationContextEvent //
+                        || aEvent instanceof ServletRequestHandledEvent //
+                        || aEvent instanceof SessionCreationEvent //
+                        || aEvent instanceof SessionDestroyedEvent //
+                        || aEvent instanceof AbstractAuthorizationEvent //
+                        || aEvent instanceof AbstractAuthenticationEvent //
+                        || aEvent instanceof WebServerInitializedEvent);
     }
 }

--- a/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/ProjectStateChangedEventAdapter.java
+++ b/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/ProjectStateChangedEventAdapter.java
@@ -47,17 +47,11 @@ public class ProjectStateChangedEventAdapter
     }
 
     @Override
-    public String getDetails(ProjectStateChangedEvent aEvent)
+    public String getDetails(ProjectStateChangedEvent aEvent) throws IOException
     {
-        try {
-            StateChangeDetails details = new StateChangeDetails();
-            details.setState(Objects.toString(aEvent.getNewState(), null));
-            details.setPreviousState(Objects.toString(aEvent.getPreviousState(), null));
-            return JSONUtil.toJsonString(details);
-        }
-        catch (IOException e) {
-            log.error("Unable to log event [{}]", aEvent, e);
-            return "<ERROR>";
-        }
+        StateChangeDetails details = new StateChangeDetails();
+        details.setState(Objects.toString(aEvent.getNewState(), null));
+        details.setPreviousState(Objects.toString(aEvent.getPreviousState(), null));
+        return JSONUtil.toJsonString(details);
     }
 }

--- a/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/RelationEventAdapter.java
+++ b/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/RelationEventAdapter.java
@@ -40,16 +40,10 @@ public class RelationEventAdapter
     }
 
     @Override
-    public String getDetails(RelationEvent aEvent)
+    public String getDetails(RelationEvent aEvent) throws IOException
     {
-        try {
-            AnnotationDetails details = new AnnotationDetails(aEvent.getTargetAnnotation());
-            return JSONUtil.toJsonString(details);
-        }
-        catch (IOException e) {
-            log.error("Unable to log event [{}]", aEvent, e);
-            return "<ERROR>";
-        }
+        AnnotationDetails details = new AnnotationDetails(aEvent.getTargetAnnotation());
+        return JSONUtil.toJsonString(details);
     }
 
     @Override

--- a/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/SpanCreatedEventAdapter.java
+++ b/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/SpanCreatedEventAdapter.java
@@ -58,15 +58,9 @@ public class SpanCreatedEventAdapter
     }
 
     @Override
-    public String getDetails(SpanCreatedEvent aEvent)
+    public String getDetails(SpanCreatedEvent aEvent) throws IOException
     {
-        try {
-            AnnotationDetails details = new AnnotationDetails(aEvent.getAnnotation());
-            return JSONUtil.toJsonString(details);
-        }
-        catch (IOException e) {
-            log.error("Unable to log event [{}]", aEvent, e);
-            return "<ERROR>";
-        }
+        AnnotationDetails details = new AnnotationDetails(aEvent.getAnnotation());
+        return JSONUtil.toJsonString(details);
     }
 }

--- a/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/SpanDeletedEventAdapter.java
+++ b/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/SpanDeletedEventAdapter.java
@@ -58,15 +58,9 @@ public class SpanDeletedEventAdapter
     }
 
     @Override
-    public String getDetails(SpanDeletedEvent aEvent)
+    public String getDetails(SpanDeletedEvent aEvent) throws IOException
     {
-        try {
-            AnnotationDetails details = new AnnotationDetails(aEvent.getAnnotation());
-            return JSONUtil.toJsonString(details);
-        }
-        catch (IOException e) {
-            log.error("Unable to log event [{}]", aEvent, e);
-            return "<ERROR>";
-        }
+        AnnotationDetails details = new AnnotationDetails(aEvent.getAnnotation());
+        return JSONUtil.toJsonString(details);
     }
 }

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/log/RecommendationAcceptedEventAdapter.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/log/RecommendationAcceptedEventAdapter.java
@@ -65,20 +65,14 @@ public class RecommendationAcceptedEventAdapter
     }
 
     @Override
-    public String getDetails(RecommendationAcceptedEvent aEvent)
+    public String getDetails(RecommendationAcceptedEvent aEvent) throws IOException
     {
-        try {
-            AnnotationDetails annotation = new AnnotationDetails(aEvent.getFS());
+        AnnotationDetails annotation = new AnnotationDetails(aEvent.getFS());
 
-            FeatureChangeDetails details = new FeatureChangeDetails();
-            details.setAnnotation(annotation);
-            details.setValue(aEvent.getRecommendedValue());
+        FeatureChangeDetails details = new FeatureChangeDetails();
+        details.setAnnotation(annotation);
+        details.setValue(aEvent.getRecommendedValue());
 
-            return JSONUtil.toJsonString(details);
-        }
-        catch (IOException e) {
-            log.error("Unable to log event [{}]", aEvent, e);
-            return "<ERROR>";
-        }
+        return JSONUtil.toJsonString(details);
     }
 }

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/log/RecommendationRejectedEventAdapter.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/log/RecommendationRejectedEventAdapter.java
@@ -65,24 +65,18 @@ public class RecommendationRejectedEventAdapter
     }
 
     @Override
-    public String getDetails(RecommendationRejectedEvent aEvent)
+    public String getDetails(RecommendationRejectedEvent aEvent) throws IOException
     {
-        try {
-            AnnotationDetails annotation = new AnnotationDetails();
-            annotation.setBegin(aEvent.getBegin());
-            annotation.setEnd(aEvent.getEnd());
-            annotation.setText(aEvent.getText());
-            annotation.setType(aEvent.getFeature().getLayer().getName());
+        AnnotationDetails annotation = new AnnotationDetails();
+        annotation.setBegin(aEvent.getBegin());
+        annotation.setEnd(aEvent.getEnd());
+        annotation.setText(aEvent.getText());
+        annotation.setType(aEvent.getFeature().getLayer().getName());
 
-            FeatureChangeDetails details = new FeatureChangeDetails();
-            details.setAnnotation(annotation);
-            details.setValue(aEvent.getRecommendedValue());
+        FeatureChangeDetails details = new FeatureChangeDetails();
+        details.setAnnotation(annotation);
+        details.setValue(aEvent.getRecommendedValue());
 
-            return JSONUtil.toJsonString(details);
-        }
-        catch (IOException e) {
-            log.error("Unable to log event [{}]", aEvent, e);
-            return "<ERROR>";
-        }
+        return JSONUtil.toJsonString(details);
     }
 }

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/log/RecommenderEvaluationResultEventAdapter.java
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/log/RecommenderEvaluationResultEventAdapter.java
@@ -66,35 +66,29 @@ public class RecommenderEvaluationResultEventAdapter
     }
 
     @Override
-    public String getDetails(RecommenderEvaluationResultEvent aEvent)
+    public String getDetails(RecommenderEvaluationResultEvent aEvent) throws IOException
     {
-        try {
-            Details details = new Details();
+        Details details = new Details();
 
-            details.recommenderId = aEvent.getRecommender().getId();
+        details.recommenderId = aEvent.getRecommender().getId();
 
-            EvaluationResult result = aEvent.getResult();
-            details.accuracy = result.computeAccuracyScore();
-            details.f1 = result.computeF1Score();
-            details.precision = result.computePrecisionScore();
-            details.recall = result.computeRecallScore();
+        EvaluationResult result = aEvent.getResult();
+        details.accuracy = result.computeAccuracyScore();
+        details.f1 = result.computeF1Score();
+        details.precision = result.computePrecisionScore();
+        details.recall = result.computeRecallScore();
 
-            details.trainSetSize = result.getTrainingSetSize();
-            details.testSetSize = result.getTestSetSize();
+        details.trainSetSize = result.getTrainingSetSize();
+        details.testSetSize = result.getTestSetSize();
 
-            details.active = aEvent.isActive();
-            details.duration = aEvent.getDuration();
-            details.threshold = aEvent.getRecommender().getThreshold();
-            details.layer = aEvent.getRecommender().getLayer().getName();
-            details.feature = aEvent.getRecommender().getFeature().getName();
-            details.tool = aEvent.getRecommender().getTool();
+        details.active = aEvent.isActive();
+        details.duration = aEvent.getDuration();
+        details.threshold = aEvent.getRecommender().getThreshold();
+        details.layer = aEvent.getRecommender().getLayer().getName();
+        details.feature = aEvent.getRecommender().getFeature().getName();
+        details.tool = aEvent.getRecommender().getTool();
 
-            return JSONUtil.toJsonString(details);
-        }
-        catch (IOException e) {
-            log.error("Unable to log event [{}]", aEvent, e);
-            return "<ERROR>";
-        }
+        return JSONUtil.toJsonString(details);
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/log/SearchQueryEventAdapter.java
+++ b/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/log/SearchQueryEventAdapter.java
@@ -58,20 +58,14 @@ public class SearchQueryEventAdapter
     }
 
     @Override
-    public String getDetails(SearchQueryEvent aEvent)
+    public String getDetails(SearchQueryEvent aEvent) throws IOException
     {
-        try {
-            Details details = new Details();
+        Details details = new Details();
 
-            details.query = aEvent.getQuery();
-            details.documentId = aEvent.getSourceDocument().map(SourceDocument::getId).orElse(null);
+        details.query = aEvent.getQuery();
+        details.documentId = aEvent.getSourceDocument().map(SourceDocument::getId).orElse(null);
 
-            return JSONUtil.toJsonString(details);
-        }
-        catch (IOException e) {
-            log.error("Unable to log event [{}]", aEvent, e);
-            return "<ERROR>";
-        }
+        return JSONUtil.toJsonString(details);
     }
 
     public static class Details


### PR DESCRIPTION
**What's in the PR**
- Let the adapters throw an exception when generating the details so they do not have to return "<ERROR>"
- If an adapter generates and exception, let the EventLoggingListener report the error and then just skip logging the event

**How to test manually**
* Check if exporting and importing still works - in particular if the events are exported/imported

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
