### PR TITLE
#1954 - Info badge and link to not appear immediately when linking concept

### DIFF
--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureEditor.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureEditor.java
@@ -108,10 +108,12 @@ public class ConceptFeatureEditor
         IModel<String> iriModel = LoadableDetachableModel.of(this::iriTooltipValue);
 
         iriBadge = new IriInfoBadge("iriInfoBadge", iriModel);
+        iriBadge.setOutputMarkupPlaceholderTag(true);
         iriBadge.add(visibleWhen(() -> isNotBlank(iriBadge.getModelObject())));
         add(iriBadge);
 
         openIriLink = new ExternalLink("openIri", iriModel);
+        openIriLink.setOutputMarkupPlaceholderTag(true);
         openIriLink.add(visibleWhen(() -> isNotBlank(iriBadge.getModelObject())));
         add(openIriLink);
 
@@ -271,7 +273,7 @@ public class ConceptFeatureEditor
             @Override
             protected void onUpdate(AjaxRequestTarget aTarget)
             {
-                aTarget.add(descriptionContainer);
+                aTarget.add(descriptionContainer, iriBadge, openIriLink);
                 send(focusComponent, BUBBLE,
                         new FeatureEditorValueChangedEvent(ConceptFeatureEditor.this, aTarget));
             }


### PR DESCRIPTION
**What's in the PR**
- Redraw badge and link when updating the feature value

**How to test manually**
* See issue

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
