### PR TITLE
#1971 Cannot annotate properties only concept feature with wiki-data

### DIFF
--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
@@ -855,7 +855,7 @@ public class SPARQLQueryBuilder
             addPattern(PRIMARY, withLabelMatchingAnyOf_Wikidata_FTS(values));
         }
         else if (FTS_NONE.equals(ftsMode) || ftsMode == null) {
-            addPattern(PRIMARY, withLabelMatchingAnyOf_No_FTS(values));
+            addPattern(SECONDARY, withLabelMatchingAnyOf_No_FTS(values));
         }
         else {
             throw new IllegalStateException(

--- a/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
+++ b/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
@@ -855,6 +855,12 @@ public class SPARQLQueryBuilder
             addPattern(PRIMARY, withLabelMatchingAnyOf_Wikidata_FTS(values));
         }
         else if (FTS_NONE.equals(ftsMode) || ftsMode == null) {
+            // The WikiData search service does not support properties. So we disable the use of the
+            // WikiData search service when looking for properties. But then, searching first by
+            // the label becomes very slow because withLabelMatchingAnyOf falls back to "containing"
+            // when no FTS is used. To avoid forcing the SPARQL server to perform a full scan
+            // of its database, we demote the label matching to a secondary condition, allowing the
+            // the matching by type (e.g. PRIMARY_RESTRICTIONS is-a property) to take precedence.
             addPattern(SECONDARY, withLabelMatchingAnyOf_No_FTS(values));
         }
         else {

--- a/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderTest.java
+++ b/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderTest.java
@@ -1370,6 +1370,25 @@ public class SPARQLQueryBuilderTest
         assertThat(results).extracting(KBHandle::getUiLabel)
                 .allMatch(label -> "Labour".equals(label));
     }
+    
+    @Category(SlowTests.class)
+    @Test
+    public void testWithPropertyMatchingAnyOf_Wikidata_noFTS() throws Exception
+    {
+        assertIsReachable(wikidata);
+
+        kb.setType(REMOTE);
+        kb.setFullTextSearchIri(null);
+        initWikidataMapping();
+
+        List<KBHandle> results = asHandles(wikidata, SPARQLQueryBuilder //
+                .forProperties(kb) //
+                .withLabelMatchingAnyOf("academic"));
+        assertThat(results).extracting(KBHandle::getIdentifier).doesNotHaveDuplicates();
+        assertThat(results).isNotEmpty();
+        assertThat(results).extracting(KBHandle::getUiLabel)
+                .allMatch(label -> label.toLowerCase().contains("academic"));
+    }
 
     @Category(SlowTests.class)
     @Ignore


### PR DESCRIPTION
**What's in the PR**
* Moved query for label to secondary pattern for query with regex in *matchAnyOf...* if Fulltextsearch is not available. This is still slow, but we get a result.

**How to test manually**
* Add wikidata as your knowledge base
* Configure a layer with a concept feature, restrict the feature to properties
* Annotate a text span and try setting the feature by searching for something
 

**Automatic testing**
* [x] PR includes unit tests
