### PR TITLE
#1996 - Memory leak in BeanInitializationTimesLogger

### DIFF
--- a/inception-support/pom.xml
+++ b/inception-support/pom.xml
@@ -64,6 +64,10 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-beans</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
 
     <!-- Wicket -->
 


### PR DESCRIPTION
**What's in the PR**
- Disable BeanInitializationTimesLogger by default
- Even if it is enabled, kill it once the application has started up

**How to test manually**
* I put a breakpoint into the bean and checked it is not called during startup if the property enabling it is not set

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
