### PR TITLE
#2031 - StringMatchingRecommender fails to find some matches

### DIFF
--- a/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/StringMatchingRecommender.java
+++ b/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/StringMatchingRecommender.java
@@ -511,7 +511,7 @@ public class StringMatchingRecommender
         }
     }
 
-    private static class DictEntry
+    public static class DictEntry
     {
         private String key;
         private String[] labels;

--- a/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/trie/Trie.java
+++ b/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/trie/Trie.java
@@ -227,6 +227,7 @@ public class Trie<V>
         }
         Node last = root;
         Node match = null;
+        int acceptedKeyChars = 0;
         for (int i = offset; i < offset + length; i++) {
             char k = key.charAt(i);
 
@@ -236,6 +237,8 @@ public class Trie<V>
                     continue;
                 }
             }
+
+            acceptedKeyChars++;
 
             final Node cur = last.children.get(k);
             if (cur == null) {
@@ -247,7 +250,11 @@ public class Trie<V>
             last = cur;
         }
 
-        return match;
+        if (match != null && acceptedKeyChars == match.level) {
+            return match;
+        }
+
+        return null;
     }
 
     /**

--- a/inception-imls-stringmatch/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/trie/TrieTest.java
+++ b/inception-imls-stringmatch/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/trie/TrieTest.java
@@ -25,14 +25,16 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 
+import de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.StringMatchingRecommender.DictEntry;
+
 public class TrieTest
 {
-    private Trie<String> sut;
+    private Trie<DictEntry> sut;
 
     @Before
     public void setup()
     {
-        sut = new Trie<String>();
+        sut = new Trie<DictEntry>();
     }
 
     @Test
@@ -40,10 +42,8 @@ public class TrieTest
     {
         List<String> keys = asList("1", "asf", "asf sadf", "dsjkla sfasd kj92");
 
-        int i = 0;
         for (String key : keys) {
-            sut.put(key, String.valueOf(i));
-            i++;
+            sut.put(key, new DictEntry(key));
         }
 
         assertThat(sut.size()).isEqualTo(keys.size());
@@ -58,11 +58,19 @@ public class TrieTest
     }
 
     @Test
+    public void thatExactMatchesCanBeFound()
+    {
+        sut.put("in", new DictEntry("in"));
+
+        assertThat(sut.get("initially")).isNull();
+    }
+
+    @Test
     public void testThatKeySanitizerWorks()
     {
-        sut = new Trie<String>(WhitespaceNormalizingSanitizer.factory());
+        sut = new Trie<DictEntry>(WhitespaceNormalizingSanitizer.factory());
 
-        sut.put("  this is\ta test  .", "exists");
+        sut.put("  this is\ta test  .", new DictEntry("exists"));
 
         System.out.println(sut.keys());
 


### PR DESCRIPTION
**What's in the PR**
- Fixed handling of prefix length when retrieving a trie node
- Added unit test

**How to test manually**
* See issue description

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
