### PR TITLE
#2034 - OpenNlpPosRecommender provides no suggestions if tagged token is set to 100%

### DIFF
--- a/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/pos/OpenNlpPosRecommender.java
+++ b/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/pos/OpenNlpPosRecommender.java
@@ -298,7 +298,7 @@ public class OpenNlpPosRecommender
         // Require at least X percent of the sentence to have tags to avoid class imbalance on PAD
         // tag.
         double coverage = ((double) withTagCount * 100) / (double) numberOfTokens;
-        if (coverage > traits.getTaggedTokensThreshold()) {
+        if (coverage >= traits.getTaggedTokensThreshold()) {
             return Optional.of(new POSSample(tokens, tags));
         }
         else {


### PR DESCRIPTION
**What's in the PR**
- Fixed comparison of coverage against threshold

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
