### PR TITLE
#2050 - Cannot see agreement menuitem icon

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -824,7 +824,7 @@
       <dependency>
         <groupId>org.webjars</groupId>
         <artifactId>font-awesome</artifactId>
-        <version>5.11.2</version>
+        <version>5.15.2</version>
       </dependency>
       <dependency>
         <groupId>org.webjars</groupId>


### PR DESCRIPTION
**What's in the PR**
- Update Font Awesome to a version that includes the icon that was missing

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
