### PR TITLE
#2043 - Turn the project settings into a dashboard-like construct

### DIFF
--- a/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/config/DashboardAutoConfiguration.java
+++ b/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/config/DashboardAutoConfiguration.java
@@ -29,16 +29,17 @@ import de.tudarmstadt.ukp.inception.ui.core.dashboard.settings.ProjectSettingsPa
 public class DashboardAutoConfiguration
 {
     @Bean
-    @ConditionalOnProperty(prefix = "dashboard", name = "new-settings")
     @Order(8000)
+    @ConditionalOnProperty(prefix = "dashboard", name = "new-settings", matchIfMissing = true)
     public ProjectSettingsDashboardMenuItem projectSettingsDashboardMenuItem()
     {
         return new ProjectSettingsDashboardMenuItem();
     }
 
     @Bean
-    @ConditionalOnProperty(prefix = "dashboard", name = "new-settings", havingValue = "false", matchIfMissing = true)
+    @ConditionalOnProperty(prefix = "dashboard", name = "new-settings", havingValue = "false", matchIfMissing = false)
     @Order(8000)
+    @Deprecated
     public ProjectSettingsPageMenuItem projectSettingsPageMenuItem()
     {
         return new ProjectSettingsPageMenuItem();

--- a/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/ProjectSettingsDashboardMenuItem.java
+++ b/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/ProjectSettingsDashboardMenuItem.java
@@ -18,9 +18,12 @@
 package de.tudarmstadt.ukp.inception.ui.core.dashboard.settings;
 
 import org.apache.wicket.Page;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import de.agilecoders.wicket.core.markup.html.bootstrap.image.IconType;
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.icon.FontAwesome5IconType;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.inception.ui.core.dashboard.config.DashboardAutoConfiguration;
 import de.tudarmstadt.ukp.inception.ui.core.dashboard.settings.details.ProjectDetailPage;
 
@@ -33,6 +36,8 @@ import de.tudarmstadt.ukp.inception.ui.core.dashboard.settings.details.ProjectDe
 public class ProjectSettingsDashboardMenuItem
     extends ProjectSettingsMenuItemBase
 {
+    private @Autowired UserDao userRepo;
+
     @Override
     public String getPath()
     {
@@ -55,5 +60,11 @@ public class ProjectSettingsDashboardMenuItem
     public Class<? extends Page> getPageClass()
     {
         return ProjectDetailPage.class;
+    }
+    
+    @Override
+    public boolean applies(Project aProject)
+    {
+        return super.applies(aProject) || userRepo.isAdministrator(userRepo.getCurrentUser());
     }
 }

--- a/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/ProjectSettingsPageMenuItem.java
+++ b/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/ProjectSettingsPageMenuItem.java
@@ -36,6 +36,7 @@ import de.tudarmstadt.ukp.inception.ui.core.dashboard.config.DashboardAutoConfig
  * {@link DashboardAutoConfiguration#projectSettingsPageMenuItem()}.
  * </p>
  */
+@Deprecated
 public class ProjectSettingsPageMenuItem
     implements ProjectMenuItem
 {


### PR DESCRIPTION
**What's in the PR**
- Fix issue that admins do not see the settings menu item
- Make the new dashboard-like settings the default

**How to test manually**
* Log in as admin
* Enter a project where the admin user does not have any role
* Check if the settings button is there
* Check if clicking on the settings button takes you to the dashboard-like settings page

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
