### PR TITLE
#1117 - Ability to export recommender model

### DIFF
--- a/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/StringMatchingRecommenderFactory.java
+++ b/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/StringMatchingRecommenderFactory.java
@@ -100,4 +100,16 @@ public class StringMatchingRecommenderFactory
     {
         return new StringMatchingRecommenderTraits();
     }
+
+    @Override
+    public boolean isModelExportSupported()
+    {
+        return true;
+    }
+
+    @Override
+    public String getExportModelName(Recommender aRecommender)
+    {
+        return "model.txt";
+    }
 }

--- a/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/recommender/RecommendationEngine.java
+++ b/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/recommender/RecommendationEngine.java
@@ -22,6 +22,8 @@ import static de.tudarmstadt.ukp.inception.recommendation.api.RecommendationServ
 import static de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService.FEATURE_NAME_SCORE_SUFFIX;
 import static org.apache.uima.fit.util.CasUtil.getType;
 
+import java.io.IOException;
+import java.io.OutputStream;
 import java.util.List;
 
 import org.apache.uima.cas.CAS;
@@ -161,5 +163,10 @@ public abstract class RecommendationEngine
     protected Feature getIsPredictionFeature(CAS aCas)
     {
         return getPredictedType(aCas).getFeatureByBaseName(FEATURE_NAME_IS_PREDICTION);
+    }
+
+    public void exportModel(RecommenderContext aContext, OutputStream aOutput) throws IOException
+    {
+        throw new UnsupportedOperationException("Model export not supported");
     }
 }

--- a/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/recommender/RecommendationEngineFactory.java
+++ b/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/recommender/RecommendationEngineFactory.java
@@ -45,6 +45,16 @@ public interface RecommendationEngineFactory<T>
         return true;
     }
 
+    default boolean isModelExportSupported()
+    {
+        return false;
+    }
+
+    default String getExportModelName(Recommender aRecommender)
+    {
+        throw new UnsupportedOperationException("Model export not supported");
+    }
+
     RecommendationEngine build(Recommender aRecommender);
 
     boolean accepts(AnnotationLayer aLayer, AnnotationFeature aFeature);

--- a/inception-recommendation/pom.xml
+++ b/inception-recommendation/pom.xml
@@ -149,6 +149,10 @@
       <artifactId>wicket-extensions</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.wicket</groupId>
+      <artifactId>wicket-util</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.danekja</groupId>
       <artifactId>jdk-serializable-functional</artifactId>
     </dependency>

--- a/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommenderInfoPanel.html
+++ b/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommenderInfoPanel.html
@@ -50,6 +50,9 @@
           </div>
           <div class="text-right">
             <span wicket:id="state" class="badge badge-pill float-left"/>
+            <button wicket:id="exportModel" class="btn btn-sm btn-secondary">
+              <i class="fas fa-download"></i>
+            </button>
             <button wicket:id="acceptBest" class="btn btn-sm btn-success">
               <i class="fas fa-check"></i>&nbsp;
               Accept best


### PR DESCRIPTION
**What's in the PR**
- Added option to export the current model from the recommender sidebar on the annotation page

**How to test manually**
* Configure a string matching recommender (currently the only supported one)
* Make some annotations
* Open the recommender sidebar 
* Export the model

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
