### PR TITLE
#2086 - Import string matcher models as gazetters

### DIFF
--- a/inception-imls-stringmatch/pom.xml
+++ b/inception-imls-stringmatch/pom.xml
@@ -120,6 +120,10 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
 
     <!-- LOGGING DEPENDENCIES - SLF4J -->
     <dependency>

--- a/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/StringMatchingRecommender.java
+++ b/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/StringMatchingRecommender.java
@@ -295,6 +295,13 @@ public class StringMatchingRecommender
         final int minTrainingSetSize = 1;
         final int minTestSetSize = 1;
         if (trainingSetSize < minTrainingSetSize || testSetSize < minTestSetSize) {
+            if (!gazeteerService.listGazeteers(recommender).isEmpty()) {
+                // We cannot evaluate, but the user expects to see immediate results from the
+                // gazeteer - so we return with an "unknown" result but without marking it as
+                // skipped so that the selection task allows the recommender to activate.
+                return new EvaluationResult();
+            }
+
             String info = String.format(
                     "Not enough evaluation data: training set size [%d] (min. %d), test set size [%d] (min. %d) of total [%d] (min. %d)",
                     trainingSetSize, minTrainingSetSize, testSetSize, minTestSetSize, data.size(),

--- a/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/StringMatchingRecommenderTraits.java
+++ b/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/StringMatchingRecommenderTraits.java
@@ -17,6 +17,11 @@
  */
 package de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+//The @JsonSerialize annotation avoid the "InvalidDefinitionException: No serializer found"
+//exception without having to set SerializationFeature.FAIL_ON_EMPTY_BEANS
+@JsonSerialize
 public class StringMatchingRecommenderTraits
 {
 

--- a/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/gazeteer/GazeteerServiceImpl.java
+++ b/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/gazeteer/GazeteerServiceImpl.java
@@ -191,7 +191,7 @@ public class GazeteerServiceImpl
             }
 
             String[] fields = line.split("\t");
-            if (fields.length == 2) {
+            if (fields.length >= 2) {
                 String text = trimToNull(fields[0]);
                 String label = trimToNull(fields[1]);
                 if (label != null && text != null) {


### PR DESCRIPTION
**What's in the PR**
- Allow additional columns in gazeteers
- Avoid potential exception when serializing StringMatchingRecommenderTraits
- If a gazeteer is set, do not mark the evaluation as skipped even if there is no evaluation data so that the recommender may get activated

**How to test manually**
* Import some pre-annotated data (e.g. Part-of-speech from GUM)
* Create String matching recommender for POS
* Export its model
* Create new project with fresh document
* Also create String matching recommender for POS
* Import the previously exported model as a gazeteer

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
