### PR TITLE
#1516 - Long annotations (e.g. sentences) don't allow lines to wrap

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/paging/TokenWrappingPagingStrategy.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/paging/TokenWrappingPagingStrategy.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.api.annotation.paging;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.uima.cas.CAS;
+import org.apache.uima.cas.text.AnnotationFS;
+import org.apache.wicket.Component;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.model.IModel;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil;
+
+public class TokenWrappingPagingStrategy
+    implements PagingStrategy
+{
+    private static final long serialVersionUID = -3983123604003839467L;
+
+    private int maxLineLength;
+
+    public TokenWrappingPagingStrategy(int aMaxLineLength)
+    {
+        maxLineLength = aMaxLineLength;
+    }
+
+    @Override
+    public List<Unit> units(CAS aCas, int aFirstIndex, int aLastIndex)
+    {
+        Iterator<AnnotationFS> tokenIterator = WebAnnoCasUtil.selectTokens(aCas).iterator();
+
+        List<Unit> units = new ArrayList<>();
+
+        int currentUnitStart = 0;
+        int currentUnitEnd = 0;
+        while (tokenIterator.hasNext()) {
+            AnnotationFS currentToken = tokenIterator.next();
+
+            String gap = aCas.getDocumentText().substring(currentUnitEnd, currentToken.getBegin());
+            int lineBreakIndex = gap.indexOf("\n");
+            while (lineBreakIndex > -1) {
+                currentUnitEnd = currentUnitEnd + lineBreakIndex;
+                units.add(new Unit(units.size() + 1, currentUnitStart, currentUnitEnd));
+                currentUnitStart = currentUnitEnd + 1; // +1 because of the line break character
+                lineBreakIndex = gap.indexOf("\n", lineBreakIndex + 1);
+            }
+
+            boolean unitNonEmpty = (currentUnitEnd - currentUnitStart) > 0;
+            boolean unitFull = unitNonEmpty
+                    && ((currentToken.getEnd() - currentUnitStart) > maxLineLength);
+
+            // If the unit is full, finish the unit and start a new one
+            if (unitFull) {
+                units.add(new Unit(units.size() + 1, currentUnitStart, currentUnitEnd));
+                currentUnitStart = -1;
+            }
+
+            if (currentUnitStart == -1) {
+                currentUnitStart = currentToken.getBegin();
+            }
+
+            currentUnitEnd = currentToken.getEnd();
+        }
+
+        if (currentUnitEnd - currentUnitStart > 0) {
+            units.add(new Unit(units.size() + 1, currentUnitStart, currentUnitEnd));
+        }
+
+        return units;
+    }
+
+    @Override
+    public Component createPositionLabel(String aId, IModel<AnnotatorState> aModel)
+    {
+        Label label = new Label(aId, () -> {
+            AnnotatorState state = aModel.getObject();
+            return String.format("%d-%d / %d blocks [doc %d / %d]",
+                    state.getFirstVisibleUnitIndex(), state.getLastVisibleUnitIndex(),
+                    state.getUnitCount(), state.getDocumentIndex() + 1,
+                    state.getNumberOfDocuments());
+        });
+        label.setOutputMarkupPlaceholderTag(true);
+        return label;
+    }
+
+    @Override
+    public DefaultPagingNavigator createPageNavigator(String aId, AnnotationPageBase aPage)
+    {
+        return new DefaultPagingNavigator(aId, aPage);
+    }
+}

--- a/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/annotation/BratTokenWrappingAnnotationEditorFactory.java
+++ b/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/annotation/BratTokenWrappingAnnotationEditorFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.brat.annotation;
+
+import org.apache.wicket.model.IModel;
+import org.springframework.stereotype.Component;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.CasProvider;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.AnnotationEditorBase;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.AnnotationEditorFactoryImplBase;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.action.AnnotationActionHandler;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.paging.TokenWrappingPagingStrategy;
+
+@Component("tokenWrappingBratEditor")
+public class BratTokenWrappingAnnotationEditorFactory
+    extends AnnotationEditorFactoryImplBase
+{
+    @Override
+    public String getDisplayName()
+    {
+        return "brat (wrapping @ 120 chars)";
+    }
+
+    @Override
+    public AnnotationEditorBase create(String aId, IModel<AnnotatorState> aModel,
+            AnnotationActionHandler aActionHandler, CasProvider aCasProvider)
+    {
+        return new BratAnnotationEditor(aId, aModel, aActionHandler, aCasProvider);
+    }
+
+    @Override
+    public int getOrder()
+    {
+        return 1;
+    }
+
+    @Override
+    public void initState(AnnotatorState aModelObject)
+    {
+        aModelObject.setPagingStrategy(new TokenWrappingPagingStrategy(120));
+    }
+}

--- a/inception/inception-brat-editor/src/test/resources/longlines.json
+++ b/inception/inception-brat-editor/src/test/resources/longlines.json
@@ -1,0 +1,10 @@
+{
+  "action" : "getDocument",
+  "text" : "Zero  One two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty. One two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty.  One two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty. ",
+  "args" : { },
+  "rtl_mode" : false,
+  "font_zoom" : 100,
+  "sentence_number_offset" : 1,
+  "token_offsets" : [ [ 0, 4 ], [ 6, 9 ], [ 10, 13 ], [ 14, 19 ], [ 20, 24 ], [ 25, 29 ], [ 30, 33 ], [ 34, 39 ], [ 40, 45 ], [ 46, 50 ], [ 51, 54 ], [ 55, 61 ], [ 62, 68 ], [ 69, 77 ], [ 78, 86 ], [ 87, 94 ], [ 95, 102 ], [ 103, 112 ], [ 113, 121 ], [ 122, 130 ], [ 131, 137 ], [ 137, 138 ], [ 139, 142 ], [ 143, 146 ], [ 147, 152 ], [ 153, 157 ], [ 158, 162 ], [ 163, 166 ], [ 167, 172 ], [ 173, 178 ], [ 179, 183 ], [ 184, 187 ], [ 188, 194 ], [ 195, 201 ], [ 202, 210 ], [ 211, 219 ], [ 220, 227 ], [ 228, 235 ], [ 236, 245 ], [ 246, 254 ], [ 255, 263 ], [ 264, 270 ], [ 270, 271 ], [ 273, 276 ], [ 277, 280 ], [ 281, 286 ], [ 287, 291 ], [ 292, 296 ], [ 297, 300 ], [ 301, 306 ], [ 307, 312 ], [ 313, 317 ], [ 318, 321 ], [ 322, 328 ], [ 329, 335 ], [ 336, 344 ], [ 345, 353 ], [ 354, 361 ], [ 362, 369 ], [ 370, 379 ], [ 380, 388 ], [ 389, 397 ], [ 398, 404 ], [ 404, 405 ] ],
+  "sentence_offsets" : [ [ 0, 4 ], [ 5, 5 ], [ 6, 86 ], [ 87, 138 ], [ 139, 219 ], [ 220, 271 ], [ 272, 272 ], [ 273, 353 ], [ 354, 405 ], [ 406, 406 ] ]
+}

--- a/inception/inception-brat-editor/src/test/resources/longlines.txt
+++ b/inception/inception-brat-editor/src/test/resources/longlines.txt
@@ -1,0 +1,8 @@
+Zero
+
+One two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty.
+One two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty.
+
+One two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty.
+
+One hundred


### PR DESCRIPTION
**What's in the PR**
- Added a new "brat wrapping" mode which tries to wrap lines at 120 characters respecting token boundaries

**How to test manually**
* Import a document
* Switch to "brat (wrapping @ 120 chars)" mode
* Check if rendering, paging, annotation works

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
