### PR TITLE
#2105 - Gazetteer Case Sensitive

### DIFF
--- a/inception/inception-imls-stringmatch/pom.xml
+++ b/inception/inception-imls-stringmatch/pom.xml
@@ -192,6 +192,12 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -218,6 +224,10 @@
   <build>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+        </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>

--- a/inception/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/StringMatchingRecommender.java
+++ b/inception/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/StringMatchingRecommender.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -213,6 +214,9 @@ public class StringMatchingRecommender
 
         List<Sample> data = new ArrayList<>();
         String text = aCas.getDocumentText();
+        if (traits != null && traits.isIgnoreCase()) {
+            text = text.toLowerCase(Locale.ROOT);
+        }
 
         for (Annotation sentence : aCas.<Annotation> select(sentenceType)) {
             List<Span> spans = new ArrayList<>();
@@ -241,8 +245,8 @@ public class StringMatchingRecommender
                         if (label == UNKNOWN_LABEL) {
                             label = null;
                         }
-                        spans.add(new Span(begin, end, text.substring(begin, end), label,
-                                lc.getRelFreq()));
+                        spans.add(new Span(begin, end, aCas.getDocumentText().substring(begin, end),
+                                label, lc.getRelFreq()));
                     }
                 }
             }
@@ -295,7 +299,7 @@ public class StringMatchingRecommender
         final int minTrainingSetSize = 1;
         final int minTestSetSize = 1;
         if (trainingSetSize < minTrainingSetSize || testSetSize < minTestSetSize) {
-            if (!gazeteerService.listGazeteers(recommender).isEmpty()) {
+            if (gazeteerService != null && !gazeteerService.listGazeteers(recommender).isEmpty()) {
                 // We cannot evaluate, but the user expects to see immediate results from the
                 // gazeteer - so we return with an "unknown" result but without marking it as
                 // skipped so that the selection task allows the recommender to activate.
@@ -358,10 +362,15 @@ public class StringMatchingRecommender
     {
         String label = isBlank(aLabel) ? UNKNOWN_LABEL : aLabel;
 
-        DictEntry entry = aDict.get(aText);
+        String text = aText;
+        if (traits != null && traits.isIgnoreCase()) {
+            text = text.toLowerCase(Locale.ROOT);
+        }
+
+        DictEntry entry = aDict.get(text);
         if (entry == null) {
-            entry = new DictEntry(aText);
-            aDict.put(aText, entry);
+            entry = new DictEntry(text);
+            aDict.put(text, entry);
         }
 
         entry.put(label);

--- a/inception/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/StringMatchingRecommenderFactory.java
+++ b/inception/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/StringMatchingRecommenderFactory.java
@@ -64,7 +64,7 @@ public class StringMatchingRecommenderFactory
     @Override
     public RecommendationEngine build(Recommender aRecommender)
     {
-        StringMatchingRecommenderTraits traits = new StringMatchingRecommenderTraits();
+        StringMatchingRecommenderTraits traits = readTraits(aRecommender);
         return new StringMatchingRecommender(aRecommender, traits, gazeteerService);
     }
 

--- a/inception/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/StringMatchingRecommenderTraits.java
+++ b/inception/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/StringMatchingRecommenderTraits.java
@@ -28,4 +28,16 @@ public class StringMatchingRecommenderTraits
     implements Serializable
 {
     private static final long serialVersionUID = -7433406243352691789L;
+
+    private boolean ignoreCase;
+
+    public boolean isIgnoreCase()
+    {
+        return ignoreCase;
+    }
+
+    public void setIgnoreCase(boolean aIgnoreCase)
+    {
+        ignoreCase = aIgnoreCase;
+    }
 }

--- a/inception/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/settings/StringMatchingRecommenderTraitsEditor.html
+++ b/inception/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/settings/StringMatchingRecommenderTraitsEditor.html
@@ -18,6 +18,18 @@
 <html xmlns:wicket="http://wicket.apache.org">
 <body>
   <wicket:extend>
+    <form wicket:id="form">
+      <div class="form-group form-row" wicket:enclosure="ignoreCase">
+        <div class="offset-sm-3 col-sm-9">
+          <div class="form-check">
+            <input wicket:id="ignoreCase" class="form-check-input" type="checkbox"/>
+            <label wicket:for="ignoreCase" class="form-check-label">
+              <wicket:label key="ignoreCase"/>
+            </label>
+          </div>
+        </div>
+      </div>
+    </form>
     <wicket:remove>
       <!-- 
         NOTE: The enclosure needs to be defined on the upload field. Defining it on the

--- a/inception/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/settings/StringMatchingRecommenderTraitsEditor.properties
+++ b/inception/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/settings/StringMatchingRecommenderTraitsEditor.properties
@@ -14,3 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 gazeteers=Gazeteers
+ignoreCase=Case insensitive

--- a/inception/inception-imls-stringmatch/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/gazeteer/GazeteerServiceImplTest.java
+++ b/inception/inception-imls-stringmatch/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/gazeteer/GazeteerServiceImplTest.java
@@ -50,6 +50,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -64,7 +65,7 @@ import de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.model.Gazete
 import de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.model.GazeteerEntry;
 
 @RunWith(SpringRunner.class)
-@DataJpaTest
+@DataJpaTest(excludeAutoConfiguration = LiquibaseAutoConfiguration.class)
 @Transactional
 @EntityScan(basePackages = { "de.tudarmstadt.ukp.inception",
         "de.tudarmstadt.ukp.clarin.webanno.model" })
@@ -214,7 +215,7 @@ public class GazeteerServiceImplTest
     }
 
     @Test
-    public void thatInvalidGazeteerGeneratesException() throws Exception
+    public void thatGazeteerWithExtraColumnsCanBeRead() throws Exception
     {
         Gazeteer gaz = new Gazeteer("gaz", rec1);
 
@@ -227,11 +228,9 @@ public class GazeteerServiceImplTest
                 .isThrownBy(() -> sut.parseGazeteer(gaz, toInputStream(gazeteer1, UTF_8), data))
                 .withMessageContaining("Unable to parse line 2");
 
-        String gazeteer2 = "Bill\tPER\tDUMMY";
+        String gazeteer2 = "Bill\tPER\t40";
 
-        assertThatExceptionOfType(IOException.class).describedAs("Line without too many fields")
-                .isThrownBy(() -> sut.parseGazeteer(gaz, toInputStream(gazeteer2, UTF_8), data))
-                .withMessageContaining("Unable to parse line 1");
+        sut.parseGazeteer(gaz, toInputStream(gazeteer2, UTF_8), data);
     }
 
     @SpringBootConfiguration

--- a/inception/inception-ui-core/pom.xml
+++ b/inception/inception-ui-core/pom.xml
@@ -169,6 +169,12 @@
     <dependency>
       <groupId>io.bit3</groupId>
       <artifactId>jsass</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     
     <dependency>


### PR DESCRIPTION
**What's in the PR**
- Add case-sensitivity switch to string matcher
- Make string matcher unit tests run again
- Fix a bunch of bugs that got undetected because the unit tests did not run

**How to test manually**
* Enable case insensitivity in string recommender
* Have a text in which a word appears in different capitalizations
* Annotate one of the words, look for suggestion on the other

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
