### PR TITLE
#2126 - Open proper editor for document

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/AnnotationEditorFactory.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/AnnotationEditorFactory.java
@@ -17,6 +17,8 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.api.annotation;
 
+import static java.lang.Integer.MIN_VALUE;
+
 import org.apache.wicket.model.IModel;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.CasProvider;
@@ -25,12 +27,21 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
 
 public interface AnnotationEditorFactory
 {
+    static int NOT_SUITABLE = MIN_VALUE;
+    static int DEFAULT = 1_000;
+    static int PREFERRED = 10_000;
+
     /**
      * @return get the bean name.
      */
     String getBeanName();
 
     String getDisplayName();
+
+    default int accepts(String aFormat)
+    {
+        return DEFAULT;
+    }
 
     AnnotationEditorBase create(String id, IModel<AnnotatorState> aModel,
             final AnnotationActionHandler aActionHandler, final CasProvider aCasProvider);

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/AnnotationEditorRegistry.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/AnnotationEditorRegistry.java
@@ -26,4 +26,6 @@ public interface AnnotationEditorRegistry
     AnnotationEditorFactory getEditorFactory(String aId);
 
     AnnotationEditorFactory getDefaultEditorFactory();
+
+    AnnotationEditorFactory getPreferredEditorFactory(String aFormat);
 }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/AnnotationEditorRegistryImpl.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/AnnotationEditorRegistryImpl.java
@@ -17,6 +17,8 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.api.annotation;
 
+import static java.util.Comparator.comparing;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -92,5 +94,13 @@ public class AnnotationEditorRegistryImpl
     public AnnotationEditorFactory getDefaultEditorFactory()
     {
         return getEditorFactories().get(0);
+    }
+
+    @Override
+    public AnnotationEditorFactory getPreferredEditorFactory(String aFormat)
+    {
+        return getEditorFactories().stream() //
+                .max(comparing(factory -> factory.accepts(aFormat))) //
+                .orElseGet(this::getDefaultEditorFactory);
     }
 }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/paging/NoPagingStrategy.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/paging/NoPagingStrategy.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.api.annotation.paging;
+
+import static java.util.Arrays.asList;
+
+import java.util.List;
+
+import org.apache.uima.cas.CAS;
+import org.apache.wicket.Component;
+import org.apache.wicket.markup.html.panel.EmptyPanel;
+import org.apache.wicket.model.IModel;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.paging.DefaultPagingNavigator;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.paging.PagingStrategy;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.paging.Unit;
+
+public class NoPagingStrategy
+    implements PagingStrategy
+{
+    private static final long serialVersionUID = 1589886937787735472L;
+
+    @Override
+    public List<Unit> units(CAS aCas, int aFirstIndex, int aLastIndex)
+    {
+        return asList(new Unit(0, 0, aCas.getDocumentText().length()));
+    }
+
+    @Override
+    public Component createPositionLabel(String aId, IModel<AnnotatorState> aModel)
+    {
+        EmptyPanel emptyPanel = new EmptyPanel(aId);
+        // Just to avoid errors when re-rendering this is requested in an AJAX request
+        emptyPanel.setOutputMarkupId(true);
+        return emptyPanel;
+    }
+
+    @Override
+    public DefaultPagingNavigator createPageNavigator(String aId, AnnotationPageBase aPage)
+    {
+        DefaultPagingNavigator navi = new DefaultPagingNavigator(aId, aPage);
+        navi.setOutputMarkupPlaceholderTag(true);
+        navi.setVisible(false);
+        return navi;
+    }
+}

--- a/inception/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/htmleditor/HtmlAnnotationEditorFactory.java
+++ b/inception/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/htmleditor/HtmlAnnotationEditorFactory.java
@@ -47,6 +47,18 @@ public class HtmlAnnotationEditorFactory
     }
 
     @Override
+    public int accepts(String aFormat)
+    {
+        switch (aFormat) {
+        case LegacyHtmlFormatSupport.ID: // fall-through
+        case HtmlFormatSupport.ID:
+            return PREFERRED;
+        default:
+            return DEFAULT;
+        }
+    }
+
+    @Override
     public AnnotationEditorBase create(String aId, IModel<AnnotatorState> aModel,
             AnnotationActionHandler aActionHandler, CasProvider aCasProvider)
     {

--- a/inception/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/PdfAnnotationEditorFactory.java
+++ b/inception/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/PdfAnnotationEditorFactory.java
@@ -47,6 +47,17 @@ public class PdfAnnotationEditorFactory
     }
 
     @Override
+    public int accepts(String aFormat)
+    {
+        switch (aFormat) {
+        case PdfFormatSupport.ID:
+            return PREFERRED;
+        default:
+            return NOT_SUITABLE;
+        }
+    }
+
+    @Override
     public AnnotationEditorBase create(String aId, IModel<AnnotatorState> aModel,
             AnnotationActionHandler aActionHandler, CasProvider aCasProvider)
     {

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
@@ -312,7 +312,12 @@ public class AnnotationPage
 
         AnnotationEditorFactory factory = editorRegistry.getEditorFactory(editorId);
         if (factory == null) {
-            factory = editorRegistry.getDefaultEditorFactory();
+            if (state.getDocument() != null) {
+                factory = editorRegistry.getPreferredEditorFactory(state.getDocument().getFormat());
+            }
+            else {
+                factory = editorRegistry.getDefaultEditorFactory();
+            }
         }
 
         annotationEditor = factory.create("editor", getModel(), detailEditor, this::getEditorCas);
@@ -681,7 +686,8 @@ public class AnnotationPage
     }
 
     @Override
-    public List<DecoratedObject<SourceDocument>> listAccessibleDocuments(Project aProject, User aUser)
+    public List<DecoratedObject<SourceDocument>> listAccessibleDocuments(Project aProject,
+            User aUser)
     {
         final List<DecoratedObject<SourceDocument>> allSourceDocuments = new ArrayList<>();
 


### PR DESCRIPTION
**What's in the PR**
- Added "auto" option to the list of viewers and made it the default for new projects
- Added API for editors to say how well they support a certain format and whether they should be preferred

**How to test manually**
* In a project with multiple types of documents (text, html, pdf) set the editor to "auto" in the annotation page preferences
* Switch between the documents

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
