### PR TITLE
#2146 - Limit document size on import

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/actionbar/export/ExportDocumentDialogContent.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/actionbar/export/ExportDocumentDialogContent.java
@@ -36,7 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.form.select.BootstrapSelect;
-import de.tudarmstadt.ukp.clarin.webanno.api.ImportExportService;
+import de.tudarmstadt.ukp.clarin.webanno.api.DocumentImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
 import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxFormComponentUpdatingBehavior;
@@ -53,7 +53,7 @@ public class ExportDocumentDialogContent
 
     private static final Logger LOG = LoggerFactory.getLogger(ExportDocumentDialogContent.class);
 
-    private @SpringBean ImportExportService importExportService;
+    private @SpringBean DocumentImportExportService importExportService;
 
     private IModel<AnnotatorState> state;
     private IModel<Preferences> preferences;

--- a/inception/inception-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentServiceImpl.java
+++ b/inception/inception-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentServiceImpl.java
@@ -71,8 +71,8 @@ import org.springframework.transaction.event.TransactionalEventListener;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.CasStorageService;
 import de.tudarmstadt.ukp.clarin.webanno.api.CasUpgradeMode;
+import de.tudarmstadt.ukp.clarin.webanno.api.DocumentImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
-import de.tudarmstadt.ukp.clarin.webanno.api.ImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
 import de.tudarmstadt.ukp.clarin.webanno.api.RepositoryProperties;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode;
@@ -104,14 +104,14 @@ public class DocumentServiceImpl
     private EntityManager entityManager;
 
     private final CasStorageService casStorageService;
-    private final ImportExportService importExportService;
+    private final DocumentImportExportService importExportService;
     private final ProjectService projectService;
     private final ApplicationEventPublisher applicationEventPublisher;
     private final RepositoryProperties repositoryProperties;
 
     @Autowired
     public DocumentServiceImpl(RepositoryProperties aRepositoryProperties,
-            CasStorageService aCasStorageService, ImportExportService aImportExportService,
+            CasStorageService aCasStorageService, DocumentImportExportService aImportExportService,
             ProjectService aProjectService, ApplicationEventPublisher aApplicationEventPublisher)
     {
         repositoryProperties = aRepositoryProperties;
@@ -124,7 +124,7 @@ public class DocumentServiceImpl
     }
 
     public DocumentServiceImpl(RepositoryProperties aRepositoryProperties,
-            CasStorageService aCasStorageService, ImportExportService aImportExportService,
+            CasStorageService aCasStorageService, DocumentImportExportService aImportExportService,
             ProjectService aProjectService, ApplicationEventPublisher aApplicationEventPublisher,
             EntityManager aEntityManager)
     {

--- a/inception/inception-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/docimexport/config/DocumentImportExportServiceProperties.java
+++ b/inception/inception-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/docimexport/config/DocumentImportExportServiceProperties.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.api.dao.docimexport.config;
+
+public interface DocumentImportExportServiceProperties
+{
+    int getMaxTokens();
+
+    int getMaxSentences();
+}

--- a/inception/inception-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/docimexport/config/DocumentImportExportServicePropertiesImpl.java
+++ b/inception/inception-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/docimexport/config/DocumentImportExportServicePropertiesImpl.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.api.dao.docimexport.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties("document-import")
+public class DocumentImportExportServicePropertiesImpl
+    implements DocumentImportExportServiceProperties
+{
+    private int maxTokens = 2_000_000;
+    private int maxSentences = 20_000;
+
+    @Override
+    public int getMaxTokens()
+    {
+        return maxTokens;
+    }
+
+    public void setMaxTokens(int aMaxTokens)
+    {
+        maxTokens = aMaxTokens;
+    }
+
+    @Override
+    public int getMaxSentences()
+    {
+        return maxSentences;
+    }
+
+    public void setMaxSentences(int aMaxSentences)
+    {
+        maxSentences = aMaxSentences;
+    }
+}

--- a/inception/inception-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/export/ProjectExportCuratedDocumentsTask.java
+++ b/inception/inception-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/export/ProjectExportCuratedDocumentsTask.java
@@ -26,8 +26,8 @@ import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import de.tudarmstadt.ukp.clarin.webanno.api.DocumentImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
-import de.tudarmstadt.ukp.clarin.webanno.api.ImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExportException;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExportRequest;
@@ -50,7 +50,7 @@ public class ProjectExportCuratedDocumentsTask
 
     private @Autowired ProjectExportService exportService;
     private @Autowired DocumentService documentService;
-    private @Autowired ImportExportService importExportService;
+    private @Autowired DocumentImportExportService importExportService;
 
     public ProjectExportCuratedDocumentsTask(ProjectExportTaskHandle aHandle,
             ProjectExportTaskMonitor aMonitor, ProjectExportRequest aRequest, String aUsername)

--- a/inception/inception-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/export/exporters/AnnotationDocumentExporter.java
+++ b/inception/inception-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/export/exporters/AnnotationDocumentExporter.java
@@ -62,8 +62,8 @@ import org.springframework.stereotype.Component;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 
+import de.tudarmstadt.ukp.clarin.webanno.api.DocumentImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
-import de.tudarmstadt.ukp.clarin.webanno.api.ImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.RepositoryProperties;
 import de.tudarmstadt.ukp.clarin.webanno.api.dao.casstorage.CasStorageSession;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExportRequest;
@@ -94,12 +94,12 @@ public class AnnotationDocumentExporter
 
     private final DocumentService documentService;
     private final UserDao userRepository;
-    private final ImportExportService importExportService;
+    private final DocumentImportExportService importExportService;
     private final RepositoryProperties repositoryProperties;
 
     @Autowired
     public AnnotationDocumentExporter(DocumentService aDocumentService, UserDao aUserRepository,
-            ImportExportService aImportExportService, RepositoryProperties aRepositoryProperties)
+            DocumentImportExportService aImportExportService, RepositoryProperties aRepositoryProperties)
     {
         documentService = aDocumentService;
         userRepository = aUserRepository;

--- a/inception/inception-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/export/exporters/CuratedDocumentsExporter.java
+++ b/inception/inception-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/export/exporters/CuratedDocumentsExporter.java
@@ -45,8 +45,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import de.tudarmstadt.ukp.clarin.webanno.api.DocumentImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
-import de.tudarmstadt.ukp.clarin.webanno.api.ImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExportException;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExportRequest;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExportTaskMonitor;
@@ -70,11 +70,11 @@ public class CuratedDocumentsExporter
     private final Logger log = LoggerFactory.getLogger(getClass());
 
     private final DocumentService documentService;
-    private final ImportExportService importExportService;
+    private final DocumentImportExportService importExportService;
 
     @Autowired
     public CuratedDocumentsExporter(DocumentService aDocumentService,
-            ImportExportService aImportExportService)
+            DocumentImportExportService aImportExportService)
     {
         documentService = aDocumentService;
         importExportService = aImportExportService;

--- a/inception/inception-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentImportExportServiceImplTest.java
+++ b/inception/inception-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentImportExportServiceImplTest.java
@@ -53,20 +53,22 @@ import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.RepositoryProperties;
 import de.tudarmstadt.ukp.clarin.webanno.api.dao.casstorage.CasStorageSession;
 import de.tudarmstadt.ukp.clarin.webanno.api.dao.casstorage.config.CasStoragePropertiesImpl;
+import de.tudarmstadt.ukp.clarin.webanno.api.dao.docimexport.config.DocumentImportExportServiceProperties;
+import de.tudarmstadt.ukp.clarin.webanno.api.dao.docimexport.config.DocumentImportExportServicePropertiesImpl;
 import de.tudarmstadt.ukp.clarin.webanno.api.type.CASMetadata;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.xmi.XmiFormatSupport;
 import de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData;
 
-public class ImportExportServiceImplTest
+public class DocumentImportExportServiceImplTest
 {
     private CasStorageSession casStorageSession;
     private @Spy AnnotationSchemaService schemaService;
 
     public @Rule TemporaryFolder testFolder = new TemporaryFolder();
 
-    private ImportExportServiceImpl sut;
+    private DocumentImportExportServiceImpl sut;
 
     @Before
     public void setup() throws Exception
@@ -76,14 +78,16 @@ public class ImportExportServiceImplTest
         // schemaService = mock(AnnotationSchemaServiceImpl.class);
         schemaService = Mockito.spy(new AnnotationSchemaServiceImpl());
 
+        DocumentImportExportServiceProperties properties = new DocumentImportExportServicePropertiesImpl();
+
         RepositoryProperties repositoryProperties = new RepositoryProperties();
         repositoryProperties.setPath(testFolder.newFolder());
 
         CasStorageServiceImpl storageService = new CasStorageServiceImpl(null, null,
                 repositoryProperties, new CasStoragePropertiesImpl(), new BackupProperties());
 
-        sut = new ImportExportServiceImpl(repositoryProperties, List.of(new XmiFormatSupport()),
-                storageService, schemaService);
+        sut = new DocumentImportExportServiceImpl(repositoryProperties,
+                List.of(new XmiFormatSupport()), storageService, schemaService, properties);
         sut.onContextRefreshedEvent();
 
         doReturn(emptyList()).when(schemaService).listAnnotationLayer(any());

--- a/inception/inception-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentServiceImplTest.java
+++ b/inception/inception-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentServiceImplTest.java
@@ -59,8 +59,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationEventPublisher;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.CasStorageService;
+import de.tudarmstadt.ukp.clarin.webanno.api.DocumentImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
-import de.tudarmstadt.ukp.clarin.webanno.api.ImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
 import de.tudarmstadt.ukp.clarin.webanno.api.RepositoryProperties;
 import de.tudarmstadt.ukp.clarin.webanno.api.dao.casstorage.CasStorageSession;
@@ -75,7 +75,7 @@ public class DocumentServiceImplTest
 {
     private Logger log = LoggerFactory.getLogger(getClass());
 
-    private @Mock ImportExportService importExportService;
+    private @Mock DocumentImportExportService importExportService;
     private @Mock ProjectService projectService;
     private @Mock ApplicationEventPublisher applicationEventPublisher;
     private @Mock EntityManager entityManager;

--- a/inception/inception-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/SegmentationTest.java
+++ b/inception/inception-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/SegmentationTest.java
@@ -36,7 +36,7 @@ public class SegmentationTest
     {
         JCas jcas = JCasFactory.createText("I am one. I am two.", "en");
 
-        ImportExportServiceImpl.splitSentences(jcas.getCas());
+        DocumentImportExportServiceImpl.splitSentences(jcas.getCas());
 
         assertEquals(asList("I am one.", "I am two."), toText(select(jcas, Sentence.class)));
     }
@@ -49,7 +49,7 @@ public class SegmentationTest
         ;
         new Sentence(jcas, 9, 18).addToIndexes();
 
-        ImportExportServiceImpl.tokenize(jcas.getCas());
+        DocumentImportExportServiceImpl.tokenize(jcas.getCas());
 
         assertEquals(asList("i am one.", "i am two."), toText(select(jcas, Sentence.class)));
         assertEquals(asList("i", "am", "one", ".", "i", "am", "two", "."),

--- a/inception/inception-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/export/exporters/AnnotationDocumentsExporterTest.java
+++ b/inception/inception-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/export/exporters/AnnotationDocumentsExporterTest.java
@@ -39,13 +39,15 @@ import org.mockito.Mock;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.CasStorageService;
+import de.tudarmstadt.ukp.clarin.webanno.api.DocumentImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
-import de.tudarmstadt.ukp.clarin.webanno.api.ImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.RepositoryProperties;
 import de.tudarmstadt.ukp.clarin.webanno.api.dao.BackupProperties;
 import de.tudarmstadt.ukp.clarin.webanno.api.dao.CasStorageServiceImpl;
-import de.tudarmstadt.ukp.clarin.webanno.api.dao.ImportExportServiceImpl;
+import de.tudarmstadt.ukp.clarin.webanno.api.dao.DocumentImportExportServiceImpl;
 import de.tudarmstadt.ukp.clarin.webanno.api.dao.casstorage.config.CasStoragePropertiesImpl;
+import de.tudarmstadt.ukp.clarin.webanno.api.dao.docimexport.config.DocumentImportExportServiceProperties;
+import de.tudarmstadt.ukp.clarin.webanno.api.dao.docimexport.config.DocumentImportExportServicePropertiesImpl;
 import de.tudarmstadt.ukp.clarin.webanno.api.dao.export.ProjectExportServiceImpl;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectImportRequest;
 import de.tudarmstadt.ukp.clarin.webanno.export.model.ExportedProject;
@@ -59,7 +61,7 @@ public class AnnotationDocumentsExporterTest
     public @Rule TemporaryFolder tempFolder = new TemporaryFolder();
 
     private RepositoryProperties repositoryProperties;
-    private ImportExportService importExportSerivce;
+    private DocumentImportExportService importExportSerivce;
     private CasStorageService casStorageService;
 
     private @Mock DocumentService documentService;
@@ -82,14 +84,16 @@ public class AnnotationDocumentsExporterTest
         project.setId(1l);
         project.setName("Test Project");
 
+        DocumentImportExportServiceProperties properties = new DocumentImportExportServicePropertiesImpl();
+
         repositoryProperties = new RepositoryProperties();
         repositoryProperties.setPath(workFolder);
 
         casStorageService = new CasStorageServiceImpl(null, schemaService, repositoryProperties,
                 new CasStoragePropertiesImpl(), new BackupProperties());
 
-        importExportSerivce = new ImportExportServiceImpl(repositoryProperties,
-                asList(new XmiFormatSupport()), casStorageService, schemaService);
+        importExportSerivce = new DocumentImportExportServiceImpl(repositoryProperties,
+                asList(new XmiFormatSupport()), casStorageService, schemaService, properties);
 
         sut = new AnnotationDocumentExporter(documentService, null, importExportSerivce,
                 repositoryProperties);

--- a/inception/inception-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/export/exporters/CuratedDocumentsExporterTest.java
+++ b/inception/inception-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/export/exporters/CuratedDocumentsExporterTest.java
@@ -42,13 +42,15 @@ import org.mockito.Mock;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.CasStorageService;
+import de.tudarmstadt.ukp.clarin.webanno.api.DocumentImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
-import de.tudarmstadt.ukp.clarin.webanno.api.ImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.RepositoryProperties;
 import de.tudarmstadt.ukp.clarin.webanno.api.dao.BackupProperties;
 import de.tudarmstadt.ukp.clarin.webanno.api.dao.CasStorageServiceImpl;
-import de.tudarmstadt.ukp.clarin.webanno.api.dao.ImportExportServiceImpl;
+import de.tudarmstadt.ukp.clarin.webanno.api.dao.DocumentImportExportServiceImpl;
 import de.tudarmstadt.ukp.clarin.webanno.api.dao.casstorage.config.CasStoragePropertiesImpl;
+import de.tudarmstadt.ukp.clarin.webanno.api.dao.docimexport.config.DocumentImportExportServiceProperties;
+import de.tudarmstadt.ukp.clarin.webanno.api.dao.docimexport.config.DocumentImportExportServicePropertiesImpl;
 import de.tudarmstadt.ukp.clarin.webanno.api.dao.export.ProjectExportServiceImpl;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectImportRequest;
 import de.tudarmstadt.ukp.clarin.webanno.export.model.ExportedProject;
@@ -61,7 +63,7 @@ public class CuratedDocumentsExporterTest
     public @Rule TemporaryFolder tempFolder = new TemporaryFolder();
 
     private RepositoryProperties repositoryProperties;
-    private ImportExportService importExportSerivce;
+    private DocumentImportExportService importExportSerivce;
     private CasStorageService casStorageService;
 
     private @Mock DocumentService documentService;
@@ -84,14 +86,16 @@ public class CuratedDocumentsExporterTest
         project.setId(1l);
         project.setName("Test Project");
 
+        DocumentImportExportServiceProperties properties = new DocumentImportExportServicePropertiesImpl();
+
         repositoryProperties = new RepositoryProperties();
         repositoryProperties.setPath(workFolder);
 
         casStorageService = spy(new CasStorageServiceImpl(null, schemaService, repositoryProperties,
                 new CasStoragePropertiesImpl(), new BackupProperties()));
 
-        importExportSerivce = new ImportExportServiceImpl(repositoryProperties,
-                asList(new XmiFormatSupport()), casStorageService, schemaService);
+        importExportSerivce = new DocumentImportExportServiceImpl(repositoryProperties,
+                asList(new XmiFormatSupport()), casStorageService, schemaService, properties);
 
         // documentService.getCasFile() is just a stupid wrapper around storageService.getCasFile()
         // and it is easiest we emulate it here

--- a/inception/inception-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/DocumentImportExportService.java
+++ b/inception/inception-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/DocumentImportExportService.java
@@ -36,7 +36,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 
-public interface ImportExportService
+public interface DocumentImportExportService
 {
     String SERVICE_NAME = "importExportService";
 

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide.adoc
@@ -82,6 +82,8 @@ include::{include-dir}settings_internal-backup.adoc[leveloffset=+1]
 
 include::{include-dir}settings_cas-storage_cache.adoc[leveloffset=+1]
 
+include::{include-dir}settings_document-import-export.adoc[leveloffset=+1]
+
 include::{include-dir}settings_custom-header-icons.adoc[leveloffset=+1]
 
 include::{include-dir}settings_annotation-editor.adoc[leveloffset=+1]

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/settings_document-import-export.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/settings_document-import-export.adoc
@@ -1,0 +1,39 @@
+// Licensed to the Technische Universität Darmstadt under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The Technische Universität Darmstadt 
+// licenses this file to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.
+//  
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+= Document Im-/Export
+
+Control the importing and exporting of documents:
+
+.Document import/export settings in the `settings.properties` file
+[cols="4*", options="header"]
+|===
+| Setting
+| Description
+| Default
+| Example
+
+| document-import.max-tokens
+| Token-count limit for imported documents
+| 2000000
+| 0 _(no limit)_
+
+| document-import.max-sentences
+| Sentence-count limit for imported documents
+| 20000
+| 0 _(no limit)_
+|===
+

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/LegacyRemoteApiController.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/LegacyRemoteApiController.java
@@ -54,8 +54,8 @@ import org.springframework.web.multipart.MultipartFile;
 import com.github.openjson.JSONArray;
 import com.github.openjson.JSONObject;
 
+import de.tudarmstadt.ukp.clarin.webanno.api.DocumentImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
-import de.tudarmstadt.ukp.clarin.webanno.api.ImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
 import de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst;
 import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
@@ -100,7 +100,7 @@ public class LegacyRemoteApiController
 
     private @Autowired ProjectService projectRepository;
     private @Autowired DocumentService documentRepository;
-    private @Autowired ImportExportService importExportService;
+    private @Autowired DocumentImportExportService importExportService;
     private @Autowired UserDao userRepository;
 
     /**

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
@@ -82,8 +82,8 @@ import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
+import de.tudarmstadt.ukp.clarin.webanno.api.DocumentImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
-import de.tudarmstadt.ukp.clarin.webanno.api.ImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
 import de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExportRequest;
@@ -162,7 +162,7 @@ public class AeroRemoteApiController
     private @Autowired DocumentService documentService;
     private @Autowired CurationDocumentService curationService;
     private @Autowired ProjectService projectService;
-    private @Autowired ImportExportService importExportService;
+    private @Autowired DocumentImportExportService importExportService;
     private @Autowired AnnotationSchemaService annotationService;
     private @Autowired UserDao userRepository;
     private @Autowired ProjectExportService exportService;

--- a/inception/inception-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/AeroRemoteApiControllerTest.java
+++ b/inception/inception-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/AeroRemoteApiControllerTest.java
@@ -60,8 +60,8 @@ import org.springframework.web.context.WebApplicationContext;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.CasStorageService;
+import de.tudarmstadt.ukp.clarin.webanno.api.DocumentImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
-import de.tudarmstadt.ukp.clarin.webanno.api.ImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
 import de.tudarmstadt.ukp.clarin.webanno.api.RepositoryProperties;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRegistry;
@@ -74,10 +74,12 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.layer.SpanLayerSupport;
 import de.tudarmstadt.ukp.clarin.webanno.api.dao.AnnotationSchemaServiceImpl;
 import de.tudarmstadt.ukp.clarin.webanno.api.dao.BackupProperties;
 import de.tudarmstadt.ukp.clarin.webanno.api.dao.CasStorageServiceImpl;
+import de.tudarmstadt.ukp.clarin.webanno.api.dao.DocumentImportExportServiceImpl;
 import de.tudarmstadt.ukp.clarin.webanno.api.dao.DocumentServiceImpl;
-import de.tudarmstadt.ukp.clarin.webanno.api.dao.ImportExportServiceImpl;
 import de.tudarmstadt.ukp.clarin.webanno.api.dao.casstorage.OpenCasStorageSessionForRequestFilter;
 import de.tudarmstadt.ukp.clarin.webanno.api.dao.casstorage.config.CasStoragePropertiesImpl;
+import de.tudarmstadt.ukp.clarin.webanno.api.dao.docimexport.config.DocumentImportExportServiceProperties;
+import de.tudarmstadt.ukp.clarin.webanno.api.dao.docimexport.config.DocumentImportExportServicePropertiesImpl;
 import de.tudarmstadt.ukp.clarin.webanno.api.dao.export.ProjectExportServiceImpl;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExportService;
 import de.tudarmstadt.ukp.clarin.webanno.curation.storage.CurationDocumentService;
@@ -345,10 +347,13 @@ public class AeroRemoteApiControllerTest
         }
 
         @Bean
-        public ImportExportService importExportService()
+        public DocumentImportExportService importExportService()
         {
-            return new ImportExportServiceImpl(repositoryProperties(),
-                    asList(new TextFormatSupport()), casStorageService(), annotationService());
+            DocumentImportExportServiceProperties properties = new DocumentImportExportServicePropertiesImpl();
+
+            return new DocumentImportExportServiceImpl(repositoryProperties(),
+                    asList(new TextFormatSupport()), casStorageService(), annotationService(),
+                    properties);
         }
 
         @Bean

--- a/inception/inception-search-mtas/src/test/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndexTest.java
+++ b/inception/inception-search-mtas/src/test/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndexTest.java
@@ -59,8 +59,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.CasStorageService;
+import de.tudarmstadt.ukp.clarin.webanno.api.DocumentImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
-import de.tudarmstadt.ukp.clarin.webanno.api.ImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
 import de.tudarmstadt.ukp.clarin.webanno.api.RepositoryProperties;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.BooleanFeatureSupport;
@@ -76,10 +76,12 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.layer.SpanLayerSupport;
 import de.tudarmstadt.ukp.clarin.webanno.api.dao.AnnotationSchemaServiceImpl;
 import de.tudarmstadt.ukp.clarin.webanno.api.dao.BackupProperties;
 import de.tudarmstadt.ukp.clarin.webanno.api.dao.CasStorageServiceImpl;
+import de.tudarmstadt.ukp.clarin.webanno.api.dao.DocumentImportExportServiceImpl;
 import de.tudarmstadt.ukp.clarin.webanno.api.dao.DocumentServiceImpl;
-import de.tudarmstadt.ukp.clarin.webanno.api.dao.ImportExportServiceImpl;
 import de.tudarmstadt.ukp.clarin.webanno.api.dao.casstorage.CasStorageSession;
 import de.tudarmstadt.ukp.clarin.webanno.api.dao.casstorage.config.CasStoragePropertiesImpl;
+import de.tudarmstadt.ukp.clarin.webanno.api.dao.docimexport.config.DocumentImportExportServiceProperties;
+import de.tudarmstadt.ukp.clarin.webanno.api.dao.docimexport.config.DocumentImportExportServicePropertiesImpl;
 import de.tudarmstadt.ukp.clarin.webanno.api.project.ProjectInitializer;
 import de.tudarmstadt.ukp.clarin.webanno.conll.Conll2002FormatSupport;
 import de.tudarmstadt.ukp.clarin.webanno.curation.storage.CurationDocumentService;
@@ -622,11 +624,12 @@ public class MtasDocumentIndexTest
         }
 
         @Bean
-        public ImportExportService importExportService()
+        public DocumentImportExportService importExportService()
         {
-            return new ImportExportServiceImpl(repositoryProperties(),
+            DocumentImportExportServiceProperties properties = new DocumentImportExportServicePropertiesImpl();
+            return new DocumentImportExportServiceImpl(repositoryProperties(),
                     asList(new TextFormatSupport(), new Conll2002FormatSupport()),
-                    casStorageService(), annotationSchemaService());
+                    casStorageService(), annotationSchemaService(), properties);
         }
 
         @Bean

--- a/inception/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/sidebar/ExternalSearchAnnotationSidebar.java
+++ b/inception/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/sidebar/ExternalSearchAnnotationSidebar.java
@@ -55,8 +55,8 @@ import org.wicketstuff.event.annotation.OnEvent;
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.form.select.BootstrapSelect;
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.CasProvider;
+import de.tudarmstadt.ukp.clarin.webanno.api.DocumentImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
-import de.tudarmstadt.ukp.clarin.webanno.api.ImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.action.AnnotationActionHandler;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
@@ -98,7 +98,7 @@ public class ExternalSearchAnnotationSidebar
     private @SpringBean ProjectService projectService;
     private @SpringBean ExternalSearchService externalSearchService;
     private @SpringBean UserDao userRepository;
-    private @SpringBean ImportExportService importExportService;
+    private @SpringBean DocumentImportExportService importExportService;
     private @SpringBean ApplicationEventPublisherHolder applicationEventPublisher;
     private @SpringBean DocumentImporter documentImporter;
 

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/value/NumericLiteralValueSupport.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/value/NumericLiteralValueSupport.java
@@ -18,20 +18,20 @@
 package de.tudarmstadt.ukp.inception.ui.kb.value;
 
 import static java.util.Arrays.asList;
-import static org.eclipse.rdf4j.model.vocabulary.XMLSchema.DECIMAL;
-import static org.eclipse.rdf4j.model.vocabulary.XMLSchema.DOUBLE;
-import static org.eclipse.rdf4j.model.vocabulary.XMLSchema.FLOAT;
-import static org.eclipse.rdf4j.model.vocabulary.XMLSchema.INT;
-import static org.eclipse.rdf4j.model.vocabulary.XMLSchema.INTEGER;
-import static org.eclipse.rdf4j.model.vocabulary.XMLSchema.LONG;
-import static org.eclipse.rdf4j.model.vocabulary.XMLSchema.NEGATIVE_INTEGER;
-import static org.eclipse.rdf4j.model.vocabulary.XMLSchema.NON_NEGATIVE_INTEGER;
-import static org.eclipse.rdf4j.model.vocabulary.XMLSchema.NON_POSITIVE_INTEGER;
-import static org.eclipse.rdf4j.model.vocabulary.XMLSchema.POSITIVE_INTEGER;
-import static org.eclipse.rdf4j.model.vocabulary.XMLSchema.SHORT;
-import static org.eclipse.rdf4j.model.vocabulary.XMLSchema.UNSIGNED_INT;
-import static org.eclipse.rdf4j.model.vocabulary.XMLSchema.UNSIGNED_LONG;
-import static org.eclipse.rdf4j.model.vocabulary.XMLSchema.UNSIGNED_SHORT;
+import static org.eclipse.rdf4j.model.vocabulary.XSD.DECIMAL;
+import static org.eclipse.rdf4j.model.vocabulary.XSD.DOUBLE;
+import static org.eclipse.rdf4j.model.vocabulary.XSD.FLOAT;
+import static org.eclipse.rdf4j.model.vocabulary.XSD.INT;
+import static org.eclipse.rdf4j.model.vocabulary.XSD.INTEGER;
+import static org.eclipse.rdf4j.model.vocabulary.XSD.LONG;
+import static org.eclipse.rdf4j.model.vocabulary.XSD.NEGATIVE_INTEGER;
+import static org.eclipse.rdf4j.model.vocabulary.XSD.NON_NEGATIVE_INTEGER;
+import static org.eclipse.rdf4j.model.vocabulary.XSD.NON_POSITIVE_INTEGER;
+import static org.eclipse.rdf4j.model.vocabulary.XSD.POSITIVE_INTEGER;
+import static org.eclipse.rdf4j.model.vocabulary.XSD.SHORT;
+import static org.eclipse.rdf4j.model.vocabulary.XSD.UNSIGNED_INT;
+import static org.eclipse.rdf4j.model.vocabulary.XSD.UNSIGNED_LONG;
+import static org.eclipse.rdf4j.model.vocabulary.XSD.UNSIGNED_SHORT;
 
 import java.util.List;
 import java.util.Optional;

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/casdoctor/ProjectCasDoctorPanel.java
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/casdoctor/ProjectCasDoctorPanel.java
@@ -48,8 +48,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.CasStorageService;
+import de.tudarmstadt.ukp.clarin.webanno.api.DocumentImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
-import de.tudarmstadt.ukp.clarin.webanno.api.ImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.curation.storage.CurationDocumentService;
 import de.tudarmstadt.ukp.clarin.webanno.diag.CasDoctor;
 import de.tudarmstadt.ukp.clarin.webanno.diag.repairs.Repair;
@@ -73,7 +73,7 @@ public class ProjectCasDoctorPanel
     private @SpringBean DocumentService documentService;
     private @SpringBean CurationDocumentService curationService;
     private @SpringBean CasStorageService casStorageService;
-    private @SpringBean ImportExportService importExportService;
+    private @SpringBean DocumentImportExportService importExportService;
 
     // Data properties
     private FormModel formModel = new FormModel();

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/documents/ImportDocumentsPanel.java
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/documents/ImportDocumentsPanel.java
@@ -44,8 +44,8 @@ import org.slf4j.LoggerFactory;
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.form.fileinput.BootstrapFileInputField;
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.form.select.BootstrapSelect;
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
+import de.tudarmstadt.ukp.clarin.webanno.api.DocumentImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
-import de.tudarmstadt.ukp.clarin.webanno.api.ImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
@@ -61,7 +61,7 @@ public class ImportDocumentsPanel
     private final static Logger LOG = LoggerFactory.getLogger(ImportDocumentsPanel.class);
 
     private @SpringBean DocumentService documentService;
-    private @SpringBean ImportExportService importExportService;
+    private @SpringBean DocumentImportExportService importExportService;
     private @SpringBean AnnotationSchemaService annotationService;
 
     private BootstrapFileInputField fileUpload;

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/export/ProjectExportPanel.java
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/export/ProjectExportPanel.java
@@ -54,8 +54,8 @@ import org.wicketstuff.progressbar.ProgressionModel;
 
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.form.select.BootstrapSelect;
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
+import de.tudarmstadt.ukp.clarin.webanno.api.DocumentImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
-import de.tudarmstadt.ukp.clarin.webanno.api.ImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExportRequest;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExportService;
@@ -85,7 +85,7 @@ public class ProjectExportPanel
     private @SpringBean DocumentService documentService;
     private @SpringBean ProjectService projectService;
     private @SpringBean ProjectExportService exportService;
-    private @SpringBean ImportExportService importExportService;
+    private @SpringBean DocumentImportExportService importExportService;
     private @SpringBean ConstraintsService constraintsService;
     private @SpringBean UserDao userRepository;
 

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/guidelines/ImportGuidelinesPanel.java
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/guidelines/ImportGuidelinesPanel.java
@@ -37,7 +37,7 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.form.fileinput.BootstrapFileInputField;
-import de.tudarmstadt.ukp.clarin.webanno.api.ImportExportService;
+import de.tudarmstadt.ukp.clarin.webanno.api.DocumentImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxButton;
@@ -49,7 +49,7 @@ public class ImportGuidelinesPanel
     private static final long serialVersionUID = 3503932088128261675L;
 
     private @SpringBean ProjectService projectRepository;
-    private @SpringBean ImportExportService importExportService;
+    private @SpringBean DocumentImportExportService importExportService;
 
     private BootstrapFileInputField fileUpload;
 

--- a/inception/inception-versioning/src/test/java/de/tudarmstadt/ukp/inception/versioning/VersioningServiceImplTest.java
+++ b/inception/inception-versioning/src/test/java/de/tudarmstadt/ukp/inception/versioning/VersioningServiceImplTest.java
@@ -59,8 +59,8 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.CasStorageService;
+import de.tudarmstadt.ukp.clarin.webanno.api.DocumentImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
-import de.tudarmstadt.ukp.clarin.webanno.api.ImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
 import de.tudarmstadt.ukp.clarin.webanno.api.RepositoryProperties;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.BooleanFeatureSupport;
@@ -76,10 +76,12 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.layer.SpanLayerSupport;
 import de.tudarmstadt.ukp.clarin.webanno.api.dao.AnnotationSchemaServiceImpl;
 import de.tudarmstadt.ukp.clarin.webanno.api.dao.BackupProperties;
 import de.tudarmstadt.ukp.clarin.webanno.api.dao.CasStorageServiceImpl;
+import de.tudarmstadt.ukp.clarin.webanno.api.dao.DocumentImportExportServiceImpl;
 import de.tudarmstadt.ukp.clarin.webanno.api.dao.DocumentServiceImpl;
-import de.tudarmstadt.ukp.clarin.webanno.api.dao.ImportExportServiceImpl;
 import de.tudarmstadt.ukp.clarin.webanno.api.dao.casstorage.CasStorageSession;
 import de.tudarmstadt.ukp.clarin.webanno.api.dao.casstorage.config.CasStoragePropertiesImpl;
+import de.tudarmstadt.ukp.clarin.webanno.api.dao.docimexport.config.DocumentImportExportServiceProperties;
+import de.tudarmstadt.ukp.clarin.webanno.api.dao.docimexport.config.DocumentImportExportServicePropertiesImpl;
 import de.tudarmstadt.ukp.clarin.webanno.api.project.ProjectInitializer;
 import de.tudarmstadt.ukp.clarin.webanno.curation.storage.CurationDocumentService;
 import de.tudarmstadt.ukp.clarin.webanno.curation.storage.CurationDocumentServiceImpl;
@@ -107,7 +109,7 @@ public class VersioningServiceImplTest
     private @Autowired AnnotationSchemaService annotationSchemaService;
     private @Autowired ProjectService projectService;
     private @Autowired UserDao userDao;
-    private @Autowired ImportExportService importExportService;
+    private @Autowired DocumentImportExportService importExportService;
     private @Autowired DocumentService documentService;
 
     @Rule
@@ -352,8 +354,8 @@ public class VersioningServiceImplTest
 
         @Bean
         public DocumentService documentService(RepositoryProperties aRepositoryProperties,
-                CasStorageService aCasStorageService, ImportExportService aImportExportService,
-                ProjectService aProjectService,
+                CasStorageService aCasStorageService,
+                DocumentImportExportService aImportExportService, ProjectService aProjectService,
                 ApplicationEventPublisher aApplicationEventPublisher)
         {
             return new DocumentServiceImpl(aRepositoryProperties, aCasStorageService,
@@ -369,13 +371,15 @@ public class VersioningServiceImplTest
         }
 
         @Bean
-        public ImportExportService importExportService(RepositoryProperties aRepositoryProperties,
+        public DocumentImportExportService importExportService(
+                RepositoryProperties aRepositoryProperties,
                 AnnotationSchemaService aAnnotationSchemaService,
                 CasStorageService aCasStorageService)
         {
-            return new ImportExportServiceImpl(aRepositoryProperties,
+            DocumentImportExportServiceProperties properties = new DocumentImportExportServicePropertiesImpl();
+            return new DocumentImportExportServiceImpl(aRepositoryProperties,
                     List.of(new XmiFormatSupport(), new PretokenizedTextFormatSupport()),
-                    aCasStorageService, aAnnotationSchemaService);
+                    aCasStorageService, aAnnotationSchemaService, properties);
         }
 
         @Bean


### PR DESCRIPTION
**What's in the PR**
- Rename ImportExportService to DocumentImportExportService (and friends)
- Add configuration properties for DocumentImportExportService including sentence/token limits
- Check limits during import and generate exception if limits are exceeded
- Update documentation

**How to test manually**
* Upload a large PDF file as plain text
* Upload a **very** large text file

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
