### PR TITLE
#2151 - Clearer handling of stack traces on the error page

### DIFF
--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/settings_general.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/settings_general.adoc
@@ -29,11 +29,6 @@
 | true
 | false
 
-| debug.showExceptionPage
-| Show a page with a stack trace instead of an "Internal error" page. Do not use in production!
-| false
-| true
-
 | login.message
 | Custom message to appear on the login page, such as project web-site, annotation guideline link, ... The message can be an HTML content.
 | _unset_

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.java
@@ -45,7 +45,6 @@ import org.apache.wicket.request.resource.SharedResourceReference;
 import org.apache.wicket.resource.JQueryResourceReference;
 import org.apache.wicket.resource.loader.IStringResourceLoader;
 import org.apache.wicket.resource.loader.NestedStringResourceLoader;
-import org.apache.wicket.settings.ExceptionSettings;
 import org.slf4j.MDC;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.context.ApplicationContext;
@@ -116,9 +115,6 @@ public abstract class WicketApplicationBase
         initWebFrameworks();
 
         initLogoReference();
-
-        // Display stack trace instead of internal error
-        initShowExceptionPage();
 
         initMDCLifecycle();
 
@@ -247,15 +243,6 @@ public abstract class WicketApplicationBase
                 MDC.remove(Logging.KEY_REPOSITORY_PATH);
             }
         });
-    }
-
-    protected void initShowExceptionPage()
-    {
-        Properties settings = SettingsUtil.getSettings();
-        if ("true".equalsIgnoreCase(settings.getProperty("debug.showExceptionPage"))) {
-            getExceptionSettings()
-                    .setUnexpectedExceptionDisplay(ExceptionSettings.SHOW_EXCEPTION_PAGE);
-        }
     }
 
     protected void initLogoReference()

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/ErrorPage.html
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/ErrorPage.html
@@ -19,11 +19,12 @@
 <html xmlns:wicket="http://wicket.apache.org">
 <body>
   <wicket:extend>
-    <div class="scrolling flex-content flex-h-container flex-centered" style="min-width: 30em;">
+    <div class="scrolling flex-content flex-h-container mt-5 pt-5" style="min-width: 30em;">
       <div class="flex-content flex-v-container flex-centered" style="min-height: 20em;">
         <h1 class="display-1">Whoops!</h1>
         <p class="lead">Something went wrong...</p>
-        <table class="table-sm small" style="width: auto; max-width: 80em;">
+        <div style="max-width: 90%;">
+        <table class="table-sm small">
           <tr wicket:enclosure="statusCode">
             <th>Status</th>
             <td>
@@ -55,8 +56,8 @@
           <tr wicket:enclosure="exceptionStackTrace">
             <th style="vertical-align: top;">Exception&nbsp;stack&nbsp;trace</th>
             <td class="border">
-              <div class="scrolling" style="max-height: 10em;">
-                <pre><span wicket:id="exceptionStackTrace" /></pre>
+              <div class="scrolling fit-child-snug" style="height: 10rem;">
+                <pre class="m-0 p-0" wicket:id="exceptionStackTrace"/>
               </div>
             </td>
           </tr>
@@ -83,6 +84,7 @@
             </td>
           </tr>
         </table>
+        </div>
       </div>
     </div>
   </wicket:extend>

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/ErrorPage.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/ErrorPage.java
@@ -89,8 +89,7 @@ public class ErrorPage
         Label exceptionStackTrace = new Label("exceptionStackTrace",
                 LoadableDetachableModel.of(this::getExceptionStackTrace));
         exceptionStackTrace
-                .add(visibleWhen(() -> exceptionStackTrace.getDefaultModelObject() != null
-                        && (isDeveloper() || isAdministrator())));
+                .add(visibleWhen(() -> exceptionStackTrace.getDefaultModelObject() != null));
         add(exceptionStackTrace);
 
         Label appVersion = new Label("appVersion", SettingsUtil.getVersionString());
@@ -207,11 +206,15 @@ public class ErrorPage
     {
         Throwable e = getException();
 
-        if (e != null) {
-            return String.join("\n", ExceptionUtils.getRootCauseStackTrace(e));
+        if (e == null) {
+            return null;
         }
 
-        return null;
+        if (!(isDeveloper() || isAdministrator())) {
+            return "Exception as been recorded in the log files. Please ask your administrator.";
+        }
+
+        return String.join("\n", ExceptionUtils.getRootCauseStackTrace(e));
     }
 
     private Throwable getException()


### PR DESCRIPTION
**What's in the PR**
- Display a message that a stack trace was not shown because a user has no permissions to see it - tell user to ask admin
- Remove the documentation for "debug.showExceptionPage"

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
