### PR TITLE
#2156 - Sidebar cluttered with unused items

### DIFF
--- a/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/config/ActiveLearningAutoConfiguration.java
+++ b/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/config/ActiveLearningAutoConfiguration.java
@@ -66,8 +66,9 @@ public class ActiveLearningAutoConfiguration
     }
 
     @Bean
-    public ActiveLearningSidebarFactory activeLearningSidebarFactory()
+    public ActiveLearningSidebarFactory activeLearningSidebarFactory(
+            RecommendationService aRecommendationService)
     {
-        return new ActiveLearningSidebarFactory();
+        return new ActiveLearningSidebarFactory(aRecommendationService);
     }
 }

--- a/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.java
+++ b/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.java
@@ -209,7 +209,6 @@ public class ActiveLearningSidebar
             ActiveLearningUserState alState = new ActiveLearningUserState();
             alState.setStrategy(new UncertaintySamplingStrategy());
             alStateModel.setObject(alState);
-            ;
         }
 
         mainContainer = new WebMarkupContainer(CID_MAIN_CONTAINER);
@@ -247,11 +246,12 @@ public class ActiveLearningSidebar
                 alStateModel.getObject().setDoExistRecommenders(false);
             }
         }
+
         Label noRecommendersMessage = new Label(CID_NO_RECOMMENDERS, "None of the layers have any "
                 + "recommenders configured. Please set the recommenders first in the Project "
                 + "Settings.");
-        noRecommendersMessage.add(LambdaBehavior.onConfigure(component -> component
-                .setVisible(!alStateModel.getObject().isDoExistRecommenders())));
+        noRecommendersMessage
+                .add(visibleWhen(() -> !alStateModel.getObject().isDoExistRecommenders()));
         return noRecommendersMessage;
     }
 
@@ -466,11 +466,11 @@ public class ActiveLearningSidebar
         LambdaAjaxLink link = new LambdaAjaxLink(CID_RECOMMENDATION_COVERED_TEXT_LINK,
                 this::actionJumpToSuggestion);
         link.add(new Label("leftContext",
-                LoadableDetachableModel.of(() -> alStateModel.getObject().getLeftContext())));
+                alStateModel.map(ActiveLearningUserState::getLeftContext)));
         link.add(new Label("text", LoadableDetachableModel.of(() -> alStateModel.getObject()
                 .getSuggestion().map(AnnotationSuggestion::getCoveredText).orElse(""))));
         link.add(new Label("rightContext",
-                LoadableDetachableModel.of(() -> alStateModel.getObject().getRightContext())));
+                alStateModel.map(ActiveLearningUserState::getRightContext)));
         return link;
     }
 

--- a/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebarFactory.java
+++ b/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebarFactory.java
@@ -63,7 +63,7 @@ public class ActiveLearningSidebarFactory
     @Override
     public boolean applies(AnnotatorState aState)
     {
-        return recommendationService.hasEnabledRecommenders(aState.getProject());
+        return recommendationService.existsEnabledRecommender(aState.getProject());
     }
 
     @Override

--- a/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebarFactory.java
+++ b/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebarFactory.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.inception.active.learning.sidebar;
 
 import org.apache.wicket.model.IModel;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import de.agilecoders.wicket.core.markup.html.bootstrap.image.IconType;
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.icon.FontAwesome5IconType;
@@ -28,6 +29,7 @@ import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.AnnotationPage;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar.AnnotationSidebarFactory_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar.AnnotationSidebar_ImplBase;
 import de.tudarmstadt.ukp.inception.active.learning.config.ActiveLearningAutoConfiguration;
+import de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService;
 
 /**
  * <p>
@@ -38,6 +40,14 @@ import de.tudarmstadt.ukp.inception.active.learning.config.ActiveLearningAutoCon
 public class ActiveLearningSidebarFactory
     extends AnnotationSidebarFactory_ImplBase
 {
+    private final RecommendationService recommendationService;
+
+    @Autowired
+    public ActiveLearningSidebarFactory(RecommendationService aRecommendationService)
+    {
+        recommendationService = aRecommendationService;
+    }
+
     @Override
     public String getDisplayName()
     {
@@ -48,6 +58,12 @@ public class ActiveLearningSidebarFactory
     public IconType getIcon()
     {
         return FontAwesome5IconType.robot_s;
+    }
+
+    @Override
+    public boolean applies(AnnotatorState aState)
+    {
+        return recommendationService.hasEnabledRecommenders(aState.getProject());
     }
 
     @Override

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/AnnotationSchemaService.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/AnnotationSchemaService.java
@@ -171,6 +171,8 @@ public interface AnnotationSchemaService
      */
     boolean existsLayer(String name, String type, Project project);
 
+    boolean existsEnabledLayerOfType(Project aProject, String aType);
+
     /**
      * Check if this {@link AnnotationFeature} already exists
      * 
@@ -181,6 +183,8 @@ public interface AnnotationSchemaService
      * @return if the feature exists.
      */
     boolean existsFeature(String name, AnnotationLayer type);
+
+    boolean existsEnabledFeatureOfType(Project aProject, String aType);
 
     /**
      * get a {@link TagSet} with this name in a {@link Project}

--- a/inception/inception-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/AnnotationSchemaServiceImpl.java
+++ b/inception/inception-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/AnnotationSchemaServiceImpl.java
@@ -385,6 +385,24 @@ public class AnnotationSchemaServiceImpl
     }
 
     @Override
+    @Transactional
+    public boolean existsEnabledLayerOfType(Project aProject, String aType)
+    {
+        String query = String.join("\n", //
+                "SELECT COUNT(*)", //
+                "FROM AnnotationLayer", //
+                "WHERE project = :project ", //
+                "AND type = :type", //
+                "AND enabled = true");
+
+        return entityManager.createQuery(query, Long.class) //
+                .setParameter("project", aProject) //
+                .setParameter("type", aType) //
+                .getSingleResult() > 0;
+    }
+
+    @Override
+    @Transactional
     public boolean existsFeature(String aName, AnnotationLayer aLayer)
     {
         try {
@@ -399,6 +417,24 @@ public class AnnotationSchemaServiceImpl
         catch (NoResultException e) {
             return false;
         }
+    }
+
+    @Override
+    @Transactional
+    public boolean existsEnabledFeatureOfType(Project aProject, String aType)
+    {
+        String query = String.join("\n", //
+                "SELECT COUNT(*)", //
+                "FROM AnnotationFeature", //
+                "WHERE project = :project ", //
+                "AND type = :type", //
+                "AND enabled = true", //
+                "AND layer.enabled = true");
+
+        return entityManager.createQuery(query, Long.class) //
+                .setParameter("project", aProject) //
+                .setParameter("type", aType) //
+                .getSingleResult() > 0;
     }
 
     @Override

--- a/inception/inception-external-search-core/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/ExternalSearchService.java
+++ b/inception/inception-external-search-core/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/ExternalSearchService.java
@@ -61,4 +61,6 @@ public interface ExternalSearchService
     String getDocumentFormat(DocumentRepository aRepository, String aCollectionId,
             String aDocumentId)
         throws IOException;
+
+    boolean existsEnabledDocumentRepository(Project aProject);
 }

--- a/inception/inception-external-search-core/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/ExternalSearchServiceImpl.java
+++ b/inception/inception-external-search-core/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/ExternalSearchServiceImpl.java
@@ -89,11 +89,28 @@ public class ExternalSearchServiceImpl
     @Transactional
     public List<DocumentRepository> listDocumentRepositories(Project aProject)
     {
-        List<DocumentRepository> settings = entityManager
-                .createQuery("FROM DocumentRepository WHERE project = :project ORDER BY name ASC",
-                        DocumentRepository.class)
-                .setParameter("project", aProject).getResultList();
-        return settings;
+        String query = String.join("\n", //
+                "FROM DocumentRepository", //
+                "WHERE project = :project", //
+                "ORDER BY name ASC");
+
+        return entityManager.createQuery(query, DocumentRepository.class)
+                .setParameter("project", aProject) //
+                .getResultList();
+    }
+
+    @Override
+    @Transactional
+    public boolean existsEnabledDocumentRepository(Project aProject)
+    {
+        String query = String.join("\n", //
+                "SELECT COUNT(*)", //
+                "FROM DocumentRepository", //
+                "WHERE project = :project");
+
+        return entityManager.createQuery(query, Long.class) //
+                .setParameter("project", aProject) //
+                .getSingleResult() > 0;
     }
 
     @Override

--- a/inception/inception-image/src/main/java/de/tudarmstadt/ukp/inception/image/sidebar/ImageSidebarFactory.java
+++ b/inception/inception-image/src/main/java/de/tudarmstadt/ukp/inception/image/sidebar/ImageSidebarFactory.java
@@ -17,11 +17,14 @@
  */
 package de.tudarmstadt.ukp.inception.image.sidebar;
 
+import static de.tudarmstadt.ukp.inception.image.feature.ImageFeatureSupport.TYPE_IMAGE_URL;
+
 import org.apache.wicket.model.IModel;
 import org.springframework.stereotype.Component;
 
 import de.agilecoders.wicket.core.markup.html.bootstrap.image.IconType;
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.icon.FontAwesome5IconType;
+import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.CasProvider;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.action.AnnotationActionHandler;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
@@ -33,6 +36,13 @@ import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar.AnnotationSidebar
 public class ImageSidebarFactory
     extends AnnotationSidebarFactory_ImplBase
 {
+    private final AnnotationSchemaService schemaService;
+
+    public ImageSidebarFactory(AnnotationSchemaService aSchemaService)
+    {
+        schemaService = aSchemaService;
+    }
+
     @Override
     public String getDisplayName()
     {
@@ -43,6 +53,12 @@ public class ImageSidebarFactory
     public IconType getIcon()
     {
         return FontAwesome5IconType.images_s;
+    }
+
+    @Override
+    public boolean applies(AnnotatorState aState)
+    {
+        return schemaService.existsEnabledFeatureOfType(aState.getProject(), TYPE_IMAGE_URL);
     }
 
     @Override

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/config/DocumentMetadataLayerSupportAutoConfiguration.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/config/DocumentMetadataLayerSupportAutoConfiguration.java
@@ -23,6 +23,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRegistry;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.layer.LayerType;
 import de.tudarmstadt.ukp.inception.ui.core.docanno.layer.DocumentMetadataLayerSupport;
@@ -37,9 +38,10 @@ public class DocumentMetadataLayerSupportAutoConfiguration
 {
     @Bean
     @ConditionalOnProperty(prefix = "documentmetadata", name = "enabled", havingValue = "true", matchIfMissing = true)
-    public DocumentMetadataSidebarFactory documentMetadataSidebarFactory()
+    public DocumentMetadataSidebarFactory documentMetadataSidebarFactory(
+            AnnotationSchemaService aSchemaService)
     {
-        return new DocumentMetadataSidebarFactory();
+        return new DocumentMetadataSidebarFactory(aSchemaService);
     }
 
     /**

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataSidebarFactory.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataSidebarFactory.java
@@ -21,6 +21,7 @@ import org.apache.wicket.model.IModel;
 
 import de.agilecoders.wicket.core.markup.html.bootstrap.image.IconType;
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.icon.FontAwesome5IconType;
+import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.CasProvider;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.action.AnnotationActionHandler;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
@@ -28,6 +29,7 @@ import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.AnnotationPage;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar.AnnotationSidebarFactory_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar.AnnotationSidebar_ImplBase;
 import de.tudarmstadt.ukp.inception.ui.core.docanno.config.DocumentMetadataLayerSupportAutoConfiguration;
+import de.tudarmstadt.ukp.inception.ui.core.docanno.layer.DocumentMetadataLayerSupport;
 
 /**
  * Support for document-level annotations through a sidebar.
@@ -39,6 +41,13 @@ import de.tudarmstadt.ukp.inception.ui.core.docanno.config.DocumentMetadataLayer
 public class DocumentMetadataSidebarFactory
     extends AnnotationSidebarFactory_ImplBase
 {
+    private final AnnotationSchemaService schemaService;
+
+    public DocumentMetadataSidebarFactory(AnnotationSchemaService aSchemaService)
+    {
+        schemaService = aSchemaService;
+    }
+
     @Override
     public String getDisplayName()
     {
@@ -49,6 +58,13 @@ public class DocumentMetadataSidebarFactory
     public IconType getIcon()
     {
         return FontAwesome5IconType.tags_s;
+    }
+
+    @Override
+    public boolean applies(AnnotatorState aState)
+    {
+        return schemaService.existsEnabledLayerOfType(aState.getProject(),
+                DocumentMetadataLayerSupport.TYPE);
     }
 
     @Override

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataSidebarFactory.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataSidebarFactory.java
@@ -35,7 +35,7 @@ import de.tudarmstadt.ukp.inception.ui.core.docanno.layer.DocumentMetadataLayerS
  * Support for document-level annotations through a sidebar.
  * <p>
  * This class is exposed as a Spring Component via
- * {@link DocumentMetadataLayerSupportAutoConfiguration#documentMetadataSidebarFactory()}.
+ * {@link DocumentMetadataLayerSupportAutoConfiguration#documentMetadataSidebarFactory}.
  * </p>
  */
 public class DocumentMetadataSidebarFactory

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/RecommendationService.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/RecommendationService.java
@@ -68,11 +68,15 @@ public interface RecommendationService
 
     List<Recommender> listRecommenders(Project aProject);
 
+    boolean hasEnabledRecommenders(Project aProject);
+
     List<Recommender> listRecommenders(AnnotationLayer aLayer);
 
     Optional<Recommender> getEnabledRecommender(long aRecommenderId);
 
     List<Recommender> listEnabledRecommenders(Project aProject);
+
+    List<Recommender> listEnabledRecommenders(AnnotationLayer aLayer);
 
     /**
      * Returns all annotation layers in the given project which have any enabled recommenders.
@@ -154,8 +158,6 @@ public interface RecommendationService
 
     void calculateVisibility(CAS aCas, String aUser, AnnotationLayer aLayer,
             Collection<SuggestionGroup> aRecommendations, int aWindowBegin, int aWindowEnd);
-
-    List<Recommender> listEnabledRecommenders(AnnotationLayer aLayer);
 
     void clearState(String aUsername);
 

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/RecommendationService.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/RecommendationService.java
@@ -68,7 +68,7 @@ public interface RecommendationService
 
     List<Recommender> listRecommenders(Project aProject);
 
-    boolean hasEnabledRecommenders(Project aProject);
+    boolean existsEnabledRecommender(Project aProject);
 
     List<Recommender> listRecommenders(AnnotationLayer aLayer);
 

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/config/RecommenderServiceAutoConfiguration.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/config/RecommenderServiceAutoConfiguration.java
@@ -129,9 +129,10 @@ public class RecommenderServiceAutoConfiguration
     }
 
     @Bean
-    public RecommendationSidebarFactory recommendationSidebarFactory()
+    public RecommendationSidebarFactory recommendationSidebarFactory(
+            RecommendationService aRecommendationService)
     {
-        return new RecommendationSidebarFactory();
+        return new RecommendationSidebarFactory(aRecommendationService);
     }
 
     @Bean(name = RecommendationEditorExtension.BEAN_NAME)

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
@@ -1691,30 +1691,35 @@ public class RecommendationServiceImpl
     }
 
     @Override
-    public boolean hasEnabledRecommenders(Project aProject)
+    public boolean existsEnabledRecommender(Project aProject)
     {
         String query = String.join("\n", //
-                "SELECT COUNT(*)", //
                 "FROM Recommender WHERE", //
                 "enabled = :enabled AND", //
                 "project = :project");
 
-        return entityManager.createQuery(query, Long.class) //
+        List<Recommender> recommenders = entityManager.createQuery(query, Recommender.class) //
                 .setParameter("enabled", true) //
                 .setParameter("project", aProject) //
-                .getSingleResult() > 0;
+                .getResultList();
+
+        return recommenders.stream() //
+                .anyMatch(rec -> getRecommenderFactory(rec) != null);
     }
 
     @Override
     public long countEnabledRecommenders()
     {
         String query = String.join("\n", //
-                "SELECT COUNT(*)", //
                 "FROM Recommender WHERE", //
                 "enabled = :enabled");
 
-        return entityManager.createQuery(query, Long.class) //
+        List<Recommender> recommenders = entityManager.createQuery(query, Recommender.class) //
                 .setParameter("enabled", true) //
-                .getSingleResult();
+                .getResultList();
+
+        return recommenders.stream() //
+                .filter(rec -> getRecommenderFactory(rec) != null) //
+                .count();
     }
 }

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
@@ -1691,12 +1691,30 @@ public class RecommendationServiceImpl
     }
 
     @Override
+    public boolean hasEnabledRecommenders(Project aProject)
+    {
+        String query = String.join("\n", //
+                "SELECT COUNT(*)", //
+                "FROM Recommender WHERE", //
+                "enabled = :enabled AND", //
+                "project = :project");
+
+        return entityManager.createQuery(query, Long.class) //
+                .setParameter("enabled", true) //
+                .setParameter("project", aProject) //
+                .getSingleResult() > 0;
+    }
+
+    @Override
     public long countEnabledRecommenders()
     {
-        String query = String.join("\n", "SELECT COUNT(*)", "FROM Recommender WHERE",
+        String query = String.join("\n", //
+                "SELECT COUNT(*)", //
+                "FROM Recommender WHERE", //
                 "enabled = :enabled");
 
-        return entityManager.createQuery(query, Long.class).setParameter("enabled", true)
+        return entityManager.createQuery(query, Long.class) //
+                .setParameter("enabled", true) //
                 .getSingleResult();
     }
 }

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommendationSidebarFactory.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommendationSidebarFactory.java
@@ -63,7 +63,7 @@ public class RecommendationSidebarFactory
     @Override
     public boolean applies(AnnotatorState aState)
     {
-        return recommendationService.hasEnabledRecommenders(aState.getProject());
+        return recommendationService.existsEnabledRecommender(aState.getProject());
     }
 
     @Override

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommendationSidebarFactory.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommendationSidebarFactory.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.inception.recommendation.sidebar;
 
 import org.apache.wicket.model.IModel;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import de.agilecoders.wicket.core.markup.html.bootstrap.image.IconType;
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.icon.FontAwesome5IconType;
@@ -27,6 +28,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.AnnotationPage;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar.AnnotationSidebarFactory_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar.AnnotationSidebar_ImplBase;
+import de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService;
 import de.tudarmstadt.ukp.inception.recommendation.config.RecommenderServiceAutoConfiguration;
 
 /**
@@ -38,6 +40,14 @@ import de.tudarmstadt.ukp.inception.recommendation.config.RecommenderServiceAuto
 public class RecommendationSidebarFactory
     extends AnnotationSidebarFactory_ImplBase
 {
+    private final RecommendationService recommendationService;
+
+    @Autowired
+    public RecommendationSidebarFactory(RecommendationService aRecommendationService)
+    {
+        recommendationService = aRecommendationService;
+    }
+
     @Override
     public String getDisplayName()
     {
@@ -48,6 +58,12 @@ public class RecommendationSidebarFactory
     public IconType getIcon()
     {
         return FontAwesome5IconType.chart_line_s;
+    }
+
+    @Override
+    public boolean applies(AnnotatorState aState)
+    {
+        return recommendationService.hasEnabledRecommenders(aState.getProject());
     }
 
     @Override

--- a/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImplIntegrationTest.java
+++ b/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImplIntegrationTest.java
@@ -26,7 +26,9 @@ import static org.apache.uima.util.TypeSystemUtil.typeSystem2TypeSystemDescripti
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.List;
 import java.util.Optional;
@@ -46,24 +48,19 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-import org.springframework.security.core.session.SessionRegistry;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.transaction.annotation.Transactional;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode;
 import de.tudarmstadt.ukp.clarin.webanno.api.dao.AnnotationSchemaServiceImpl;
 import de.tudarmstadt.ukp.clarin.webanno.api.dao.casstorage.CasStorageSession;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
-import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
-import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity;
-import de.tudarmstadt.ukp.inception.recommendation.api.LearningRecordService;
 import de.tudarmstadt.ukp.inception.recommendation.api.RecommenderFactoryRegistry;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
-import de.tudarmstadt.ukp.inception.scheduling.SchedulingService;
+import de.tudarmstadt.ukp.inception.recommendation.api.recommender.RecommendationEngineFactory;
 
 @ContextConfiguration(classes = SpringConfig.class)
 @Transactional
@@ -75,31 +72,25 @@ public class RecommendationServiceImplIntegrationTest
     private @Autowired TestEntityManager testEntityManager;
 
     private RecommendationServiceImpl sut;
-    private SessionRegistry sessionRegistry;
-    private UserDao userRepository;
-    private RecommenderFactoryRegistry recommenderFactoryRegistry;
-    private SchedulingService schedulingService;
+    private @Mock RecommenderFactoryRegistry recommenderFactoryRegistry;
     private @Mock AnnotationSchemaServiceImpl annoService;
-    private DocumentService documentService;
-    private LearningRecordService learningRecordService;
 
     private Project project;
     private AnnotationLayer layer;
-    private User user;
     private Recommender rec;
     private AnnotationFeature feature;
 
     @BeforeEach
     public void setUp() throws Exception
     {
-        sut = new RecommendationServiceImpl(sessionRegistry, userRepository,
-                recommenderFactoryRegistry, schedulingService, annoService, documentService,
-                learningRecordService, testEntityManager.getEntityManager());
+        openMocks(this);
+
+        sut = new RecommendationServiceImpl(null, null, recommenderFactoryRegistry, null,
+                annoService, null, null, testEntityManager.getEntityManager());
 
         project = createProject(PROJECT_NAME);
         layer = createAnnotationLayer();
         layer.setProject(project);
-        user = createUser();
         feature = createAnnotationFeature(layer, "value");
 
         rec = buildRecommender(project, feature);
@@ -131,6 +122,13 @@ public class RecommendationServiceImplIntegrationTest
     @Test
     public void getNumOfEnabledRecommenders_WithOneEnabledRecommender()
     {
+        RecommendationEngineFactory recFactory = mock(RecommendationEngineFactory.class);
+        when(recommenderFactoryRegistry.getFactory(any(String.class))).thenReturn(recFactory);
+        when(recFactory.accepts(any(AnnotationLayer.class), any(AnnotationFeature.class)))
+                .thenReturn(true);
+
+        assertThat(recommenderFactoryRegistry.getFactory("nummy")).isNotNull();
+
         sut.createOrUpdateRecommender(rec);
 
         long numOfRecommenders = sut.countEnabledRecommenders();
@@ -226,13 +224,6 @@ public class RecommendationServiceImplIntegrationTest
         return testEntityManager.persist(layer);
     }
 
-    private User createUser()
-    {
-        User user = new User();
-
-        return user;
-    }
-
     private Recommender buildRecommender(Project aProject, AnnotationFeature aFeature)
     {
         Recommender recommender = new Recommender();
@@ -242,6 +233,7 @@ public class RecommendationServiceImplIntegrationTest
         recommender.setAlwaysSelected(true);
         recommender.setSkipEvaluation(false);
         recommender.setMaxRecommendations(3);
+        recommender.setTool("dummyRecommenderTool");
 
         return recommender;
     }

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/sidebar/docinfo/DocumentInfoSidebarFactory.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/sidebar/docinfo/DocumentInfoSidebarFactory.java
@@ -18,9 +18,6 @@
 package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar.docinfo;
 
 import org.apache.wicket.model.IModel;
-import org.apache.wicket.request.Url;
-import org.apache.wicket.request.resource.ResourceReference;
-import org.apache.wicket.request.resource.UrlResourceReference;
 import org.springframework.stereotype.Component;
 
 import de.agilecoders.wicket.core.markup.html.bootstrap.image.IconType;
@@ -36,9 +33,6 @@ import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar.AnnotationSidebar
 public class DocumentInfoSidebarFactory
     extends AnnotationSidebarFactory_ImplBase
 {
-    private static final ResourceReference ICON = new UrlResourceReference(
-            Url.parse("images/information.png")).setContextRelative(true);
-
     @Override
     public String getDisplayName()
     {
@@ -49,6 +43,12 @@ public class DocumentInfoSidebarFactory
     public IconType getIcon()
     {
         return FontAwesome5IconType.info_s;
+    }
+
+    @Override
+    public boolean applies(AnnotatorState aState)
+    {
+        return false;
     }
 
     @Override

--- a/inception/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/SearchPageMenuItem.java
+++ b/inception/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/SearchPageMenuItem.java
@@ -66,7 +66,7 @@ public class SearchPageMenuItem
     @Override
     public boolean applies(Project aProject)
     {
-        return !externalSearchService.listDocumentRepositories(aProject).isEmpty();
+        return externalSearchService.existsEnabledDocumentRepository(aProject);
     }
 
     @Override

--- a/inception/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/config/ExternalSearchUIAutoConfiguration.java
+++ b/inception/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/config/ExternalSearchUIAutoConfiguration.java
@@ -53,9 +53,10 @@ public class ExternalSearchUIAutoConfiguration
     }
 
     @Bean
-    public ExternalSearchAnnotationSidebarFactory externalSearchAnnotationSidebarFactory()
+    public ExternalSearchAnnotationSidebarFactory externalSearchAnnotationSidebarFactory(
+            ExternalSearchService aExternalSearchService)
     {
-        return new ExternalSearchAnnotationSidebarFactory();
+        return new ExternalSearchAnnotationSidebarFactory(aExternalSearchService);
     }
 
     @Bean

--- a/inception/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/sidebar/ExternalSearchAnnotationSidebarFactory.java
+++ b/inception/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/sidebar/ExternalSearchAnnotationSidebarFactory.java
@@ -34,7 +34,7 @@ import de.tudarmstadt.ukp.inception.externalsearch.ExternalSearchService;
  * Sidebar to access the external search on the annotation page.
  * <p>
  * This class is exposed as a Spring Component via
- * {@link ExternalSearchUIAutoConfiguration#externalSearchAnnotationSidebarFactory()}.
+ * {@link ExternalSearchUIAutoConfiguration#externalSearchAnnotationSidebarFactory}.
  * </p>
  */
 public class ExternalSearchAnnotationSidebarFactory

--- a/inception/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/sidebar/ExternalSearchAnnotationSidebarFactory.java
+++ b/inception/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/sidebar/ExternalSearchAnnotationSidebarFactory.java
@@ -18,8 +18,6 @@
 package de.tudarmstadt.ukp.inception.app.ui.externalsearch.sidebar;
 
 import org.apache.wicket.model.IModel;
-import org.apache.wicket.request.resource.PackageResourceReference;
-import org.apache.wicket.request.resource.ResourceReference;
 
 import de.agilecoders.wicket.core.markup.html.bootstrap.image.IconType;
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.icon.FontAwesome5IconType;
@@ -30,6 +28,7 @@ import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.AnnotationPage;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar.AnnotationSidebarFactory_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar.AnnotationSidebar_ImplBase;
 import de.tudarmstadt.ukp.inception.app.ui.externalsearch.config.ExternalSearchUIAutoConfiguration;
+import de.tudarmstadt.ukp.inception.externalsearch.ExternalSearchService;
 
 /**
  * Sidebar to access the external search on the annotation page.
@@ -41,8 +40,12 @@ import de.tudarmstadt.ukp.inception.app.ui.externalsearch.config.ExternalSearchU
 public class ExternalSearchAnnotationSidebarFactory
     extends AnnotationSidebarFactory_ImplBase
 {
-    private static final ResourceReference ICON = new PackageResourceReference(
-            ExternalSearchAnnotationSidebarFactory.class, "world_go.png");
+    private final ExternalSearchService externalSearchService;
+
+    public ExternalSearchAnnotationSidebarFactory(ExternalSearchService aExternalSearchService)
+    {
+        externalSearchService = aExternalSearchService;
+    }
 
     @Override
     public String getDisplayName()
@@ -54,6 +57,12 @@ public class ExternalSearchAnnotationSidebarFactory
     public IconType getIcon()
     {
         return FontAwesome5IconType.database_s;
+    }
+
+    @Override
+    public boolean applies(AnnotatorState aState)
+    {
+        return externalSearchService.existsEnabledDocumentRepository(aState.getProject());
     }
 
     @Override


### PR DESCRIPTION
**What's in the PR**
- Show external search sidebar only if there are external repos
- Show document metadata sidebar only if there is am enabled layer of type document metadata
- Show the recommender / active learning sidebars only if there are enabled recommenders
- Show image sidebar only if there is an enabled feature of type image-url on any enabeld layer
- Disable the document info sidebar - that was mainly a toy to get the sidebar off the ground

**How to test manually**
* Disable search in the settings.properties file
* Enter into a project as a plain annotator
* See that there is no sidebar anymore at all
* Fulfill any of the prerequisites for sidebar items to show up and check that the corresponding sidebars appear

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
