### PR TITLE
#2159 - Ability to accept/reject telemetry without user interaction

### DIFF
--- a/inception/inception-telemetry/pom.xml
+++ b/inception/inception-telemetry/pom.xml
@@ -80,6 +80,10 @@
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-web</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.wicket</groupId>

--- a/inception/inception-telemetry/src/main/java/de/tudarmstadt/ukp/clarin/webanno/telemetry/TelemetryServiceImpl.java
+++ b/inception/inception-telemetry/src/main/java/de/tudarmstadt/ukp/clarin/webanno/telemetry/TelemetryServiceImpl.java
@@ -46,23 +46,32 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.annotation.AnnotationAwareOrderComparator;
-import org.springframework.stereotype.Component;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
+import de.tudarmstadt.ukp.clarin.webanno.telemetry.config.TelemetryServiceAutoConfiguration;
+import de.tudarmstadt.ukp.clarin.webanno.telemetry.config.TelemetryServiceProperties;
 import de.tudarmstadt.ukp.clarin.webanno.telemetry.event.TelemetrySettingsSavedEvent;
 import de.tudarmstadt.ukp.clarin.webanno.telemetry.model.TelemetrySettings;
 
-@Component
+/**
+ * <p>
+ * This class is exposed as a Spring Component via
+ * {@link TelemetryServiceAutoConfiguration#telemetryService}.
+ * </p>
+ */
 public class TelemetryServiceImpl
     implements TelemetryService
 {
     private final Logger log = LoggerFactory.getLogger(getClass());
 
-    @PersistenceContext
-    private EntityManager entityManager;
+    private @PersistenceContext EntityManager entityManager;
 
+    private final TelemetryServiceProperties properties;
     private final List<TelemetrySupport> telemetrySupportsProxy;
     private final ApplicationEventPublisher eventPublisher;
+    private final TransactionTemplate transactionTemplate;
 
     private List<TelemetrySupport> telemetrySupports;
 
@@ -73,10 +82,13 @@ public class TelemetryServiceImpl
 
     public TelemetryServiceImpl(
             @Lazy @Autowired(required = false) List<TelemetrySupport> aTelemetrySupports,
-            ApplicationEventPublisher aEventPublisher)
+            ApplicationEventPublisher aEventPublisher, TelemetryServiceProperties aProperties,
+            PlatformTransactionManager aTransactionManager)
     {
         telemetrySupportsProxy = aTelemetrySupports;
         eventPublisher = aEventPublisher;
+        properties = aProperties;
+        transactionTemplate = new TransactionTemplate(aTransactionManager);
     }
 
     @EventListener
@@ -105,6 +117,34 @@ public class TelemetryServiceImpl
         }
 
         telemetrySupports = Collections.unmodifiableList(tsp);
+
+        autoAcceptOrReject();
+    }
+
+    private void autoAcceptOrReject()
+    {
+        transactionTemplate.executeWithoutResult(transactionStatus -> {
+            List<TelemetrySettings> settingsToSave = new ArrayList<>();
+
+            for (TelemetrySupport support : getTelemetrySupports()) {
+                if (!support.hasValidSettings()) {
+                    TelemetrySettings settings = readOrCreateSettings(support);
+                    Object traits = support.readTraits(settings);
+                    switch (properties.getAutoRespond()) {
+                    case ACCEPT:
+                        support.acceptAll(traits);
+                        break;
+                    case REJECT:
+                        support.rejectAll(traits);
+                        break;
+                    }
+                    support.writeTraits(settings, traits);
+                    settingsToSave.add(settings);
+                }
+            }
+
+            writeAllSettings(settingsToSave);
+        });
     }
 
     /**
@@ -227,7 +267,6 @@ public class TelemetryServiceImpl
         }
     }
 
-    @Transactional
     private void writeSettings(TelemetrySettings aSettings)
     {
         if (isNull(aSettings.getId())) {

--- a/inception/inception-telemetry/src/main/java/de/tudarmstadt/ukp/clarin/webanno/telemetry/TelemetrySupport.java
+++ b/inception/inception-telemetry/src/main/java/de/tudarmstadt/ukp/clarin/webanno/telemetry/TelemetrySupport.java
@@ -102,4 +102,8 @@ public interface TelemetrySupport<T>
      * are in sync.
      */
     List<TelemetryDetail> getDetails();
+
+    void acceptAll(T aTraits);
+
+    void rejectAll(T aTraits);
 }

--- a/inception/inception-telemetry/src/main/java/de/tudarmstadt/ukp/clarin/webanno/telemetry/config/TelemetryServiceAutoConfiguration.java
+++ b/inception/inception-telemetry/src/main/java/de/tudarmstadt/ukp/clarin/webanno/telemetry/config/TelemetryServiceAutoConfiguration.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.telemetry.config;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.security.core.session.SessionRegistry;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.identity.InstanceIdentityService;
+import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
+import de.tudarmstadt.ukp.clarin.webanno.telemetry.TelemetryService;
+import de.tudarmstadt.ukp.clarin.webanno.telemetry.TelemetryServiceImpl;
+import de.tudarmstadt.ukp.clarin.webanno.telemetry.TelemetrySupport;
+import de.tudarmstadt.ukp.clarin.webanno.telemetry.matomo.MatomoTelemetrySupport;
+import de.tudarmstadt.ukp.clarin.webanno.telemetry.matomo.MatomoTelemetrySupportImpl;
+import de.tudarmstadt.ukp.clarin.webanno.telemetry.ui.TelemetryFooterItem;
+import de.tudarmstadt.ukp.clarin.webanno.telemetry.ui.TelemetrySettingsInterceptor;
+
+@Configuration
+@EnableConfigurationProperties(TelemetryServicePropertiesImpl.class)
+@ConditionalOnProperty(prefix = "telemetry", name = "enabled", havingValue = "true", matchIfMissing = true)
+public class TelemetryServiceAutoConfiguration
+{
+    @Bean
+    public TelemetryService telemetryService(
+            @Lazy @Autowired(required = false) List<TelemetrySupport> aTelemetrySupports,
+            ApplicationEventPublisher aEventPublisher, TelemetryServiceProperties aProperties,
+            PlatformTransactionManager aTransactionManager)
+    {
+        return new TelemetryServiceImpl(aTelemetrySupports, aEventPublisher, aProperties,
+                aTransactionManager);
+    }
+
+    @Bean
+    public TelemetrySettingsInterceptor telemetrySettingsInterceptor(UserDao aUserService,
+            TelemetryService aTelemetryService)
+    {
+        return new TelemetrySettingsInterceptor(aUserService, aTelemetryService);
+    }
+
+    @Bean
+    public MatomoTelemetrySupport matomoTelemetrySupport(TelemetryService aTelemetryService,
+            InstanceIdentityService aIdentityService, UserDao aUserDao,
+            SessionRegistry aSessionRegistry,
+            @Value("${spring.application.name}") String aApplicationName)
+    {
+        return new MatomoTelemetrySupportImpl(aTelemetryService, aIdentityService, aUserDao,
+                aSessionRegistry, aApplicationName);
+    }
+
+    @Bean
+    public TelemetryFooterItem telemetryFooterItem()
+    {
+        return new TelemetryFooterItem();
+    }
+}

--- a/inception/inception-telemetry/src/main/java/de/tudarmstadt/ukp/clarin/webanno/telemetry/config/TelemetryServiceProperties.java
+++ b/inception/inception-telemetry/src/main/java/de/tudarmstadt/ukp/clarin/webanno/telemetry/config/TelemetryServiceProperties.java
@@ -15,20 +15,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package de.tudarmstadt.ukp.clarin.webanno.telemetry.ui;
+package de.tudarmstadt.ukp.clarin.webanno.telemetry.config;
 
-import org.apache.wicket.Component;
-import org.springframework.core.annotation.Order;
+import de.tudarmstadt.ukp.clarin.webanno.telemetry.config.TelemetryServicePropertiesImpl.AutoResponse;
 
-import de.tudarmstadt.ukp.clarin.webanno.ui.core.footer.FooterItem;
-
-@Order(FooterItem.ORDER_LEFT)
-public class TelemetryFooterItem
-    implements FooterItem
+public interface TelemetryServiceProperties
 {
-    @Override
-    public Component create(String aId)
-    {
-        return new TelemetryFooterPanel(aId);
-    }
+    AutoResponse getAutoRespond();
 }

--- a/inception/inception-telemetry/src/main/java/de/tudarmstadt/ukp/clarin/webanno/telemetry/config/TelemetryServicePropertiesImpl.java
+++ b/inception/inception-telemetry/src/main/java/de/tudarmstadt/ukp/clarin/webanno/telemetry/config/TelemetryServicePropertiesImpl.java
@@ -15,20 +15,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package de.tudarmstadt.ukp.clarin.webanno.telemetry.ui;
+package de.tudarmstadt.ukp.clarin.webanno.telemetry.config;
 
-import org.apache.wicket.Component;
-import org.springframework.core.annotation.Order;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 
-import de.tudarmstadt.ukp.clarin.webanno.ui.core.footer.FooterItem;
-
-@Order(FooterItem.ORDER_LEFT)
-public class TelemetryFooterItem
-    implements FooterItem
+@ConfigurationProperties("telemetry")
+public class TelemetryServicePropertiesImpl
+    implements TelemetryServiceProperties
 {
+    private AutoResponse autoRespond;
+
     @Override
-    public Component create(String aId)
+    public AutoResponse getAutoRespond()
     {
-        return new TelemetryFooterPanel(aId);
+        return autoRespond;
+    }
+
+    public void setAutoRespond(AutoResponse aAutoRespond)
+    {
+        autoRespond = aAutoRespond;
+    }
+
+    public static enum AutoResponse
+    {
+        ACCEPT, REJECT
     }
 }

--- a/inception/inception-telemetry/src/main/java/de/tudarmstadt/ukp/clarin/webanno/telemetry/matomo/MatomoTelemetrySupportImpl.java
+++ b/inception/inception-telemetry/src/main/java/de/tudarmstadt/ukp/clarin/webanno/telemetry/matomo/MatomoTelemetrySupportImpl.java
@@ -54,7 +54,6 @@ import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.security.core.session.SessionRegistry;
 import org.springframework.security.web.session.HttpSessionCreatedEvent;
-import org.springframework.stereotype.Component;
 
 import com.github.openjson.JSONArray;
 import com.github.openjson.JSONObject;
@@ -68,11 +67,17 @@ import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.support.JSONUtil;
 import de.tudarmstadt.ukp.clarin.webanno.telemetry.TelemetryDetail;
 import de.tudarmstadt.ukp.clarin.webanno.telemetry.TelemetryService;
+import de.tudarmstadt.ukp.clarin.webanno.telemetry.config.TelemetryServiceAutoConfiguration;
 import de.tudarmstadt.ukp.clarin.webanno.telemetry.event.TelemetrySettingsSavedEvent;
 import de.tudarmstadt.ukp.clarin.webanno.telemetry.model.TelemetrySettings;
 import okhttp3.OkHttpClient;
 
-@Component
+/**
+ * <p>
+ * This class is exposed as a Spring Component via
+ * {@link TelemetryServiceAutoConfiguration#matomoTelemetrySupport}.
+ * </p>
+ */
 public class MatomoTelemetrySupportImpl
     implements MatomoTelemetrySupport, DisposableBean
 {
@@ -211,8 +216,9 @@ public class MatomoTelemetrySupportImpl
         // is generated from the settings page itself when the settings are updated - thus they
         // must have the latest version.
 
-        return aSettings.stream().filter(settings -> settings.getSupport().equals(getId()))
-                .findFirst().map(this::readTraits)
+        return aSettings.stream() //
+                .filter(settings -> settings.getSupport().equals(getId())).findFirst()
+                .map(this::readTraits)
                 .map(traits -> traits.isEnabled() != null && traits.isEnabled() == true)
                 .orElse(false);
     }
@@ -451,5 +457,17 @@ public class MatomoTelemetrySupportImpl
         catch (IOException e) {
             log.error("Unable to write traits", e);
         }
+    }
+
+    @Override
+    public void acceptAll(MatomoTelemetryTraits aTraits)
+    {
+        aTraits.setEnabled(true);
+    }
+
+    @Override
+    public void rejectAll(MatomoTelemetryTraits aTraits)
+    {
+        aTraits.setEnabled(false);
     }
 }

--- a/inception/inception-telemetry/src/main/java/de/tudarmstadt/ukp/clarin/webanno/telemetry/model/TelemetrySettings.java
+++ b/inception/inception-telemetry/src/main/java/de/tudarmstadt/ukp/clarin/webanno/telemetry/model/TelemetrySettings.java
@@ -116,18 +116,18 @@ public class TelemetrySettings
     }
 
     @PrePersist
-    protected void onCreate()
+    public void onCreate()
     {
         // When we import data, we set the fields via setters and don't want these to be
         // overwritten by this event handler.
-        if (created != null) {
+        if (created == null) {
             created = new Date();
             updated = created;
         }
     }
 
     @PreUpdate
-    protected void onUpdate()
+    public void onUpdate()
     {
         updated = new Date();
     }

--- a/inception/inception-telemetry/src/main/java/de/tudarmstadt/ukp/clarin/webanno/telemetry/ui/TelemetrySettingsInterceptor.java
+++ b/inception/inception-telemetry/src/main/java/de/tudarmstadt/ukp/clarin/webanno/telemetry/ui/TelemetrySettingsInterceptor.java
@@ -23,18 +23,22 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Component;
 
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.support.interceptors.GlobalInterceptor;
 import de.tudarmstadt.ukp.clarin.webanno.telemetry.TelemetryService;
 import de.tudarmstadt.ukp.clarin.webanno.telemetry.TelemetrySupport;
+import de.tudarmstadt.ukp.clarin.webanno.telemetry.config.TelemetryServiceAutoConfiguration;
 
 /**
  * Make sure that administrator users are force to provide valid choices for telemetry collection
  * before they can use the application.
+ *
+ * <p>
+ * This class is exposed as a Spring Component via
+ * {@link TelemetryServiceAutoConfiguration#telemetrySettingsInterceptor}.
+ * </p>
  */
-@Component
 public class TelemetrySettingsInterceptor
     implements GlobalInterceptor
 {
@@ -76,7 +80,7 @@ public class TelemetrySettingsInterceptor
             return;
         }
 
-        for (TelemetrySupport<?> support : telemetryService.getTelemetrySupports()) {
+        for (TelemetrySupport support : telemetryService.getTelemetrySupports()) {
             if (!support.hasValidSettings()) {
                 throw new RestartResponseException(TelemetrySettingsPage.class);
             }

--- a/inception/inception-telemetry/src/main/resources/META-INF/spring.factories
+++ b/inception/inception-telemetry/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+de.tudarmstadt.ukp.clarin.webanno.telemetry.config.TelemetryServiceAutoConfiguration


### PR DESCRIPTION
**What's in the PR**
- Switch module to auto-configuration including adding a switch to turn it off
- Added an auto-respond setting
- Fixed properly setting the "created" timestamp in the telemetry setting DB entry

**How to test manually**
* Add e.g. `telemetry.auto-respond=ACCEPT` to the properties file

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
