### PR TITLE
#2164 - Override default admin password and allow remote access

### DIFF
--- a/inception/inception-security/pom.xml
+++ b/inception/inception-security/pom.xml
@@ -85,6 +85,10 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot</artifactId>
+    </dependency>
 
     <!-- SPRING SECURITY -->
     <dependency>

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/UserDao.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/UserDao.java
@@ -28,6 +28,9 @@ import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
  */
 public interface UserDao
 {
+    static final String ADMIN_DEFAULT_USERNAME = "admin";
+    static final String ADMIN_DEFAULT_PASSWORD = "admin";
+
     User getCurrentUser();
 
     /**

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/UserDaoImpl.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/UserDaoImpl.java
@@ -61,7 +61,7 @@ public class UserDaoImpl
     @EventListener
     public void onContextRefreshedEvent(ContextRefreshedEvent aEvent)
     {
-        if (securityProperties.getDefaultAdminPassword() == null) {
+        if (securityProperties == null || securityProperties.getDefaultAdminPassword() == null) {
             return;
         }
 

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/UserDaoImpl.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/UserDaoImpl.java
@@ -18,7 +18,10 @@
 package de.tudarmstadt.ukp.clarin.webanno.security;
 
 import static de.tudarmstadt.ukp.clarin.webanno.security.model.Role.ROLE_ADMIN;
+import static de.tudarmstadt.ukp.clarin.webanno.security.model.Role.ROLE_REMOTE;
+import static de.tudarmstadt.ukp.clarin.webanno.security.model.Role.ROLE_USER;
 
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -28,12 +31,18 @@ import javax.persistence.NoResultException;
 import javax.persistence.PersistenceContext;
 
 import org.apache.commons.lang3.Validate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
+import de.tudarmstadt.ukp.clarin.webanno.security.config.SecurityProperties;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.Authority;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.Role;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
@@ -45,8 +54,37 @@ import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 public class UserDaoImpl
     implements UserDao
 {
-    @PersistenceContext
-    private EntityManager entityManager;
+    private @PersistenceContext EntityManager entityManager;
+    private @Autowired(required = false) SecurityProperties securityProperties;
+    private @Autowired(required = false) PlatformTransactionManager transactionManager;
+
+    @EventListener
+    public void onContextRefreshedEvent(ContextRefreshedEvent aEvent)
+    {
+        if (securityProperties.getDefaultAdminPassword() == null) {
+            return;
+        }
+
+        if (transactionManager == null) {
+            return;
+        }
+
+        new TransactionTemplate(transactionManager).executeWithoutResult(transactionStatus -> {
+            if (list().isEmpty()) {
+                User admin = new User();
+                admin.setUsername(ADMIN_DEFAULT_USERNAME);
+                admin.setEncodedPassword(securityProperties.getDefaultAdminPassword());
+                admin.setEnabled(true);
+                if (securityProperties.isDefaultAdminRemoteAccess()) {
+                    admin.setRoles(EnumSet.of(ROLE_ADMIN, ROLE_USER, ROLE_REMOTE));
+                }
+                else {
+                    admin.setRoles(EnumSet.of(ROLE_ADMIN, ROLE_USER));
+                }
+                create(admin);
+            }
+        });
+    }
 
     @Override
     @Transactional

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/config/SecurityProperties.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/config/SecurityProperties.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.security.config;
+
+import de.tudarmstadt.ukp.clarin.webanno.security.model.Role;
+
+public interface SecurityProperties
+{
+    /**
+     * @return encoded default password for the admin user. If this is set, the system will create
+     *         the admin user with the given encoded password on startup unless the user already
+     *         exists.
+     */
+    String getDefaultAdminPassword();
+
+    /**
+     * @return whether to create the default admin user with {@link Role#ROLE_REMOTE}. Has no effect
+     *         if the user already exists and is ignored if {@link #getDefaultAdminPassword} is not
+     *         also set.
+     */
+    boolean isDefaultAdminRemoteAccess();
+}

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/config/SecurityPropertiesImpl.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/config/SecurityPropertiesImpl.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.security.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties("security")
+public class SecurityPropertiesImpl
+    implements SecurityProperties
+{
+    private String defaultAdminPassword;
+
+    private boolean defaultAdminRemoteAccess = false;
+
+    @Override
+    public String getDefaultAdminPassword()
+    {
+        return defaultAdminPassword;
+    }
+
+    public void setDefaultAdminPassword(String aDefaultAdminPassword)
+    {
+        defaultAdminPassword = aDefaultAdminPassword;
+    }
+
+    @Override
+    public boolean isDefaultAdminRemoteAccess()
+    {
+        return defaultAdminRemoteAccess;
+    }
+
+    public void setDefaultAdminRemoteAccess(boolean aDefaultAdminRemoteAccess)
+    {
+        defaultAdminRemoteAccess = aDefaultAdminRemoteAccess;
+    }
+}

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/model/User.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/model/User.java
@@ -177,6 +177,11 @@ public class User
         password = encodePassword(aPassword);
     }
 
+    public void setEncodedPassword(String aPassword)
+    {
+        password = aPassword;
+    }
+
     public boolean isEnabled()
     {
         return enabled;

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/login/LoginPage.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/login/LoginPage.java
@@ -17,6 +17,10 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.ui.core.login;
 
+import static de.tudarmstadt.ukp.clarin.webanno.security.UserDao.ADMIN_DEFAULT_PASSWORD;
+import static de.tudarmstadt.ukp.clarin.webanno.security.UserDao.ADMIN_DEFAULT_USERNAME;
+import static de.tudarmstadt.ukp.clarin.webanno.security.model.Role.ROLE_ADMIN;
+import static de.tudarmstadt.ukp.clarin.webanno.security.model.Role.ROLE_USER;
 import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
@@ -60,7 +64,7 @@ import com.giffing.wicket.spring.boot.context.scan.WicketSignInPage;
 import de.agilecoders.wicket.webjars.request.resource.WebjarsCssResourceReference;
 import de.tudarmstadt.ukp.clarin.webanno.api.SessionMetaData;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
-import de.tudarmstadt.ukp.clarin.webanno.security.model.Role;
+import de.tudarmstadt.ukp.clarin.webanno.security.config.SecurityProperties;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.clarin.webanno.support.SettingsUtil;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior;
@@ -77,14 +81,12 @@ public class LoginPage
 {
     private static final long serialVersionUID = -333578034707672294L;
 
-    private static final String ADMIN_DEFAULT_USERNAME = "admin";
-    private static final String ADMIN_DEFAULT_PASSWORD = "admin";
-
     private final Logger log = LoggerFactory.getLogger(getClass());
 
     private @SpringBean UserDao userRepository;
     private @SpringBean(required = false) SessionRegistry sessionRegistry;
     private @SpringBean LoginProperties loginProperties;
+    private @SpringBean SecurityProperties securityProperties;
 
     private LoginForm form;
     private final WebMarkupContainer tooManyUsersLabel;
@@ -112,14 +114,15 @@ public class LoginPage
             admin.setUsername(ADMIN_DEFAULT_USERNAME);
             admin.setPassword(ADMIN_DEFAULT_PASSWORD);
             admin.setEnabled(true);
-            admin.setRoles(EnumSet.of(Role.ROLE_ADMIN, Role.ROLE_USER));
-            userRepository.create(admin);
+            admin.setRoles(EnumSet.of(ROLE_ADMIN, ROLE_USER));
 
-            String msg = "No user accounts have been found. An admin account has been created: "
-                    + ADMIN_DEFAULT_USERNAME + "/" + ADMIN_DEFAULT_PASSWORD;
             // We log this as a warning so the message sticks on the screen. Success and info
             // messages are set to auto-close after a short time.
+            String msg = "No user accounts have been found. An admin account has been created: "
+                    + ADMIN_DEFAULT_USERNAME + "/" + ADMIN_DEFAULT_PASSWORD;
             warn(msg);
+
+            userRepository.create(admin);
         }
     }
 


### PR DESCRIPTION
**What's in the PR**
- Added option to set an encoded default admin PW
- Added option to allow remote API access to default admin user

**How to test manually**
* Try the new settings

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
