### PR TITLE
#2172 - Importing documents from external search sidebar gives errors

### DIFF
--- a/inception/inception-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentServiceImpl.java
+++ b/inception/inception-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentServiceImpl.java
@@ -76,6 +76,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
 import de.tudarmstadt.ukp.clarin.webanno.api.RepositoryProperties;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode;
+import de.tudarmstadt.ukp.clarin.webanno.api.dao.casstorage.CasStorageSession;
 import de.tudarmstadt.ukp.clarin.webanno.api.event.AfterCasWrittenEvent;
 import de.tudarmstadt.ukp.clarin.webanno.api.event.AfterDocumentCreatedEvent;
 import de.tudarmstadt.ukp.clarin.webanno.api.event.AfterDocumentResetEvent;
@@ -546,8 +547,7 @@ public class DocumentServiceImpl
 
         // Import the actual content
         File targetFile = getSourceDocumentFile(aDocument);
-        CAS cas;
-        try {
+        try (CasStorageSession session = CasStorageSession.openNested()) {
             FileUtils.forceMkdir(targetFile.getParentFile());
 
             try (OutputStream os = new FileOutputStream(targetFile)) {
@@ -556,7 +556,18 @@ public class DocumentServiceImpl
 
             // Check if the file has a valid format / can be converted without error
             // This requires that the document ID has already been assigned
-            cas = createOrReadInitialCas(aDocument, NO_CAS_UPGRADE, aFullProjectTypeSystem);
+            CAS cas = createOrReadInitialCas(aDocument, NO_CAS_UPGRADE, aFullProjectTypeSystem);
+
+            log.trace("Sending AfterDocumentCreatedEvent for {}", aDocument);
+            applicationEventPublisher
+                    .publishEvent(new AfterDocumentCreatedEvent(this, aDocument, cas));
+
+            try (MDC.MDCCloseable closable = MDC.putCloseable(Logging.KEY_PROJECT_ID,
+                    String.valueOf(aDocument.getProject().getId()))) {
+                Project project = aDocument.getProject();
+                log.info("Imported source document [{}]({}) to project [{}]({})",
+                        aDocument.getName(), aDocument.getId(), project.getName(), project.getId());
+            }
         }
         catch (IOException e) {
             FileUtils.forceDelete(targetFile);
@@ -567,16 +578,6 @@ public class DocumentServiceImpl
             FileUtils.forceDelete(targetFile);
             removeSourceDocument(aDocument);
             throw new IOException(e.getMessage(), e);
-        }
-
-        log.trace("Sending AfterDocumentCreatedEvent for {}", aDocument);
-        applicationEventPublisher.publishEvent(new AfterDocumentCreatedEvent(this, aDocument, cas));
-
-        try (MDC.MDCCloseable closable = MDC.putCloseable(Logging.KEY_PROJECT_ID,
-                String.valueOf(aDocument.getProject().getId()))) {
-            Project project = aDocument.getProject();
-            log.info("Imported source document [{}]({}) to project [{}]({})", aDocument.getName(),
-                    aDocument.getId(), project.getName(), project.getId());
         }
     }
 

--- a/inception/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/SearchPage.html
+++ b/inception/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/SearchPage.html
@@ -61,10 +61,12 @@
           </div>
         </div>
       </form>
-      <div wicket:id="dataTableContainer" class="scrolling flex-content flex-h-container">
-        <table wicket:id="resultsTable" class="table" cellspacing="0" >
-          [Results table]
-        </table>
+      <div class="scrolling flex-content flex-h-container">
+        <div wicket:id="dataTableContainer">
+          <table wicket:id="resultsTable" class="table" cellspacing="0" >
+            [Results table]
+          </table>
+        </div>
       </div>
     </div>
   </wicket:extend>

--- a/inception/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/sidebar/ExternalSearchAnnotationSidebar$ResultRowView.html
+++ b/inception/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/sidebar/ExternalSearchAnnotationSidebar$ResultRowView.html
@@ -26,7 +26,7 @@
           <div class="small text-right" style="flex-grow: 9" wicket:id="score"/>
         </div>
         <div class="flex-content">
-          <div wicket:id="title"/>
+          <div wicket:id="title" class="text-break"/>
           <div wicket:id="highlight" class="small text-body"/>
         </div>
       </div>

--- a/inception/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/sidebar/ExternalSearchAnnotationSidebar.html
+++ b/inception/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/sidebar/ExternalSearchAnnotationSidebar.html
@@ -51,7 +51,7 @@
             </div>
           </form>
         </div>
-        <div wicket:id="dataTableContainer" class="scrolling flex-content flex-h-container">
+        <div wicket:id="dataTableContainer" class="scrolling flex-content fit-child-snug">
           <table wicket:id="resultsTable" class="table table-sm" cellspacing="0" >
             [Results table]
           </table>


### PR DESCRIPTION
**What's in the PR**
- Fix importing a document via the external search sidebar by wrapping the import in a separate storage session - this avoids the INITIAL_CAS being locked by the current session while it is then later again attempted to be locked by an isolated session that runs as part of initializing the annotation document in order to load it in the editor
- Fix scroll position jumping when importing a document via the external search page
- Fix external search sidebar exploding when a document has a long title

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
