### PR TITLE
#2161 - Upgrade dependencies

### DIFF
--- a/inception/pom.xml
+++ b/inception/pom.xml
@@ -88,8 +88,8 @@
 
     <mariadb.driver.version>2.7.1</mariadb.driver.version>
     <mysql-driver.version>8.0.20</mysql-driver.version>
-    <hibernate.version>5.4.15.Final</hibernate.version>
-    <hibernate.validator.version>6.1.4.Final</hibernate.validator.version>
+    <hibernate.version>5.4.30.Final</hibernate.version>
+    <hibernate.validator.version>6.2.0.Final</hibernate.validator.version>
 
     <wicket.version>9.3.0</wicket.version>
     <wicketstuff.version>9.3.0</wicketstuff.version>
@@ -1041,12 +1041,12 @@
       <dependency>
         <groupId>org.javassist</groupId>
         <artifactId>javassist</artifactId>
-        <version>3.26.0-GA</version>
+        <version>3.27.0-GA</version>
       </dependency>
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy</artifactId>
-        <version>1.10.2</version>
+        <version>1.10.22</version>
       </dependency>
       <dependency>
         <groupId>org.wicketstuff</groupId>


### PR DESCRIPTION
**What's in the PR**
- Hibernate 5.4.15 -> 5.4.30
- Hibernate Validator 6.1.4 -> 6.2.0
- Javassist 3.26.0 -> 3.27.0
- byte-buddy 1.10.2 -> 1.10.22

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
