### PR TITLE
#2191 - Agreement does not take tagset into account

### DIFF
--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/AgreementUtils.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/AgreementUtils.java
@@ -31,6 +31,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
@@ -60,10 +61,11 @@ import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.relation.RelationPosit
 public class AgreementUtils
 {
     public static CodingAgreementResult makeCodingStudy(CasDiff aDiff, String aType,
-            String aFeature, boolean aExcludeIncomplete, Map<String, List<CAS>> aCasMap)
+            String aFeature, Set<String> aTagSet, boolean aExcludeIncomplete,
+            Map<String, List<CAS>> aCasMap)
     {
-        return makeCodingStudy(aDiff, aCasMap.keySet(), aType, aFeature, aExcludeIncomplete, true,
-                aCasMap);
+        return makeCodingStudy(aDiff, aCasMap.keySet(), aType, aFeature, aTagSet,
+                aExcludeIncomplete, true, aCasMap);
     }
 
     private static CAS findSomeCas(Map<String, List<CAS>> aCasMap)
@@ -82,8 +84,8 @@ public class AgreementUtils
     }
 
     private static CodingAgreementResult makeCodingStudy(CasDiff aDiff, Collection<String> aUsers,
-            String aType, String aFeature, boolean aExcludeIncomplete, boolean aNullLabelsAsEmpty,
-            Map<String, List<CAS>> aCasMap)
+            String aType, String aFeature, Set<String> aTagSet, boolean aExcludeIncomplete,
+            boolean aNullLabelsAsEmpty, Map<String, List<CAS>> aCasMap)
     {
         List<String> users = new ArrayList<>(aUsers);
         Collections.sort(users);
@@ -95,6 +97,10 @@ public class AgreementUtils
         List<ConfigurationSet> pluralitySets = new ArrayList<>();
         List<ConfigurationSet> irrelevantSets = new ArrayList<>();
         CodingAnnotationStudy study = new CodingAnnotationStudy(users.size());
+
+        if (aTagSet != null) {
+            aTagSet.forEach(study::addCategory);
+        }
 
         // Check if the feature we are looking at is a primitive feature or a link feature
         // We do this by looking it up in the first available CAS. Mind that at this point all

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/cohenkappa/CohenKappaAgreementMeasure.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/cohenkappa/CohenKappaAgreementMeasure.java
@@ -74,7 +74,7 @@ public class CohenKappaAgreementMeasure
         if (agreementResult.getStudy().getItemCount() == 0) {
             agreementResult.setAgreement(Double.NaN);
         }
-        else if (getObservedCategories(agreementResult).size() == 1) {
+        else if (agreementResult.getObservedCategories().size() == 1) {
             agreementResult.setAgreement(1.0d);
         }
         else {

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/fleisskappa/FleissKappaAgreementMeasure.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/fleisskappa/FleissKappaAgreementMeasure.java
@@ -75,7 +75,7 @@ public class FleissKappaAgreementMeasure
         if (agreementResult.getStudy().getItemCount() == 0) {
             agreementResult.setAgreement(Double.NaN);
         }
-        else if (getObservedCategories(agreementResult).size() == 1) {
+        else if (agreementResult.getObservedCategories().size() == 1) {
             agreementResult.setAgreement(1.0d);
         }
         else {

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/fleisskappa/FleissKappaAgreementMeasure.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/fleisskappa/FleissKappaAgreementMeasure.java
@@ -21,13 +21,16 @@ import static de.tudarmstadt.ukp.clarin.webanno.agreement.AgreementUtils.makeCod
 import static de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.doDiff;
 import static de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.getDiffAdapters;
 import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toCollection;
 
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.uima.cas.CAS;
-import org.dkpro.statistics.agreement.IAgreementMeasure;
 import org.dkpro.statistics.agreement.coding.FleissKappaAgreement;
+import org.dkpro.statistics.agreement.coding.ICodingAnnotationStudy;
 
 import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.DefaultAgreementTraits;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.results.coding.CodingAgreementMeasure_ImplBase;
@@ -36,6 +39,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.api.DiffAdapter;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.Tag;
 
 public class FleissKappaAgreementMeasure
     extends CodingAgreementMeasure_ImplBase<DefaultAgreementTraits>
@@ -59,18 +63,47 @@ public class FleissKappaAgreementMeasure
 
         CasDiff diff = doDiff(adapters, traits.getLinkCompareBehavior(), aCasMap);
 
+        Set<String> tagset = annotationService.listTags(feature.getTagset()).stream()
+                .map(Tag::getName).collect(toCollection(LinkedHashSet::new));
+
         CodingAgreementResult agreementResult = makeCodingStudy(diff, feature.getLayer().getName(),
-                feature.getName(), true, aCasMap);
+                feature.getName(), tagset, true, aCasMap);
 
-        IAgreementMeasure agreement = new FleissKappaAgreement(agreementResult.getStudy());
+        InspectableFleissKappaAgreement agreement = new InspectableFleissKappaAgreement(
+                agreementResult.getStudy());
 
-        if (agreementResult.getStudy().getItemCount() > 0) {
-            agreementResult.setAgreement(agreement.calculateAgreement());
+        if (agreementResult.getStudy().getItemCount() == 0) {
+            agreementResult.setAgreement(Double.NaN);
+        }
+        else if (getObservedCategories(agreementResult).size() == 1) {
+            agreementResult.setAgreement(1.0d);
         }
         else {
-            agreementResult.setAgreement(Double.NaN);
+            agreementResult.setAgreement(agreement.calculateAgreement());
         }
 
         return agreementResult;
+    }
+
+    private static class InspectableFleissKappaAgreement
+        extends FleissKappaAgreement
+    {
+
+        public InspectableFleissKappaAgreement(ICodingAnnotationStudy aStudy)
+        {
+            super(aStudy);
+        }
+
+        @Override
+        public double calculateObservedAgreement()
+        {
+            return super.calculateObservedAgreement();
+        }
+
+        @Override
+        public double calculateExpectedAgreement()
+        {
+            return super.calculateExpectedAgreement();
+        }
     }
 }

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/coding/CodingAgreementMeasure_ImplBase.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/coding/CodingAgreementMeasure_ImplBase.java
@@ -18,12 +18,17 @@
 package de.tudarmstadt.ukp.clarin.webanno.agreement.results.coding;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
 import org.apache.uima.cas.CAS;
+import org.dkpro.statistics.agreement.IAnnotationUnit;
+import org.dkpro.statistics.agreement.coding.ICodingAnnotationItem;
+import org.dkpro.statistics.agreement.coding.ICodingAnnotationStudy;
 
 import de.tudarmstadt.ukp.clarin.webanno.agreement.PairwiseAnnotationResult;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.AgreementMeasure_ImplBase;
@@ -58,6 +63,21 @@ public abstract class CodingAgreementMeasure_ImplBase<T extends DefaultAgreement
             }
         }
         return result;
+    }
+
+    protected Set<Object> getObservedCategories(CodingAgreementResult aResult)
+    {
+        Set<Object> observedCategories = new HashSet<>();
+        ICodingAnnotationStudy study = aResult.getStudy();
+        for (ICodingAnnotationItem item : study.getItems()) {
+            for (IAnnotationUnit unit : item.getUnits()) {
+                Object category = unit.getCategory();
+                if (category != null) {
+                    observedCategories.add(category);
+                }
+            }
+        }
+        return observedCategories;
     }
 
     public abstract CodingAgreementResult calculatePairAgreement(Map<String, List<CAS>> aCasMap);

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/coding/CodingAgreementMeasure_ImplBase.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/coding/CodingAgreementMeasure_ImplBase.java
@@ -18,17 +18,12 @@
 package de.tudarmstadt.ukp.clarin.webanno.agreement.results.coding;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
 
 import org.apache.uima.cas.CAS;
-import org.dkpro.statistics.agreement.IAnnotationUnit;
-import org.dkpro.statistics.agreement.coding.ICodingAnnotationItem;
-import org.dkpro.statistics.agreement.coding.ICodingAnnotationStudy;
 
 import de.tudarmstadt.ukp.clarin.webanno.agreement.PairwiseAnnotationResult;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.AgreementMeasure_ImplBase;
@@ -63,21 +58,6 @@ public abstract class CodingAgreementMeasure_ImplBase<T extends DefaultAgreement
             }
         }
         return result;
-    }
-
-    protected Set<Object> getObservedCategories(CodingAgreementResult aResult)
-    {
-        Set<Object> observedCategories = new HashSet<>();
-        ICodingAnnotationStudy study = aResult.getStudy();
-        for (ICodingAnnotationItem item : study.getItems()) {
-            for (IAnnotationUnit unit : item.getUnits()) {
-                Object category = unit.getCategory();
-                if (category != null) {
-                    observedCategories.add(category);
-                }
-            }
-        }
-        return observedCategories;
     }
 
     public abstract CodingAgreementResult calculatePairAgreement(Map<String, List<CAS>> aCasMap);

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/coding/CodingAgreementResult.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/coding/CodingAgreementResult.java
@@ -20,8 +20,12 @@ package de.tudarmstadt.ukp.clarin.webanno.agreement.results.coding;
 import static java.util.Collections.unmodifiableList;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
+import org.dkpro.statistics.agreement.IAnnotationUnit;
+import org.dkpro.statistics.agreement.coding.ICodingAnnotationItem;
 import org.dkpro.statistics.agreement.coding.ICodingAnnotationStudy;
 
 import de.tudarmstadt.ukp.clarin.webanno.agreement.AgreementResult;
@@ -132,6 +136,20 @@ public class CodingAgreementResult
     public DiffResult getDiff()
     {
         return diff;
+    }
+
+    public Set<Object> getObservedCategories()
+    {
+        Set<Object> observedCategories = new HashSet<>();
+        for (ICodingAnnotationItem item : getStudy().getItems()) {
+            for (IAnnotationUnit unit : item.getUnits()) {
+                Object category = unit.getCategory();
+                if (category != null) {
+                    observedCategories.add(category);
+                }
+            }
+        }
+        return observedCategories;
     }
 
     @Override

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/coding/PairwiseCodingAgreementTable.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/coding/PairwiseCodingAgreementTable.java
@@ -284,7 +284,7 @@ public class PairwiseCodingAgreementTable
                 + String.format("- %s: %d/%d%n", result.getCasGroupIds().get(1),
                         getNonNullCount(result, result.getCasGroupIds().get(1)),
                         result.getStudy().getItemCount())
-                + String.format("Distinct labels used: %d%n", result.getStudy().getCategoryCount());
+                + String.format("Distinct labels: %d%n", result.getStudy().getCategoryCount());
 
         Label l = new Label("label", Model.of(label));
         l.add(makeDownloadBehavior(aRater1, aRater2));

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/coding/PairwiseCodingAgreementTable.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/coding/PairwiseCodingAgreementTable.java
@@ -23,6 +23,7 @@ import static de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.doDiff;
 import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.enabledWhen;
 import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
 import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toCollection;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -30,8 +31,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.uima.cas.CAS;
 import org.apache.wicket.ajax.AjaxEventBehavior;
@@ -76,6 +79,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.api.DiffAdapter;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.Tag;
 import de.tudarmstadt.ukp.clarin.webanno.support.AJAXDownload;
 import de.tudarmstadt.ukp.clarin.webanno.support.DefaultRefreshingView;
 import de.tudarmstadt.ukp.clarin.webanno.support.DescriptionTooltipBehavior;
@@ -411,13 +415,16 @@ public class PairwiseCodingAgreementTable
 
                 CasDiff diff = doDiff(adapters, traits.getLinkCompareBehavior(), casMap);
 
+                Set<String> tagset = annotationService.listTags(feature.getTagset()).stream()
+                        .map(Tag::getName).collect(toCollection(LinkedHashSet::new));
+
                 // AgreementResult agreementResult = AgreementUtils.makeStudy(diff,
                 // feature.getLayer().getName(), feature.getName(),
                 // pref.excludeIncomplete, casMap);
                 // TODO: for the moment, we always include incomplete annotations during this
                 // export.
                 CodingAgreementResult agreementResult = makeCodingStudy(diff,
-                        feature.getLayer().getName(), feature.getName(), false, casMap);
+                        feature.getLayer().getName(), feature.getName(), tagset, false, casMap);
 
                 try {
                     return AgreementUtils.generateCsvReport(agreementResult);

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/unitizing/PairwiseUnitizingAgreementTable.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/unitizing/PairwiseUnitizingAgreementTable.java
@@ -235,7 +235,7 @@ public class PairwiseUnitizingAgreementTable
                         getNonNullCount(result, 0), result.getStudy().getUnitCount(0))
                 + String.format("- %s: %d/%d%n", result.getCasGroupIds().get(1),
                         getNonNullCount(result, 1), result.getStudy().getUnitCount(1))
-                + String.format("Distinct labels used: %d%n", result.getStudy().getCategoryCount());
+                + String.format("Distinct labels: %d%n", result.getStudy().getCategoryCount());
 
         Label l = new Label("label", Model.of(label));
         DescriptionTooltipBehavior tooltip = new DescriptionTooltipBehavior(tooltipTitle,

--- a/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/AgreementMeasureTestSuite_ImplBase.java
+++ b/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/AgreementMeasureTestSuite_ImplBase.java
@@ -27,6 +27,7 @@ import static de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.LinkCompareBeha
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.SINGLE_TOKEN;
 import static de.tudarmstadt.ukp.clarin.webanno.model.LinkMode.WITH_ROLE;
 import static de.tudarmstadt.ukp.clarin.webanno.model.OverlapMode.NO_OVERLAP;
+import static de.tudarmstadt.ukp.clarin.webanno.support.uima.AnnotationBuilder.buildAnnotation;
 import static java.util.Arrays.asList;
 import static org.apache.uima.fit.factory.JCasFactory.createJCas;
 import static org.mockito.ArgumentMatchers.any;
@@ -40,9 +41,10 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.uima.cas.CAS;
+import org.apache.uima.fit.factory.CasFactory;
 import org.apache.uima.fit.factory.JCasFactory;
 import org.apache.uima.jcas.JCas;
-import org.dkpro.statistics.agreement.coding.ICodingAnnotationStudy;
+import org.dkpro.statistics.agreement.IAnnotationStudy;
 import org.junit.Before;
 import org.mockito.Mock;
 
@@ -60,6 +62,8 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.layer.SpanLayerSupport;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.model.Tag;
+import de.tudarmstadt.ukp.clarin.webanno.model.TagSet;
 import de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.POS;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Lemma;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
@@ -108,8 +112,8 @@ public class AgreementMeasureTestSuite_ImplBase
         });
     }
 
-    public <R extends Serializable, T extends DefaultAgreementTraits> R multiLinkWithRoleLabelDifferenceTest(
-            AgreementMeasureSupport<T, R, ICodingAnnotationStudy> aSupport)
+    public <R extends Serializable, T extends DefaultAgreementTraits, S extends IAnnotationStudy> //
+    R multiLinkWithRoleLabelDifferenceTest(AgreementMeasureSupport<T, R, S> aSupport)
         throws Exception
     {
         AnnotationLayer layer = new AnnotationLayer(HOST_TYPE, HOST_TYPE, SPAN_TYPE, project, false,
@@ -130,9 +134,11 @@ public class AgreementMeasureTestSuite_ImplBase
         traits.setLinkCompareBehavior(LINK_TARGET_AS_LABEL);
 
         JCas jcasA = createJCas(createMultiLinkWithRoleTestTypeSystem());
+        jcasA.setDocumentText("This is a test.");
         makeLinkHostFS(jcasA, 0, 0, makeLinkFS(jcasA, "slot1", 0, 0));
 
         JCas jcasB = createJCas(createMultiLinkWithRoleTestTypeSystem());
+        jcasB.setDocumentText("This is a test.");
         makeLinkHostFS(jcasB, 0, 0, makeLinkFS(jcasB, "slot2", 0, 0));
 
         Map<String, List<CAS>> casByUser = new LinkedHashMap<>();
@@ -144,9 +150,8 @@ public class AgreementMeasureTestSuite_ImplBase
         return measure.getAgreement(casByUser);
     }
 
-    public <R extends Serializable, T extends DefaultAgreementTraits> R twoEmptyCasTest(
-            AgreementMeasureSupport<T, R, ICodingAnnotationStudy> aSupport)
-        throws Exception
+    public <R extends Serializable, T extends DefaultAgreementTraits, S extends IAnnotationStudy> //
+    R twoEmptyCasTest(AgreementMeasureSupport<T, R, S> aSupport) throws Exception
     {
         AnnotationLayer layer = new AnnotationLayer(Lemma.class.getName(),
                 Lemma.class.getSimpleName(), SPAN_TYPE, project, false, SINGLE_TOKEN, NO_OVERLAP);
@@ -162,11 +167,9 @@ public class AgreementMeasureTestSuite_ImplBase
 
         String text = "";
 
-        CAS user1Cas = JCasFactory.createJCas().getCas();
-        user1Cas.setDocumentText(text);
+        CAS user1Cas = JCasFactory.createText(text).getCas();
 
-        CAS user2Cas = JCasFactory.createJCas().getCas();
-        user2Cas.setDocumentText(text);
+        CAS user2Cas = JCasFactory.createText(text).getCas();
 
         Map<String, List<CAS>> casByUser = new LinkedHashMap<>();
         casByUser.put("user1", asList(user1Cas));
@@ -177,8 +180,8 @@ public class AgreementMeasureTestSuite_ImplBase
         return measure.getAgreement(casByUser);
     }
 
-    public <R extends Serializable, T extends DefaultAgreementTraits> R singleNoDifferencesWithAdditionalCasTest(
-            AgreementMeasureSupport<T, R, ICodingAnnotationStudy> aSupport)
+    public <R extends Serializable, T extends DefaultAgreementTraits, S extends IAnnotationStudy> //
+    R singleNoDifferencesWithAdditionalCasTest(AgreementMeasureSupport<T, R, S> aSupport)
         throws Exception
     {
         AnnotationLayer layer = new AnnotationLayer(POS.class.getName(), POS.class.getSimpleName(),
@@ -193,14 +196,11 @@ public class AgreementMeasureTestSuite_ImplBase
 
         T traits = aSupport.createTraits();
 
-        JCas user1 = JCasFactory.createJCas();
-        user1.setDocumentText("test");
+        JCas user1 = JCasFactory.createText("test");
 
-        JCas user2 = JCasFactory.createJCas();
-        user2.setDocumentText("test");
+        JCas user2 = JCasFactory.createText("test");
 
-        JCas user3 = JCasFactory.createJCas();
-        user3.setDocumentText("test");
+        JCas user3 = JCasFactory.createText("test");
         POS pos3 = new POS(user3, 0, 4);
         pos3.setPosValue("test");
         pos3.addToIndexes();
@@ -215,9 +215,8 @@ public class AgreementMeasureTestSuite_ImplBase
         return measure.getAgreement(casByUser);
     }
 
-    public <R extends Serializable, T extends DefaultAgreementTraits> R twoWithoutLabelTest(
-            AgreementMeasureSupport<T, R, ICodingAnnotationStudy> aSupport, T aTraits)
-        throws Exception
+    public <R extends Serializable, T extends DefaultAgreementTraits, S extends IAnnotationStudy> //
+    R twoWithoutLabelTest(AgreementMeasureSupport<T, R, S> aSupport, T aTraits) throws Exception
     {
         AnnotationLayer layer = new AnnotationLayer(POS.class.getName(), POS.class.getSimpleName(),
                 SPAN_TYPE, project, false, SINGLE_TOKEN, NO_OVERLAP);
@@ -229,16 +228,16 @@ public class AgreementMeasureTestSuite_ImplBase
         feature.setId(1l);
         features.add(feature);
 
-        JCas user1 = JCasFactory.createJCas();
-        user1.setDocumentText("test");
+        JCas user1 = JCasFactory.createText("test");
+
         new POS(user1, 0, 1).addToIndexes();
         new POS(user1, 1, 2).addToIndexes();
         POS p1 = new POS(user1, 3, 4);
         p1.setPosValue("A");
         p1.addToIndexes();
 
-        JCas user2 = JCasFactory.createJCas();
-        user2.setDocumentText("test");
+        JCas user2 = JCasFactory.createText("test");
+
         new POS(user2, 0, 1).addToIndexes();
         new POS(user2, 2, 3).addToIndexes();
         POS p2 = new POS(user2, 3, 4);
@@ -252,5 +251,42 @@ public class AgreementMeasureTestSuite_ImplBase
         AgreementMeasure<R> measure = aSupport.createMeasure(feature, aTraits);
 
         return measure.getAgreement(casByUser);
+    }
+
+    public <R extends Serializable, T extends DefaultAgreementTraits, S extends IAnnotationStudy> //
+    R fullSingleCategoryAgreementWithTagset(AgreementMeasureSupport<T, R, S> aSupport, T aTraits)
+        throws Exception
+    {
+        TagSet tagset = new TagSet(project, "tagset");
+        Tag tag1 = new Tag(tagset, "+");
+        Tag tag2 = new Tag(tagset, "-");
+        when(annotationService.listTags(tagset)).thenReturn(asList(tag1, tag2));
+
+        AnnotationLayer layer = new AnnotationLayer(POS.class.getName(), POS.class.getSimpleName(),
+                SPAN_TYPE, project, false, SINGLE_TOKEN, NO_OVERLAP);
+        layer.setId(1l);
+        layers.add(layer);
+
+        AnnotationFeature feature = new AnnotationFeature(project, layer, "PosValue", "PosValue",
+                CAS.TYPE_NAME_STRING);
+        feature.setId(1l);
+        feature.setTagset(tagset);
+        features.add(feature);
+
+        CAS user1 = CasFactory.createText("test");
+
+        buildAnnotation(user1, POS.class).at(0, 1) //
+                .withFeature(POS._FeatName_PosValue, "+") //
+                .buildAndAddToIndexes();
+
+        CAS user2 = CasFactory.createText("test");
+
+        buildAnnotation(user2, POS.class).at(0, 1) //
+                .withFeature(POS._FeatName_PosValue, "+") //
+                .buildAndAddToIndexes();
+
+        return aSupport.createMeasure(feature, aTraits).getAgreement(Map.of( //
+                "user1", asList(user1), //
+                "user2", asList(user2)));
     }
 }

--- a/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/AgreementTestUtils.java
+++ b/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/AgreementTestUtils.java
@@ -24,6 +24,7 @@ import static de.tudarmstadt.ukp.clarin.webanno.agreement.measures.ConcreteAgree
 import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.RELATION_TYPE;
 import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.SPAN_TYPE;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptySet;
 import static org.apache.uima.fit.factory.CollectionReaderFactory.createReader;
 
 import java.io.File;
@@ -342,7 +343,7 @@ public class AgreementTestUtils
             throw new IllegalArgumentException("CAS map must contain exactly two CASes");
         }
 
-        CodingAgreementResult agreementResult = makeCodingStudy(aDiff, aType, aFeature,
+        CodingAgreementResult agreementResult = makeCodingStudy(aDiff, aType, aFeature, emptySet(),
                 aExcludeIncomplete, aCasMap);
         try {
             IAgreementMeasure agreement = aMeasure.make(agreementResult.getStudy());

--- a/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/CohenKappaAgreementMeasureTest.java
+++ b/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/CohenKappaAgreementMeasureTest.java
@@ -98,6 +98,10 @@ public class CohenKappaAgreementMeasureTest
         assertEquals(1, result2.getTotalSetCount());
         assertEquals(0, result2.getIrrelevantSets().size());
         assertEquals(1, result2.getRelevantSetCount());
+
+        assertEquals(NaN, agreement.getStudy("user1", "user2").getAgreement(), 0.01);
+        assertEquals(NaN, agreement.getStudy("user1", "user3").getAgreement(), 0.01);
+        assertEquals(NaN, agreement.getStudy("user2", "user3").getAgreement(), 0.01);
     }
 
     @Test
@@ -123,5 +127,25 @@ public class CohenKappaAgreementMeasureTest
         assertEquals(1, result.getSetsWithDifferences().size());
         assertEquals(4, result.getRelevantSetCount());
         assertEquals(0.333, result.getAgreement(), 0.01);
+    }
+
+    @Test
+    public void fullSingleCategoryAgreementWithTagsetTest() throws Exception
+    {
+        PairwiseAnnotationResult<CodingAgreementResult> agreement = fullSingleCategoryAgreementWithTagset(
+                sut, traits);
+
+        CodingAgreementResult result = agreement.getStudy("user1", "user2");
+
+        ICodingAnnotationItem item1 = result.getStudy().getItem(0);
+        assertEquals("+", item1.getUnit(0).getCategory());
+
+        assertEquals(1, result.getTotalSetCount());
+        assertEquals(0, result.getIrrelevantSets().size());
+        assertEquals(0, result.getIncompleteSetsByPosition().size());
+        assertEquals(0, result.getIncompleteSetsByLabel().size());
+        assertEquals(0, result.getSetsWithDifferences().size());
+        assertEquals(1, result.getRelevantSetCount());
+        assertEquals(1.0, result.getAgreement(), 0.01);
     }
 }

--- a/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/FleissKappaAgreementMeasureTest.java
+++ b/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/FleissKappaAgreementMeasureTest.java
@@ -98,6 +98,10 @@ public class FleissKappaAgreementMeasureTest
         assertEquals(1, result2.getTotalSetCount());
         assertEquals(0, result2.getIrrelevantSets().size());
         assertEquals(1, result2.getRelevantSetCount());
+
+        assertEquals(NaN, agreement.getStudy("user1", "user2").getAgreement(), 0.01);
+        assertEquals(NaN, agreement.getStudy("user1", "user3").getAgreement(), 0.01);
+        assertEquals(NaN, agreement.getStudy("user2", "user3").getAgreement(), 0.01);
     }
 
     @Test
@@ -121,5 +125,25 @@ public class FleissKappaAgreementMeasureTest
         assertEquals(1, result.getSetsWithDifferences().size());
         assertEquals(4, result.getRelevantSetCount());
         assertEquals(0.2, result.getAgreement(), 0.01);
+    }
+
+    @Test
+    public void fullSingleCategoryAgreementWithTagsetTest() throws Exception
+    {
+        PairwiseAnnotationResult<CodingAgreementResult> agreement = fullSingleCategoryAgreementWithTagset(
+                sut, traits);
+
+        CodingAgreementResult result = agreement.getStudy("user1", "user2");
+
+        ICodingAnnotationItem item1 = result.getStudy().getItem(0);
+        assertEquals("+", item1.getUnit(0).getCategory());
+
+        assertEquals(1, result.getTotalSetCount());
+        assertEquals(0, result.getIrrelevantSets().size());
+        assertEquals(0, result.getIncompleteSetsByPosition().size());
+        assertEquals(0, result.getIncompleteSetsByLabel().size());
+        assertEquals(0, result.getSetsWithDifferences().size());
+        assertEquals(1, result.getRelevantSetCount());
+        assertEquals(1.0, result.getAgreement(), 0.01);
     }
 }

--- a/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/KrippendorffAlphaNominalAgreementMeasureTest.java
+++ b/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/KrippendorffAlphaNominalAgreementMeasureTest.java
@@ -99,6 +99,10 @@ public class KrippendorffAlphaNominalAgreementMeasureTest
         assertEquals(1, result2.getTotalSetCount());
         assertEquals(0, result2.getIrrelevantSets().size());
         assertEquals(1, result2.getRelevantSetCount());
+
+        assertEquals(NaN, agreement.getStudy("user1", "user2").getAgreement(), 0.01);
+        assertEquals(NaN, agreement.getStudy("user1", "user3").getAgreement(), 0.01);
+        assertEquals(NaN, agreement.getStudy("user2", "user3").getAgreement(), 0.01);
     }
 
     @Test
@@ -129,5 +133,25 @@ public class KrippendorffAlphaNominalAgreementMeasureTest
         assertEquals(3, result.getSetsWithDifferences().size());
         assertEquals(4, result.getRelevantSetCount());
         assertEquals(0.4, result.getAgreement(), 0.01);
+    }
+
+    @Test
+    public void fullSingleCategoryAgreementWithTagsetTest() throws Exception
+    {
+        PairwiseAnnotationResult<CodingAgreementResult> agreement = fullSingleCategoryAgreementWithTagset(
+                sut, traits);
+
+        CodingAgreementResult result = agreement.getStudy("user1", "user2");
+
+        ICodingAnnotationItem item1 = result.getStudy().getItem(0);
+        assertEquals("+", item1.getUnit(0).getCategory());
+
+        assertEquals(1, result.getTotalSetCount());
+        assertEquals(0, result.getIrrelevantSets().size());
+        assertEquals(0, result.getIncompleteSetsByPosition().size());
+        assertEquals(0, result.getIncompleteSetsByLabel().size());
+        assertEquals(0, result.getSetsWithDifferences().size());
+        assertEquals(1, result.getRelevantSetCount());
+        assertEquals(1.0, result.getAgreement(), 0.01);
     }
 }

--- a/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/KrippendorffAlphaUnitizingAgreementMeasureTest.java
+++ b/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/KrippendorffAlphaUnitizingAgreementMeasureTest.java
@@ -88,7 +88,7 @@ public class KrippendorffAlphaUnitizingAgreementMeasureTest
 
         UnitizingAgreementResult result = agreement.getStudy("user1", "user2");
 
-        assertEquals(0.4, result.getAgreement(), 0.01);
+        assertEquals(0.0, result.getAgreement(), 0.01);
     }
 
     @Test

--- a/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/KrippendorffAlphaUnitizingAgreementMeasureTest.java
+++ b/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/KrippendorffAlphaUnitizingAgreementMeasureTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.agreement.measures;
+
+import static java.lang.Double.NaN;
+import static org.junit.Assert.assertEquals;
+
+import org.dkpro.statistics.agreement.unitizing.IUnitizingAnnotationStudy;
+import org.junit.Before;
+import org.junit.Test;
+
+import de.tudarmstadt.ukp.clarin.webanno.agreement.PairwiseAnnotationResult;
+import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.krippendorffalphaunitizing.KrippendorffAlphaUnitizingAgreementMeasureSupport;
+import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.krippendorffalphaunitizing.KrippendorffAlphaUnitizingAgreementTraits;
+import de.tudarmstadt.ukp.clarin.webanno.agreement.results.unitizing.UnitizingAgreementResult;
+
+public class KrippendorffAlphaUnitizingAgreementMeasureTest
+    extends AgreementMeasureTestSuite_ImplBase
+{
+    private AgreementMeasureSupport_ImplBase<KrippendorffAlphaUnitizingAgreementTraits, //
+            PairwiseAnnotationResult<UnitizingAgreementResult>, IUnitizingAnnotationStudy> sut;
+    private KrippendorffAlphaUnitizingAgreementTraits traits;
+
+    @Override
+    @Before
+    public void setup()
+    {
+        super.setup();
+
+        sut = new KrippendorffAlphaUnitizingAgreementMeasureSupport(annotationService);
+        traits = sut.createTraits();
+    }
+
+    @Test
+    public void multiLinkWithRoleLabelDifference() throws Exception
+    {
+        PairwiseAnnotationResult<UnitizingAgreementResult> agreement = multiLinkWithRoleLabelDifferenceTest(
+                sut);
+
+        UnitizingAgreementResult result = agreement.getStudy("user1", "user2");
+
+        assertEquals(0.0, result.getAgreement(), 0.00001d);
+    }
+
+    @Test
+    public void twoEmptyCasTest() throws Exception
+    {
+        PairwiseAnnotationResult<UnitizingAgreementResult> agreement = twoEmptyCasTest(sut);
+
+        UnitizingAgreementResult result = agreement.getStudy("user1", "user2");
+
+        assertEquals(NaN, result.getAgreement(), 0.000001d);
+    }
+
+    @Test
+    public void singleNoDifferencesWithAdditionalCasTest() throws Exception
+    {
+        PairwiseAnnotationResult<UnitizingAgreementResult> agreement = singleNoDifferencesWithAdditionalCasTest(
+                sut);
+
+        assertEquals(NaN, agreement.getStudy("user1", "user2").getAgreement(), 0.01);
+        assertEquals(-4.5d, agreement.getStudy("user1", "user3").getAgreement(), 0.01);
+        assertEquals(-4.5d, agreement.getStudy("user2", "user3").getAgreement(), 0.01);
+    }
+
+    @Test
+    public void testTwoWithoutLabel_noExcludeIncomplete() throws Exception
+    {
+        traits.setExcludeIncomplete(false);
+
+        PairwiseAnnotationResult<UnitizingAgreementResult> agreement = twoWithoutLabelTest(sut,
+                traits);
+
+        UnitizingAgreementResult result = agreement.getStudy("user1", "user2");
+
+        assertEquals(0.4, result.getAgreement(), 0.01);
+    }
+
+    @Test
+    public void fullSingleCategoryAgreementWithTagsetTest() throws Exception
+    {
+        PairwiseAnnotationResult<UnitizingAgreementResult> agreement = fullSingleCategoryAgreementWithTagset(
+                sut, traits);
+
+        UnitizingAgreementResult result = agreement.getStudy("user1", "user2");
+
+        assertEquals(1.0, result.getAgreement(), 0.01);
+    }
+}

--- a/inception/inception-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/AnnotationSchemaServiceImpl.java
+++ b/inception/inception-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/AnnotationSchemaServiceImpl.java
@@ -27,6 +27,7 @@ import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUt
 import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.isSame;
 import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.selectByAddr;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.Objects.isNull;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.stream.Collectors.toList;
@@ -741,6 +742,10 @@ public class AnnotationSchemaServiceImpl
     @Transactional
     public List<Tag> listTags(TagSet aTagSet)
     {
+        if (aTagSet == null) {
+            return emptyList();
+        }
+
         return entityManager
                 .createQuery("FROM Tag WHERE tagSet = :tagSet ORDER BY name ASC", Tag.class)
                 .setParameter("tagSet", aTagSet) //


### PR DESCRIPTION
**What's in the PR**
- If there is a tagset, forward it to the agreement calculation measure
- Added unit tests for KrippendorffAlphaUnitizingAgreement

**How to test manually**
* See issue description

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
