### PR TITLE
#2195 - UX / Curation / Bad UX with multiple annotators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ idea/
 *.eml
 */*.eml
 .gradle
+log4j2-dev.xml

--- a/inception/inception-ui-curation/pom.xml
+++ b/inception/inception-ui-curation/pom.xml
@@ -145,6 +145,14 @@
       <groupId>com.googlecode.wicket-jquery-ui</groupId>
       <artifactId>wicket-jquery-ui</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.googlecode.wicket-jquery-ui</groupId>
+      <artifactId>wicket-jquery-ui-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.googlecode.wicket-jquery-ui</groupId>
+      <artifactId>wicket-kendo-ui</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.wicketstuff</groupId>

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/CurationPage.html
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/CurationPage.html
@@ -92,8 +92,8 @@
       </div>
 
       <div wicket:id="centerArea" class="flex-content flex-v-container">
-        <div class="flex-content flex-v-container flex-gutter">
-          <div class="flex-content card">
+        <div wicket:id="splitter" class="flex-content flex-v-container flex-gutter">
+          <div class="card">
             <div class="card-header border-bottom-0">
               <span wicket:id="documentNamePanel"/> 
               <span wicket:id="numberOfPages" class="small text-muted float-right"/>
@@ -103,7 +103,7 @@
               <div wicket:id="annotationEditor" class="text-center flex-content flex-v-container"/>
             </div>
           </div>
-          <div wicket:id="annotatorsPanel" class="scrolling flex-content"/>
+          <div class="scrolling" wicket:id="annotatorsPanel"/>
         </div>
       </div>
 

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/CurationPage.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/CurationPage.java
@@ -73,6 +73,10 @@ import org.slf4j.LoggerFactory;
 import org.wicketstuff.annotation.mount.MountPath;
 import org.wicketstuff.event.annotation.OnEvent;
 
+import com.googlecode.wicket.jquery.core.Options;
+import com.googlecode.wicket.kendo.ui.widget.splitter.SplitterAdapter;
+import com.googlecode.wicket.kendo.ui.widget.splitter.SplitterBehavior;
+
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
@@ -150,6 +154,7 @@ public class CurationPage
     private AnnotationDetailEditorPanel detailPanel;
 
     private WebMarkupContainer centerArea;
+    private WebMarkupContainer splitter;
     private AnnotationEditorBase annotationEditor;
     private AnnotatorsPanel annotatorsPanel;
 
@@ -191,11 +196,19 @@ public class CurationPage
         centerArea = new WebMarkupContainer("centerArea");
         centerArea.add(visibleWhen(() -> getModelObject().getDocument() != null));
         centerArea.setOutputMarkupPlaceholderTag(true);
-        centerArea.add(new DocumentNamePanel("documentNamePanel", getModel()));
-        centerArea.add(new ActionBar("actionBar"));
         add(centerArea);
 
-        centerArea.add(getModelObject().getPagingStrategy()
+        splitter = new WebMarkupContainer("splitter");
+        splitter.setOutputMarkupId(true);
+        centerArea.add(splitter);
+
+        splitter.add(new DocumentNamePanel("documentNamePanel", getModel()));
+        splitter.add(new ActionBar("actionBar"));
+
+        splitter.add(new SplitterBehavior("#" + splitter.getMarkupId(),
+                new Options("orientation", Options.asString("vertical")), new SplitterAdapter()));
+
+        splitter.add(getModelObject().getPagingStrategy()
                 .createPositionLabel(MID_NUMBER_OF_PAGES, getModel())
                 .add(visibleWhen(() -> getModelObject().getDocument() != null))
                 .add(LambdaBehavior.onEvent(RenderAnnotationsEvent.class,
@@ -213,7 +226,7 @@ public class CurationPage
         annotatorsPanel.setOutputMarkupPlaceholderTag(true);
         annotatorsPanel.add(visibleWhen(
                 () -> getModelObject() != null && getModelObject().getDocument() != null));
-        centerArea.add(annotatorsPanel);
+        splitter.add(annotatorsPanel);
 
         rightSidebar = makeRightSidebar("rightSidebar");
         rightSidebar
@@ -226,7 +239,7 @@ public class CurationPage
         annotationEditor.add(visibleWhen(
                 () -> getModelObject() != null && getModelObject().getDocument() != null));
         annotationEditor.setOutputMarkupPlaceholderTag(true);
-        centerArea.add(annotationEditor);
+        splitter.add(annotationEditor);
 
         curationUnitOverview = new WebMarkupContainer("unitOverview");
         curationUnitOverview.setOutputMarkupPlaceholderTag(true);
@@ -559,7 +572,7 @@ public class CurationPage
             annotationEditor.requestRender(aTarget);
             annotatorsPanel.requestRender(aTarget, getModelObject(), focussedUnit);
             aTarget.add(curationUnitOverview);
-            aTarget.add(centerArea.get(MID_NUMBER_OF_PAGES));
+            aTarget.add(splitter.get(MID_NUMBER_OF_PAGES));
         }
         catch (Exception e) {
             handleException(aTarget, e);


### PR DESCRIPTION
**What's in the PR**
- Use a splitter to make the height of the top-part adjustable

**How to test manually**
* Try using the curation page and adjusting the splitter
* Mind that the splitter position is not remembered across page loads - but accepting an annotation, paging and switching between documents should (probably) not make the splitter jump

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
