### PR TITLE
#2216 - Multi-Token Sequence Classifier (OpenNLP NER) matches an additional token

### DIFF
--- a/inception/inception-imls-opennlp/pom.xml
+++ b/inception/inception-imls-opennlp/pom.xml
@@ -25,7 +25,7 @@
   <artifactId>inception-imls-opennlp</artifactId>
   <name>INCEpTION - ML - OpenNLP (v ${opennlp.version})</name>
   <properties>
-    <opennlp.version>1.9.1</opennlp.version>
+    <opennlp.version>1.9.3</opennlp.version>
   </properties>
   <dependencies>
     <dependency>


### PR DESCRIPTION
**What's in the PR**
- Upgrade to OpenNLP 1.9.3
- Fix bug that single adjacent token at end is always considered part of the training data (e.g. full stops)
- Avoid NPE if score or prediction flag features are missing from type system

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
