### PR TITLE
#2219 - Krippendorff's Alpha Agreement = 1.0 (Unitization) although documents differ completely

### DIFF
--- a/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/AgreementMeasureTestSuite_ImplBase.java
+++ b/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/AgreementMeasureTestSuite_ImplBase.java
@@ -289,4 +289,42 @@ public class AgreementMeasureTestSuite_ImplBase
                 "user1", asList(user1), //
                 "user2", asList(user2)));
     }
+
+    public <R extends Serializable, T extends DefaultAgreementTraits, S extends IAnnotationStudy> //
+    R twoDocumentsNoOverlap(AgreementMeasureSupport<T, R, S> aSupport, T aTraits) throws Exception
+    {
+        TagSet tagset = new TagSet(project, "tagset");
+        Tag tag1 = new Tag(tagset, "+");
+        Tag tag2 = new Tag(tagset, "-");
+        when(annotationService.listTags(tagset)).thenReturn(asList(tag1, tag2));
+
+        AnnotationLayer layer = new AnnotationLayer(POS.class.getName(), POS.class.getSimpleName(),
+                SPAN_TYPE, project, false, SINGLE_TOKEN, NO_OVERLAP);
+        layer.setId(1l);
+        layers.add(layer);
+
+        AnnotationFeature feature = new AnnotationFeature(project, layer, "PosValue", "PosValue",
+                CAS.TYPE_NAME_STRING);
+        feature.setId(1l);
+        feature.setTagset(tagset);
+        features.add(feature);
+
+        CAS user1a = CasFactory.createText("test");
+        CAS user1b = CasFactory.createText("test");
+
+        buildAnnotation(user1a, POS.class).at(0, 1) //
+                .withFeature(POS._FeatName_PosValue, "+") //
+                .buildAndAddToIndexes();
+
+        CAS user2a = CasFactory.createText("test");
+        CAS user2b = CasFactory.createText("test");
+
+        buildAnnotation(user2b, POS.class).at(0, 1) //
+                .withFeature(POS._FeatName_PosValue, "+") //
+                .buildAndAddToIndexes();
+
+        return aSupport.createMeasure(feature, aTraits).getAgreement(Map.of( //
+                "user1", asList(user1a, user1b), //
+                "user2", asList(user2a, user2b)));
+    }
 }

--- a/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/CohenKappaAgreementMeasureTest.java
+++ b/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/CohenKappaAgreementMeasureTest.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.clarin.webanno.agreement.measures;
 
 import static java.lang.Double.NaN;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import org.dkpro.statistics.agreement.coding.ICodingAnnotationItem;
@@ -147,5 +148,16 @@ public class CohenKappaAgreementMeasureTest
         assertEquals(0, result.getSetsWithDifferences().size());
         assertEquals(1, result.getRelevantSetCount());
         assertEquals(1.0, result.getAgreement(), 0.01);
+    }
+
+    @Test
+    public void twoDocumentsNoOverlapTest() throws Exception
+    {
+        PairwiseAnnotationResult<CodingAgreementResult> agreement = twoDocumentsNoOverlap(sut,
+                traits);
+
+        CodingAgreementResult result = agreement.getStudy("user1", "user2");
+
+        assertThat(result.getAgreement()).isNaN();
     }
 }

--- a/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/FleissKappaAgreementMeasureTest.java
+++ b/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/FleissKappaAgreementMeasureTest.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.clarin.webanno.agreement.measures;
 
 import static java.lang.Double.NaN;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import org.dkpro.statistics.agreement.coding.ICodingAnnotationItem;
@@ -145,5 +146,16 @@ public class FleissKappaAgreementMeasureTest
         assertEquals(0, result.getSetsWithDifferences().size());
         assertEquals(1, result.getRelevantSetCount());
         assertEquals(1.0, result.getAgreement(), 0.01);
+    }
+
+    @Test
+    public void twoDocumentsNoOverlapTest() throws Exception
+    {
+        PairwiseAnnotationResult<CodingAgreementResult> agreement = twoDocumentsNoOverlap(sut,
+                traits);
+
+        CodingAgreementResult result = agreement.getStudy("user1", "user2");
+
+        assertThat(result.getAgreement()).isNaN();
     }
 }

--- a/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/KrippendorffAlphaNominalAgreementMeasureTest.java
+++ b/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/KrippendorffAlphaNominalAgreementMeasureTest.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.clarin.webanno.agreement.measures;
 
 import static java.lang.Double.NaN;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import org.dkpro.statistics.agreement.coding.ICodingAnnotationItem;
@@ -153,5 +154,16 @@ public class KrippendorffAlphaNominalAgreementMeasureTest
         assertEquals(0, result.getSetsWithDifferences().size());
         assertEquals(1, result.getRelevantSetCount());
         assertEquals(1.0, result.getAgreement(), 0.01);
+    }
+
+    @Test
+    public void twoDocumentsNoOverlapTest() throws Exception
+    {
+        PairwiseAnnotationResult<CodingAgreementResult> agreement = twoDocumentsNoOverlap(sut,
+                traits);
+
+        CodingAgreementResult result = agreement.getStudy("user1", "user2");
+
+        assertThat(result.getAgreement()).isNaN();
     }
 }

--- a/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/KrippendorffAlphaUnitizingAgreementMeasureTest.java
+++ b/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/KrippendorffAlphaUnitizingAgreementMeasureTest.java
@@ -101,4 +101,15 @@ public class KrippendorffAlphaUnitizingAgreementMeasureTest
 
         assertEquals(1.0, result.getAgreement(), 0.01);
     }
+
+    @Test
+    public void twoDocumentsNoOverlapTest() throws Exception
+    {
+        PairwiseAnnotationResult<UnitizingAgreementResult> agreement = twoDocumentsNoOverlap(sut,
+                traits);
+
+        UnitizingAgreementResult result = agreement.getStudy("user1", "user2");
+
+        assertEquals(-0.0714, result.getAgreement(), 0.001);
+    }
 }


### PR DESCRIPTION
**What's in the PR**
- Fixed issue by ensuring that annotations extracted from CASes are re-based using the offset of the document containing them within the batch continuum
- Added unit tests

**How to test manually**
* See issue

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
