### PR TITLE
#2231 - Allow asking user for mail address on the accept invite page

### DIFF
--- a/inception/inception-sharing/pom.xml
+++ b/inception/inception-sharing/pom.xml
@@ -65,6 +65,11 @@
       <artifactId>javax.persistence-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
     </dependency>

--- a/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/AcceptInvitePage.html
+++ b/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/AcceptInvitePage.html
@@ -25,7 +25,7 @@
         --input-padding-y: 1.5rem;
       }
       
-      .form-group input[type=text],input[type=password] {
+      .form-group input[type=text],input[type=password],input[type=email] {
         padding: var(--input-padding-y) var(--input-padding-x);
         border-radius: 2rem;
       }
@@ -64,6 +64,9 @@
               </div>
               <div class="form-group form-row mb-3" wicket:enclosure="password">
                 <input wicket:id="password" type="password" class="form-control" placeholder="Password"/>
+              </div>
+              <div class="form-group form-row mb-3" wicket:enclosure="eMail">
+                <input wicket:id="eMail" type="email" class="form-control" placeholder="eMail address"/>
               </div>
               <div class="form-group form-row text-center" wicket:enclosure="registeredLogin">
                 <div class="form-check w-100">

--- a/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/InviteService.java
+++ b/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/InviteService.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.inception.sharing;
 
 import java.util.Date;
+import java.util.Optional;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
@@ -87,6 +88,8 @@ public interface InviteService
     ProjectInvite readProjectInvite(Project aProject);
 
     void writeProjectInvite(ProjectInvite aInvite);
+
+    Optional<User> getProjectUser(Project aProject, String aUsername);
 
     User getOrCreateProjectUser(Project aProject, String aUsername);
 }

--- a/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/InviteServiceImpl.java
+++ b/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/InviteServiceImpl.java
@@ -20,6 +20,7 @@ package de.tudarmstadt.ukp.inception.sharing;
 import static de.tudarmstadt.ukp.clarin.webanno.security.UserDao.EMPTY_PASSWORD;
 import static de.tudarmstadt.ukp.clarin.webanno.security.UserDao.REALM_PROJECT_PREFIX;
 import static de.tudarmstadt.ukp.clarin.webanno.security.model.Role.ROLE_USER;
+import static de.tudarmstadt.ukp.inception.sharing.model.Mandatoriness.NOT_ALLOWED;
 
 import java.io.IOException;
 import java.security.SecureRandom;
@@ -27,6 +28,7 @@ import java.util.Base64;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import javax.persistence.EntityManager;
@@ -166,6 +168,10 @@ public class InviteServiceImpl
     @Transactional
     public void writeProjectInvite(ProjectInvite aInvite)
     {
+        if (!aInvite.isGuestAccessible()) {
+            aInvite.setAskForEMail(NOT_ALLOWED);
+        }
+
         if (aInvite.getId() == null) {
             entityManager.persist(aInvite);
         }
@@ -244,6 +250,14 @@ public class InviteServiceImpl
         invite.setExpirationDate(aExpirationDate);
         entityManager.merge(invite);
         return true;
+    }
+
+    @Override
+    public Optional<User> getProjectUser(Project aProject, String aUsername)
+    {
+        String realm = REALM_PROJECT_PREFIX + aProject.getId();
+
+        return Optional.ofNullable(userRepository.getUserByRealmAndUiName(realm, aUsername));
     }
 
     @Override

--- a/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/model/Mandatoriness.java
+++ b/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/model/Mandatoriness.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.sharing.model;
+
+import java.io.Serializable;
+
+import de.tudarmstadt.ukp.clarin.webanno.support.PersistentEnum;
+
+public enum Mandatoriness
+    implements PersistentEnum, Serializable
+{
+    NOT_ALLOWED("not-allowed"),
+
+    OPTIONAL("optional"),
+
+    MANDATORY("mandatory");
+
+    private final String id;
+
+    public String getName()
+    {
+        return this.name().toLowerCase();
+    }
+
+    @Override
+    public String toString()
+    {
+        return this.name().toLowerCase();
+    }
+
+    Mandatoriness(String aId)
+    {
+        this.id = aId;
+    }
+
+    @Override
+    public String getId()
+    {
+        return id;
+    }
+}

--- a/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/model/MandatorinessType.java
+++ b/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/model/MandatorinessType.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.sharing.model;
+
+import de.tudarmstadt.ukp.clarin.webanno.support.PersistentEnumUserType;
+
+/**
+ * Implementation of {@link PersistentEnumUserType}
+ */
+public class MandatorinessType
+    extends PersistentEnumUserType<Mandatoriness>
+{
+    private static final long serialVersionUID = 7378581246428809177L;
+
+    @Override
+    public Class<Mandatoriness> returnedClass()
+    {
+        return Mandatoriness.class;
+    }
+}

--- a/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/model/ProjectInvite.java
+++ b/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/model/ProjectInvite.java
@@ -17,6 +17,8 @@
  */
 package de.tudarmstadt.ukp.inception.sharing.model;
 
+import static de.tudarmstadt.ukp.inception.sharing.model.Mandatoriness.NOT_ALLOWED;
+
 import java.io.Serializable;
 import java.util.Date;
 import java.util.Objects;
@@ -34,6 +36,8 @@ import javax.persistence.PreUpdate;
 import javax.persistence.Table;
 import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
+
+import org.hibernate.annotations.Type;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 
@@ -76,6 +80,10 @@ public class ProjectInvite
 
     @Column(nullable = false)
     private boolean guestAccessible = false;
+
+    @Type(type = "de.tudarmstadt.ukp.inception.sharing.model.MandatorinessType")
+    @Column(nullable = false)
+    private Mandatoriness askForEMail = NOT_ALLOWED;
 
     public ProjectInvite()
     {
@@ -158,6 +166,16 @@ public class ProjectInvite
     public void setGuestAccessible(boolean aGuestAccessible)
     {
         guestAccessible = aGuestAccessible;
+    }
+
+    public Mandatoriness getAskForEMail()
+    {
+        return askForEMail;
+    }
+
+    public void setAskForEMail(Mandatoriness aAskForEMail)
+    {
+        askForEMail = aAskForEMail;
     }
 
     @PrePersist

--- a/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/project/InviteProjectSettingsPanel.html
+++ b/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/project/InviteProjectSettingsPanel.html
@@ -86,6 +86,14 @@
             <input wicket:id="userIdPlaceholder" class="form-control" type="text" placeholder="User ID"/>
           </div>
         </div>
+        <div class="form-group form-row" wicket:enclosure="askForEMail">
+          <label class="col-form-label col-sm-2">
+            <wicket:message key="askForEMail"/>
+          </label>
+          <div class="col-sm-10">
+            <select wicket:id="askForEMail" class="form-control" data-container="body"></select>
+          </div>
+        </div>
       </div>
     </div>
     <div class="card-footer text-right">

--- a/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/project/InviteProjectSettingsPanel.java
+++ b/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/project/InviteProjectSettingsPanel.java
@@ -19,6 +19,7 @@ package de.tudarmstadt.ukp.inception.sharing.project;
 
 import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
 import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhenNot;
+import static java.util.Arrays.asList;
 
 import java.util.Date;
 
@@ -30,6 +31,7 @@ import org.apache.wicket.feedback.IFeedback;
 import org.apache.wicket.markup.ComponentTag;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.form.CheckBox;
+import org.apache.wicket.markup.html.form.EnumChoiceRenderer;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.form.TextArea;
 import org.apache.wicket.markup.html.form.TextField;
@@ -44,6 +46,7 @@ import org.wicketstuff.clipboardjs.ClipboardJsBehavior;
 
 import com.googlecode.wicket.kendo.ui.form.datetime.DatePicker;
 
+import de.agilecoders.wicket.extensions.markup.html.bootstrap.form.select.BootstrapSelect;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxButton;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxFormSubmittingBehavior;
@@ -52,6 +55,7 @@ import de.tudarmstadt.ukp.clarin.webanno.ui.core.settings.ProjectSettingsPanelBa
 import de.tudarmstadt.ukp.inception.sharing.AcceptInvitePage;
 import de.tudarmstadt.ukp.inception.sharing.InviteService;
 import de.tudarmstadt.ukp.inception.sharing.config.InviteServiceProperties;
+import de.tudarmstadt.ukp.inception.sharing.model.Mandatoriness;
 import de.tudarmstadt.ukp.inception.sharing.model.ProjectInvite;
 
 public class InviteProjectSettingsPanel
@@ -98,6 +102,13 @@ public class InviteProjectSettingsPanel
         detailsForm.add(new CheckBox("guestAccessible").setOutputMarkupId(true)
                 .add(visibleWhen(() -> inviteServiceProperties.isGuestsEnabled()))
                 .add(new LambdaAjaxFormSubmittingBehavior("change", _target -> _target.add(this))));
+        detailsForm.add(new BootstrapSelect<Mandatoriness>("askForEMail",
+                asList(Mandatoriness.values()), new EnumChoiceRenderer<>(this))
+                        .setOutputMarkupId(true)
+                        .add(visibleWhen(() -> inviteServiceProperties.isGuestsEnabled() && invite
+                                .map(ProjectInvite::isGuestAccessible).orElse(false).getObject()))
+                        .add(new LambdaAjaxFormSubmittingBehavior("change",
+                                _target -> _target.add(this))));
         detailsForm.add(new TextField<>("userIdPlaceholder")
                 .add(visibleWhen(invite.map(ProjectInvite::isGuestAccessible))));
         detailsForm.add(new LambdaAjaxLink("extendLink", this::actionExtendInviteDate));

--- a/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/project/InviteProjectSettingsPanel.properties
+++ b/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/project/InviteProjectSettingsPanel.properties
@@ -26,3 +26,7 @@ save=Save
 extend=Extend by a year
 guestAccessible=Allow guest annotators
 userIdPlaceholder=User ID placeholder
+askForEMail=Ask for eMail
+Mandatoriness.NOT_ALLOWED=No
+Mandatoriness.OPTIONAL=Yes
+Mandatoriness.MANDATORY=Required

--- a/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/project/exporters/ExportedProjectInvite.java
+++ b/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/project/exporters/ExportedProjectInvite.java
@@ -17,8 +17,12 @@
  */
 package de.tudarmstadt.ukp.inception.sharing.project.exporters;
 
+import static de.tudarmstadt.ukp.inception.sharing.model.Mandatoriness.NOT_ALLOWED;
+
 import java.io.Serializable;
 import java.util.Date;
+
+import de.tudarmstadt.ukp.inception.sharing.model.Mandatoriness;
 
 public class ExportedProjectInvite
     implements Serializable
@@ -32,6 +36,7 @@ public class ExportedProjectInvite
     private Date created;
     private Date updated;
     private boolean guestAccessible;
+    private Mandatoriness askForEMail;
 
     public String getInviteId()
     {
@@ -103,4 +108,13 @@ public class ExportedProjectInvite
         guestAccessible = aGuestAccessible;
     }
 
+    public Mandatoriness getAskForEMail()
+    {
+        return askForEMail != null ? askForEMail : NOT_ALLOWED;
+    }
+
+    public void setAskForEMail(Mandatoriness aAskForEMail)
+    {
+        askForEMail = aAskForEMail != null ? aAskForEMail : NOT_ALLOWED;
+    }
 }

--- a/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/project/exporters/ProjectInviteExporter.java
+++ b/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/project/exporters/ProjectInviteExporter.java
@@ -76,6 +76,7 @@ public class ProjectInviteExporter
             exportedInvite.setInviteId(invite.getInviteId());
             exportedInvite.setUpdated(invite.getUpdated());
             exportedInvite.setUserIdPlaceholder(invite.getUserIdPlaceholder());
+            exportedInvite.setAskForEMail(invite.getAskForEMail());
             projectInvites.add(exportedInvite);
         }
 
@@ -104,6 +105,7 @@ public class ProjectInviteExporter
             invite.setInviteId(exportedInvite.getInviteId());
             invite.setUpdated(exportedInvite.getUpdated());
             invite.setUserIdPlaceholder(exportedInvite.getUserIdPlaceholder());
+            invite.setAskForEMail(exportedInvite.getAskForEMail());
             inviteService.writeProjectInvite(invite);
 
             LOG.info("Exported [{}] invites for project [{}]", 1, aProject.getName());

--- a/inception/inception-sharing/src/main/resources/de/tudarmstadt/ukp/inception/sharing/model/db-changelog.xml
+++ b/inception/inception-sharing/src/main/resources/de/tudarmstadt/ukp/inception/sharing/model/db-changelog.xml
@@ -78,4 +78,15 @@
       </column>
     </addColumn>
   </changeSet>
+  
+  <changeSet author="INCEpTION Team" id="20210427-1">
+    <preConditions onFail="WARN">
+      <changeSetExecuted author="INCEpTION Team" id="20210416-1"/>
+    </preConditions>
+    <addColumn tableName="project_invite">
+      <column name="askForEMail" type="VARCHAR(255)" defaultValue="not-allowed">
+        <constraints nullable="false"/>
+      </column>
+    </addColumn>
+  </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
**What's in the PR**
- Optionally ask or require user to enter a mail address when accepting an invite
- If the mail address provided does not match a previously provided one, then login fails

**How to test manually**
* Configure invite with different levels of mandatoriness for the email address
* Accept invites and try also providing two different email addresses for the same nick

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
