### PR TITLE
#2243 - Directly select tags for small tagsets

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/StringFeatureSupport.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/StringFeatureSupport.java
@@ -191,7 +191,8 @@ public class StringFeatureSupport
         FeatureState featureState = aFeatureStateModel.getObject();
 
         // For really small tagsets where tag creation is not supported, use a radio group
-        if (!featureState.feature.getTagset().isCreateTag() && featureState.tagset.size() <= 3) {
+        if (!featureState.feature.getTagset().isCreateTag()
+                && featureState.tagset.size() < properties.getComboBoxThreshold()) {
             return RADIOGROUP;
         }
 

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/StringFeatureSupport.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/StringFeatureSupport.java
@@ -150,7 +150,7 @@ public class StringFeatureSupport
 
         StringFeatureTraits traits = readTraits(feature);
 
-        if (feature.getTagset() == null) {
+        if (feature.getTagset() == null || traits.isMultipleRows()) {
             if (traits.isMultipleRows()) {
                 // If multiple rows are set use a textarea
                 if (traits.isDynamicSize()) {

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/StringFeatureSupport.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/StringFeatureSupport.java
@@ -168,7 +168,7 @@ public class StringFeatureSupport
 
         EditorType editorType = traits.getEditorType();
         if (editorType == EditorType.AUTO) {
-            editorType = autoChooseFeatureEditor(aFeatureStateModel);
+            editorType = autoChooseFeatureEditorWithTagset(aFeatureStateModel);
         }
 
         switch (editorType) {
@@ -185,15 +185,18 @@ public class StringFeatureSupport
         }
     }
 
-    private EditorType autoChooseFeatureEditor(final IModel<FeatureState> aFeatureStateModel)
+    private EditorType autoChooseFeatureEditorWithTagset(
+            final IModel<FeatureState> aFeatureStateModel)
     {
-        // For really small tagsets, use a radio group
-        if (aFeatureStateModel.getObject().tagset.size() <= 3) {
+        FeatureState featureState = aFeatureStateModel.getObject();
+
+        // For really small tagsets where tag creation is not supported, use a radio group
+        if (!featureState.feature.getTagset().isCreateTag() && featureState.tagset.size() <= 3) {
             return RADIOGROUP;
         }
 
         // For mid-sized tagsets, use a combobox
-        if (aFeatureStateModel.getObject().tagset.size() < properties.getAutoCompleteThreshold()) {
+        if (featureState.tagset.size() < properties.getAutoCompleteThreshold()) {
             return COMBOBOX;
         }
 

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/config/PrimitiveUimaFeatureSupportProperties.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/config/PrimitiveUimaFeatureSupportProperties.java
@@ -25,6 +25,11 @@ import org.springframework.stereotype.Component;
 public class PrimitiveUimaFeatureSupportProperties
 {
     /**
+     * If the tagset is larger than the threshold, a combo-box is used instead of a radio choice.
+     */
+    private int comboBoxThreshold = 6;
+
+    /**
      * If the tagset is larger than the threshold, an auto-complete field is used instead of a
      * standard combobox.
      */
@@ -35,6 +40,16 @@ public class PrimitiveUimaFeatureSupportProperties
      * dropdown menu.
      */
     private int autoCompleteMaxResults = 100;
+
+    public int getComboBoxThreshold()
+    {
+        return comboBoxThreshold;
+    }
+
+    public void setComboBoxThreshold(int aComboBoxThreshold)
+    {
+        comboBoxThreshold = aComboBoxThreshold;
+    }
 
     public int getAutoCompleteThreshold()
     {

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/NumberFeatureTraits.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/NumberFeatureTraits.java
@@ -29,7 +29,8 @@ public class NumberFeatureTraits
 
     public enum EDITOR_TYPE
     {
-        SPINNER("Spinner"), RADIO_BUTTONS("Radio Buttons");
+        SPINNER("Spinner"), //
+        RADIO_BUTTONS("Radio Buttons");
 
         private final String name;
 

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/RadioGroupStringFeatureEditor.html
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/RadioGroupStringFeatureEditor.html
@@ -34,6 +34,9 @@
         <div wicket:id="radios" class="flex-h-container radio-button">
           <input wicket:id="radio" type="radio"/>
           <label wicket:id="label" class="flex-content"/>
+          <span wicket:id="description" class="btn px-0" style="margin-left: -26px; margin-right: 8px; z-index: 10;">
+            <i class="fas fa-info-circle"/>
+          </span>
         </div>
       </div>
       <div wicket:id="keyBindings" class="col-sm-12"/>

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/RadioGroupStringFeatureEditor.html
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/RadioGroupStringFeatureEditor.html
@@ -27,6 +27,9 @@
       </span>
     </label>
     <div class="feature-editor-value">
+      <div wicket:id="emptyTagsetWarning" class="flex-content flex-h-container no-data-notice m-0">
+        <div>Tagset contains no tags</div>
+      </div>
       <div wicket:id="value" class="radio-button-group">
         <div wicket:id="radios" class="flex-h-container radio-button">
           <input wicket:id="radio" type="radio"/>

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/RadioGroupStringFeatureEditor.html
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/RadioGroupStringFeatureEditor.html
@@ -23,13 +23,14 @@
       <span wicket:id="feature"/>
       <span class="float-right">
         <span wicket:id="textIndicator"></span>
+        <a wicket:id="clear"><i class="fas fa-times"></i></a>
       </span>
     </label>
     <div class="feature-editor-value">
-      <div wicket:id="value">
-        <div wicket:id="radios">
+      <div wicket:id="value" class="radio-button-group">
+        <div wicket:id="radios" class="flex-h-container radio-button">
           <input wicket:id="radio" type="radio"/>
-          <label wicket:id="label" style="margin-right: 5%; padding-left: 20px;"></label>
+          <label wicket:id="label" class="flex-content"/>
         </div>
       </div>
       <div wicket:id="keyBindings" class="col-sm-12"/>

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/RadioGroupStringFeatureEditor.html
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/RadioGroupStringFeatureEditor.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<!--
+  Licensed to the Technische Universität Darmstadt under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The Technische Universität Darmstadt 
+  licenses this file to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.
+   
+  http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<html xmlns:wicket="http://wicket.apache.org">
+<wicket:panel>
+  <div class="form-group form-row" wicket:enclosure="value">
+    <label wicket:for="value" wicket:enclosure="feature" class="feature-editor-label col-form-label">
+      <span wicket:id="feature"/>
+      <span class="float-right">
+        <span wicket:id="textIndicator"></span>
+      </span>
+    </label>
+    <div class="feature-editor-value">
+      <div wicket:id="value">
+        <div wicket:id="radios">
+          <input wicket:id="radio" type="radio"/>
+          <label wicket:id="label" style="margin-right: 5%; padding-left: 20px;"></label>
+        </div>
+      </div>
+      <div wicket:id="keyBindings" class="col-sm-12"/>
+    </div>
+  </div>
+</wicket:panel>
+</html>

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/RadioGroupStringFeatureEditor.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/RadioGroupStringFeatureEditor.java
@@ -18,11 +18,13 @@
 package de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor;
 
 import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.wicket.event.Broadcast.BUBBLE;
 
 import java.util.List;
 
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.Component;
 import org.apache.wicket.MarkupContainer;
 import org.apache.wicket.ajax.AjaxRequestTarget;
@@ -37,7 +39,9 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.IModelComparator;
 import org.apache.wicket.model.PropertyModel;
 
+import com.googlecode.wicket.jquery.core.Options;
 import com.googlecode.wicket.kendo.ui.form.Radio;
+import com.googlecode.wicket.kendo.ui.widget.tooltip.TooltipBehavior;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.action.AnnotationActionHandler;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.event.FeatureEditorValueChangedEvent;
@@ -145,7 +149,26 @@ public class RadioGroupStringFeatureEditor
                 Radio<Object> radio = new Radio<Object>("radio", (IModel) item.getModel(), aGroup);
                 Radio.Label label = new Radio.Label("label",
                         item.getModel().map(ReorderableTag::getName), radio);
-                item.add(radio, label);
+                label.add(AttributeModifier.append("class",
+                        item.getModel().map(ReorderableTag::getReordered)
+                                .map(_flag -> _flag ? "font-weight-bold" : "")));
+
+                String descriptionText = item.getModel().getObject().getDescription();
+
+                WebMarkupContainer description = new WebMarkupContainer("description");
+                description.add(visibleWhen(() -> isNotBlank(descriptionText)));
+
+                if (isNotBlank(descriptionText)) {
+                    TooltipBehavior tip = new TooltipBehavior();
+                    tip.setOption("autoHide", false);
+                    tip.setOption("showOn", Options.asString("click"));
+                    tip.setOption("content", Options.asString(descriptionText));
+                    description.add(tip);
+                }
+
+                add(description);
+
+                item.add(radio, label, description);
             }
         };
     }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/RadioGroupStringFeatureEditor.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/RadioGroupStringFeatureEditor.java
@@ -43,6 +43,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.keybindings.KeyBindingsP
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.FeatureState;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.ReorderableTag;
+import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxLink;
 
 public class RadioGroupStringFeatureEditor
     extends TextFeatureEditorBase
@@ -57,11 +58,21 @@ public class RadioGroupStringFeatureEditor
         AnnotationFeature feat = getModelObject().feature;
         StringFeatureTraits traits = readFeatureTraits(feat);
 
+        add(new LambdaAjaxLink("clear", this::actionClear));
+
         add(new KeyBindingsPanel("keyBindings", () -> traits.getKeyBindings(), aModel, aHandler)
                 // The key bindings are only visible when the label is also enabled, i.e. when the
                 // editor is used in a "normal" context and not e.g. in the keybindings
                 // configuration panel
                 .add(visibleWhen(() -> getLabelComponent().isVisible())));
+    }
+
+    private void actionClear(AjaxRequestTarget aTarget)
+    {
+        getModelObject().value = null;
+        aTarget.add(this);
+        send(getFocusComponent(), BUBBLE,
+                new FeatureEditorValueChangedEvent(RadioGroupStringFeatureEditor.this, aTarget));
     }
 
     @Override

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/RadioGroupStringFeatureEditor.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/RadioGroupStringFeatureEditor.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor;
+
+import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
+import static org.apache.wicket.event.Broadcast.BUBBLE;
+
+import java.util.List;
+
+import org.apache.wicket.Component;
+import org.apache.wicket.MarkupContainer;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.attributes.AjaxRequestAttributes;
+import org.apache.wicket.ajax.form.AjaxFormChoiceComponentUpdatingBehavior;
+import org.apache.wicket.markup.html.form.FormComponent;
+import org.apache.wicket.markup.html.form.RadioGroup;
+import org.apache.wicket.markup.html.list.ListItem;
+import org.apache.wicket.markup.html.list.ListView;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.IModelComparator;
+import org.apache.wicket.model.PropertyModel;
+
+import com.googlecode.wicket.kendo.ui.form.Radio;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.action.AnnotationActionHandler;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.event.FeatureEditorValueChangedEvent;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.keybindings.KeyBindingsPanel;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.FeatureState;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.ReorderableTag;
+
+public class RadioGroupStringFeatureEditor
+    extends TextFeatureEditorBase
+{
+    private static final long serialVersionUID = 9112762779124263198L;
+
+    public RadioGroupStringFeatureEditor(String aId, MarkupContainer aItem,
+            IModel<FeatureState> aModel, AnnotationActionHandler aHandler)
+    {
+        super(aId, aItem, aModel);
+
+        AnnotationFeature feat = getModelObject().feature;
+        StringFeatureTraits traits = readFeatureTraits(feat);
+
+        add(new KeyBindingsPanel("keyBindings", () -> traits.getKeyBindings(), aModel, aHandler)
+                // The key bindings are only visible when the label is also enabled, i.e. when the
+                // editor is used in a "normal" context and not e.g. in the keybindings
+                // configuration panel
+                .add(visibleWhen(() -> getLabelComponent().isVisible())));
+    }
+
+    @Override
+    protected FormComponent createInputField()
+    {
+        RadioGroup<Object> group = new RadioGroup<Object>("value",
+                new PropertyModel<>(getModel(), "value"))
+        {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public IModelComparator getModelComparator()
+            {
+                return new IModelComparator()
+                {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public boolean compare(Component component, Object b)
+                    {
+                        final Object a = component.getDefaultModelObject();
+                        if (a == null && b == null) {
+                            return true;
+                        }
+                        if (a == null || b == null) {
+                            return false;
+                        }
+
+                        String tagA = a instanceof ReorderableTag ? ((ReorderableTag) a).getName()
+                                : String.valueOf(a);
+                        String tagB = b instanceof ReorderableTag ? ((ReorderableTag) b).getName()
+                                : String.valueOf(b);
+
+                        return tagA.equals(tagB);
+                    }
+                };
+            }
+
+            @Override
+            public void convertInput()
+            {
+                super.convertInput();
+                Object convertedInput = getConvertedInput();
+                if (convertedInput instanceof ReorderableTag) {
+                    setConvertedInput(((ReorderableTag) convertedInput).getName());
+                }
+            };
+        };
+        group.add(createFeaturesList(group, getModelObject().tagset));
+        return group;
+    }
+
+    private ListView<ReorderableTag> createFeaturesList(RadioGroup<Object> aGroup,
+            List<ReorderableTag> aOptions)
+    {
+        return new ListView<ReorderableTag>("radios", aOptions)
+        {
+            private static final long serialVersionUID = 6856342528153905386L;
+
+            @Override
+            protected void populateItem(ListItem<ReorderableTag> item)
+            {
+                Radio<Object> radio = new Radio<Object>("radio", (IModel) item.getModel(), aGroup);
+                Radio.Label label = new Radio.Label("label",
+                        item.getModel().map(ReorderableTag::getName), radio);
+                item.add(radio, label);
+            }
+        };
+    }
+
+    @Override
+    public void addFeatureUpdateBehavior()
+    {
+        // Need to use a AjaxFormChoiceComponentUpdatingBehavior here since we use a RadioGroup
+        // here.
+        FormComponent focusComponent = getFocusComponent();
+        focusComponent.add(new AjaxFormChoiceComponentUpdatingBehavior()
+        {
+            private static final long serialVersionUID = -5058365578109385064L;
+
+            @Override
+            protected void updateAjaxAttributes(AjaxRequestAttributes aAttributes)
+            {
+                super.updateAjaxAttributes(aAttributes);
+                addDelay(aAttributes, 300);
+            }
+
+            @Override
+            protected void onUpdate(AjaxRequestTarget aTarget)
+            {
+                send(focusComponent, BUBBLE, new FeatureEditorValueChangedEvent(
+                        RadioGroupStringFeatureEditor.this, aTarget));
+            }
+        });
+    }
+}

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/RadioGroupStringFeatureEditor.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/RadioGroupStringFeatureEditor.java
@@ -22,11 +22,13 @@ import static org.apache.wicket.event.Broadcast.BUBBLE;
 
 import java.util.List;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.wicket.Component;
 import org.apache.wicket.MarkupContainer;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.attributes.AjaxRequestAttributes;
 import org.apache.wicket.ajax.form.AjaxFormChoiceComponentUpdatingBehavior;
+import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.form.FormComponent;
 import org.apache.wicket.markup.html.form.RadioGroup;
 import org.apache.wicket.markup.html.list.ListItem;
@@ -59,6 +61,11 @@ public class RadioGroupStringFeatureEditor
         StringFeatureTraits traits = readFeatureTraits(feat);
 
         add(new LambdaAjaxLink("clear", this::actionClear));
+
+        WebMarkupContainer emptyTagsetWarning = new WebMarkupContainer("emptyTagsetWarning");
+        emptyTagsetWarning.setOutputMarkupPlaceholderTag(true);
+        emptyTagsetWarning.add(visibleWhen(() -> CollectionUtils.isEmpty(getModelObject().tagset)));
+        add(emptyTagsetWarning);
 
         add(new KeyBindingsPanel("keyBindings", () -> traits.getKeyBindings(), aModel, aHandler)
                 // The key bindings are only visible when the label is also enabled, i.e. when the

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/StringFeatureTraits.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/StringFeatureTraits.java
@@ -35,10 +35,32 @@ public class StringFeatureTraits
 {
     private static final long serialVersionUID = -8450181605003189055L;
 
+    public enum EditorType
+    {
+        AUTO("Auto (depending on tagset size)"), //
+        RADIOGROUP("Radio group (small tagsets)"), //
+        COMBOBOX("Combobox (mid-size tagsets)"), //
+        AUTOCOMPLETE("Autocomplete (large tagsets)");
+
+        private final String name;
+
+        EditorType(String name)
+        {
+            this.name = name;
+        }
+
+        @Override
+        public String toString()
+        {
+            return name;
+        }
+    }
+
     private boolean multipleRows = false;
     private boolean dynamicSize = false;
     private int collapsedRows = 1;
     private int expandedRows = 1;
+    private EditorType editorType = EditorType.AUTO;
     private List<KeyBinding> keyBindings = new ArrayList<>();
 
     public StringFeatureTraits()
@@ -84,6 +106,16 @@ public class StringFeatureTraits
     public void setExpandedRows(int expandedRows)
     {
         this.expandedRows = expandedRows;
+    }
+
+    public EditorType getEditorType()
+    {
+        return editorType;
+    }
+
+    public void setEditorType(EditorType aEditorType)
+    {
+        editorType = aEditorType;
     }
 
     @Override

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/StringFeatureTraits.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/StringFeatureTraits.java
@@ -39,7 +39,7 @@ public class StringFeatureTraits
     {
         AUTO("Auto (depending on tagset size)"), //
         RADIOGROUP("Radio group (small tagsets)"), //
-        COMBOBOX("Combobox (mid-size tagsets)"), //
+        COMBOBOX("Combo box (mid-size tagsets)"), //
         AUTOCOMPLETE("Autocomplete (large tagsets)");
 
         private final String name;

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/StringFeatureTraitsEditor.html
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/StringFeatureTraitsEditor.html
@@ -63,7 +63,7 @@
         <select wicket:id="tagset" class="form-control" data-container="body"></select>
       </div>
     </div>
-    <div class="form-group form-row" wicket:enclosure="editorType">
+    <div class="form-group form-row" wicket:id="editorTypeContainer">
       <label wicket:for="editorType" class="col-sm-4 col-form-label">
         Editor type
       </label>

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/StringFeatureTraitsEditor.html
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/StringFeatureTraitsEditor.html
@@ -63,6 +63,14 @@
         <select wicket:id="tagset" class="form-control" data-container="body"></select>
       </div>
     </div>
+    <div class="form-group form-row" wicket:enclosure="editorType">
+      <label wicket:for="editorType" class="col-sm-4 col-form-label">
+        Editor type
+      </label>
+      <div class="col-sm-8">
+        <select class="form-control flex-content" wicket:id="editorType"></select>
+      </div>
+    </div>
   </form>
   <div class="form-group form-row">
     <label class="col-sm-4 col-form-label">

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/StringFeatureTraitsEditor.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/StringFeatureTraitsEditor.java
@@ -19,6 +19,8 @@ package de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor;
 
 import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
 
+import java.util.Arrays;
+
 import org.apache.wicket.markup.html.form.CheckBox;
 import org.apache.wicket.markup.html.form.ChoiceRenderer;
 import org.apache.wicket.markup.html.form.DropDownChoice;
@@ -143,15 +145,24 @@ public class StringFeatureTraitsEditor
                 new LambdaAjaxFormComponentUpdatingBehavior("change", target -> target.add(form)));
         dynamicSize.add(visibleWhen(() -> traits.getObject().isMultipleRows()));
         form.add(dynamicSize);
+
+        DropDownChoice<StringFeatureTraits.EditorType> editorType = new BootstrapSelect<>(
+                "editorType");
+        editorType.setModel(PropertyModel.of(traits, "editorType"));
+        editorType.setChoices(Arrays.asList(StringFeatureTraits.EditorType.values()));
+        editorType.add(new LambdaAjaxFormComponentUpdatingBehavior("change"));
+        editorType.add(visibleWhen(() -> !traits.getObject().isMultipleRows()));
+        form.add(editorType);
     }
 
     private KeyBindingsConfigurationPanel newKeyBindingsConfigurationPanel(
             IModel<AnnotationFeature> aFeature)
     {
-        KeyBindingsConfigurationPanel keyBindings = new KeyBindingsConfigurationPanel("keyBindings",
+        KeyBindingsConfigurationPanel panel = new KeyBindingsConfigurationPanel("keyBindings",
                 aFeature, traits.bind("keyBindings"));
-        keyBindings.setOutputMarkupId(true);
-        return keyBindings;
+        panel.setOutputMarkupId(true);
+        // panel.add(visibleWhen(() -> !traits.getObject().isMultipleRows()));
+        return panel;
     }
 
     private UimaPrimitiveFeatureSupport_ImplBase<StringFeatureTraits> getFeatureSupport()

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/StringFeatureTraitsEditor.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/StringFeatureTraitsEditor.java
@@ -21,6 +21,7 @@ import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.vi
 
 import java.util.Arrays;
 
+import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.form.CheckBox;
 import org.apache.wicket.markup.html.form.ChoiceRenderer;
 import org.apache.wicket.markup.html.form.DropDownChoice;
@@ -146,13 +147,16 @@ public class StringFeatureTraitsEditor
         dynamicSize.add(visibleWhen(() -> traits.getObject().isMultipleRows()));
         form.add(dynamicSize);
 
+        WebMarkupContainer editorTypeContainer = new WebMarkupContainer("editorTypeContainer");
+        editorTypeContainer.setOutputMarkupPlaceholderTag(true);
+        editorTypeContainer.add(visibleWhen(() -> !traits.getObject().isMultipleRows()));
         DropDownChoice<StringFeatureTraits.EditorType> editorType = new BootstrapSelect<>(
                 "editorType");
         editorType.setModel(PropertyModel.of(traits, "editorType"));
         editorType.setChoices(Arrays.asList(StringFeatureTraits.EditorType.values()));
         editorType.add(new LambdaAjaxFormComponentUpdatingBehavior("change"));
-        editorType.add(visibleWhen(() -> !traits.getObject().isMultipleRows()));
-        form.add(editorType);
+        editorTypeContainer.add(editorType);
+        form.add(editorTypeContainer);
     }
 
     private KeyBindingsConfigurationPanel newKeyBindingsConfigurationPanel(

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/settings_annotation-editor.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/settings_annotation-editor.adoc
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+[[sect_settings_annotation]]
 = Annotation editor
 
 [cols="4*", options="header"]

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/settings_annotation-editor.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/settings_annotation-editor.adoc
@@ -38,6 +38,11 @@
 | false
 | 
 
+| annotation.feature-support.string.comboBoxThreshold
+| If the tagset is larger than the threshold, an combo-box field is used instead of a radio-choice.
+| 6
+| 16
+
 | annotation.feature-support.string.autoCompleteThreshold
 | If the tagset is larger than the threshold, an auto-complete field is used instead of a standard combobox.
 | 75

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/user-guide.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/user-guide.adoc
@@ -193,11 +193,12 @@ include::{include-dir}workload.adoc[leveloffset=+1]
 
 <<<
 
-include::{include-dir}faq.adoc[]
+= Appendices
+
+[appendix]
+include::{include-dir}faq.adoc[leveloffset=+1]
 
 <<<
-
-= Appendices
 
 [appendix]
 include::{include-dir}formats.adoc[leveloffset=+1]
@@ -243,8 +244,6 @@ include::{include-dir}formats-webannotsv1.adoc[leveloffset=+2]
 include::{include-dir}formats-webannotsv2.adoc[leveloffset=+2]
 
 include::{include-dir}formats-webannotsv3.adoc[leveloffset=+2]
-
-include::{include-dir}faq.adoc[leveloffset=+1]
 
 <<<
 

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/bootstrap/webanno-custom.scss
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/bootstrap/webanno-custom.scss
@@ -434,3 +434,52 @@ div.left-tabpanel div.tab-row a:hover {
   border-bottom-left-radius:  0px;
   border-left: none;
 }
+
+.radio-button-group {
+  .radio-button label {
+    border-radius: 0px 0px 0px 0px;
+    border-bottom-width: 0px;
+  }
+
+  .radio-button:first-child label {
+    border-radius: $btn-border-radius $btn-border-radius 0px 0px;
+  }
+
+  .radio-button:last-child label {
+    border-radius: 0px 0px $btn-border-radius $btn-border-radius;
+    border-bottom-width: 1px;
+  }
+
+  .radio-button:first-child:last-child label {
+    border-radius: $btn-border-radius;
+    border-bottom-width: 1px;
+  }
+}
+
+.radio-button {
+  input[type="radio"] {
+    opacity: 0;
+    position: fixed;
+    width: 0;
+  }
+
+  label {
+    @extend .btn;
+    border: $border-width solid $primary;
+  }
+
+  input[type="radio"]:checked + label {
+    @include box-shadow($btn-active-box-shadow);
+    background: $component-active-bg;
+    color: $component-active-color;
+    
+    &:focus {
+      @include box-shadow($btn-focus-box-shadow, $btn-active-box-shadow);
+    }
+  }
+
+  input[type="radio"]:focus + label {
+    outline: 0;
+    box-shadow: $btn-focus-box-shadow;
+  }
+}

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/bootstrap/webanno-custom.scss
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/bootstrap/webanno-custom.scss
@@ -466,12 +466,16 @@ div.left-tabpanel div.tab-row a:hover {
   label {
     @extend .btn;
     border: $border-width solid $primary;
+    text-align: left;
+  }
+
+  input[type="radio"]:checked ~ * {
+    color: $component-active-color;
   }
 
   input[type="radio"]:checked + label {
     @include box-shadow($btn-active-box-shadow);
     background: $component-active-bg;
-    color: $component-active-color;
     
     &:focus {
       @include box-shadow($btn-focus-box-shadow, $btn-active-box-shadow);

--- a/inception/inception-ui-project/src/main/resources/META-INF/asciidoc/user-guide/projects_layers.adoc
+++ b/inception/inception-ui-project/src/main/resources/META-INF/asciidoc/user-guide/projects_layers.adoc
@@ -286,13 +286,40 @@ of the same type in a row.
 
 === String features
 
-A string feature uses a simple input field to enter text. When enabling *multiple rows*, then a
-multi-line text area is used instead - in this case, no tagset can be assigned to the feature.
+A string feature either holds a short tag (optionally from a restricted tag set) or a note (i.e.
+a multi-line text).
 
-If a tagset is assigned, then a combo box or auto-complete input field will be used - depending
-on the number of tags in the tagset. The instance administrator can globally configure the threshold
-for switching from a combo box to an auto-complete via the 
-`annotation.feature-support.string.autoCompleteThreshold` in the `settings.properties` file.
+When no tagset is associated with the string feature, it is displayed to the user simply as a
+single line input field. You can enable the *multiple rows* option to turn it into a multi-line
+text area. If you do so, additional options appear allowing to configure the size of the text area
+which can be fixed or dynamic (i.e. automatically adjust to the text area content).
+
+Optionally, a <<sect_projects_tagsets,tagset>> can be associated with a string feature (unless you enabled multiple rows). If string feature is associated with a tagset, there are different options
+as to which type of *editor type* (i.e. input field) is displayed to the user.
+
+.Editor types for string features with tagsets
+[cols="1v,2", options="header"]
+|====
+| Editor type | Description
+
+| Auto
+| An editor is chosen automatically depending on the size of the tagset and whether annotators can add to it.
+
+| Radio group
+| Each tag is shown as a button. Only one button can be active at a time. Best for quick access to small tagsets. Does not allow annotators to a new tags (yet).
+
+| Combo box
+| A text field with auto-completion and button that opens a drop-down list showing all possible tags and their descriptions. Best for mid-sized tagsets.
+
+| Autocomplete
+| A text field with auto-completion. A dropdown opens when the user starts typing into the field and it displays matching tags. There is no way to browse all available tags. Best for large tagsets.
+
+|====
+
+The tagset size thresholds used by the *Auto* mode to determine which editor to choose can be
+globally configured by an administrator via the <<admin_guide.adoc#sect_settings_annotation,`settings.properties`>>
+file. Because the radio group editor does not support adding new tags (yet), it chosen automatically
+only if the associated tagset does not allow annotators to add new tags.
 
 .String feature properties
 [cols="1v,2", options="header"]
@@ -301,6 +328,9 @@ for switching from a combo box to an auto-complete via the
 
 | Tagset
 | The tagset controlling the possible values for a string feature.
+
+| Editor type
+| The type of input field shown to the annotators.
 
 | Multiple Rows
 | If enabled the textfield will be replaced by a textarea which expands on focus. This also enables options to set the size of the textarea and disables tagsets.

--- a/inception/inception-ui-project/src/main/resources/META-INF/asciidoc/user-guide/projects_layers.adoc
+++ b/inception/inception-ui-project/src/main/resources/META-INF/asciidoc/user-guide/projects_layers.adoc
@@ -306,7 +306,7 @@ as to which type of *editor type* (i.e. input field) is displayed to the user.
 | An editor is chosen automatically depending on the size of the tagset and whether annotators can add to it.
 
 | Radio group
-| Each tag is shown as a button. Only one button can be active at a time. Best for quick access to small tagsets. Does not allow annotators to a new tags (yet).
+| Each tag is shown as a button. Only one button can be active at a time. Best for quick access to small tagsets. Does not allow annotators to add new tags (yet).
 
 | Combo box
 | A text field with auto-completion and button that opens a drop-down list showing all possible tags and their descriptions. Best for mid-sized tagsets.

--- a/inception/inception-ui-project/src/main/resources/META-INF/asciidoc/user-guide/projects_tagsets.adoc
+++ b/inception/inception-ui-project/src/main/resources/META-INF/asciidoc/user-guide/projects_tagsets.adoc
@@ -1,3 +1,4 @@
+[[sect_projects_tagsets]]
 = Tagsets
 
 To manager the tagsets, click on the tab *Tagsets* in the project pane. 


### PR DESCRIPTION
**What's in the PR**
- Add radio-group-based editor
- Add option to select the preferred editor in the feature traits

**How to test manually**
* Use with tagset <= 5 tags
* Manually configure which editor to use in the feature settings
* Also try with tagsets that have or have not descriptions

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
