### PR TITLE
#2247 - Insufficient eval data should not fail eval if threshold is 0

### DIFF
--- a/inception/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/doccat/OpenNlpDoccatRecommender.java
+++ b/inception/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/doccat/OpenNlpDoccatRecommender.java
@@ -182,7 +182,13 @@ public class OpenNlpDoccatRecommender
         double overallTrainingSize = data.size() - testSetSize;
         double trainRatio = (overallTrainingSize > 0) ? trainingSetSize / overallTrainingSize : 0.0;
 
-        if (trainingSetSize < 2 || testSetSize < 2) {
+        final int minTrainingSetSize = 2;
+        final int minTestSetSize = 2;
+        if (trainingSetSize < minTrainingSetSize || testSetSize < minTestSetSize) {
+            if ((getRecommender().getThreshold() <= 0.0d)) {
+                return new EvaluationResult();
+            }
+
             String info = String.format(
                     "Not enough evaluation data: training set [%s] items, test set [%s] of total [%s].",
                     trainingSetSize, testSetSize, data.size());

--- a/inception/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/ner/OpenNlpNerRecommender.java
+++ b/inception/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/ner/OpenNlpNerRecommender.java
@@ -192,7 +192,13 @@ public class OpenNlpNerRecommender
         double overallTrainingSize = data.size() - testSetSize;
         double trainRatio = (overallTrainingSize > 0) ? trainingSetSize / overallTrainingSize : 0.0;
 
-        if (trainingSetSize < 2 || testSetSize < 2) {
+        final int minTrainingSetSize = 2;
+        final int minTestSetSize = 2;
+        if (trainingSetSize < minTrainingSetSize || testSetSize < minTestSetSize) {
+            if ((getRecommender().getThreshold() <= 0.0d)) {
+                return new EvaluationResult();
+            }
+
             String info = String.format(
                     "Not enough evaluation data: training set [%s] sentences, test set [%s] of total [%s]",
                     trainingSetSize, testSetSize, data.size());

--- a/inception/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/pos/OpenNlpPosRecommender.java
+++ b/inception/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/pos/OpenNlpPosRecommender.java
@@ -210,6 +210,10 @@ public class OpenNlpPosRecommender
         final int minTrainingSetSize = 2;
         final int minTestSetSize = 2;
         if (trainingSetSize < minTrainingSetSize || testSetSize < minTestSetSize) {
+            if ((getRecommender().getThreshold() <= 0.0d)) {
+                return new EvaluationResult();
+            }
+
             String info = String.format(
                     "Not enough evaluation data: training set size [%d] (min. %d), test set size [%d] (min. %d) of total [%d] (min. %d)",
                     trainingSetSize, minTrainingSetSize, testSetSize, minTestSetSize, data.size(),

--- a/inception/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/relation/StringMatchingRelationRecommender.java
+++ b/inception/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/relation/StringMatchingRelationRecommender.java
@@ -172,11 +172,22 @@ public class StringMatchingRelationRecommender
         double overallTrainingSize = data.size() - testSetSize;
         double trainRatio = (overallTrainingSize > 0) ? trainingSetSize / overallTrainingSize : 0.0;
 
-        if (trainingData.size() < 1 || testData.size() < 1) {
-            log.info("Not enough data to evaluate, skipping!");
+        final int minTrainingSetSize = 1;
+        final int minTestSetSize = 1;
+        if (trainingData.size() < minTrainingSetSize || testData.size() < minTestSetSize) {
+            if ((getRecommender().getThreshold() <= 0.0d)) {
+                return new EvaluationResult();
+            }
+
+            String info = String.format(
+                    "Not enough evaluation data: training set size [%d] (min. %d), test set size [%d] (min. %d) of total [%d] (min. %d)",
+                    trainingSetSize, minTrainingSetSize, testSetSize, minTestSetSize, data.size(),
+                    (minTrainingSetSize + minTestSetSize));
+            log.info(info);
             EvaluationResult result = new EvaluationResult(trainingSetSize, testSetSize,
                     trainRatio);
             result.setEvaluationSkipped(true);
+            result.setErrorMsg(info);
             return result;
         }
 

--- a/inception/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/span/StringMatchingRecommender.java
+++ b/inception/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/span/StringMatchingRecommender.java
@@ -6,9 +6,9 @@
  * licenses this file to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.
- *  
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -299,7 +299,8 @@ public class StringMatchingRecommender
         final int minTrainingSetSize = 1;
         final int minTestSetSize = 1;
         if (trainingSetSize < minTrainingSetSize || testSetSize < minTestSetSize) {
-            if (gazeteerService != null && !gazeteerService.listGazeteers(recommender).isEmpty()) {
+            if ((getRecommender().getThreshold() <= 0.0d) || (gazeteerService != null
+                    && !gazeteerService.listGazeteers(recommender).isEmpty())) {
                 // We cannot evaluate, but the user expects to see immediate results from the
                 // gazeteer - so we return with an "unknown" result but without marking it as
                 // skipped so that the selection task allows the recommender to activate.

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommenderInfoPanel.html
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommenderInfoPanel.html
@@ -24,7 +24,7 @@
     </div>
     <div class="card-body p-0">
       <div wicket:id="recommenderContainer" class="list-group-flush">
-        <div wicket:id="recommender" class="list-group-item">
+        <div wicket:id="recommender" class="list-group-item px-2">
           <div wicket:id="name" class="list-group-item-heading small mb-2"></div>
           <div wicket:id="resultsContainer" class="d-flex small rounded border mb-2">
             <div class="d-flex flex-fill flex-column p-2 border-right">


### PR DESCRIPTION
**What's in the PR**
- If the threshold is 0, do not fail evaluation if there is insufficient training data
- Slightly improve layout of recommender sidebar

**How to test manually**
* See issue description
* Try e.g. string matching or OpenNLP recommenders

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
