### PR TITLE
#2279 No longer able to create new users

### DIFF
--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/users/UserSelectionPanel.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/users/UserSelectionPanel.java
@@ -112,7 +112,7 @@ class UserSelectionPanel
         add(realm);
 
         // Only allow creating accounts in the global realm
-        createButton.add(visibleWhen(() -> realm.getModelObject() == null));
+        createButton.add(visibleWhen(() -> realm.getModelObject().getId() == null));
     }
 
     private List<Realm> listRealms()


### PR DESCRIPTION
Fix create button.

**What's in the PR**
* Check if realm id is null i.e. the global realm is selected and we should be able to create new users.

**How to test manually**
* Sign in as an admin
* Go to **Administration** -> **Users** and try to create a new user
* To check if user creation is still disabled for project specific realms (should be). 
    * Add `sharing.invites.enabled=true` and `sharing.invites.guests-enabled=true` to your project settings. 
    * Create invite links for a project in **Settings** -> **Sharing** and check `Allow guest annotators`
    * Copy invite link and follow it after logging out to create a new project specific user
    * As an admin again, check that you can switch in **Administration** -> **Users** between realms and only create users in the global realm
