### PR TITLE
#2264 - Risk of permanently unfinished documents using dynamic workflow

### DIFF
--- a/inception/inception-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/DocumentService.java
+++ b/inception/inception-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/DocumentService.java
@@ -519,6 +519,9 @@ public interface DocumentService
     List<AnnotationDocument> listAnnotationDocumentsInState(Project aProject,
             AnnotationDocumentState... aStates);
 
+    List<AnnotationDocument> listAnnotationDocumentsWithStateForUser(Project aProject, User aUser,
+            AnnotationDocumentState aState);
+
     /**
      * List all the {@link AnnotationDocument annotation documents} for a given
      * {@link SourceDocument}.
@@ -569,6 +572,8 @@ public interface DocumentService
 
     /**
      * List all annotation documents for a given source document that are already closed.
+     * 
+     * @Override
      *
      * @param aDocument
      *            a source document.

--- a/inception/inception-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/DocumentService.java
+++ b/inception/inception-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/DocumentService.java
@@ -573,8 +573,6 @@ public interface DocumentService
     /**
      * List all annotation documents for a given source document that are already closed.
      * 
-     * @Override
-     *
      * @param aDocument
      *            a source document.
      * @return the annotation documents.

--- a/inception/inception-versioning/src/test/resources/log4j2.xml
+++ b/inception/inception-versioning/src/test/resources/log4j2.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+  <Appenders>
+    <Console name="ConsoleAppender" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} %level{length=5} %logger{1} - %msg%n" />
+    </Console>
+  </Appenders>
+
+  <Loggers>
+    <Root level="WARN">
+      <AppenderRef ref="ConsoleAppender" />
+    </Root>
+  </Loggers>
+</Configuration>

--- a/inception/inception-workload-dynamic/pom.xml
+++ b/inception/inception-workload-dynamic/pom.xml
@@ -108,6 +108,10 @@
     </dependency>
 
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>

--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/DynamicWorkloadExtensionImpl.java
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/DynamicWorkloadExtensionImpl.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.uima.UIMAException;
 import org.slf4j.Logger;
@@ -69,7 +70,7 @@ import de.tudarmstadt.ukp.inception.workload.model.WorkloadManager;
  * {@link DynamicWorkloadManagerAutoConfiguration#dynamicWorkloadExtension}
  * </p>
  */
-public class DynamicWorkloadExtension_Impl
+public class DynamicWorkloadExtensionImpl
     implements DynamicWorkloadExtension
 {
     private final Logger log = LoggerFactory.getLogger(this.getClass());
@@ -81,7 +82,7 @@ public class DynamicWorkloadExtension_Impl
     private final UserDao userRepository;
     private final SessionRegistry sessionRegistry;
 
-    public DynamicWorkloadExtension_Impl(WorkloadManagementService aWorkloadManagementService,
+    public DynamicWorkloadExtensionImpl(WorkloadManagementService aWorkloadManagementService,
             WorkflowExtensionPoint aWorkflowExtensionPoint, DocumentService aDocumentService,
             ProjectService aProjectService, UserDao aUserRepository,
             SessionRegistry aSessionRegistry)
@@ -144,11 +145,15 @@ public class DynamicWorkloadExtension_Impl
     {
         // First, check if there are other documents which have been in the state INPROGRESS
         // Load the first one found
-        List<AnnotationDocument> inProgressDocuments = workloadManagementService
-                .getAnnotationDocumentListForUserWithState(aProject, aUser, IN_PROGRESS);
+        List<AnnotationDocument> inProgressDocuments = documentService
+                .listAnnotationDocumentsWithStateForUser(aProject, aUser, IN_PROGRESS);
         if (!inProgressDocuments.isEmpty()) {
             return Optional.of(inProgressDocuments.get(0).getDocument());
         }
+
+        // Make sure that any documents that could be eligible for annotation due to having been
+        // abandoned by another user are available
+        freshenStatus(aProject);
 
         WorkloadManager currentWorkload = workloadManagementService
                 .loadOrCreateWorkloadManagerConfiguration(aProject);
@@ -161,8 +166,11 @@ public class DynamicWorkloadExtension_Impl
                 .orElseGet(DefaultWorkflowExtension::new);
 
         // Get all documents for which the state is NEW, or which have not been created yet.
-        List<SourceDocument> sourceDocuments = workloadManagementService
-                .listAnnotationDocumentsForUser(aProject, aUser);
+        List<SourceDocument> sourceDocuments = documentService
+                .listAnnotatableDocuments(aProject, aUser).entrySet().stream()
+                .filter(entry -> entry.getValue() == null
+                        || entry.getValue().getState() == AnnotationDocumentState.NEW)
+                .map(entry -> entry.getKey()).collect(Collectors.toList());
 
         // Rearrange list of documents according to current workflow
         sourceDocuments = currentWorkflowExtension.rankDocuments(sourceDocuments);

--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/config/DynamicWorkloadManagerAutoConfiguration.java
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/config/DynamicWorkloadManagerAutoConfiguration.java
@@ -30,7 +30,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.inception.workload.dynamic.DynamicWorkloadExtension;
-import de.tudarmstadt.ukp.inception.workload.dynamic.DynamicWorkloadExtension_Impl;
+import de.tudarmstadt.ukp.inception.workload.dynamic.DynamicWorkloadExtensionImpl;
 import de.tudarmstadt.ukp.inception.workload.dynamic.annotation.DynamicWorkflowActionBarExtension;
 import de.tudarmstadt.ukp.inception.workload.dynamic.annotation.DynamicWorkflowDocumentNavigationActionBarExtension;
 import de.tudarmstadt.ukp.inception.workload.dynamic.workflow.WorkflowExtension;
@@ -50,7 +50,7 @@ public class DynamicWorkloadManagerAutoConfiguration
             WorkflowExtensionPoint aWorkflowExtensionPoint, ProjectService aProjectService,
             UserDao aUserRepository, SessionRegistry aSessionRegistry)
     {
-        return new DynamicWorkloadExtension_Impl(aWorkloadManagementService,
+        return new DynamicWorkloadExtensionImpl(aWorkloadManagementService,
                 aWorkflowExtensionPoint, documentService, aProjectService, aUserRepository,
                 aSessionRegistry);
     }

--- a/inception/inception-workload-dynamic/src/test/java/de/tudarmstadt/ukp/inception/workload/dynamic/DefaultWorkflowExtensionTest.java
+++ b/inception/inception-workload-dynamic/src/test/java/de/tudarmstadt/ukp/inception/workload/dynamic/DefaultWorkflowExtensionTest.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.workload.dynamic;
+
+import static java.lang.Thread.sleep;
+import static java.time.temporal.ChronoUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.time.Duration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.session.SessionRegistry;
+import org.springframework.util.FileSystemUtils;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
+import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
+import de.tudarmstadt.ukp.clarin.webanno.api.config.RepositoryAutoConfiguration;
+import de.tudarmstadt.ukp.clarin.webanno.api.dao.annotationservice.config.AnnotationSchemaServiceAutoConfiguration;
+import de.tudarmstadt.ukp.clarin.webanno.api.dao.casstorage.config.CasStorageServiceAutoConfiguration;
+import de.tudarmstadt.ukp.clarin.webanno.api.dao.docimexport.config.DocumentImportExportServiceAutoConfiguration;
+import de.tudarmstadt.ukp.clarin.webanno.api.dao.documentservice.config.DocumentServiceAutoConfiguration;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.clarin.webanno.project.config.ProjectServiceAutoConfiguration;
+import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
+import de.tudarmstadt.ukp.clarin.webanno.security.config.SecurityAutoConfiguration;
+import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
+import de.tudarmstadt.ukp.clarin.webanno.text.TextFormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.text.config.TextFormatsAutoConfiguration;
+import de.tudarmstadt.ukp.inception.scheduling.config.SchedulingServiceAutoConfiguration;
+import de.tudarmstadt.ukp.inception.workload.config.WorkloadManagementAutoConfiguration;
+import de.tudarmstadt.ukp.inception.workload.dynamic.config.DynamicWorkloadManagerAutoConfiguration;
+import de.tudarmstadt.ukp.inception.workload.dynamic.trait.DynamicWorkloadTraits;
+import de.tudarmstadt.ukp.inception.workload.model.WorkloadManagementService;
+import de.tudarmstadt.ukp.inception.workload.model.WorkloadManager;
+
+@EnableAutoConfiguration
+@DataJpaTest(excludeAutoConfiguration = LiquibaseAutoConfiguration.class, showSql = false, //
+        properties = { //
+                "spring.main.banner-mode=off", //
+                "workload.dynamic.enabled=true", //
+                "repository.path=" + DefaultWorkflowExtensionTest.TEST_OUTPUT_FOLDER })
+@EntityScan({ //
+        "de.tudarmstadt.ukp.inception", //
+        "de.tudarmstadt.ukp.clarin.webanno" })
+@Import({ //
+        TextFormatsAutoConfiguration.class, //
+        DocumentImportExportServiceAutoConfiguration.class, //
+        DocumentServiceAutoConfiguration.class, //
+        ProjectServiceAutoConfiguration.class, //
+        CasStorageServiceAutoConfiguration.class, //
+        RepositoryAutoConfiguration.class, //
+        AnnotationSchemaServiceAutoConfiguration.class, //
+        SecurityAutoConfiguration.class, //
+        SchedulingServiceAutoConfiguration.class, //
+        WorkloadManagementAutoConfiguration.class, //
+        DynamicWorkloadManagerAutoConfiguration.class })
+public class DefaultWorkflowExtensionTest
+{
+    static final String TEST_OUTPUT_FOLDER = "target/test-output/DefaultWorkflowExtensionTest";
+
+    private @Autowired ProjectService projectService;
+    private @Autowired DocumentService documentService;
+    private @Autowired UserDao userService;
+    private @Autowired WorkloadManagementService workloadManagementService;
+    private @Autowired DynamicWorkloadExtension dynamicWorkloadExtension;
+    private @Autowired SessionRegistry sessionRegistry;
+
+    private User annotator;
+    private Project project;
+    private AnnotationDocument annotationDocument;
+    private DynamicWorkloadTraits traits;
+
+    @BeforeAll
+    public static void setupClass()
+    {
+        FileSystemUtils.deleteRecursively(new File(TEST_OUTPUT_FOLDER));
+    }
+
+    @BeforeEach
+    public void setup() throws Exception
+    {
+        annotator = userService.create(new User("anno1"));
+        project = projectService.createProject(new Project("test"));
+
+        SourceDocument doc = documentService
+                .createSourceDocument(new SourceDocument("doc.txt", project, TextFormatSupport.ID));
+        annotationDocument = documentService
+                .createAnnotationDocument(new AnnotationDocument(annotator.getUsername(), doc));
+
+        Fixtures.importTestSourceDocumentAndAddNamedEntity(documentService, annotationDocument);
+
+        WorkloadManager workloadManager = workloadManagementService
+                .loadOrCreateWorkloadManagerConfiguration(project);
+        workloadManager.setType(DynamicWorkloadExtension.DYNAMIC_WORKLOAD_MANAGER_EXTENSION_ID);
+        traits = new DynamicWorkloadTraits();
+        traits.setAbandonationTimeout(Duration.of(1, SECONDS));
+        traits.setAbandonationState(AnnotationDocumentState.NEW);
+        dynamicWorkloadExtension.writeTraits(traits, project);
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception
+    {
+        projectService.removeProject(project);
+    }
+
+    @Test
+    public void thatAbandonedDocumentsAreReset() throws Exception
+    {
+        var ann = documentService.getAnnotationDocument(annotationDocument.getDocument(),
+                annotationDocument.getUser());
+        assertThat(ann.getState()) //
+                .as("Effective state is in-progress after the CAS update")
+                .isEqualTo(AnnotationDocumentState.IN_PROGRESS);
+        assertThat(ann.getAnnotatorState()) //
+                .as("Annotator state is in-progress as the CAS update was marked as explicit action")
+                .isEqualTo(AnnotationDocumentState.IN_PROGRESS);
+
+        sleep(traits.getAbandonationTimeout().multipliedBy(2).toMillis());
+
+        dynamicWorkloadExtension.freshenStatus(project);
+
+        var annAfterRefresh = documentService.getAnnotationDocument(
+                annotationDocument.getDocument(), annotationDocument.getUser());
+        assertThat(annAfterRefresh.getState())
+                .as("After the abandonation timeout has passed, the effective state has been reset")
+                .isEqualTo(traits.getAbandonationState());
+        assertThat(annAfterRefresh.getAnnotatorState()) //
+                .as("After the abandonation timeout has passed, the annotator state has been cleared")
+                .isNull();
+    }
+
+    @Test
+    public void thatDocumentsForUsersLoggedInAreExemptFromAbandonation() throws Exception
+    {
+        var ann = documentService.getAnnotationDocument(annotationDocument.getDocument(),
+                annotationDocument.getUser());
+        assertThat(ann.getState()) //
+                .as("Effective state is in-progress after the CAS update")
+                .isEqualTo(AnnotationDocumentState.IN_PROGRESS);
+        assertThat(ann.getAnnotatorState()) //
+                .as("Annotator state is in-progress as the CAS update was marked as explicit action")
+                .isEqualTo(AnnotationDocumentState.IN_PROGRESS);
+
+        sessionRegistry.registerNewSession("dummy-session-id", annotator.getUsername());
+
+        sleep(traits.getAbandonationTimeout().multipliedBy(2).toMillis());
+
+        dynamicWorkloadExtension.freshenStatus(project);
+
+        var annAfterRefresh = documentService.getAnnotationDocument(ann.getDocument(),
+                ann.getUser());
+        assertThat(annAfterRefresh.getUpdated()) //
+                .as("Database record was not updated at all") //
+                .isEqualTo(ann.getUpdated());
+        assertThat(annAfterRefresh.getState())
+                .as("Even After the abandonation timeout has passed, nothing has changed")
+                .isEqualTo(AnnotationDocumentState.IN_PROGRESS);
+        assertThat(annAfterRefresh.getAnnotatorState()) //
+                .as("Even After the abandonation timeout has passed, nothing has changed") //
+                .isEqualTo(AnnotationDocumentState.IN_PROGRESS);
+    }
+
+    @SpringBootConfiguration
+    public static class TestContext
+    {
+        // All handled via auto-configuration
+    }
+}

--- a/inception/inception-workload-dynamic/src/test/java/de/tudarmstadt/ukp/inception/workload/dynamic/Fixtures.java
+++ b/inception/inception-workload-dynamic/src/test/java/de/tudarmstadt/ukp/inception/workload/dynamic/Fixtures.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.workload.dynamic;
+
+import static de.tudarmstadt.ukp.clarin.webanno.support.uima.FeatureStructureBuilder.buildFS;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.commons.io.IOUtils.toInputStream;
+
+import org.apache.uima.cas.CAS;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
+import de.tudarmstadt.ukp.clarin.webanno.api.dao.casstorage.CasStorageSession;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
+import de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity;
+
+public class Fixtures
+{
+    public static void importTestSourceDocumentAndAddNamedEntity(DocumentService documentService,
+            AnnotationDocument annotationDocument)
+        throws Exception
+    {
+        try (var session = CasStorageSession.open()) {
+            documentService.uploadSourceDocument(toInputStream("This is a test.", UTF_8),
+                    annotationDocument.getDocument());
+            CAS cas = documentService.readAnnotationCas(annotationDocument);
+            buildFS(cas, NamedEntity.class.getName()) //
+                    .withFeature("value", "test") //
+                    .buildAndAddToIndexes();
+            documentService.writeAnnotationCas(cas, annotationDocument, true);
+        }
+    }
+}

--- a/inception/inception-workload-dynamic/src/test/java/de/tudarmstadt/ukp/inception/workload/dynamic/workflow/types/DynamicWorkloadExtensionImplTest.java
+++ b/inception/inception-workload-dynamic/src/test/java/de/tudarmstadt/ukp/inception/workload/dynamic/workflow/types/DynamicWorkloadExtensionImplTest.java
@@ -23,6 +23,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
 import java.util.Optional;
 
 import org.junit.jupiter.api.AfterEach;
@@ -174,7 +177,10 @@ public class DynamicWorkloadExtensionImplTest
     {
         AnnotationDocument ann = new AnnotationDocument(otherAnnotator.getUsername(),
                 createSourceDocument("1.txt"));
+        Fixtures.importTestSourceDocumentAndAddNamedEntity(documentService, ann);
         ann.setState(AnnotationDocumentState.IN_PROGRESS);
+        ann = documentService.getAnnotationDocument(ann.getDocument(), ann.getUser());
+        ann.setTimestamp(new Date(Instant.now().plus(1, ChronoUnit.HOURS).toEpochMilli()));
         documentService.createAnnotationDocument(ann);
 
         Optional<SourceDocument> nextDoc = dynamicWorkloadExtension.nextDocumentToAnnotate(project,
@@ -183,7 +189,6 @@ public class DynamicWorkloadExtensionImplTest
         assertThat(nextDoc) //
                 .as("There are no documents left to annotate") //
                 .isNotPresent();
-
     }
 
     @Test

--- a/inception/inception-workload-dynamic/src/test/resources/log4j2.xml
+++ b/inception/inception-workload-dynamic/src/test/resources/log4j2.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+  <Appenders>
+    <Console name="ConsoleAppender" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} %level{length=5} %logger{1} - %msg%n" />
+    </Console>
+  </Appenders>
+
+  <Loggers>
+    <Root level="WARN">
+      <AppenderRef ref="ConsoleAppender" />
+    </Root>
+  </Loggers>
+</Configuration>

--- a/inception/inception-workload/pom.xml
+++ b/inception/inception-workload/pom.xml
@@ -45,10 +45,6 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
-      <artifactId>inception-security</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-ui-core</artifactId>
     </dependency>
     

--- a/inception/inception-workload/src/main/java/de/tudarmstadt/ukp/inception/workload/model/WorkloadManagementService.java
+++ b/inception/inception-workload/src/main/java/de/tudarmstadt/ukp/inception/workload/model/WorkloadManagementService.java
@@ -23,7 +23,6 @@ import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
-import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.inception.workload.extension.WorkloadManagerExtension;
 
 /**
@@ -42,9 +41,4 @@ public interface WorkloadManagementService
             SourceDocument aSourceDocument, AnnotationDocumentState aState);
 
     Long getNumberOfUsersWorkingOnADocument(SourceDocument aDocument);
-
-    List<SourceDocument> listAnnotationDocumentsForUser(Project aProject, User aUser);
-
-    List<AnnotationDocument> getAnnotationDocumentListForUserWithState(Project aProject, User aUser,
-            AnnotationDocumentState aState);
 }

--- a/inception/inception-workload/src/main/java/de/tudarmstadt/ukp/inception/workload/model/WorkloadManagementServiceImpl.java
+++ b/inception/inception-workload/src/main/java/de/tudarmstadt/ukp/inception/workload/model/WorkloadManagementServiceImpl.java
@@ -34,7 +34,6 @@ import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
-import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.inception.workload.config.WorkloadManagementAutoConfiguration;
 import de.tudarmstadt.ukp.inception.workload.extension.WorkloadManagerExtension;
 import de.tudarmstadt.ukp.inception.workload.extension.WorkloadManagerExtensionPoint;
@@ -159,51 +158,5 @@ public class WorkloadManagementServiceImpl
                 .setParameter("document", aDocument) //
                 .setParameter("states", asList(IN_PROGRESS, FINISHED)) //
                 .getSingleResult();
-    }
-
-    /**
-     * This method is a fast DB search to get all SOURCE DOCUMENTS (List) for a specific User in a
-     * specific Project with a State NEW.
-     */
-    @Override
-    @Transactional
-    public List<SourceDocument> listAnnotationDocumentsForUser(Project aProject, User aUser)
-    {
-        String query = String.join("\n", //
-                "SELECT source FROM SourceDocument source ", //
-                "WHERE source.project = :project", //
-                "AND source.name NOT IN (SELECT anno.name ", //
-                "  FROM AnnotationDocument anno ", //
-                "  WHERE anno.user = :user ", //
-                "  AND anno.project = :project ", //
-                "  AND (anno.state = 'INPROGRESS' OR anno.state = 'FINISHED')", //
-                ")");
-
-        return entityManager.createQuery(query, SourceDocument.class) //
-                .setParameter("project", aProject) //
-                .setParameter("user", aUser.getUsername()) //
-                .getResultList();
-    }
-
-    /**
-     * This method is a fast DB search to get all ANNOTATION DOCUMENTS (List) for a specific User in
-     * a specific Project with a specific State.
-     */
-    @Override
-    @Transactional
-    public List<AnnotationDocument> getAnnotationDocumentListForUserWithState(Project aProject,
-            User aUser, AnnotationDocumentState aState)
-    {
-        String query = String.join("\n", //
-                "FROM AnnotationDocument", //
-                "WHERE user = :user", //
-                "AND project = :project", //
-                "AND state = :state");
-
-        return entityManager.createQuery(query, AnnotationDocument.class) //
-                .setParameter("project", aProject) //
-                .setParameter("user", aUser.getUsername()) //
-                .setParameter("state", aState) //
-                .getResultList();
     }
 }


### PR DESCRIPTION
**What's in the PR**
- Move DB query method from WorkloadManagementService to DocumentService
- Use already existing method from DocumentService in favor of new method from WorkloadManagementService
- Added unit tests for default workflow policy including that abandoned documents immediately become available to users when switching to the next document

**How to test manually**
* No particular testing procedure

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
