### PR TITLE
#2263 - External recommender timeout too short and not configurable

### DIFF
--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide.adoc
@@ -102,9 +102,10 @@ include::{include-dir}settings_external-search.adoc[leveloffset=+1]
 
 include::{include-dir}settings_recommender.adoc[leveloffset=+1]
 include::{include-dir}settings_string_relation_recommender.adoc[leveloffset=+2]
+include::{include-dir}settings_recommendation_external.adoc[leveloffset=+2]
 
-include::{include-dir}settings_sharing.adoc[leveloffset=-1]
+include::{include-dir}settings_sharing.adoc[leveloffset=+1]
 
-include::{include-dir}settings_versioning.adoc[leveloffset=-1]
+include::{include-dir}settings_versioning.adoc[leveloffset=+1]
 
-include::{include-dir}settings_websocket.adoc[leveloffset=-1]
+include::{include-dir}settings_websocket.adoc[leveloffset=+1]

--- a/inception/inception-imls-external/pom.xml
+++ b/inception/inception-imls-external/pom.xml
@@ -87,6 +87,14 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
     
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderFactory.java
+++ b/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderFactory.java
@@ -21,21 +21,34 @@ import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.RELATION_TYPE;
 import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.SPAN_TYPE;
 
 import org.apache.wicket.model.IModel;
-import org.springframework.stereotype.Component;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
 import de.tudarmstadt.ukp.inception.recommendation.api.recommender.RecommendationEngine;
 import de.tudarmstadt.ukp.inception.recommendation.api.recommender.RecommendationEngineFactoryImplBase;
+import de.tudarmstadt.ukp.inception.recommendation.imls.external.config.ExternalRecommenderAutoConfiguration;
+import de.tudarmstadt.ukp.inception.recommendation.imls.external.config.ExternalRecommenderProperties;
 
-@Component
+/**
+ * <p>
+ * This class is exposed as a Spring Component via
+ * {@link ExternalRecommenderAutoConfiguration#externalRecommenderFactory}.
+ * </p>
+ */
 public class ExternalRecommenderFactory
     extends RecommendationEngineFactoryImplBase<ExternalRecommenderTraits>
 {
     // This is a string literal so we can rename/refactor the class without it changing its ID
     // and without the database starting to refer to non-existing recommendation tools.
     public static final String ID = "de.tudarmstadt.ukp.inception.recommendation.imls.external.ExternalClassificationTool";
+
+    private final ExternalRecommenderProperties properties;
+
+    public ExternalRecommenderFactory(ExternalRecommenderProperties aProperties)
+    {
+        properties = aProperties;
+    }
 
     @Override
     public String getId()
@@ -47,7 +60,7 @@ public class ExternalRecommenderFactory
     public RecommendationEngine build(Recommender aRecommender)
     {
         ExternalRecommenderTraits traits = readTraits(aRecommender);
-        return new ExternalRecommender(aRecommender, traits);
+        return new ExternalRecommender(properties, aRecommender, traits);
     }
 
     @Override

--- a/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/config/ExternalRecommenderAutoConfiguration.java
+++ b/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/config/ExternalRecommenderAutoConfiguration.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.imls.external.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import de.tudarmstadt.ukp.inception.recommendation.imls.external.ExternalRecommenderFactory;
+
+@Configuration
+@ConditionalOnProperty(prefix = "recommender.external", name = "enabled", havingValue = "true", matchIfMissing = true)
+@EnableConfigurationProperties(ExternalRecommenderPropertiesImpl.class)
+public class ExternalRecommenderAutoConfiguration
+{
+    @Bean
+    public ExternalRecommenderFactory externalRecommenderFactory(
+            ExternalRecommenderProperties aProperties)
+    {
+        return new ExternalRecommenderFactory(aProperties);
+    }
+}

--- a/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/config/ExternalRecommenderProperties.java
+++ b/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/config/ExternalRecommenderProperties.java
@@ -15,22 +15,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package de.tudarmstadt.ukp.inception.recommendation.imls.external;
+package de.tudarmstadt.ukp.inception.recommendation.imls.external.config;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Duration;
 
-public class PredictionResponse
+public interface ExternalRecommenderProperties
 {
-    @JsonProperty("document")
-    private String document;
+    Duration getConnectTimeout();
 
-    public String getDocument()
-    {
-        return document;
-    }
-
-    public void setDocument(String aDocument)
-    {
-        document = aDocument;
-    }
+    Duration getReadTimeout();
 }

--- a/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/config/ExternalRecommenderPropertiesImpl.java
+++ b/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/config/ExternalRecommenderPropertiesImpl.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.imls.external.config;
+
+import static java.time.temporal.ChronoUnit.SECONDS;
+
+import java.time.Duration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * <p>
+ * This class is exposed as a Spring Component via {@link ExternalRecommenderAutoConfiguration}.
+ * </p>
+ */
+@ConfigurationProperties("recommender.external")
+public class ExternalRecommenderPropertiesImpl
+    implements ExternalRecommenderProperties
+{
+    private Duration connectTimeout = Duration.of(30, SECONDS);
+    private Duration readTimeout = Duration.of(30, SECONDS);
+
+    @Override
+    public Duration getConnectTimeout()
+    {
+        return connectTimeout;
+    }
+
+    public void setConnectTimeout(Duration aConnectTimeout)
+    {
+        connectTimeout = aConnectTimeout;
+    }
+
+    @Override
+    public Duration getReadTimeout()
+    {
+        return readTimeout;
+    }
+
+    public void setReadTimeout(Duration aReadTimeout)
+    {
+        readTimeout = aReadTimeout;
+    }
+
+}

--- a/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/messages/PredictionRequest.java
+++ b/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/messages/PredictionRequest.java
@@ -15,20 +15,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package de.tudarmstadt.ukp.inception.recommendation.imls.external;
-
-import java.util.List;
+package de.tudarmstadt.ukp.inception.recommendation.imls.external.messages;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class TrainingRequest
-{
+import de.tudarmstadt.ukp.inception.recommendation.imls.external.model.Document;
+import de.tudarmstadt.ukp.inception.recommendation.imls.external.model.Metadata;
 
+public class PredictionRequest
+{
     @JsonProperty("typeSystem")
     private String typeSystem;
 
-    @JsonProperty("documents")
-    private List<Document> documents;
+    @JsonProperty("document")
+    private Document document;
 
     @JsonProperty("metadata")
     private Metadata metadata;
@@ -43,14 +43,14 @@ public class TrainingRequest
         typeSystem = aTypeSystem;
     }
 
-    public List<Document> getDocuments()
+    public Document getDocument()
     {
-        return documents;
+        return document;
     }
 
-    public void setDocuments(List<Document> aDocuments)
+    public void setDocument(Document aDocument)
     {
-        documents = aDocuments;
+        document = aDocument;
     }
 
     public Metadata getMetadata()

--- a/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/messages/PredictionResponse.java
+++ b/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/messages/PredictionResponse.java
@@ -15,39 +15,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package de.tudarmstadt.ukp.inception.recommendation.imls.external;
+package de.tudarmstadt.ukp.inception.recommendation.imls.external.messages;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class Document
+public class PredictionResponse
 {
+    @JsonProperty("document")
+    private String document;
 
-    private final String xmi;
-    private final long documentId;
-    private final String userId;
-
-    public Document(@JsonProperty(value = "xmi", required = true) String aXmi,
-            @JsonProperty(value = "documentId", required = true) long aDocumentId,
-            @JsonProperty(value = "userId", required = true) String aUserId)
+    public String getDocument()
     {
-        xmi = aXmi;
-        documentId = aDocumentId;
-        userId = aUserId;
+        return document;
     }
 
-    public String getXmi()
+    public void setDocument(String aDocument)
     {
-        return xmi;
+        document = aDocument;
     }
-
-    public Long getDocumentId()
-    {
-        return documentId;
-    }
-
-    public String getUserId()
-    {
-        return userId;
-    }
-
 }

--- a/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/messages/TrainingRequest.java
+++ b/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/messages/TrainingRequest.java
@@ -15,17 +15,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package de.tudarmstadt.ukp.inception.recommendation.imls.external;
+package de.tudarmstadt.ukp.inception.recommendation.imls.external.messages;
+
+import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class PredictionRequest
+import de.tudarmstadt.ukp.inception.recommendation.imls.external.model.Document;
+import de.tudarmstadt.ukp.inception.recommendation.imls.external.model.Metadata;
+
+public class TrainingRequest
 {
+
     @JsonProperty("typeSystem")
     private String typeSystem;
 
-    @JsonProperty("document")
-    private Document document;
+    @JsonProperty("documents")
+    private List<Document> documents;
 
     @JsonProperty("metadata")
     private Metadata metadata;
@@ -40,14 +46,14 @@ public class PredictionRequest
         typeSystem = aTypeSystem;
     }
 
-    public Document getDocument()
+    public List<Document> getDocuments()
     {
-        return document;
+        return documents;
     }
 
-    public void setDocument(Document aDocument)
+    public void setDocuments(List<Document> aDocuments)
     {
-        document = aDocument;
+        documents = aDocuments;
     }
 
     public Metadata getMetadata()

--- a/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/model/Document.java
+++ b/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/model/Document.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.imls.external.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Document
+{
+
+    private final String xmi;
+    private final long documentId;
+    private final String userId;
+
+    public Document(@JsonProperty(value = "xmi", required = true) String aXmi,
+            @JsonProperty(value = "documentId", required = true) long aDocumentId,
+            @JsonProperty(value = "userId", required = true) String aUserId)
+    {
+        xmi = aXmi;
+        documentId = aDocumentId;
+        userId = aUserId;
+    }
+
+    public String getXmi()
+    {
+        return xmi;
+    }
+
+    public Long getDocumentId()
+    {
+        return documentId;
+    }
+
+    public String getUserId()
+    {
+        return userId;
+    }
+
+}

--- a/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/model/Metadata.java
+++ b/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/model/Metadata.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package de.tudarmstadt.ukp.inception.recommendation.imls.external;
+package de.tudarmstadt.ukp.inception.recommendation.imls.external.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/inception/inception-imls-external/src/main/resources/META-INF/asciidoc/admin-guide/settings_recommendation_external.adoc
+++ b/inception/inception-imls-external/src/main/resources/META-INF/asciidoc/admin-guide/settings_recommendation_external.adoc
@@ -1,35 +1,43 @@
 // Licensed to the Technische Universität Darmstadt under one
 // or more contributor license agreements.  See the NOTICE file
 // distributed with this work for additional information
-// regarding copyright ownership.  The Technische Universität Darmstadt
+// regarding copyright ownership.  The Technische Universität Darmstadt 
 // licenses this file to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License.
-//
+//  
 // http://www.apache.org/licenses/LICENSE-2.0
-//
+// 
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-[[sect_settings_String_relation_recommender]]
-= String Matching Recommender for Relations Settings
+[[sect_settings_recommender_external]]
+= External Recommender Settings
 
-You can enable the String recommender for relations in your {product-name} instance.
-
-.String Matching Relation Recommnder Settings
-[cols="4*",options="header"]
+.External recommender settings
+[cols="4*", options="header"]
 |===
 | Setting
 | Description
 | Default
 | Example
 
-| recommender.string-matching.relation
-| enable/disable String relation recommender
-| false
+| recommender.external.enabled
+| enable/disable external recommender support
 | true
+| false
+
+| recommender.external.connect-timeout
+| duration of connect timeout
+| 30s
+| 3m
+
+| recommender.external.read-timeout
+| duration of read timeout
+| 30s
+| 3m
 |===
 

--- a/inception/inception-imls-external/src/main/resources/META-INF/spring.factories
+++ b/inception/inception-imls-external/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+de.tudarmstadt.ukp.inception.recommendation.imls.external.config.ExternalRecommenderAutoConfiguration

--- a/inception/inception-imls-external/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderIntegrationTest.java
+++ b/inception/inception-imls-external/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderIntegrationTest.java
@@ -63,6 +63,10 @@ import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
 import de.tudarmstadt.ukp.inception.recommendation.api.recommender.RecommenderContext;
+import de.tudarmstadt.ukp.inception.recommendation.imls.external.config.ExternalRecommenderPropertiesImpl;
+import de.tudarmstadt.ukp.inception.recommendation.imls.external.messages.PredictionRequest;
+import de.tudarmstadt.ukp.inception.recommendation.imls.external.messages.TrainingRequest;
+import de.tudarmstadt.ukp.inception.recommendation.imls.external.model.Document;
 import de.tudarmstadt.ukp.inception.support.test.recommendation.DkproTestHelper;
 import de.tudarmstadt.ukp.inception.support.test.recommendation.RecommenderTestHelper;
 import okhttp3.mockwebserver.MockResponse;
@@ -98,7 +102,7 @@ public class ExternalRecommenderIntegrationTest
         context = new RecommenderContext();
 
         traits = new ExternalRecommenderTraits();
-        sut = new ExternalRecommender(recommender, traits);
+        sut = new ExternalRecommender(new ExternalRecommenderPropertiesImpl(), recommender, traits);
 
         remoteRecommender = new RemoteStringMatchingNerRecommender(recommender);
 

--- a/inception/inception-imls-external/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/RemoteStringMatchingNerRecommender.java
+++ b/inception/inception-imls-external/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/RemoteStringMatchingNerRecommender.java
@@ -50,6 +50,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
 import de.tudarmstadt.ukp.inception.recommendation.api.recommender.RecommendationException;
 import de.tudarmstadt.ukp.inception.recommendation.api.recommender.RecommenderContext;
+import de.tudarmstadt.ukp.inception.recommendation.imls.external.messages.PredictionRequest;
+import de.tudarmstadt.ukp.inception.recommendation.imls.external.messages.PredictionResponse;
+import de.tudarmstadt.ukp.inception.recommendation.imls.external.messages.TrainingRequest;
+import de.tudarmstadt.ukp.inception.recommendation.imls.external.model.Document;
 import de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.span.StringMatchingRecommender;
 import de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.span.StringMatchingRecommenderTraits;
 

--- a/inception/inception-recommendation/src/main/resources/META-INF/asciidoc/admin-guide/settings_recommender.adoc
+++ b/inception/inception-recommendation/src/main/resources/META-INF/asciidoc/admin-guide/settings_recommender.adoc
@@ -15,7 +15,7 @@
 // limitations under the License.
 
 [[sect_settings_recommender]]
-=== Recommender Settings
+= Recommender Settings
 
 This section describes the global settings related to the recommender module.
 

--- a/inception/inception-sharing/src/main/resources/META-INF/asciidoc/admin-guide/settings_sharing.adoc
+++ b/inception/inception-sharing/src/main/resources/META-INF/asciidoc/admin-guide/settings_sharing.adoc
@@ -15,7 +15,11 @@
 // limitations under the License.
 
 [[sect_settings_sharing]]
-=== Invite Links Settings
+= Invite Links Settings
+
+====
+CAUTION: Experimental feature.
+====
 
 You can enable invite links for your {product-name} instance. This will allow project managers to 
 generate invite links for their project which will expire automatically after one year or at a 

--- a/inception/inception-versioning/src/main/resources/META-INF/asciidoc/admin-guide/settings_versioning.adoc
+++ b/inception/inception-versioning/src/main/resources/META-INF/asciidoc/admin-guide/settings_versioning.adoc
@@ -15,7 +15,11 @@
 // limitations under the License.
 
 [[sect_settings_versioning]]
-=== Versioning Settings
+= Versioning Settings
+
+====
+CAUTION: Experimental feature.
+====
 
 You can enable versioning for projects in your {product-name} instance.
 Project managers can create snapshots of all documents in the project as well as its layer configuration via the versioning panel.

--- a/inception/inception-websocket/src/main/resources/META-INF/asciidoc/admin-guide/settings_websocket.adoc
+++ b/inception/inception-websocket/src/main/resources/META-INF/asciidoc/admin-guide/settings_websocket.adoc
@@ -15,7 +15,11 @@
 // limitations under the License.
 
 [[sect_settings_websocket]]
-=== Websocket Settings
+= Websocket Settings
+
+====
+CAUTION: Experimental feature.
+====
 
 You can enable websocket support for your instance which allows to push messages to the client browser. This can e.g. be information for Admin users on recently logged events. 
 


### PR DESCRIPTION
**What's in the PR**
- Switched to auto-configuration
- Added feature switch
- Added settings for the connection / read timeouts
- Moved messages to own package
- Moved model classes to own package
- Update documentation

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
