### PR TITLE
#1182 - AL does not always jump to the text passage

### DIFF
--- a/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/ActiveLearningServiceImpl.java
+++ b/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/ActiveLearningServiceImpl.java
@@ -21,10 +21,10 @@ import static de.tudarmstadt.ukp.inception.recommendation.api.model.AnnotationSu
 import static de.tudarmstadt.ukp.inception.recommendation.api.model.AnnotationSuggestion.FLAG_SKIPPED;
 import static de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordType.REJECTED;
 import static de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordType.SKIPPED;
+import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 
 import java.io.Serializable;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -84,13 +84,14 @@ public class ActiveLearningServiceImpl
         Predictions predictions = recommendationService.getPredictions(aUser, aLayer.getProject());
 
         if (predictions == null) {
-            return Collections.emptyList();
+            return emptyList();
         }
 
         Map<String, SuggestionDocumentGroup<SpanSuggestion>> recommendationsMap = predictions
                 .getPredictionsForWholeProject(SpanSuggestion.class, aLayer, documentService);
 
-        return recommendationsMap.values().stream().flatMap(docMap -> docMap.stream())
+        return recommendationsMap.values().stream() //
+                .flatMap(docMap -> docMap.stream()) //
                 .collect(toList());
     }
 
@@ -170,8 +171,8 @@ public class ActiveLearningServiceImpl
                 (getRecommendationsFromRecommendationService - startTimer));
 
         // remove duplicate recommendations
-        suggestions = suggestions.stream().map(it -> removeDuplicateRecommendations(it))
-                .collect(Collectors.toList());
+        suggestions = suggestions.stream() //
+                .map(it -> removeDuplicateRecommendations(it)).collect(Collectors.toList());
         long removeDuplicateRecommendation = System.currentTimeMillis();
         log.trace("Removing duplicate recommendations costs {} ms.",
                 (removeDuplicateRecommendation - getRecommendationsFromRecommendationService));

--- a/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.html
+++ b/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.html
@@ -43,7 +43,7 @@
         <div wicket:id="mainContainer" class="flex-content flex-v-container flex-gutter flex-only-internal-gutter">
           <span class="flex-content no-data-notice" wicket:id="noRecommenders">no Recommenders</span>
         
-          <div class="card" wicket:enclosure="noRecommendationLabel">
+          <div class="card mt-3" wicket:enclosure="noRecommendationLabel">
             <div class="card-body">
               <span class="no-data-notice" wicket:id="noRecommendationLabel"></span>
             </div>
@@ -60,7 +60,7 @@
             <div class="card-header small">
               <wicket:message key="recommendation"/>
             </div>
-            <div class="card-body">
+            <div class="card-body  pb-1">
               <div class="form-group form-row">
                 <div class="col-sm-12 p-0" style="position: relative; height: 5em;">
                   <div class="form-control"
@@ -90,15 +90,17 @@
                   <div class="feature-editor-value">
                     <span class="form-control"> 
                       <wicket:container wicket:id="recommendedScore"/>
+                      <span class="float-right small text-muted">
                       (<wicket:message key="delta"/>
                       <wicket:container wicket:id="recommendedDifference"/>)
+                      </span>
                     </span>
                   </div>
                 </div>
                 <div wicket:id="editor"></div>
               </div>
             </div>
-            <div class="card-footer text-right">
+            <div class="card-footer flex-h-container btn-group">
               <input type="submit" class="btn btn-success" wicket:id="annotateButton" value="Annotate"/>
               <input type="button" class="btn btn-danger" wicket:id="rejectButton" value="Reject"/>
               <input type="button" class="btn btn-warning" wicket:id="skipButton" value="Skip"/>

--- a/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.html
+++ b/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.html
@@ -62,12 +62,11 @@
             </div>
             <div class="card-body">
               <div class="form-group form-row">
-                <label class="col-sm-3 col-form-label"><wicket:message key="text"/></label>
-                <div class="col-sm-9" style="position: relative; height: 5em;">
+                <div class="col-sm-12 p-0" style="position: relative; height: 5em;">
                   <div class="form-control"
-                    style="overflow-y: auto; width: unset; word-wrap: break-word; height: 5em; position: absolute; top: 0; left: 10px; right: 10px;"
+                    style="overflow-y: auto; width: unset; word-wrap: break-word; height: 5em; position: absolute; top: 0; left: 5px; right: 5px;"
                     readonly>
-                    <a wicket:id="recommendationCoveredTextLink">
+                    <a wicket:id="recommendationCoveredTextLink" class="small">
                       <wicket:container wicket:id="leftContext"/>
                       <kbd><wicket:container wicket:id="text"/></kbd>
                       <wicket:container wicket:id="rightContext"/>
@@ -75,23 +74,29 @@
                   </div>
                 </div>
               </div>
-              <div class="form-group form-row">
-                <label class="col-sm-3 col-form-label"><wicket:message key="suggestion"/></label>
-                <div class="col-sm-9">
-                  <span class="form-control" wicket:id="recommendedPredition"></span>
+              <div class="feature-editors-sidebar">
+                <div class="form-group form-row">
+                  <label class="feature-editor-label col-form-label">
+                    <wicket:message key="suggestion"/>
+                  </label>
+                  <div class="feature-editor-value">
+                    <span class="form-control" wicket:id="recommendedPredition"></span>
+                  </div>
                 </div>
-              </div>
-              <div class="form-group form-row">
-                <label class="col-sm-3 col-form-label"><wicket:message key="score"/></label>
-                <div class="col-sm-9">
-                  <span class="form-control"> 
-                    <wicket:container wicket:id="recommendedScore"/>
-                    (<wicket:message key="delta"/>
-                    <wicket:container wicket:id="recommendedDifference"/>)
-                  </span>
+                <div class="form-group form-row">
+                  <label class="feature-editor-label col-form-label">
+                    <wicket:message key="score"/>
+                  </label>
+                  <div class="feature-editor-value">
+                    <span class="form-control"> 
+                      <wicket:container wicket:id="recommendedScore"/>
+                      (<wicket:message key="delta"/>
+                      <wicket:container wicket:id="recommendedDifference"/>)
+                    </span>
+                  </div>
                 </div>
+                <div wicket:id="editor"></div>
               </div>
-              <div wicket:id="editor"></div>
             </div>
             <div class="card-footer text-right">
               <input type="submit" class="btn btn-success" wicket:id="annotateButton" value="Annotate"/>

--- a/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.java
+++ b/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.java
@@ -17,7 +17,9 @@
  */
 package de.tudarmstadt.ukp.inception.active.learning.sidebar;
 
+import static de.tudarmstadt.ukp.clarin.webanno.api.CasUpgradeMode.AUTO_CAS_UPGRADE;
 import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.SPAN_TYPE;
+import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode.SHARED_READ_ONLY_ACCESS;
 import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
 import static de.tudarmstadt.ukp.inception.active.learning.sidebar.ActiveLearningUserStateMetaData.CURRENT_AL_USER_STATE;
 import static de.tudarmstadt.ukp.inception.recommendation.api.model.AnnotationSuggestion.FLAG_REJECTED;
@@ -60,6 +62,7 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.LoadableDetachableModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.model.StringResourceModel;
+import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -175,7 +178,7 @@ public class ActiveLearningSidebar
     private IModel<List<LearningRecord>> learningRecords;
     private CompoundPropertyModel<ActiveLearningServiceImpl.ActiveLearningUserState> alStateModel;
 
-    private final WebMarkupContainer mainContainer;
+    private final WebMarkupContainer alMainContainer;
 
     private AnnotationPage annotationPage;
     private ConfirmationDialog confirmationDialog;
@@ -187,6 +190,11 @@ public class ActiveLearningSidebar
     private VID highlightVID;
     private Offset highlightSpan;
     private boolean protectHighlight;
+
+    enum FeatureDetailEditorUpdateFlag
+    {
+        KEEP_SELECTED_ANNOTATION_AND_VIEW, CLEAR_SELECTED_ANNOTATION_AND_JUMP_TO_SUGGESTION
+    }
 
     public ActiveLearningSidebar(String aId, IModel<AnnotatorState> aModel,
             AnnotationActionHandler aActionHandler, CasProvider aCasProvider,
@@ -216,14 +224,14 @@ public class ActiveLearningSidebar
 
         add(sessionControlForm = createSessionControlForm());
 
-        mainContainer = new WebMarkupContainer(CID_MAIN_CONTAINER);
-        mainContainer.setOutputMarkupId(true);
-        mainContainer.add(createNoRecommendersMessage());
-        mainContainer.add(createNoRecommendationLabel());
-        mainContainer.add(clearSkippedRecommendationForm());
-        mainContainer.add(createRecommendationOperationForm());
-        mainContainer.add(createLearningHistory());
-        add(mainContainer);
+        alMainContainer = new WebMarkupContainer(CID_MAIN_CONTAINER);
+        alMainContainer.setOutputMarkupId(true);
+        alMainContainer.add(createNoRecommendersMessage());
+        alMainContainer.add(createNoRecommendationLabel());
+        alMainContainer.add(clearSkippedRecommendationForm());
+        alMainContainer.add(createRecommendationOperationForm());
+        alMainContainer.add(createLearningHistory());
+        add(alMainContainer);
 
         confirmationDialog = new ConfirmationDialog(CID_CONFIRMATION_DIALOG);
         confirmationDialog.setAutoSize(true);
@@ -302,9 +310,10 @@ public class ActiveLearningSidebar
 
         aTarget.add(sessionControlForm);
 
-        refreshSuggestions();
+        refreshAvailableSuggestions();
 
-        moveToNextRecommendation(aTarget, false);
+        requestClearningSelectionAndJumpingToSuggestion();
+        moveToNextSuggestion(aTarget);
 
         String userName = state.getUser().getUsername();
         Project project = state.getProject();
@@ -313,12 +322,30 @@ public class ActiveLearningSidebar
                 .publishEvent(new ActiveLearningSessionStartedEvent(this, project, userName));
     }
 
+    /**
+     * Called by action handles from the active learning sidebar to indicate that during later
+     * processing, the selection should automatically move to the next active learning suggestion.
+     * If an action is performed via the main editor, this should not be called so the annotation
+     * that was explicitly created and selected remains editable by the user.
+     */
+    private void requestClearningSelectionAndJumpingToSuggestion()
+    {
+        RequestCycle.get().setMetaData(ClearSelectionAndJumpToSuggestionKey.INSTANCE, true);
+    }
+
+    private boolean shouldBeClearningSelectionAndJumpingToSuggestion()
+    {
+        Boolean flag = RequestCycle.get()
+                .getMetaData(ClearSelectionAndJumpToSuggestionKey.INSTANCE);
+        return flag != null ? flag : false;
+    }
+
     private void actionStopSession(AjaxRequestTarget target)
     {
         ActiveLearningUserState alState = alStateModel.getObject();
         AnnotatorState state = getModelObject();
 
-        target.add(mainContainer, sessionControlForm);
+        target.add(alMainContainer, sessionControlForm);
 
         // Stop current session
         alState.setSessionActive(false);
@@ -330,7 +357,7 @@ public class ActiveLearningSidebar
                 .publishEvent(new ActiveLearningSessionCompletedEvent(this, project, userName));
     }
 
-    private void setHighlight(SpanSuggestion aSuggestion)
+    private void setActiveLearningHighlight(SpanSuggestion aSuggestion)
     {
         if (protectHighlight) {
             LOG.trace("Active learning sidebar not updating protected highlights");
@@ -344,7 +371,7 @@ public class ActiveLearningSidebar
         highlightDocumentName = aSuggestion.getDocumentName();
     }
 
-    private void setHighlight(LearningRecord aRecord)
+    private void setActiveLearningHighlight(LearningRecord aRecord)
     {
         LOG.trace("Active learning sidebar set highlight history record: {}", aRecord);
         highlightVID = null;
@@ -358,7 +385,7 @@ public class ActiveLearningSidebar
         protectHighlight = true;
     }
 
-    private void setHighlight(SourceDocument aDocument, AnnotationFS aAnnotation)
+    private void setActiveLearningHighlight(SourceDocument aDocument, AnnotationFS aAnnotation)
     {
         LOG.trace("Active learning sidebar set highlight annotation: {}", aAnnotation);
         highlightVID = new VID(WebAnnoCasUtil.getAddr(aAnnotation));
@@ -367,7 +394,7 @@ public class ActiveLearningSidebar
         protectHighlight = false;
     }
 
-    private void clearHighlight()
+    private void clearActiveLearningHighlight()
     {
         if (protectHighlight) {
             LOG.trace("Active learning sidebar not clearing protected highlights");
@@ -385,12 +412,9 @@ public class ActiveLearningSidebar
     {
         Label noRecommendation = new Label(CID_NO_RECOMMENDATION_LABEL,
                 "There are no further suggestions.");
-        noRecommendation.add(visibleWhen(() -> {
-            ActiveLearningUserState alState = alStateModel.getObject();
-            return alState.isSessionActive() && !alState.getSuggestion().isPresent()
-                    && !activeLearningService.hasSkippedSuggestions(getModelObject().getUser(),
-                            alState.getLayer());
-        }));
+        noRecommendation.add(visibleWhen(alStateModel.map(alState -> alState.isSessionActive()
+                && !alState.getSuggestion().isPresent() && !activeLearningService
+                        .hasSkippedSuggestions(getModelObject().getUser(), alState.getLayer()))));
         noRecommendation.setOutputMarkupPlaceholderTag(true);
         return noRecommendation;
     }
@@ -398,12 +422,9 @@ public class ActiveLearningSidebar
     private Form<Void> clearSkippedRecommendationForm()
     {
         Form<Void> form = new Form<>(CID_LEARN_FROM_SKIPPED_RECOMMENDATION_FORM);
-        form.add(LambdaBehavior.visibleWhen(() -> {
-            ActiveLearningUserState alState = alStateModel.getObject();
-            return alState.isSessionActive() && !alState.getSuggestion().isPresent()
-                    && activeLearningService.hasSkippedSuggestions(getModelObject().getUser(),
-                            alState.getLayer());
-        }));
+        form.add(visibleWhen(alStateModel.map(alState -> alState.isSessionActive()
+                && !alState.getSuggestion().isPresent() && activeLearningService
+                        .hasSkippedSuggestions(getModelObject().getUser(), alState.getLayer()))));
         form.setOutputMarkupPlaceholderTag(true);
         form.add(new Label(CID_ONLY_SKIPPED_RECOMMENDATION_LABEL,
                 "There are only skipped suggestions. Do you want to learn these again?"));
@@ -418,18 +439,16 @@ public class ActiveLearningSidebar
         learningRecordService.deleteSkippedSuggestions(getModelObject().getUser(),
                 alStateModel.getObject().getLayer());
 
-        ActiveLearningUserState alState = alStateModel.getObject();
-
         // The history records caused suggestions to disappear. Since visibility is only fully
         // recalculated when new predictions come in, we need to update the visibility explicitly
         // here
-        alState.getSuggestions().stream().flatMap(group -> group.stream())
+        alStateModel.getObject().getSuggestions().stream() //
+                .flatMap(group -> group.stream())
                 .forEach(suggestion -> suggestion.show(FLAG_SKIPPED));
 
-        refreshSuggestions();
-        moveToNextRecommendation(aTarget, false);
-
-        aTarget.add(mainContainer);
+        refreshAvailableSuggestions();
+        requestClearningSelectionAndJumpingToSuggestion();
+        moveToNextSuggestion(aTarget);
     }
 
     private Form<Void> createRecommendationOperationForm()
@@ -502,7 +521,7 @@ public class ActiveLearningSidebar
                         suggestion.getDocumentName()),
                 suggestion.getBegin(), suggestion.getEnd());
 
-        setHighlight(suggestion);
+        setActiveLearningHighlight(suggestion);
     }
 
     private Component initializeFeatureEditor()
@@ -511,12 +530,12 @@ public class ActiveLearningSidebar
         return editor;
     }
 
-    private void refreshFeatureEditor(IPartialPageRequestHandler aTarget,
+    private void refreshActiveLearningFeatureEditor(IPartialPageRequestHandler aTarget,
             SpanSuggestion aCurrentRecommendation)
     {
         editor = createFeatureEditor(aCurrentRecommendation);
         recommendationForm.addOrReplace(editor);
-        aTarget.add(mainContainer);
+        aTarget.add(alMainContainer);
     }
 
     private FeatureEditor createFeatureEditor(SpanSuggestion aCurrentRecommendation)
@@ -568,7 +587,7 @@ public class ActiveLearningSidebar
         featureState.tagset = reorderedTagList;
 
         // Finally, create the editor
-        FeatureEditor featureEditor = featureSupport.createEditor(CID_EDITOR, mainContainer,
+        FeatureEditor featureEditor = featureSupport.createEditor(CID_EDITOR, alMainContainer,
                 this.getActionHandler(), this.getModel(), Model.of(featureState));
         featureEditor.setOutputMarkupPlaceholderTag(true);
         featureEditor.add(visibleWhen(() -> alStateModel.getObject().getLayer() != null
@@ -653,7 +672,10 @@ public class ActiveLearningSidebar
                 .getLayer(state.getProject(), suggestion.getLayerId())
                 .orElseThrow(() -> new IllegalArgumentException(
                         "No such layer: [" + suggestion.getLayerId() + "]"));
+
         AnnotationFeature feature = annotationService.getFeature(suggestion.getFeature(), layer);
+
+        requestClearningSelectionAndJumpingToSuggestion();
         recommendationService.upsertSpanFeature(annotationService, sourceDoc, username, cas, layer,
                 feature, selectedValue, suggestion.getBegin(), suggestion.getEnd());
 
@@ -677,20 +699,14 @@ public class ActiveLearningSidebar
         // Log the action to the learning record
         writeLearningRecordInDatabaseAndEventLog(suggestion,
                 (areLabelsEqual) ? ACCEPTED : CORRECTED, selectedValue);
-
-        recommendationService.getPredictions(state.getUser(), state.getProject())
-                .getPredictionsByTokenAndFeature(suggestion.getDocumentName(),
-                        alStateModel.getObject().getLayer(), suggestion.getBegin(),
-                        suggestion.getEnd(), feat.getName());
-
-        moveToNextRecommendation(aTarget, false);
     }
 
     private void actionSkip(AjaxRequestTarget aTarget)
     {
         alStateModel.getObject().getSuggestion().ifPresent(rec -> {
             writeLearningRecordInDatabaseAndEventLog(rec, SKIPPED);
-            moveToNextRecommendation(aTarget, false);
+            requestClearningSelectionAndJumpingToSuggestion();
+            moveToNextSuggestion(aTarget);
         });
     }
 
@@ -698,120 +714,128 @@ public class ActiveLearningSidebar
     {
         alStateModel.getObject().getSuggestion().ifPresent(rec -> {
             writeLearningRecordInDatabaseAndEventLog(rec, REJECTED);
-            moveToNextRecommendation(aTarget, false);
+            requestClearningSelectionAndJumpingToSuggestion();
+            moveToNextSuggestion(aTarget);
         });
     }
 
-    private void moveToNextRecommendation(IPartialPageRequestHandler aTarget, boolean aStay)
+    private void moveToNextSuggestion(AjaxRequestTarget aTarget)
     {
-        AnnotatorState state = getModelObject();
         ActiveLearningUserState alState = alStateModel.getObject();
-
-        // Clear the annotation detail editor and the selection to avoid confusions with the
-        // highlight because the selection highlight from the right sidebar and the one from the
-        // AL sidebar have the same color!
-        if (!aStay) {
-            state.getSelection().clear();
-            aTarget.add((Component) getActionHandler());
-        }
-
-        User user = state.getUser();
+        AnnotatorState state = getModelObject();
         Project project = state.getProject();
+        User user = state.getUser();
 
-        Optional<Delta<SpanSuggestion>> recommendationDifference = activeLearningService
-                .generateNextSuggestion(user, alState);
+        // Generate the next recommendation but remember the current one
         Optional<SpanSuggestion> prevSuggestion = alState.getSuggestion();
-        alState.setCurrentDifference(recommendationDifference);
-
-        // If the active suggestion has changed, inform the user
-        if (prevSuggestion.isPresent() && (alState.getSuggestion().isPresent()
-                && !alState.getSuggestion().get().equals(prevSuggestion.get()))) {
-            String message = "Active learning has moved to next best suggestion.";
-            // Avoid logging the message multiple times in case the move to the next suggestion has
-            // been requested multiple times in a single request
-            if (getFeedbackMessages().messages(msg -> msg.getMessage().equals(message)).isEmpty()) {
-                info(message);
-                aTarget.addChildren(getPage(), IFeedback.class);
-            }
-        }
-        else if (prevSuggestion.isPresent() && !alState.getSuggestion().isPresent()) {
-            String message = "There are no more recommendations right now.";
-            // Avoid logging the message multiple times in case the move to the next suggestion has
-            // been requested multiple times in a single request
-            if (getFeedbackMessages().messages(msg -> msg.getMessage().equals(message)).isEmpty()) {
-                info(message);
-                aTarget.addChildren(getPage(), IFeedback.class);
-            }
-        }
+        alState.setCurrentDifference(activeLearningService.generateNextSuggestion(user, alState));
 
         // If there is no new suggestion, nothing left to do here
         if (!alState.getSuggestion().isPresent()) {
-            clearHighlight();
-            aTarget.add(mainContainer);
-            if (!aStay) {
-                // Main editor
-                annotationPage.actionRefreshDocument((AjaxRequestTarget) aTarget);
+            if (prevSuggestion.isPresent()) {
+                infoOnce(aTarget, "There are no more recommendations right now.");
             }
+
+            clearActiveLearningHighlight();
+            aTarget.add(alMainContainer);
+
             return;
         }
 
-        // If there is one, open it in the sidebar and take the main editor to its location
+        // If the active suggestion has changed, inform the user
+        if (prevSuggestion.isPresent()
+                && !alState.getSuggestion().get().equals(prevSuggestion.get())) {
+            infoOnce(aTarget, "Active learning has moved to next best suggestion.");
+            LOG.trace("Moving from {} to {}", prevSuggestion.get(), alState.getSuggestion().get());
+        }
+
+        // If there is a suggestion, open it in the sidebar and take the main editor to its location
+        SpanSuggestion suggestion = alState.getSuggestion().get();
+        SourceDocument sourceDocument = documentService.getSourceDocument(project,
+                suggestion.getDocumentName());
+        loadSuggestionInActiveLearningSidebar(aTarget, suggestion, sourceDocument);
+
+        if (shouldBeClearningSelectionAndJumpingToSuggestion()) {
+            clearSelectedAnnotationAndJumpToSuggestion(aTarget);
+        }
+
+        List<SpanSuggestion> alternativeSuggestions = recommendationService
+                .getPredictions(user, project)
+                .getPredictionsByTokenAndFeature(suggestion.getDocumentName(), alState.getLayer(),
+                        suggestion.getBegin(), suggestion.getEnd(), suggestion.getFeature());
+
+        applicationEventPublisherHolder.get()
+                .publishEvent(new ActiveLearningSuggestionOfferedEvent(this, sourceDocument,
+                        suggestion, user.getUsername(), alState.getLayer(), suggestion.getFeature(),
+                        alternativeSuggestions));
+    }
+
+    private void clearSelectedAnnotationAndJumpToSuggestion(AjaxRequestTarget aTarget)
+    {
+        ActiveLearningUserState alState = alStateModel.getObject();
+        if (!alState.getSuggestion().isPresent()) {
+            return;
+        }
+
+        // If the user performed an action in the main editor, then we need to behave "as usual".
+        // I.e. we must not make the editor/feature details jump to the next suggestion but rather
+        // keep the view and selected annotation that the user has chosen to provide the opportunity
+        // to the user to continue editing on it
+        SpanSuggestion suggestion = alState.getSuggestion().get();
+        AnnotatorState state = getModelObject();
+        Project project = state.getProject();
+        User user = state.getUser();
+        SourceDocument sourceDocument = documentService.getSourceDocument(project,
+                suggestion.getDocumentName());
+
+        LOG.trace("Jumping to {}", suggestion);
+
         try {
-            SpanSuggestion suggestion = alState.getSuggestion().get();
-            SourceDocument sourceDocument = documentService.getSourceDocument(project,
-                    suggestion.getDocumentName());
+            // Clear the annotation detail editor and the selection to avoid confusions with the
+            // highlight because the selection highlight from the right sidebar and the one from
+            // the AL sidebar have the same color!
+            state.getSelection().clear();
+            aTarget.add((Component) getActionHandler());
 
-            // Refresh feature editor
-            refreshFeatureEditor(aTarget, suggestion);
+            actionShowSelectedDocument(aTarget, sourceDocument, suggestion.getBegin(),
+                    suggestion.getEnd());
+            // When the document is opened, the recommendation service defaults to only
+            // predicting for the current document. Therefore, while in an AL session,
+            // we kindly as again to predict for all documents
+            // See also RecommendationServiceImpl::onDocumentOpened where it is set again
+            // to predict on single documents only.
+            recommendationService.setPredictForAllDocuments(user.getUsername(), project, true);
+        }
+        catch (IOException e) {
+            LOG.error("Error reading CAS: {}", e.getMessage());
+            error("Error reading CAS " + e.getMessage());
+            aTarget.addChildren(getPage(), IFeedback.class);
+        }
+    }
 
-            if (!aStay) {
-                // Open the corresponding document in the main editor and jump to the respective
-                // location
-                actionShowSelectedDocument((AjaxRequestTarget) aTarget, sourceDocument,
-                        suggestion.getBegin(), suggestion.getEnd());
-            }
-            setHighlight(suggestion);
+    private void loadSuggestionInActiveLearningSidebar(AjaxRequestTarget aTarget,
+            SpanSuggestion suggestion, SourceDocument sourceDocument)
+    {
+        aTarget.add(alMainContainer);
+        setActiveLearningHighlight(suggestion);
+        refreshActiveLearningFeatureEditor(aTarget, suggestion);
 
-            if (!aStay) {
-                // Main editor
-                annotationPage.actionRefreshDocument((AjaxRequestTarget) aTarget);
-            }
-
-            // Obtain some left and right context of the active suggestion while we have easy
-            // access to the document which contains the current suggestion
-            CAS cas;
-            if (state.getDocument().getName().equals(suggestion.getDocumentName())) {
-                cas = getCasProvider().get();
-            }
-            else {
-                cas = documentService.readAnnotationCas(sourceDocument, user.getUsername());
-
-                // When the document is opened, the recommendation service defaults to only
-                // predicting for the current document. Therefore, while in an AL session,
-                // we kindly as again to predict for all documents
-                // See also RecommendationServiceImpl::onDocumentOpened where it is set again
-                // to predict on single documents only.
-                recommendationService.setPredictForAllDocuments(user.getUsername(), project, true);
-            }
+        // Obtain some left and right context of the active suggestion while we have easy
+        // access to the document which contains the current suggestion
+        try {
+            CAS cas = documentService.readAnnotationCas(sourceDocument,
+                    getModelObject().getUser().getUsername(), AUTO_CAS_UPGRADE,
+                    SHARED_READ_ONLY_ACCESS);
             String text = cas.getDocumentText();
+
+            ActiveLearningUserState alState = alStateModel.getObject();
             alState.setLeftContext(
                     text.substring(Math.max(0, suggestion.getBegin() - 20), suggestion.getBegin()));
             alState.setRightContext(text.substring(suggestion.getEnd(),
                     Math.min(suggestion.getEnd() + 20, text.length())));
-
-            // Send an application event that the suggestion has been rejected
-            List<SpanSuggestion> alternativeSuggestions = recommendationService
-                    .getPredictions(user, project).getPredictionsByTokenAndFeature(
-                            suggestion.getDocumentName(), alState.getLayer(), suggestion.getBegin(),
-                            suggestion.getEnd(), suggestion.getFeature());
-
-            applicationEventPublisherHolder.get()
-                    .publishEvent(new ActiveLearningSuggestionOfferedEvent(this, sourceDocument,
-                            suggestion, user.getUsername(), alState.getLayer(),
-                            suggestion.getFeature(), alternativeSuggestions));
         }
         catch (IOException e) {
-            LOG.info("Error reading CAS: {}", e.getMessage());
+            LOG.error("Error reading CAS: {}", e.getMessage());
             error("Error reading CAS " + e.getMessage());
             aTarget.addChildren(getPage(), IFeedback.class);
         }
@@ -894,11 +918,11 @@ public class ActiveLearningSidebar
         Optional<AnnotationFS> annotation = getMatchingAnnotation(cas, aRecord);
 
         if (annotation.isPresent()) {
-            setHighlight(aRecord.getSourceDocument(), annotation.get());
+            setActiveLearningHighlight(aRecord.getSourceDocument(), annotation.get());
         }
         // ... otherwise highlight the text
         else {
-            setHighlight(aRecord);
+            setActiveLearningHighlight(aRecord);
 
             info("No annotation could be highlighted.");
             aTarget.addChildren(getPage(), IFeedback.class);
@@ -934,7 +958,8 @@ public class ActiveLearningSidebar
             List<SuggestionGroup<SpanSuggestion>> aSuggestions, String aDocumentName, long aLayerId,
             String aFeature, int aBegin, int aEnd, String aLabel)
     {
-        return aSuggestions.stream().filter(group -> group.getPosition() instanceof Offset)
+        return aSuggestions.stream() //
+                .filter(group -> group.getPosition() instanceof Offset) //
                 .filter(group -> aDocumentName.equals(group.getDocumentName())
                         && aLayerId == group.getLayerId()
                         && (aFeature == null || aFeature == group.getFeature())
@@ -954,7 +979,7 @@ public class ActiveLearningSidebar
     private void actionRemoveHistoryItem(AjaxRequestTarget aTarget, LearningRecord aRecord)
         throws IOException
     {
-        aTarget.add(mainContainer);
+        aTarget.add(alMainContainer);
 
         ActiveLearningUserState alState = alStateModel.getObject();
 
@@ -994,8 +1019,9 @@ public class ActiveLearningSidebar
         // good chance that deleting the history item makes suggestions become available again, so
         // we try to find a new one.
         if (!alState.getSuggestion().isPresent()) {
-            refreshSuggestions();
-            moveToNextRecommendation(aTarget, false);
+            refreshAvailableSuggestions();
+            requestClearningSelectionAndJumpingToSuggestion();
+            moveToNextSuggestion(aTarget);
         }
     }
 
@@ -1056,7 +1082,7 @@ public class ActiveLearningSidebar
         }
     }
 
-    private void reactToAnnotationsBeingCreatedOrDeleted(IPartialPageRequestHandler aTarget,
+    private void reactToAnnotationsBeingCreatedOrDeleted(AjaxRequestTarget aTarget,
             AnnotationLayer aLayer)
     {
         try {
@@ -1073,9 +1099,7 @@ public class ActiveLearningSidebar
                     (List) alState.getSuggestions(), state.getWindowBeginOffset(),
                     state.getWindowEndOffset());
 
-            // Update the suggestion in the AL sidebar, but do not jump or touch the right
-            // sidebar such that the user can happily continue to edit the annotation
-            moveToNextRecommendation(aTarget, true);
+            moveToNextSuggestion(aTarget);
         }
         catch (IOException e) {
             LOG.info("Error reading CAS: {}", e.getMessage());
@@ -1123,9 +1147,10 @@ public class ActiveLearningSidebar
             if (doc.equals(annotatorState.getDocument())
                     && vid.getLayerId() == alStateModel.getObject().getLayer().getId() && prediction
                             .get().equals(alStateModel.getObject().getSuggestion().orElse(null))) {
-                moveToNextRecommendation(aEvent.getTarget(), false);
+                requestClearningSelectionAndJumpingToSuggestion();
+                moveToNextSuggestion(aEvent.getTarget());
             }
-            aEvent.getTarget().add(mainContainer);
+            aEvent.getTarget().add(alMainContainer);
         }
     }
 
@@ -1170,9 +1195,10 @@ public class ActiveLearningSidebar
             if (acceptedSuggestion.getPosition().equals(suggestion.getPosition())
                     && vid.getLayerId() == suggestion.getLayerId()
                     && acceptedSuggestion.getFeature().equals(suggestion.getFeature())) {
-                moveToNextRecommendation(aEvent.getTarget(), false);
+                requestClearningSelectionAndJumpingToSuggestion();
+                moveToNextSuggestion(aEvent.getTarget());
             }
-            aEvent.getTarget().add(mainContainer);
+            aEvent.getTarget().add(alMainContainer);
         }
     }
 
@@ -1226,7 +1252,7 @@ public class ActiveLearningSidebar
         }
     }
 
-    private void refreshSuggestions()
+    private void refreshAvailableSuggestions()
     {
         AnnotatorState state = getModelObject();
         ActiveLearningUserState alState = alStateModel.getObject();
@@ -1237,69 +1263,89 @@ public class ActiveLearningSidebar
     @OnEvent
     public void onDocumentReset(AfterDocumentResetEvent aEvent)
     {
-        reactToChangeInPredictions(aEvent.getRequestTarget());
+        // If active learning is not active, update the sidebar in case the session auto-terminated
+        ActiveLearningUserState alState = alStateModel.getObject();
+        if (!alState.isSessionActive()) {
+            aEvent.getRequestTarget().add(alMainContainer);
+            return;
+        }
+
+        // Make sure we know about the current suggestions and their visibility state
+        refreshAvailableSuggestions();
+
+        // Maybe the prediction switch has made a new suggestion available for us to go to
+        if (alState.getSuggestion().isEmpty()) {
+            moveToNextSuggestion(aEvent.getRequestTarget());
+            return;
+        }
+
+        refreshCurrentSuggestionOrMoveToNextSuggestion(aEvent.getRequestTarget());
     }
 
     @OnEvent
     public void onPredictionsSwitched(PredictionsSwitchedEvent aEvent)
     {
-        reactToChangeInPredictions(aEvent.getRequestHandler());
-        // As a reaction to the change in predictions, the highlights may have to be placed at
-        // a different location. This the prediction switch is announced late in the rendering
-        // process and the highlights have already been added to the VDocument at this time,
-        // we need to remove and re-add them. renderHighlights() takes care of this.
-        renderHighlights(aEvent.getVDocument());
-    }
-
-    private void reactToChangeInPredictions(IPartialPageRequestHandler aTarget)
-    {
+        // If active learning is not active, update the sidebar in case the session auto-terminated
         ActiveLearningUserState alState = alStateModel.getObject();
-
-        // If active learning is not active, nothing to do here
         if (!alState.isSessionActive()) {
-            // Re-render the AL sidebar in case the session auto-terminated
-            aTarget.add(mainContainer);
+            aEvent.getRequestHandler().add(alMainContainer);
             return;
         }
 
         // Make sure we know about the current suggestions and their visibility state
-        refreshSuggestions();
+        refreshAvailableSuggestions();
 
+        // Maybe the prediction switch has made a new suggestion available for us to go to
+        if (alState.getSuggestion().isEmpty()) {
+            moveToNextSuggestion(aEvent.getRequestHandler());
+            return;
+        }
+
+        refreshCurrentSuggestionOrMoveToNextSuggestion(aEvent.getRequestHandler());
+    }
+
+    private void refreshCurrentSuggestionOrMoveToNextSuggestion(AjaxRequestTarget aTarget)
+    {
         // If there is currently a suggestion displayed in the sidebar, we need to check if it
         // is still relevant - if yes, we need to replace it with its current counterpart since.
         // if no counterpart exists in the current suggestions, then we need to load a
         // suggestion from the current list.
-        if (alState.getSuggestion().isPresent()) {
-            SpanSuggestion activeSuggestion = alState.getSuggestion().get();
-            // Find the groups which matches the active recommendation
-            Optional<SpanSuggestion> updatedSuggestion = getMatchingSuggestion(
-                    alState.getSuggestions(), activeSuggestion).stream().findFirst();
+        ActiveLearningUserState alState = alStateModel.getObject();
+        SpanSuggestion activeSuggestion = alState.getSuggestion().get();
+        // Find the groups which matches the active recommendation
+        Optional<SpanSuggestion> updatedSuggestion = getMatchingSuggestion(alState.getSuggestions(),
+                activeSuggestion).stream().findFirst();
 
-            if (updatedSuggestion.isPresent()) {
-                LOG.debug("Replacing outdated suggestion {} with new suggestion {}",
-                        alState.getCurrentDifference().get().getFirst().getId(),
-                        updatedSuggestion.get().getId());
-
-                // Update the highlight
-                if (alState.getSuggestion().get().getVID().equals(highlightVID)) {
-                    highlightVID = updatedSuggestion.get().getVID();
-                }
-
-                // We found a matching suggestion, but we look for its second-best. So for the
-                // moment we assume that the second-best has not changed and we simply fake
-                // a delta
-                Delta fakeDelta = new Delta(updatedSuggestion.get(),
-                        alState.getCurrentDifference().get().getSecond().orElse(null));
-                alState.setCurrentDifference(Optional.of(fakeDelta));
-            }
-            else {
-                moveToNextRecommendation(aTarget, true);
-            }
+        if (updatedSuggestion.isEmpty()) {
+            moveToNextSuggestion(aTarget);
+            return;
         }
-        else {
-            // Still need to re-render the AL sidebar so we can show stuff to the user like asking
-            // whether to review skipped items or just informing that there is nothing more to do.
-            aTarget.add(mainContainer);
+
+        LOG.debug("Replacing outdated suggestion {} with new suggestion {}",
+                alState.getCurrentDifference().get().getFirst().getId(),
+                updatedSuggestion.get().getId());
+
+        // Update the highlight
+        if (alState.getSuggestion().get().getVID().equals(highlightVID)) {
+            highlightVID = updatedSuggestion.get().getVID();
         }
+
+        // We found a matching suggestion, but we look for its second-best. So for the moment we
+        // assume that the second-best has not changed and we simply fake a delta
+        alState.setCurrentDifference(Optional.of(new Delta(updatedSuggestion.get(),
+                alState.getCurrentDifference().get().getSecond().orElse(null))));
+    }
+
+    private void infoOnce(IPartialPageRequestHandler aTarget, String aMessage)
+    {
+        info(aMessage);
+        aTarget.addChildren(getPage(), IFeedback.class);
+
+        // // Avoid logging the message multiple times in case the move to the next suggestion has
+        // // been requested multiple times in a single request
+        // if (getFeedbackMessages().messages(msg -> msg.getMessage().equals(aMessage)).isEmpty()) {
+        // info(aMessage);
+        // aTarget.addChildren(getPage(), IFeedback.class);
+        // }
     }
 }

--- a/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ClearSelectionAndJumpToSuggestionKey.java
+++ b/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ClearSelectionAndJumpToSuggestionKey.java
@@ -15,30 +15,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package de.tudarmstadt.ukp.inception.recommendation.event;
+package de.tudarmstadt.ukp.inception.active.learning.sidebar;
 
-import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.MetaDataKey;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
-
-public class PredictionsSwitchedEvent
+public class ClearSelectionAndJumpToSuggestionKey
+    extends MetaDataKey<Boolean>
 {
-    private final AjaxRequestTarget requestHandler;
-    private final AnnotatorState state;
-
-    public PredictionsSwitchedEvent(AjaxRequestTarget aTarget, AnnotatorState aState)
-    {
-        requestHandler = aTarget;
-        state = aState;
-    }
-
-    public AjaxRequestTarget getRequestHandler()
-    {
-        return requestHandler;
-    }
-
-    public AnnotatorState getState()
-    {
-        return state;
-    }
+    private static final long serialVersionUID = -4244853609075676915L;
+    public final static ClearSelectionAndJumpToSuggestionKey INSTANCE = new ClearSelectionAndJumpToSuggestionKey();
 }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/AnnotationEditorBase.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/AnnotationEditorBase.java
@@ -131,6 +131,10 @@ public abstract class AnnotationEditorBase
 
                 render(_target);
             }));
+
+            if (getModelObject().getDocument() != null) {
+                extensionRegistry.fireRenderRequested(getModelObject());
+            }
         }
         catch (IllegalStateException e) {
             LOG.warn("Cannot request editor rendering anymore - request is already frozen");
@@ -146,12 +150,12 @@ public abstract class AnnotationEditorBase
 
     protected VDocument render(CAS aCas, int aWindowBeginOffset, int aWindowEndOffset)
     {
+        AnnotatorState state = getModelObject();
+
         VDocument vdoc = new VDocument();
         preRenderer.render(vdoc, aWindowBeginOffset, aWindowEndOffset, aCas, getLayersToRender());
 
-        // Fire render event into backend
-        extensionRegistry.fireRender(aCas, getModelObject(), vdoc, aWindowBeginOffset,
-                aWindowEndOffset);
+        extensionRegistry.fireRender(aCas, state, vdoc, aWindowBeginOffset, aWindowEndOffset);
 
         // Fire render event into UI
         Page page = null;
@@ -159,7 +163,6 @@ public abstract class AnnotationEditorBase
         if (handler.isPresent()) {
             page = (Page) handler.get().getPage();
         }
-        ;
 
         if (page == null) {
             page = getPage();
@@ -170,8 +173,6 @@ public abstract class AnnotationEditorBase
                         getModelObject(), vdoc));
 
         if (isHighlightEnabled()) {
-            AnnotatorState state = getModelObject();
-
             // Disabling for 3.3.0 by default per #406
             // FIXME: should be enabled by default and made optional per #606
             // if (state.getFocusUnitIndex() > 0) {

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/AnnotationEditorExtension.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/AnnotationEditorExtension.java
@@ -53,6 +53,11 @@ public interface AnnotationEditorExtension
         // Do nothing by default
     }
 
+    default void renderRequested(AnnotatorState aState)
+    {
+        // Do nothing by default
+    }
+
     /**
      * Post-process the output during rendering.
      */

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/AnnotationEditorExtensionRegistry.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/AnnotationEditorExtensionRegistry.java
@@ -41,6 +41,8 @@ public interface AnnotationEditorExtensionRegistry
             AjaxRequestTarget aTarget, CAS aCas, VID aParamId, String aAction)
         throws IOException, AnnotationException;
 
+    void fireRenderRequested(AnnotatorState aState);
+
     void fireRender(CAS aCas, AnnotatorState aModelObject, VDocument aVdoc, int aWindowBeginOffset,
             int aWindowEndOffset);
 

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/AnnotationEditorExtensionRegistryImpl.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/AnnotationEditorExtensionRegistryImpl.java
@@ -114,11 +114,19 @@ public class AnnotationEditorExtensionRegistryImpl
     }
 
     @Override
-    public void fireRender(CAS aCas, AnnotatorState aModelObject, VDocument aVdoc,
-            int aWindowBeginOffset, int aWindowEndOffset)
+    public void fireRenderRequested(AnnotatorState aState)
     {
         for (AnnotationEditorExtension ext : getExtensions()) {
-            ext.render(aCas, aModelObject, aVdoc, aWindowBeginOffset, aWindowEndOffset);
+            ext.renderRequested(aState);
+        }
+    }
+
+    @Override
+    public void fireRender(CAS aCas, AnnotatorState aState, VDocument aVdoc, int aWindowBeginOffset,
+            int aWindowEndOffset)
+    {
+        for (AnnotationEditorExtension ext : getExtensions()) {
+            ext.render(aCas, aState, aVdoc, aWindowBeginOffset, aWindowEndOffset);
         }
     }
 

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/rendering/model/VMarker.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/rendering/model/VMarker.java
@@ -19,6 +19,7 @@ package de.tudarmstadt.ukp.clarin.webanno.api.annotation.rendering.model;
 
 public abstract class VMarker
 {
+    public static final String EDITED = "edited";
     public static final String FOCUS = "focus";
     public static final String MATCH_FOCUS = "matchfocus";
     public static final String MATCH = "match";

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/RecommendationService.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/RecommendationService.java
@@ -173,6 +173,8 @@ public interface RecommendationService
 
     void clearState(String aUsername);
 
+    void triggerPrediction(String aUsername, String aEventName, SourceDocument aDocument);
+
     void triggerTrainingAndClassification(String aUser, Project aProject, String aEventName,
             SourceDocument aCurrentDocument);
 

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/RecommendationEditorExtension.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/RecommendationEditorExtension.java
@@ -368,8 +368,7 @@ public class RecommendationEditorExtension
     }
 
     @Override
-    public void render(CAS aCas, AnnotatorState aState, VDocument aVDoc, int aWindowBeginOffset,
-            int aWindowEndOffset)
+    public void renderRequested(AnnotatorState aState)
     {
         // do not show predictions during curation or when viewing others' work
         if (!aState.getMode().equals(ANNOTATION)
@@ -389,7 +388,18 @@ public class RecommendationEditorExtension
         if (switched) {
             RequestCycle.get().find(AjaxRequestTarget.class)
                     .ifPresent(_target -> _target.getPage().send(_target.getPage(), BREADTH,
-                            new PredictionsSwitchedEvent(_target, aCas, aState, aVDoc)));
+                            new PredictionsSwitchedEvent(_target, aState)));
+        }
+    }
+
+    @Override
+    public void render(CAS aCas, AnnotatorState aState, VDocument aVDoc, int aWindowBeginOffset,
+            int aWindowEndOffset)
+    {
+        // do not show predictions during curation or when viewing others' work
+        if (!aState.getMode().equals(ANNOTATION)
+                || !aState.getUser().getUsername().equals(userRegistry.getCurrentUsername())) {
+            return;
         }
 
         // Add the suggestions to the visual document

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/LogDialogContent.html
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/LogDialogContent.html
@@ -21,7 +21,7 @@
 <wicket:panel>
   <div class="w_flex_container">
     <div class="w_flex_content scrolling">
-      <table class="col-sm-12 table table-sm">
+      <table class="col-sm-12 table table-sm small">
         <tbody>
           <wicket:container wicket:id="messageSets">
             <tr class="info" style="vertical-align: top;">

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommenderInfoPanel.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommenderInfoPanel.java
@@ -116,7 +116,7 @@ public class RecommenderInfoPanel
                         state.add(AttributeAppender.append("class", "badge-success"));
                     }
                     else {
-                        state.add(new Icon("state", FontAwesome5IconType.stop_circle_s));
+                        state.add(new Icon("icon", FontAwesome5IconType.stop_circle_s));
                         state.add(AttributeModifier.replace("title",
                                 evalRec.getDeactivationReason()));
                         state.add(AttributeModifier.append("style", "; cursor: help"));
@@ -124,7 +124,7 @@ public class RecommenderInfoPanel
                     }
                 }
                 else {
-                    state.add(new Icon("state", FontAwesome5IconType.hourglass_half_s));
+                    state.add(new Icon("icon", FontAwesome5IconType.hourglass_half_s));
                     state.add(AttributeAppender.append("class", "badge-light"));
                 }
                 item.add(state);

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/PredictionTask.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/PredictionTask.java
@@ -21,10 +21,12 @@
  */
 package de.tudarmstadt.ukp.inception.recommendation.tasks;
 
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,10 +57,9 @@ public class PredictionTask
     private final SourceDocument currentDocument;
     private final List<LogMessage> logMessages = new ArrayList<>();
 
-    public PredictionTask(User aUser, Project aProject, String aTrigger,
-            SourceDocument aCurrentDocument)
+    public PredictionTask(User aUser, String aTrigger, SourceDocument aCurrentDocument)
     {
-        super(aUser, aProject, aTrigger);
+        super(aUser, aCurrentDocument.getProject(), aTrigger);
         currentDocument = aCurrentDocument;
     }
 
@@ -76,9 +77,10 @@ public class PredictionTask
 
             // Limit prediction to a single document and inherit the rest?
             if (!recommendationService.isPredictForAllDocuments(username, project)) {
-                inherit = docs.stream().filter(d -> !d.equals(currentDocument))
-                        .collect(Collectors.toList());
-                docs = Collections.singletonList(currentDocument);
+                inherit = docs.stream() //
+                        .filter(d -> !d.equals(currentDocument)) //
+                        .collect(toList());
+                docs = singletonList(currentDocument);
                 log.debug("[{}][{}]: Limiting prediction to [{}]", getId(), username,
                         currentDocument.getName());
             }
@@ -97,6 +99,11 @@ public class PredictionTask
                     (System.currentTimeMillis() - startTime));
 
             recommendationService.putIncomingPredictions(user, project, predictions);
+
+            // We reset this in case the state was not properly cleared, e.g. the AL session
+            // was started but then the browser closed. Places where it is set include
+            // - ActiveLearningSideBar::moveToNextRecommendation
+            recommendationService.setPredictForAllDocuments(username, project, false);
         }
     }
 

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/TrainingTask.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/TrainingTask.java
@@ -270,7 +270,7 @@ public class TrainingTask
                 return;
             }
 
-            PredictionTask predictionTask = new PredictionTask(user, getProject(),
+            PredictionTask predictionTask = new PredictionTask(user,
                     String.format("TrainingTask %s complete", getId()), currentDocument);
             predictionTask.inheritLog(logMessages);
             schedulingService.enqueue(predictionTask);

--- a/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/SpanSuggestionVisibilityCalculationTests.java
+++ b/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/SpanSuggestionVisibilityCalculationTests.java
@@ -81,7 +81,7 @@ public class SpanSuggestionVisibilityCalculationTests
 
         layer = new AnnotationLayer();
         layer.setName(neName);
-        layer.setId(new Long(42));
+        layer.setId(42l);
         layerId = layer.getId();
 
         project = new Project();

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
@@ -547,7 +547,12 @@ public class AnnotationPage
         }
 
         // Update URL for current document
-        updateUrlFragment(aTarget);
+        try {
+            updateUrlFragment(aTarget);
+        }
+        catch (Exception e) {
+            LOG.warn("Unable to request URL fragment update anymore", e);
+        }
     }
 
     @Override

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
@@ -613,6 +613,9 @@ public abstract class AnnotationDetailEditorPanel
         editorPage.ensureIsEditable();
 
         AnnotatorState state = getModelObject();
+        if (!state.getSelection().isSet()) {
+            return;
+        }
 
         // Note that refresh changes the selected layer if a relation is created. Then the layer
         // switches from the selected span layer to the relation layer that is attached to the span

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/MatrixWorkloadManagementPage.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/MatrixWorkloadManagementPage.java
@@ -415,7 +415,7 @@ public class MatrixWorkloadManagementPage
                 ANNOTATOR);
 
         Map<String, User> annotatorIndex = new HashMap<>();
-        annotators.forEach(annotator -> annotatorIndex.put(annotator.getUsername(), annotator));
+        annotators.forEach(annotator -> annotatorIndex.put(annotator.getUiName(), annotator));
 
         Set<User> selectedUserObjects = new HashSet<>();
         selectedUsers.getObject()


### PR DESCRIPTION
**What's in the PR**
- Switch to new predictions when rendering is requested, not when rendering is performed
- This gives the AL sidebar the opportunity to change the viewport depending on the latest prediction information (which it couldn't do when rendering had already started)
- Add a flag to the request cycle indicating whether moving to a new suggestion should actually affect the viewport
- This flag helps disambiguating between actions triggered from the AL sidebar (do jump) vs. actions triggered via the main viewport (do not jump)

**How to test manually**
* Use active learning (also normal recommenders without active learning)

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
