### PR TITLE
#2317 - Error: Feature "webanno.custom.EntiteitenArg_misdaadLink:role" is not defined for type "webanno.custom.EntiteitenArg_activiteitLink"

### DIFF
--- a/inception/pom.xml
+++ b/inception/pom.xml
@@ -65,8 +65,8 @@
     <assertj.version>3.18.1</assertj.version>
 
     <dkpro.version>2.2.0</dkpro.version>
-    <uima.version>3.1.1</uima.version>
-    <uimafit.version>3.1.0</uimafit.version>
+    <uima.version>3.2.0</uima.version>
+    <uimafit.version>3.2.0</uimafit.version>
 
     <spring.version>5.3.3</spring.version>
     <spring.boot.version>2.4.2</spring.boot.version>


### PR DESCRIPTION
**What's in the PR**
- An upgrade to UIMA 3.2.0 seems to fix the issue. Note that the problematic file needs to be deleted and re-imported

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
