### PR TITLE
#2335 - Document states not properly updated when switching betweeen workload managers

### DIFF
--- a/inception/inception-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/ProjectService.java
+++ b/inception/inception-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/ProjectService.java
@@ -67,6 +67,8 @@ public interface ProjectService
     @PreAuthorize("hasAnyRole('ROLE_ADMIN','ROLE_USER', 'ROLE_REMOTE')")
     void createProjectPermission(ProjectPermission permission);
 
+    void removeProjectPermission(ProjectPermission projectPermission);
+
     /**
      * Check if a user have at least one {@link PermissionLevel } for this {@link Project}
      *
@@ -145,13 +147,9 @@ public interface ProjectService
     List<User> listProjectUsersWithPermissions(Project project, PermissionLevel permissionLevel);
 
     /**
-     * remove a user permission from the project
-     *
-     * @param projectPermission
-     *            The ProjectPermission to be removed
+     * Removes all permissions for the given user to the given proejct.
      */
-    @PreAuthorize("hasAnyRole('ROLE_ADMIN','ROLE_USER')")
-    void removeProjectPermission(ProjectPermission projectPermission);
+    void leaveProject(User aObject, Project aProject);
 
     /**
      * list Projects which contain with those annotation documents state is finished

--- a/inception/inception-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/event/ProjectPermissionsChangedEvent.java
+++ b/inception/inception-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/event/ProjectPermissionsChangedEvent.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.api.event;
+
+import static java.util.Collections.unmodifiableList;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.model.ProjectPermission;
+
+public class ProjectPermissionsChangedEvent
+    extends ProjectPermissionsEvent
+{
+    private static final long serialVersionUID = -5906708649928817973L;
+
+    private final List<ProjectPermission> added;
+    private final List<ProjectPermission> removed;
+
+    public ProjectPermissionsChangedEvent(Object aSource, Project aProject,
+            Collection<ProjectPermission> aAdded, Collection<ProjectPermission> aRemoved)
+    {
+        super(aSource, aProject);
+        added = unmodifiableList(new ArrayList<>(aAdded));
+        removed = unmodifiableList(new ArrayList<>(aRemoved));
+    }
+
+    public List<ProjectPermission> getAddedPermissions()
+    {
+        return added;
+    }
+
+    public List<ProjectPermission> getRemovedPermissions()
+    {
+        return removed;
+    }
+}

--- a/inception/inception-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/event/ProjectPermissionsEvent.java
+++ b/inception/inception-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/event/ProjectPermissionsEvent.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.api.event;
+
+import org.springframework.context.ApplicationEvent;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+
+public abstract class ProjectPermissionsEvent
+    extends ApplicationEvent
+{
+    private static final long serialVersionUID = 7855947621810920967L;
+
+    private final Project project;
+
+    public ProjectPermissionsEvent(Object aSource, Project aProject)
+    {
+        super(aSource);
+        project = aProject;
+    }
+
+    public Project getProject()
+    {
+        return project;
+    }
+}

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/ProjectPermissionsChangedEventAdapter.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/ProjectPermissionsChangedEventAdapter.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.log.adapter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.event.ProjectPermissionsChangedEvent;
+import de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel;
+import de.tudarmstadt.ukp.clarin.webanno.model.ProjectPermission;
+import de.tudarmstadt.ukp.clarin.webanno.support.JSONUtil;
+
+@Component
+public class ProjectPermissionsChangedEventAdapter
+    implements EventLoggingAdapter<ProjectPermissionsChangedEvent>
+{
+    @Override
+    public boolean accepts(Object aEvent)
+    {
+        return aEvent instanceof ProjectPermissionsChangedEvent;
+    }
+
+    @Override
+    public long getProject(ProjectPermissionsChangedEvent aEvent)
+    {
+        return aEvent.getProject().getId();
+    }
+
+    @Override
+    public String getDetails(ProjectPermissionsChangedEvent aEvent) throws IOException
+    {
+        Map<String, PermissionChanges> permissionChangesByUser = new LinkedHashMap<>();
+
+        for (ProjectPermission p : aEvent.getAddedPermissions()) {
+            PermissionChanges changes = permissionChangesByUser.computeIfAbsent(p.getUser(),
+                    _key -> new PermissionChanges());
+            changes.granted.add(p.getLevel());
+        }
+
+        for (ProjectPermission p : aEvent.getRemovedPermissions()) {
+            PermissionChanges changes = permissionChangesByUser.computeIfAbsent(p.getUser(),
+                    _key -> new PermissionChanges());
+            changes.revoked.add(p.getLevel());
+        }
+
+        return JSONUtil.toJsonString(permissionChangesByUser);
+    }
+
+    public static class PermissionChanges
+    {
+        public List<PermissionLevel> granted = new ArrayList<>();
+        public List<PermissionLevel> revoked = new ArrayList<>();
+    }
+}

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/projectlist/ProjectsOverviewPage.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/projectlist/ProjectsOverviewPage.java
@@ -351,8 +351,7 @@ public class ProjectsOverviewPage
     private void actionConfirmLeaveProject(AjaxRequestTarget aTarget, Project aProject)
     {
         confirmLeaveDialog.setConfirmAction((_target) -> {
-            projectService.listProjectPermissionLevel(currentUser.getObject(), aProject).stream()
-                    .forEach(projectService::removeProjectPermission);
+            projectService.leaveProject(currentUser.getObject(), aProject);
             _target.add(projectListContainer);
             _target.addChildren(getPage(), IFeedback.class);
             success("You are no longer a member of project [" + aProject.getName() + "]");

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/UserPermissionsPanel.html
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/UserPermissionsPanel.html
@@ -27,12 +27,16 @@
               <wicket:message key="permissions.for"/> "<wicket:container wicket:id="username"/>"
             </div>
             <button wicket:id="save" class="btn btn-primary">
-              <i class="fas fa-save"></i>&nbsp;
-              <wicket:message key="save"/>
+              <i class="fas fa-save"></i>
+              <span class="d-none d-lg-inline">
+                &nbsp;<wicket:message key="save"/>
+              </span>
             </button>
             <button wicket:id="cancel" class="btn btn-secondary">
-              <i class="fas fa-times"></i>&nbsp;
-              <wicket:message key="cancel"/>
+              <i class="fas fa-times"></i>
+              <span class="d-none d-lg-inline">
+                &nbsp;<wicket:message key="cancel"/>
+              </span>
             </button>
           </div>
         </div>

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/UserSelectionPanel.html
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/UserSelectionPanel.html
@@ -27,8 +27,10 @@
           </label>
           <select class="flex-content" wicket:id="usersToAdd"></select>
           <button wicket:id="add" class="btn btn-primary">
-            <i class="fas fa-plus-square"></i>&nbsp;
-            <wicket:message key="add"/>
+            <i class="fas fa-plus-square"></i>
+            <span class="d-none d-lg-inline">
+              &nbsp;<wicket:message key="add"/>
+            </span>
           </button>
         </div>
       </form>

--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/management/DynamicWorkloadManagementPage.html
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/management/DynamicWorkloadManagementPage.html
@@ -66,8 +66,10 @@ $( document ).ready(function() {
               <button
                 class="btn btn-action btn-secondary dropdown-toggle flex-content"
                 type="button" data-toggle="dropdown">
-                <i class="fas fa-filter"></i>&nbsp;
-                <wicket:message key="Filter" />
+                <i class="fas fa-filter"></i>
+                <span class="d-none d-lg-inline">
+                  &nbsp;<wicket:message key="Filter" />
+                </span>
               </button> 
               <form wicket:id="searchForm" class="dropdown-menu shadow-lg pt-0 pb-0 ddFilterForm" role="menu"
                 style="min-width: 600px;">
@@ -131,8 +133,10 @@ $( document ).ready(function() {
               <button
                 class="btn btn-action btn-secondary dropdown-toggle flex-content dd-annotator"
                 type="button" data-toggle="dropdown">
-                <i class="fas fa-user"></i>&nbsp;
-                <wicket:message key="Annotators" />
+                <i class="fas fa-user"></i>
+                <span class="d-none d-lg-inline">
+                  &nbsp;<wicket:message key="Annotators" />
+                </span>
               </button>
               <form wicket:id="userForm" class="dropdown-menu shadow-lg pt-0 pb-0 ddUserForm" role="menu"
                 style="width: 800px; height: 385px;">
@@ -195,8 +199,10 @@ $( document ).ready(function() {
             <span class="dropdown sticky-dropdown" aria-haspopup="true" aria-expanded="false">
               <button class="btn btn-action btn-secondary dropdown-toggle flex-content"
                 type="button" data-toggle="dropdown">
-                <i class="fas fa-cog"></i>&nbsp;
-                <wicket:message key="settings" />
+                <i class="fas fa-cog"></i>
+                <span class="d-none d-lg-inline">
+                  &nbsp;<wicket:message key="settings" />
+                </span>
               </button>
               <div class="dropdown-menu shadow-lg pt-0 pb-0" role="menu"
                 style="min-width: 600px;">
@@ -268,8 +274,10 @@ $( document ).ready(function() {
               </div>
             </span>
             <button wicket:id="refresh" class="btn btn-action btn-secondary">
-              <i class="fas fa-redo"></i>&nbsp;
-              <wicket:message key="refresh" />
+              <i class="fas fa-redo"></i>
+              <span class="d-none d-lg-inline">
+                &nbsp;<wicket:message key="refresh" />
+              </span>
             </button>
           </div>
           <div class="flex-content flex-h-container flex-gutter flex-only-internal-gutter">

--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/management/DynamicWorkloadManagementPage.java
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/management/DynamicWorkloadManagementPage.java
@@ -198,6 +198,7 @@ public class DynamicWorkloadManagementPage
     private @SpringBean WorkloadManagementService workloadManagementService;
     private @SpringBean DynamicWorkloadExtension dynamicWorkloadExtension;
     private @SpringBean WorkflowExtensionPoint workflowExtensionPoint;
+    private @SpringBean DynamicWorkloadManagementPageMenuItem pageMenuItem;
 
     public DynamicWorkloadManagementPage(final PageParameters aPageParameters)
     {
@@ -205,7 +206,14 @@ public class DynamicWorkloadManagementPage
 
         requireProjectRole(userRepository.getCurrentUser(), CURATOR, MANAGER);
 
-        currentProject.setObject(getProject());
+        Project project = getProject();
+
+        if (!pageMenuItem.applies(project)) {
+            getSession().error("The project is not configured for dynamic workload management");
+            backToProjectPage();
+        }
+
+        currentProject.setObject(project);
 
         commonInit();
     }

--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/management/support/AnnotationStateList.java
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/management/support/AnnotationStateList.java
@@ -69,8 +69,11 @@ public class AnnotationStateList
                         .map(AnnotationDocumentState::symbol) //
                         .orElse(NEW.symbol());
                 Label stateLabel = new Label("stateSymbol");
-                Duration idleTime = between(row.getTimestamp().toInstant(), now());
-                if (!aAbandonationTimeout.isZero() && !aAbandonationTimeout.isNegative()
+                Duration idleTime = row.getTimestamp() != null
+                        ? between(row.getTimestamp().toInstant(), now())
+                        : null;
+                if (idleTime != null && !aAbandonationTimeout.isZero()
+                        && !aAbandonationTimeout.isNegative()
                         && idleTime.compareTo(aAbandonationTimeout) > 0) {
                     labelModel = labelModel
                             .map(_label -> "<i class=\"fas fa-user-clock\"></i> " + _label);

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/MatrixWorkloadExtensionImpl.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/MatrixWorkloadExtensionImpl.java
@@ -86,6 +86,7 @@ public class MatrixWorkloadExtensionImpl
     }
 
     @Override
+    @Transactional
     public MatrixWorkloadTrait readTraits(WorkloadManager aWorkloadManager)
     {
         MatrixWorkloadTrait traits = null;
@@ -106,6 +107,7 @@ public class MatrixWorkloadExtensionImpl
     }
 
     @Override
+    @Transactional
     public void writeTraits(MatrixWorkloadTrait aTrait, Project aProject)
     {
         try {
@@ -117,6 +119,24 @@ public class MatrixWorkloadExtensionImpl
         catch (Exception e) {
             this.log.error("Unable to write traits", e);
         }
+    }
+
+    @Override
+    @Transactional
+    public ProjectState recalculate(Project aProject)
+    {
+        int annotatorCount = projectService.listProjectUsersWithPermissions(aProject).size();
+
+        for (SourceDocument doc : documentService.listSourceDocuments(aProject)) {
+            updateDocumentState(doc, annotatorCount);
+        }
+
+        // Refresh the project stats and recalculate them
+        Project project = projectService.getProject(aProject.getId());
+        SourceDocumentStateStats stats = documentService.getSourceDocumentStats(project);
+        projectService.setProjectState(aProject, stats.getProjectState());
+
+        return project.getState();
     }
 
     @Override

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/event/MatrixWorkloadStateWatcher.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/event/MatrixWorkloadStateWatcher.java
@@ -20,8 +20,9 @@ package de.tudarmstadt.ukp.inception.workload.matrix.event;
 import org.springframework.context.event.EventListener;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.event.AnnotationStateChangeEvent;
-import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
+import de.tudarmstadt.ukp.clarin.webanno.api.event.ProjectPermissionsChangedEvent;
 import de.tudarmstadt.ukp.inception.scheduling.SchedulingService;
+import de.tudarmstadt.ukp.inception.workload.event.RecalculateProjectStateTask;
 import de.tudarmstadt.ukp.inception.workload.matrix.config.MatrixWorkloadManagerAutoConfiguration;
 
 /**
@@ -41,14 +42,16 @@ public class MatrixWorkloadStateWatcher
     }
 
     @EventListener
-    public void onAnnotationStateChangeEvent(AnnotationStateChangeEvent aEvent)
+    public void onProjectPermissionsChangedEvent(ProjectPermissionsChangedEvent aEvent)
     {
-        recalculateDocumentState(aEvent.getAnnotationDocument());
+        schedulingService.enqueue(new RecalculateProjectStateTask(aEvent.getProject(),
+                "onProjectPermissionsChangedEvent"));
     }
 
-    private void recalculateDocumentState(AnnotationDocument aAnnotationDocument)
+    @EventListener
+    public void onAnnotationStateChangeEvent(AnnotationStateChangeEvent aEvent)
     {
-        schedulingService.enqueue(new MatrixWorkloadUpdateDocumentStateTask(
-                aAnnotationDocument.getDocument(), getClass().getSimpleName()));
+        schedulingService.enqueue(new MatrixWorkloadUpdateDocumentStateTask(aEvent.getDocument(),
+                getClass().getSimpleName()));
     }
 }

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/MatrixWorkloadManagementPage.html
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/MatrixWorkloadManagementPage.html
@@ -44,6 +44,12 @@
               <wicket:message key="document_status" />
               <a wicket:id="documentStatusHelpLink"/>
               <div wicket:id="actionContainer" class="actions">
+                <button wicket:id="refresh" class="btn btn-action btn-secondary">
+                  <i class="fas fa-redo"></i>
+                  <span class="d-none d-lg-inline">
+                    &nbsp;<wicket:message key="refresh" />
+                  </span>
+                </button>
                 <span class="dropdown" aria-haspopup="true" aria-expanded="false">
                   <span class="btn-group" role="group">
                     <button class="btn btn-secondary btn-action" type="button">

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/MatrixWorkloadManagementPage.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/MatrixWorkloadManagementPage.java
@@ -117,6 +117,7 @@ public class MatrixWorkloadManagementPage
     private @SpringBean ProjectService projectService;
     private @SpringBean UserDao userRepository;
     private @SpringBean CurationDocumentService curationService;
+    private @SpringBean MatrixWorkloadManagementPageMenuItem pageMenuItem;
 
     private DataTable<DocumentMatrixRow, DocumentMatrixSortKey> documentMatrix;
     private LambdaAjaxLink toggleBulkChange;
@@ -144,6 +145,11 @@ public class MatrixWorkloadManagementPage
         Project project = getProject();
 
         requireProjectRole(user, CURATOR, MANAGER);
+
+        if (!pageMenuItem.applies(project)) {
+            getSession().error("The project is not configured for static workload management");
+            backToProjectPage();
+        }
 
         add(new Label("name", project.getName()));
 

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/MatrixWorkloadManagementPage.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/MatrixWorkloadManagementPage.java
@@ -161,6 +161,8 @@ public class MatrixWorkloadManagementPage
         actionContainer.setOutputMarkupPlaceholderTag(true);
         add(actionContainer);
 
+        actionContainer.add(new LambdaAjaxLink("refresh", this::actionRefresh));
+
         bulkActionDropdown = new WebMarkupContainer("bulkActionDropdown");
         bulkActionDropdown.add(LambdaBehavior.visibleWhen(() -> bulkChangeMode));
         actionContainer.add(bulkActionDropdown);
@@ -225,14 +227,7 @@ public class MatrixWorkloadManagementPage
     private void actionToggleBulkChange(AjaxRequestTarget aTarget)
     {
         bulkChangeMode = !bulkChangeMode;
-        selectedUsers.getObject().clear();
-
-        DataTable<DocumentMatrixRow, DocumentMatrixSortKey> newMatrix = createDocumentMatrix(
-                "documentMatrix", bulkChangeMode);
-        documentMatrix.replaceWith(newMatrix);
-        documentMatrix = newMatrix;
-
-        aTarget.add(documentMatrix, toggleBulkChange, actionContainer);
+        actionRefresh(aTarget);
     }
 
     private void actionBulkResetDocument(AjaxRequestTarget aTarget)
@@ -413,6 +408,18 @@ public class MatrixWorkloadManagementPage
 
         reloadMatrixData();
         aTarget.add(documentMatrix);
+    }
+
+    private void actionRefresh(AjaxRequestTarget aTarget)
+    {
+        selectedUsers.getObject().clear();
+
+        DataTable<DocumentMatrixRow, DocumentMatrixSortKey> newMatrix = createDocumentMatrix(
+                "documentMatrix", bulkChangeMode);
+        documentMatrix.replaceWith(newMatrix);
+        documentMatrix = newMatrix;
+
+        aTarget.add(documentMatrix, toggleBulkChange, actionContainer);
     }
 
     private Collection<AnnotationDocument> selectedAnnotationDocuments()

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/MatrixWorkloadManagementPage.properties
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/MatrixWorkloadManagementPage.properties
@@ -16,6 +16,8 @@
 page.title=Monitoring
 page.help.link=sect_matrix_workload
 
+refresh=Refresh
+
 INPROGRESS=in progress
 NEW=new
 FINISHED=finished

--- a/inception/inception-workload/pom.xml
+++ b/inception/inception-workload/pom.xml
@@ -37,6 +37,10 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-scheduling</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-model</artifactId>
     </dependency>
     

--- a/inception/inception-workload/pom.xml
+++ b/inception/inception-workload/pom.xml
@@ -33,6 +33,10 @@
   
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-support</artifactId>
     </dependency>
     <dependency>

--- a/inception/inception-workload/src/main/java/de/tudarmstadt/ukp/inception/workload/config/WorkloadManagementAutoConfiguration.java
+++ b/inception/inception-workload/src/main/java/de/tudarmstadt/ukp/inception/workload/config/WorkloadManagementAutoConfiguration.java
@@ -26,6 +26,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 
+import de.tudarmstadt.ukp.inception.scheduling.SchedulingService;
 import de.tudarmstadt.ukp.inception.workload.extension.WorkloadManagerExtension;
 import de.tudarmstadt.ukp.inception.workload.extension.WorkloadManagerExtensionPoint;
 import de.tudarmstadt.ukp.inception.workload.extension.WorkloadManagerExtensionPointImpl;
@@ -45,9 +46,11 @@ public class WorkloadManagementAutoConfiguration<T>
 
     @Bean
     public WorkloadManagementService workloadManagementService(EntityManager aEntityManager,
-            WorkloadManagerExtensionPoint aWorkloadManagerExtensionPoint)
+            WorkloadManagerExtensionPoint aWorkloadManagerExtensionPoint,
+            SchedulingService aSchedulingService)
     {
-        return new WorkloadManagementServiceImpl(aEntityManager, aWorkloadManagerExtensionPoint);
+        return new WorkloadManagementServiceImpl(aEntityManager, aWorkloadManagerExtensionPoint,
+                aSchedulingService);
     }
 
     @Bean

--- a/inception/inception-workload/src/main/java/de/tudarmstadt/ukp/inception/workload/extension/WorkloadManagerExtension.java
+++ b/inception/inception-workload/src/main/java/de/tudarmstadt/ukp/inception/workload/extension/WorkloadManagerExtension.java
@@ -42,6 +42,13 @@ public interface WorkloadManagerExtension<T>
     void writeTraits(T aTrait, Project aProject);
 
     /**
+     * Ask the workload manager to immediately recalculate the state of all documents in the project
+     * and of the project itself. This is necessary when switching from one workload manager to
+     * another.
+     */
+    ProjectState recalculate(Project aProject);
+
+    /**
      * Ask the workload manager to immediately refresh the state of the documents and overall
      * project. This can be called immediately before fetching the project status in order to ensure
      * that the project status is reliable.

--- a/inception/inception-workload/src/main/java/de/tudarmstadt/ukp/inception/workload/model/WorkloadManagementServiceImpl.java
+++ b/inception/inception-workload/src/main/java/de/tudarmstadt/ukp/inception/workload/model/WorkloadManagementServiceImpl.java
@@ -34,7 +34,9 @@ import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.inception.scheduling.SchedulingService;
 import de.tudarmstadt.ukp.inception.workload.config.WorkloadManagementAutoConfiguration;
+import de.tudarmstadt.ukp.inception.workload.event.RecalculateProjectStateTask;
 import de.tudarmstadt.ukp.inception.workload.extension.WorkloadManagerExtension;
 import de.tudarmstadt.ukp.inception.workload.extension.WorkloadManagerExtensionPoint;
 
@@ -53,13 +55,16 @@ public class WorkloadManagementServiceImpl
 
     private final EntityManager entityManager;
     private final WorkloadManagerExtensionPoint workloadManagerExtensionPoint;
+    private final SchedulingService schedulingService;
 
     @Autowired
     public WorkloadManagementServiceImpl(EntityManager aEntityManager,
-            WorkloadManagerExtensionPoint aWorkloadManagerExtensionPoint)
+            WorkloadManagerExtensionPoint aWorkloadManagerExtensionPoint,
+            SchedulingService aSchedulingService)
     {
         entityManager = aEntityManager;
         workloadManagerExtensionPoint = aWorkloadManagerExtensionPoint;
+        schedulingService = aSchedulingService;
     }
 
     /**
@@ -121,8 +126,8 @@ public class WorkloadManagementServiceImpl
                 .setParameter("projectID", aManager.getProject()) //
                 .executeUpdate();
 
-        WorkloadManagerExtension<?> ext = getWorkloadManagerExtension(aManager.getProject());
-        ext.recalculate(aManager.getProject());
+        schedulingService.enqueue(new RecalculateProjectStateTask(aManager.getProject(),
+                "Workload configuration changed"));
     }
 
     /**

--- a/inception/inception-workload/src/main/java/de/tudarmstadt/ukp/inception/workload/model/WorkloadManagementServiceImpl.java
+++ b/inception/inception-workload/src/main/java/de/tudarmstadt/ukp/inception/workload/model/WorkloadManagementServiceImpl.java
@@ -120,6 +120,9 @@ public class WorkloadManagementServiceImpl
                 .setParameter("traits", aManager.getTraits()) //
                 .setParameter("projectID", aManager.getProject()) //
                 .executeUpdate();
+
+        WorkloadManagerExtension<?> ext = getWorkloadManagerExtension(aManager.getProject());
+        ext.recalculate(aManager.getProject());
     }
 
     /**

--- a/inception/pom.xml
+++ b/inception/pom.xml
@@ -1606,11 +1606,6 @@
         <artifactId>kinetic</artifactId>
         <version>5.2.0</version>
       </dependency>
-      <dependency>
-        <groupId>org.webjars.bower</groupId>
-        <artifactId>jquery.scrollTo</artifactId>
-        <version>2.1.2</version>
-      </dependency>
 
       <dependency>
         <groupId>org.mariadb.jdbc</groupId>


### PR DESCRIPTION
**What's in the PR**
- After switching the workload manager (or rather after pressing save on the workload manager settings panel) recalculate the document state for the entire project

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
