### PR TITLE
#2347 - Allow setting command to open browser

### DIFF
--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/settings_general.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/settings_general.adoc
@@ -43,5 +43,10 @@
 | Whether the list of users show in the users tab of the project settings is restricted. If this setting is enable, the full name of a user has to be entered into the input field before the user can be added. If this setting is disabled, it is possible to see all enabled users and to add any of them to the project.
 | false
 | true
+
+| commands.open-browser
+| Execute this command instead of the operating-systems's default command to open the browser window when running in standalone mode. `%u` is replaced with the INCEpTION URL.
+| _unset_
+| `/usr/bin/open %u -a "/Applications/Google Chrome.app"`
 |===
 

--- a/inception/inception-support-standalone/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/standalone/StandaloneShutdownDialogManager.java
+++ b/inception/inception-support-standalone/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/standalone/StandaloneShutdownDialogManager.java
@@ -38,7 +38,6 @@ import java.awt.PopupMenu;
 import java.awt.SystemTray;
 import java.awt.TrayIcon;
 import java.net.URI;
-import java.util.concurrent.TimeUnit;
 
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
@@ -253,11 +252,10 @@ public class StandaloneShutdownDialogManager
                     }
                 }
 
-                Process proc = new ProcessBuilder(cmdTokens) //
+                new ProcessBuilder(cmdTokens) //
                         .redirectOutput(INHERIT) //
                         .redirectError(INHERIT) //
                         .start();
-                proc.waitFor(5, TimeUnit.SECONDS);
 
                 return;
             }


### PR DESCRIPTION
**What's in the PR**
- Added `commands.open-browser` setting.

**How to test manually**
* Set a custom command and start the standalone version

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
