### PR TITLE
#2349 - String matching recommender not working with Windows linebreaks

### DIFF
--- a/inception/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/span/trie/Trie.java
+++ b/inception/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/span/trie/Trie.java
@@ -193,7 +193,7 @@ public class Trie<V>
             last = cur;
         }
 
-        return match != null ? new MatchedNode(match, i) : null;
+        return match != null ? new MatchedNode(match, i - offset) : null;
     }
 
     /**
@@ -265,7 +265,7 @@ public class Trie<V>
         }
 
         if (match != null && acceptedKeyChars == match.level) {
-            return new MatchedNode(match, i);
+            return new MatchedNode(match, i - offset);
         }
 
         return null;

--- a/inception/inception-imls-stringmatch/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/span/trie/TrieTest.java
+++ b/inception/inception-imls-stringmatch/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/span/trie/TrieTest.java
@@ -26,8 +26,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.span.StringMatchingRecommender.DictEntry;
-import de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.span.trie.Trie;
-import de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.span.trie.WhitespaceNormalizingSanitizer;
 
 public class TrieTest
 {
@@ -72,11 +70,15 @@ public class TrieTest
     {
         sut = new Trie<DictEntry>(WhitespaceNormalizingSanitizer.factory());
 
-        sut.put("  this is\ta test  .", new DictEntry("exists"));
+        sut.put("  this is\ta test\n  .", new DictEntry("exists"));
 
         System.out.println(sut.keys());
 
         assertThat(sut.getNode("this is a test .")).isNotNull();
+        assertThat(sut.getNode("this is a test .").node.level).isEqualTo(16);
+        assertThat(sut.getNode("this is a test .").matchLength).isEqualTo(16);
         assertThat(sut.getNode("  this is\ta test  .")).isNotNull();
+        assertThat(sut.getNode("  this is\ta test  .").node.level).isEqualTo(16);
+        assertThat(sut.getNode("  this is\ta test  .").matchLength).isEqualTo(19);
     }
 }

--- a/inception/inception-support-standalone/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/standalone/StandaloneShutdownDialogManager.java
+++ b/inception/inception-support-standalone/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/standalone/StandaloneShutdownDialogManager.java
@@ -82,7 +82,7 @@ public class StandaloneShutdownDialogManager
     @Value("${spring.application.name}")
     private String applicationName;
 
-    @Value("${commands.open-browser}")
+    @Value("${commands.open-browser:}")
     private String openBrowserCommand;
 
     private int port = -1;


### PR DESCRIPTION
**What's in the PR**
- When matching against the trie, we need to obtain the match length and not the key length to check if the match has the expected length

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
