### PR TITLE
#2358 - Unrecognized fields when switching recommender type

### DIFF
--- a/inception/inception-imls-dl4j/pom.xml
+++ b/inception/inception-imls-dl4j/pom.xml
@@ -96,6 +96,11 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+
     <!-- LOGGING DEPENDENCIES - SLF4J -->
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/inception/inception-imls-dl4j/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommenderTraits.java
+++ b/inception/inception-imls-dl4j/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/dl4j/pos/DL4JSequenceRecommenderTraits.java
@@ -28,6 +28,9 @@ import org.deeplearning4j.nn.weights.WeightInit;
 import org.nd4j.linalg.activations.Activation;
 import org.nd4j.linalg.lossfunctions.LossFunctions.LossFunction;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class DL4JSequenceRecommenderTraits
 {
     // General parameters

--- a/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderTraits.java
+++ b/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/ExternalRecommenderTraits.java
@@ -19,6 +19,9 @@ package de.tudarmstadt.ukp.inception.recommendation.imls.external;
 
 import java.io.Serializable;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ExternalRecommenderTraits
     implements Serializable
 {

--- a/inception/inception-imls-lapps/pom.xml
+++ b/inception/inception-imls-lapps/pom.xml
@@ -130,6 +130,10 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
 
     <!-- LOGGING DEPENDENCIES - SLF4J -->
     <dependency>

--- a/inception/inception-imls-lapps/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/lapps/LappsGridRecommenderFactory.java
+++ b/inception/inception-imls-lapps/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/lapps/LappsGridRecommenderFactory.java
@@ -25,6 +25,8 @@ import static de.tudarmstadt.ukp.inception.recommendation.imls.lapps.traits.Lapp
 
 import org.apache.wicket.model.IModel;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
@@ -42,6 +44,7 @@ import de.tudarmstadt.ukp.inception.recommendation.imls.lapps.traits.LappsGridRe
  * {@link LappsGridRecommenderAutoConfiguration#lappsGridRecommenderFactory()}.
  * </p>
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class LappsGridRecommenderFactory
     extends RecommendationEngineFactoryImplBase<LappsGridRecommenderTraits>
 {

--- a/inception/inception-imls-lapps/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/lapps/traits/LappsGridRecommenderTraits.java
+++ b/inception/inception-imls-lapps/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/lapps/traits/LappsGridRecommenderTraits.java
@@ -19,6 +19,9 @@ package de.tudarmstadt.ukp.inception.recommendation.imls.lapps.traits;
 
 import java.io.Serializable;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class LappsGridRecommenderTraits
     implements Serializable
 {

--- a/inception/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/doccat/OpenNlpDoccatRecommenderTraits.java
+++ b/inception/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/doccat/OpenNlpDoccatRecommenderTraits.java
@@ -19,9 +19,12 @@ package de.tudarmstadt.ukp.inception.recommendation.imls.opennlp.doccat;
 
 import java.io.Serializable;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import opennlp.tools.ml.AbstractTrainer;
 import opennlp.tools.util.TrainingParameters;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class OpenNlpDoccatRecommenderTraits
     implements Serializable
 {

--- a/inception/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/ner/OpenNlpNerRecommenderTraits.java
+++ b/inception/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/ner/OpenNlpNerRecommenderTraits.java
@@ -20,10 +20,12 @@ package de.tudarmstadt.ukp.inception.recommendation.imls.opennlp.ner;
 import java.io.Serializable;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import opennlp.tools.ml.AbstractTrainer;
 import opennlp.tools.util.TrainingParameters;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class OpenNlpNerRecommenderTraits
     implements Serializable
 {

--- a/inception/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/pos/OpenNlpPosRecommenderTraits.java
+++ b/inception/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/pos/OpenNlpPosRecommenderTraits.java
@@ -20,10 +20,12 @@ package de.tudarmstadt.ukp.inception.recommendation.imls.opennlp.pos;
 import java.io.Serializable;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import opennlp.tools.ml.AbstractTrainer;
 import opennlp.tools.util.TrainingParameters;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class OpenNlpPosRecommenderTraits
     implements Serializable
 {

--- a/inception/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/StringMatchingRecommenderTraits.java
+++ b/inception/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/StringMatchingRecommenderTraits.java
@@ -19,11 +19,13 @@ package de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch;
 
 import java.io.Serializable;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
 //The @JsonSerialize annotation avoid the "InvalidDefinitionException: No serializer found"
 //exception without having to set SerializationFeature.FAIL_ON_EMPTY_BEANS
 @JsonSerialize
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class StringMatchingRecommenderTraits
     implements Serializable
 {

--- a/inception/inception-imls-weblicht/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/weblicht/traits/WeblichtRecommenderTraits.java
+++ b/inception/inception-imls-weblicht/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/weblicht/traits/WeblichtRecommenderTraits.java
@@ -20,6 +20,9 @@ package de.tudarmstadt.ukp.inception.recommendation.imls.weblicht.traits;
 import java.io.Serializable;
 import java.util.Date;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class WeblichtRecommenderTraits
     implements Serializable
 {


### PR DESCRIPTION
**What's in the PR**
We now ignore unknown fields in recommender traits to not fail when switching recommender types and then reusing old traits with potentially unknown fields in them.

**How to test manually**
* Change from a saved string matcher to a remote one and see whether you get the error

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
