### PR TITLE
Bugfix/2369 document metadata editable for finished documents

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/LinkFeatureEditor.html
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/LinkFeatureEditor.html
@@ -27,7 +27,7 @@
     </div>
     <div class="card">
       <div wicket:id="content">
-        <div class="card-body">
+        <div class="card-body" wicket:enclosure="slots">
           <div wicket:id="slots">
             <div class="form-group form-row">
               <label class="feature-editor-label col-form-label">

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/LinkFeatureEditor.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/LinkFeatureEditor.java
@@ -143,10 +143,20 @@ public class LinkFeatureEditor
         content.setOutputMarkupId(true);
         add(content);
 
-        content.add(new RefreshingView<LinkWithRoleModel>("slots",
-                PropertyModel.of(getModel(), "value"))
+        IModel<List<LinkWithRoleModel>> slotsModel = getModel() //
+                .map(FeatureState::getValue) //
+                .map(v -> (List<LinkWithRoleModel>) v);
+        content.add(new RefreshingView<LinkWithRoleModel>("slots", slotsModel)
         {
             private static final long serialVersionUID = 5475284956525780698L;
+
+            @Override
+            public void onConfigure()
+            {
+                super.onConfigure();
+                setOutputMarkupPlaceholderTag(true);
+                setVisible(!slotsModel.map(List::isEmpty).orElse(true).getObject());
+            }
 
             @Override
             protected Iterator<IModel<LinkWithRoleModel>> getItemModels()

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/page/AnnotationPageBase.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/page/AnnotationPageBase.java
@@ -408,22 +408,13 @@ public abstract class AnnotationPageBase
 
     public boolean isEditable()
     {
-        AnnotatorState state = getModelObject();
-
-        if (state.getDocument() == null) {
+        try {
+            ensureIsEditable();
+            return true;
+        }
+        catch (NotEditableException e) {
             return false;
         }
-        // If curating (check mode for curation page and user for curation sidebar),
-        // then it is editable unless the curation is finished
-        if (state.getMode().equals(CURATION)
-                || state.getUser().getUsername().equals(CURATION_USER)) {
-            return !CURATION_FINISHED.equals(state.getDocument().getState());
-        }
-
-        // If annotating normally, then it is editable unless marked as finished and unless
-        // viewing another users annotations
-        return !getModelObject().isUserViewingOthersWork(userRepository.getCurrentUsername())
-                && !isAnnotationFinished();
     }
 
     public boolean isAnnotationFinished()

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationDetailPanel.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationDetailPanel.java
@@ -19,6 +19,7 @@ package de.tudarmstadt.ukp.inception.ui.core.docanno.sidebar;
 
 import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.selectAnnotationByAddr;
 import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.selectFsByAddr;
+import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
 import static java.util.Collections.emptyList;
 
 import java.io.IOException;
@@ -68,7 +69,6 @@ import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.Tag;
 import de.tudarmstadt.ukp.clarin.webanno.support.DescriptionTooltipBehavior;
-import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.AnnotationPage;
 
 public class DocumentMetadataAnnotationDetailPanel
@@ -93,14 +93,12 @@ public class DocumentMetadataAnnotationDetailPanel
     private final IModel<SourceDocument> sourceDocument;
     private final IModel<String> username;
     private final ListView<FeatureState> featureList;
-    private final DocumentMetadataAnnotationSelectionPanel selectionPanel;
     private final AnnotationActionHandler actionHandler;
     private final AnnotatorState state;
 
     public DocumentMetadataAnnotationDetailPanel(String aId, IModel<VID> aModel,
             IModel<SourceDocument> aDocument, IModel<String> aUsername, CasProvider aCasProvider,
             IModel<Project> aProject, AnnotationPage aAnnotationPage,
-            DocumentMetadataAnnotationSelectionPanel aSelectionPanel,
             AnnotationActionHandler aActionHandler, AnnotatorState aState)
     {
         super(aId, aModel);
@@ -112,13 +110,19 @@ public class DocumentMetadataAnnotationDetailPanel
         annotationPage = aAnnotationPage;
         jcasProvider = aCasProvider;
         project = aProject;
-        selectionPanel = aSelectionPanel;
         actionHandler = aActionHandler;
         state = aState;
 
         add(featureList = createFeaturesList());
+    }
 
-        add(LambdaBehavior.visibleWhen(this::isVisible));
+    @Override
+    protected void onConfigure()
+    {
+        super.onConfigure();
+
+        add(visibleWhen(this::isVisible));
+        setEnabled(annotationPage.isEditable());
     }
 
     public VID getModelObject()
@@ -150,7 +154,7 @@ public class DocumentMetadataAnnotationDetailPanel
                         DocumentMetadataAnnotationDetailPanel.this, actionHandler,
                         annotationPage.getModel(), item.getModel());
 
-                if (!featureState.feature.getLayer().isReadonly() && annotationPage.isEditable()) {
+                if (!featureState.feature.getLayer().isReadonly()) {
                     // Whenever it is updating an annotation, it updates automatically when a
                     // component for the feature lost focus - but updating is for every component
                     // edited LinkFeatureEditors must be excluded because the auto-update will break

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationDetailPanel.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationDetailPanel.java
@@ -150,7 +150,7 @@ public class DocumentMetadataAnnotationDetailPanel
                         DocumentMetadataAnnotationDetailPanel.this, actionHandler,
                         annotationPage.getModel(), item.getModel());
 
-                if (!featureState.feature.getLayer().isReadonly()) {
+                if (!featureState.feature.getLayer().isReadonly() && annotationPage.isEditable()) {
                     // Whenever it is updating an annotation, it updates automatically when a
                     // component for the feature lost focus - but updating is for every component
                     // edited LinkFeatureEditors must be excluded because the auto-update will break
@@ -255,6 +255,8 @@ public class DocumentMetadataAnnotationDetailPanel
     private void actionAnnotate(AjaxRequestTarget aTarget)
     {
         try {
+            annotationPage.ensureIsEditable();
+
             // When updating an annotation in the sidebar, we must not force a
             // re-focus after rendering
             getRequestCycle().setMetaData(IsSidebarAction.INSTANCE, true);

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationSelectionPanel.html
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationSelectionPanel.html
@@ -54,12 +54,12 @@
                   <i class="fas fa-ellipsis-v"></i>
                 </button>
                 <div class="dropdown-menu shadow-lg" role="menu">
-                  <div class="container">
-                    <button wicket:id="delete" class="btn btn-sm btn-danger col-sm-12">
-                      <i class="fas fa-trash"></i>&nbsp;
-                      <wicket:message key="delete"/>
-                    </button>
-                  </div>
+                  <a wicket:id="delete" class="dropdown-item">
+                    <wicket:message key="delete"/>
+                    <span class="float-right badge badge-pill badge-danger">
+                      <i class="fas fa-trash"></i>
+                    </span>
+                  </a>
                 </div>
               </span>
             </div>

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationSelectionPanel.html
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationSelectionPanel.html
@@ -23,7 +23,7 @@
   </div>
   <div wicket:id="content">
     <div class="card-body flex-grow-0 pb-0">
-      <div class="form-group">
+      <div class="form-group mb-0">
         <div class="input-group">
           <select class="form-control flex-content" wicket:id="layer" data-size="10"></select>
           <div class="input-group-append">

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationSelectionPanel.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationSelectionPanel.java
@@ -37,6 +37,7 @@ import org.apache.uima.cas.FeatureStructure;
 import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxEventBehavior;
 import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.feedback.IFeedback;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
@@ -274,8 +275,7 @@ public class DocumentMetadataAnnotationSelectionPanel
 
                 DocumentMetadataAnnotationDetailPanel detailPanel = new DocumentMetadataAnnotationDetailPanel(
                         CID_ANNOTATION_DETAILS, Model.of(vid), sourceDocument, username,
-                        jcasProvider, project, annotationPage, selectionPanel, actionHandler,
-                        state);
+                        jcasProvider, project, annotationPage, actionHandler, state);
                 aItem.add(detailPanel);
 
                 container.add(new AjaxEventBehavior("click")
@@ -310,7 +310,10 @@ public class DocumentMetadataAnnotationSelectionPanel
                 container.setOutputMarkupId(true);
 
                 aItem.add(new LambdaAjaxLink(CID_DELETE,
-                        _target -> actionDelete(_target, detailPanel)));
+                        _target -> actionDelete(_target, detailPanel))
+                                .add(enabledWhen(annotationPage::isEditable))
+                                .add(AttributeAppender.append("class",
+                                        () -> annotationPage.isEditable() ? "" : "disabled")));
 
                 aItem.setOutputMarkupId(true);
             }

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
@@ -403,19 +403,6 @@ public class AnnotationPage
         }
     }
 
-    // private void actionInitialLoadComplete(AjaxRequestTarget aTarget)
-    // {
-    // // If the page has loaded and there is no document open yet, show the open-document
-    // // dialog.
-    // if (getModelObject().getDocument() == null) {
-    // actionShowOpenDocumentDialog(aTarget);
-    // }
-    // else {
-    // // Make sure the URL fragement parameters are up-to-date
-    // updateUrlFragment(aTarget);
-    // }
-    // }
-
     @Override
     public void actionLoadDocument(AjaxRequestTarget aTarget)
     {


### PR DESCRIPTION
**What's in the PR**
- Guard any documet metadata sidebar actions that modify the CAS with an ensureIsEditable
- Make the feature editors read-only when the CAS is finished
- Change implementation of isEditable in AnnotationPage to use ensureIsEditable() instead of re-implementing the checks
- Nicer design for delete item in dropdown
- Diable delete button if document is read-only
- Avoid empty space if there is are not slots in a slot feature
- Removed commented-out unused code

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
