### PR TITLE
#2375 Monitoring page is not shown

### DIFF
--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/management/DynamicWorkloadManagementPage.java
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/management/DynamicWorkloadManagementPage.java
@@ -119,6 +119,7 @@ import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaMenuItem;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaModelAdapter;
 import de.tudarmstadt.ukp.clarin.webanno.support.wicket.ContextMenu;
 import de.tudarmstadt.ukp.clarin.webanno.ui.core.menu.MenuItemRegistry;
+import de.tudarmstadt.ukp.clarin.webanno.ui.core.menu.ProjectMenuItem;
 import de.tudarmstadt.ukp.clarin.webanno.ui.core.page.ProjectPageBase;
 import de.tudarmstadt.ukp.inception.support.help.DocLink;
 import de.tudarmstadt.ukp.inception.workload.dynamic.DynamicWorkloadExtension;
@@ -198,7 +199,7 @@ public class DynamicWorkloadManagementPage
     private @SpringBean WorkloadManagementService workloadManagementService;
     private @SpringBean DynamicWorkloadExtension dynamicWorkloadExtension;
     private @SpringBean WorkflowExtensionPoint workflowExtensionPoint;
-    private @SpringBean DynamicWorkloadManagementPageMenuItem pageMenuItem;
+    private @SpringBean(name = "dynamicWorkloadManagementPageMenuItem") ProjectMenuItem pageMenuItem;
 
     public DynamicWorkloadManagementPage(final PageParameters aPageParameters)
     {

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/MatrixWorkloadManagementPage.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/MatrixWorkloadManagementPage.java
@@ -84,6 +84,7 @@ import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxLink;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaMenuItem;
 import de.tudarmstadt.ukp.clarin.webanno.support.wicket.ContextMenu;
+import de.tudarmstadt.ukp.clarin.webanno.ui.core.menu.ProjectMenuItem;
 import de.tudarmstadt.ukp.clarin.webanno.ui.core.page.ProjectPageBase;
 import de.tudarmstadt.ukp.inception.support.help.DocLink;
 import de.tudarmstadt.ukp.inception.workload.matrix.management.event.AnnotatorColumnCellClickEvent;
@@ -117,7 +118,7 @@ public class MatrixWorkloadManagementPage
     private @SpringBean ProjectService projectService;
     private @SpringBean UserDao userRepository;
     private @SpringBean CurationDocumentService curationService;
-    private @SpringBean MatrixWorkloadManagementPageMenuItem pageMenuItem;
+    private @SpringBean(name = "matrixWorkloadManagementPageMenuItem") ProjectMenuItem pageMenuItem;
 
     private DataTable<DocumentMatrixRow, DocumentMatrixSortKey> documentMatrix;
     private LambdaAjaxLink toggleBulkChange;


### PR DESCRIPTION
Clicking on the monitoring/workload menu item on the dashboard did not show the page but resulted in an `java.lang.IllegalArgumentException: Superclass has no null constructors but no arguments were given` error.

**What's in the PR**
* Use named Springbeans to inject concrete ProjectMenuItems into specific workload pages.

**How to test manually**
* Go to Dashboard and click on the workload page
* See the workload page
* Re-Configure to use the dynamic workload via settings
* Go to the workload page again and check that this one can also be loaded
