### PR TITLE
#1182 - AL does not always jump to the text passage

### DIFF
--- a/inception/inception-active-learning/pom.xml
+++ b/inception/inception-active-learning/pom.xml
@@ -82,6 +82,10 @@
       <artifactId>spring-context</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-tx</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
     </dependency>

--- a/inception/inception-active-learning/pom.xml
+++ b/inception/inception-active-learning/pom.xml
@@ -48,10 +48,6 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
-      <artifactId>inception-model</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-support</artifactId>
     </dependency>
     

--- a/inception/inception-active-learning/pom.xml
+++ b/inception/inception-active-learning/pom.xml
@@ -48,6 +48,10 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-model</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-support</artifactId>
     </dependency>
     
@@ -90,6 +94,10 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.wicket</groupId>
+      <artifactId>wicket-util</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.wicket</groupId>

--- a/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/ActiveLearningService.java
+++ b/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/ActiveLearningService.java
@@ -17,9 +17,11 @@
  */
 package de.tudarmstadt.ukp.inception.active.learning;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.AnnotationException;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.inception.active.learning.ActiveLearningServiceImpl.ActiveLearningUserState;
@@ -56,4 +58,15 @@ public interface ActiveLearningService
 
     Optional<Delta<SpanSuggestion>> generateNextSuggestion(User aUser,
             ActiveLearningUserState aAlState);
+
+    void writeLearningRecordInDatabaseAndEventLog(User aUser, AnnotationLayer aLayer,
+            SpanSuggestion aSuggestion, LearningRecordType aUserAction, String aAnnotationValue);
+
+    void acceptSpanSuggestion(User aUser, AnnotationLayer aLayer, SpanSuggestion aSuggestion,
+            Object aValue)
+        throws IOException, AnnotationException;
+
+    void rejectSpanSuggestion(User aUser, AnnotationLayer aLayer, SpanSuggestion aSuggestion);
+
+    void skipSpanSuggestion(User aUser, AnnotationLayer aLayer, SpanSuggestion aSuggestion);
 }

--- a/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/ActiveLearningServiceImpl.java
+++ b/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/ActiveLearningServiceImpl.java
@@ -172,7 +172,8 @@ public class ActiveLearningServiceImpl
 
         // remove duplicate recommendations
         suggestions = suggestions.stream() //
-                .map(it -> removeDuplicateRecommendations(it)).collect(Collectors.toList());
+                .map(it -> removeDuplicateRecommendations(it)) //
+                .collect(Collectors.toList());
         long removeDuplicateRecommendation = System.currentTimeMillis();
         log.trace("Removing duplicate recommendations costs {} ms.",
                 (removeDuplicateRecommendation - getRecommendationsFromRecommendationService));

--- a/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/ActiveLearningServiceImpl.java
+++ b/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/ActiveLearningServiceImpl.java
@@ -19,31 +19,48 @@ package de.tudarmstadt.ukp.inception.active.learning;
 
 import static de.tudarmstadt.ukp.inception.recommendation.api.model.AnnotationSuggestion.FLAG_REJECTED;
 import static de.tudarmstadt.ukp.inception.recommendation.api.model.AnnotationSuggestion.FLAG_SKIPPED;
+import static de.tudarmstadt.ukp.inception.recommendation.api.model.AnnotationSuggestion.FLAG_TRANSIENT_ACCEPTED;
+import static de.tudarmstadt.ukp.inception.recommendation.api.model.AnnotationSuggestion.FLAG_TRANSIENT_CORRECTED;
+import static de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordChangeLocation.AL_SIDEBAR;
+import static de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordType.ACCEPTED;
+import static de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordType.CORRECTED;
 import static de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordType.REJECTED;
 import static de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordType.SKIPPED;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.apache.uima.cas.CAS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.transaction.annotation.Transactional;
 
+import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.AnnotationException;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRegistry;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.inception.active.learning.config.ActiveLearningAutoConfiguration;
+import de.tudarmstadt.ukp.inception.active.learning.event.ActiveLearningRecommendationEvent;
 import de.tudarmstadt.ukp.inception.active.learning.strategy.ActiveLearningStrategy;
 import de.tudarmstadt.ukp.inception.recommendation.api.LearningRecordService;
 import de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.AnnotationSuggestion;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecord;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordType;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Predictions;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Preferences;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.SpanSuggestion;
@@ -62,20 +79,28 @@ public class ActiveLearningServiceImpl
 {
     private final Logger log = LoggerFactory.getLogger(getClass());
 
+    private final ApplicationEventPublisher applicationEventPublisher;
     private final DocumentService documentService;
     private final RecommendationService recommendationService;
     private final UserDao userService;
     private final LearningRecordService learningHistoryService;
+    private final AnnotationSchemaService schemaService;
+    private final FeatureSupportRegistry featureSupportRegistry;
 
     @Autowired
     public ActiveLearningServiceImpl(DocumentService aDocumentService,
             RecommendationService aRecommendationService, UserDao aUserDao,
-            LearningRecordService aLearningHistoryService)
+            LearningRecordService aLearningHistoryService, AnnotationSchemaService aSchemaService,
+            ApplicationEventPublisher aApplicationEventPublisher,
+            FeatureSupportRegistry aFeatureSupportRegistry)
     {
         documentService = aDocumentService;
         recommendationService = aRecommendationService;
         userService = aUserDao;
         learningHistoryService = aLearningHistoryService;
+        applicationEventPublisher = aApplicationEventPublisher;
+        schemaService = aSchemaService;
+        featureSupportRegistry = aFeatureSupportRegistry;
     }
 
     @Override
@@ -187,6 +212,99 @@ public class ActiveLearningServiceImpl
         Preferences pref = recommendationService.getPreferences(aUser,
                 alState.getLayer().getProject());
         return alState.getStrategy().generateNextSuggestion(pref, suggestions);
+    }
+
+    @Override
+    @Transactional
+    public void writeLearningRecordInDatabaseAndEventLog(User aUser, AnnotationLayer aLayer,
+            SpanSuggestion aSuggestion, LearningRecordType aUserAction, String aAnnotationValue)
+    {
+
+        AnnotationFeature feat = schemaService.getFeature(aSuggestion.getFeature(), aLayer);
+        SourceDocument sourceDoc = documentService.getSourceDocument(aLayer.getProject(),
+                aSuggestion.getDocumentName());
+
+        List<SpanSuggestion> alternativeSuggestions = recommendationService
+                .getPredictions(aUser, aLayer.getProject())
+                .getPredictionsByTokenAndFeature(aSuggestion.getDocumentName(), aLayer,
+                        aSuggestion.getBegin(), aSuggestion.getEnd(), aSuggestion.getFeature());
+
+        // Log the action to the learning record
+        learningHistoryService.logSpanRecord(sourceDoc, aUser.getUsername(), aSuggestion,
+                aAnnotationValue, aLayer, feat, aUserAction, AL_SIDEBAR);
+
+        // If the action was a correction (i.e. suggestion label != annotation value) then generate
+        // a rejection for the original value - we do not want the original value to re-appear
+        if (aUserAction == CORRECTED) {
+            learningHistoryService.logSpanRecord(sourceDoc, aUser.getUsername(), aSuggestion,
+                    aSuggestion.getLabel(), aLayer, feat, REJECTED, AL_SIDEBAR);
+        }
+
+        // Send an application event indicating if the user has accepted/skipped/corrected/rejected
+        // the suggestion
+        applicationEventPublisher.publishEvent(new ActiveLearningRecommendationEvent(this,
+                sourceDoc, aSuggestion, aUser.getUsername(), aLayer, aSuggestion.getFeature(),
+                aUserAction, alternativeSuggestions));
+    }
+
+    @Override
+    @Transactional
+    public void acceptSpanSuggestion(User aUser, AnnotationLayer aLayer, SpanSuggestion aSuggestion,
+            Object aValue)
+        throws IOException, AnnotationException
+    {
+        // There is always a current recommendation when we get here because if there is none, the
+        // button to accept the recommendation is not visible.
+        SpanSuggestion suggestion = aSuggestion;
+
+        // Create AnnotationFeature and FeatureSupport
+        AnnotationFeature feat = schemaService.getFeature(suggestion.getFeature(), aLayer);
+        FeatureSupport<?> featureSupport = featureSupportRegistry.findExtension(feat).orElseThrow();
+
+        // Load CAS in which to create the annotation. This might be different from the one that
+        // is currently viewed by the user, e.g. if the user switched to another document after
+        // the suggestion has been loaded into the sidebar.
+        SourceDocument sourceDoc = documentService.getSourceDocument(aLayer.getProject(),
+                suggestion.getDocumentName());
+        String username = aUser.getUsername();
+        CAS cas = documentService.readAnnotationCas(sourceDoc, username);
+
+        // Upsert an annotation based on the suggestion
+        String value = (String) featureSupport.unwrapFeatureValue(feat, cas, aValue);
+        AnnotationLayer layer = schemaService.getLayer(aLayer.getProject(), suggestion.getLayerId())
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "No such layer: [" + suggestion.getLayerId() + "]"));
+
+        // Log the action to the learning record and immediately hide the suggestion
+        boolean areLabelsEqual = suggestion.labelEquals(value);
+        writeLearningRecordInDatabaseAndEventLog(aUser, aLayer, suggestion,
+                (areLabelsEqual) ? ACCEPTED : CORRECTED, value);
+        suggestion.hide((areLabelsEqual) ? FLAG_TRANSIENT_ACCEPTED : FLAG_TRANSIENT_CORRECTED);
+
+        // Request clearing selection and when onFeatureValueUpdated is triggered as a callback
+        // from the update event created by upsertSpanFeature.
+        AnnotationFeature feature = schemaService.getFeature(suggestion.getFeature(), layer);
+        recommendationService.upsertSpanFeature(schemaService, sourceDoc, username, cas, layer,
+                feature, value, suggestion.getBegin(), suggestion.getEnd());
+
+        // Save CAS after annotation has been created
+        documentService.writeAnnotationCas(cas, sourceDoc, aUser, true);
+    }
+
+    @Override
+    @Transactional
+    public void rejectSpanSuggestion(User aUser, AnnotationLayer aLayer, SpanSuggestion aSuggestion)
+    {
+        writeLearningRecordInDatabaseAndEventLog(aUser, aLayer, aSuggestion, REJECTED,
+                aSuggestion.getLabel());
+    }
+
+    @Override
+    @Transactional
+    public void skipSpanSuggestion(User aUser, AnnotationLayer aLayer, SpanSuggestion aSuggestion)
+    {
+        writeLearningRecordInDatabaseAndEventLog(aUser, aLayer, aSuggestion, SKIPPED,
+                aSuggestion.getLabel());
     }
 
     private static SuggestionGroup<SpanSuggestion> removeDuplicateRecommendations(

--- a/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/config/ActiveLearningAutoConfiguration.java
+++ b/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/config/ActiveLearningAutoConfiguration.java
@@ -20,10 +20,13 @@ package de.tudarmstadt.ukp.inception.active.learning.config;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRegistry;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.inception.active.learning.ActiveLearningService;
 import de.tudarmstadt.ukp.inception.active.learning.ActiveLearningServiceImpl;
@@ -47,10 +50,13 @@ public class ActiveLearningAutoConfiguration
     @Bean
     public ActiveLearningService activeLearningService(DocumentService aDocumentService,
             RecommendationService aRecommendationService, UserDao aUserDao,
-            LearningRecordService aLearningHistoryService)
+            LearningRecordService aLearningHistoryService, AnnotationSchemaService aSchemaService,
+            ApplicationEventPublisher aApplicationEventPublisher,
+            FeatureSupportRegistry aFeatureSupportRegistry)
     {
         return new ActiveLearningServiceImpl(aDocumentService, aRecommendationService, aUserDao,
-                aLearningHistoryService);
+                aLearningHistoryService, aSchemaService, aApplicationEventPublisher,
+                aFeatureSupportRegistry);
     }
 
     @Bean

--- a/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.html
+++ b/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.html
@@ -64,7 +64,7 @@
               <div class="form-group form-row">
                 <div class="col-sm-12 p-0" style="position: relative; height: 5em;">
                   <div class="form-control"
-                    style="overflow-y: auto; width: unset; word-wrap: break-word; height: 5em; position: absolute; top: 0; left: 5px; right: 5px;"
+                    style="overflow-y: auto; width: unset; word-wrap: break-word; height: 5em; position: absolute; top: 0; left: 0px; right: 0px;"
                     readonly>
                     <a wicket:id="recommendationCoveredTextLink" class="small">
                       <wicket:container wicket:id="leftContext"/>
@@ -101,9 +101,15 @@
               </div>
             </div>
             <div class="card-footer flex-h-container btn-group">
-              <input type="submit" class="btn btn-success" wicket:id="annotateButton" value="Annotate"/>
-              <input type="button" class="btn btn-danger" wicket:id="rejectButton" value="Reject"/>
-              <input type="button" class="btn btn-warning" wicket:id="skipButton" value="Skip"/>
+              <button type="submit" class="btn btn-success" wicket:id="annotateButton" title="Annotate">
+                <i class="far fa-check-circle"/>
+              </button>
+              <button type="button" class="btn btn-danger" wicket:id="rejectButton" title="Reject">
+                <i class="far fa-times-circle"/>
+              </button>
+              <button type="button" class="btn btn-warning" wicket:id="skipButton" title="Skip">
+                <i class="far fa-arrow-alt-circle-right"/>
+              </button>
             </div>
           </form>
   
@@ -112,12 +118,12 @@
             <div class="card-header small">
               <wicket:message key="history"/>
             </div>
-            <div class="scrolling card-body p-0">
+            <div class="scrolling card-body p-0 small">
               <div class="list-group-flush">
                 <div wicket:id="historyListview" class="list-group-item px-2 py-1">
                   <div class="clearfix">
-                    <a wicket:id="removeRecord" class="btn-sm btn-outline-danger float-right" style="white-space:nowrap;">
-                      <i class="fa fa-trash" aria-hidden="true"></i>
+                    <a wicket:id="removeRecord" class="float-right" style="white-space:nowrap;">
+                      <i class="fas fa-times"/>
                     </a>
                     <a wicket:id="jumpToAnnotation"></a>
                   </div>

--- a/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.java
+++ b/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.java
@@ -17,7 +17,6 @@
  */
 package de.tudarmstadt.ukp.inception.active.learning.sidebar;
 
-import static com.google.common.base.Functions.identity;
 import static de.tudarmstadt.ukp.clarin.webanno.api.CasUpgradeMode.AUTO_CAS_UPGRADE;
 import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.SPAN_TYPE;
 import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode.SHARED_READ_ONLY_ACCESS;
@@ -30,6 +29,7 @@ import static de.tudarmstadt.ukp.inception.recommendation.api.model.LearningReco
 import static de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordType.REJECTED;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
+import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static org.apache.uima.fit.util.CasUtil.selectAt;

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/RadioGroupStringFeatureEditor.html
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/RadioGroupStringFeatureEditor.html
@@ -32,12 +32,17 @@
       </div>
       <div wicket:id="value">
         <div class="radio-button-group">
-          <div wicket:id="radios" class="flex-h-container radio-button">
-            <input wicket:id="radio" type="radio"/>
-            <label wicket:id="label" class="flex-content"/>
-            <span wicket:id="description" class="btn px-0" style="margin-left: -26px; margin-right: 8px; z-index: 10;">
-              <i class="fas fa-info-circle"/>
+          <div wicket:id="radios" class="radio-button" style="position: relative;">
+            <span style="position: absolute; right: 0; z-index: 10;" class="pt-1 pr-1">
+              <span wicket:id="detail" class="badge badge-secondary"/>
+              <span wicket:id="description">
+                <i class="fas fa-info-circle"/>
+              </span>
             </span>
+            <div class="flex-h-container">
+              <input wicket:id="radio" type="radio"/>
+              <label wicket:id="label" class="m-0 flex-content"/>
+            </div>
           </div>
         </div>
       </div>

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/RadioGroupStringFeatureEditor.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/RadioGroupStringFeatureEditor.java
@@ -31,6 +31,7 @@ import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.attributes.AjaxRequestAttributes;
 import org.apache.wicket.ajax.form.AjaxFormChoiceComponentUpdatingBehavior;
 import org.apache.wicket.markup.html.WebMarkupContainer;
+import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.FormComponent;
 import org.apache.wicket.markup.html.form.RadioGroup;
 import org.apache.wicket.markup.html.list.ListItem;
@@ -155,6 +156,8 @@ public class RadioGroupStringFeatureEditor
 
                 String descriptionText = item.getModel().getObject().getDescription();
 
+                Label detail = new Label("detail", item.getModel().map(ReorderableTag::getDetail));
+
                 WebMarkupContainer description = new WebMarkupContainer("description");
                 description.add(visibleWhen(() -> isNotBlank(descriptionText)));
 
@@ -168,7 +171,7 @@ public class RadioGroupStringFeatureEditor
 
                 add(description);
 
-                item.add(radio, label, description);
+                item.add(radio, label, detail, description);
             }
         };
     }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/rendering/PreRendererImpl.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/rendering/PreRendererImpl.java
@@ -25,6 +25,8 @@ import java.util.Objects;
 
 import org.apache.commons.lang3.Validate;
 import org.apache.uima.cas.CAS;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
@@ -44,6 +46,8 @@ import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 public class PreRendererImpl
     implements PreRenderer
 {
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
     private final AnnotationSchemaService annotationService;
     private final LayerSupportRegistry layerSupportRegistry;
 
@@ -71,6 +75,8 @@ public class PreRendererImpl
     public void render(VDocument aResponse, int windowBegin, int windowEnd, CAS aCas,
             List<AnnotationLayer> aLayers)
     {
+        log.trace("render()");
+
         Validate.notNull(aCas, "CAS cannot be null");
 
         if (aLayers.isEmpty()) {

--- a/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/ReorderableTag.java
+++ b/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/ReorderableTag.java
@@ -27,6 +27,7 @@ public class ReorderableTag
 
     private final ImmutableTag tag;
     private boolean reordered;
+    private String detail;
 
     public ReorderableTag(ImmutableTag aTag)
     {
@@ -73,6 +74,16 @@ public class ReorderableTag
     public String toString()
     {
         return tag.getName();
+    }
+
+    public String getDetail()
+    {
+        return detail;
+    }
+
+    public void setDetail(String aDetail)
+    {
+        detail = aDetail;
     }
 
     @Override

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/LearningRecordService.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/LearningRecordService.java
@@ -53,11 +53,11 @@ public interface LearningRecordService
 
     void deleteById(long id);
 
-    void logRecord(SourceDocument aDocument, String aUsername, SpanSuggestion aPrediction,
+    void logSpanRecord(SourceDocument aDocument, String aUsername, SpanSuggestion aPrediction,
             AnnotationLayer aLayer, AnnotationFeature aFeature, LearningRecordType aUserAction,
             LearningRecordChangeLocation aLocation);
 
-    void logRecord(SourceDocument aDocument, String aUsername, RelationSuggestion aPrediction,
+    void logRelationRecord(SourceDocument aDocument, String aUsername, RelationSuggestion aPrediction,
             AnnotationLayer aLayer, AnnotationFeature aFeature, LearningRecordType aUserAction,
             LearningRecordChangeLocation aLocation);
 
@@ -66,7 +66,7 @@ public interface LearningRecordService
      * duplicates of the new action are removed as part of this action. Note that the actual action
      * the user performed is not taken into account to determine duplicateness.
      */
-    void logRecord(SourceDocument aDocument, String aUsername, SpanSuggestion aSuggestion,
+    void logSpanRecord(SourceDocument aDocument, String aUsername, SpanSuggestion aSuggestion,
             String aAlternativeLabel, AnnotationLayer aLayer, AnnotationFeature aFeature,
             LearningRecordType aUserAction, LearningRecordChangeLocation aLocation);
 
@@ -75,7 +75,7 @@ public interface LearningRecordService
      * duplicates of the new action are removed as part of this action. Note that the actual action
      * the user performed is not taken into account to determine duplicateness.
      */
-    void logRecord(SourceDocument aDocument, String aUsername, RelationSuggestion aSuggestion,
+    void logRelationRecord(SourceDocument aDocument, String aUsername, RelationSuggestion aSuggestion,
             String aAlternativeLabel, AnnotationLayer aLayer, AnnotationFeature aFeature,
             LearningRecordType aUserAction, LearningRecordChangeLocation aLocation);
 

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/AnnotationSuggestion.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/AnnotationSuggestion.java
@@ -191,6 +191,9 @@ public abstract class AnnotationSuggestion
         if ((hidingFlags & FLAG_TRANSIENT_REJECTED) != 0) {
             sb.append("transient-rejected ");
         }
+        if ((hidingFlags & FLAG_TRANSIENT_CORRECTED) != 0) {
+            sb.append("transient-corrected ");
+        }
         return sb.toString();
     }
 

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/SuggestionDocumentGroup.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/SuggestionDocumentGroup.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.recommendation.api.model;
 
+import static java.util.stream.Collectors.toList;
 import static org.apache.commons.collections4.IteratorUtils.unmodifiableIterator;
 
 import java.util.AbstractCollection;
@@ -24,7 +25,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.Validate;
 
@@ -49,15 +49,16 @@ public class SuggestionDocumentGroup<T extends AnnotationSuggestion>
         addAll(SuggestionGroup.group(aSuggestions));
     }
 
-    @SuppressWarnings("unchecked")
-    /*
+    /**
      * Returns a SuggestionDocumentGroup where only suggestions of type V are added
      */
+    @SuppressWarnings("unchecked")
     public static <V extends AnnotationSuggestion> SuggestionDocumentGroup<V> filter(Class<V> type,
             List<AnnotationSuggestion> aSuggestions)
     {
         List<AnnotationSuggestion> filteredSuggestions = aSuggestions.stream()
-                .filter(type::isInstance).collect(Collectors.toList());
+                .filter(type::isInstance) //
+                .collect(toList());
         return new SuggestionDocumentGroup<V>((List<V>) filteredSuggestions);
     }
 

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/SuggestionGroup.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/SuggestionGroup.java
@@ -245,8 +245,8 @@ public class SuggestionGroup<T extends AnnotationSuggestion>
             for (Entry<Long, List<T>> e : suggestionsByRecommenders.entrySet()) {
                 long recommenderId = e.getKey();
                 // We consider only candidates that are visible
-                List<T> candidates = e.getValue().stream().filter(AnnotationSuggestion::isVisible)
-                        .collect(toList());
+                List<T> candidates = e.getValue().stream() //
+                        .filter(AnnotationSuggestion::isVisible).collect(toList());
                 List<Delta<T>> deltas = new ArrayList<>();
 
                 Iterator<T> i = candidates.iterator();

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/RecommendationEditorExtension.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/RecommendationEditorExtension.java
@@ -185,9 +185,10 @@ public class RecommendationEditorExtension
         Predictions predictions = recommendationService.getPredictions(aState.getUser(),
                 aState.getProject());
         VID recommendationVid = VID.parse(aVID.getExtensionPayload());
-        Optional<SpanSuggestion> prediction = predictions
-                .getPredictionByVID(document, recommendationVid)
-                .filter(f -> f instanceof SpanSuggestion).map(f -> (SpanSuggestion) f);
+        Optional<SpanSuggestion> prediction = predictions //
+                .getPredictionByVID(document, recommendationVid) //
+                .filter(f -> f instanceof SpanSuggestion) //
+                .map(f -> (SpanSuggestion) f);
 
         if (prediction.isEmpty()) {
             log.error("Could not find annotation in [{}] with id [{}]", document,
@@ -214,10 +215,11 @@ public class RecommendationEditorExtension
         aActionHandler.actionCreateOrUpdate(aTarget, aCas);
 
         // Log the action to the learning record
-        learningRecordService.logSpanRecord(document, aState.getUser().getUsername(), suggestion, layer,
-                feature, ACCEPTED, MAIN_EDITOR);
+        learningRecordService.logSpanRecord(document, aState.getUser().getUsername(), suggestion,
+                layer, feature, ACCEPTED, MAIN_EDITOR);
 
-        acceptRecommendation(suggestion, aState, aTarget, aCas, recommendationVid, address);
+        hideSuggestionAndPublishAceptedEvents(suggestion, aState, aTarget, aCas, recommendationVid,
+                address);
     }
 
     private void actionAcceptRelationRecommendation(AnnotationActionHandler aActionHandler,
@@ -266,14 +268,15 @@ public class RecommendationEditorExtension
         aActionHandler.actionCreateOrUpdate(aTarget, aCas);
 
         // Log the action to the learning record
-        learningRecordService.logRelationRecord(document, aState.getUser().getUsername(), suggestion, layer,
-                feature, ACCEPTED, MAIN_EDITOR);
+        learningRecordService.logRelationRecord(document, aState.getUser().getUsername(),
+                suggestion, layer, feature, ACCEPTED, MAIN_EDITOR);
 
-        acceptRecommendation(suggestion, aState, aTarget, aCas, aVID, address);
+        hideSuggestionAndPublishAceptedEvents(suggestion, aState, aTarget, aCas, aVID, address);
     }
 
-    private void acceptRecommendation(AnnotationSuggestion aSuggestion, AnnotatorState aState,
-            AjaxRequestTarget aTarget, CAS aCas, VID aSuggestionVID, int aNewAnnotationAddress)
+    private void hideSuggestionAndPublishAceptedEvents(AnnotationSuggestion aSuggestion,
+            AnnotatorState aState, AjaxRequestTarget aTarget, CAS aCas, VID aSuggestionVID,
+            int aNewAnnotationAddress)
     {
         AnnotationLayer layer = annotationService.getLayer(aSuggestion.getLayerId());
         AnnotationFeature feature = annotationService.getFeature(aSuggestion.getFeature(), layer);

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/RecommendationEditorExtension.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/RecommendationEditorExtension.java
@@ -214,7 +214,7 @@ public class RecommendationEditorExtension
         aActionHandler.actionCreateOrUpdate(aTarget, aCas);
 
         // Log the action to the learning record
-        learningRecordService.logRecord(document, aState.getUser().getUsername(), suggestion, layer,
+        learningRecordService.logSpanRecord(document, aState.getUser().getUsername(), suggestion, layer,
                 feature, ACCEPTED, MAIN_EDITOR);
 
         acceptRecommendation(suggestion, aState, aTarget, aCas, recommendationVid, address);
@@ -266,7 +266,7 @@ public class RecommendationEditorExtension
         aActionHandler.actionCreateOrUpdate(aTarget, aCas);
 
         // Log the action to the learning record
-        learningRecordService.logRecord(document, aState.getUser().getUsername(), suggestion, layer,
+        learningRecordService.logRelationRecord(document, aState.getUser().getUsername(), suggestion, layer,
                 feature, ACCEPTED, MAIN_EDITOR);
 
         acceptRecommendation(suggestion, aState, aTarget, aCas, aVID, address);
@@ -341,7 +341,7 @@ public class RecommendationEditorExtension
         if (suggestion instanceof SpanSuggestion) {
             SpanSuggestion spanSuggestion = (SpanSuggestion) suggestion;
             // Log the action to the learning record
-            learningRecordService.logRecord(document, aState.getUser().getUsername(),
+            learningRecordService.logSpanRecord(document, aState.getUser().getUsername(),
                     spanSuggestion, layer, feature, REJECTED, MAIN_EDITOR);
 
             // Send an application event that the suggestion has been rejected
@@ -370,6 +370,8 @@ public class RecommendationEditorExtension
     @Override
     public void renderRequested(AnnotatorState aState)
     {
+        log.trace("renderRequested()");
+
         // do not show predictions during curation or when viewing others' work
         if (!aState.getMode().equals(ANNOTATION)
                 || !aState.getUser().getUsername().equals(userRegistry.getCurrentUsername())) {
@@ -382,6 +384,7 @@ public class RecommendationEditorExtension
         // expect an update when she makes some interaction, so we piggy-back on this expectation.
         boolean switched = recommendationService.switchPredictions(aState.getUser(),
                 aState.getProject());
+        log.trace("switchPredictions() returned {}", switched);
 
         // Notify other UI components on the page about the prediction switch such that they can
         // also update their state to remain in sync with the new predictions

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/LearningRecordServiceImpl.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/LearningRecordServiceImpl.java
@@ -17,6 +17,9 @@
  */
 package de.tudarmstadt.ukp.inception.recommendation.service;
 
+import static de.tudarmstadt.ukp.inception.recommendation.api.model.SuggestionType.RELATION;
+import static de.tudarmstadt.ukp.inception.recommendation.api.model.SuggestionType.SPAN;
+
 import java.util.List;
 
 import javax.persistence.EntityManager;
@@ -67,54 +70,53 @@ public class LearningRecordServiceImpl
 
     @Transactional
     @Override
-    public void logRecord(SourceDocument aDocument, String aUsername, SpanSuggestion aSuggestion,
-            AnnotationLayer aLayer, AnnotationFeature aFeature, LearningRecordType aUserAction,
-            LearningRecordChangeLocation aLocation)
+    public void logSpanRecord(SourceDocument aDocument, String aUsername,
+            SpanSuggestion aSuggestion, AnnotationLayer aLayer, AnnotationFeature aFeature,
+            LearningRecordType aUserAction, LearningRecordChangeLocation aLocation)
     {
-        logRecord(aDocument, aUsername, aSuggestion, aSuggestion.getLabel(), aLayer, aFeature,
+        logSpanRecord(aDocument, aUsername, aSuggestion, aSuggestion.getLabel(), aLayer, aFeature,
                 aUserAction, aLocation);
     }
 
     @Transactional
     @Override
-    public void logRecord(SourceDocument aDocument, String aUsername, SpanSuggestion aSuggestion,
-            String aAlternativeLabel, AnnotationLayer aLayer, AnnotationFeature aFeature,
-            LearningRecordType aUserAction, LearningRecordChangeLocation aLocation)
+    public void logSpanRecord(SourceDocument aDocument, String aUsername,
+            SpanSuggestion aSuggestion, String aAlternativeLabel, AnnotationLayer aLayer,
+            AnnotationFeature aFeature, LearningRecordType aUserAction,
+            LearningRecordChangeLocation aLocation)
     {
-        logRecord(aDocument, aUsername, aSuggestion.getBegin(), aSuggestion.getEnd(), -1, -1,
-                SuggestionType.SPAN, aSuggestion.getLabel(), aUserAction, aLayer, aFeature,
-                aSuggestion.getCoveredText(), aAlternativeLabel, aLocation);
+        logRecord(aDocument, aUsername, aSuggestion.getBegin(), aSuggestion.getEnd(), -1, -1, SPAN,
+                aAlternativeLabel, aUserAction, aLayer, aFeature, aSuggestion.getCoveredText(),
+                aLocation);
     }
 
     @Transactional
     @Override
-    public void logRecord(SourceDocument aDocument, String aUsername,
+    public void logRelationRecord(SourceDocument aDocument, String aUsername,
             RelationSuggestion aSuggestion, AnnotationLayer aLayer, AnnotationFeature aFeature,
             LearningRecordType aUserAction, LearningRecordChangeLocation aLocation)
     {
-        logRecord(aDocument, aUsername, aSuggestion, aSuggestion.getLabel(), aLayer, aFeature,
-                aUserAction, aLocation);
+        logRelationRecord(aDocument, aUsername, aSuggestion, aSuggestion.getLabel(), aLayer,
+                aFeature, aUserAction, aLocation);
     }
 
     @Transactional
     @Override
-    public void logRecord(SourceDocument aDocument, String aUsername,
+    public void logRelationRecord(SourceDocument aDocument, String aUsername,
             RelationSuggestion aSuggestion, String aAlternativeLabel, AnnotationLayer aLayer,
             AnnotationFeature aFeature, LearningRecordType aUserAction,
             LearningRecordChangeLocation aLocation)
     {
         RelationPosition pos = aSuggestion.getPosition();
         logRecord(aDocument, aUsername, pos.getSourceBegin(), pos.getSourceEnd(),
-                pos.getTargetBegin(), pos.getTargetEnd(), SuggestionType.RELATION,
-                aSuggestion.getLabel(), aUserAction, aLayer, aFeature, "", aAlternativeLabel,
-                aLocation);
+                pos.getTargetBegin(), pos.getTargetEnd(), RELATION, aAlternativeLabel, aUserAction,
+                aLayer, aFeature, "", aLocation);
     }
 
     private void logRecord(SourceDocument aSourceDocument, String aUsername, int aOffsetBegin,
             int aOffsetEnd, int aOffset2Begin, int aOffset2End, SuggestionType aSuggestionType,
             String aLabel, LearningRecordType aUserAction, AnnotationLayer aLayer,
-            AnnotationFeature aFeature, String aCoveredText, String aAlternativeLabel,
-            LearningRecordChangeLocation aLocation)
+            AnnotationFeature aFeature, String aCoveredText, LearningRecordChangeLocation aLocation)
     {
         // It doesn't make any sense at all to have duplicate entries in the learning history,
         // so when adding a new entry, we dump any existing entries which basically are the
@@ -154,7 +156,7 @@ public class LearningRecordServiceImpl
         record.setOffsetBegin2(aOffset2Begin);
         record.setOffsetEnd2(aOffset2End);
         record.setTokenText(aCoveredText);
-        record.setAnnotation(aAlternativeLabel);
+        record.setAnnotation(aLabel);
         record.setLayer(aLayer);
         record.setSuggestionType(aSuggestionType);
         record.setChangeLocation(aLocation);

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/PredictionSwitchPerformedKey.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/PredictionSwitchPerformedKey.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.service;
+
+import org.apache.wicket.MetaDataKey;
+
+/**
+ * Indicates whether a prediction switch has already been performed during a request. If this is the
+ * case, no second switch should take place.
+ */
+public class PredictionSwitchPerformedKey
+    extends MetaDataKey<Boolean>
+{
+    private static final long serialVersionUID = -4244853609075676915L;
+    public final static PredictionSwitchPerformedKey INSTANCE = new PredictionSwitchPerformedKey();
+}

--- a/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/LearningRecordServiceImplIntegrationTest.java
+++ b/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/LearningRecordServiceImplIntegrationTest.java
@@ -86,7 +86,7 @@ public class LearningRecordServiceImplIntegrationTest
                 feature.getName(), sourceDoc.getName(), 7, 14, "aCoveredText", "testLabel",
                 "testUiLabel", 0.42, "Test confidence");
 
-        sut.logRecord(sourceDoc, USER_NAME, suggestion, layer, feature, LearningRecordType.ACCEPTED,
+        sut.logSpanRecord(sourceDoc, USER_NAME, suggestion, layer, feature, LearningRecordType.ACCEPTED,
                 MAIN_EDITOR);
 
         List<LearningRecord> records = sut.listRecords(USER_NAME, layer);
@@ -120,7 +120,7 @@ public class LearningRecordServiceImplIntegrationTest
                 layer.getId(), feature.getName(), sourceDoc.getName(), 7, 14, 21, 28, "testLabel",
                 "testUiLabel", 0.42, "Test confidence");
 
-        sut.logRecord(sourceDoc, USER_NAME, suggestion, layer, feature, LearningRecordType.REJECTED,
+        sut.logRelationRecord(sourceDoc, USER_NAME, suggestion, layer, feature, LearningRecordType.REJECTED,
                 DETAIL_EDITOR);
 
         List<LearningRecord> records = sut.listRecords(USER_NAME, layer);


### PR DESCRIPTION
**What's in the PR**
- Ensure that per request only a single prediction switch is performed
- Fix wrong label being written to learning record
- When a suggestion is corrected, then generate a rejection for the original value
- Fix transient-corrected flag not appearing as a reason for hiding
- Suppress key bindings for feature editors in the active learning sidebar

**How to test manually**
* Do active learning, in particular with cases where stacking is allowed, multiple suggestions are given for a particular position and correction is being used

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
