### PR TITLE
#2377 Using activity link after layer creation NPE

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/rendering/ChainRenderer.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/rendering/ChainRenderer.java
@@ -78,10 +78,11 @@ public class ChainRenderer
     protected boolean typeSystemInit(TypeSystem aTypeSystem)
     {
         ChainAdapter typeAdapter = getTypeAdapter();
-        try {
-            chainType = aTypeSystem.getType(typeAdapter.getChainTypeName());
-        }
-        catch (IllegalArgumentException e) {
+        chainType = aTypeSystem.getType(typeAdapter.getChainTypeName());
+        
+        if (chainType == null) {
+            // If the types are not defined, then we do not need to try and render them because the
+            // CAS does not contain any instances of them
             return false;
         }
 

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/rendering/RelationRenderer.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/rendering/RelationRenderer.java
@@ -94,11 +94,10 @@ public class RelationRenderer
     protected boolean typeSystemInit(TypeSystem aTypeSystem)
     {
         RelationAdapter typeAdapter = getTypeAdapter();
-        try {
-            type = aTypeSystem.getType(typeAdapter.getAnnotationTypeName());
-            spanType = aTypeSystem.getType(typeAdapter.getAttachTypeName());
-        }
-        catch (IllegalArgumentException e) {
+        type = aTypeSystem.getType(typeAdapter.getAnnotationTypeName());
+        spanType = aTypeSystem.getType(typeAdapter.getAttachTypeName());
+        
+        if (type == null || spanType == null) {
             // If the types are not defined, then we do not need to try and render them because the
             // CAS does not contain any instances of them
             return false;

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/rendering/SpanRenderer.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/rendering/SpanRenderer.java
@@ -78,11 +78,10 @@ public class SpanRenderer
     {
         SpanAdapter typeAdapter = getTypeAdapter();
 
-        // Iterate over the span annotations of the current type and render each of them
-        try {
-            type = aTypeSystem.getType(typeAdapter.getAnnotationTypeName());
-        }
-        catch (IllegalArgumentException e) {
+        type = aTypeSystem.getType(typeAdapter.getAnnotationTypeName());
+        if (type == null) {
+            // If the types are not defined, then we do not need to try and render them because the
+            // CAS does not contain any instances of them
             return false;
         }
 


### PR DESCRIPTION
**What's in the PR**
* typesystem.getlayer does not throw an exception when the type is not found instead it returns null, therefore check for null so types are not rendered if they are not in the typesystem 

**How to test manually**
* see issue
