### PR TITLE
#2382 - Allow unlocking of liquibase from command line/tray icon

### DIFF
--- a/inception/inception-app-webapp/pom.xml
+++ b/inception/inception-app-webapp/pom.xml
@@ -452,10 +452,6 @@
 
     <!-- DATABASE / HIBERNATE -->
 
-    <!-- <dependency> -->
-    <!-- <groupId>org.hibernate</groupId> -->
-    <!-- <artifactId>hibernate-entitymanager</artifactId> -->
-    <!-- </dependency> -->
     <dependency>
       <groupId>org.liquibase</groupId>
       <artifactId>liquibase-core</artifactId>
@@ -841,7 +837,6 @@
               <usedDependency>org.mariadb.jdbc:mariadb-java-client</usedDependency>
               <usedDependency>mysql:mysql-connector-java</usedDependency>
               <usedDependency>org.hsqldb:hsqldb</usedDependency>
-              <usedDependency>org.liquibase:liquibase-core</usedDependency>
               <usedDependency>org.ehcache:ehcache</usedDependency>
               <!-- Logging - used via reflection / optional -->
               <usedDependency>org.slf4j:log4j-over-slf4j</usedDependency>

--- a/inception/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/app/config/LiquibaseLockCheckAutoConfiguration.java
+++ b/inception/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/app/config/LiquibaseLockCheckAutoConfiguration.java
@@ -28,6 +28,9 @@ import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfigurati
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 
+import de.tudarmstadt.ukp.clarin.webanno.support.db.LiquibaseLockManager;
+import de.tudarmstadt.ukp.clarin.webanno.support.db.LockRemovedException;
+import de.tudarmstadt.ukp.clarin.webanno.support.db.NotLockedException;
 import liquibase.exception.LockException;
 import liquibase.integration.spring.SpringLiquibase;
 
@@ -36,7 +39,8 @@ import liquibase.integration.spring.SpringLiquibase;
 public class LiquibaseLockCheckAutoConfiguration
 {
     @Bean
-    public LiquibaseLockManager liquibaseLockCheck(DataSource aDataSource) throws LockException
+    public LiquibaseLockManager liquibaseLockCheck(DataSource aDataSource)
+        throws LockException, NotLockedException, LockRemovedException
     {
         return new LiquibaseLockManager(aDataSource);
     }

--- a/inception/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/app/config/LiquibaseLockCheckAutoConfiguration.java
+++ b/inception/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/app/config/LiquibaseLockCheckAutoConfiguration.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.app.config;
+
+import javax.sql.DataSource;
+
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.boot.autoconfigure.AbstractDependsOnBeanFactoryPostProcessor;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import liquibase.exception.LockException;
+import liquibase.integration.spring.SpringLiquibase;
+
+@AutoConfigureBefore(LiquibaseAutoConfiguration.class)
+@AutoConfigureAfter({ DataSourceAutoConfiguration.class, HibernateJpaAutoConfiguration.class })
+public class LiquibaseLockCheckAutoConfiguration
+{
+    @Bean
+    public LiquibaseLockManager liquibaseLockCheck(DataSource aDataSource) throws LockException
+    {
+        return new LiquibaseLockManager(aDataSource);
+    }
+
+    @Bean
+    public BeanFactoryPostProcessor ensureLiquibaseLockCheckRunsBeforeLiquibase()
+    {
+        return new AbstractDependsOnBeanFactoryPostProcessor(SpringLiquibase.class,
+                LiquibaseLockManager.class)
+        {
+            // No content
+        };
+    }
+}

--- a/inception/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/app/config/LiquibaseLockManager.java
+++ b/inception/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/app/config/LiquibaseLockManager.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.app.config;
+
+import static java.text.DateFormat.SHORT;
+import static java.text.DateFormat.getDateTimeInstance;
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import liquibase.database.Database;
+import liquibase.database.DatabaseConnection;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.exception.DatabaseException;
+import liquibase.exception.LockException;
+import liquibase.lockservice.DatabaseChangeLogLock;
+import liquibase.lockservice.LockService;
+import liquibase.lockservice.LockServiceFactory;
+
+public class LiquibaseLockManager
+{
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    private final DataSource dataSource;
+
+    public LiquibaseLockManager(DataSource aDataSource) throws LockException
+    {
+        dataSource = aDataSource;
+
+        try {
+            List<DatabaseChangeLogLock> locks = listLocks();
+            log.info("Liquibase locks: {}", listLocks());
+            if (!locks.isEmpty()) {
+                DatabaseChangeLogLock lock = locks.get(0);
+                throw new LockException("Could not acquire change log lock. Currently locked by "
+                        + lock.getLockedBy() + " since "
+                        + getDateTimeInstance(SHORT, SHORT).format(lock.getLockGranted()));
+            }
+            else {
+                throw new LockException(
+                        "Could not acquire change log lock. Currently locked by DUMMY");
+            }
+        }
+        catch (LockException e) {
+            throw e;
+        }
+        catch (Exception e) {
+            log.error("Unable to list Liquibase locks: ", e.getMessage());
+        }
+    }
+
+    public List<DatabaseChangeLogLock> listLocks()
+        throws DatabaseException, LockException, SQLException
+    {
+        Database database = null;
+        try {
+            Connection c = dataSource.getConnection();
+
+            DatabaseConnection liquibaseConnection = new JdbcConnection(c);
+
+            database = DatabaseFactory.getInstance()
+                    .findCorrectDatabaseImplementation(liquibaseConnection);
+
+            LockService lockService = LockServiceFactory.getInstance().getLockService(database);
+            return unmodifiableList(asList(lockService.listLocks()));
+        }
+        finally {
+            if (database != null) {
+                database.close();
+            }
+        }
+    }
+
+    public void forceReleaseLock() throws DatabaseException, LockException, SQLException
+    {
+        Database database = null;
+        try {
+            Connection c = dataSource.getConnection();
+
+            DatabaseConnection liquibaseConnection = new JdbcConnection(c);
+
+            database = DatabaseFactory.getInstance()
+                    .findCorrectDatabaseImplementation(liquibaseConnection);
+
+            LockService lockService = LockServiceFactory.getInstance().getLockService(database);
+            lockService.forceReleaseLock();
+        }
+        finally {
+            if (database != null) {
+                database.close();
+            }
+        }
+    }
+}

--- a/inception/inception-app-webapp/src/main/resources/META-INF/spring.factories
+++ b/inception/inception-app-webapp/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-de.tudarmstadt.ukp.inception.app.config.InceptionProjectInitializersAutoConfiguration
+de.tudarmstadt.ukp.inception.app.config.InceptionProjectInitializersAutoConfiguration,\
+de.tudarmstadt.ukp.inception.app.config.LiquibaseLockCheckAutoConfiguration

--- a/inception/inception-curation/src/test/java/de/tudarmstadt/ukp/inception/curation/CurationServiceTest.java
+++ b/inception/inception-curation/src/test/java/de/tudarmstadt/ukp/inception/curation/CurationServiceTest.java
@@ -32,6 +32,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
@@ -43,8 +44,9 @@ import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.Role;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 
-@DataJpaTest(showSql = false, properties = { //
-        "spring.main.banner-mode=off" })
+@DataJpaTest(excludeAutoConfiguration = LiquibaseAutoConfiguration.class, showSql = false, //
+        properties = { //
+                "spring.main.banner-mode=off" })
 @EnableAutoConfiguration
 @EntityScan({ //
         "de.tudarmstadt.ukp.inception.curation", //

--- a/inception/inception-project/src/test/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImplTest.java
+++ b/inception/inception-project/src/test/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImplTest.java
@@ -36,6 +36,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
@@ -46,7 +47,9 @@ import de.tudarmstadt.ukp.clarin.webanno.model.ProjectPermission;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.Role;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 
-@DataJpaTest
+@DataJpaTest(excludeAutoConfiguration = LiquibaseAutoConfiguration.class, showSql = false, //
+        properties = { //
+                "spring.main.banner-mode=off" })
 @ExtendWith(SpringExtension.class)
 public class ProjectServiceImplTest
 {

--- a/inception/inception-support-standalone/pom.xml
+++ b/inception/inception-support-standalone/pom.xml
@@ -39,6 +39,11 @@
       <artifactId>commons-text</artifactId>
     </dependency>
     
+    <dependency>
+      <groupId>org.liquibase</groupId>
+      <artifactId>liquibase-core</artifactId>
+    </dependency>
+    
 
     <!-- Spring dependencies -->
     <dependency>

--- a/inception/inception-support-standalone/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/standalone/StartupErrorHandler.java
+++ b/inception/inception-support-standalone/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/standalone/StartupErrorHandler.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.support.standalone;
+
+import static javax.swing.JOptionPane.ERROR_MESSAGE;
+import static javax.swing.WindowConstants.DISPOSE_ON_CLOSE;
+import static org.apache.commons.lang3.exception.ExceptionUtils.getRootCause;
+import static org.apache.commons.lang3.exception.ExceptionUtils.getRootCauseMessage;
+import static org.apache.commons.text.WordUtils.wrap;
+
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.net.BindException;
+
+import javax.swing.JDialog;
+import javax.swing.JOptionPane;
+
+import org.springframework.boot.context.event.ApplicationFailedEvent;
+
+import liquibase.exception.LockException;
+
+public class StartupErrorHandler
+{
+    private final String applicationName;
+
+    public StartupErrorHandler(String aApplicationName)
+    {
+        super();
+        applicationName = aApplicationName;
+    }
+
+    public void handleError(ApplicationFailedEvent aEvent)
+    {
+        JOptionPane pane = new JOptionPane(getErrorMessage(aEvent), ERROR_MESSAGE);
+        pane.addPropertyChangeListener(event -> {
+            if (JOptionPane.VALUE_PROPERTY.equals(event.getPropertyName())) {
+                System.exit(0);
+            }
+        });
+
+        JDialog dialog = pane.createDialog(null, applicationName + " - Error");
+        dialog.setModal(false);
+        dialog.setVisible(true);
+        dialog.setDefaultCloseOperation(DISPOSE_ON_CLOSE);
+        dialog.setAlwaysOnTop(true); // bring to front...
+        dialog.setAlwaysOnTop(false); // ... but do not annoy user
+        dialog.requestFocus();
+        dialog.addWindowListener(new WindowAdapter()
+        {
+            @Override
+            public void windowClosed(WindowEvent aE)
+            {
+                System.exit(0);
+            }
+        });
+    }
+
+    public String getErrorMessage(ApplicationFailedEvent aEvent)
+    {
+        if (aEvent.getException() == null) {
+            return "Unknown error";
+        }
+
+        StringBuilder msg = new StringBuilder();
+
+        String rootCauseMsg = getRootCauseMessage(aEvent.getException());
+        Throwable rootCause = getRootCause(aEvent.getException());
+
+        if (rootCause instanceof BindException || rootCauseMsg.contains("already in use")) {
+            msg.append("It appears the network port " + applicationName
+                    + " is trying to use is already being used by another application.\nMaybe "
+                    + "you have already started " + applicationName + " before?\n");
+            msg.append("\n");
+        }
+
+        if (rootCause instanceof LockException) {
+            msg.append("It appears that another instance of " + applicationName
+                    + " is already using the database.\n"
+                    + "Please check if any other instances of " + applicationName
+                    + " are running.\n"
+                    + "When you are sure no other instances are running, you can forcibly "
+                    + "release the lock by\nrunning " + applicationName
+                    + " ONCE with the parameter '-DforceReleaseLock=true'.");
+            msg.append("\n");
+        }
+
+        msg.append("\n");
+        msg.append("Error type: " + getRootCause(aEvent.getException()).getClass() + "\n");
+        msg.append("Error message: " + wrap(rootCauseMsg, 80));
+
+        return msg.toString();
+    }
+}

--- a/inception/inception-support/pom.xml
+++ b/inception/inception-support/pom.xml
@@ -138,7 +138,7 @@
       <version>1.9.6</version>
     </dependency>
 
-    <!-- Hibernate dependencies -->
+    <!-- Database dependencies -->
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-core</artifactId>
@@ -146,6 +146,10 @@
     <dependency>
       <groupId>javax.persistence</groupId>
       <artifactId>javax.persistence-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.liquibase</groupId>
+      <artifactId>liquibase-core</artifactId>
     </dependency>
 
     <!-- Jackson dependencies -->

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/db/LockRemovedException.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/db/LockRemovedException.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.support.db;
+
+/**
+ * Indicates that the database lock has been removed. Not really an exception but a way to cause the
+ * application to shut down.
+ */
+public class LockRemovedException
+    extends Exception
+{
+    private static final long serialVersionUID = -3218948315544678593L;
+
+    public LockRemovedException(String aMessage)
+    {
+        super(aMessage);
+    }
+}

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/db/NotLockedException.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/db/NotLockedException.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.support.db;
+
+/**
+ * Indicates that the database lock has been removed. Not really an exception but a way to cause the
+ * application to shut down.
+ */
+public class NotLockedException
+    extends Exception
+{
+    private static final long serialVersionUID = -3218948315544678593L;
+
+    public NotLockedException(String aMessage)
+    {
+        super(aMessage);
+    }
+}


### PR DESCRIPTION
**What's in the PR**
- Hook in between DB initialization and Liquibase
- If there is a lock, generate an exception immediately
- Provide helpful message how to recover when running in standalone mode
- Actual unlocking when user requests is is not yet done
- Added system property which can be set to force-remove the lock

**How to test manually**
* Run INCEpTION with MySQL (for easier DB access)
* Manually enter locking information in the table `DATABASECHANGELOGLOCK`
* Start the application in desktop mode and see message
* Start again with `-DforceReleaseLock=true` and see message
* Start a second time with `-DforceReleaseLock=true` and see message
* Start normally

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
