### PR TITLE
#2390 - More fine-grained info during startup

### DIFF
--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/AgreementMeasureSupportRegistryImpl.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/AgreementMeasureSupportRegistryImpl.java
@@ -66,10 +66,12 @@ public class AgreementMeasureSupportRegistryImpl
             AnnotationAwareOrderComparator.sort(fsp);
 
             for (AgreementMeasureSupport fs : fsp) {
-                log.info("Found agreement measure support: {}",
+                log.debug("Found agreement measure support: {}",
                         ClassUtils.getAbbreviatedName(fs.getClass(), 20));
             }
         }
+
+        log.info("Found [{}] agreement measure supports", fsp.size());
 
         agreementMeasures = Collections.unmodifiableList(fsp);
     }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/AnnotationEditorExtensionRegistryImpl.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/AnnotationEditorExtensionRegistryImpl.java
@@ -17,9 +17,10 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.api.annotation;
 
+import static java.util.Collections.unmodifiableList;
+
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.lang3.ClassUtils;
@@ -73,12 +74,14 @@ public class AnnotationEditorExtensionRegistryImpl
             AnnotationAwareOrderComparator.sort(exts);
 
             for (AnnotationEditorExtension fs : exts) {
-                log.info("Found annotation editor extension: {}",
+                log.debug("Found annotation editor extension: {}",
                         ClassUtils.getAbbreviatedName(fs.getClass(), 20));
             }
         }
 
-        extensions = Collections.unmodifiableList(exts);
+        log.info("Found [{}] annotation editor extensions", exts.size());
+
+        extensions = unmodifiableList(exts);
     }
 
     @Override

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/AnnotationEditorRegistryImpl.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/AnnotationEditorRegistryImpl.java
@@ -17,10 +17,10 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.api.annotation;
 
+import static java.util.Collections.unmodifiableList;
 import static java.util.Comparator.comparing;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.lang3.ClassUtils;
@@ -64,12 +64,14 @@ public class AnnotationEditorRegistryImpl
             AnnotationAwareOrderComparator.sort(exts);
 
             for (AnnotationEditorFactory fs : exts) {
-                log.info("Found annotation editor: {}",
+                log.debug("Found annotation editor: {}",
                         ClassUtils.getAbbreviatedName(fs.getClass(), 20));
             }
         }
 
-        extensions = Collections.unmodifiableList(exts);
+        log.info("Found [{}] annotation editors", exts.size());
+
+        extensions = unmodifiableList(exts);
     }
 
     @Override

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/layer/LayerBehaviorRegistryImpl.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/layer/LayerBehaviorRegistryImpl.java
@@ -17,8 +17,9 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.api.annotation.layer;
 
+import static java.util.Collections.unmodifiableList;
+
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -69,12 +70,14 @@ public class LayerBehaviorRegistryImpl
             AnnotationAwareOrderComparator.sort(lsp);
 
             for (LayerBehavior fs : lsp) {
-                log.info("Found layer behavior: {}",
+                log.debug("Found layer behavior: {}",
                         ClassUtils.getAbbreviatedName(fs.getClass(), 20));
             }
         }
 
-        layerBehaviors = Collections.unmodifiableList(lsp);
+        log.info("Found [{}] layer behaviors", lsp.size());
+
+        layerBehaviors = unmodifiableList(lsp);
     }
 
     @Override

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/layer/LayerSupportRegistryImpl.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/layer/LayerSupportRegistryImpl.java
@@ -17,9 +17,10 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.api.annotation.layer;
 
+import static java.util.Collections.unmodifiableList;
+
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -79,13 +80,15 @@ public class LayerSupportRegistryImpl
             AnnotationAwareOrderComparator.sort(lsp);
 
             for (LayerSupport<?, ?> fs : lsp) {
-                log.info("Found layer support: {}",
+                log.debug("Found layer support: {}",
                         ClassUtils.getAbbreviatedName(fs.getClass(), 20));
                 fs.setLayerSupportRegistry(this);
             }
         }
 
-        layerSupports = Collections.unmodifiableList(lsp);
+        log.info("Found [{}] layer supports", lsp.size());
+
+        layerSupports = unmodifiableList(lsp);
     }
 
     @Override

--- a/inception/inception-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentImportExportServiceImpl.java
+++ b/inception/inception-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentImportExportServiceImpl.java
@@ -31,6 +31,7 @@ import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUt
 import static de.tudarmstadt.ukp.clarin.webanno.support.ZipUtils.zipFolder;
 import static java.io.File.createTempFile;
 import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableMap;
 import static org.apache.commons.io.FileUtils.copyFile;
 import static org.apache.commons.io.FileUtils.forceDelete;
 import static org.apache.uima.fit.factory.AnalysisEngineFactory.createEngine;
@@ -46,7 +47,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.text.BreakIterator;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -147,38 +147,15 @@ public class DocumentImportExportServiceImpl
             AnnotationAwareOrderComparator.sort(forms);
             forms.forEach(format -> {
                 formatMap.put(format.getId(), format);
-                log.info("Found format: {} ({}, {})",
+                log.debug("Found format: {} ({}, {})",
                         ClassUtils.getAbbreviatedName(format.getClass(), 20), format.getId(),
                         readWriteMsg(format));
             });
         }
 
-        // Parse "formats.properties" information into format supports
-        // if (readWriteFileFormats != null) {
-        // for (String key : readWriteFileFormats.stringPropertyNames()) {
-        // if (key.endsWith(".label")) {
-        // String formatId = key.substring(0, key.lastIndexOf(".label"));
-        // String formatName = readWriteFileFormats.getProperty(key);
-        // String readerClass = readWriteFileFormats.getProperty(formatId + ".reader");
-        // String writerClass = readWriteFileFormats.getProperty(formatId + ".writer");
-        //
-        // if (formatMap.containsKey(formatId)) {
-        // log.info("Found format (format.properties): {} - format already defined by "
-        // + "a built-in format support, ignoring entry from "
-        // + "formats.properties file", formatId);
-        // }
-        // else {
-        // FormatSupport format = new FormatSupportDescription(formatId, formatName,
-        // readerClass, writerClass);
-        // formatMap.put(format.getId(), format);
-        // log.info("Found format (format.properties): {} ({})", formatId,
-        // readWriteMsg(format));
-        // }
-        // }
-        // }
-        // }
+        log.info("Found [{}] format supports", formatMap.size());
 
-        formats = Collections.unmodifiableMap(formatMap);
+        formats = unmodifiableMap(formatMap);
     }
 
     private String readWriteMsg(FormatSupport aFormat)

--- a/inception/inception-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/export/ProjectExportServiceImpl.java
+++ b/inception/inception-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/export/ProjectExportServiceImpl.java
@@ -22,6 +22,7 @@ import static de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExportTaskStat
 import static de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExportTaskState.RUNNING;
 import static java.lang.System.currentTimeMillis;
 import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
 import static org.apache.commons.lang3.time.DurationFormatUtils.formatDurationWords;
 
 import java.io.File;
@@ -29,7 +30,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Deque;
 import java.util.Enumeration;
 import java.util.HashSet;
@@ -139,7 +139,7 @@ public class ProjectExportServiceImpl
             Set<Class<? extends ProjectExporter>> exporterClasses = new HashSet<>();
             for (ProjectExporter init : exps) {
                 if (exporterClasses.add(init.getClass())) {
-                    log.info("Found project exporter: {}",
+                    log.debug("Found project exporter: {}",
                             ClassUtils.getAbbreviatedName(init.getClass(), 20));
                 }
                 else {
@@ -150,7 +150,9 @@ public class ProjectExportServiceImpl
             }
         }
 
-        exporters = Collections.unmodifiableList(exps);
+        log.info("Found [{}] project exporters", exps.size());
+
+        exporters = unmodifiableList(exps);
     }
 
     @Override

--- a/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/service/ConceptLinkingServiceImpl.java
+++ b/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/service/ConceptLinkingServiceImpl.java
@@ -125,10 +125,12 @@ public class ConceptLinkingServiceImpl
             AnnotationAwareOrderComparator.sort(generators);
 
             for (EntityRankingFeatureGenerator generator : generators) {
-                log.info("Found entity ranking feature generator: {}",
+                log.debug("Found entity ranking feature generator: {}",
                         ClassUtils.getAbbreviatedName(generator.getClass(), 20));
             }
         }
+
+        log.info("Found [{}] entity ranking feature generators", generators.size());
 
         featureGenerators = unmodifiableList(generators);
     }

--- a/inception/inception-external-search-core/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/ExternalSearchProviderRegistryImpl.java
+++ b/inception/inception-external-search-core/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/ExternalSearchProviderRegistryImpl.java
@@ -70,10 +70,12 @@ public class ExternalSearchProviderRegistryImpl
             AnnotationAwareOrderComparator.sort(exts);
 
             for (ExternalSearchProviderFactory fs : exts) {
-                log.info("Found external search provider: {}",
+                log.debug("Found external search provider: {}",
                         ClassUtils.getAbbreviatedName(fs.getClass(), 20));
             }
         }
+
+        log.info("Found [{}] external search providers", exts.size());
 
         providers = Collections.unmodifiableList(exts);
     }

--- a/inception/inception-kb/pom.xml
+++ b/inception/inception-kb/pom.xml
@@ -213,11 +213,6 @@
     </dependency>
     
     <dependency>
-      <groupId>org.apache.wicket</groupId>
-      <artifactId>wicket-spring</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>
     </dependency>

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
@@ -23,6 +23,7 @@ import static de.tudarmstadt.ukp.inception.kb.querybuilder.Path.zeroOrMore;
 import static de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilder.DEFAULT_LIMIT;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static java.util.stream.Collectors.toList;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
 
 import java.io.BufferedInputStream;
@@ -53,7 +54,6 @@ import org.apache.commons.compress.compressors.CompressorStreamFactory;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.eclipse.rdf4j.common.iteration.Iterations;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Statement;
@@ -105,7 +105,6 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRegistry;
 import de.tudarmstadt.ukp.clarin.webanno.api.config.RepositoryProperties;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.support.SettingsUtil;
@@ -146,8 +145,6 @@ public class KnowledgeBaseServiceImpl
     private @PersistenceContext EntityManager entityManager;
     private final RepositoryManager repoManager;
     private final File kbRepositoriesRoot;
-
-    private @SpringBean FeatureSupportRegistry featureSupportRegistry;
 
     private final LoadingCache<QueryKey, List<KBHandle>> queryCache;
 
@@ -197,6 +194,7 @@ public class KnowledgeBaseServiceImpl
         repoManager = RepositoryProvider.getRepositoryManager(kbRepositoriesRoot);
         repoManager.setHttpClient(PerThreadSslCheckingHttpClientUtils
                 .newPerThreadSslCheckingHttpClientBuilder().build());
+
         log.info("Knowledge base repository path: {}", kbRepositoriesRoot);
     }
 
@@ -235,8 +233,8 @@ public class KnowledgeBaseServiceImpl
         }
 
         if (!orphanedIDs.isEmpty()) {
-            log.info("Found orphaned KB repositories: {}",
-                    orphanedIDs.stream().sorted().collect(Collectors.toList()));
+            log.info("Found [{}] orphaned KB repositories: {}", orphanedIDs.size(),
+                    orphanedIDs.stream().sorted().collect(toList()));
         }
 
         repoManager.refresh();

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/EventLoggingListener.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/EventLoggingListener.java
@@ -17,8 +17,9 @@
  */
 package de.tudarmstadt.ukp.inception.log;
 
+import static java.util.Collections.unmodifiableList;
+
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
@@ -45,6 +46,7 @@ import de.tudarmstadt.ukp.inception.log.adapter.GenericEventAdapter;
 import de.tudarmstadt.ukp.inception.log.config.EventLoggingAutoConfiguration;
 import de.tudarmstadt.ukp.inception.log.config.EventLoggingProperties;
 import de.tudarmstadt.ukp.inception.log.model.LoggedEvent;
+import de.tudarmstadt.ukp.inception.support.spring.StartupProgressInfoEvent;
 
 /**
  * <p>
@@ -102,12 +104,14 @@ public class EventLoggingListener
             AnnotationAwareOrderComparator.sort(exts);
 
             for (EventLoggingAdapter<?> fs : exts) {
-                log.info("Found event logging adapter: {}",
+                log.debug("Found event logging adapter: {}",
                         ClassUtils.getAbbreviatedName(fs.getClass(), 20));
             }
         }
 
-        adapters = Collections.unmodifiableList(exts);
+        log.info("Found [{}] event logging adapters", exts.size());
+
+        adapters = unmodifiableList(exts);
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
@@ -138,6 +142,10 @@ public class EventLoggingListener
     @EventListener
     public void onApplicationEvent(ApplicationEvent aEvent)
     {
+        if (aEvent instanceof StartupProgressInfoEvent) {
+            return;
+        }
+
         Optional<EventLoggingAdapter<ApplicationEvent>> adapter = getAdapter(aEvent);
 
         if (adapter.isPresent()) {

--- a/inception/inception-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
+++ b/inception/inception-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
@@ -24,6 +24,7 @@ import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.MANAGER;
 import static java.nio.file.Files.newDirectoryStream;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.unmodifiableList;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.io.IOUtils.copyLarge;
 import static org.apache.commons.lang3.time.DurationFormatUtils.formatDurationWords;
@@ -795,7 +796,7 @@ public class ProjectServiceImpl
             Set<Class<? extends ProjectInitializer>> initializerClasses = new HashSet<>();
             for (ProjectInitializer init : inits) {
                 if (initializerClasses.add(init.getClass())) {
-                    log.info("Found project initializer: {}",
+                    log.debug("Found project initializer: {}",
                             ClassUtils.getAbbreviatedName(init.getClass(), 20));
                 }
                 else {
@@ -806,7 +807,9 @@ public class ProjectServiceImpl
             }
         }
 
-        initializers = Collections.unmodifiableList(inits);
+        log.info("Found [{}] project initializers", inits.size());
+
+        initializers = unmodifiableList(inits);
     }
 
     @Override

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommenderFactoryRegistryImpl.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommenderFactoryRegistryImpl.java
@@ -21,6 +21,8 @@
  */
 package de.tudarmstadt.ukp.inception.recommendation.service;
 
+import static java.util.Collections.unmodifiableMap;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -76,13 +78,15 @@ public class RecommenderFactoryRegistryImpl
 
         if (extensionsProxy != null) {
             for (RecommendationEngineFactory ext : extensionsProxy) {
-                log.info("Found recommendation engine: {}",
+                log.debug("Found recommendation engine: {}",
                         ClassUtils.getAbbreviatedName(ext.getClass(), 20));
                 exts.put(ext.getId(), ext);
             }
         }
 
-        extensions = Collections.unmodifiableMap(exts);
+        log.info("Found [{}] recommendation engines", exts.size());
+
+        extensions = unmodifiableMap(exts);
     }
 
     @Override

--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/FeatureIndexingSupportRegistryImpl.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/FeatureIndexingSupportRegistryImpl.java
@@ -21,8 +21,9 @@
  */
 package de.tudarmstadt.ukp.inception.search;
 
+import static java.util.Collections.unmodifiableList;
+
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -78,12 +79,14 @@ public class FeatureIndexingSupportRegistryImpl
             AnnotationAwareOrderComparator.sort(fsp);
 
             for (FeatureIndexingSupport fs : fsp) {
-                log.info("Found indexing support: {}",
+                log.debug("Found feature indexing support: {}",
                         ClassUtils.getAbbreviatedName(fs.getClass(), 20));
             }
         }
 
-        indexingSupports = Collections.unmodifiableList(fsp);
+        log.info("Found [{}] feature indexing supports", fsp.size());
+
+        indexingSupports = unmodifiableList(fsp);
     }
 
     @Override

--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/index/PhysicalIndexRegistryImpl.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/index/PhysicalIndexRegistryImpl.java
@@ -17,8 +17,9 @@
  */
 package de.tudarmstadt.ukp.inception.search.index;
 
+import static java.util.Collections.unmodifiableList;
+
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.lang3.ClassUtils;
@@ -69,12 +70,14 @@ public class PhysicalIndexRegistryImpl
             AnnotationAwareOrderComparator.sort(exts);
 
             for (PhysicalIndexFactory fs : exts) {
-                log.info("Found index extension: {}",
+                log.debug("Found index extension: {}",
                         ClassUtils.getAbbreviatedName(fs.getClass(), 20));
             }
         }
 
-        extensions = Collections.unmodifiableList(exts);
+        log.info("Found [{}] index extensions", exts.size());
+
+        extensions = unmodifiableList(exts);
     }
 
     @Override

--- a/inception/inception-support-standalone/pom.xml
+++ b/inception/inception-support-standalone/pom.xml
@@ -62,6 +62,10 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
 
     <!-- LOGGING DEPENDENCIES - SLF4J/LOG4J -->
     <dependency>

--- a/inception/inception-support-standalone/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/standalone/LoadingSplashScreen.java
+++ b/inception/inception-support-standalone/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/standalone/LoadingSplashScreen.java
@@ -17,10 +17,13 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.support.standalone;
 
+import static java.awt.BorderLayout.CENTER;
+import static java.awt.BorderLayout.SOUTH;
+import static java.awt.Color.WHITE;
+import static javax.swing.BorderFactory.createEmptyBorder;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.awt.AWTException;
-import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.GraphicsEnvironment;
 import java.awt.Point;
@@ -36,11 +39,21 @@ import java.util.Optional;
 import javax.swing.ImageIcon;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
+import javax.swing.SwingConstants;
 
 import org.slf4j.Logger;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceSchemaCreatedEvent;
+import org.springframework.boot.context.event.ApplicationContextInitializedEvent;
+import org.springframework.boot.context.event.ApplicationEnvironmentPreparedEvent;
 import org.springframework.boot.context.event.ApplicationFailedEvent;
+import org.springframework.boot.context.event.ApplicationPreparedEvent;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.boot.context.event.ApplicationStartingEvent;
+import org.springframework.boot.web.servlet.context.ServletWebServerInitializedEvent;
 import org.springframework.context.ApplicationEvent;
+import org.springframework.context.event.ContextRefreshedEvent;
+
+import de.tudarmstadt.ukp.inception.support.spring.StartupProgressInfoEvent;
 
 public class LoadingSplashScreen
 {
@@ -81,10 +94,13 @@ public class LoadingSplashScreen
             applicationName = aApplicationName;
 
             JLabel l = new JLabel(new ImageIcon(aSplashScreenImageUrl));
-            getContentPane().add(l, BorderLayout.CENTER);
+            getContentPane().add(l, CENTER);
 
-            info = new JLabel(applicationName + " is loading...");
-            getContentPane().add(info, BorderLayout.SOUTH);
+            info = new JLabel(applicationName + " is loading...", SwingConstants.CENTER);
+            info.setBackground(WHITE);
+            info.setOpaque(true);
+            info.setBorder(createEmptyBorder(5, 5, 5, 5));
+            getContentPane().add(info, SOUTH);
 
             ImageIcon img = new ImageIcon(aIconUrl);
             setIconImage(img.getImage());
@@ -167,13 +183,51 @@ public class LoadingSplashScreen
             }
 
             if (!isDisposed()) {
-                setInfo(applicationName + " is loading... - " + aEvent.getClass().getSimpleName());
+                setInfo(applicationName + " is loading... - " + mapEvent(aEvent));
             }
 
             if (aEvent instanceof ApplicationFailedEvent) {
                 new StartupErrorHandler(applicationName)
                         .handleError((ApplicationFailedEvent) aEvent);
             }
+        }
+
+        public String mapEvent(ApplicationEvent aEvent)
+        {
+            if (aEvent instanceof ApplicationStartingEvent) {
+                return "Application starting";
+            }
+
+            if (aEvent instanceof ApplicationEnvironmentPreparedEvent) {
+                return "Application environment prepared";
+            }
+
+            if (aEvent instanceof ApplicationContextInitializedEvent) {
+                return "Application context initialized";
+            }
+
+            if (aEvent instanceof ApplicationPreparedEvent) {
+                return "Application prepared";
+            }
+
+            if (aEvent instanceof DataSourceSchemaCreatedEvent) {
+                return "Data source schema created";
+            }
+
+            if (aEvent instanceof ServletWebServerInitializedEvent) {
+                return "Servlet web server initialized";
+            }
+
+            if (aEvent instanceof ContextRefreshedEvent) {
+                return "Context refreshed";
+            }
+
+            if (aEvent instanceof StartupProgressInfoEvent) {
+                return ((StartupProgressInfoEvent) aEvent).getMessage();
+            }
+
+            LOG.debug("Unmapped event: " + aEvent);
+            return aEvent.getClass().getSimpleName();
         }
     }
 }

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/extensionpoint/ExtensionPoint_ImplBase.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/extensionpoint/ExtensionPoint_ImplBase.java
@@ -17,11 +17,11 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.support.extensionpoint;
 
+import static java.util.Collections.unmodifiableList;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.ClassUtils.getAbbreviatedName;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -60,12 +60,14 @@ public abstract class ExtensionPoint_ImplBase<C, E extends Extension<C>>
             AnnotationAwareOrderComparator.sort(extensions);
 
             for (E fs : extensions) {
-                log.info("Found {} extension: {}", getClass().getSimpleName(),
+                log.debug("Found {} extension: {}", getClass().getSimpleName(),
                         getAbbreviatedName(fs.getClass(), 20));
             }
         }
 
-        extensionsList = Collections.unmodifiableList(extensions);
+        log.debug("Found [{}] {} extensions", extensions.size(), getClass().getSimpleName());
+
+        extensionsList = unmodifiableList(extensions);
     }
 
     @Override

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/interceptors/GlobalInterceptorsRegistryImpl.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/interceptors/GlobalInterceptorsRegistryImpl.java
@@ -62,10 +62,12 @@ public class GlobalInterceptorsRegistryImpl
             AnnotationAwareOrderComparator.sort(fsp);
 
             for (GlobalInterceptor fs : fsp) {
-                log.info("Found global interceptor: {}",
+                log.debug("Found global interceptor: {}",
                         ClassUtils.getAbbreviatedName(fs.getClass(), 20));
             }
         }
+
+        log.info("Found [{}] global interceptors", fsp.size());
 
         interceptors = Collections.unmodifiableList(fsp);
     }

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/spring/StartupProgressInfoEvent.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/spring/StartupProgressInfoEvent.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.support.spring;
+
+import org.springframework.context.ApplicationEvent;
+
+public class StartupProgressInfoEvent
+    extends ApplicationEvent
+{
+    private static final long serialVersionUID = -5071565761764354387L;
+
+    private final String message;
+
+    public StartupProgressInfoEvent(Object aSource, String aMessage)
+    {
+        super(aSource);
+        message = aMessage;
+    }
+
+    public String getMessage()
+    {
+        return message;
+    }
+}

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/spring/StartupWatcher.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/spring/StartupWatcher.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.support.spring;
+
+import static org.apache.commons.lang3.StringUtils.SPACE;
+import static org.apache.commons.lang3.StringUtils.join;
+import static org.apache.commons.lang3.StringUtils.lowerCase;
+import static org.apache.commons.lang3.StringUtils.splitByCharacterTypeCamelCase;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StartupWatcher
+    implements BeanPostProcessor
+{
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    private @Autowired ApplicationEventPublisher eventPublisher;
+
+    @Override
+    public Object postProcessBeforeInitialization(Object aBean, String aBeanName)
+        throws BeansException
+    {
+        String className = aBean.getClass().getName();
+        boolean isOurs = className.contains(".webanno.") || className.contains(".inception.");
+
+        String name = aBean.getClass().getSimpleName();
+        if (name.contains("$")) {
+            name = StringUtils.substringBefore(name, "$");
+        }
+
+        if (name.isBlank()) {
+            name = aBean.getClass().getSimpleName();
+        }
+
+        if (name.isBlank()) {
+            name = aBean.getClass().getName();
+        }
+
+        boolean isInterestingForUser = isOurs && name.endsWith("AutoConfiguration");
+
+        if (log.isTraceEnabled() && !isInterestingForUser) {
+            log.trace("Initializing " + name);
+        }
+
+        if (isInterestingForUser) {
+            name = StringUtils.removeEnd(name, "AutoConfiguration");
+            name = lowerCase(join(splitByCharacterTypeCamelCase(name), SPACE));
+
+            log.info("Initializing " + name);
+
+            eventPublisher
+                    .publishEvent(new StartupProgressInfoEvent(aBean, "Initializing " + name));
+        }
+
+        return aBean;
+    }
+}

--- a/inception/inception-telemetry/src/main/java/de/tudarmstadt/ukp/clarin/webanno/telemetry/TelemetryServiceImpl.java
+++ b/inception/inception-telemetry/src/main/java/de/tudarmstadt/ukp/clarin/webanno/telemetry/TelemetryServiceImpl.java
@@ -23,13 +23,13 @@ import static de.tudarmstadt.ukp.clarin.webanno.telemetry.DeploymentMode.SERVER_
 import static de.tudarmstadt.ukp.clarin.webanno.telemetry.DeploymentMode.SERVER_WAR;
 import static de.tudarmstadt.ukp.clarin.webanno.telemetry.DeploymentMode.SERVER_WAR_DOCKER;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.isNull;
 import static org.apache.commons.io.FileUtils.readFileToString;
 
 import java.awt.GraphicsEnvironment;
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -112,11 +112,13 @@ public class TelemetryServiceImpl
             AnnotationAwareOrderComparator.sort(tsp);
 
             for (TelemetrySupport ts : tsp) {
-                log.info("Found telemetry support: {}", ts.getId());
+                log.debug("Found telemetry support: {}", ts.getId());
             }
         }
 
-        telemetrySupports = Collections.unmodifiableList(tsp);
+        log.info("Found [{}] telemetry supports", tsp.size());
+
+        telemetrySupports = unmodifiableList(tsp);
 
         autoAcceptOrReject();
     }

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/sidebar/AnnotationSidebarRegistryImpl.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/sidebar/AnnotationSidebarRegistryImpl.java
@@ -17,8 +17,9 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar;
 
+import static java.util.Collections.unmodifiableList;
+
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
@@ -64,12 +65,14 @@ public class AnnotationSidebarRegistryImpl
             exts.sort(buildComparator());
 
             for (AnnotationSidebarFactory fs : exts) {
-                log.info("Found annotation sidebar extension: {}",
+                log.debug("Found annotation sidebar extension: {}",
                         ClassUtils.getAbbreviatedName(fs.getClass(), 20));
             }
         }
 
-        extensions = Collections.unmodifiableList(exts);
+        log.info("Found [{}] annotation sidebar extensions", exts.size());
+
+        extensions = unmodifiableList(exts);
     }
 
     @Override

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/footer/FooterItemRegistryImpl.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/footer/FooterItemRegistryImpl.java
@@ -61,9 +61,12 @@ public class FooterItemRegistryImpl
             AnnotationAwareOrderComparator.sort(exts);
 
             for (FooterItem fs : exts) {
-                log.info("Found footer item: {}", ClassUtils.getAbbreviatedName(fs.getClass(), 20));
+                log.debug("Found footer item: {}",
+                        ClassUtils.getAbbreviatedName(fs.getClass(), 20));
             }
         }
+
+        log.info("Found [{}] footer items", exts.size());
 
         extensions = Collections.unmodifiableList(exts);
     }

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/menu/MenuItemRegistryImpl.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/menu/MenuItemRegistryImpl.java
@@ -65,7 +65,7 @@ public class MenuItemRegistryImpl
             AnnotationAwareOrderComparator.sort(exts);
 
             for (MenuItem fs : exts) {
-                log.info("Found menu item: {}", ClassUtils.getAbbreviatedName(fs.getClass(), 20));
+                log.debug("Found menu item: {}", ClassUtils.getAbbreviatedName(fs.getClass(), 20));
 
                 if (fs.getPageClass() == null) {
                     throw new IllegalStateException("Menu item [" + fs.getClass().getName()
@@ -73,6 +73,8 @@ public class MenuItemRegistryImpl
                 }
             }
         }
+
+        log.info("Found [{}] menu items", exts.size());
 
         extensions = Collections.unmodifiableList(exts);
     }

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/settings/ProjectSettingsPanelRegistryImpl.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/settings/ProjectSettingsPanelRegistryImpl.java
@@ -17,8 +17,9 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.ui.core.settings;
 
+import static java.util.Collections.unmodifiableList;
+
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.lang3.ClassUtils;
@@ -62,12 +63,14 @@ public class ProjectSettingsPanelRegistryImpl
             AnnotationAwareOrderComparator.sort(exts);
 
             for (ProjectSettingsPanelFactory fs : exts) {
-                log.info("Found project setting panel: {}",
+                log.debug("Found project setting panel: {}",
                         ClassUtils.getAbbreviatedName(fs.getClass(), 20));
             }
         }
 
-        extensions = Collections.unmodifiableList(exts);
+        log.info("Found [{}] project setting panels", exts.size());
+
+        extensions = unmodifiableList(exts);
     }
 
     @Override

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/coloring/StatementColoringRegistryImpl.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/coloring/StatementColoringRegistryImpl.java
@@ -17,8 +17,9 @@
  */
 package de.tudarmstadt.ukp.inception.ui.kb.stmt.coloring;
 
+import static java.util.Collections.unmodifiableList;
+
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.lang3.ClassUtils;
@@ -69,12 +70,14 @@ public class StatementColoringRegistryImpl
             AnnotationAwareOrderComparator.sort(fsp);
 
             for (StatementColoringStrategy fs : fsp) {
-                log.info("Found value type support: {}",
+                log.debug("Found statement coloring strategies: {}",
                         ClassUtils.getAbbreviatedName(fs.getClass(), 20));
             }
         }
 
-        statementColoringStrategies = Collections.unmodifiableList(fsp);
+        log.info("Found [{}] statement coloring strategies", fsp.size());
+
+        statementColoringStrategies = unmodifiableList(fsp);
     }
 
     @Override

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/value/ValueTypeSupportRegistryImpl.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/value/ValueTypeSupportRegistryImpl.java
@@ -21,8 +21,9 @@
  */
 package de.tudarmstadt.ukp.inception.ui.kb.value;
 
+import static java.util.Collections.unmodifiableList;
+
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -81,12 +82,14 @@ public class ValueTypeSupportRegistryImpl
             AnnotationAwareOrderComparator.sort(fsp);
 
             for (ValueTypeSupport fs : fsp) {
-                log.info("Found value type support: {}",
+                log.debug("Found value type support: {}",
                         ClassUtils.getAbbreviatedName(fs.getClass(), 20));
             }
         }
 
-        valueSupports = Collections.unmodifiableList(fsp);
+        log.info("Found [{}] value type supports", fsp.size());
+
+        valueSupports = unmodifiableList(fsp);
     }
 
     @Override


### PR DESCRIPTION
**What's in the PR**
- Move detail information about what is found by the registries to debug level and only log the number of the extensions in each registry
- Send info events when a auto-config module in an application package is being initialized
- Slightly improve visual style of the splash screen

**How to test manually**
* Start the app (in desktop mode)

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
