### PR TITLE
#2399 - Sentence overview wrongly indicates agreement

### DIFF
--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/overview/CurationUnitOverviewLink.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/overview/CurationUnitOverviewLink.java
@@ -40,8 +40,6 @@ public class CurationUnitOverviewLink
 
     private static final String CSS_CLASS_OUT_RANGE = "out-range";
     private static final String CSS_CLASS_IN_RANGE = "in-range";
-    private static final String CSS_CLASS_AGREE = "agree";
-    private static final String CSS_CLASS_DISAGREE = "disagree";
     private static final String CSS_CLASS_CURRENT = "current";
 
     private IModel<AnnotatorState> annotatorState;

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/CurationPage.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/CurationPage.java
@@ -751,7 +751,7 @@ public class CurationPage
         }
 
         boolean allCurated = true;
-        curatedDiffSet: for (ConfigurationSet d : diff.getDifferingConfigurationSets().values()) {
+        curatedDiffSet: for (ConfigurationSet d : diff.getConfigurationSets()) {
             if (!d.getCasGroupIds().contains(WebAnnoConst.CURATION_USER)) {
                 allCurated = false;
                 break curatedDiffSet;


### PR DESCRIPTION
**What's in the PR**
- When checking if a position has been curated, we need to look at all configurations, not only at the ones with differences between the annotators

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
