### PR TITLE
#2415 - Stale document states may cause error when accessing the curation page

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/page/AnnotationPageBase.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/page/AnnotationPageBase.java
@@ -215,13 +215,21 @@ public abstract class AnnotationPageBase
     public boolean actionShowSelectedDocument(AjaxRequestTarget aTarget, SourceDocument aDocument)
     {
         if (!Objects.equals(aDocument.getId(), getModelObject().getDocument().getId())) {
-            getModelObject().setDocument(aDocument, getListOfDocs());
+            List<SourceDocument> docs = getListOfDocs();
+            if (!docs.contains(aDocument)) {
+                error("The document [" + aDocument.getName() + "] is not accessible");
+                if (aTarget != null) {
+                    aTarget.addChildren(getPage(), IFeedback.class);
+                }
+                return false;
+            }
+
+            getModelObject().setDocument(aDocument, docs);
             actionLoadDocument(aTarget);
             return true;
         }
-        else {
-            return false;
-        }
+
+        return false;
     }
 
     /**

--- a/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/storage/config/CurationDocumentServiceAutoConfiguration.java
+++ b/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/storage/config/CurationDocumentServiceAutoConfiguration.java
@@ -24,6 +24,7 @@ import org.springframework.context.annotation.Configuration;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.CasStorageService;
+import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
 import de.tudarmstadt.ukp.clarin.webanno.curation.storage.CurationDocumentService;
 import de.tudarmstadt.ukp.clarin.webanno.curation.storage.CurationDocumentServiceImpl;
 
@@ -32,9 +33,10 @@ public class CurationDocumentServiceAutoConfiguration
 {
     @Bean(CurationDocumentService.SERVICE_NAME)
     public CurationDocumentService curationDocumentService(CasStorageService aCasStorageService,
-            AnnotationSchemaService aAnnotationService, EntityManager aEntityManager)
+            AnnotationSchemaService aAnnotationService, ProjectService aProjectService,
+            EntityManager aEntityManager)
     {
         return new CurationDocumentServiceImpl(aCasStorageService, aAnnotationService,
-                aEntityManager);
+                aProjectService, aEntityManager);
     }
 }

--- a/inception/inception-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
+++ b/inception/inception-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
@@ -436,13 +436,17 @@ public class ProjectServiceImpl
     public List<User> listProjectUsersWithPermissions(Project aProject,
             PermissionLevel aPermissionLevel)
     {
-        String query = "SELECT DISTINCT u FROM User u, ProjectPermission pp "
-                + "WHERE pp.user = u.username " + "AND pp.project = :project AND pp.level = :level "
-                + "ORDER BY u.username ASC";
-        List<User> users = entityManager.createQuery(query, User.class)
-                .setParameter("project", aProject).setParameter("level", aPermissionLevel)
+        String query = String.join("\n", //
+                "SELECT DISTINCT u FROM User u, ProjectPermission pp ", //
+                "WHERE pp.user = u.username ", //
+                "AND pp.project = :project ", //
+                "AND pp.level = :level ", //
+                "ORDER BY u.username ASC");
+
+        return entityManager.createQuery(query, User.class) //
+                .setParameter("project", aProject) //
+                .setParameter("level", aPermissionLevel) //
                 .getResultList();
-        return users;
     }
 
     @Override

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
@@ -456,7 +456,8 @@ public class AnnotationPage
             // scheduled and *after* the preferences have been loaded (because the current editor
             // type is set in the preferences.
             createAnnotationEditor(aTarget);
-            // update paging, only do it during document load so we load the cas after it has been upgraded
+            // update paging, only do it during document load so we load the cas after it has been
+            // upgraded
             try {
                 state.getPagingStrategy().recalculatePage(state, getEditorCas());
             }
@@ -671,9 +672,8 @@ public class AnnotationPage
     {
         final List<DecoratedObject<SourceDocument>> allSourceDocuments = new ArrayList<>();
 
-        // Remove from the list source documents that are in IGNORE state OR
-        // that do not have at least one annotation document marked as
-        // finished for curation dialog
+        // FIXME: This should be changed to call getListOfDocs or getListOfDocs should base on
+        // this call - in any case, the selection/filtering code should only be there once
         Map<SourceDocument, AnnotationDocument> docs = documentService.listAllDocuments(aProject,
                 aUser);
 

--- a/inception/inception-ui-curation/pom.xml
+++ b/inception/inception-ui-curation/pom.xml
@@ -49,6 +49,10 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-workload</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-model</artifactId>
     </dependency>
     <dependency>

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/CurationPage.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/CurationPage.java
@@ -124,6 +124,7 @@ import de.tudarmstadt.ukp.clarin.webanno.ui.curation.event.CurationUnitClickedEv
 import de.tudarmstadt.ukp.clarin.webanno.ui.curation.overview.CurationUnit;
 import de.tudarmstadt.ukp.clarin.webanno.ui.curation.overview.CurationUnitOverviewLink;
 import de.tudarmstadt.ukp.clarin.webanno.ui.curation.overview.CurationUnitState;
+import de.tudarmstadt.ukp.inception.workload.model.WorkloadManagementService;
 
 /**
  * This is the main class for the curation page. It contains an interface which displays differences
@@ -146,6 +147,7 @@ public class CurationPage
     private @SpringBean ConstraintsService constraintsService;
     private @SpringBean AnnotationSchemaService annotationService;
     private @SpringBean UserDao userRepository;
+    private @SpringBean WorkloadManagementService workloadManagementService;
 
     private long currentprojectId;
 
@@ -429,6 +431,11 @@ public class CurationPage
     @Override
     public List<SourceDocument> getListOfDocs()
     {
+        AnnotatorState state = getModelObject();
+        // Since the curatable documents depend on the document state, let's make sure the document
+        // state is up-to-date
+        workloadManagementService.getWorkloadManagerExtension(state.getProject())
+                .freshenStatus(state.getProject());
         return curationDocumentService.listCuratableSourceDocuments(getModelObject().getProject());
     }
 
@@ -451,7 +458,7 @@ public class CurationPage
     @Override
     public CAS getEditorCas() throws IOException
     {
-        AnnotatorState state = CurationPage.this.getModelObject();
+        AnnotatorState state = getModelObject();
 
         if (state.getDocument() == null) {
             throw new IllegalStateException("Please open a document first!");
@@ -500,7 +507,7 @@ public class CurationPage
 
         try {
             // Update source document state to CURRATION_INPROGRESS, if it was not
-            // ANNOTATION_FINISHED
+            // CURATION_FINISHED
             if (!CURATION_FINISHED.equals(state.getDocument().getState())) {
                 documentService.transitionSourceDocumentState(state.getDocument(),
                         ANNOTATION_IN_PROGRESS_TO_CURATION_IN_PROGRESS);
@@ -559,9 +566,8 @@ public class CurationPage
                 .listFinishedAnnotationDocuments(state.getDocument());
 
         if (finishedAnnotationDocuments.isEmpty()) {
-            throw new IllegalStateException("This document has the state "
-                    + state.getDocument().getState() + " but "
-                    + "there are no finished annotation documents! This "
+            getSession().error("This document has the state " + state.getDocument().getState()
+                    + " but " + "there are no finished annotation documents! This "
                     + "can for example happen when curation on a document has already started "
                     + "and afterwards all annotators have been remove from the project, have been "
                     + "disabled or if all were put back into " + AnnotationDocumentState.IN_PROGRESS
@@ -571,6 +577,7 @@ public class CurationPage
                     + "administration dashboard and if none of the imported users have been "
                     + "enabled via the users management page after the import (also something "
                     + "that only administrators can do).");
+            backToProjectPage();
         }
 
         AnnotationDocument randomAnnotationDocument = finishedAnnotationDocuments.get(0);
@@ -618,7 +625,9 @@ public class CurationPage
         // Check access to project
         if (project != null
                 && !projectService.isCurator(project, userRepository.getCurrentUser())) {
-            error("You have no permission to access project [" + project.getId() + "]");
+            getSession()
+                    .error("You have no permission to access project [" + project.getId() + "]");
+            backToProjectPage();
             return;
         }
 
@@ -634,6 +643,12 @@ public class CurationPage
         // or a change of focus (or both)
         if (document != null && !document.equals(state.getDocument())) {
             state.setDocument(document, getListOfDocs());
+
+            if (state.getDocumentIndex() == -1) {
+                getSession().error("The document [" + document.getName() + "] is not curatable");
+                backToProjectPage();
+                return;
+            }
         }
     }
 
@@ -694,7 +709,7 @@ public class CurationPage
             User aUser)
     {
         final List<DecoratedObject<SourceDocument>> allSourceDocuments = new ArrayList<>();
-        List<SourceDocument> sdocs = curationDocumentService.listCuratableSourceDocuments(aProject);
+        List<SourceDocument> sdocs = getListOfDocs();
 
         for (SourceDocument sourceDocument : sdocs) {
             DecoratedObject<SourceDocument> dsd = DecoratedObject.of(sourceDocument);


### PR DESCRIPTION
**What's in the PR**
- Prevent switching to a document which is not in the list of accessible documents that is shown in the open document dialog
- Align listCuratableDocuments with listFinishedDocuments by not showing any documents of users that have been removed from the project
- Slightly reorganize and format the code in ProjectServiceImpl.listProjectUsersWithPermissions
- Build CurationPage.listAccessibleDocuments (used by the open document dialog) on getListOfDocs (used by the navbar)
- Build CurationPage.listAccessibleDocuments (used by the open document dialog) on getListOfDocs (used by the navbar)
- When trying to open the CurationPage on a document that is not curatable via a URL parameter, send user back to the project dashboard and show error
- In CurationPage.getlistOfDocs() first refresh the project state so we know which documents are actually curatable

**How to test manually**
* Access annotation and curation pages, in particular also on older projects

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
