### PR TITLE
Bugfix for #2467 and partially addresses #2442

### DIFF
--- a/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchAnnotationSidebar.java
+++ b/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchAnnotationSidebar.java
@@ -36,6 +36,7 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.Type;
@@ -646,9 +647,24 @@ public class SearchAnnotationSidebar
             return;
         }
 
+        boolean match = false;
+
         // create a new annotation if not already there or if stacking is enabled and the
         // new annotation has different features than the existing one
-        if (annoFS == null || (!overrideExisting && !featureValuesMatchCurrentState(annoFS))) {
+        Stream<AnnotationFS> annoFSs = selectAt(aCas, type, aSearchResult.getOffsetStart(),
+                aSearchResult.getOffsetEnd()).stream();
+
+        for (AnnotationFS eannoFS : annoFSs.collect(Collectors.toList())) {
+            if (overrideExisting) {
+                setFeatureValues(aDocument, aCas, aAdapter, state, eannoFS);
+                aBulkResult.updated++;
+            }
+            else if (featureValuesMatchCurrentState(eannoFS)) {
+                match = true;
+            }
+        }
+
+        if (annoFS == null || (!match && !overrideExisting)) {
             try {
                 annoFS = aAdapter.add(aDocument, currentUser.getUsername(), aCas,
                         aSearchResult.getOffsetStart(), aSearchResult.getOffsetEnd());
@@ -658,12 +674,15 @@ public class SearchAnnotationSidebar
                 aBulkResult.conflict++;
                 return;
             }
-        }
-        else {
-            aBulkResult.updated++;
-        }
 
-        // set values for all features according to current state
+            // set values for all features according to current state
+            setFeatureValues(aDocument, aCas, aAdapter, state, annoFS);
+        }
+    }
+
+    private void setFeatureValues(SourceDocument aDocument, CAS aCas, SpanAdapter aAdapter,
+            AnnotatorState state, AnnotationFS annoFS)
+    {
         int addr = getAddr(annoFS);
         List<FeatureState> featureStates = state.getFeatureStates();
         for (FeatureState featureState : featureStates) {
@@ -680,16 +699,16 @@ public class SearchAnnotationSidebar
             SpanAdapter aAdapter, SearchResult aSearchResult, BulkOperationResult aBulkResult)
     {
         Type type = CasUtil.getAnnotationType(aCas, aAdapter.getAnnotationTypeName());
-        AnnotationFS annoFS = selectAt(aCas, type, aSearchResult.getOffsetStart(),
-                aSearchResult.getOffsetEnd()).stream().findFirst().orElse(null);
+        Stream<AnnotationFS> annoFSs = selectAt(aCas, type, aSearchResult.getOffsetStart(),
+                aSearchResult.getOffsetEnd()).stream();
 
-        if (annoFS == null || !featureValuesMatchCurrentState(annoFS)
-                && deleteOptions.getObject().isDeleteOnlyMatchingFeatureValues()) {
-            return;
+        for (AnnotationFS annoFS : annoFSs.collect(Collectors.toList())) {
+            if ((annoFS != null && featureValuesMatchCurrentState(annoFS))
+                    || !deleteOptions.getObject().isDeleteOnlyMatchingFeatureValues()) {
+                aAdapter.delete(aDocument, currentUser.getUsername(), aCas, new VID(annoFS));
+                aBulkResult.deleted++;
+            }
         }
-
-        aAdapter.delete(aDocument, currentUser.getUsername(), aCas, new VID(annoFS));
-        aBulkResult.deleted++;
     }
 
     private void writeJCasAndUpdateTimeStamp(SourceDocument aSourceDoc, CAS aCas)

--- a/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchAnnotationSidebar.java
+++ b/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchAnnotationSidebar.java
@@ -36,7 +36,6 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.Type;
@@ -214,7 +213,7 @@ public class SearchAnnotationSidebar
         resultsGroupContainer = new WebMarkupContainer("resultsGroupContainer");
         resultsGroupContainer.setOutputMarkupId(true);
         mainContainer.add(resultsGroupContainer);
-        
+
         searchResultGroups = new DataView<ResultsGroup>("searchResultGroups", resultsProvider)
         {
             private static final long serialVersionUID = -631500052426449048L;
@@ -651,10 +650,8 @@ public class SearchAnnotationSidebar
 
         // create a new annotation if not already there or if stacking is enabled and the
         // new annotation has different features than the existing one
-        Stream<AnnotationFS> annoFSs = selectAt(aCas, type, aSearchResult.getOffsetStart(),
-                aSearchResult.getOffsetEnd()).stream();
-
-        for (AnnotationFS eannoFS : annoFSs.collect(Collectors.toList())) {
+        for (AnnotationFS eannoFS : selectAt(aCas, type, aSearchResult.getOffsetStart(),
+                aSearchResult.getOffsetEnd())) {
             if (overrideExisting) {
                 setFeatureValues(aDocument, aCas, aAdapter, state, eannoFS);
                 aBulkResult.updated++;
@@ -699,10 +696,9 @@ public class SearchAnnotationSidebar
             SpanAdapter aAdapter, SearchResult aSearchResult, BulkOperationResult aBulkResult)
     {
         Type type = CasUtil.getAnnotationType(aCas, aAdapter.getAnnotationTypeName());
-        Stream<AnnotationFS> annoFSs = selectAt(aCas, type, aSearchResult.getOffsetStart(),
-                aSearchResult.getOffsetEnd()).stream();
 
-        for (AnnotationFS annoFS : annoFSs.collect(Collectors.toList())) {
+        for (AnnotationFS annoFS : selectAt(aCas, type, aSearchResult.getOffsetStart(),
+                aSearchResult.getOffsetEnd())) {
             if ((annoFS != null && featureValuesMatchCurrentState(annoFS))
                     || !deleteOptions.getObject().isDeleteOnlyMatchingFeatureValues()) {
                 aAdapter.delete(aDocument, currentUser.getUsername(), aCas, new VID(annoFS));


### PR DESCRIPTION
**What's in the PR**
This is a fix for bug #2467 and it also partially address #2442 (I realised it also only looked at the first annotation and so would create a duplicate even if one of the others was a match).

**How to test manually**
Assuming you use the named entity layer. Using a search for words you should be able to create multiple sets using a different value feature tag, with repeated calls with the same tag not creating duplicates. You will also then be able to delete any matching annotation using any of the tag values you have created (assuming you have more than one stacked up).

Note the exact behaviour on creating multiple annotations when one exists with matching values alongside the override isn't really defined well so I went with just trying to avoid creating duplicates when not overriding. However if override is on then it will set all matches to the template annotations as before, this may result in duplicates if there were multiple distinct ones beforehand.

**Automatic testing**
No matching test class

