### PR TITLE
#2497 - Exceptions during task selection and accept best

### DIFF
--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommenderInfoPanel.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommenderInfoPanel.java
@@ -263,8 +263,13 @@ public class RecommenderInfoPanel
 
         CAS cas = page.getEditorCas();
 
-        // SourceDocument document = state.getDocument();
         Predictions predictions = recommendationService.getPredictions(user, state.getProject());
+        if (predictions == null) {
+            error("Recommenders did not yet provide any suggestions.");
+            aTarget.addChildren(getPage(), IFeedback.class);
+            return;
+        }
+
         Preferences pref = recommendationService.getPreferences(user, state.getProject());
 
         // TODO #176 use the document Id once it it available in the CAS


### PR DESCRIPTION
**What's in the PR**
- Avoid NPE when user tries to accept best but there are actually no predictions

**How to test manually**
* Not really sure how to reproduce the situation where a recommender is considered as active but then there are no predictions. Maybe open the recommender sidebar, look for an active recommender that has a long training time, reset recommenders and then click accept best then.

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
