### PR TITLE
#2517 - Avoid multiple property conditions for websocket-related features

### DIFF
--- a/inception/inception-websocket/src/main/java/de/tudarmstadt/ukp/inception/websocket/config/WebsocketAutoConfiguration.java
+++ b/inception/inception-websocket/src/main/java/de/tudarmstadt/ukp/inception/websocket/config/WebsocketAutoConfiguration.java
@@ -17,38 +17,35 @@
  */
 package de.tudarmstadt.ukp.inception.websocket.config;
 
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
-import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
-import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+import de.tudarmstadt.ukp.inception.log.config.EventLoggingAutoConfiguration;
+import de.tudarmstadt.ukp.inception.websocket.controller.LoggedEventMessageController;
+import de.tudarmstadt.ukp.inception.websocket.footer.LoggedEventFooterItem;
+import de.tudarmstadt.ukp.inception.websocket.footer.RecommendationEventFooterItem;
 
 @Configuration
 @EnableWebSocketMessageBroker
+@AutoConfigureAfter(EventLoggingAutoConfiguration.class)
 @ConditionalOnProperty(prefix = "websocket", name = "enabled", havingValue = "true", matchIfMissing = true)
-public class WebsocketConfig
-    implements WebSocketMessageBrokerConfigurer
+public class WebsocketAutoConfiguration
 {
-    public static final String WS_ENDPOINT = "/ws-endpoint";
-
-    @Override
-    public void registerStompEndpoints(StompEndpointRegistry aRegistry)
+    @ConditionalOnBean(LoggedEventMessageController.class)
+    @ConditionalOnProperty(name = "websocket.loggedevent.enabled", havingValue = "true")
+    @Bean
+    public LoggedEventFooterItem loggedEventFooterItem()
     {
-        // client will use this endpoint to first establish connection
-        aRegistry.addEndpoint(WS_ENDPOINT);
+        return new LoggedEventFooterItem();
     }
 
-    @Override
-    public void configureMessageBroker(MessageBrokerRegistry aRegistry)
+    @Bean
+    public RecommendationEventFooterItem recommendationEventFooterItem()
     {
-        // broker will send to destinations with this prefix, queue is custom for user-specific
-        // channels. client will subscribe to /queue/{subtopic} where subtopic is a specific topic
-        // that controller or service will address messages to
-        aRegistry.enableSimpleBroker("/queue", "/topic");
-        // clients should send messages to channels pre-fixed with this
-        aRegistry.setApplicationDestinationPrefixes("/app");
-        // messages to clients are by default not ordered, need to explicitly set order here
-        aRegistry.setPreservePublishOrder(true);
+        return new RecommendationEventFooterItem();
     }
 }

--- a/inception/inception-websocket/src/main/java/de/tudarmstadt/ukp/inception/websocket/config/WebsocketSecurityConfig.java
+++ b/inception/inception-websocket/src/main/java/de/tudarmstadt/ukp/inception/websocket/config/WebsocketSecurityConfig.java
@@ -26,7 +26,7 @@ import org.springframework.security.config.annotation.web.messaging.MessageSecur
 import org.springframework.security.config.annotation.web.socket.AbstractSecurityWebSocketMessageBrokerConfigurer;
 
 @Configuration
-@ConditionalOnProperty(prefix = "websocket", name = "enabled", havingValue = "true")
+@ConditionalOnProperty(prefix = "websocket", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class WebsocketSecurityConfig
     extends AbstractSecurityWebSocketMessageBrokerConfigurer
 {

--- a/inception/inception-websocket/src/main/java/de/tudarmstadt/ukp/inception/websocket/controller/LoggedEventMessageControllerImpl.java
+++ b/inception/inception-websocket/src/main/java/de/tudarmstadt/ukp/inception/websocket/controller/LoggedEventMessageControllerImpl.java
@@ -24,6 +24,7 @@ import java.util.Date;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.event.EventListener;
@@ -40,8 +41,8 @@ import de.tudarmstadt.ukp.inception.log.adapter.EventLoggingAdapterRegistry;
 import de.tudarmstadt.ukp.inception.websocket.model.LoggedEventMessage;
 
 @Controller
-@ConditionalOnProperty(name = { "websocket.enabled", "websocket.loggedevent.enabled",
-        "event-logging.enabled" }, havingValue = "true", matchIfMissing = false)
+@ConditionalOnBean(SimpMessagingTemplate.class)
+@ConditionalOnProperty(name = "websocket.loggedevent.enabled", havingValue = "true", matchIfMissing = false)
 public class LoggedEventMessageControllerImpl
     implements LoggedEventMessageController
 {

--- a/inception/inception-websocket/src/main/java/de/tudarmstadt/ukp/inception/websocket/controller/RecommendationEventMessageControllerImpl.java
+++ b/inception/inception-websocket/src/main/java/de/tudarmstadt/ukp/inception/websocket/controller/RecommendationEventMessageControllerImpl.java
@@ -20,7 +20,7 @@ package de.tudarmstadt.ukp.inception.websocket.controller;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.event.EventListener;
 import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -32,8 +32,8 @@ import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
 import de.tudarmstadt.ukp.inception.recommendation.event.RecommenderTaskEvent;
 import de.tudarmstadt.ukp.inception.websocket.model.LoggedEventMessage;
 
+@ConditionalOnBean(SimpMessagingTemplate.class)
 @Controller
-@ConditionalOnProperty("websocket.enabled")
 public class RecommendationEventMessageControllerImpl
     implements RecommendationEventMessageController
 {

--- a/inception/inception-websocket/src/main/java/de/tudarmstadt/ukp/inception/websocket/footer/LoggedEventFooterItem.java
+++ b/inception/inception-websocket/src/main/java/de/tudarmstadt/ukp/inception/websocket/footer/LoggedEventFooterItem.java
@@ -18,14 +18,18 @@
 package de.tudarmstadt.ukp.inception.websocket.footer;
 
 import org.apache.wicket.Component;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.core.annotation.Order;
 
 import de.tudarmstadt.ukp.clarin.webanno.ui.core.footer.FooterItem;
+import de.tudarmstadt.ukp.inception.websocket.config.WebsocketAutoConfiguration;
 
+/**
+ * <p>
+ * This class is exposed as a Spring Component via
+ * {@link WebsocketAutoConfiguration#loggedEventFooterItem}.
+ * </p>
+ */
 @Order(FooterItem.ORDER_LEFT + 500)
-@org.springframework.stereotype.Component
-@ConditionalOnProperty({ "websocket.enabled", "websocket.loggedevent.enabled" })
 public class LoggedEventFooterItem
     implements FooterItem
 {

--- a/inception/inception-websocket/src/main/java/de/tudarmstadt/ukp/inception/websocket/footer/RecommendationEventFooterItem.java
+++ b/inception/inception-websocket/src/main/java/de/tudarmstadt/ukp/inception/websocket/footer/RecommendationEventFooterItem.java
@@ -18,22 +18,24 @@
 package de.tudarmstadt.ukp.inception.websocket.footer;
 
 import org.apache.wicket.Component;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.core.annotation.Order;
 
 import de.tudarmstadt.ukp.clarin.webanno.ui.core.footer.FooterItem;
+import de.tudarmstadt.ukp.inception.websocket.config.WebsocketAutoConfiguration;
 
+/**
+ * <p>
+ * This class is exposed as a Spring Component via
+ * {@link WebsocketAutoConfiguration#recommendationEventFooterItem}.
+ * </p>
+ */
 @Order(FooterItem.ORDER_RIGHT - 100)
-@org.springframework.stereotype.Component
-@ConditionalOnProperty("websocket.enabled")
 public class RecommendationEventFooterItem
     implements FooterItem
 {
-
     @Override
     public Component create(String aId)
     {
         return new RecommendationEventFooterPanel(aId);
     }
-
 }

--- a/inception/inception-websocket/src/main/resources/META-INF/spring.factories
+++ b/inception/inception-websocket/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+de.tudarmstadt.ukp.inception.websocket.config.WebsocketAutoConfiguration

--- a/inception/inception-websocket/src/test/java/de/tudarmstadt/ukp/inception/websocket/LoggedEventMessageControllerImplTest.java
+++ b/inception/inception-websocket/src/test/java/de/tudarmstadt/ukp/inception/websocket/LoggedEventMessageControllerImplTest.java
@@ -49,6 +49,7 @@ import de.tudarmstadt.ukp.inception.log.EventRepository;
 import de.tudarmstadt.ukp.inception.log.adapter.EventLoggingAdapterRegistryImpl;
 import de.tudarmstadt.ukp.inception.log.adapter.SpanEventAdapter;
 import de.tudarmstadt.ukp.inception.log.config.EventLoggingAutoConfiguration;
+import de.tudarmstadt.ukp.inception.websocket.config.WebsocketAutoConfiguration;
 import de.tudarmstadt.ukp.inception.websocket.controller.LoggedEventMessageControllerImpl;
 import de.tudarmstadt.ukp.inception.websocket.model.LoggedEventMessage;
 
@@ -105,7 +106,9 @@ public class LoggedEventMessageControllerImplTest
     }
 
     @SpringBootConfiguration
-    @EnableAutoConfiguration(exclude = { EventLoggingAutoConfiguration.class,
+    @EnableAutoConfiguration(exclude = { //
+            WebsocketAutoConfiguration.class, //
+            EventLoggingAutoConfiguration.class, //
             LiquibaseAutoConfiguration.class })
     @EntityScan(basePackages = { "de.tudarmstadt.ukp.inception.websocket" })
     public static class SpringConfig


### PR DESCRIPTION
**What's in the PR**
- Ensure that each of the websocket beans uses only a single property in the @ConditionalOnProperty
- Enable basic websocket support by default

**How to test manually**
* Run with websocket / websocket logging enabled and disabled and check if it works as expected

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
