### PR TITLE
#2526 - Allow selective disabling of COEP for developers

### DIFF
--- a/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/AcceptInvitePage.java
+++ b/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/AcceptInvitePage.java
@@ -207,7 +207,7 @@ public class AcceptInvitePage
 
         User user;
         if (aForm.getModelObject().registeredLogin) {
-            user = signInAsRegisteredUserIfNecessary(aTarget);
+            user = signInAsRegisteredUserIfNecessary();
         }
         else {
             user = signInAsProjectUser(aForm.getModelObject());
@@ -255,7 +255,7 @@ public class AcceptInvitePage
         return user;
     }
 
-    private User signInAsRegisteredUserIfNecessary(AjaxRequestTarget aTarget)
+    private User signInAsRegisteredUserIfNecessary()
     {
         User user = userRepository.getCurrentUser();
 

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/wicket/PatternMatchingCrossOriginEmbedderPolicyRequestCycleListener.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/wicket/PatternMatchingCrossOriginEmbedderPolicyRequestCycleListener.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.support.wicket;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.wicket.coep.CrossOriginEmbedderPolicyConfiguration;
+import org.apache.wicket.coep.CrossOriginEmbedderPolicyRequestCycleListener;
+import org.apache.wicket.request.IRequestHandler;
+import org.apache.wicket.request.cycle.RequestCycle;
+import org.apache.wicket.request.http.WebResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PatternMatchingCrossOriginEmbedderPolicyRequestCycleListener
+    extends CrossOriginEmbedderPolicyRequestCycleListener
+{
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    private static final String REGEX_PREFIX = "regex:";
+
+    private CrossOriginEmbedderPolicyConfiguration coepConfig;
+    private List<Pattern> patterns;
+
+    public PatternMatchingCrossOriginEmbedderPolicyRequestCycleListener(
+            CrossOriginEmbedderPolicyConfiguration aCoepConfig)
+    {
+        super(aCoepConfig);
+        coepConfig = aCoepConfig;
+    }
+
+    @Override
+    public void onRequestHandlerResolved(RequestCycle aCycle, IRequestHandler aHandler)
+    {
+        if (!(aCycle.getResponse() instanceof WebResponse)) {
+            return;
+        }
+
+        final Object containerRequest = aCycle.getRequest().getContainerRequest();
+        if (!(containerRequest instanceof HttpServletRequest)) {
+            return;
+        }
+
+        final String coepHeaderName = coepConfig.getCoepHeader();
+        HttpServletRequest request = (HttpServletRequest) containerRequest;
+        // CrossOriginEmbedderPolicyRequestCycleListener uses requesrt.getContextPath()
+        // here which seems to make no sense at all!
+        String path = request.getRequestURI();
+
+        WebResponse webResponse = (WebResponse) aCycle.getResponse();
+        if (webResponse.isHeaderSupported()) {
+            if (coepConfig.getExemptions().contains(path) || matchesExemptionPatten(path)) {
+                log.debug("Request path {} is exempted from COEP, no '{}' header added", path,
+                        coepHeaderName);
+                // We cannot un-set a header, so we set explicitly to disable COEP
+                webResponse.setHeader(coepHeaderName, "unsafe-none");
+            }
+            else {
+                webResponse.setHeader(coepHeaderName, "require-corp");
+            }
+        }
+    };
+
+    private boolean matchesExemptionPatten(String aPath)
+    {
+        initPatterns();
+
+        for (Pattern p : patterns) {
+            if (p.matcher(aPath).matches()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private synchronized void initPatterns()
+    {
+        if (patterns != null) {
+            return;
+        }
+
+        patterns = new ArrayList<>();
+        for (String exemption : coepConfig.getExemptions()) {
+            if (exemption.startsWith(REGEX_PREFIX)) {
+                patterns.add(Pattern.compile(exemption.substring(REGEX_PREFIX.length())));
+            }
+        }
+    }
+}

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.java
@@ -35,6 +35,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.wicket.Page;
 import org.apache.wicket.authorization.strategies.CompoundAuthorizationStrategy;
 import org.apache.wicket.authroles.authorization.strategies.role.RoleAuthorizationStrategy;
+import org.apache.wicket.coep.CrossOriginEmbedderPolicyConfiguration;
+import org.apache.wicket.coep.CrossOriginEmbedderPolicyRequestCycleListener;
 import org.apache.wicket.devutils.stateless.StatelessChecker;
 import org.apache.wicket.request.Response;
 import org.apache.wicket.request.cycle.IRequestCycleListener;
@@ -58,6 +60,7 @@ import de.agilecoders.wicket.sass.SassCompilerOptionsFactory;
 import de.agilecoders.wicket.webjars.WicketWebjars;
 import de.tudarmstadt.ukp.clarin.webanno.support.FileSystemResource;
 import de.tudarmstadt.ukp.clarin.webanno.support.SettingsUtil;
+import de.tudarmstadt.ukp.clarin.webanno.support.wicket.PatternMatchingCrossOriginEmbedderPolicyRequestCycleListener;
 import de.tudarmstadt.ukp.clarin.webanno.ui.config.BootstrapAwareJQueryUIJavaScriptResourceReference;
 import de.tudarmstadt.ukp.clarin.webanno.ui.config.CssBrowserSelectorResourceBehavior;
 import de.tudarmstadt.ukp.clarin.webanno.ui.config.FontAwesomeResourceBehavior;
@@ -88,7 +91,11 @@ public abstract class WicketApplicationBase
 
         getCspSettings().blocking().disabled();
 
-        getSecuritySettings().setCrossOriginEmbedderPolicyConfiguration(ENFORCING);
+        // Enforce COEP while inheriting any exemptions that might already have been set e.g. via
+        // WicketApplicationInitConfiguration beans
+        getSecuritySettings().setCrossOriginEmbedderPolicyConfiguration(ENFORCING,
+                getSecuritySettings().getCrossOriginEmbedderPolicyConfiguration().getExemptions()
+                        .stream().toArray(String[]::new));
         getSecuritySettings().setCrossOriginOpenerPolicyConfiguration(SAME_ORIGIN);
 
         initStatelessChecker();
@@ -97,6 +104,29 @@ public abstract class WicketApplicationBase
             initOnce();
 
             isInitialized = true;
+        }
+    }
+
+    @Override
+    protected void validateInit()
+    {
+        super.validateInit();
+
+        CrossOriginEmbedderPolicyConfiguration coepConfig = getSecuritySettings()
+                .getCrossOriginEmbedderPolicyConfiguration();
+        if (coepConfig.isEnabled()) {
+            // Remove the CrossOriginEmbedderPolicyRequestCycleListener that was configured
+            // by Wicket
+            List<IRequestCycleListener> toRemove = new ArrayList<>();
+            for (IRequestCycleListener listener : getRequestCycleListeners()) {
+                if (listener instanceof CrossOriginEmbedderPolicyRequestCycleListener) {
+                    toRemove.add(listener);
+                }
+            }
+            toRemove.forEach(listener -> getRequestCycleListeners().remove(listener));
+
+            getRequestCycleListeners().add(
+                    new PatternMatchingCrossOriginEmbedderPolicyRequestCycleListener(coepConfig));
         }
     }
 


### PR DESCRIPTION
**What's in the PR**
- Unregister the default COEP listener from Wicket
- Register an alternative COEP listener which also supports regex-based matching
- Remove unused parameter from a private method

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
