### PR TITLE
#2426 - Difference in labelling of annotation marker vs identifier lookup

### DIFF
--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/ConceptFeatureValueType.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/ConceptFeatureValueType.java
@@ -19,8 +19,10 @@ package de.tudarmstadt.ukp.inception.kb;
 
 public enum ConceptFeatureValueType
 {
-    ANY_OBJECT("<any concept/instance>"), CONCEPT("concepts only"), INSTANCE("instances only"),
-    PROPERTY("properties only");
+    ANY_OBJECT("any"), //
+    CONCEPT("concepts only"), //
+    INSTANCE("instances only"), //
+    PROPERTY("properties only"); //
 
     private final String uiLabel;
 

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
@@ -1116,8 +1116,10 @@ public class KnowledgeBaseServiceImpl
     public Optional<KBHandle> readHandle(KnowledgeBase aKB, String aIdentifier)
     {
         try (StopWatch watch = new StopWatch(log, "readHandle(%s)", aIdentifier)) {
-            SPARQLQuery query = SPARQLQueryBuilder.forItems(aKB).withIdentifier(aIdentifier)
-                    .retrieveLabel();
+            SPARQLQuery query = SPARQLQueryBuilder.forItems(aKB) //
+                    .withIdentifier(aIdentifier) //
+                    .retrieveLabel() //
+                    .retrieveDescription();
 
             Optional<KBHandle> result;
             if (aKB.isReadOnly()) {

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/config/KnowledgeBaseProperties.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/config/KnowledgeBaseProperties.java
@@ -46,4 +46,10 @@ public interface KnowledgeBaseProperties
      * @return whether do delete orphaned knowledge bases during startup.
      */
     boolean isRemoveOrphansOnStart();
+
+    Duration getRenderCacheRefreshDelay();
+
+    Duration getRenderCacheExpireDelay();
+
+    long getRenderCacheSize();
 }

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/config/KnowledgeBasePropertiesImpl.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/config/KnowledgeBasePropertiesImpl.java
@@ -17,8 +17,10 @@
  */
 package de.tudarmstadt.ukp.inception.kb.config;
 
+import static java.time.Duration.ofMinutes;
+import static java.time.temporal.ChronoUnit.MINUTES;
+
 import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.convert.DurationUnit;
@@ -36,14 +38,16 @@ public class KnowledgeBasePropertiesImpl
 
     private int defaultMaxResults = 1_000;
     private int hardMaxResults = 10_000;
-    private long cacheSize = 100_000;
+
     private boolean removeOrphansOnStart = false;
 
-    @DurationUnit(ChronoUnit.MINUTES)
-    private Duration cacheExpireDelay = Duration.ofMinutes(15);
+    private long cacheSize = 100_000;
+    private @DurationUnit(MINUTES) Duration cacheExpireDelay = ofMinutes(15);
+    private @DurationUnit(MINUTES) Duration cacheRefreshDelay = ofMinutes(5);
 
-    @DurationUnit(ChronoUnit.MINUTES)
-    private Duration cacheRefreshDelay = Duration.ofMinutes(5);
+    private long renderCacheSize = 10_000;
+    private @DurationUnit(MINUTES) Duration renderCacheExpireDelay = ofMinutes(10);
+    private @DurationUnit(MINUTES) Duration renderCacheRefreshDelay = ofMinutes(1);
 
     @Override
     public int getDefaultMaxResults()
@@ -109,5 +113,38 @@ public class KnowledgeBasePropertiesImpl
     public void setRemoveOrphansOnStart(boolean aRemoveOrphansOnStart)
     {
         removeOrphansOnStart = aRemoveOrphansOnStart;
+    }
+
+    @Override
+    public long getRenderCacheSize()
+    {
+        return renderCacheSize;
+    }
+
+    public void setRenderCacheSize(long aRenderCacheSize)
+    {
+        renderCacheSize = aRenderCacheSize;
+    }
+
+    @Override
+    public Duration getRenderCacheExpireDelay()
+    {
+        return renderCacheExpireDelay;
+    }
+
+    public void setRenderCacheExpireDelay(Duration aRenderCacheExpireDelay)
+    {
+        renderCacheExpireDelay = aRenderCacheExpireDelay;
+    }
+
+    @Override
+    public Duration getRenderCacheRefreshDelay()
+    {
+        return renderCacheRefreshDelay;
+    }
+
+    public void setRenderCacheRefreshDelay(Duration aRenderCacheRefreshDelay)
+    {
+        renderCacheRefreshDelay = aRenderCacheRefreshDelay;
     }
 }

--- a/inception/inception-kb/src/main/resources/META-INF/asciidoc/admin-guide/settings_knowledgebase.adoc
+++ b/inception/inception-kb/src/main/resources/META-INF/asciidoc/admin-guide/settings_knowledgebase.adoc
@@ -43,30 +43,45 @@ an example of how the parameter can be configured below:
 | true
 | false
 
-| knowledge-base.defaultMaxResults
+| knowledge-base.default-max-results
 | default result limit for SPARQL query
 | 1000
 | 10000
 
-| knowledge-base.hardMaxResults
+| knowledge-base.hard-max-results
 | hard limit for the maximum number of results from a query
 | 10000
 | 5000
 
-| knowledge-base.cacheSize
+| knowledge-base.cache-size
 | number of items (classes, instances and properties) to cache
 | 100000
 | 500000
 
-| knowledge-base.cacheExpireDelay
+| knowledge-base.cache-expire-delay
 | time before items are expunged from the cache
 | 15m
 | 1h
 
-| knowledge-base.cacheRefreshDelay
+| knowledge-base.cache-refresh-delay
 | time before items are asynchronously refreshed
 | 5m
 | 30m
+
+| knowledge-base.render-cache-size
+| number of items (classes, instances and properties) to cache during rendering
+| 10000
+| 50000
+
+| knowledge-base.render-cache-expire-delay
+| time before items are expunged from the render cache
+| 10m
+| 1h
+
+| knowledge-base.render-cache-refresh-delay
+| time before items are asynchronously refreshed when rendering
+| 1m
+| 5m
 
 | knowledge-base.remove-orphans-on-start
 | whether to delete orphaned KBs on start

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/KnowledgeBasePanel.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/KnowledgeBasePanel.java
@@ -165,10 +165,14 @@ public class KnowledgeBasePanel
                 Optional<KBObject> optKbObject = kbService.readItem(kbModel.getObject(),
                         selectedResource.getIdentifier());
 
-                if (optKbObject.isPresent()) {
-                    KBObject kbObject = optKbObject.get();
-                    sendSelectionChangedEvents(aTarget, kbObject);
+                if (!optKbObject.isPresent()) {
+                    error("The selected item is neither a concept, nor an instance nor a property. "
+                            + "It cannot be viewed/edited on this page.");
+                    aTarget.addChildren(getPage(), IFeedback.class);
+                    return;
                 }
+
+                sendSelectionChangedEvents(aTarget, optKbObject.get());
             }
         };
 
@@ -253,7 +257,7 @@ public class KnowledgeBasePanel
             models.stream().filter(model -> model.getObject() != null && model.getObject()
                     .getIdentifier().equals(statement.getInstance().getIdentifier()))
                     .forEach(model -> {
-                        Optional<KBObject> kbObject = kbService.readItem(kbModel.getObject(),
+                        Optional<KBHandle> kbObject = kbService.readHandle(kbModel.getObject(),
                                 model.getObject().getIdentifier());
                         if (kbObject.isPresent()) {
                             model.getObject().setName(kbObject.get().getName());

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/config/KnowledgeBaseServiceUIAutoConfiguration.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/config/KnowledgeBaseServiceUIAutoConfiguration.java
@@ -32,6 +32,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRegistry;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.inception.kb.KnowledgeBaseService;
+import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBaseProperties;
 import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBaseServiceAutoConfiguration;
 import de.tudarmstadt.ukp.inception.ui.kb.KnowledgeBasePageMenuItem;
 import de.tudarmstadt.ukp.inception.ui.kb.feature.ConceptFeatureSupport;
@@ -77,9 +78,10 @@ public class KnowledgeBaseServiceUIAutoConfiguration
 
     @Bean
     @Autowired
-    public ConceptFeatureSupport conceptFeatureSupport(KnowledgeBaseService aKbService)
+    public ConceptFeatureSupport conceptFeatureSupport(KnowledgeBaseService aKbService,
+            KnowledgeBaseProperties aKBProperties)
     {
-        return new ConceptFeatureSupport(aKbService);
+        return new ConceptFeatureSupport(aKbService, aKBProperties);
     }
 
     @Bean

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/search/ConceptFeatureIndexingSupport.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/search/ConceptFeatureIndexingSupport.java
@@ -104,7 +104,7 @@ public class ConceptFeatureIndexingSupport
         }
 
         // Get object from the KB
-        Optional<KBObject> kbObject = kbService.readItem(aFeature.getProject(),
+        Optional<KBHandle> kbObject = kbService.readHandle(aFeature.getProject(),
                 WebAnnoCasUtil.getFeature(aAnnotation, aFeature.getName()));
 
         if (!kbObject.isPresent()) {

--- a/inception/inception-ui-kb/src/main/resources/META-INF/asciidoc/user-guide/knowledge_base.adoc
+++ b/inception/inception-ui-kb/src/main/resources/META-INF/asciidoc/user-guide/knowledge_base.adoc
@@ -45,7 +45,7 @@ The same is true for the object of a statement: After choosing the property for 
 
 Concept features are features that allow referencing concepts in the knowledge base during annotation.
 
-To create a new concept feature, a new feature has to be created under *Projects Settings* -> *Layers*. The type of the new feature should be *KB: Concept/Instance*. Features of this type also can be configured to either take only concepts (select *Only Concept*), only instances (select *Only Instances*) or both (select *Any Concept/Instance*).
+To create a new concept feature, a new feature has to be created under *Projects Settings* -> *Layers*. The type of the new feature should be *KB: Concept/Instance/Property*. Features of this type also can be configured to either take *only concepts*, *only instances*, *only properties* or either (select *any*).
 
 [.thumb]
 image::kb5.png[align="center"]

--- a/inception/inception-ui-kb/src/test/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureSupportTest.java
+++ b/inception/inception-ui-kb/src/test/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureSupportTest.java
@@ -33,24 +33,27 @@ import org.mockito.Mock;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.inception.kb.KnowledgeBaseService;
+import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBasePropertiesImpl;
 import de.tudarmstadt.ukp.inception.kb.graph.KBHandle;
 import de.tudarmstadt.ukp.inception.kb.graph.KBInstance;
 
 public class ConceptFeatureSupportTest
 {
     private @Mock KnowledgeBaseService kbService;
+    private ConceptFeatureSupport sut;
 
     @BeforeEach
     public void setUp()
     {
         initMocks(this);
+
+        ConceptFeatureSupport sut = new ConceptFeatureSupport(kbService,
+                new KnowledgeBasePropertiesImpl());
     }
 
     @Test
     public void testAccepts()
     {
-        ConceptFeatureSupport sut = new ConceptFeatureSupport(kbService);
-
         AnnotationFeature feat1 = new AnnotationFeature("Dummy feature",
                 ConceptFeatureSupport.PREFIX + "someConcept");
 
@@ -63,8 +66,6 @@ public class ConceptFeatureSupportTest
     @Test
     public void testWrapUnwrap() throws Exception
     {
-        ConceptFeatureSupport sut = new ConceptFeatureSupport(kbService);
-
         AnnotationFeature feat1 = new AnnotationFeature("Dummy feature",
                 ConceptFeatureSupport.PREFIX + "someConcept");
 

--- a/inception/inception-ui-kb/src/test/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureSupportTest.java
+++ b/inception/inception-ui-kb/src/test/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureSupportTest.java
@@ -35,7 +35,6 @@ import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.inception.kb.KnowledgeBaseService;
 import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBasePropertiesImpl;
 import de.tudarmstadt.ukp.inception.kb.graph.KBHandle;
-import de.tudarmstadt.ukp.inception.kb.graph.KBInstance;
 
 public class ConceptFeatureSupportTest
 {
@@ -47,8 +46,7 @@ public class ConceptFeatureSupportTest
     {
         initMocks(this);
 
-        ConceptFeatureSupport sut = new ConceptFeatureSupport(kbService,
-                new KnowledgeBasePropertiesImpl());
+        sut = new ConceptFeatureSupport(kbService, new KnowledgeBasePropertiesImpl());
     }
 
     @Test
@@ -71,14 +69,14 @@ public class ConceptFeatureSupportTest
 
         KBHandle referenceHandle = new KBHandle("id", "name");
 
-        when(kbService.readItem((Project) any(), anyString()))
-                .thenReturn(Optional.of(new KBInstance("id", "name")));
+        when(kbService.readHandle((Project) any(), anyString()))
+                .thenReturn(Optional.of(new KBHandle("id", "name")));
 
-        when(kbService.readItem((Project) any(), anyString()))
-                .thenReturn(Optional.of(new KBInstance("id", "name")));
+        when(kbService.readHandle((Project) any(), anyString()))
+                .thenReturn(Optional.of(new KBHandle("id", "name")));
 
-        assertThat(sut.wrapFeatureValue(feat1, null, "id"))
-                .isEqualToComparingFieldByField(referenceHandle);
+        assertThat(sut.wrapFeatureValue(feat1, null, "id")).usingRecursiveComparison()
+                .isEqualTo(referenceHandle);
         assertThat(sut.wrapFeatureValue(feat1, null, referenceHandle)).isSameAs(referenceHandle);
         assertThat(sut.wrapFeatureValue(feat1, null, null)).isNull();
         assertThatThrownBy(() -> sut.wrapFeatureValue(feat1, null, new Object()))

--- a/inception/inception-ui-kb/src/test/java/de/tudarmstadt/ukp/inception/ui/kb/search/ConceptFeatureIndexingSupportTest.java
+++ b/inception/inception-ui-kb/src/test/java/de/tudarmstadt/ukp/inception/ui/kb/search/ConceptFeatureIndexingSupportTest.java
@@ -49,6 +49,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
 import de.tudarmstadt.ukp.inception.kb.KnowledgeBaseService;
+import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBasePropertiesImpl;
 import de.tudarmstadt.ukp.inception.kb.graph.KBHandle;
 import de.tudarmstadt.ukp.inception.kb.graph.KBInstance;
 import de.tudarmstadt.ukp.inception.kb.model.KnowledgeBase;
@@ -81,9 +82,9 @@ public class ConceptFeatureIndexingSupportTest
 
         kb = new KnowledgeBase();
 
-        featureSupportRegistry = new FeatureSupportRegistryImpl(
-                asList(new StringFeatureSupport(), new BooleanFeatureSupport(),
-                        new NumberFeatureSupport(), new ConceptFeatureSupport(kbService)));
+        featureSupportRegistry = new FeatureSupportRegistryImpl(asList(new StringFeatureSupport(),
+                new BooleanFeatureSupport(), new NumberFeatureSupport(),
+                new ConceptFeatureSupport(kbService, new KnowledgeBasePropertiesImpl())));
         featureSupportRegistry.init();
 
         featureIndexingSupportRegistry = new FeatureIndexingSupportRegistryImpl(

--- a/inception/inception-ui-kb/src/test/java/de/tudarmstadt/ukp/inception/ui/kb/search/ConceptFeatureIndexingSupportTest.java
+++ b/inception/inception-ui-kb/src/test/java/de/tudarmstadt/ukp/inception/ui/kb/search/ConceptFeatureIndexingSupportTest.java
@@ -127,11 +127,10 @@ public class ConceptFeatureIndexingSupportTest
         when(kbService.readInstance(any(Project.class), any(String.class)))
                 .thenReturn(Optional.of(new KBInstance("urn:dummy-concept", "Dummy concept")));
 
-        KBInstance kbInstance = new KBInstance("urn:dummy-concept", "Dummy concept");
-        kbInstance.setKB(kb);
-
-        when(kbService.readItem(any(Project.class), any(String.class)))
-                .thenReturn(Optional.of(kbInstance));
+        KBHandle kbHandle = new KBHandle("urn:dummy-concept", "Dummy concept");
+        kbHandle.setKB(kb);
+        when(kbService.readHandle(any(Project.class), any(String.class)))
+                .thenReturn(Optional.of(kbHandle));
 
         List<KBHandle> dummyValue = new ArrayList<KBHandle>();
         dummyValue.add(new KBHandle("urn:dummy-parent-concept", "Dummy Parent Concept"));
@@ -150,8 +149,9 @@ public class ConceptFeatureIndexingSupportTest
         tc.iterator().forEachRemaining(tokens::add);
 
         assertThat(tokens).filteredOn(t -> t.getPrefix().startsWith("Named_Entity"))
-                .extracting(MtasToken::getPrefix).contains("Named_Entity",
-                        "Named_Entity.identifier", "Named_Entity.identifier-exact");
+                .extracting(MtasToken::getPrefix) //
+                .contains("Named_Entity", "Named_Entity.identifier",
+                        "Named_Entity.identifier-exact");
 
         assertThat(tokens).filteredOn(t -> t.getPrefix().startsWith("Named_Entity"))
                 .extracting(MtasToken::getPostfix)


### PR DESCRIPTION
**What's in the PR**
- Make lookup of KB items consistent for the concept feature editor dropdown and the rendering process
- Change lookup type "any concept/instance" to "any" because in fact it would also return properties
- Update documentation
- Expose KB render cache settings in properties file and document them

**How to test manually**
* See issue description
* Also, search for `http://www.wikidata.org/entity/Q2314257` on the KB page and try to open it (should given an error)

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
