### PR TITLE
#2543 Show export progress only on export

### DIFF
--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/export/ProjectExportPanel.html
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/export/ProjectExportPanel.html
@@ -41,7 +41,9 @@
         <div class="flex-content flex-centered flex-h-container">
           <div class="flex-content flex-centered flex-v-container">
             <div class="well text-center">
-              <wicket:message key="warningMessage"/>
+              <div wicket:id="downloadWarning">
+                <wicket:message key="warningMessage"/>
+              </div>
               <div class="flex-h-container flex-centered flex-gutter">
                 <span wicket:id="progress" class="flex-content"></span>
                 <button wicket:id="cancel" class="btn btn-secondary">

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/export/ProjectExportPanel.java
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/export/ProjectExportPanel.java
@@ -36,6 +36,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.markup.html.AjaxLink;
 import org.apache.wicket.feedback.IFeedback;
+import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.form.ChoiceRenderer;
 import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.markup.html.form.Form;
@@ -234,11 +235,13 @@ public class ProjectExportPanel
                     default:
                         error("Invalid project export state after export: " + monitor.getState());
                     }
+                    setVisible(false);
                 }
             };
 
-            fileGenerationProgress.add(exportProject);
+            add(exportProject);
             add(fileGenerationProgress);
+            fileGenerationProgress.setVisible(false);
 
             add(exportProjectLink = new AjaxLink<Void>("exportProject")
             {
@@ -288,7 +291,12 @@ public class ProjectExportPanel
 
             cancelLink = new LambdaAjaxLink("cancel", this::actionCancel);
             cancelLink.add(enabledWhen(() -> exportInProgress));
+            cancelLink.add(visibleWhen(() -> exportInProgress));
             add(cancelLink);
+            
+            WebMarkupContainer warningContainer = new WebMarkupContainer("downloadWarning");
+            warningContainer.add(visibleWhen(() -> exportInProgress));
+            add(warningContainer);
         }
 
         private void actionCancel(AjaxRequestTarget aTarget)


### PR DESCRIPTION
**What's in the PR**
* Hide progressbar and message when download is not in progress
* Add download behavior to form instead of progressbar to avoid conflict between behaviors

**How to test manually**
* Go to the export tab on the settings page and try exporting (whole project or only curated docs)
* The progress bar and accompanying message should only be visible during export

