### PR TITLE
#2462 - Ability to bulk assign texts to annotators based on filter

### DIFF
--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.properties
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.properties
@@ -29,6 +29,7 @@ repair=Repair
 close=Close
 open=Open
 refresh=Refresh
+reset=Reset
 
 enabled=Enabled
 
@@ -66,6 +67,7 @@ behaviors=Behaviors
 options=Options
 legend=Legend
 users=Users
+filter=Filter
 
 attachToLayer=Attach to layer
 filesToImport=Files to import

--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/management/DynamicWorkloadManagementPage.html
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/management/DynamicWorkloadManagementPage.html
@@ -38,19 +38,19 @@
   }
 </style>
 <script>
-$( document ).ready(function() { 
-  // Prevent the dropdowns from closing if an item Kendo dropdown is selected
-  $('.sticky-dropdown').on('hide.bs.dropdown', function(e) {
-    if ($(event.target).parents('.k-popup').length) {
-      e.preventDefault();
-    }
+  $( document ).ready(function() { 
+    // Prevent the dropdowns from closing if an item Kendo dropdown is selected
+    $('.sticky-dropdown').on('hide.bs.dropdown', function(e) {
+      if ($(e.clickEvent.target).parents('.k-popup, .cbx-icon').length) {
+        e.preventDefault();
+      }
+    });
   });
-});
 </script>
 </wicket:head>
 <body>
   <wicket:extend>
-    <div class="flex-content flex-h-container flex-gutter">
+    <div class="flex-content flex-h-container flex-gutter overflow-hidden">
       <div class="flex-content flex-v-container flex-gutter">
         <div class="card">
           <div class="card-header border-bottom-0" style="position: relative">
@@ -68,7 +68,7 @@ $( document ).ready(function() {
                 type="button" data-bs-toggle="dropdown">
                 <i class="fas fa-filter"></i>
                 <span class="d-none d-lg-inline">
-                  &nbsp;<wicket:message key="Filter" />
+                  &nbsp;<wicket:message key="filter" />
                 </span>
               </button> 
               <div class="dropdown-menu shadow-lg pt-0 pb-0 ddFilterForm" role="menu"
@@ -283,19 +283,15 @@ $( document ).ready(function() {
           </div>
           <div class="flex-content flex-h-container flex-gutter flex-only-internal-gutter">
             <div wicket:id="stateFilters" class="input-group justify-content-end">
-              <div class="input-group-prepend">
-                <div class="input-group-text">
-                  <i class="fas fa-filter"></i>
-                </div>
+              <div class="input-group-text">
+                <i class="fas fa-filter"></i>
               </div>
-              <div class="input-group-append" role="group">
-                <wicket:container wicket:id="stateFilter">
-                  <button type="button" class="btn btn-outline-secondary"
-                    wicket:id="stateFilterLink">
-                    <wicket:container wicket:id="label" />
-                  </button>
-                </wicket:container>
-              </div>
+              <wicket:container wicket:id="stateFilter">
+                <button type="button" class="btn btn-outline-secondary"
+                  wicket:id="stateFilterLink">
+                  <wicket:container wicket:id="label" />
+                </button>
+              </wicket:container>
             </div>
             <span class="dropdown" aria-haspopup="true" aria-expanded="false">
               <span class="btn-group" role="group">
@@ -331,10 +327,14 @@ $( document ).ready(function() {
           </div>
         </div>
 
-        <div class="flex-content scrolling card p-0">
-          <table class="table table-sm table-hover table-striped document-table" cellspacing="0"
-            wicket:id="dataTable" align="center" style="text-align: center; overflow-x: auto;">
-          </table>
+        <div class="card-body p-0 flex-v-container">
+          <div class="flex-content scrolling">
+            <div class="fit-child-snug">
+              <table class="table table-sm table-hover table-striped document-table" cellspacing="0"
+                wicket:id="dataTable" align="center" style="text-align: center; overflow-x: auto;">
+              </table>
+            </div>
+          </div>
         </div>
         
         <div wicket:id="resetDocumentDialog"/>

--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/management/DynamicWorkloadManagementPage.properties
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/management/DynamicWorkloadManagementPage.properties
@@ -41,8 +41,6 @@ actions=Actions
 
 
 #Filter
-Filter=Filter
-filter=filter
 userFilter=userFilter
 userFilterText=User name(s)
 documentFilterText=Document Name

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/MatrixWorkloadFilterPanel.html
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/MatrixWorkloadFilterPanel.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<!--
+  Licensed to the Technische Universität Darmstadt under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The Technische Universität Darmstadt 
+  licenses this file to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.
+   
+  http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<html xmlns:wicket="http://wicket.apache.org">
+<body>
+  <wicket:panel>
+    <form wicket:id="form" class="card">
+      <div class="card-header">
+        <wicket:message key="filter" />
+      </div>
+      <div class="card-body">
+        <div class="form-group">
+          <label wicket:for="documentName">Document name</label>
+          <div class="input-group">
+            <input wicket:id="documentName" type="text" class="form-control">
+            <div class="input-group-text">
+              <label class="cbx-label" wicket:for="matchDocumentNameAsRegex">
+                <input wicket:id="matchDocumentNameAsRegex" type="checkbox" />
+                (.*)
+              </label>
+            </div>
+          </div>
+        </div>
+        <div class="form-group">
+          <label wicket:for="userName">User name</label>
+          <div class="input-group">
+            <input wicket:id="userName" type="text" class="form-control">
+            <div class="input-group-text">
+              <label class="cbx-label" wicket:for="matchUserNameAsRegex">
+                <input wicket:id="matchUserNameAsRegex" type="checkbox" />
+                (.*)
+              </label>
+             </div>
+          </div>
+        </div>
+      </div>
+      <div class="card-footer text-end">
+        <button wicket:id="reset" class="btn btn-secondary">
+          <wicket:message key="reset" />
+        </button>
+        <button wicket:id="apply" class="btn btn-primary">
+          <wicket:message key="apply" />
+        </button>
+      </div>
+     </form>
+  </wicket:panel>
+</body>
+</html>

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/MatrixWorkloadFilterPanel.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/MatrixWorkloadFilterPanel.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.workload.matrix.management;
+
+import static org.apache.wicket.event.Broadcast.BUBBLE;
+
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.markup.html.form.Form;
+import org.apache.wicket.markup.html.form.TextField;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.model.CompoundPropertyModel;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
+
+import de.agilecoders.wicket.extensions.markup.html.bootstrap.form.checkboxx.CheckBoxX;
+import de.agilecoders.wicket.extensions.markup.html.bootstrap.form.checkboxx.CheckBoxXConfig;
+import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxButton;
+import de.tudarmstadt.ukp.inception.workload.matrix.management.event.FilterStateChangedEvent;
+import de.tudarmstadt.ukp.inception.workload.matrix.management.support.Filter;
+
+public class MatrixWorkloadFilterPanel
+    extends Panel
+{
+    private static final long serialVersionUID = 7581474359089251264L;
+
+    public MatrixWorkloadFilterPanel(String aId, IModel<Filter> aModel)
+    {
+        super(aId, aModel);
+
+        Form<Filter> form = new Form<>("form", CompoundPropertyModel.of(aModel));
+        add(form);
+
+        form.add(new TextField<>("documentName", String.class));
+        form.add(configureCheckBoxX(new CheckBoxX("matchDocumentNameAsRegex")));
+        form.add(new TextField<>("userName", String.class));
+        form.add(configureCheckBoxX(new CheckBoxX("matchUserNameAsRegex")));
+
+        form.add(new LambdaAjaxButton<>("apply", this::onApplyFilter).triggerAfterSubmit());
+        form.add(new LambdaAjaxButton<>("reset", this::onResetFilter).triggerAfterSubmit());
+    }
+
+    private void onApplyFilter(AjaxRequestTarget aTarget, Form<Filter> aForm)
+    {
+        send(this, BUBBLE, new FilterStateChangedEvent(aTarget));
+    }
+
+    private void onResetFilter(AjaxRequestTarget aTarget, Form<Filter> aForm)
+    {
+        getModelObject().reset();
+        send(this, BUBBLE, new FilterStateChangedEvent(aTarget));
+    }
+
+    private CheckBoxX configureCheckBoxX(CheckBoxX aCheckBox)
+    {
+        CheckBoxXConfig config = aCheckBox.getConfig();
+        config.withIconChecked("<i class=\"fa fa-check\"></i>");
+        config.withIconUnchecked("");
+        config.withEnclosedLabel(true);
+        config.withThreeState(false);
+        return aCheckBox;
+    }
+
+    public Filter getModelObject()
+    {
+        return (Filter) getDefaultModelObject();
+    }
+
+    @SuppressWarnings("unchecked")
+    public Model<Filter> getModel()
+    {
+        return (Model<Filter>) getDefaultModel();
+    }
+}

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/MatrixWorkloadManagementPage.html
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/MatrixWorkloadManagementPage.html
@@ -18,7 +18,7 @@
 -->
 <html xmlns:wicket="http://wicket.apache.org">
 <head>
-  <wicket:head>
+<wicket:head>
   <style type="text/css">
     .page-content { overflow: auto; }
     .document-matrix tr td, .document-matrix tr th { text-align: center; }
@@ -27,11 +27,21 @@
     .document-matrix col.s, .document-matrix tr.s , .document-matrix td.s { background-color: var(--primary); }
     .document-matrix .state-toggle { white-space: nowrap; cursor: pointer; }
   </style>
+  <script>
+  $( document ).ready(function() { 
+    // Prevent the dropdowns from closing if an item Kendo dropdown is selected
+    $('.sticky-dropdown').on('hide.bs.dropdown', function(e) {
+      if ($(e.clickEvent.target).closest('.k-popup, .cbx-icon, .cbx-label').length) {
+        e.preventDefault();
+      }
+    });
+  });
+  </script>
 </wicket:head>
 </head>
 <body>
   <wicket:extend>
-    <div class="flex-content flex-h-container flex-gutter">
+    <div class="flex-content flex-h-container flex-gutter overflow-hidden">
       <div class="flex-content flex-v-container flex-gutter">
         <div class="flex-content flex-v-container flex-gutter flex-only-internal-gutter">
           <div class="page-header">
@@ -39,42 +49,64 @@
           </div>
           <div wicket:id="resetDocumentDialog"/>
           <div wicket:id="contextMenu" style="width: 250px;"></div>
+          
+          <div class="flex-h-container flex-gutter flex-only-internal-gutter">
+            <div class="flex-h-container flex-gutter flex-only-internal-gutter">
+              <span class="dropdown sticky-dropdown" aria-haspopup="true" aria-expanded="false">
+                <button
+                  class="btn btn-action btn-secondary dropdown-toggle flex-content"
+                  type="button" data-bs-toggle="dropdown">
+                  <i class="fas fa-filter"></i>
+                  <span class="d-none d-lg-inline">
+                    &nbsp;<wicket:message key="filter" />
+                  </span>
+                </button> 
+                <div class="dropdown-menu shadow-lg pt-0 pb-0 ddFilterForm" role="menu"
+                  style="min-width: 600px;">
+                  <div wicket:id="filterPanel"/>
+                </div>
+              </span> 
+              <button wicket:id="refresh" class="btn btn-action btn-secondary">
+                <i class="fas fa-redo"></i>
+                <span class="d-none d-lg-inline">
+                  &nbsp;<wicket:message key="refresh" />
+                </span>
+              </button>
+            </div>
+            <div class="flex-content flex-h-container flex-gutter flex-only-internal-gutter justify-content-end">
+              <span class="dropdown" aria-haspopup="true" aria-expanded="false">
+                <span class="btn-group" role="group">
+                  <button class="btn btn-secondary btn-action" type="button">
+                    Legend
+                  </button>
+                  <button class="btn btn-secondary btn-action dropdown-toggle flex-content border-start" type="button" data-bs-toggle="dropdown"></button>
+                  <ul class="dropdown-menu shadow-lg" role="menu" style="min-width: 20em;">
+                    <li class="dropdown-header">Document states</li>
+                    <li class="dropdown-item-text"><i class="far fa-circle"/> Not started yet</li>
+                    <li class="dropdown-item-text"><i class="far fa-play-circle"/> Annotation in progress</li>
+                    <li class="dropdown-item-text"><i class="far fa-check-circle"/> Annotation finished</li>
+                    <li class="dropdown-item-text"><i class="fas fa-clipboard"/> Curation in progress</li>
+                    <li class="dropdown-item-text"><i class="fas fa-clipboard-check"/> Curation finished</li>
+                    <li class="dropdown-header">Curation states</li>
+                    <li class="dropdown-item-text"><i class="far fa-circle"/> Not started yet</li>
+                    <li class="dropdown-item-text"><i class="fas fa-clipboard"/> In progress</li>
+                    <li class="dropdown-item-text"><i class="fas fa-clipboard-check"/> Finished</li>
+                    <li class="dropdown-header">Annotation states</li>
+                    <li class="dropdown-item-text"><i class="far fa-circle"/> Not started yet</li>
+                    <li class="dropdown-item-text"><i class="far fa-play-circle"/> In progress</li>
+                    <li class="dropdown-item-text"><i class="far fa-check-circle"/> Finished</li>
+                    <li class="dropdown-item-text"><i class="fas fa-lock"/> Locked / cannot be accessed</li>
+                  </ul>
+                </span>
+              </span>
+            </div>
+          </div>
+                    
           <div class="flex-content card" style="min-height: 220px;">
             <div class="card-header">
               <wicket:message key="document_status" />
               <a wicket:id="documentStatusHelpLink"/>
               <div wicket:id="actionContainer" class="actions">
-                <button wicket:id="refresh" class="btn btn-action btn-secondary">
-                  <i class="fas fa-redo"></i>
-                  <span class="d-none d-lg-inline">
-                    &nbsp;<wicket:message key="refresh" />
-                  </span>
-                </button>
-                <span class="dropdown" aria-haspopup="true" aria-expanded="false">
-                  <span class="btn-group" role="group">
-                    <button class="btn btn-secondary btn-action" type="button">
-                      Legend
-                    </button>
-                    <button class="btn btn-secondary btn-action dropdown-toggle flex-content border-start" type="button" data-bs-toggle="dropdown"></button>
-                    <ul class="dropdown-menu shadow-lg" role="menu" style="min-width: 20em;">
-                      <li class="dropdown-header">Document states</li>
-                      <li class="dropdown-item-text"><i class="far fa-circle"/> Not started yet</li>
-                      <li class="dropdown-item-text"><i class="far fa-play-circle"/> Annotation in progress</li>
-                      <li class="dropdown-item-text"><i class="far fa-check-circle"/> Annotation finished</li>
-                      <li class="dropdown-item-text"><i class="fas fa-clipboard"/> Curation in progress</li>
-                      <li class="dropdown-item-text"><i class="fas fa-clipboard-check"/> Curation finished</li>
-                      <li class="dropdown-header">Curation states</li>
-                      <li class="dropdown-item-text"><i class="far fa-circle"/> Not started yet</li>
-                      <li class="dropdown-item-text"><i class="fas fa-clipboard"/> In progress</li>
-                      <li class="dropdown-item-text"><i class="fas fa-clipboard-check"/> Finished</li>
-                      <li class="dropdown-header">Annotation states</li>
-                      <li class="dropdown-item-text"><i class="far fa-circle"/> Not started yet</li>
-                      <li class="dropdown-item-text"><i class="far fa-play-circle"/> In progress</li>
-                      <li class="dropdown-item-text"><i class="far fa-check-circle"/> Finished</li>
-                      <li class="dropdown-item-text"><i class="fas fa-lock"/> Locked / cannot be accessed</li>
-                    </ul>
-                  </span>
-                </span>
                 <span class="dropdown" aria-haspopup="true" aria-expanded="false">
                   <span class="btn-group" role="group">
                     <button wicket:id="toggleBulkChange" class="btn btn-action" type="button">

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/event/FilterStateChangedEvent.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/event/FilterStateChangedEvent.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.workload.matrix.management.event;
+
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.wicketstuff.event.annotation.AbstractAjaxAwareEvent;
+
+/**
+ * Fired when the filter is updated.
+ */
+public class FilterStateChangedEvent
+    extends AbstractAjaxAwareEvent
+{
+    public FilterStateChangedEvent(AjaxRequestTarget aTarget)
+    {
+        super(aTarget);
+    }
+}

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/support/AnnotatorColumn.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/support/AnnotatorColumn.java
@@ -58,6 +58,11 @@ public class AnnotatorColumn
         selectedUsers = aSelectedUsers;
     }
 
+    public User getUser()
+    {
+        return user;
+    }
+
     @Override
     public void populateItem(Item<ICellPopulator<DocumentMatrixRow>> aItem, String aComponentId,
             IModel<DocumentMatrixRow> aRowModel)

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/support/DocumentMatrixDataProvider.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/support/DocumentMatrixDataProvider.java
@@ -18,23 +18,30 @@
 package de.tudarmstadt.ukp.inception.workload.matrix.management.support;
 
 import static de.tudarmstadt.ukp.inception.workload.matrix.management.support.DocumentMatrixSortKey.DOCUMENT_NAME;
+import static java.util.stream.Collectors.toList;
 import static org.apache.wicket.extensions.markup.html.repeater.data.sort.SortOrder.ASCENDING;
 
 import java.io.Serializable;
 import java.util.Iterator;
 import java.util.List;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.wicket.extensions.markup.html.repeater.data.table.filter.IFilterStateLocator;
 import org.apache.wicket.extensions.markup.html.repeater.util.SortableDataProvider;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 
 public class DocumentMatrixDataProvider
     extends SortableDataProvider<DocumentMatrixRow, DocumentMatrixSortKey>
-    implements Serializable
+    implements IFilterStateLocator<Filter>, Serializable
 {
     private static final long serialVersionUID = -3869576909905361406L;
 
     private List<DocumentMatrixRow> matrixData;
+    private Filter filter;
 
     public DocumentMatrixDataProvider(List<DocumentMatrixRow> aData)
     {
@@ -50,30 +57,71 @@ public class DocumentMatrixDataProvider
 
     public List<DocumentMatrixRow> getMatrixData()
     {
-        return matrixData;
+        return filterTable(matrixData);
     }
 
     @Override
     public Iterator<? extends DocumentMatrixRow> iterator(long aFirst, long aCount)
     {
-        matrixData.sort((o1, o2) -> {
+        // Apply Filter
+        List<DocumentMatrixRow> newList = getMatrixData();
+
+        // Apply sorting
+        newList.sort((o1, o2) -> {
             int dir = getSort().isAscending() ? 1 : -1;
             return dir * getSort().getProperty().compare(o1, o2);
         });
 
-        return matrixData.subList((int) aFirst, (int) Math.min(matrixData.size(), aFirst + aCount))
-                .iterator();
+        if ((int) aFirst + (int) aCount > newList.size()) {
+            aCount = newList.size() - aFirst;
+        }
+
+        return newList.subList((int) aFirst, ((int) aFirst + (int) aCount)).iterator();
     }
 
     @Override
     public long size()
     {
-        return matrixData.size();
+        return getMatrixData().size();
+    }
+
+    /**
+     * Filtering performed on the table
+     */
+    public List<DocumentMatrixRow> filterTable(List<DocumentMatrixRow> aData)
+    {
+        Stream<DocumentMatrixRow> rowStream = matrixData.stream();
+
+        if (StringUtils.isNotBlank(filter.getDocumentName())) {
+            if (filter.isMatchDocumentNameAsRegex()) {
+                Predicate<String> p = Pattern.compile(".*(" + filter.getDocumentName() + ").*")
+                        .asMatchPredicate();
+                rowStream = rowStream.filter(row -> p.test(row.getSourceDocument().getName()));
+            }
+            else {
+                rowStream = rowStream.filter(row -> row.getSourceDocument().getName()
+                        .contains(filter.getDocumentName()));
+            }
+        }
+
+        return rowStream.collect(toList());
     }
 
     @Override
     public IModel<DocumentMatrixRow> model(DocumentMatrixRow aRow)
     {
         return Model.of(aRow);
+    }
+
+    @Override
+    public Filter getFilterState()
+    {
+        return filter;
+    }
+
+    @Override
+    public void setFilterState(Filter aState)
+    {
+        filter = aState;
     }
 }

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/support/DocumentMatrixRow.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/support/DocumentMatrixRow.java
@@ -65,6 +65,11 @@ public class DocumentMatrixRow
         return annotationDocuments.get(aUsername);
     }
 
+    public Set<String> getAnnotators()
+    {
+        return annotators;
+    }
+
     public void setSelected(boolean aSelected)
     {
         selected = aSelected;

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/support/Filter.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/support/Filter.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.workload.matrix.management.support;
+
+import java.io.Serializable;
+
+public class Filter
+    implements Serializable
+{
+    private static final long serialVersionUID = -8778279692135238878L;
+
+    private String documentName;
+    private boolean matchDocumentNameAsRegex;
+    private String userName;
+    private boolean matchUserNameAsRegex;
+
+    public String getDocumentName()
+    {
+        return documentName;
+    }
+
+    public void setDocumentName(String aDocumentName)
+    {
+        documentName = aDocumentName;
+    }
+
+    public boolean isMatchDocumentNameAsRegex()
+    {
+        return matchDocumentNameAsRegex;
+    }
+
+    public void setMatchDocumentNameAsRegex(boolean aMatchDocumentNameAsRegex)
+    {
+        matchDocumentNameAsRegex = aMatchDocumentNameAsRegex;
+    }
+
+    public String getUserName()
+    {
+        return userName;
+    }
+
+    public void setUserName(String aUserName)
+    {
+        userName = aUserName;
+    }
+
+    public boolean isMatchUserNameAsRegex()
+    {
+        return matchUserNameAsRegex;
+    }
+
+    public void setMatchUserNameAsRegex(boolean aMatchUserNameAsRegex)
+    {
+        matchUserNameAsRegex = aMatchUserNameAsRegex;
+    }
+
+    public void reset()
+    {
+        documentName = null;
+        userName = null;
+    }
+}

--- a/inception/inception-workload-matrix/src/main/resources/META-INF/asciidoc/user-guide/workload_matrix.adoc
+++ b/inception/inception-workload-matrix/src/main/resources/META-INF/asciidoc/user-guide/workload_matrix.adoc
@@ -95,4 +95,19 @@ When applying a bulk action, only those cells which permit the requested transit
 
 To facilitate wrapping up annotations for a user or document, there is the combo action **Close all** which will lock any documents on which work has not started yet and mark and ongoing annotations as finished. 
 
+== Filtering
+
+It is possible to filter the table by document name and/or user name. If a filter has been set, then
+bulk actions are applied only to those rows and column which match the filter and which are selected
+for the bulk operation.
+
+The document name and user name filters can be set in two ways: 
+* "contains" match or
+* regular expression
+
+The regular expression mode can be enabled by activating the checkbox `(.*)` next to the
+filter text field. For example, with the checkbox enabled, you could search for `^chapter01.*` to match
+all documents whose name starts with `chapter01` or for `train|test` to match all documents containing
+`train` or `test` in their name.
+
  


### PR DESCRIPTION
**What's in the PR**
* Added ability to filter static workflow management page by document name and user names - bulk action can then be performed limitd to the items matching the filter

**How to test manually**
* Apply filters on the static workflow management page (i.e. "monitoring") and combine them with bulk actions. Check that actions are performed but only to the matching/visible items

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
