### PR TITLE
#2495 - Ignorable features for curation mode

### DIFF
--- a/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/CasDiff.java
+++ b/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/CasDiff.java
@@ -1150,7 +1150,7 @@ public class CasDiff
 
             Set<String> labelFeatures = new LinkedHashSet<>();
             nextFeature: for (AnnotationFeature f : schemaService.listSupportedFeatures(layer)) {
-                if (!f.isEnabled()) {
+                if (!f.isEnabled() || !f.isCuratable()) {
                     continue nextFeature;
                 }
 

--- a/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casmerge/CasMerge.java
+++ b/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casmerge/CasMerge.java
@@ -438,6 +438,10 @@ public class CasMerge
         List<AnnotationFeature> features = featureCache.computeIfAbsent(aAdapter.getLayer(),
                 key -> schemaService.listSupportedFeatures(key));
         for (AnnotationFeature feature : features) {
+            if (!feature.isCuratable()) {
+                continue;
+            }
+
             Type sourceFsType = aAdapter.getAnnotationType(aSourceFs.getCAS());
             Feature sourceFeature = sourceFsType.getFeatureByBaseName(feature.getName());
 

--- a/inception/inception-curation-legacy/src/test/java/de/tudarmstadt/ukp/clarin/webanno/curation/casmerge/CasMergeTestBase.java
+++ b/inception/inception-curation-legacy/src/test/java/de/tudarmstadt/ukp/clarin/webanno/curation/casmerge/CasMergeTestBase.java
@@ -145,6 +145,7 @@ public class CasMergeTestBase
         tokenPosFeature.setLayer(tokenLayer);
         tokenPosFeature.setProject(project);
         tokenPosFeature.setVisible(true);
+        tokenPosFeature.setCuratable(true);
 
         posLayer = new AnnotationLayer(POS.class.getName(), "POS", SPAN_TYPE, project, true,
                 SINGLE_TOKEN, NO_OVERLAP);
@@ -159,6 +160,7 @@ public class CasMergeTestBase
         posFeature.setLayer(posLayer);
         posFeature.setProject(project);
         posFeature.setVisible(true);
+        posFeature.setCuratable(true);
 
         posCoarseFeature = new AnnotationFeature();
         posCoarseFeature.setName("coarseValue");
@@ -168,6 +170,7 @@ public class CasMergeTestBase
         posCoarseFeature.setLayer(posLayer);
         posCoarseFeature.setProject(project);
         posCoarseFeature.setVisible(true);
+        posCoarseFeature.setCuratable(true);
 
         neLayer = new AnnotationLayer(NamedEntity.class.getName(), "Named Entity", SPAN_TYPE,
                 project, true, TOKENS, OVERLAP_ONLY);
@@ -180,6 +183,7 @@ public class CasMergeTestBase
         neFeature.setLayer(neLayer);
         neFeature.setProject(project);
         neFeature.setVisible(true);
+        neFeature.setCuratable(true);
 
         neIdentifierFeature = new AnnotationFeature();
         neIdentifierFeature.setName("identifier");
@@ -189,6 +193,7 @@ public class CasMergeTestBase
         neIdentifierFeature.setLayer(neLayer);
         neIdentifierFeature.setProject(project);
         neIdentifierFeature.setVisible(true);
+        neIdentifierFeature.setCuratable(true);
 
         depLayer = new AnnotationLayer(Dependency.class.getName(), "Dependency", RELATION_TYPE,
                 project, true, SINGLE_TOKEN, OVERLAP_ONLY);
@@ -203,6 +208,7 @@ public class CasMergeTestBase
         depFeature.setLayer(depLayer);
         depFeature.setProject(project);
         depFeature.setVisible(true);
+        depFeature.setCuratable(true);
 
         depFlavorFeature = new AnnotationFeature();
         depFlavorFeature.setName("flavor");
@@ -212,6 +218,7 @@ public class CasMergeTestBase
         depFlavorFeature.setLayer(depLayer);
         depFlavorFeature.setProject(project);
         depFlavorFeature.setVisible(true);
+        depFlavorFeature.setCuratable(true);
 
         slotLayer = new AnnotationLayer(HOST_TYPE, HOST_TYPE, SPAN_TYPE, project, false,
                 SINGLE_TOKEN, NO_OVERLAP);
@@ -229,6 +236,7 @@ public class CasMergeTestBase
         slotFeature.setLayer(slotLayer);
         slotFeature.setProject(project);
         slotFeature.setVisible(true);
+        slotFeature.setCuratable(true);
 
         stringFeature = new AnnotationFeature();
         stringFeature.setName("f1");
@@ -238,6 +246,7 @@ public class CasMergeTestBase
         stringFeature.setLayer(slotLayer);
         stringFeature.setProject(project);
         stringFeature.setVisible(true);
+        stringFeature.setCuratable(true);
 
         multiValSpan = new AnnotationLayer("webanno.custom.Multivalspan", "Multivalspan", SPAN_TYPE,
                 project, true, TOKENS, OVERLAP_ONLY);
@@ -250,6 +259,7 @@ public class CasMergeTestBase
         multiValSpanF1.setLayer(multiValSpan);
         multiValSpanF1.setProject(project);
         multiValSpanF1.setVisible(true);
+        multiValSpanF1.setCuratable(true);
 
         multiValSpanF2 = new AnnotationFeature();
         multiValSpanF2.setName("f2");
@@ -259,6 +269,7 @@ public class CasMergeTestBase
         multiValSpanF2.setLayer(multiValSpan);
         multiValSpanF2.setProject(project);
         multiValSpanF2.setVisible(true);
+        multiValSpanF2.setCuratable(true);
 
         multiValRel = new AnnotationLayer("webanno.custom.Multivalrel", "Multivalrel",
                 RELATION_TYPE, project, true, SINGLE_TOKEN, OVERLAP_ONLY);
@@ -272,6 +283,7 @@ public class CasMergeTestBase
         multiValRelRel1.setLayer(multiValSpan);
         multiValRelRel1.setProject(project);
         multiValRelRel1.setVisible(true);
+        multiValRelRel1.setCuratable(true);
 
         multiValRelRel2 = new AnnotationFeature();
         multiValRelRel2.setName("rel2");
@@ -281,6 +293,7 @@ public class CasMergeTestBase
         multiValRelRel2.setLayer(multiValSpan);
         multiValRelRel2.setProject(project);
         multiValRelRel2.setVisible(true);
+        multiValRelRel2.setCuratable(true);
 
         when(schemaService.findLayer(any(Project.class), any(String.class))).thenAnswer(call -> {
             String type = call.getArgument(1, String.class);

--- a/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/exporters/LayerExporter.java
+++ b/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/exporters/LayerExporter.java
@@ -17,6 +17,9 @@
  */
 package de.tudarmstadt.ukp.inception.export.exporters;
 
+import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.CHAIN_TYPE;
+import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.COREFERENCE_RELATION_FEATURE;
+import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.COREFERENCE_TYPE_FEATURE;
 import static de.tudarmstadt.ukp.clarin.webanno.model.OverlapMode.ANY_OVERLAP;
 import static de.tudarmstadt.ukp.clarin.webanno.model.OverlapMode.OVERLAP_ONLY;
 import static java.util.Arrays.asList;
@@ -36,7 +39,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
-import de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExportRequest;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExportTaskMonitor;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExporter;
@@ -173,6 +175,7 @@ public class LayerExporter
         exFeature.setLinkTypeRoleFeatureName(feature.getLinkTypeRoleFeatureName());
         exFeature.setLinkTypeTargetFeatureName(feature.getLinkTypeTargetFeatureName());
         exFeature.setTraits(feature.getTraits());
+        exFeature.setCuratable(feature.isCuratable());
 
         if (feature.getTagset() != null) {
             TagSet tagSet = feature.getTagset();
@@ -294,9 +297,9 @@ public class LayerExporter
         aFeature.setUiName(aExFeature.getUiName());
         aFeature.setProject(aProject);
         aFeature.setLayer(aFeature.getLayer());
-        boolean isItChainedLayer = aFeature.getLayer().getType().equals(WebAnnoConst.CHAIN_TYPE);
-        if (isItChainedLayer && (aExFeature.getName().equals(WebAnnoConst.COREFERENCE_TYPE_FEATURE)
-                || aExFeature.getName().equals(WebAnnoConst.COREFERENCE_RELATION_FEATURE))) {
+        boolean isItChainedLayer = CHAIN_TYPE.equals(aFeature.getLayer().getType());
+        if (isItChainedLayer && (COREFERENCE_TYPE_FEATURE.equals(aExFeature.getName())
+                || COREFERENCE_RELATION_FEATURE.equals(aExFeature.getName()))) {
             aFeature.setType(CAS.TYPE_NAME_STRING);
         }
         else {
@@ -312,6 +315,7 @@ public class LayerExporter
         aFeature.setLinkTypeRoleFeatureName(aExFeature.getLinkTypeRoleFeatureName());
         aFeature.setLinkTypeTargetFeatureName(aExFeature.getLinkTypeTargetFeatureName());
         aFeature.setTraits(aExFeature.getTraits());
+        aFeature.setCuratable(aExFeature.isCuratable());
 
         if (aExFeature.getTagSet() != null) {
             TagSet tagset = annotationService.getTagSet(aExFeature.getTagSet().getName(), aProject);

--- a/inception/inception-model-export/src/main/java/de/tudarmstadt/ukp/clarin/webanno/export/model/ExportedAnnotationFeature.java
+++ b/inception/inception-model-export/src/main/java/de/tudarmstadt/ukp/clarin/webanno/export/model/ExportedAnnotationFeature.java
@@ -84,6 +84,9 @@ public class ExportedAnnotationFeature
     @JsonProperty("traits")
     private String traits;
 
+    @JsonProperty("curatable")
+    private boolean curatable = true;
+
     public String getName()
     {
         return name;
@@ -262,6 +265,16 @@ public class ExportedAnnotationFeature
     public void setTraits(String aTraits)
     {
         traits = aTraits;
+    }
+
+    public boolean isCuratable()
+    {
+        return curatable;
+    }
+
+    public void setCuratable(boolean aCuratable)
+    {
+        curatable = aCuratable;
     }
 
     @Override

--- a/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/AnnotationFeature.java
+++ b/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/AnnotationFeature.java
@@ -125,6 +125,8 @@ public class AnnotationFeature
     @Column(length = 64000)
     private String traits;
 
+    private boolean curatable;
+
     public AnnotationFeature()
     {
         // Nothing to do
@@ -505,6 +507,16 @@ public class AnnotationFeature
     public void setTraits(String aTraits)
     {
         traits = aTraits;
+    }
+
+    public boolean isCuratable()
+    {
+        return curatable;
+    }
+
+    public void setCuratable(boolean aCuratable)
+    {
+        curatable = aCuratable;
     }
 
     @Override

--- a/inception/inception-model/src/main/resources/de/tudarmstadt/ukp/clarin/webanno/model/db-changelog.xml
+++ b/inception/inception-model/src/main/resources/de/tudarmstadt/ukp/clarin/webanno/model/db-changelog.xml
@@ -1290,4 +1290,17 @@
       <column name="processed"/>
     </dropColumn>
   </changeSet>
+  
+  <changeSet author="INCEpTION Team" id="20210823-1">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="annotation_feature" columnName="curatable"/>
+      </not>
+    </preConditions>
+    <addColumn tableName="annotation_feature">
+      <column name="curatable" type="BOOLEAN" defaultValueBoolean="true">
+        <constraints nullable="false" />
+      </column>
+    </addColumn>
+  </changeSet>  
 </databaseChangeLog>

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.properties
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.properties
@@ -74,6 +74,7 @@ filesToImport=Files to import
 readonly=Read-only
 required=Required
 visible=Visible
+curatable=Curatable
 includeInHover=Show in feature text in tooltip popup 
 remember=Remember
 hideUnconstraintFeature=Hide when no constraints apply

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/layers/FeatureDetailForm.java
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/layers/FeatureDetailForm.java
@@ -108,6 +108,7 @@ public class FeatureDetailForm
         add(new TextArea<String>("description"));
         add(new CheckBox("enabled").setOutputMarkupPlaceholderTag(true));
         add(new CheckBox("visible").setOutputMarkupPlaceholderTag(true));
+        add(new CheckBox("curatable").setOutputMarkupPlaceholderTag(true));
         add(new CheckBox("hideUnconstraintFeature").setOutputMarkupPlaceholderTag(true));
         add(new CheckBox("remember").setOutputMarkupPlaceholderTag(true));
         add(new CheckBox("includeInHover").setOutputMarkupPlaceholderTag(true)

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/layers/ProjectLayersPanel.html
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/layers/ProjectLayersPanel.html
@@ -361,6 +361,12 @@
                     <wicket:label key="remember"/>
                   </label>
                 </div>
+                <div class="form-check" wicket:enclosure="curatable">
+                  <input wicket:id="curatable" class="form-check-input" type="checkbox">
+                  <label wicket:for="curatable" class="form-check-label">
+                    <wicket:label key="curatable"/>
+                  </label>
+                </div>
                 <div class="form-check" wicket:enclosure="hideUnconstraintFeature">
                   <input wicket:id="hideUnconstraintFeature" class="form-check-input" type="checkbox">
                   <label wicket:for="hideUnconstraintFeature" class="form-check-label">

--- a/inception/inception-ui-project/src/main/resources/META-INF/asciidoc/user-guide/projects_layers.adoc
+++ b/inception/inception-ui-project/src/main/resources/META-INF/asciidoc/user-guide/projects_layers.adoc
@@ -281,6 +281,13 @@ _(Span layers)_
 | Whether the annotation detail editor should carry values of this feature
 over when creating a new annotation of the same type. This can be useful when creating many annotations
 of the same type in a row.
+
+| Curatable
+| Whether the feature is considered when comparing whether annotations are equal and can be
+pre-merged during curation. This flag is enabled by default. When it is disabled, two annotations
+will be treated as the same for the purpose of curation, even if the feature value is different.
+The feature value will also not be copied to a pre-merged or manually merged annotation. Disabling
+this flag on all features of a layer will cause annotations to be only compared by their positions.
 |====
 
 


### PR DESCRIPTION
**What's in the PR**
- Added "curatable" flag to AnnotationFeature (enabled by default)
- Added import/export support for new flag (value is true if missing in imported project)
- Ignore non-curatable features when comparing CASes
- Do not copy feature value when merging
- Updated documentation

**How to test manually**
* Disable curatable flag on a feature and see what happens - try with layers that have more than one feature
* Import a project that was exported from a version of INCEpTION where the flag did not exist yet and check that the curatable flag is turned on on all features

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
