### PR TITLE
#2560 - Error importing re-zipped project containing curated documents

### DIFF
--- a/inception/inception-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/export/exporters/CuratedDocumentsExporter.java
+++ b/inception/inception-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/export/exporters/CuratedDocumentsExporter.java
@@ -180,15 +180,20 @@ public class CuratedDocumentsExporter
         for (Enumeration<? extends ZipEntry> zipEnumerate = aZip.entries(); zipEnumerate
                 .hasMoreElements();) {
             ZipEntry entry = zipEnumerate.nextElement();
-
-            log.trace("Considering ZIP entry [{}]", entry.getName());
+            if (entry.isDirectory()) {
+                log.trace("Skipping ZIP entry that is a directory: [{}]", entry.getName());
+                continue;
+            }
 
             // Strip leading "/" that we had in ZIP files prior to 2.0.8 (bug #985)
             String entryName = ProjectExporter.normalizeEntryName(entry);
 
             if (!entryName.startsWith(CURATION_AS_SERIALISED_CAS + "/")) {
+                log.trace("Skipping ZIP entry that is not a curation CAS: [{}]", entry.getName());
                 continue;
             }
+
+            log.trace("Importing curation CAS from: [{}]", entry.getName());
 
             String fileName = entryName.replace(CURATION_AS_SERIALISED_CAS + "/", "");
             // the user annotated the document is file name minus extension


### PR DESCRIPTION
**What's in the PR**
- Skip directory entries when searching for curation documents in ZIP

**How to test manually**
* Import the test project that was attached to the issue

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
