### PR TITLE
#2562 - Project name no longer unique

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/layer/LayerBehaviorRegistryImpl.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/layer/LayerBehaviorRegistryImpl.java
@@ -37,7 +37,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.adapter.LayerBehavior;
 /**
  * <p>
  * This class is exposed as a Spring Component via
- * {@code AnnotationServiceAutoConfiguration#layerBehaviorRegistry}.
+ * {@code AnnotationSchemaServiceAutoConfiguration#layerBehaviorRegistry}.
  * </p>
  */
 public class LayerBehaviorRegistryImpl

--- a/inception/inception-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/export/ProjectExportServiceImpl.java
+++ b/inception/inception-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/export/ProjectExportServiceImpl.java
@@ -269,7 +269,7 @@ public class ProjectExportServiceImpl
         try {
             ExportedProject exProject = loadExportedProject(aZip);
 
-            project.setName(deriveUniqueProjectName(exProject.getName()));
+            project.setName(exProject.getName());
 
             // Old projects do not have a slug, so we derive one from the project name
             String slug = exProject.getSlug();
@@ -315,28 +315,6 @@ public class ProjectExportServiceImpl
                 formatDurationWords(currentTimeMillis() - start, true, true));
 
         return project;
-    }
-
-    /**
-     * Get a project name to be used when importing. Use the prefix, copy_of_...+ i to avoid
-     * conflicts
-     * 
-     * @deprecated The project name will no longer be unique soon - only the URL slug will be
-     *             unique.
-     */
-    @Deprecated
-    private String deriveUniqueProjectName(String aProjectName)
-    {
-        String projectName = aProjectName;
-        int i = 0;
-        while (true) {
-            if (!projectService.existsProjectWithName(projectName)) {
-                return projectName;
-            }
-
-            i++;
-            projectName = "copy_of_" + aProjectName + "(" + i + ")";
-        }
     }
 
     public static ExportedProject loadExportedProject(ZipFile aZip) throws IOException

--- a/inception/inception-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/export/config/ProjectExportServiceAutoConfiguration.java
+++ b/inception/inception-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/export/config/ProjectExportServiceAutoConfiguration.java
@@ -20,6 +20,7 @@ package de.tudarmstadt.ukp.clarin.webanno.api.dao.export.config;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -32,6 +33,8 @@ import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExporter;
 
 @Configuration
+@AutoConfigureAfter(name = {
+        "de.tudarmstadt.ukp.clarin.webanno.project.config.ProjectServiceAutoConfiguration" })
 @ConditionalOnBean(ProjectService.class)
 public class ProjectExportServiceAutoConfiguration
 {

--- a/inception/inception-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/export/config/ProjectExportServiceAutoConfiguration.java
+++ b/inception/inception-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/export/config/ProjectExportServiceAutoConfiguration.java
@@ -20,6 +20,7 @@ package de.tudarmstadt.ukp.clarin.webanno.api.dao.export.config;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -31,6 +32,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExporter;
 
 @Configuration
+@ConditionalOnBean(ProjectService.class)
 public class ProjectExportServiceAutoConfiguration
 {
     @Bean

--- a/inception/inception-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/ProjectService.java
+++ b/inception/inception-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/ProjectService.java
@@ -19,8 +19,6 @@ package de.tudarmstadt.ukp.clarin.webanno.api;
 
 import static de.tudarmstadt.ukp.clarin.webanno.support.logging.Logging.KEY_PROJECT_ID;
 import static de.tudarmstadt.ukp.clarin.webanno.support.logging.Logging.KEY_REPOSITORY_PATH;
-import static org.apache.commons.lang3.StringUtils.containsNone;
-import static org.apache.commons.lang3.StringUtils.isEmpty;
 
 import java.io.File;
 import java.io.IOException;
@@ -50,10 +48,6 @@ import de.tudarmstadt.ukp.clarin.webanno.support.logging.MDCContext;
 public interface ProjectService
 {
     String SERVICE_NAME = "projectService";
-
-    String PROJECT_NAME_ILLEGAL_CHARACTERS = "^/\\&*?+$![]";
-    int MIN_PROJECT_SLUG_LENGTH = 3;
-    int MAX_PROJECT_SLUG_LENGTH = 40;
 
     String PROJECT_FOLDER = "project";
     String DOCUMENT_FOLDER = "document";
@@ -483,53 +477,4 @@ public interface ProjectService
     String deriveSlugFromName(String aName);
 
     String deriveUniqueSlug(String aSlug);
-
-    /**
-     * Check if the name is valid, SPecial characters are not allowed as a project/user name as it
-     * will conflict with file naming system
-     * 
-     * @param aName
-     *            a name.
-     * @return if the name is valid.
-     */
-    static boolean isValidProjectName(String aName)
-    {
-        return aName != null && containsNone(aName, PROJECT_NAME_ILLEGAL_CHARACTERS);
-    }
-
-    static boolean isValidProjectSlug(String aSlug)
-    {
-        if (isEmpty(aSlug)) {
-            return false;
-        }
-
-        if (aSlug.length() < MIN_PROJECT_SLUG_LENGTH || aSlug.length() > MAX_PROJECT_SLUG_LENGTH) {
-            return false;
-        }
-
-        // Must start with a letter character
-        if (!isValidProjectSlugInitialCharacter(aSlug.charAt(0))) {
-            return false;
-        }
-
-        // Must consist only of valid characters
-        for (int i = 0; i < aSlug.length(); i++) {
-            if (!isValidProjectSlugCharacter(aSlug.charAt(i))) {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    static boolean isValidProjectSlugInitialCharacter(char aChar)
-    {
-        return ('a' <= aChar && aChar <= 'z');
-    }
-
-    static boolean isValidProjectSlugCharacter(char aChar)
-    {
-        return ('0' <= aChar && aChar <= '9') || ('a' <= aChar && aChar <= 'z') || aChar == '-'
-                || aChar == '_';
-    }
 }

--- a/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/storage/config/CurationDocumentServiceAutoConfiguration.java
+++ b/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/storage/config/CurationDocumentServiceAutoConfiguration.java
@@ -19,6 +19,7 @@ package de.tudarmstadt.ukp.clarin.webanno.curation.storage.config;
 
 import javax.persistence.EntityManager;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -29,6 +30,7 @@ import de.tudarmstadt.ukp.clarin.webanno.curation.storage.CurationDocumentServic
 import de.tudarmstadt.ukp.clarin.webanno.curation.storage.CurationDocumentServiceImpl;
 
 @Configuration
+@ConditionalOnBean({ CasStorageService.class, AnnotationSchemaService.class, ProjectService.class })
 public class CurationDocumentServiceAutoConfiguration
 {
     @Bean(CurationDocumentService.SERVICE_NAME)

--- a/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/storage/config/CurationDocumentServiceAutoConfiguration.java
+++ b/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/storage/config/CurationDocumentServiceAutoConfiguration.java
@@ -19,6 +19,7 @@ package de.tudarmstadt.ukp.clarin.webanno.curation.storage.config;
 
 import javax.persistence.EntityManager;
 
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -30,6 +31,10 @@ import de.tudarmstadt.ukp.clarin.webanno.curation.storage.CurationDocumentServic
 import de.tudarmstadt.ukp.clarin.webanno.curation.storage.CurationDocumentServiceImpl;
 
 @Configuration
+@AutoConfigureAfter(name = {
+        "de.tudarmstadt.ukp.clarin.webanno.project.config.ProjectServiceAutoConfiguration",
+        "de.tudarmstadt.ukp.clarin.webanno.api.dao.annotationservice.config.AnnotationSchemaServiceAutoConfiguration",
+        "de.tudarmstadt.ukp.inception.curation.config.CurationServiceAutoConfiguration" })
 @ConditionalOnBean({ CasStorageService.class, AnnotationSchemaService.class, ProjectService.class })
 public class CurationDocumentServiceAutoConfiguration
 {

--- a/inception/inception-curation/src/test/java/de/tudarmstadt/ukp/inception/curation/CurationServiceTest.java
+++ b/inception/inception-curation/src/test/java/de/tudarmstadt/ukp/inception/curation/CurationServiceTest.java
@@ -79,7 +79,7 @@ public class CurationServiceTest
         testEntityManager.persist(kevin);
 
         // create project
-        testProject = new Project("testProject");
+        testProject = new Project("test-project");
         testEntityManager.persist(testProject);
         testEntityManager.persist(new ProjectPermission(testProject, "beate", ANNOTATOR));
         testEntityManager.persist(new ProjectPermission(testProject, "kevin", ANNOTATOR));

--- a/inception/inception-log/src/test/java/de/tudarmstadt/ukp/inception/log/adapter/FeatureValueUpdatedEventAdapterTest.java
+++ b/inception/inception-log/src/test/java/de/tudarmstadt/ukp/inception/log/adapter/FeatureValueUpdatedEventAdapterTest.java
@@ -54,7 +54,7 @@ public class FeatureValueUpdatedEventAdapterTest
         TypeDescription typeDesc = tsd.addType("customType", "desc", TYPE_NAME_ANNOTATION);
         FeatureDescription featDesc = typeDesc.addFeature("value", "desc", TYPE_NAME_STRING);
 
-        Project project = new Project("project name");
+        Project project = new Project("test-project");
         project.setId(1l);
         SourceDocument doc = new SourceDocument("document name", project, "format");
         doc.setId(2l);

--- a/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/Project.java
+++ b/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/Project.java
@@ -17,6 +17,10 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.model;
 
+import static java.lang.String.format;
+import static org.apache.commons.lang3.StringUtils.containsNone;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+
 import java.io.Serializable;
 import java.util.Date;
 
@@ -33,6 +37,7 @@ import javax.persistence.Temporal;
 import javax.persistence.TemporalType;
 import javax.persistence.UniqueConstraint;
 
+import org.apache.commons.lang3.Validate;
 import org.hibernate.annotations.Type;
 
 /**
@@ -44,6 +49,10 @@ public class Project
     implements Serializable
 {
     private static final long serialVersionUID = -5426914078691460011L;
+
+    public static final String PROJECT_NAME_ILLEGAL_CHARACTERS = "^/\\&*?+$![]";
+    public static final int MIN_PROJECT_SLUG_LENGTH = 3;
+    public static final int MAX_PROJECT_SLUG_LENGTH = 40;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -92,10 +101,15 @@ public class Project
         // Nothing to do
     }
 
-    public Project(String aName)
+    /**
+     * Constructor used for testing purposes. Set the {@link #name} to the same value as the
+     * {@link #slug}.
+     */
+    public Project(String aSlug)
     {
         super();
-        name = aName;
+        setName(aSlug);
+        setSlug(aSlug);
         mode = "annotation";
     }
 
@@ -116,11 +130,13 @@ public class Project
 
     public void setName(String aName)
     {
+        Validate.isTrue(isValidProjectName(aName), "Invalid project name: [%s]", aName);
         name = aName;
     }
 
     public void setSlug(String aSlug)
     {
+        Validate.isTrue(isValidProjectSlug(aSlug), format("Invalid project URL slug: [%s]", aSlug));
         slug = aSlug;
     }
 
@@ -281,5 +297,54 @@ public class Project
     public String toString()
     {
         return "[" + name + "](" + id + ")";
+    }
+
+    /**
+     * Check if the name is valid, SPecial characters are not allowed as a project/user name as it
+     * will conflict with file naming system
+     * 
+     * @param aName
+     *            a name.
+     * @return if the name is valid.
+     */
+    public static boolean isValidProjectName(String aName)
+    {
+        return aName != null && containsNone(aName, PROJECT_NAME_ILLEGAL_CHARACTERS);
+    }
+
+    public static boolean isValidProjectSlug(String aSlug)
+    {
+        if (isEmpty(aSlug)) {
+            return false;
+        }
+
+        if (aSlug.length() < MIN_PROJECT_SLUG_LENGTH || aSlug.length() > MAX_PROJECT_SLUG_LENGTH) {
+            return false;
+        }
+
+        // Must start with a letter character
+        if (!isValidProjectSlugInitialCharacter(aSlug.charAt(0))) {
+            return false;
+        }
+
+        // Must consist only of valid characters
+        for (int i = 0; i < aSlug.length(); i++) {
+            if (!isValidProjectSlugCharacter(aSlug.charAt(i))) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public static boolean isValidProjectSlugInitialCharacter(char aChar)
+    {
+        return ('a' <= aChar && aChar <= 'z');
+    }
+
+    public static boolean isValidProjectSlugCharacter(char aChar)
+    {
+        return ('0' <= aChar && aChar <= '9') || ('a' <= aChar && aChar <= 'z') || aChar == '-'
+                || aChar == '_';
     }
 }

--- a/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/Project.java
+++ b/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/Project.java
@@ -249,7 +249,7 @@ public class Project
     {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        result = prime * result + ((slug == null) ? 0 : slug.hashCode());
         return result;
     }
 
@@ -266,12 +266,12 @@ public class Project
             return false;
         }
         Project other = (Project) obj;
-        if (name == null) {
-            if (other.name != null) {
+        if (slug == null) {
+            if (other.slug != null) {
                 return false;
             }
         }
-        else if (!name.equals(other.name)) {
+        else if (!slug.equals(other.slug)) {
             return false;
         }
         return true;

--- a/inception/inception-model/src/main/resources/de/tudarmstadt/ukp/clarin/webanno/model/db-changelog.xml
+++ b/inception/inception-model/src/main/resources/de/tudarmstadt/ukp/clarin/webanno/model/db-changelog.xml
@@ -1319,5 +1319,11 @@
       tableName="project" 
       constraintName="UK_project_slug"
       columnNames="slug" />
+  </changeSet>
+
+  <changeSet author="INCEpTION Team" id="20210827-1" failOnError="false">
+    <dropUniqueConstraint
+      tableName="project"
+      constraintName="UK3k75vvu7mevyvvb5may5lj8k7" />
   </changeSet>  
 </databaseChangeLog>

--- a/inception/inception-project/pom.xml
+++ b/inception/inception-project/pom.xml
@@ -76,6 +76,10 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-beans</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
 
     <!-- DKPro Core dependencies -->
     <dependency>
@@ -132,11 +136,6 @@
     <dependency>
     	<groupId>org.springframework.boot</groupId>
     	<artifactId>spring-boot-test-autoconfigure</artifactId>
-    	<scope>test</scope>
-    </dependency>
-    <dependency>
-    	<groupId>org.springframework.boot</groupId>
-    	<artifactId>spring-boot-autoconfigure</artifactId>
     	<scope>test</scope>
     </dependency>
     <dependency>

--- a/inception/inception-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
+++ b/inception/inception-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
@@ -21,6 +21,10 @@ import static de.tudarmstadt.ukp.clarin.webanno.api.ProjectService.withProjectLo
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.ANNOTATOR;
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.CURATOR;
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.MANAGER;
+import static de.tudarmstadt.ukp.clarin.webanno.model.Project.MAX_PROJECT_SLUG_LENGTH;
+import static de.tudarmstadt.ukp.clarin.webanno.model.Project.MIN_PROJECT_SLUG_LENGTH;
+import static de.tudarmstadt.ukp.clarin.webanno.model.Project.isValidProjectSlug;
+import static de.tudarmstadt.ukp.clarin.webanno.model.Project.isValidProjectSlugInitialCharacter;
 import static java.lang.Math.min;
 import static java.nio.file.Files.newDirectoryStream;
 import static java.util.Arrays.asList;
@@ -817,7 +821,7 @@ public class ProjectServiceImpl
         List<Project> projects = entityManager.createQuery(query, Project.class).getResultList();
         for (Project project : projects) {
             String slug = deriveSlugFromName(project.getName());
-            if (!ProjectService.isValidProjectSlug(slug)) {
+            if (!isValidProjectSlug(slug)) {
                 log.warn("Attempt to derive slug from project name [{}] resulted in invalid slug "
                         + "[{}], generating random slug...", project.getName(), slug);
                 slug = generateRandomSlug();
@@ -996,7 +1000,7 @@ public class ProjectServiceImpl
         StringBuilder buf = new StringBuilder();
         for (int i = 0; i < min(name.length(), MAX_PROJECT_SLUG_LENGTH); i++) {
             char c = name.charAt(i);
-            if (ProjectService.isValidProjectSlugCharacter(c)) {
+            if (Project.isValidProjectSlugCharacter(c)) {
                 lastCharMappedToUnderscore = c == '_';
                 buf.append(c);
                 continue;
@@ -1015,7 +1019,7 @@ public class ProjectServiceImpl
             lastCharMappedToUnderscore = true;
         }
 
-        if (!ProjectService.isValidProjectSlugInitialCharacter(buf.charAt(0))) {
+        if (!isValidProjectSlugInitialCharacter(buf.charAt(0))) {
             buf.insert(0, 'x');
             if (buf.length() > MAX_PROJECT_SLUG_LENGTH) {
                 buf.setLength(MAX_PROJECT_SLUG_LENGTH);

--- a/inception/inception-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/initializers/config/ProjectInitializersAutoConfiguration.java
+++ b/inception/inception-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/initializers/config/ProjectInitializersAutoConfiguration.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.project.initializers.config;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -41,6 +42,7 @@ import de.tudarmstadt.ukp.clarin.webanno.project.initializers.SurfaceFormLayerIn
 import de.tudarmstadt.ukp.clarin.webanno.project.initializers.TokenLayerInitializer;
 
 @Configuration
+@ConditionalOnBean({ AnnotationSchemaService.class })
 public class ProjectInitializersAutoConfiguration
 {
     @Bean

--- a/inception/inception-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/initializers/config/ProjectInitializersAutoConfiguration.java
+++ b/inception/inception-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/initializers/config/ProjectInitializersAutoConfiguration.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.project.initializers.config;
 
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -42,6 +43,8 @@ import de.tudarmstadt.ukp.clarin.webanno.project.initializers.SurfaceFormLayerIn
 import de.tudarmstadt.ukp.clarin.webanno.project.initializers.TokenLayerInitializer;
 
 @Configuration
+@AutoConfigureAfter(name = {
+        "de.tudarmstadt.ukp.clarin.webanno.api.dao.annotationservice.config.AnnotationSchemaServiceAutoConfiguration" })
 @ConditionalOnBean({ AnnotationSchemaService.class })
 public class ProjectInitializersAutoConfiguration
 {

--- a/inception/inception-project/src/test/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImplTest.java
+++ b/inception/inception-project/src/test/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImplTest.java
@@ -21,10 +21,10 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.project;
 
-import static de.tudarmstadt.ukp.clarin.webanno.api.ProjectService.MAX_PROJECT_SLUG_LENGTH;
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.ANNOTATOR;
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.CURATOR;
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.MANAGER;
+import static de.tudarmstadt.ukp.clarin.webanno.model.Project.MAX_PROJECT_SLUG_LENGTH;
 import static org.apache.commons.lang3.StringUtils.repeat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -82,14 +82,14 @@ public class ProjectServiceImplTest
         testEntityManager.persist(kevin);
 
         // create project and projectPermissions for users
-        testProject = new Project("testProject");
+        testProject = new Project("test-project");
         testEntityManager.persist(testProject);
         testEntityManager.persist(new ProjectPermission(testProject, "beate", ANNOTATOR));
         testEntityManager.persist(new ProjectPermission(testProject, "kevin", ANNOTATOR));
         testEntityManager.persist(new ProjectPermission(testProject, "beate", CURATOR));
 
         // create additional project and projectPermissions for users
-        testProject2 = new Project("testProject2");
+        testProject2 = new Project("test-project2");
         testEntityManager.persist(testProject2);
         testEntityManager.persist(new ProjectPermission(testProject2, "beate", ANNOTATOR));
         testEntityManager.persist(new ProjectPermission(testProject2, "beate", CURATOR));

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/LegacyRemoteApiController.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/LegacyRemoteApiController.java
@@ -26,6 +26,7 @@ import java.net.URLConnection;
 import java.text.SimpleDateFormat;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Optional;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -94,6 +95,7 @@ public class LegacyRemoteApiController
     private static final String PARAM_FILE = "file";
     private static final String PARAM_FILETYPE = "filetype";
     private static final String PARAM_NAME = "name";
+    private static final String PARAM_TITLE = "title";
     private static final String PARAM_FORMAT = "format";
 
     private final Logger LOG = LoggerFactory.getLogger(getClass());
@@ -111,7 +113,7 @@ public class LegacyRemoteApiController
      * curl -v -F 'file=@test.zip' -F 'name=Test' -F 'filetype=tcf'
      * 'http://USERNAME:PASSWORD@localhost:8080/webanno-webapp/api/projects'
      *
-     * @param aName
+     * @param aSlug
      *            the name of the project to create.
      * @param aFileType
      *            the type of the files contained in the ZIP.
@@ -124,8 +126,11 @@ public class LegacyRemoteApiController
     @PostMapping(//
             value = ("/" + PROJECTS), //
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseEntity<String> projectCreate(@RequestParam(PARAM_FILE) MultipartFile aFile,
-            @RequestParam(PARAM_NAME) String aName, @RequestParam(PARAM_FILETYPE) String aFileType)
+    public ResponseEntity<String> projectCreate( //
+            @RequestParam(PARAM_FILE) MultipartFile aFile, //
+            @RequestParam(PARAM_NAME) String aSlug, //
+            @RequestParam(PARAM_TITLE) Optional<String> aName, //
+            @RequestParam(PARAM_FILETYPE) String aFileType)
         throws Exception
     {
         // Get current user
@@ -144,9 +149,9 @@ public class LegacyRemoteApiController
         }
 
         // Existing project
-        if (projectRepository.existsProjectWithName(aName)) {
+        if (projectRepository.existsProjectWithSlug(aSlug)) {
             return ResponseEntity.status(HttpStatus.CONFLICT)
-                    .body("A project with name [" + aName + "] already exists");
+                    .body("A project with URL slug [" + aSlug + "] already exists");
         }
 
         // Check archive
@@ -157,9 +162,10 @@ public class LegacyRemoteApiController
         }
 
         // Create the project and initialize tags
-        LOG.info("Creating project [" + aName + "]");
+        LOG.info("Creating project [" + aSlug + "]");
         Project project = new Project();
-        project.setName(aName);
+        project.setSlug(aSlug);
+        project.setName(aName.orElse(aSlug));
         project = projectRepository.createProject(project);
         projectRepository.initializeProject(project);
 
@@ -210,10 +216,10 @@ public class LegacyRemoteApiController
             }
         }
 
-        LOG.info("Successfully created project [" + aName + "] for user [" + username + "]");
+        LOG.info("Successfully created project [" + aSlug + "] for user [" + username + "]");
 
         JSONObject projectJSON = new JSONObject();
-        projectJSON.append(aName, project.getId());
+        projectJSON.append(aSlug, project.getId());
         return ResponseEntity.ok(projectJSON.toString());
     }
 
@@ -255,7 +261,7 @@ public class LegacyRemoteApiController
             for (ProjectPermission p : projectPermissions) {
                 permissionArr.put(p.getLevel().getName());
             }
-            projectJSON.put(project.getName(), permissionArr);
+            projectJSON.put(project.getSlug(), permissionArr);
             returnJSONObj.put(projectId, projectJSON);
         }
         return ResponseEntity.ok(returnJSONObj.toString());

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
@@ -139,6 +139,7 @@ public class AeroRemoteApiController
     private static final String PARAM_FILE = "file";
     private static final String PARAM_CONTENT = "content";
     private static final String PARAM_NAME = "name";
+    private static final String PARAM_TITLE = "title";
     private static final String PARAM_FORMAT = "format";
     private static final String PARAM_STATE = "state";
     private static final String PARAM_CREATOR = "creator";
@@ -283,8 +284,11 @@ public class AeroRemoteApiController
             value = ("/" + PROJECTS), //
             consumes = { ALL_VALUE, MULTIPART_FORM_DATA_VALUE }, //
             produces = APPLICATION_JSON_VALUE)
-    public ResponseEntity<RResponse<RProject>> projectCreate(@RequestParam(PARAM_NAME) String aName,
-            @RequestParam(PARAM_CREATOR) Optional<String> aCreator, UriComponentsBuilder aUcb)
+    public ResponseEntity<RResponse<RProject>> projectCreate( //
+            @RequestParam(PARAM_NAME) String aSlug, //
+            @RequestParam(PARAM_TITLE) Optional<String> aName, //
+            @RequestParam(PARAM_CREATOR) Optional<String> aCreator, //
+            UriComponentsBuilder aUcb)
         throws Exception
     {
         // Get current user - this will throw an exception if the current user does not exit
@@ -302,14 +306,16 @@ public class AeroRemoteApiController
                         || (aCreator.isPresent() && aCreator.get().equals(user.getUsername())));
 
         // Existing project
-        if (projectService.existsProjectWithName(aName)) {
-            throw new ObjectExistsException("A project with name [" + aName + "] already exists");
+        if (projectService.existsProjectWithSlug(aSlug)) {
+            throw new ObjectExistsException(
+                    "A project with URL slug [" + aSlug + "] already exists");
         }
 
         // Create the project and initialize tags
-        LOG.info("Creating project [" + aName + "]");
+        LOG.info("Creating project [{}]", aSlug);
         Project project = new Project();
-        project.setName(aName);
+        project.setSlug(aSlug);
+        project.setName(aName.orElse(aSlug));
         project.setScriptDirection(ScriptDirection.LTR);
         project.setState(ProjectState.NEW);
         projectService.createProject(project);

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/model/RProject.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/model/RProject.java
@@ -23,17 +23,20 @@ public class RProject
 {
     public long id;
     public String name;
+    public String title;
 
     public RProject(Project aProject)
     {
         id = aProject.getId();
-        name = aProject.getName();
+        name = aProject.getSlug();
+        title = aProject.getName();
     }
 
-    public RProject(long aId, String aName)
+    public RProject(long aId, String aTitle, String aSlug)
     {
         super();
         id = aId;
-        name = aName;
+        name = aSlug;
+        title = aTitle;
     }
 }

--- a/inception/inception-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/AeroRemoteApiControllerTest.java
+++ b/inception/inception-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/AeroRemoteApiControllerTest.java
@@ -79,15 +79,15 @@ import de.tudarmstadt.ukp.inception.export.config.DocumentImportExportServiceAut
                 "repository.path=" + AeroRemoteApiControllerTest.TEST_OUTPUT_FOLDER })
 @EnableWebSecurity
 @Import({ //
+        ProjectServiceAutoConfiguration.class, //
         ProjectExportServiceAutoConfiguration.class, //
+        AnnotationSchemaServiceAutoConfiguration.class, //
+        CasStorageServiceAutoConfiguration.class, //
         CurationDocumentServiceAutoConfiguration.class, //
         TextFormatsAutoConfiguration.class, //
         DocumentImportExportServiceAutoConfiguration.class, //
         DocumentServiceAutoConfiguration.class, //
-        ProjectServiceAutoConfiguration.class, //
-        CasStorageServiceAutoConfiguration.class, //
         RepositoryAutoConfiguration.class, //
-        AnnotationSchemaServiceAutoConfiguration.class, //
         SecurityAutoConfiguration.class, //
         RemoteApiAutoConfiguration.class })
 @EntityScan({ //

--- a/inception/inception-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/webhooks/WebhookServiceTest.java
+++ b/inception/inception-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/webhooks/WebhookServiceTest.java
@@ -45,6 +45,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
+import de.tudarmstadt.ukp.clarin.webanno.api.dao.annotationservice.config.AnnotationSchemaServiceAutoConfiguration;
+import de.tudarmstadt.ukp.clarin.webanno.api.dao.documentservice.config.DocumentServiceAutoConfiguration;
 import de.tudarmstadt.ukp.clarin.webanno.api.event.AnnotationStateChangeEvent;
 import de.tudarmstadt.ukp.clarin.webanno.api.event.DocumentStateChangedEvent;
 import de.tudarmstadt.ukp.clarin.webanno.api.event.ProjectStateChangedEvent;
@@ -54,14 +56,20 @@ import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.ProjectState;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState;
+import de.tudarmstadt.ukp.clarin.webanno.project.config.ProjectServiceAutoConfiguration;
 import de.tudarmstadt.ukp.clarin.webanno.support.ApplicationContextProvider;
 import de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.webhooks.json.AnnotationStateChangeMessage;
 import de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.webhooks.json.DocumentStateChangeMessage;
 import de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.webhooks.json.ProjectStateChangeMessage;
+import de.tudarmstadt.ukp.inception.export.config.DocumentImportExportServiceAutoConfiguration;
 
 @SpringBootApplication(exclude = { //
         SecurityAutoConfiguration.class, //
-        LiquibaseAutoConfiguration.class })
+        LiquibaseAutoConfiguration.class, //
+        AnnotationSchemaServiceAutoConfiguration.class, //
+        DocumentImportExportServiceAutoConfiguration.class, //
+        DocumentServiceAutoConfiguration.class, //
+        ProjectServiceAutoConfiguration.class })
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, //
         properties = { //
                 "spring.main.banner-mode=off" })

--- a/inception/inception-scheduling/src/test/java/de/tudarmstadt/ukp/inception/scheduling/SchedulingServiceTest.java
+++ b/inception/inception-scheduling/src/test/java/de/tudarmstadt/ukp/inception/scheduling/SchedulingServiceTest.java
@@ -40,9 +40,7 @@ import de.tudarmstadt.ukp.inception.scheduling.config.SchedulingProperties;
 
 public class SchedulingServiceTest
 {
-
-    @Mock
-    private ApplicationContext mockContext;
+    private @Mock ApplicationContext mockContext;
 
     private List<Task> executedTasks;
 
@@ -67,8 +65,10 @@ public class SchedulingServiceTest
     @Test
     public void thatRunningTasksCanBeRetrieved()
     {
-        List<Task> tasks = asList(buildDummyTask("user1", "project1"),
-                buildDummyTask("user1", "project2"), buildDummyTask("user2", "project1"));
+        List<Task> tasks = asList( //
+                buildDummyTask("user1", "project1"), //
+                buildDummyTask("user1", "project2"), //
+                buildDummyTask("user2", "project1"));
 
         for (Task task : tasks) {
             sut.enqueue(task);
@@ -77,25 +77,28 @@ public class SchedulingServiceTest
         // Wait until the threads have actually been started
         await().atMost(15, SECONDS).until(() -> sut.getRunningTasks().size() == tasks.size());
 
-        assertThat(sut.getRunningTasks()).as("All enqueued tasks should be running")
+        assertThat(sut.getRunningTasks()) //
+                .as("All enqueued tasks should be running")
                 .containsExactlyInAnyOrderElementsOf(tasks);
     }
 
     @Test
     public void thatTasksForUserCanBeStopped()
     {
-        List<Task> tasks = asList(buildDummyTask("testUser", "project1"),
-                buildDummyTask("unimportantUser1", "project1"),
-                buildDummyTask("unimportantUser2", "project2"),
-                buildDummyTask("unimportantUser3", "project3"),
-                buildDummyTask("testUser", "project2"),
-                buildDummyTask("unimportantUser4", "project4"),
-                buildDummyTask("testUser", "project3"),
-                buildDummyTask("unimportantUser1", "project2"),
-                buildDummyTask("testUser", "project4"),
-                buildDummyTask("unimportantUser2", "project3"),
-                buildDummyTask("unimportantUser3", "project4"),
-                buildDummyTask("testUser", "project2"), buildDummyTask("testUser", "project2"));
+        List<Task> tasks = asList( //
+                buildDummyTask("testUser", "project1"), //
+                buildDummyTask("unimportantUser1", "project1"), //
+                buildDummyTask("unimportantUser2", "project2"), //
+                buildDummyTask("unimportantUser3", "project3"), //
+                buildDummyTask("testUser", "project2"), //
+                buildDummyTask("unimportantUser4", "project4"), //
+                buildDummyTask("testUser", "project3"), //
+                buildDummyTask("unimportantUser1", "project2"), //
+                buildDummyTask("testUser", "project4"), //
+                buildDummyTask("unimportantUser2", "project3"), //
+                buildDummyTask("unimportantUser3", "project4"), //
+                buildDummyTask("testUser", "project2"), //
+                buildDummyTask("testUser", "project2"));
         Task[] tasksToRemove = tasks.stream()
                 .filter(t -> t.getUser().getUsername().equals("testUser")).toArray(Task[]::new);
 
@@ -117,6 +120,7 @@ public class SchedulingServiceTest
     private Project buildProject(String aProjectName)
     {
         Project project = new Project();
+        project.setSlug(aProjectName);
         project.setName(aProjectName);
         return project;
     }

--- a/inception/inception-search-mtas/src/test/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndexTest.java
+++ b/inception/inception-search-mtas/src/test/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndexTest.java
@@ -96,6 +96,7 @@ import de.tudarmstadt.ukp.inception.search.index.mtas.config.MtasDocumentIndexAu
 // waits forever for the indexing to complete...
 @Transactional(propagation = Propagation.NEVER)
 @Import({ //
+        AnnotationSchemaServiceAutoConfiguration.class, //
         TextFormatsAutoConfiguration.class, //
         ConllFormatsAutoConfiguration.class, //
         DocumentImportExportServiceAutoConfiguration.class, //
@@ -104,7 +105,6 @@ import de.tudarmstadt.ukp.inception.search.index.mtas.config.MtasDocumentIndexAu
         ProjectInitializersAutoConfiguration.class, //
         CasStorageServiceAutoConfiguration.class, //
         RepositoryAutoConfiguration.class, //
-        AnnotationSchemaServiceAutoConfiguration.class, //
         SecurityAutoConfiguration.class, //
         SearchServiceAutoConfiguration.class, //
         SchedulingServiceAutoConfiguration.class, //

--- a/inception/inception-sharing/src/test/java/de/tudarmstadt/ukp/inception/sharing/InviteServiceImplTest.java
+++ b/inception/inception-sharing/src/test/java/de/tudarmstadt/ukp/inception/sharing/InviteServiceImplTest.java
@@ -62,7 +62,7 @@ public class InviteServiceImplTest
     @BeforeEach
     public void setUp() throws Exception
     {
-        testProject = new Project("testProject");
+        testProject = new Project("test-project");
         testProject.setState(ANNOTATION_IN_PROGRESS);
         testEntityManager.persist(testProject);
 

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/login/LoginPage.html
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/login/LoginPage.html
@@ -21,7 +21,7 @@
   <wicket:extend>
     <div class="scrolling flex-content flex-h-container flex-centered">
       <div class="flex-content flex-v-container flex-centered">
-        <form wicket:id="loginForm" class="card hvr-shadow-radial login-form">
+        <form wicket:id="loginForm" class="card hvr-shadow-radial login-form w-min-440px">
           <div class="card-body container-sm">
             <h5 class="card-title mb-3 text-center">
               Welcome!

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/login/LoginPage.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/login/LoginPage.java
@@ -229,8 +229,8 @@ public class LoginPage
             super(id);
             setModel(new CompoundPropertyModel<>(this));
 
-            add(new RequiredTextField<String>("username"));
-            add(new PasswordTextField("password"));
+            add(new RequiredTextField<String>("username").setOutputMarkupId(true));
+            add(new PasswordTextField("password").setOutputMarkupId(true));
             add(new HiddenField<>("urlfragment"));
             add(new Button("signInBtn").add(enabledWhen(() -> !isTooManyUsers())));
             add(new Label("loginMessage", loginProperties.getMessage()).setEscapeModelStrings(false)

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/projectlist/ProjectsOverviewPage.html
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/projectlist/ProjectsOverviewPage.html
@@ -60,7 +60,7 @@
             <wicket:container wicket:id="roleFilter">
               <button type="button" class="btn btn-outline-secondary" wicket:id="roleFilterLink">
                 <wicket:container wicket:id="label"/>
-                </button>
+              </button>
             </wicket:container>
           </div>
         </div>
@@ -73,7 +73,7 @@
             <div class="d-flex">
               <div class="flex-grow-1 d-flex flex-column">
                 <div>
-                  <a wicket:id="projectLink">
+                  <a wicket:id="projectLink" class="text-decoration-none">
                     <wicket:container wicket:id="name"/>
                   </a>
                 </div>

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/projectlist/ProjectsOverviewPage.html
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/projectlist/ProjectsOverviewPage.html
@@ -72,19 +72,22 @@
           <div wicket:id="project" class="list-group-item">
             <div class="d-flex">
               <div class="flex-grow-1 d-flex flex-column">
-                <div class="flex-grow-1">
-                  <div class="float-end">
-                    <span wicket:id="role" class="badge bg-secondary ms-1"><wicket:container wicket:id="label"/></span>
-                  </div>
+                <div>
                   <a wicket:id="projectLink">
                     <wicket:container wicket:id="name"/>
                   </a>
                 </div>
-                <div class="list-group-item-text">
-                  <div class="text-end">
-                    <small class="text-muted" wicket:enclosure="created">Created: <wicket:container wicket:id="created"/></small>
-                    <small class="text-muted" wicket:enclosure="id">ID: <wicket:container wicket:id="id"/></small>
-                  </div>
+                <div class="list-group-item-text text-muted">
+                  <wicket:container wicket:id="description"/>
+                </div>
+              </div>
+              <div class="d-flex flex-column text-end">
+                <div class="d-flex flex-nowrap">
+                  <span wicket:id="role" class="badge bg-secondary ms-1"><wicket:container wicket:id="label"/></span>
+                </div>
+                <div class="text-nowrap mt-auto">
+                  <small class="text-muted" wicket:enclosure="created">Created: <wicket:container wicket:id="created"/></small>
+                  <small class="text-muted" wicket:enclosure="id">ID: <wicket:container wicket:id="id"/></small>
                 </div>
               </div>
               <div wicket:id="actionDropdown" class="d-flex">

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/projectlist/ProjectsOverviewPage.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/projectlist/ProjectsOverviewPage.java
@@ -29,6 +29,7 @@ import static java.lang.String.join;
 import static java.util.Arrays.asList;
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toList;
+import static org.apache.commons.lang3.StringUtils.substringBefore;
 import static org.apache.wicket.RuntimeConfigurationType.DEVELOPMENT;
 import static org.apache.wicket.authroles.authorization.strategies.role.metadata.MetaDataRoleAuthorizationStrategy.authorize;
 
@@ -39,6 +40,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.wicket.ClassAttributeModifier;
@@ -66,6 +68,8 @@ import org.wicketstuff.annotation.mount.MountPath;
 import org.wicketstuff.datetime.markup.html.basic.DateLabel;
 import org.wicketstuff.event.annotation.OnEvent;
 
+import com.github.rjeschke.txtmark.Processor;
+
 import de.agilecoders.wicket.core.markup.html.bootstrap.behavior.CssClassNameAppender;
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExportService;
@@ -91,6 +95,7 @@ public class ProjectsOverviewPage
 {
     private static final String MID_CREATED = "created";
     private static final String MID_NAME = "name";
+    private static final String MID_DESCRIPTION = "description";
     private static final String MID_PROJECT_LINK = "projectLink";
     private static final String MID_LABEL = "label";
     private static final String MID_ROLE = "role";
@@ -289,6 +294,8 @@ public class ProjectsOverviewPage
                 BookmarkablePageLink<Void> projectLink = new BookmarkablePageLink<>(
                         MID_PROJECT_LINK, ProjectDashboardPage.class, pageParameters);
                 projectLink.add(new Label(MID_NAME, aItem.getModelObject().getName()));
+                aItem.add(new Label(MID_DESCRIPTION, aItem.getModelObject().getShortDescription())
+                        .setEscapeModelStrings(false));
                 DateLabel createdLabel = DateLabel.forDatePattern(MID_CREATED,
                         () -> project.getCreated(), "yyyy-MM-dd");
                 addActionsDropdown(aItem);
@@ -540,6 +547,24 @@ public class ProjectsOverviewPage
         public String getName()
         {
             return project.getName();
+        }
+
+        public String getSlug()
+        {
+            return project.getSlug();
+        }
+
+        public String getShortDescription()
+        {
+            if (StringUtils.isBlank(project.getDescription())) {
+                return null;
+            }
+
+            var shortDescription = substringBefore(project.getDescription(), "\n");
+            var shortDescriptionHtml = Processor.process(shortDescription, true);
+            shortDescriptionHtml = StringUtils.removeStart(shortDescriptionHtml, "<p>");
+            shortDescriptionHtml = StringUtils.removeEnd(shortDescriptionHtml, "</p>");
+            return shortDescriptionHtml;
         }
 
         public Project getProject()

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/detail/ProjectDetailPanel.html
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/detail/ProjectDetailPanel.html
@@ -56,7 +56,7 @@
             </div>
             <div class="small text-muted">
               <i class="fab fa-markdown"></i> Markdown supported - The first line of the description
-              is displayed as a short description on the project overview page.
+              is displayed as a short description on the project overview page. 
             </div>
           </div>
         </div>

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/detail/ProjectDetailPanel.html
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/detail/ProjectDetailPanel.html
@@ -55,7 +55,8 @@
              <textarea wicket:id="description" class="form-control" rows="10"></textarea>
             </div>
             <div class="small text-muted">
-              <i class="fab fa-markdown"></i> Markdown supported
+              <i class="fab fa-markdown"></i> Markdown supported - The first line of the description
+              is displayed as a short description on the project overview page.
             </div>
           </div>
         </div>

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/detail/ProjectDetailPanel.java
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/detail/ProjectDetailPanel.java
@@ -17,8 +17,8 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.ui.project.detail;
 
-import static de.tudarmstadt.ukp.clarin.webanno.api.ProjectService.isValidProjectName;
-import static de.tudarmstadt.ukp.clarin.webanno.api.ProjectService.isValidProjectSlug;
+import static de.tudarmstadt.ukp.clarin.webanno.model.Project.isValidProjectName;
+import static de.tudarmstadt.ukp.clarin.webanno.model.Project.isValidProjectSlug;
 import static java.util.Arrays.asList;
 import static java.util.Objects.isNull;
 import static org.apache.commons.lang3.StringUtils.isBlank;
@@ -148,7 +148,7 @@ public class ProjectDetailPanel
         slug = projectService.deriveUniqueSlug(slug);
         // Just a safe-guard in case we would generate an invalid slug which we would not want
         // to get written back to the database
-        if (ProjectService.isValidProjectSlug(slug)) {
+        if (isValidProjectSlug(slug)) {
             return Optional.of(slug);
         }
 

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/detail/ProjectDetailPanel.java
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/detail/ProjectDetailPanel.java
@@ -116,7 +116,6 @@ public class ProjectDetailPanel
         TextField<String> projectNameTextField = new TextField<>("name");
         projectNameTextField.setOutputMarkupId(true);
         projectNameTextField.setRequired(true);
-        projectNameTextField.add(new ProjectWithNameAlreadyExistsValidator());
         projectNameTextField.add(new ProjectNameIsValidValidator());
         projectNameTextField.add(new LambdaAjaxFormComponentUpdatingBehavior("change", _target -> {
             deriveSlugFromName(projectModel.getObject()).ifPresent(slugSuggestionModel::setObject);
@@ -255,24 +254,6 @@ public class ProjectDetailPanel
                     && projectService.existsProjectWithSlug(newSlug)) {
                 aValidatable.error(new ValidationError(
                         "Another project with this URL slug exists. Please try a different one."));
-            }
-        }
-    }
-
-    private class ProjectWithNameAlreadyExistsValidator
-        implements IValidator<String>
-    {
-        private static final long serialVersionUID = -267638869839503827L;
-
-        @Override
-        public void validate(IValidatable<String> aValidatable)
-        {
-            String newName = aValidatable.getValue();
-            String oldName = aValidatable.getModel().getObject();
-            if (!StringUtils.equals(newName, oldName) && isNotBlank(newName)
-                    && projectService.existsProjectWithName(newName)) {
-                aValidatable.error(new ValidationError(
-                        "Another project with the same name exists. Please try a different name"));
             }
         }
     }

--- a/inception/inception-versioning/src/test/java/de/tudarmstadt/ukp/inception/versioning/VersioningServiceImplTest.java
+++ b/inception/inception-versioning/src/test/java/de/tudarmstadt/ukp/inception/versioning/VersioningServiceImplTest.java
@@ -81,14 +81,16 @@ import de.tudarmstadt.ukp.inception.versioning.config.VersioningServiceAutoConfi
         "de.tudarmstadt.ukp.clarin.webanno.model",
         "de.tudarmstadt.ukp.clarin.webanno.security.model" })
 @Import({ //
+        AnnotationSchemaServiceAutoConfiguration.class, //
+        ProjectServiceAutoConfiguration.class, //
+        CasStorageServiceAutoConfiguration.class, //
         CurationDocumentServiceAutoConfiguration.class, //
         TextFormatsAutoConfiguration.class, //
         UimaFormatsAutoConfiguration.class, //
+        RepositoryAutoConfiguration.class, //
         DocumentServiceAutoConfiguration.class, //
         DocumentImportExportServiceAutoConfiguration.class, //
-        ProjectServiceAutoConfiguration.class, //
-        VersioningServiceAutoConfiguration.class, CasStorageServiceAutoConfiguration.class, //
-        RepositoryAutoConfiguration.class, AnnotationSchemaServiceAutoConfiguration.class, //
+        VersioningServiceAutoConfiguration.class, //
         SecurityAutoConfiguration.class })
 public class VersioningServiceImplTest
 {
@@ -111,7 +113,7 @@ public class VersioningServiceImplTest
     @BeforeEach
     public void setUp()
     {
-        testProject = new Project("testProject");
+        testProject = new Project("test-project");
     }
 
     @AfterEach

--- a/inception/inception-websocket/src/test/java/de/tudarmstadt/ukp/inception/websocket/LoggedEventMessageControllerImplTest.java
+++ b/inception/inception-websocket/src/test/java/de/tudarmstadt/ukp/inception/websocket/LoggedEventMessageControllerImplTest.java
@@ -70,7 +70,7 @@ public class LoggedEventMessageControllerImplTest
         outboundChannel = new TestChannel();
         adapterRegistry = new EventLoggingAdapterRegistryImpl(asList(new SpanEventAdapter()));
         adapterRegistry.onContextRefreshedEvent(null);
-        testProject = new Project("testProject");
+        testProject = new Project("test-project");
         testProject.setId(1L);
         testDoc = new SourceDocument("testDoc", testProject, "text");
         testDoc.setId(2L);

--- a/inception/inception-websocket/src/test/java/de/tudarmstadt/ukp/inception/websocket/WebSocketIntegrationTest.java
+++ b/inception/inception-websocket/src/test/java/de/tudarmstadt/ukp/inception/websocket/WebSocketIntegrationTest.java
@@ -137,7 +137,7 @@ public class WebSocketIntegrationTest
         repositoryProperties.setPath(repositoryDir);
         MDC.put(Logging.KEY_REPOSITORY_PATH, repositoryProperties.getPath().toString());
 
-        testProject = new Project("testProject");
+        testProject = new Project("test-project");
         testDoc = new SourceDocument("testDoc", testProject, "text");
         projectService.createProject(testProject);
         docService.createSourceDocument(testDoc);


### PR DESCRIPTION
**What's in the PR**
- Drop unique index on name
- Change hashCode / equals on Project from name to slug
- Automatically add slugs to all project which do not have one yet during startup
- No longer create unique name when importing a project and the name was already taken
- No longer check if project name is already used when setting project name in project details / dashboard
- Adjustments to the remote APIs: the project "name" parameter in the remote API requests and responses is actually the URL slug and the "title" parameter is the project name. In the legacy remote API responses, the slug replaces the name.
- The first line of a project description is now shown as a short description in the project overview page

**How to test manually**
* Start up with external or embedded DB and check if the slugs are auto-generated
* Check if the slugs were actually persisted by hovering with the mouse cursor over the links in the project dashboard
* Try giving two projects the same name manually
* Export a project, then re-import it 

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
