### PR TITLE
#2571 - Email validation kicks in even if it is turned off

### DIFF
--- a/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/AcceptInvitePage.java
+++ b/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/AcceptInvitePage.java
@@ -236,10 +236,12 @@ public class AcceptInvitePage
     {
         Optional<User> existingUser = inviteService.getProjectUser(getProject(),
                 aFormData.username);
-        String storedEMail = existingUser.map(User::getEmail).orElse(null);
-        if (storedEMail != null && !storedEMail.equals(aFormData.eMail)) {
-            error("Provided eMail address does not match stored eMail address");
-            return null;
+        if (invite.getObject().getAskForEMail() != NOT_ALLOWED) {
+            String storedEMail = existingUser.map(User::getEmail).orElse(null);
+            if (storedEMail != null && !storedEMail.equals(aFormData.eMail)) {
+                error("Provided eMail address does not match stored eMail address");
+                return null;
+            }
         }
 
         User user = inviteService.getOrCreateProjectUser(getProject(), aFormData.username);


### PR DESCRIPTION
**What's in the PR**
- If providing an email has been turned off, do no try to validate it

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
