### PR TITLE
#2496 - Activate tooltip for annotation in curation mode

### DIFF
--- a/inception/inception-brat-editor/pom.xml
+++ b/inception/inception-brat-editor/pom.xml
@@ -49,6 +49,10 @@
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-support</artifactId>
     </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-security</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/annotation/BratLazyDetailsLookupService.java
+++ b/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/annotation/BratLazyDetailsLookupService.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.brat.annotation;
+
+import java.io.IOException;
+
+import org.apache.wicket.request.IRequestParameters;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.CasProvider;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.AnnotationException;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.VID;
+import de.tudarmstadt.ukp.clarin.webanno.brat.message.NormDataResponse;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
+
+public interface BratLazyDetailsLookupService
+{
+
+    NormDataResponse actionLookupNormData(IRequestParameters request, VID paramId, CasProvider aCas,
+            SourceDocument aSourceDocument, User aUser)
+        throws AnnotationException, IOException;
+
+}

--- a/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/annotation/BratLazyDetailsLookupServiceImpl.java
+++ b/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/annotation/BratLazyDetailsLookupServiceImpl.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.brat.annotation;
+
+import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.adapter.TypeAdapter.decodeTypeName;
+import static de.tudarmstadt.ukp.clarin.webanno.brat.annotation.BratProtocolNames.PARAM_LAZY_DETAIL_DATABASE;
+import static de.tudarmstadt.ukp.clarin.webanno.brat.annotation.BratProtocolNames.PARAM_LAZY_DETAIL_KEY;
+import static de.tudarmstadt.ukp.clarin.webanno.brat.annotation.BratProtocolNames.PARAM_TYPE;
+import static java.util.stream.Collectors.toList;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.wicket.request.IRequestParameters;
+import org.apache.wicket.util.string.StringValue;
+import org.springframework.stereotype.Component;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
+import de.tudarmstadt.ukp.clarin.webanno.api.CasProvider;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.AnnotationEditorExtensionRegistry;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.AnnotationException;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRegistry;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.layer.LayerSupportRegistry;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.VID;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.rendering.Renderer;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.rendering.model.VLazyDetailResult;
+import de.tudarmstadt.ukp.clarin.webanno.brat.message.NormDataResponse;
+import de.tudarmstadt.ukp.clarin.webanno.brat.render.model.NormalizationQueryResult;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
+
+@Component
+public class BratLazyDetailsLookupServiceImpl
+    implements BratLazyDetailsLookupService
+{
+    private final AnnotationSchemaService annotationService;
+    private final AnnotationEditorExtensionRegistry extensionRegistry;
+    private final LayerSupportRegistry layerSupportRegistry;
+    private final FeatureSupportRegistry featureSupportRegistry;
+
+    public BratLazyDetailsLookupServiceImpl(AnnotationSchemaService aAnnotationService,
+            AnnotationEditorExtensionRegistry aExtensionRegistry,
+            LayerSupportRegistry aLayerSupportRegistry,
+            FeatureSupportRegistry aFeatureSupportRegistry)
+    {
+        super();
+        annotationService = aAnnotationService;
+        extensionRegistry = aExtensionRegistry;
+        layerSupportRegistry = aLayerSupportRegistry;
+        featureSupportRegistry = aFeatureSupportRegistry;
+    }
+
+    @Override
+    public NormDataResponse actionLookupNormData(IRequestParameters request, VID paramId,
+            CasProvider aCas, SourceDocument aSourceDocument, User aUser)
+        throws AnnotationException, IOException
+    {
+        NormDataResponse response = new NormDataResponse();
+
+        // We interpret the databaseParam as the feature which we need to look up the feature
+        // support
+        StringValue databaseParam = request.getParameterValue(PARAM_LAZY_DETAIL_DATABASE);
+
+        // We interpret the key as the feature value or as a kind of query to be handled by the
+        // feature support
+        StringValue keyParam = request.getParameterValue(PARAM_LAZY_DETAIL_KEY);
+
+        StringValue layerParam = request.getParameterValue(PARAM_TYPE);
+
+        if (layerParam.isEmpty() || databaseParam.isEmpty()) {
+            return response;
+        }
+
+        Project project = aSourceDocument.getProject();
+        String database = databaseParam.toString();
+        long layerId = decodeTypeName(layerParam.toString());
+        AnnotationLayer layer = annotationService.getLayer(project, layerId)
+                .orElseThrow(() -> new AnnotationException(
+                        "Layer with ID [" + layerId + "] does not exist in project " + project));
+
+        // Check where the query needs to be routed: to an editor extension or to a feature support
+        if (paramId.isSynthetic()) {
+            if (keyParam.isEmpty()) {
+                return response;
+            }
+
+            AnnotationFeature feature = annotationService.getFeature(database, layer);
+
+            String extensionId = paramId.getExtensionId();
+            response.setResults(extensionRegistry.getExtension(extensionId)
+                    .renderLazyDetails(aSourceDocument, aUser, paramId, feature,
+                            keyParam.toString())
+                    .stream().map(d -> new NormalizationQueryResult(d.getLabel(), d.getValue()))
+                    .collect(Collectors.toList()));
+            return response;
+        }
+
+        List<VLazyDetailResult> details;
+
+        // Is it a layer-level lazy detail?
+        if (Renderer.QUERY_LAYER_LEVEL_DETAILS.equals(database)) {
+            details = layerSupportRegistry.getLayerSupport(layer)
+                    .createRenderer(layer, () -> annotationService.listAnnotationFeature(layer))
+                    .renderLazyDetails(aCas.get(), paramId);
+        }
+        // Is it a feature-level lazy detail?
+        else {
+            AnnotationFeature feature = annotationService.getFeature(database, layer);
+            details = featureSupportRegistry.findExtension(feature).orElseThrow()
+                    .renderLazyDetails(feature, keyParam.toString());
+        }
+
+        response.setResults(
+                details.stream().map(d -> new NormalizationQueryResult(d.getLabel(), d.getValue()))
+                        .collect(toList()));
+
+        return response;
+    }
+
+}

--- a/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/annotation/BratProtocolNames.java
+++ b/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/annotation/BratProtocolNames.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.brat.annotation;
+
+public interface BratProtocolNames
+{
+    String PARAM_ACTION = "action";
+    String PARAM_ARC_ID = "arcId";
+    String PARAM_ID = "id";
+    String PARAM_OFFSETS = "offsets";
+    String PARAM_TARGET_SPAN_ID = "targetSpanId";
+    String PARAM_ORIGIN_SPAN_ID = "originSpanId";
+    String PARAM_TYPE = "type";
+    String PARAM_LAZY_DETAIL_DATABASE = "database";
+    String PARAM_LAZY_DETAIL_KEY = "key";
+
+    String ACTION_CONTEXT_MENU = "contextMenu";
+
+}

--- a/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/annotation/BratRequestUtils.java
+++ b/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/annotation/BratRequestUtils.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.brat.annotation;
+
+import static de.tudarmstadt.ukp.clarin.webanno.brat.annotation.BratProtocolNames.PARAM_ACTION;
+import static de.tudarmstadt.ukp.clarin.webanno.brat.annotation.BratProtocolNames.PARAM_ARC_ID;
+import static de.tudarmstadt.ukp.clarin.webanno.brat.annotation.BratProtocolNames.PARAM_ID;
+
+import java.io.IOException;
+
+import org.apache.wicket.Component;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.request.IRequestParameters;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.VID;
+import de.tudarmstadt.ukp.clarin.webanno.brat.message.ArcAnnotationResponse;
+import de.tudarmstadt.ukp.clarin.webanno.brat.message.SpanAnnotationResponse;
+import de.tudarmstadt.ukp.clarin.webanno.support.JSONUtil;
+
+public class BratRequestUtils
+{
+    public static String getActionFromRequest(IRequestParameters request)
+    {
+        return request.getParameterValue(PARAM_ACTION).toString();
+    }
+
+    /**
+     * Parse annotation ID if present in request
+     */
+    public static VID getVidFromRequest(IRequestParameters request)
+    {
+        String action = getActionFromRequest(request);
+        final VID paramId;
+        if (!request.getParameterValue(PARAM_ID).isEmpty()
+                && !request.getParameterValue(PARAM_ARC_ID).isEmpty()) {
+            throw new IllegalStateException(
+                    "[id] and [arcId] cannot be both set at the same time!");
+        }
+        else if (!request.getParameterValue(PARAM_ID).isEmpty()) {
+            paramId = VID.parseOptional(request.getParameterValue(PARAM_ID).toString());
+        }
+        else {
+            VID arcId = VID.parseOptional(request.getParameterValue(PARAM_ARC_ID).toString());
+            // HACK: If an arc was clicked that represents a link feature, then
+            // open the associated span annotation instead.
+            if (arcId.isSlotSet() && ArcAnnotationResponse.is(action)) {
+                action = SpanAnnotationResponse.COMMAND;
+                paramId = new VID(arcId.getId());
+            }
+            else {
+                paramId = arcId;
+            }
+        }
+        return paramId;
+    }
+
+    public static void attachResponse(AjaxRequestTarget aTarget, Component vis, Object result)
+        throws IOException
+    {
+        String json;
+        if (result instanceof String) {
+            json = (String) result;
+        }
+        else {
+            json = toJson(result);
+        }
+
+        // Since we cannot pass the JSON directly to Brat, we attach it to the HTML
+        // element into which BRAT renders the SVG. In our modified ajax.js, we pick it
+        // up from there and then pass it on to BRAT to do the rendering.
+        aTarget.prependJavaScript("Wicket.$('" + vis.getMarkupId() + "').temp = " + json + ";");
+
+    }
+
+    private static String toJson(Object result) throws IOException
+    {
+        String json = "[]";
+        if (result instanceof JsonNode) {
+            json = JSONUtil.toInterpretableJsonString((JsonNode) result);
+        }
+        else {
+            json = JSONUtil.toInterpretableJsonString(result);
+        }
+        return json;
+    }
+
+}

--- a/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/annotation/BratVisualizer.java
+++ b/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/annotation/BratVisualizer.java
@@ -137,9 +137,12 @@ public abstract class BratVisualizer
         aResponse.render(JavaScriptHeaderItem.forReference(BratAnnotatorUiResourceReference.get()));
 
         // BRAT call to load the BRAT JSON from our collProvider and docProvider.
-        String[] script = { "Util.embedByURL(", "  '" + vis.getMarkupId() + "',",
-                "  '" + collProvider.getCallbackUrl() + "', ",
-                "  '" + docProvider.getCallbackUrl() + "', ", "  null);", };
+        String[] script = { //
+                "Util.embedByURL(", //
+                "  '" + vis.getMarkupId() + "',", //
+                "  '" + collProvider.getCallbackUrl() + "', ", //
+                "  '" + docProvider.getCallbackUrl() + "', ", //
+                "  null);" };
 
         // This doesn't work with head.js because the onLoad event is fired before all the
         // JavaScript references are loaded.

--- a/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/resource/util.js
+++ b/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/resource/util.js
@@ -624,6 +624,7 @@ var Util = (function (window, undefined) {
   var embed = function (container, collData, docData, webFontURLs) {
     var dispatcher = new Dispatcher();
     var visualizer = new Visualizer(dispatcher, container, webFontURLs);
+    new VisualizerUI(dispatcher, visualizer.svg);
     docData.collection = null;
     dispatcher.post('collectionLoaded', [collData]);
     dispatcher.post('requestRenderData', [docData]);


### PR DESCRIPTION
**What's in the PR**
- Factor part of the code for handling brat-related requests out into a utility class so it can be shared between the BratAnnotationEditor and the BratSuggestionVisualizer (curation)
- Enable the popover in the BratSuggestionVisualizer
- Enable lazy details for the BratSuggestionVisualizer so that the curator may see some features in the popover (requires that these features have "show in popup" enabled)

**How to test manually**
* Enable "show in popup" for some features of a layer
* Make annotations on this layer using different users
* Mark the users as finished so curation becomes available
* Hover the mouse over the annotations of the users in the lower part of the screen
* Check if popup comes up and shows the correct data

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
