### PR TITLE
#2585 - Add AGROVOC Thesaurus kb profile

### DIFF
--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/yaml/KnowledgeBaseProfile.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/yaml/KnowledgeBaseProfile.java
@@ -61,7 +61,7 @@ public class KnowledgeBaseProfile
     @JsonProperty("root-concepts")
     private List<String> rootConcepts;
 
-    @JsonProperty("additional-search-properties")
+    @JsonProperty("additional-matching-properties")
     private List<String> additionalMatchingProperties;
 
     @JsonProperty("info")

--- a/inception/inception-kb/src/main/resources/de/tudarmstadt/ukp/inception/kb/yaml/knowledgebase-profiles.yaml
+++ b/inception/inception-kb/src/main/resources/de/tudarmstadt/ukp/inception/kb/yaml/knowledgebase-profiles.yaml
@@ -44,30 +44,32 @@ babel_net:
     host-institution-name: Linguistic Computing Laboratory at Sapienza University of Rome
     author-name: Linguistic Computing Laboratory at Sapienza University of Rome
     website-url: https://babelnet.org/
-    
-british_museum:
-  name: British Museum
-  type: REMOTE
-  default-language: en
-  reification: NONE
-  access:
-    access-url: http://collection.britishmuseum.org/sparql
-    full-text-search: text:query
-  mapping:
-    class: http://www.w3.org/2000/01/rdf-schema#Class
-    subclass-of: http://www.w3.org/2000/01/rdf-schema#subClassOf
-    instance-of: http://www.w3.org/1999/02/22-rdf-syntax-ns#type
-    label: http://www.w3.org/2000/01/rdf-schema#label
-    property-type: http://www.w3.org/1999/02/22-rdf-syntax-ns#Property
-    description: http://www.w3.org/2000/01/rdf-schema#comment
-    property-label: http://www.w3.org/2000/01/rdf-schema#label
-    property-description: http://www.w3.org/2000/01/rdf-schema#comment
-    subproperty-of: http://www.w3.org/2000/01/rdf-schema#subPropertyOf
-  info:
-    description: Collection of the British Museum in Semantic Web format
-    host-institution-name: British Museum
-    author-name: British Museum
-    website-url: https://www.britishmuseum.org/about_us/news_and_press/press_releases/2011/semantic_web_endpoint.aspx
+
+# 2021-09-07: Looks like this service was discontinued
+# british_museum:
+#   disabled: true
+#   name: British Museum
+#   type: REMOTE
+#   default-language: en
+#   reification: NONE
+#   access:
+#     access-url: http://collection.britishmuseum.org/sparql
+#     full-text-search: text:query
+#   mapping:
+#     class: http://www.w3.org/2000/01/rdf-schema#Class
+#     subclass-of: http://www.w3.org/2000/01/rdf-schema#subClassOf
+#     instance-of: http://www.w3.org/1999/02/22-rdf-syntax-ns#type
+#     label: http://www.w3.org/2000/01/rdf-schema#label
+#     property-type: http://www.w3.org/1999/02/22-rdf-syntax-ns#Property
+#     description: http://www.w3.org/2000/01/rdf-schema#comment
+#     property-label: http://www.w3.org/2000/01/rdf-schema#label
+#     property-description: http://www.w3.org/2000/01/rdf-schema#comment
+#     subproperty-of: http://www.w3.org/2000/01/rdf-schema#subPropertyOf
+#   info:
+#     description: Collection of the British Museum in Semantic Web format
+#     host-institution-name: British Museum
+#     author-name: British Museum
+#     website-url: https://www.britishmuseum.org/about_us/news_and_press/press_releases/2011/semantic_web_endpoint.aspx
 
 db_pedia:
   name: DBpedia (German)
@@ -127,8 +129,6 @@ wikidata:
 
 yago:
   name: YAGO v4
-  # Disabled, see #1708 for more info
-  #disabled: true
   type: REMOTE
   default-language: de
   reification: NONE
@@ -207,6 +207,50 @@ zbw-gnd:
     website-url: http://zbw.eu/stw/version/9.02/mapping/gnd/about.en.html
   root-concepts:
     - https://d-nb.info/standards/elementset/gnd#AuthorityResource
+
+agrovoc:
+  name: AGROVOC Thesaurus
+  type: REMOTE
+  default-language: en
+  reification: NONE
+  access:
+    access-url: https://agrovoc.fao.org/sparql
+    full-text-search: text:query
+  mapping:
+    class: http://www.w3.org/2004/02/skos/core#Concept
+    subclass-of: http://www.w3.org/2004/02/skos/core#broader
+    instance-of: http://www.w3.org/1999/02/22-rdf-syntax-ns#type
+    label: http://www.w3.org/2004/02/skos/core#prefLabel
+    description: http://www.w3.org/2000/01/rdf-schema#comment
+    property-type: http://www.w3.org/1999/02/22-rdf-syntax-ns#Property
+    subproperty-of: http://www.w3.org/2000/01/rdf-schema#subPropertyOf
+    property-label: http://www.w3.org/2004/02/skos/core#prefLabel
+    property-description: http://www.w3.org/2000/01/rdf-schema#comment
+  additional-matching-properties:
+    - http://www.w3.org/2004/02/skos/core#altLabel
+  info:
+    description: |
+      AGROVOC is a multilingual and controlled vocabulary designed to cover concepts and 
+      terminology under FAO's areas of interest. It is the largest Linked Open Data set 
+      about agriculture available for public use and its greatest impact is through providing 
+      the access and visibility of data across domains and languages.
+
+      It offers a structured collection of agricultural concepts, terms, definitions and 
+      relationships which are used to unambiguously identify resources, allowing standardized 
+      indexing processes and making searches more efficient. The thesaurus is hierarchically 
+      organized under 25 top concepts.
+
+      AGROVOC uses semantic web technologies, linking to other multilingual knowledge 
+      organization systems and building bridges between datasets. AGROVOC is edited using 
+      VocBench 3, a web-based vocabulary management tool.
+
+      For more information, please consult <http://www.fao.org/agrovoc/>.
+      
+      Source: <https://agrovoc.fao.org/browse/en/about>
+    host-institution-name: Food and Agriculture Organization (FAO) of the United Nations
+    author-name: Food and Agriculture Organization (FAO) of the United Nations
+    website-url: http://www.fao.org/agrovoc/
+
 
 # ##################################################################################################
 #

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/bootstrap/shim-bootstrapselect.scss
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/bootstrap/shim-bootstrapselect.scss
@@ -16,10 +16,12 @@
  * limitations under the License.
  */
 
+/*
 .bs3.bootstrap-select .dropdown-toggle .filter-option, .k-autocomplete .k-input {
 	padding-top: 0px;
 	padding-bottom: 0px;
 }
+*/
 
 // Add a border around the select inputs to make them easier on the eyes
 .bootstrap-select {

--- a/inception/inception-ui-kb/pom.xml
+++ b/inception/inception-ui-kb/pom.xml
@@ -85,6 +85,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.github.rjeschke</groupId>
+      <artifactId>txtmark</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/AccessSpecificSettingsPanel.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/AccessSpecificSettingsPanel.java
@@ -17,6 +17,8 @@
  */
 package de.tudarmstadt.ukp.inception.ui.kb.project;
 
+import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -53,19 +55,17 @@ import org.apache.wicket.model.StringResourceModel;
 import org.apache.wicket.model.util.ListModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.apache.wicket.util.resource.IResourceStream;
-import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.repository.RepositoryException;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.github.rjeschke.txtmark.Processor;
+
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.form.fileinput.BootstrapFileInputField;
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.form.fileinput.FileInputConfig;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxLink;
-import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaModel;
-import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaModelAdapter;
 import de.tudarmstadt.ukp.clarin.webanno.support.wicket.AjaxDownloadLink;
 import de.tudarmstadt.ukp.clarin.webanno.support.wicket.TempFileResource;
 import de.tudarmstadt.ukp.inception.kb.KnowledgeBaseService;
@@ -186,13 +186,9 @@ public class AccessSpecificSettingsPanel
         wmc.add(defaultDatasetField);
     }
 
-    private TextField<String> defaultDataset(String aId, IModel<IRI> model)
+    private TextField<String> defaultDataset(String aId, IModel<String> model)
     {
-        IModel<String> adapter = new LambdaModelAdapter<String>(() -> {
-            return model.getObject() != null ? model.getObject().stringValue() : null;
-        }, str -> model
-                .setObject(str != null ? SimpleValueFactory.getInstance().createIRI(str) : null));
-        TextField<String> defaultDataset = new TextField<>(aId, adapter);
+        TextField<String> defaultDataset = new TextField<>(aId, model);
         defaultDataset.add(Validators.IRI_VALIDATOR);
         return defaultDataset;
     }
@@ -237,15 +233,18 @@ public class AccessSpecificSettingsPanel
     private WebMarkupContainer createKbInfoContainer(String aId)
     {
         WebMarkupContainer wmc = new WebMarkupContainer(aId);
-        wmc.add(new Label("description", kbInfoModel.bind("description"))
-                .add(LambdaBehavior.visibleWhen(() -> kbInfoModel.getObject() != null)));
+        wmc.add(new Label("description",
+                kbInfoModel.bind("description")
+                        .map(description -> Processor.process((String) description, true)))
+                                .setEscapeModelStrings(false)
+                                .add(visibleWhen(() -> kbInfoModel.getObject() != null)));
         wmc.add(new Label("hostInstitutionName", kbInfoModel.bind("hostInstitutionName"))
-                .add(LambdaBehavior.visibleWhen(() -> kbInfoModel.getObject() != null)));
+                .add(visibleWhen(() -> kbInfoModel.getObject() != null)));
         wmc.add(new Label("authorName", kbInfoModel.bind("authorName"))
-                .add(LambdaBehavior.visibleWhen(() -> kbInfoModel.getObject() != null)));
+                .add(visibleWhen(() -> kbInfoModel.getObject() != null)));
         wmc.add(new ExternalLink("websiteURL", kbInfoModel.bind("websiteURL"),
                 kbInfoModel.bind("websiteURL"))
-                        .add(LambdaBehavior.visibleWhen(() -> kbInfoModel.getObject() != null)));
+                        .add(visibleWhen(() -> kbInfoModel.getObject() != null)));
         return wmc;
     }
 

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/wizard/KnowledgeBaseCreationWizard.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/wizard/KnowledgeBaseCreationWizard.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -111,6 +112,7 @@ public class KnowledgeBaseCreationWizard
         try {
             profiles = KnowledgeBaseProfile.readKnowledgeBaseProfiles().entrySet().stream()
                     .filter(e -> !e.getValue().isDisabled())
+                    .sorted(Comparator.comparing(e -> e.getValue().getName()))
                     .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         }
         catch (IOException e) {


### PR DESCRIPTION
**What's in the PR**
- Add AGROVOC profile
- Allow KB profile info to use markdown
- Improve visual of auto-complete fields by removing padding override
- Fix bug accessing a KB profile which defines a default dataset
- No longer offer British Museum SPARQL endpoint because it seem to be gone

**How to test manually**
* Set up AGROVOC from the profile and try it

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
