### PR TITLE
#2590 - Error page when opening annotations as manager of different annotator

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/page/AnnotationPageBase.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/page/AnnotationPageBase.java
@@ -22,8 +22,11 @@ import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUt
 import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.selectSentenceCovering;
 import static de.tudarmstadt.ukp.clarin.webanno.model.Mode.CURATION;
 import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.CURATION_FINISHED;
+import static java.lang.String.format;
+import static java.util.stream.Collectors.joining;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
@@ -76,6 +79,7 @@ public abstract class AnnotationPageBase
     private static final long serialVersionUID = -1133219266479577443L;
 
     public static final String PAGE_PARAM_DOCUMENT = "d";
+    public static final String PAGE_PARAM_USER = "u";
     public static final String PAGE_PARAM_FOCUS = "f";
 
     private @SpringBean AnnotationSchemaService annotationService;
@@ -91,6 +95,7 @@ public abstract class AnnotationPageBase
         super(aParameters);
 
         StringValue documentParameter = getPageParameters().get(PAGE_PARAM_DOCUMENT);
+        StringValue userParameter = getPageParameters().get(PAGE_PARAM_USER);
 
         // If the page was accessed using an URL form ending in a document ID, let's move
         // the document ID into the fragment and redirect to the form without the document ID.
@@ -101,8 +106,12 @@ public abstract class AnnotationPageBase
             RequestCycle requestCycle = getRequestCycle();
             Url clientUrl = requestCycle.getRequest().getClientUrl();
             clientUrl.resolveRelative(Url.parse("./"));
-            clientUrl.setFragment(
-                    String.format("!%s=%s", PAGE_PARAM_DOCUMENT, documentParameter.toString()));
+            List<String> fragmentParams = new ArrayList<>();
+            fragmentParams.add(format("%s=%s", PAGE_PARAM_DOCUMENT, documentParameter.toString()));
+            if (!userParameter.isEmpty()) {
+                fragmentParams.add(format("%s=%s", PAGE_PARAM_USER, userParameter.toString()));
+            }
+            clientUrl.setFragment("!" + fragmentParams.stream().collect(joining("&")));
             String url = requestCycle.getUrlRenderer().renderRelativeUrl(clientUrl);
             throw new RedirectToUrlException(url.toString());
         }
@@ -167,6 +176,7 @@ public abstract class AnnotationPageBase
             {
                 StringValue document = aRequestParameters.getParameterValue(PAGE_PARAM_DOCUMENT);
                 StringValue focus = aRequestParameters.getParameterValue(PAGE_PARAM_FOCUS);
+                StringValue user = aRequestParameters.getParameterValue(PAGE_PARAM_USER);
 
                 // nothing changed, do not check for project, because inception always opens
                 // on a project
@@ -175,18 +185,19 @@ public abstract class AnnotationPageBase
                 }
 
                 SourceDocument previousDoc = getModelObject().getDocument();
-                handleParameters(document, focus, false);
+                User aPreviousUser = getModelObject().getUser();
+                handleParameters(document, focus, user, false);
 
-                updateDocumentView(aTarget, previousDoc, focus);
+                updateDocumentView(aTarget, previousDoc, aPreviousUser, focus);
             }
         };
     }
 
     protected abstract void handleParameters(StringValue aDocumentParameter,
-            StringValue aFocusParameter, boolean aLockIfPreset);
+            StringValue aFocusParameter, StringValue aUser, boolean aLockIfPreset);
 
     protected abstract void updateDocumentView(AjaxRequestTarget aTarget,
-            SourceDocument aPreviousDocument, StringValue aFocusParameter);
+            SourceDocument aPreviousDocument, User aPreviousUser, StringValue aFocusParameter);
 
     protected void updateUrlFragment(AjaxRequestTarget aTarget)
     {
@@ -474,9 +485,13 @@ public abstract class AnnotationPageBase
                 return;
             }
 
+            urlFragmentLastDocumentId = currentDocumentId;
+            urlFragmentLastFocusUnitIndex = currentFocusUnitIndex;
+
             UrlFragment fragment = new UrlFragment(aTarget);
 
             fragment.putParameter(PAGE_PARAM_DOCUMENT, currentDocumentId);
+
             if (state.getFocusUnitIndex() > 0) {
                 fragment.putParameter(PAGE_PARAM_FOCUS, currentFocusUnitIndex);
             }
@@ -484,8 +499,12 @@ public abstract class AnnotationPageBase
                 fragment.removeParameter(PAGE_PARAM_FOCUS);
             }
 
-            urlFragmentLastDocumentId = currentDocumentId;
-            urlFragmentLastFocusUnitIndex = currentFocusUnitIndex;
+            if (userRepository.getCurrentUsername().equals(state.getUser().getUsername())) {
+                fragment.removeParameter(PAGE_PARAM_USER);
+            }
+            else {
+                fragment.putParameter(PAGE_PARAM_USER, state.getUser().getUsername());
+            }
 
             // If we do not manually set editedFragment to false, then changing the URL
             // manually or using the back/forward buttons in the browser only works every

--- a/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/sidebar/CurationSidebar.html
+++ b/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/sidebar/CurationSidebar.html
@@ -19,6 +19,10 @@
 <html xmlns:wicket="http://wicket.apache.org">
 <wicket:panel>
   <div class="flex-content flex-v-container flex-gutter flex-only-internal-gutter">
+    <div wicket:id="notCuratableNotice" class="no-data-notice flex-content">
+      Curation not possible while viewing another users annotations.
+    </div>
+    
     <div wicket:id="mainContainer" class="card flex-content">
       <div wicket:id="mergeConfirmDialog"></div>
     

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/sidebar/SidebarTabbedPanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/sidebar/SidebarTabbedPanel.java
@@ -81,7 +81,7 @@ public class SidebarTabbedPanel<T extends SidebarTab>
         super.onAjaxUpdate(aTarget);
         if (!expanded) {
             expanded = true;
-            aTarget.ifPresent(_target -> _target.add(getPage()));
+            aTarget.ifPresent(_target -> WicketUtil.refreshPage(_target, getPage()));
         }
     }
 

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/CurationPage.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/CurationPage.java
@@ -185,11 +185,11 @@ public class CurationPage
         StringValue document = aPageParameters.get(PAGE_PARAM_DOCUMENT);
         StringValue focus = aPageParameters.get(PAGE_PARAM_FOCUS);
 
-        handleParameters(document, focus, true);
+        handleParameters(document, focus, null, true);
 
         commonInit();
 
-        updateDocumentView(null, null, focus);
+        updateDocumentView(null, null, null, focus);
     }
 
     private void commonInit()
@@ -607,7 +607,7 @@ public class CurationPage
 
     @Override
     protected void handleParameters(StringValue aDocumentParameter, StringValue aFocusParameter,
-            boolean aLockIfPreset)
+            StringValue aUser, boolean aLockIfPreset)
     {
         Project project = getProject();
 
@@ -655,7 +655,7 @@ public class CurationPage
 
     @Override
     protected void updateDocumentView(AjaxRequestTarget aTarget, SourceDocument aPreviousDocument,
-            StringValue aFocusParameter)
+            User aPreviousUser, StringValue aFocusParameter)
     {
         SourceDocument currentDocument = getModelObject().getDocument();
         if (currentDocument == null) {


### PR DESCRIPTION
**What's in the PR**
- When expanding/collapsing the sidebar, we must not add the entire page to the AJAX request target because then Wicket tires to "optimize" by redirecting to the current URL which resets the URL fragment parameters. Instead, we use WicketUtil.refreshPage() which adds all top-level updatable children
- Add support for having the user to view in the URL
- If the curation sidebar really needs to switch the user, we use a redirect instead of an AJAX refresh which may come too late to be allowed
- Disable curation sidebar when viewing annotations from another user

**How to test manually**
* Open annotation page as a project manager user in a project with multiple users
* Open a document as another user
* Open a sidebar
* Switch to another document via the open dialog or via navigation buttons
* Switch to another user (also own user) via the open dialog

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
