### PR TITLE
#2589 - SPARQL Endpoint URL with authentication

### DIFF
--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/KnowledgeBaseDetailsPanel.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/KnowledgeBaseDetailsPanel.java
@@ -165,8 +165,7 @@ public class KnowledgeBaseDetailsPanel
             KnowledgeBaseWrapper kbw = kbwModel.getObject();
 
             // if dealing with a remote repository and a non-empty URL, get a new
-            // RepositoryImplConfig
-            // for the new URL; otherwise keep using the existing config
+            // RepositoryImplConfig for the new URL; otherwise keep using the existing config
             RepositoryImplConfig cfg;
             if (kbw.getKb().getType() == RepositoryType.REMOTE && kbw.getUrl() != null) {
                 cfg = kbService.getRemoteConfig(kbw.getUrl());


### PR DESCRIPTION
**What's in the PR**
- If a username/pw is specified in the URL of a knowledge base, parse it out and pass it as username/pw to the SPARQLRepository

**How to test manually**
* Try with a remote repository that has authentication enabled

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
