### PR TITLE
#2610 - Remember sidebar state

### DIFF
--- a/inception/inception-ui-annotation/pom.xml
+++ b/inception/inception-ui-annotation/pom.xml
@@ -67,6 +67,10 @@
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-security</artifactId>
     </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-preferences</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>com.googlecode.wicket-jquery-ui</groupId>

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/sidebar/AnnotationSidebarState.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/sidebar/AnnotationSidebarState.java
@@ -17,33 +17,28 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar;
 
-import org.apache.wicket.extensions.markup.html.tabs.AbstractTab;
-import org.apache.wicket.model.IModel;
-
-import de.agilecoders.wicket.core.markup.html.bootstrap.image.IconType;
-
-public abstract class SidebarTab
-    extends AbstractTab
+public class AnnotationSidebarState
 {
-    private static final long serialVersionUID = -3205381571000021331L;
+    private String selectedTab;
+    private boolean expanded;
 
-    private final IconType icon;
-    private final String factoryId;
-
-    public SidebarTab(IModel<String> aTitle, IconType aIcon, String aFactoryId)
+    public void setSelectedTab(String aFactoryId)
     {
-        super(aTitle);
-        icon = aIcon;
-        factoryId = aFactoryId;
+        selectedTab = aFactoryId;
     }
 
-    public IconType getIcon()
+    public String getSelectedTab()
     {
-        return icon;
+        return selectedTab;
     }
 
-    public String getFactoryId()
+    public void setExpanded(boolean aExpanded)
     {
-        return factoryId;
+        expanded = aExpanded;
+    }
+
+    public boolean isExpanded()
+    {
+        return expanded;
     }
 }

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/sidebar/SidebarPanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/sidebar/SidebarPanel.java
@@ -68,7 +68,7 @@ public class SidebarPanel
         annotationPage = aAnnotationPage;
         stateModel = aModel;
 
-        tabsPanel = new SidebarTabbedPanel<>("leftSidebarContent", makeTabs());
+        tabsPanel = new SidebarTabbedPanel<>("leftSidebarContent", makeTabs(), stateModel);
         add(tabsPanel);
 
         add(new AttributeAppender("class",
@@ -109,7 +109,8 @@ public class SidebarPanel
             }
 
             String factoryId = factory.getBeanName();
-            SidebarTab tab = new SidebarTab(Model.of(factory.getDisplayName()), factory.getIcon())
+            SidebarTab tab = new SidebarTab(Model.of(factory.getDisplayName()), factory.getIcon(),
+                    factory.getBeanName())
             {
                 private static final long serialVersionUID = 2144644282070158783L;
 


### PR DESCRIPTION
**What's in the PR**
- Store the sidebar state (selected tab and expansion state) as a per-user/per-project preference.

**How to test manually**
* Open a sidebar on the annotation page, leave the page, come back
* Try with and without leaving the sidebar in an expanded state

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
