### PR TITLE
#2612 - Add possibility to enforce singelton document level annotations

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/event/BeforeDocumentOpenedEvent.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/event/BeforeDocumentOpenedEvent.java
@@ -22,10 +22,15 @@ import org.springframework.context.ApplicationEvent;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 
-public class DocumentOpenedEvent
+/**
+ * Fire BeforeDocumentOpenedEvent to give listeners a chance to look at or even modify the CAS
+ * before the editor gets it. Modification should not be performed if editable is false. If editable
+ * is true, then the modification is persisted.
+ */
+public class BeforeDocumentOpenedEvent
     extends ApplicationEvent
 {
-    private static final long serialVersionUID = -2739175937794842083L;
+    private static final long serialVersionUID = -4644605041626140906L;
 
     private final CAS cas;
     private final SourceDocument document;
@@ -33,15 +38,17 @@ public class DocumentOpenedEvent
     private final String annotator;
     // user who opened the document
     private final String opener;
+    private final boolean editable;
 
-    public DocumentOpenedEvent(Object aSource, CAS aCas, SourceDocument aDocument,
-            String aAnnotator, String aOpener)
+    public BeforeDocumentOpenedEvent(Object aSource, CAS aCas, SourceDocument aDocument,
+            String aAnnotator, String aOpener, boolean aEditable)
     {
         super(aSource);
         cas = aCas;
         document = aDocument;
         annotator = aAnnotator;
         opener = aOpener;
+        editable = aEditable;
     }
 
     public CAS getCas()
@@ -62,5 +69,10 @@ public class DocumentOpenedEvent
     public String getAnnotator()
     {
         return annotator;
+    }
+
+    public boolean isEditable()
+    {
+        return editable;
     }
 }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/event/DocumentOpenedEvent.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/event/DocumentOpenedEvent.java
@@ -21,9 +21,11 @@ import org.apache.uima.cas.CAS;
 import org.springframework.context.ApplicationEvent;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.clarin.webanno.support.wicket.event.HybridApplicationUIEvent;
 
 public class DocumentOpenedEvent
     extends ApplicationEvent
+    implements HybridApplicationUIEvent
 {
     private static final long serialVersionUID = -2739175937794842083L;
 

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/model/AnnotatorState.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/model/AnnotatorState.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.config.AnnotationEditorProperties;
 import de.tudarmstadt.ukp.clarin.webanno.constraints.model.ParsedConstraints;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
@@ -210,6 +211,10 @@ public interface AnnotatorState
      *            usable layers
      */
     void setAnnotationLayers(List<AnnotationLayer> aAnnotationLayers);
+
+    void refreshSelectableLayers(AnnotationEditorProperties aProperties);
+
+    List<AnnotationLayer> getSelectableLayers();
 
     // ---------------------------------------------------------------------------------------------
     // Feature value models

--- a/inception/inception-layer-docmetadata/pom.xml
+++ b/inception/inception-layer-docmetadata/pom.xml
@@ -31,6 +31,10 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-api-dao</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-ui-annotation</artifactId>
     </dependency>
     <dependency>

--- a/inception/inception-layer-docmetadata/pom.xml
+++ b/inception/inception-layer-docmetadata/pom.xml
@@ -73,6 +73,10 @@
       <artifactId>spring-beans</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-tx</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot</artifactId>
     </dependency>

--- a/inception/inception-layer-docmetadata/pom.xml
+++ b/inception/inception-layer-docmetadata/pom.xml
@@ -31,10 +31,6 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
-      <artifactId>inception-api-dao</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-ui-annotation</artifactId>
     </dependency>
     <dependency>

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/config/DocumentMetadataLayerSupportAutoConfiguration.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/config/DocumentMetadataLayerSupportAutoConfiguration.java
@@ -24,8 +24,11 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
+import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRegistry;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.layer.LayerSupportRegistry;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.layer.LayerType;
+import de.tudarmstadt.ukp.inception.ui.core.docanno.layer.DocumentMetadataLayerSingletonCreatingWatcher;
 import de.tudarmstadt.ukp.inception.ui.core.docanno.layer.DocumentMetadataLayerSupport;
 import de.tudarmstadt.ukp.inception.ui.core.docanno.sidebar.DocumentMetadataSidebarFactory;
 
@@ -57,5 +60,14 @@ public class DocumentMetadataLayerSupportAutoConfiguration
     {
         return new DocumentMetadataLayerSupport(aFeatureSupportRegistry, aEventPublisher,
                 aProperties);
+    }
+
+    @Bean
+    public DocumentMetadataLayerSingletonCreatingWatcher documentMetadataLayerSingletonCreatingWatcher(
+            DocumentService aDocumentService, AnnotationSchemaService aAnnotationService,
+            LayerSupportRegistry aLayerRegistry)
+    {
+        return new DocumentMetadataLayerSingletonCreatingWatcher(aDocumentService,
+                aAnnotationService, aLayerRegistry);
     }
 }

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/layer/DocumentMetadataLayerSingletonCreatingWatcher.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/layer/DocumentMetadataLayerSingletonCreatingWatcher.java
@@ -21,10 +21,9 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import javax.transaction.Transactional;
-
 import org.apache.uima.cas.CAS;
 import org.springframework.context.event.EventListener;
+import org.springframework.transaction.annotation.Transactional;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/layer/DocumentMetadataLayerSingletonCreatingWatcher.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/layer/DocumentMetadataLayerSingletonCreatingWatcher.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.core.docanno.layer;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.transaction.Transactional;
+
+import org.apache.uima.cas.CAS;
+import org.springframework.context.event.EventListener;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
+import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.event.BeforeDocumentOpenedEvent;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.AnnotationException;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.layer.LayerSupportRegistry;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.inception.ui.core.docanno.config.DocumentMetadataLayerSupportAutoConfiguration;
+
+/**
+ * Initializes singleton document-level annotations if necessary when a new document is opened.
+ * <p>
+ * This class is exposed as a Spring Component via
+ * {@link DocumentMetadataLayerSupportAutoConfiguration#documentMetadataLayerSingletonCreatingWatcher}.
+ * </p>
+ */
+public class DocumentMetadataLayerSingletonCreatingWatcher
+{
+    private final AnnotationSchemaService annotationService;
+    private final LayerSupportRegistry layerSupportRegistry;
+
+    public DocumentMetadataLayerSingletonCreatingWatcher(DocumentService aDocumentService,
+            AnnotationSchemaService aAnnotationService, LayerSupportRegistry aLayerRegistry)
+    {
+        super();
+        annotationService = aAnnotationService;
+        layerSupportRegistry = aLayerRegistry;
+    }
+
+    private List<AnnotationLayer> listMetadataLayers(Project aProject)
+    {
+        return annotationService.listAnnotationLayer(aProject).stream()
+                .filter(layer -> DocumentMetadataLayerSupport.TYPE.equals(layer.getType())
+                        && layer.isEnabled())
+                .collect(Collectors.toList());
+    }
+
+    @EventListener
+    @Transactional
+    public void onBeforeDocumentOpenedEvent(BeforeDocumentOpenedEvent aEvent)
+        throws IOException, AnnotationException
+    {
+        if (!aEvent.isEditable()) {
+            return;
+        }
+
+        CAS cas = aEvent.getCas();
+        for (AnnotationLayer layer : listMetadataLayers(aEvent.getDocument().getProject())) {
+            if (!getLayerSupport(layer).readTraits(layer).isSingleton()) {
+                continue;
+            }
+
+            DocumentMetadataLayerAdapter adapter = (DocumentMetadataLayerAdapter) annotationService
+                    .getAdapter(layer);
+            if (cas.select(adapter.getAnnotationType(cas)).isEmpty()) {
+                adapter.add(aEvent.getDocument(), aEvent.getUser(), cas);
+            }
+        }
+    }
+
+    private DocumentMetadataLayerSupport getLayerSupport(AnnotationLayer aLayer)
+    {
+        return (DocumentMetadataLayerSupport) layerSupportRegistry.getLayerSupport(aLayer);
+    }
+
+}

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/layer/DocumentMetadataLayerSupport.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/layer/DocumentMetadataLayerSupport.java
@@ -27,6 +27,8 @@ import java.util.function.Supplier;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.resource.metadata.TypeDescription;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.model.IModel;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
@@ -49,7 +51,7 @@ import de.tudarmstadt.ukp.inception.ui.core.docanno.config.DocumentMetadataLayer
  * </p>
  */
 public class DocumentMetadataLayerSupport
-    extends LayerSupport_ImplBase<DocumentMetadataLayerAdapter, Void>
+    extends LayerSupport_ImplBase<DocumentMetadataLayerAdapter, DocumentMetadataLayerTraits>
     implements InitializingBean
 {
     public static final String TYPE = "document-metadata";
@@ -129,5 +131,23 @@ public class DocumentMetadataLayerSupport
     {
         return new NopRenderer(createAdapter(aLayer, aFeatures), getLayerSupportRegistry(),
                 featureSupportRegistry);
+    }
+
+    @Override
+    public Panel createTraitsEditor(String aId, IModel<AnnotationLayer> aLayerModel)
+    {
+        AnnotationLayer layer = aLayerModel.getObject();
+
+        if (!accepts(layer)) {
+            throw unsupportedLayerTypeException(layer);
+        }
+
+        return new DocumentMetadataLayerTraitsEditor(aId, this, aLayerModel);
+    }
+
+    @Override
+    public DocumentMetadataLayerTraits createTraits()
+    {
+        return new DocumentMetadataLayerTraits();
     }
 }

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/layer/DocumentMetadataLayerTraits.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/layer/DocumentMetadataLayerTraits.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.core.docanno.layer;
+
+import java.io.Serializable;
+
+public class DocumentMetadataLayerTraits
+    implements Serializable
+{
+    private static final long serialVersionUID = -266971494687450612L;
+
+    private boolean singleton;
+
+    public void setSingleton(boolean aSingleton)
+    {
+        singleton = aSingleton;
+    }
+
+    public boolean isSingleton()
+    {
+        return singleton;
+    }
+}

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/layer/DocumentMetadataLayerTraitsEditor.html
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/layer/DocumentMetadataLayerTraitsEditor.html
@@ -17,11 +17,16 @@
   limitations under the License.
 -->
 <html xmlns:wicket="http://wicket.apache.org">
-<wicket:panel>
-  <div class="flex-content flex-v-container flex-gutter flex-only-internal-gutter">
-    <div wicket:id="featureValues" class="feature-editors-sidebar">
-      <div wicket:id="editor"></div>
+<wicket:extend>
+  <div class="row form-row" wicket:enclosure="singleton">
+    <div class="offset-sm-4 col-sm-8">
+      <div class="form-check">
+        <input wicket:id="singleton" class="form-check-input" type="checkbox"/>
+        <label wicket:for="singleton" class="form-check-label">
+          <wicket:label key="singleton"/>
+        </label>
+      </div>
     </div>
   </div>
-</wicket:panel>
+</wicket:extend>
 </html>

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/layer/DocumentMetadataLayerTraitsEditor.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/layer/DocumentMetadataLayerTraitsEditor.java
@@ -38,6 +38,6 @@ public class DocumentMetadataLayerTraitsEditor
     @Override
     protected void initializeForm(Form<DocumentMetadataLayerTraits> aForm)
     {
-        aForm.add(new CheckBox("singleton"));
+        aForm.add(new CheckBox("singleton").setOutputMarkupId(true));
     }
 }

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/layer/DocumentMetadataLayerTraitsEditor.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/layer/DocumentMetadataLayerTraitsEditor.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.core.docanno.layer;
+
+import org.apache.wicket.markup.html.form.CheckBox;
+import org.apache.wicket.markup.html.form.Form;
+import org.apache.wicket.model.IModel;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.layer.LayerTraitsEditor_ImplBase;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+
+public class DocumentMetadataLayerTraitsEditor
+    extends LayerTraitsEditor_ImplBase<DocumentMetadataLayerTraits, DocumentMetadataLayerSupport>
+{
+    private static final long serialVersionUID = -9082045435380184514L;
+
+    public DocumentMetadataLayerTraitsEditor(String aId, DocumentMetadataLayerSupport aLayerSupport,
+            IModel<AnnotationLayer> aLayer)
+    {
+        super(aId, aLayerSupport, aLayer);
+    }
+
+    @Override
+    protected void initializeForm(Form<DocumentMetadataLayerTraits> aForm)
+    {
+        aForm.add(new CheckBox("singleton"));
+    }
+}

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/layer/DocumentMetadataLayerTraitsEditor.properties
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/layer/DocumentMetadataLayerTraitsEditor.properties
@@ -1,0 +1,16 @@
+# Licensed to the Technische Universität Darmstadt under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The Technische Universität Darmstadt 
+# licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.
+#  
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+singleton=Singleton

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationSelectionPanel.html
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationSelectionPanel.html
@@ -47,19 +47,9 @@
               </div>
             </div>
             <div class="d-flex align-items-center">
-              <span class="dropdown" aria-haspopup="true" aria-expanded="false">
-                <button class="btn btn-sm dropdown-toggle pe-0" type="button" data-bs-toggle="dropdown">
-                  <i class="fas fa-ellipsis-v"></i>
-                </button>
-                <div class="dropdown-menu shadow-lg" role="menu">
-                  <a wicket:id="delete" class="dropdown-item">
-                    <wicket:message key="delete"/>
-                    <span class="float-end badge badge-pill bg-danger">
-                      <i class="fas fa-trash"></i>
-                    </span>
-                  </a>
-                </div>
-              </span>
+              <button wicket:id="delete" type="button" class="btn btn-sm btn-danger">
+                <i class="fas fa-trash"></i>
+              </button>
             </div>
           </div>
           

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
@@ -319,7 +319,7 @@ public class AnnotationPage
     private WebMarkupContainer createRightSidebar()
     {
         WebMarkupContainer rightSidebar = new WebMarkupContainer("rightSidebar");
-        rightSidebar.setOutputMarkupId(true);
+        rightSidebar.setOutputMarkupPlaceholderTag(true);
         // Override sidebar width from preferences
         rightSidebar.add(new AttributeModifier("style",
                 LoadableDetachableModel.of(() -> String.format("flex-basis: %d%%;",

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
@@ -68,6 +68,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.AnnotationEditorFactory;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.AnnotationEditorRegistry;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.actionbar.ActionBar;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.event.AnnotationEvent;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.event.BeforeDocumentOpenedEvent;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.event.DocumentOpenedEvent;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.event.FeatureValueUpdatedEvent;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.AnnotationException;
@@ -325,7 +326,7 @@ public class AnnotationPage
                         getModelObject().getPreferences().getSidebarSizeRight()))));
         detailEditor = createDetailEditor();
         rightSidebar.add(detailEditor);
-        rightSidebar.add(visibleWhen(getModel().map(AnnotatorState::getAnnotationLayers)
+        rightSidebar.add(visibleWhen(getModel().map(AnnotatorState::getSelectableLayers)
                 .map(List::isEmpty).map(b -> !b)));
         return rightSidebar;
     }
@@ -399,7 +400,14 @@ public class AnnotationPage
             // (Re)initialize brat model after potential creating / upgrading CAS
             state.reset();
 
-            if (isEditable()) {
+            boolean editable = isEditable();
+            applicationEventPublisherHolder.get()
+                    .publishEvent(new BeforeDocumentOpenedEvent(this, editorCas,
+                            getModelObject().getDocument(),
+                            getModelObject().getUser().getUsername(),
+                            userRepository.getCurrentUser().getUsername(), editable));
+
+            if (editable) {
                 // After creating an new CAS or upgrading the CAS, we need to save it. If the
                 // document is accessed for the first time and thus will transition from NEW to
                 // IN_PROGRESS, then we use this opportunity also to set the timestamp of the

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
@@ -325,6 +325,8 @@ public class AnnotationPage
                         getModelObject().getPreferences().getSidebarSizeRight()))));
         detailEditor = createDetailEditor();
         rightSidebar.add(detailEditor);
+        rightSidebar.add(visibleWhen(getModel().map(AnnotatorState::getAnnotationLayers)
+                .map(List::isEmpty).map(b -> !b)));
         return rightSidebar;
     }
 

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
@@ -910,13 +910,12 @@ public abstract class AnnotationDetailEditorPanel
         // If we created a new annotation, then refresh the available annotation layers in the
         // detail panel.
         if (state.getSelection().getAnnotation().isNotSet()) {
-            if (layerSelectionPanel.getSelectableLayers().isEmpty()) {
+            if (state.getSelectableLayers().isEmpty()) {
                 state.setSelectedAnnotationLayer(new AnnotationLayer());
             }
             else if (state.getSelectedAnnotationLayer() == null) {
                 if (state.getRememberedSpanLayer() == null) {
-                    state.setSelectedAnnotationLayer(
-                            layerSelectionPanel.getSelectableLayers().get(0));
+                    state.setSelectedAnnotationLayer(state.getSelectableLayers().get(0));
                 }
                 else {
                     state.setSelectedAnnotationLayer(state.getRememberedSpanLayer());
@@ -1301,7 +1300,7 @@ public abstract class AnnotationDetailEditorPanel
             // If we reset the layers while doing a relation, we won't be able to complete the
             // relation - so in this case, we leave the layers alone...
             if (!selection.isArc()) {
-                layerSelectionPanel.refreshSelectableLayers();
+                state.refreshSelectableLayers(annotationEditorProperties);
             }
 
             if (selection.getAnnotation().isSet()) {
@@ -1629,7 +1628,7 @@ public abstract class AnnotationDetailEditorPanel
         state.getSelection().clear();
 
         // Refresh the selectable layers dropdown
-        layerSelectionPanel.refreshSelectableLayers();
+        state.refreshSelectableLayers(annotationEditorProperties);
         if (aTarget != null) {
             aTarget.add(layerSelectionPanel);
         }

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/LayerSelectionPanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/LayerSelectionPanel.java
@@ -17,7 +17,6 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.detail;
 
-import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.CHAIN_TYPE;
 import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.SPAN_TYPE;
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.SINGLE_TOKEN;
 import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
@@ -26,7 +25,6 @@ import static java.util.Objects.isNull;
 import static org.apache.wicket.util.string.Strings.escapeMarkup;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -41,7 +39,6 @@ import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
-import org.apache.wicket.model.LoadableDetachableModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 
@@ -73,8 +70,6 @@ public class LayerSelectionPanel
     private final DropDownChoice<AnnotationLayer> layerSelector;
     private final WebMarkupContainer forwardAnnotationGroup;
     private final AnnotationDetailEditorPanel owner;
-
-    private final List<AnnotationLayer> selectableLayers = new ArrayList<>();
 
     public LayerSelectionPanel(String aId, IModel<AnnotatorState> aModel,
             AnnotationDetailEditorPanel aOwner)
@@ -111,6 +106,11 @@ public class LayerSelectionPanel
     public AnnotationPageBase getEditorPage()
     {
         return (AnnotationPageBase) getPage();
+    }
+
+    public IModel<AnnotatorState> getModel()
+    {
+        return (IModel<AnnotatorState>) getDefaultModel();
     }
 
     public AnnotatorState getModelObject()
@@ -152,7 +152,7 @@ public class LayerSelectionPanel
     private DropDownChoice<AnnotationLayer> createDefaultAnnotationLayerSelector()
     {
         DropDownChoice<AnnotationLayer> selector = new DropDownChoice<>("defaultAnnotationLayer");
-        selector.setChoices(LoadableDetachableModel.of(this::getSelectableLayers));
+        selector.setChoices(getModel().map(AnnotatorState::getSelectableLayers));
         selector.setChoiceRenderer(new ChoiceRenderer<>("uiName"));
         selector.setOutputMarkupId(true);
         selector.add(LambdaAjaxFormComponentUpdatingBehavior.onUpdate("change",
@@ -272,39 +272,5 @@ public class LayerSelectionPanel
     {
         return annotationService.listAnnotationFeature(aLayer).stream().filter(f -> f.isEnabled())
                 .filter(f -> f.isVisible()).collect(Collectors.toList());
-    }
-
-    public void refreshSelectableLayers()
-    {
-        AnnotatorState state = getModelObject();
-        selectableLayers.clear();
-
-        for (AnnotationLayer layer : state.getAnnotationLayers()) {
-            if (!layer.isEnabled() || layer.isReadonly()
-                    || annotationEditorProperties.isLayerBlocked(layer)) {
-                continue;
-            }
-
-            if (layer.getType().equals(SPAN_TYPE) || layer.getType().equals(CHAIN_TYPE)) {
-                selectableLayers.add(layer);
-            }
-        }
-
-        // if there is only one layer, we use it to create new annotations
-        if (selectableLayers.size() == 1) {
-            state.setDefaultAnnotationLayer(selectableLayers.get(0));
-        }
-
-        if (state.getDefaultAnnotationLayer() != null) {
-            state.setSelectedAnnotationLayer(state.getDefaultAnnotationLayer());
-        }
-        else if (!selectableLayers.isEmpty()) {
-            state.setSelectedAnnotationLayer(selectableLayers.get(0));
-        }
-    }
-
-    public List<AnnotationLayer> getSelectableLayers()
-    {
-        return selectableLayers;
     }
 }


### PR DESCRIPTION
**What's in the PR**
- Add option to mark a document metadata layer as a singleton
- Route DocumentOpenedEvents to the UI so the DocumentMetadataSidebar can react and initialize the singletons
- Put delete button direclty into the sidebar without wrapping it in a dropdown

**How to test manually**
* Mark a document metadata layer as singleton
* Open annotation page, open metadata sidebar, enter data, switch between documents

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
