### PR TITLE
#2621 - Incomplete and disagreeing annotations have the same color code in curation

### DIFF
--- a/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/render/BratRenderer.java
+++ b/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/render/BratRenderer.java
@@ -20,6 +20,7 @@ package de.tudarmstadt.ukp.clarin.webanno.brat.render;
 import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.CHAIN_TYPE;
 import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.TypeUtil.getUiLabelText;
 import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.selectAnnotationByAddr;
+import static de.tudarmstadt.ukp.clarin.webanno.model.ScriptDirection.RTL;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.groupingBy;
@@ -86,7 +87,6 @@ import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.LinkMode;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
-import de.tudarmstadt.ukp.clarin.webanno.model.ScriptDirection;
 import de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.POS;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.TrimUtils;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
@@ -127,13 +127,17 @@ public class BratRenderer
      *            the response.
      * @param aState
      *            the annotator model.
+     * @param aVDoc
+     *            the visual document representation.
      * @param aCas
      *            the CAS.
+     * @param aColoringStrategy
+     *            the coloring strategy.
      */
     public void render(GetDocumentResponse aResponse, AnnotatorState aState, VDocument aVDoc,
             CAS aCas, ColoringStrategy aColoringStrategy)
     {
-        aResponse.setRtlMode(ScriptDirection.RTL.equals(aState.getScriptDirection()));
+        aResponse.setRtlMode(RTL == aState.getScriptDirection());
         aResponse.setFontZoom(aState.getPreferences().getFontZoom());
 
         renderText(aCas, aResponse, aState);

--- a/inception/inception-curation-legacy/pom.xml
+++ b/inception/inception-curation-legacy/pom.xml
@@ -31,6 +31,10 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-collections4</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/FeatureEditorListPanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/FeatureEditorListPanel.java
@@ -348,20 +348,6 @@ public class FeatureEditorListPanel
             item.add(editor);
         }
 
-        private void addRefreshFeaturePanelBehavior(final FeatureEditor aFrag)
-        {
-            aFrag.getFocusComponent().add(new AjaxFormComponentUpdatingBehavior("change")
-            {
-                private static final long serialVersionUID = 5179816588460867471L;
-
-                @Override
-                protected void onUpdate(AjaxRequestTarget aTarget)
-                {
-                    owner.refresh(aTarget);
-                }
-            });
-        }
-
         @Override
         protected Iterator<IModel<FeatureState>> getItemModels()
         {
@@ -459,5 +445,4 @@ public class FeatureEditorListPanel
 
         aTarget.focusComponent(aComponent);
     }
-
 }

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/model/AnnotationState.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/model/AnnotationState.java
@@ -23,32 +23,35 @@ package de.tudarmstadt.ukp.clarin.webanno.ui.curation.component.model;
 public enum AnnotationState
 {
     /**
-     * All annotators and the curated document have the same annotation.
+     * Curator selected this configuration.
      */
-    AGREE("#bbbbbb"),
+    ACCEPTED_BY_CURATOR("#77dd77"), // cf. "curated" class in CurationPage.html
     /**
-     * color for the arc annotation that is in agreement
+     * Curator did choose a configuration but not this one. The configuration the curator chose does
+     * not have to match any configuration that provided by the annotators - it can be a completely
+     * new one.
      */
-    AGREE_ARC("#000000"),
+    REJECTED_BY_CURATOR("#0dcaf0"), // Bootstrap 5 cyan
     /**
-     * Annotators have annotated differently. Curated document not yet has any annotations.
+     * All annotators agree but the curator did not make a choice yet.
      */
-    DISAGREE("#7fa2ff"),
+    // Bootstrap 5 orange - cannot use "agree" class in CurationPage.html because that is white and
+    // that would cause relations to become invisible.
+
+    ANNOTATORS_AGREE("#fd7e14"),
     /**
-     * Annotators have annotated differently. Annotation for current document and curation document
-     * are equal.
+     * Annotators disagree and curator did not make a decision yet.
      */
-    USE("#004413"),
+    ANNOTATORS_DISAGREE("#FF9999"), // cf. "disagree" class in CurationPage.html
     /**
-     * Annotators have annotated differently. Annotation for current document and curation document
-     * are not equal.
+     * Annotators have not all annotated (incomplete) and curator did not make a decision yet.
      */
-    DO_NOT_USE("#ff7fa2"),
+    ANNOTATORS_INCOMPLETE("#DDA0DD"), // cf. "incomplete" class in CurationPage.html
     /**
      * Error state. Annotation has been added to the visualization, but has not been identified by
      * the CasDiff.
      */
-    NOT_SUPPORTED("#111111");
+    ERROR("#111111"); // almost black
 
     private String colorCode;
 

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/render/AnnotationStateColoringStrategy.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/render/AnnotationStateColoringStrategy.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.ui.curation.component.render;
+
+import static de.tudarmstadt.ukp.clarin.webanno.ui.curation.component.model.AnnotationState.ERROR;
+
+import java.util.Map;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.coloring.ColoringRules;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.coloring.ColoringStrategy;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.VID;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.rendering.model.VObject;
+import de.tudarmstadt.ukp.clarin.webanno.ui.curation.component.model.AnnotationState;
+
+public class AnnotationStateColoringStrategy
+    implements ColoringStrategy
+{
+    private final Map<VID, AnnotationState> annotationStates;
+
+    public AnnotationStateColoringStrategy(Map<VID, AnnotationState> aAnnotationStates)
+    {
+        annotationStates = aAnnotationStates;
+    }
+
+    @Override
+    public String getColor(VObject aVObject, String aLabel, ColoringRules aColoringRules)
+    {
+        return annotationStates.getOrDefault(aVObject.getVid(), ERROR).getColorCode();
+    }
+}

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/render/CurationRenderer.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/render/CurationRenderer.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.ui.curation.component.render;
+
+import java.io.IOException;
+
+import org.apache.uima.cas.CAS;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.coloring.ColoringStrategy;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
+
+public interface CurationRenderer
+{
+    String render(CAS aCas, AnnotatorState aState, ColoringStrategy aColoringStrategy)
+        throws IOException;
+}

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/render/CurationRendererImpl.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/render/CurationRendererImpl.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.ui.curation.component.render;
+
+import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.CHAIN_TYPE;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.uima.cas.CAS;
+import org.springframework.stereotype.Component;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.coloring.ColoringService;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.coloring.ColoringStrategy;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.rendering.PreRenderer;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.rendering.model.VDocument;
+import de.tudarmstadt.ukp.clarin.webanno.brat.config.BratAnnotationEditorProperties;
+import de.tudarmstadt.ukp.clarin.webanno.brat.message.GetDocumentResponse;
+import de.tudarmstadt.ukp.clarin.webanno.brat.render.BratRenderer;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.support.JSONUtil;
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
+
+@Component
+public class CurationRendererImpl
+    implements CurationRenderer
+{
+    private final PreRenderer preRenderer;
+    private final AnnotationSchemaService schemaService;
+    private final ColoringService coloringService;
+    private final BratAnnotationEditorProperties bratProperties;
+
+    public CurationRendererImpl(PreRenderer aPreRenderer, AnnotationSchemaService aSchemaService,
+            ColoringService aColoringService, BratAnnotationEditorProperties aBratProperties)
+    {
+        preRenderer = aPreRenderer;
+        schemaService = aSchemaService;
+        coloringService = aColoringService;
+        bratProperties = aBratProperties;
+    }
+
+    @Override
+    public String render(CAS aCas, AnnotatorState aState, ColoringStrategy aColoringStrategy)
+        throws IOException
+    {
+        List<AnnotationLayer> layersToRender = new ArrayList<>();
+        for (AnnotationLayer layer : aState.getAnnotationLayers()) {
+            boolean isSegmentationLayer = layer.getName().equals(Token.class.getName())
+                    || layer.getName().equals(Sentence.class.getName());
+            boolean isUnsupportedLayer = layer.getType().equals(CHAIN_TYPE);
+
+            if (layer.isEnabled() && !isSegmentationLayer && !isUnsupportedLayer) {
+                layersToRender.add(layer);
+            }
+        }
+
+        VDocument vdoc = new VDocument();
+        preRenderer.render(vdoc, aState.getWindowBeginOffset(), aState.getWindowEndOffset(), aCas,
+                layersToRender);
+
+        GetDocumentResponse response = new GetDocumentResponse();
+        BratRenderer renderer = new BratRenderer(schemaService, coloringService, bratProperties);
+        renderer.render(response, aState, vdoc, aCas, aColoringStrategy);
+        return JSONUtil.toInterpretableJsonString(response);
+    }
+}

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/overview/CurationUnit.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/overview/CurationUnit.java
@@ -29,25 +29,13 @@ public class CurationUnit
     private static final long serialVersionUID = 9219600871129699568L;
 
     // begin/end offset of sentences list, default is the begin of the document
-    private final Integer begin;
-    private final Integer end;
-    private final Integer sentenceNumber;
-
-    // begin of the curation/suggestion sentences list
-    private int curationBegin;
-    // end of the curation/suggestion sentences list
-    private int curationEnd;
+    private final int begin;
+    private final int end;
+    private final int sentenceNumber;
 
     private CurationUnitState sentenceState;
 
     private boolean isCurrentSentence;
-
-    public CurationUnit()
-    {
-        begin = null;
-        end = null;
-        sentenceNumber = null;
-    }
 
     public CurationUnit(int aBegin, int aEnd, int aUnitIndex)
     {
@@ -66,27 +54,7 @@ public class CurationUnit
         return end;
     }
 
-    public int getCurationBegin()
-    {
-        return curationBegin;
-    }
-
-    public void setCurationBegin(int curationBegin)
-    {
-        this.curationBegin = curationBegin;
-    }
-
-    public int getCurationEnd()
-    {
-        return curationEnd;
-    }
-
-    public void setCurationEnd(int curationEnd)
-    {
-        this.curationEnd = curationEnd;
-    }
-
-    public CurationUnitState getSentenceState()
+    public CurationUnitState getState()
     {
         return sentenceState;
     }

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/overview/CurationUnitOverviewLink.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/overview/CurationUnitOverviewLink.java
@@ -60,7 +60,7 @@ public class CurationUnitOverviewLink
         final CurationUnit unitState = getModelObject();
         final AnnotatorState state = annotatorState.getObject();
 
-        aTag.append(ATTR_CLASS, unitState.getSentenceState().getCssClass(), " ");
+        aTag.append(ATTR_CLASS, unitState.getState().getCssClass(), " ");
 
         // Is in focus?
         if (unitState.getUnitIndex() == state.getFocusUnitIndex()) {

--- a/inception/inception-ui-curation/src/main/resources/META-INF/asciidoc/user-guide/curation.adoc
+++ b/inception/inception-ui-curation/src/main/resources/META-INF/asciidoc/user-guide/curation.adoc
@@ -72,8 +72,28 @@ When a document is opened for the first time in the curation page, the applicati
 and disagreements between annotators. All annotations on which all annotators agree are automatically
 copied to the *Annotation* pane. Any annotations on which the annotators disagree are skipped.
 
-The annotator's panes are color-coded according to their relation with the contents of the *Annotation*
-pane and according to the agreement status. If the annotations were the same, they are marked *grey* in the lower panels. If the annotators do not agree, the respective annotations are show in dark blue in the lower panels. By default, they are not taken into the merged file (cf. <<merging-strategies>>). 
+The annotator's panes are color-coded according to their relation with the contents of the *Annotation* pane and according to the agreement status. The colors largely match the colors also used in the status over in the left sidebar.
+
+NOTE: The upper *Annotation* pane that the curator uses to edit annotations is not color-coded. It uses whatever coloring strategy is configured in the *Settings* dialog.
+
+.Explanation of the annotation colors in the annotator's panes (lower panes)
+[cols="1,3"]
+|===
+| Green 
+| *Accepted by the curator:* the annotation matches the corresponding annotation in the *Annotation* pane.
+
+| Cyan 
+| *Rejected by the curator: *the annotation does not match the corresponding annotation in the *Annotation* pane.
+
+| Orange
+| *Annotators agree:* the annotators all agree but curator has not accepted the annotation yet (there is no corresponding annotation in the *Annotation* pane).
+
+| Red
+| *Annotators disagree:* the annotators disagree and the curator has not yet taken any action (there is also no corresponding annotation in the upper *Annotation* pane).
+
+| Purple
+| *Annotation is incomplete:* not all annotators have provided a annotation for this position and the curator has not yet taken any action (there is no corresponding annotation in the upper *Annotation* pane).
+|===
 
 **Left-click** on an annotation in one of the lower panels to merge it. This action copies the annotation to the upper panel. The merged annotation will turn green in the lower panel from which it was selected. If other annotators had a conflicting opinion, these will turn red in the lower panels of the respective annotators. 
 
@@ -82,25 +102,6 @@ pane and according to the agreement status. If the annotations were the same, th
 * **Merge all XXX**: merge all annotations of the given type from the selected annotator. Note that
   this overrides any annotations of the type which may previously have been merged or manually 
   created in the upper panel.
-
-NOTE: The upper *Annotation* pane is not color-coded. It uses whatever coloring strategy is
-      configured in the *Settings* dialog.
-
-.Explanation of the annotation colors in the annotator's panes (lower panes)
-[cols="1,3"]
-|===
-| Grey
-| all annotators agree
-
-| Blue 
-| disagreement requiring curation; annotators disagree and there is no corresponding annotation in the upper *Annotation* pane yet
-
-| Green 
-| accepted; matches the corresponding annotation in the upper *Annotation* pane
-
-| Red 
-| rejected; different to the corresponding annotation in the upper *Annotation* pane
-|===
 
 [#merging-strategies]
 == Merging strategies


### PR DESCRIPTION
**What's in the PR**
- Clean up code and remove some legacy/redundant crusts here and there
- Add ability to CasDiff to exclude certain annotators (e.g. Curator) when calculating completeness and agreement
- Updated coloring in the annotator views to largely match the coloring in the left sidebar
- Updated documentation
- Pulled coloring strategy and curation renderer out from the AnnotatorsPanel

**How to test manually**
* Use curation and report anything that looks odd

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
