### PR TITLE
#2619 - Cannot save feature value using enter in document-level annotations

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/DynamicTextAreaFeatureEditor.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/DynamicTextAreaFeatureEditor.java
@@ -18,7 +18,6 @@
 package de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor;
 
 import org.apache.wicket.MarkupContainer;
-import org.apache.wicket.ajax.AjaxPreventSubmitBehavior;
 import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.head.JavaScriptHeaderItem;
 import org.apache.wicket.markup.head.OnDomReadyHeaderItem;
@@ -45,7 +44,6 @@ public class DynamicTextAreaFeatureEditor
     {
         textarea = new TextArea<>("value");
         textarea.setOutputMarkupId(true);
-        textarea.add(new AjaxPreventSubmitBehavior());
         return textarea;
     }
 

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/InputFieldTextFeatureEditor.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/InputFieldTextFeatureEditor.java
@@ -20,7 +20,6 @@ package de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor;
 import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
 
 import org.apache.wicket.MarkupContainer;
-import org.apache.wicket.ajax.AjaxPreventSubmitBehavior;
 import org.apache.wicket.markup.html.form.AbstractTextComponent;
 import org.apache.wicket.model.IModel;
 
@@ -51,11 +50,10 @@ public class InputFieldTextFeatureEditor
                 .add(visibleWhen(() -> getLabelComponent().isVisible())));
     }
 
+    @SuppressWarnings("rawtypes")
     @Override
     protected AbstractTextComponent createInputField()
     {
-        TextField<String> textfield = new TextField<>("value");
-        textfield.add(new AjaxPreventSubmitBehavior());
-        return textfield;
+        return new TextField<>("value");
     }
 }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/TextAreaFeatureEditor.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/TextAreaFeatureEditor.java
@@ -18,14 +18,16 @@
 package de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 
 import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.MarkupContainer;
-import org.apache.wicket.ajax.AjaxPreventSubmitBehavior;
 import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.markup.html.form.AbstractTextComponent;
 import org.apache.wicket.markup.html.form.TextArea;
 import org.apache.wicket.model.IModel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.FeatureState;
 import de.tudarmstadt.ukp.clarin.webanno.support.JSONUtil;
@@ -34,6 +36,8 @@ public class TextAreaFeatureEditor
     extends TextFeatureEditorBase
 {
     private static final long serialVersionUID = 8686646370500180943L;
+
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     public TextAreaFeatureEditor(String aId, MarkupContainer aItem, IModel<FeatureState> aModel)
     {
@@ -44,7 +48,6 @@ public class TextAreaFeatureEditor
     protected AbstractTextComponent createInputField()
     {
         TextArea<String> textarea = new TextArea<>("value");
-        textarea.add(new AjaxPreventSubmitBehavior());
         try {
             String traitsString = getModelObject().feature.getTraits();
             StringFeatureTraits traits = JSONUtil.fromJsonString(StringFeatureTraits.class,
@@ -56,7 +59,7 @@ public class TextAreaFeatureEditor
                     "this.rows=" + traits.getCollapsedRows() + ";"));
         }
         catch (IOException e) {
-            e.printStackTrace();
+            LOG.error("Unable to create feature editor", e);
         }
         return textarea;
     }

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationDetailPanel.html
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationDetailPanel.html
@@ -18,10 +18,10 @@
 -->
 <html xmlns:wicket="http://wicket.apache.org">
 <wicket:panel>
-  <div class="flex-content flex-v-container flex-gutter flex-only-internal-gutter">
-    <div wicket:id="featureValues" class="feature-editors-sidebar">
+  <div class="flex-content flex-v-container flex-gutter flex-only-internal-gutter feature-editors-sidebar">
+    <wicket:container wicket:id="featureEditors">
       <div wicket:id="editor"></div>
-    </div>
+    </wicket:container>
   </div>
 </wicket:panel>
 </html>

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationSelectionPanel.html
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationSelectionPanel.html
@@ -34,7 +34,7 @@
     </div>
     <div class="scrolling card-body flex-v-container">
       <ul wicket:id="annotationsContainer" class=" list-group">
-        <li wicket:id="annotations" class="list-group-item ps-2 pe-2">
+        <li wicket:id="annotations" class="list-group-item">
           <div class="d-flex">
             <div class="flex-grow-1" style="min-width: 0px;">
               <div wicket:id="annotation" class="d-flex align-items-center">

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
@@ -39,6 +39,7 @@ import static wicket.contrib.input.events.key.KeyType.Shift;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -131,7 +132,7 @@ public abstract class AnnotationDetailEditorPanel
 {
     private static final long serialVersionUID = 7324241992353693848L;
 
-    private static final Logger LOG = LoggerFactory.getLogger(AnnotationDetailEditorPanel.class);
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private static final String KEY_BACKSPACE = "8";
     private static final String KEY_ENTER = "13";

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/FeatureEditorListPanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/FeatureEditorListPanel.java
@@ -275,10 +275,6 @@ public class FeatureEditorListPanel
                     + item.getModelObject().feature.getUiName() + ": " + item.getModelObject().value
                     + ")");
 
-            // Feature editors that allow multiple values may want to update themselves,
-            // e.g. to add another slot.
-            item.setOutputMarkupId(true);
-
             final FeatureState featureState = item.getModelObject();
             final FeatureEditor editor;
 
@@ -291,8 +287,6 @@ public class FeatureEditorListPanel
 
             // We need to enable the markup ID here because we use it during the AJAX behavior
             // that automatically saves feature editors on change/blur.
-            // Check addAnnotateActionBehavior.
-            editor.setOutputMarkupId(true);
             editor.setOutputMarkupPlaceholderTag(true);
 
             // Ensure that markup IDs of feature editor focus components remain constant across


### PR DESCRIPTION
**What's in the PR**
- Removed `AjaxPreventSubmitBehavior()` from the DynamicTextAreaFeatureEditor, the InputFieldTextFeatureEditor and the TextAreaFeatureEditor - this was preventing saving in the document metadata sidebar and for some reason apparently had no effect whatsoever in the right annotation detail sidebar
- Clean up layout of document metadata sidebar a bit more
- Slightly clean up code

**How to test manually**
* Use the document metadata sidebar as well as the right annotation detail sidebar with tab/enter and with different kinds of feature editors

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
