### PR TITLE
#2599 - Allow a default sidebar per project be open

### DIFF
--- a/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebarFactory.java
+++ b/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebarFactory.java
@@ -25,6 +25,7 @@ import de.agilecoders.wicket.extensions.markup.html.bootstrap.icon.FontAwesome5I
 import de.tudarmstadt.ukp.clarin.webanno.api.CasProvider;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.action.AnnotationActionHandler;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.AnnotationPage;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar.AnnotationSidebarFactory_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar.AnnotationSidebar_ImplBase;
@@ -55,15 +56,28 @@ public class ActiveLearningSidebarFactory
     }
 
     @Override
+    public String getDescription()
+    {
+        return "Guides the user through recommendations to be reviewed. Only available if the "
+                + "project contains enabled recommenders.";
+    }
+
+    @Override
     public IconType getIcon()
     {
         return FontAwesome5IconType.robot_s;
     }
 
     @Override
+    public boolean available(Project aProject)
+    {
+        return recommendationService.existsEnabledRecommender(aProject);
+    }
+
+    @Override
     public boolean applies(AnnotatorState aState)
     {
-        return recommendationService.existsEnabledRecommender(aState.getProject());
+        return available(aState.getProject());
     }
 
     @Override

--- a/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/config/CurationServiceAutoConfiguration.java
+++ b/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/config/CurationServiceAutoConfiguration.java
@@ -61,9 +61,10 @@ public class CurationServiceAutoConfiguration
     }
 
     @Bean("curationSidebar")
-    public CurationSidebarFactory curationSidebarFactory(ProjectService aProjectService)
+    public CurationSidebarFactory curationSidebarFactory(ProjectService aProjectService,
+            UserDao aUserService)
     {
-        return new CurationSidebarFactory(aProjectService);
+        return new CurationSidebarFactory(aProjectService, aUserService);
     }
 
     @Bean

--- a/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/sidebar/CurationSidebarFactory.java
+++ b/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/sidebar/CurationSidebarFactory.java
@@ -26,6 +26,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.CasProvider;
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.action.AnnotationActionHandler;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
+import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.AnnotationPage;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar.AnnotationSidebarFactory_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar.AnnotationSidebar_ImplBase;
@@ -41,17 +42,25 @@ public class CurationSidebarFactory
     extends AnnotationSidebarFactory_ImplBase
 {
     private final ProjectService projectService;
+    private final UserDao userService;
 
     @Autowired
-    public CurationSidebarFactory(ProjectService aProjectService)
+    public CurationSidebarFactory(ProjectService aProjectService, UserDao aUserService)
     {
         projectService = aProjectService;
+        userService = aUserService;
     }
 
     @Override
     public String getDisplayName()
     {
         return "Curation";
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Allows curation via the annotation page. Only available to curators.";
     }
 
     @Override
@@ -71,8 +80,8 @@ public class CurationSidebarFactory
     @Override
     public boolean applies(AnnotatorState aState)
     {
+        String currentUser = userService.getCurrentUsername();
         boolean isCurator = projectService.isCurator(aState.getProject(), aState.getUser());
-        return isCurator;
+        return isCurator && aState.getUser().getUsername().equals(currentUser);
     }
-
 }

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/user-guide.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/user-guide.adoc
@@ -125,6 +125,8 @@ include::{include-dir}projects_documents.adoc[leveloffset=+2]
 
 include::{include-dir}projects_layers.adoc[leveloffset=+2]
 
+include::{include-dir}projects_annotation.adoc[leveloffset=+2]
+
 include::{include-dir}projects_knowledge-base.adoc[leveloffset=+2]
 
 include::{include-dir}projects_recommendation.adoc[leveloffset=+2]

--- a/inception/inception-image/src/main/java/de/tudarmstadt/ukp/inception/image/sidebar/ImageSidebarFactory.java
+++ b/inception/inception-image/src/main/java/de/tudarmstadt/ukp/inception/image/sidebar/ImageSidebarFactory.java
@@ -28,6 +28,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.CasProvider;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.action.AnnotationActionHandler;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.AnnotationPage;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar.AnnotationSidebarFactory_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar.AnnotationSidebar_ImplBase;
@@ -50,15 +51,28 @@ public class ImageSidebarFactory
     }
 
     @Override
+    public String getDescription()
+    {
+        return "Displays images linked to annotations that are currently visible on screen. Only "
+                + "available if the project defines at least one image feature on any layer.";
+    }
+
+    @Override
     public IconType getIcon()
     {
         return FontAwesome5IconType.images_s;
     }
 
     @Override
+    public boolean available(Project aProject)
+    {
+        return schemaService.existsEnabledFeatureOfType(aProject, TYPE_IMAGE_URL);
+    }
+
+    @Override
     public boolean applies(AnnotatorState aState)
     {
-        return schemaService.existsEnabledFeatureOfType(aState.getProject(), TYPE_IMAGE_URL);
+        return available(aState.getProject());
     }
 
     @Override

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataSidebarFactory.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataSidebarFactory.java
@@ -25,6 +25,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.CasProvider;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.action.AnnotationActionHandler;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.AnnotationPage;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar.AnnotationSidebarFactory_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar.AnnotationSidebar_ImplBase;
@@ -55,16 +56,27 @@ public class DocumentMetadataSidebarFactory
     }
 
     @Override
+    public String getDescription()
+    {
+        return "Document-level annotations.";
+    }
+
+    @Override
     public IconType getIcon()
     {
         return FontAwesome5IconType.tags_s;
     }
 
     @Override
+    public boolean available(Project aProject)
+    {
+        return schemaService.existsEnabledLayerOfType(aProject, DocumentMetadataLayerSupport.TYPE);
+    }
+
+    @Override
     public boolean applies(AnnotatorState aState)
     {
-        return schemaService.existsEnabledLayerOfType(aState.getProject(),
-                DocumentMetadataLayerSupport.TYPE);
+        return available(aState.getProject());
     }
 
     @Override

--- a/inception/inception-preferences/pom.xml
+++ b/inception/inception-preferences/pom.xml
@@ -31,6 +31,10 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-model-export</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-support</artifactId>
     </dependency>
     <dependency>
@@ -64,6 +68,10 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
     </dependency>
 
     <dependency>

--- a/inception/inception-preferences/src/main/java/de/tudarmstadt/ukp/inception/preferences/PreferencesService.java
+++ b/inception/inception-preferences/src/main/java/de/tudarmstadt/ukp/inception/preferences/PreferencesService.java
@@ -17,8 +17,11 @@
  */
 package de.tudarmstadt.ukp.inception.preferences;
 
+import java.util.List;
+
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
+import de.tudarmstadt.ukp.inception.preferences.model.DefaultProjectPreference;
 
 public interface PreferencesService
 {
@@ -33,4 +36,8 @@ public interface PreferencesService
     <T> T loadDefaultTraitsForProject(Key<T> aKey, Project aProject);
 
     <T> void saveDefaultTraitsForProject(Key<T> aKey, Project aProject, T aTraits);
+
+    List<DefaultProjectPreference> listDefaultTraitsForProject(Project aProject);
+
+    void saveDefaultProjectPreference(DefaultProjectPreference aPreference);
 }

--- a/inception/inception-preferences/src/main/java/de/tudarmstadt/ukp/inception/preferences/PreferencesService.java
+++ b/inception/inception-preferences/src/main/java/de/tudarmstadt/ukp/inception/preferences/PreferencesService.java
@@ -29,4 +29,8 @@ public interface PreferencesService
     <T> T loadTraitsForUserAndProject(Key<T> aKey, User aUser, Project aProject);
 
     <T> void saveTraitsForUserAndProject(Key<T> aKey, User aUser, Project aProject, T aTraits);
+
+    <T> T loadDefaultTraitsForProject(Key<T> aKey, Project aProject);
+
+    <T> void saveDefaultTraitsForProject(Key<T> aKey, Project aProject, T aTraits);
 }

--- a/inception/inception-preferences/src/main/java/de/tudarmstadt/ukp/inception/preferences/PreferencesServiceImpl.java
+++ b/inception/inception-preferences/src/main/java/de/tudarmstadt/ukp/inception/preferences/PreferencesServiceImpl.java
@@ -20,6 +20,7 @@ package de.tudarmstadt.ukp.inception.preferences;
 import static de.tudarmstadt.ukp.clarin.webanno.support.JSONUtil.toJsonString;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Optional;
 
 import javax.persistence.EntityManager;
@@ -253,6 +254,27 @@ public class PreferencesServiceImpl
         catch (NoResultException e) {
             return Optional.empty();
         }
+    }
+
+    @Override
+    @Transactional
+    public List<DefaultProjectPreference> listDefaultTraitsForProject(Project aProject)
+    {
+        String query = String.join("\n", //
+                "FROM DefaultProjectPreference ", //
+                "WHERE project = :project");
+
+        return entityManager //
+                .createQuery(query, DefaultProjectPreference.class) //
+                .setParameter("project", aProject) //
+                .getResultList();
+    }
+
+    @Override
+    @Transactional
+    public void saveDefaultProjectPreference(DefaultProjectPreference aPreference)
+    {
+        entityManager.persist(aPreference);
     }
 
     /*

--- a/inception/inception-preferences/src/main/java/de/tudarmstadt/ukp/inception/preferences/config/PreferencesServiceAutoConfig.java
+++ b/inception/inception-preferences/src/main/java/de/tudarmstadt/ukp/inception/preferences/config/PreferencesServiceAutoConfig.java
@@ -25,6 +25,7 @@ import org.springframework.context.annotation.Configuration;
 
 import de.tudarmstadt.ukp.inception.preferences.PreferencesService;
 import de.tudarmstadt.ukp.inception.preferences.PreferencesServiceImpl;
+import de.tudarmstadt.ukp.inception.preferences.exporter.DefaultProjectPreferencesExporter;
 
 @Configuration
 public class PreferencesServiceAutoConfig
@@ -35,5 +36,12 @@ public class PreferencesServiceAutoConfig
     public PreferencesService preferencesService()
     {
         return new PreferencesServiceImpl(entityManager);
+    }
+
+    @Bean
+    public DefaultProjectPreferencesExporter defaultPreferenceExporter(
+            PreferencesService aPreferencesService)
+    {
+        return new DefaultProjectPreferencesExporter(aPreferencesService);
     }
 }

--- a/inception/inception-preferences/src/main/java/de/tudarmstadt/ukp/inception/preferences/exporter/DefaultProjectPreferencesExporter.java
+++ b/inception/inception-preferences/src/main/java/de/tudarmstadt/ukp/inception/preferences/exporter/DefaultProjectPreferencesExporter.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.preferences.exporter;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.zip.ZipFile;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExportRequest;
+import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExportTaskMonitor;
+import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExporter;
+import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectImportRequest;
+import de.tudarmstadt.ukp.clarin.webanno.export.model.ExportedProject;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.inception.preferences.PreferencesService;
+import de.tudarmstadt.ukp.inception.preferences.config.PreferencesServiceAutoConfig;
+import de.tudarmstadt.ukp.inception.preferences.model.DefaultProjectPreference;
+
+/**
+ * <p>
+ * This class is exposed as a Spring Component via
+ * {@link PreferencesServiceAutoConfig#defaultPreferenceExporter}.
+ * </p>
+ */
+public class DefaultProjectPreferencesExporter
+    implements ProjectExporter
+{
+    private static final String KEY = "default-preferences";
+    private static final Logger LOG = LoggerFactory.getLogger(DefaultProjectPreferencesExporter.class);
+
+    private final PreferencesService preferencesService;
+
+    @Autowired
+    public DefaultProjectPreferencesExporter(PreferencesService aPreferencesService)
+    {
+        preferencesService = aPreferencesService;
+    }
+
+    @Override
+    public void exportData(ProjectExportRequest aRequest, ProjectExportTaskMonitor aMonitor,
+            ExportedProject aExProject, File aFile)
+    {
+        Project project = aRequest.getProject();
+
+        List<ExportedDefaultProjectPreference> exportedDefaultPreferences = new ArrayList<>();
+        for (DefaultProjectPreference defaultPreference : preferencesService
+                .listDefaultTraitsForProject(project)) {
+            ExportedDefaultProjectPreference exportedDefaultPreference = new ExportedDefaultProjectPreference();
+            exportedDefaultPreference.setName(defaultPreference.getName());
+            exportedDefaultPreference.setTraits(defaultPreference.getTraits());
+            exportedDefaultPreferences.add(exportedDefaultPreference);
+        }
+
+        aExProject.setProperty(KEY, exportedDefaultPreferences);
+        int n = exportedDefaultPreferences.size();
+        LOG.info("Exported [{}] default preferences for project [{}]", n, project.getName());
+    }
+
+    @Override
+    public void importData(ProjectImportRequest aRequest, Project aProject,
+            ExportedProject aExProject, ZipFile aZip)
+    {
+        ExportedDefaultProjectPreference[] exportedDefaultPreferences = aExProject
+                .getArrayProperty(KEY, ExportedDefaultProjectPreference.class);
+
+        for (ExportedDefaultProjectPreference exportedDefaultPreference : exportedDefaultPreferences) {
+            DefaultProjectPreference defaultPreference = new DefaultProjectPreference();
+            defaultPreference.setName(exportedDefaultPreference.getName());
+            defaultPreference.setTraits(exportedDefaultPreference.getTraits());
+
+            preferencesService.saveDefaultProjectPreference(defaultPreference);
+        }
+
+        int n = exportedDefaultPreferences.length;
+        LOG.info("Imported [{}] default preferences for project [{}]", n, aProject.getName());
+    }
+}

--- a/inception/inception-preferences/src/main/java/de/tudarmstadt/ukp/inception/preferences/exporter/ExportedDefaultProjectPreference.java
+++ b/inception/inception-preferences/src/main/java/de/tudarmstadt/ukp/inception/preferences/exporter/ExportedDefaultProjectPreference.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.preferences.exporter;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonPropertyOrder(alphabetic = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ExportedDefaultProjectPreference
+{
+    @JsonProperty("name")
+    private String name;
+
+    @JsonProperty("traits")
+    private String traits;
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public void setName(String aName)
+    {
+        name = aName;
+    }
+
+    public String getTraits()
+    {
+        return traits;
+    }
+
+    public void setTraits(String aTraits)
+    {
+        traits = aTraits;
+    }
+}

--- a/inception/inception-preferences/src/main/java/de/tudarmstadt/ukp/inception/preferences/model/DefaultProjectPreference.java
+++ b/inception/inception-preferences/src/main/java/de/tudarmstadt/ukp/inception/preferences/model/DefaultProjectPreference.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.preferences.model;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+
+@Entity
+@Table(name = "default_project_preference", uniqueConstraints = {
+        @UniqueConstraint(columnNames = { "project", "name" }) })
+public class DefaultProjectPreference
+    implements Serializable
+{
+    private static final long serialVersionUID = 1858327366055504001L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @ManyToOne
+    @JoinColumn(name = "project", nullable = false)
+    private Project project;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Lob
+    @Column(length = 64000)
+    private String traits;
+
+    public Long getId()
+    {
+        return id;
+    }
+
+    public void setId(Long aId)
+    {
+        id = aId;
+    }
+
+    public Project getProject()
+    {
+        return project;
+    }
+
+    public void setProject(Project aProject)
+    {
+        project = aProject;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public void setName(String aName)
+    {
+        name = aName;
+    }
+
+    public String getTraits()
+    {
+        return traits;
+    }
+
+    public void setTraits(String aTraits)
+    {
+        traits = aTraits;
+    }
+
+    @Override
+    public boolean equals(final Object other)
+    {
+        if (!(other instanceof DefaultProjectPreference)) {
+            return false;
+        }
+        DefaultProjectPreference castOther = (DefaultProjectPreference) other;
+        return Objects.equals(project, castOther.project) && Objects.equals(name, castOther.name);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(project, name);
+    }
+}

--- a/inception/inception-preferences/src/main/resources/de/tudarmstadt/ukp/inception/preferences/model/db-changelog.xml
+++ b/inception/inception-preferences/src/main/resources/de/tudarmstadt/ukp/inception/preferences/model/db-changelog.xml
@@ -84,4 +84,35 @@
       constraintName="UK_user_project_preference_user_name_project"
       tableName="user_project_preference" columnNames="user, project, name" />
   </changeSet>
+
+  <changeSet author="INCEpTION Team" id="20210925-1">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="default_project_preference" />
+      </not>
+    </preConditions>
+
+    <createTable tableName="default_project_preference">
+      <column autoIncrement="true" name="id" type="BIGINT">
+        <constraints primaryKey="true" />
+      </column>
+      <column name="project" type="BIGINT"/>
+      <column name="name" type="VARCHAR(255)">
+        <constraints nullable="false"/>
+      </column>
+      <column name="traits" type="LONGTEXT">
+        <constraints nullable="true" />
+      </column>
+    </createTable>
+
+    <addForeignKeyConstraint 
+      constraintName="FK_default_project_preference_project"
+      baseTableName="default_project_preference" baseColumnNames="project"
+      referencedTableName="project" referencedColumnNames="id"
+      deferrable="false" initiallyDeferred="false"
+      onDelete="CASCADE" onUpdate="CASCADE"/>
+    <addUniqueConstraint
+      constraintName="UK_default_project_preference_name_project"
+      tableName="default_project_preference" columnNames="project, name" />
+  </changeSet>
 </databaseChangeLog>

--- a/inception/inception-preferences/src/test/java/de/tudarmstadt/ukp/inception/preferences/exporter/DefaultPreferenceExporterTest.java
+++ b/inception/inception-preferences/src/test/java/de/tudarmstadt/ukp/inception/preferences/exporter/DefaultPreferenceExporterTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.preferences.exporter;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.ZipFile;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExportRequest;
+import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExportTaskMonitor;
+import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectImportRequest;
+import de.tudarmstadt.ukp.clarin.webanno.export.model.ExportedProject;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.support.JSONUtil;
+import de.tudarmstadt.ukp.inception.preferences.PreferencesService;
+import de.tudarmstadt.ukp.inception.preferences.model.DefaultProjectPreference;
+
+public class DefaultPreferenceExporterTest
+{
+    private @Mock PreferencesService preferencesService;
+
+    private Project project;
+
+    private DefaultProjectPreferencesExporter sut;
+
+    @BeforeEach
+    public void setUp()
+    {
+        openMocks(this);
+
+        project = new Project();
+        project.setName("Test Project");
+
+        sut = new DefaultProjectPreferencesExporter(preferencesService);
+    }
+
+    @Test
+    public void thatExportingWorks() throws Exception
+    {
+        when(preferencesService.listDefaultTraitsForProject(project))
+                .thenReturn(defaultPreferences());
+
+        // Export the project and import it again
+        ArgumentCaptor<DefaultProjectPreference> captor = runExportImportAndFetchRecommenders();
+
+        // Check that after re-importing the exported projects, they are identical to the original
+        assertThat(captor.getAllValues()) //
+                .usingRecursiveFieldByFieldElementComparator() //
+                .containsExactlyInAnyOrderElementsOf(defaultPreferences());
+    }
+
+    private ArgumentCaptor<DefaultProjectPreference> runExportImportAndFetchRecommenders()
+    {
+        // Export the project
+        ProjectExportRequest exportRequest = new ProjectExportRequest();
+        ProjectExportTaskMonitor monitor = new ProjectExportTaskMonitor();
+        exportRequest.setProject(project);
+        ExportedProject exportedProject = new ExportedProject();
+        File file = mock(File.class);
+
+        sut.exportData(exportRequest, monitor, exportedProject, file);
+
+        // Import the project again
+        ArgumentCaptor<DefaultProjectPreference> captor = ArgumentCaptor
+                .forClass(DefaultProjectPreference.class);
+        doNothing().when(preferencesService).saveDefaultProjectPreference(captor.capture());
+
+        ProjectImportRequest importRequest = new ProjectImportRequest(true);
+        ZipFile zipFile = mock(ZipFile.class);
+        sut.importData(importRequest, project, exportedProject, zipFile);
+
+        return captor;
+    }
+
+    private List<DefaultProjectPreference> defaultPreferences() throws IOException
+    {
+        return asList( //
+                buildDefaultPreference("key_1", Map.of("a", 1, "b", 2)), //
+                buildDefaultPreference("key_2", Map.of("x", "X", "y", "Y")), //
+                buildDefaultPreference("key_3", Map.of("la", true, "lo", false)));
+    }
+
+    private DefaultProjectPreference buildDefaultPreference(String aKey, Object aTraits)
+        throws IOException
+    {
+        DefaultProjectPreference defaultPreference = new DefaultProjectPreference();
+        defaultPreference.setName(aKey);
+        defaultPreference.setTraits(JSONUtil.toJsonString(aTraits));
+        return defaultPreference;
+    }
+}

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommendationSidebarFactory.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommendationSidebarFactory.java
@@ -25,6 +25,7 @@ import de.agilecoders.wicket.extensions.markup.html.bootstrap.icon.FontAwesome5I
 import de.tudarmstadt.ukp.clarin.webanno.api.CasProvider;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.action.AnnotationActionHandler;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.AnnotationPage;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar.AnnotationSidebarFactory_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar.AnnotationSidebar_ImplBase;
@@ -55,15 +56,28 @@ public class RecommendationSidebarFactory
     }
 
     @Override
+    public String getDescription()
+    {
+        return "Provides information about the recommender sub-system. Only available if the "
+                + "project has at least one enabled recommender.";
+    }
+
+    @Override
     public IconType getIcon()
     {
         return FontAwesome5IconType.chart_line_s;
     }
 
     @Override
+    public boolean available(Project aProject)
+    {
+        return recommendationService.existsEnabledRecommender(aProject);
+    }
+
+    @Override
     public boolean applies(AnnotatorState aState)
     {
-        return recommendationService.existsEnabledRecommender(aState.getProject());
+        return available(aState.getProject());
     }
 
     @Override

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/sidebar/AnnotationSidebarFactory.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/sidebar/AnnotationSidebarFactory.java
@@ -23,6 +23,7 @@ import de.agilecoders.wicket.core.markup.html.bootstrap.image.IconType;
 import de.tudarmstadt.ukp.clarin.webanno.api.CasProvider;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.action.AnnotationActionHandler;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.AnnotationPage;
 
 public interface AnnotationSidebarFactory
@@ -34,11 +35,21 @@ public interface AnnotationSidebarFactory
 
     String getDisplayName();
 
+    String getDescription();
+
     IconType getIcon();
 
     AnnotationSidebar_ImplBase create(String id, IModel<AnnotatorState> aModel,
             final AnnotationActionHandler aActionHandler, final CasProvider aCasProvider,
             AnnotationPage aAnnotationPage);
+
+    /**
+     * Override for cases when sidebar should not be available by default
+     */
+    default boolean available(Project aProject)
+    {
+        return true;
+    }
 
     /**
      * Override for cases when sidebar should not be added by default

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/sidebar/SidebarTabbedPanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/sidebar/SidebarTabbedPanel.java
@@ -137,8 +137,8 @@ public class SidebarTabbedPanel<T extends SidebarTab>
             var tabIndex = tabFactories.indexOf(sidebarState.getSelectedTab());
             if (tabIndex >= 0) {
                 super.setSelectedTab(tabIndex);
+                expanded = sidebarState.isExpanded();
             }
-            expanded = sidebarState.isExpanded();
         }
     }
 

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/sidebar/docinfo/DocumentInfoSidebarFactory.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/sidebar/docinfo/DocumentInfoSidebarFactory.java
@@ -18,18 +18,19 @@
 package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar.docinfo;
 
 import org.apache.wicket.model.IModel;
-import org.springframework.stereotype.Component;
 
 import de.agilecoders.wicket.core.markup.html.bootstrap.image.IconType;
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.icon.FontAwesome5IconType;
 import de.tudarmstadt.ukp.clarin.webanno.api.CasProvider;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.action.AnnotationActionHandler;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.AnnotationPage;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar.AnnotationSidebarFactory_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar.AnnotationSidebar_ImplBase;
 
-@Component("documentInfoSidebar")
+// This now mainly serves as example code - we do not actually use it
+//@Component("documentInfoSidebar")
 public class DocumentInfoSidebarFactory
     extends AnnotationSidebarFactory_ImplBase
 {
@@ -40,9 +41,21 @@ public class DocumentInfoSidebarFactory
     }
 
     @Override
+    public String getDescription()
+    {
+        return "Displays basic information about the current document.";
+    }
+
+    @Override
     public IconType getIcon()
     {
         return FontAwesome5IconType.info_s;
+    }
+
+    @Override
+    public boolean available(Project aProject)
+    {
+        return false;
     }
 
     @Override

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/AnnotationPreferencesMenuItem.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/AnnotationPreferencesMenuItem.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.core.dashboard.settings.annotation;
+
+import org.apache.wicket.Page;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import de.agilecoders.wicket.core.markup.html.bootstrap.image.IconType;
+import de.agilecoders.wicket.extensions.markup.html.bootstrap.icon.FontAwesome5IconType;
+import de.tudarmstadt.ukp.inception.ui.core.dashboard.settings.ProjectSettingsMenuItemBase;
+
+@Component
+@Order(AnnotationPreferencesProjectSettingsPanelFactory.ORDER)
+public class AnnotationPreferencesMenuItem
+    extends ProjectSettingsMenuItemBase
+{
+    @Override
+    public String getPath()
+    {
+        return "/settings/annotation";
+    }
+
+    @Override
+    public IconType getIcon()
+    {
+        return FontAwesome5IconType.highlighter_s;
+    }
+
+    @Override
+    public String getLabel()
+    {
+        return "Annotation";
+    }
+
+    @Override
+    public Class<? extends Page> getPageClass()
+    {
+        return AnnotationPreferencesPage.class;
+    }
+}

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/AnnotationPreferencesPage.html
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/AnnotationPreferencesPage.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<!--
+  Licensed to the Technische Universität Darmstadt under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The Technische Universität Darmstadt 
+  licenses this file to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.
+   
+  http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<html xmlns:wicket="http://wicket.apache.org">
+<body>
+  <wicket:extend>
+    <div class="flex-content flex-v-container" wicket:id="panel"></div>
+  </wicket:extend>
+</body>
+</html>

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/AnnotationPreferencesPage.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/AnnotationPreferencesPage.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.core.dashboard.settings.annotation;
+
+import static de.tudarmstadt.ukp.clarin.webanno.ui.core.page.ProjectPageBase.NS_PROJECT;
+import static de.tudarmstadt.ukp.clarin.webanno.ui.core.page.ProjectPageBase.PAGE_PARAM_PROJECT;
+
+import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.wicketstuff.annotation.mount.MountPath;
+
+import de.tudarmstadt.ukp.inception.ui.core.dashboard.settings.ProjectSettingsDashboardPageBase;
+
+@MountPath(NS_PROJECT + "/${" + PAGE_PARAM_PROJECT + "}/settings/annotation")
+public class AnnotationPreferencesPage
+    extends ProjectSettingsDashboardPageBase
+{
+    private static final long serialVersionUID = 5889016668816051716L;
+
+    public AnnotationPreferencesPage(PageParameters aParameters)
+    {
+        super(aParameters);
+    }
+
+    @Override
+    protected void onInitialize()
+    {
+        super.onInitialize();
+
+        add(new AnnotationPreferencesProjectSettingsPanel("panel", getProjectModel()));
+    }
+}

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/AnnotationPreferencesProjectSettingsPanel.html
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/AnnotationPreferencesProjectSettingsPanel.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<!--
+  Licensed to the Technische Universität Darmstadt under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The Technische Universität Darmstadt 
+  licenses this file to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.
+   
+  http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<html xmlns:wicket="http://wicket.apache.org">
+<body>
+  <wicket:panel>
+    <div class="flex-h-container flex-gutter">
+      <div class="flex-v-container flex-content flex-gutter">
+        <div wicket:id="annotationSidebar"/>
+      </div>
+    </div>
+  </wicket:panel>
+</body>
+</html>

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/AnnotationPreferencesProjectSettingsPanel.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/AnnotationPreferencesProjectSettingsPanel.java
@@ -15,35 +15,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar;
+package de.tudarmstadt.ukp.inception.ui.core.dashboard.settings.annotation;
 
-import java.io.Serializable;
+import org.apache.wicket.model.IModel;
 
-public class AnnotationSidebarState
-    implements Serializable
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.ui.core.settings.ProjectSettingsPanelBase;
+
+public class AnnotationPreferencesProjectSettingsPanel
+    extends ProjectSettingsPanelBase
 {
-    private static final long serialVersionUID = -5212679894035839772L;
+    private static final long serialVersionUID = 4618192360418016955L;
 
-    private String selectedTab;
-    private boolean expanded;
+    private static final String CID_ANNOTATION_SIDEBAR = "annotationSidebar";
 
-    public void setSelectedTab(String aFactoryId)
+    public AnnotationPreferencesProjectSettingsPanel(String aId, IModel<Project> aProjectModel)
     {
-        selectedTab = aFactoryId;
-    }
+        super(aId, aProjectModel);
+        setOutputMarkupPlaceholderTag(true);
 
-    public String getSelectedTab()
-    {
-        return selectedTab;
-    }
-
-    public void setExpanded(boolean aExpanded)
-    {
-        expanded = aExpanded;
-    }
-
-    public boolean isExpanded()
-    {
-        return expanded;
+        add(new DefaultAnnotationSidebarStatePanel(CID_ANNOTATION_SIDEBAR, aProjectModel));
     }
 }

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/AnnotationPreferencesProjectSettingsPanelFactory.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/AnnotationPreferencesProjectSettingsPanelFactory.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.core.dashboard.settings.annotation;
+
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.model.IModel;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.ui.core.settings.ProjectSettingsPanelFactory;
+
+@Component
+@Order(AnnotationPreferencesProjectSettingsPanelFactory.ORDER)
+public class AnnotationPreferencesProjectSettingsPanelFactory
+    implements ProjectSettingsPanelFactory
+{
+    public static final int ORDER = 350;
+
+    @Override
+    public String getPath()
+    {
+        return "/annotation";
+    }
+
+    @Override
+    public String getLabel()
+    {
+        return "Annotation";
+    }
+
+    @Override
+    public Panel createSettingsPanel(String aID, IModel<Project> aProjectModel)
+    {
+        return new AnnotationPreferencesProjectSettingsPanel(aID, aProjectModel);
+    }
+}

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/DefaultAnnotationSidebarStatePanel.html
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/DefaultAnnotationSidebarStatePanel.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<!--
+  Licensed to the Technische Universität Darmstadt under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The Technische Universität Darmstadt 
+  licenses this file to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.
+   
+  http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<html xmlns:wicket="http://wicket.apache.org">
+<body>
+  <wicket:panel>
+    <form wicket:id="form" class="card">
+      <div class="card-header">
+        <wicket:message key="defaultAnnotationSidebarState"/>
+      </div>
+      <div class="card-body">
+        <div class="row form-row">
+          <label wicket:for="defaultTab" class="col-sm-4 col-form-label">
+            <wicket:label key="defaultTab" />
+          </label>
+          <div class="col-sm-8">
+            <select wicket:id="defaultTab" class="form-select" data-container="body"/>
+          </div>
+          <div class="offset-sm-4 col-sm-8 small text-muted">
+            <span wicket:id="description" />
+          </div>
+        </div>
+      </div>
+      <div class="card-footer text-end">
+        <button wicket:id="save" class="btn btn-primary">
+          <i class="fas fa-save"></i>&nbsp;
+          <wicket:message key="save"/>
+        </button>
+      </div>
+    </form>
+  </wicket:panel>
+</body>
+</html>

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/DefaultAnnotationSidebarStatePanel.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/DefaultAnnotationSidebarStatePanel.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.core.dashboard.settings.annotation;
+
+import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
+import static java.util.stream.Collectors.toList;
+
+import java.io.Serializable;
+import java.util.List;
+
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.form.ChoiceRenderer;
+import org.apache.wicket.markup.html.form.DropDownChoice;
+import org.apache.wicket.markup.html.form.Form;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.LoadableDetachableModel;
+import org.apache.wicket.model.Model;
+import org.apache.wicket.spring.injection.annot.SpringBean;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxButton;
+import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxFormComponentUpdatingBehavior;
+import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar.AnnotationSidebarFactory;
+import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar.AnnotationSidebarRegistry;
+import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar.AnnotationSidebarState;
+import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar.SidebarTabbedPanel;
+import de.tudarmstadt.ukp.inception.preferences.PreferencesService;
+
+public class DefaultAnnotationSidebarStatePanel
+    extends Panel
+{
+    private static final long serialVersionUID = -8186980821674705506L;
+
+    private @SpringBean AnnotationSidebarRegistry annotationSidebarRegistry;
+    private @SpringBean PreferencesService preferencesService;
+
+    private IModel<SidebarHandle> defaultTab;
+
+    public DefaultAnnotationSidebarStatePanel(String aId, IModel<Project> aProjectModel)
+    {
+        super(aId, aProjectModel);
+        setOutputMarkupPlaceholderTag(true);
+
+        defaultTab = Model.of();
+
+        Form<Void> form = new Form<>("form");
+
+        Label description = new Label("description", defaultTab.map(SidebarHandle::getDescription));
+        description.setOutputMarkupPlaceholderTag(true);
+        description.add(visibleWhen(defaultTab.isPresent()));
+        form.add(description);
+
+        DropDownChoice<SidebarHandle> defaultTabSelect = new DropDownChoice<>("defaultTab",
+                defaultTab, LoadableDetachableModel.of(this::listAvailableSidebars),
+                new ChoiceRenderer<>("displayName", "id"));
+        defaultTabSelect.setNullValid(true);
+        defaultTabSelect.add(new LambdaAjaxFormComponentUpdatingBehavior("change",
+                _target -> _target.add(description)));
+        form.add(defaultTabSelect);
+
+        form.add(new LambdaAjaxButton<>("save", this::actionSave));
+
+        add(form);
+
+        actionLoad();
+    }
+
+    @SuppressWarnings("unchecked")
+    public IModel<Project> getModel()
+    {
+        return (IModel<Project>) getDefaultModel();
+    }
+
+    private void actionLoad()
+    {
+        AnnotationSidebarState state = preferencesService.loadDefaultTraitsForProject(
+                SidebarTabbedPanel.KEY_SIDEBAR_STATE, getModel().getObject());
+
+        AnnotationSidebarFactory factory = annotationSidebarRegistry
+                .getSidebarFactory(state.getSelectedTab());
+
+        if (factory != null) {
+            defaultTab.setObject(new SidebarHandle(factory));
+        }
+        else {
+            defaultTab.setObject(null);
+        }
+    }
+
+    private void actionSave(AjaxRequestTarget aTarget, Form<Void> aDummy)
+    {
+        AnnotationSidebarState state = preferencesService.loadDefaultTraitsForProject(
+                SidebarTabbedPanel.KEY_SIDEBAR_STATE, getModel().getObject());
+
+        state.setSelectedTab(defaultTab.map(SidebarHandle::getId).orElse(null).getObject());
+        state.setExpanded(defaultTab.isPresent().getObject());
+
+        preferencesService.saveDefaultTraitsForProject(SidebarTabbedPanel.KEY_SIDEBAR_STATE,
+                getModel().getObject(), state);
+
+    }
+
+    private List<SidebarHandle> listAvailableSidebars()
+    {
+        return annotationSidebarRegistry.getSidebarFactories().stream() //
+                .map(SidebarHandle::new) //
+                .collect(toList());
+    }
+
+    private class SidebarHandle
+        implements Serializable
+    {
+        private static final long serialVersionUID = 5906057376121692416L;
+
+        private String id;
+        private String displayName;
+        private String description;
+
+        public SidebarHandle(AnnotationSidebarFactory aFactory)
+        {
+            id = aFactory.getBeanName();
+            displayName = aFactory.getDisplayName();
+            if (!aFactory.available(getModel().getObject())) {
+                displayName += " (not available)";
+            }
+            description = aFactory.getDescription();
+        }
+
+        public String getId()
+        {
+            return id;
+        }
+
+        @SuppressWarnings("unused")
+        public String getDisplayName()
+        {
+            return displayName;
+        }
+
+        public String getDescription()
+        {
+            return description;
+        }
+    }
+}

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/DefaultAnnotationSidebarStatePanel.properties
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/DefaultAnnotationSidebarStatePanel.properties
@@ -1,0 +1,19 @@
+# Licensed to the Technische Universität Darmstadt under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The Technische Universität Darmstadt 
+# licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.
+#  
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defaultTab=Default tab
+defaultTab.nullValid=None
+defaultAnnotationSidebarState=Annotation sidebar

--- a/inception/inception-ui-dashboard/src/main/resources/META-INF/asciidoc/user-guide/projects_annotation.adoc
+++ b/inception/inception-ui-dashboard/src/main/resources/META-INF/asciidoc/user-guide/projects_annotation.adoc
@@ -1,0 +1,16 @@
+[[sect_projects_annotation]]
+= Annotation 
+
+Here the project manager can configure settings that affect the experience on the annotation page.
+
+== Default sidebar
+
+Certain functionalities such as for example document-level annotations are accessible via a sidebar
+on the annotation page. A project manager may choose a default sidebar here which will be expanded
+by default when a new annotator opens a document for annotation. Note that this does not affect
+any annotators that are already working in the current project. Thus, the manager should set the
+default sidebar before adding annotators to the project. Not all pipelines are available to all
+users. If the selected default sidebar is not available to a user, this setting has no effect. A
+typical use for this setting is to set the document metadata sidebar as the default sidebar such
+that annotators can open a document and immediately edit the document-level annotations without 
+first having to search for the sidebar.

--- a/inception/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/sidebar/ExternalSearchAnnotationSidebarFactory.java
+++ b/inception/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/sidebar/ExternalSearchAnnotationSidebarFactory.java
@@ -24,6 +24,7 @@ import de.agilecoders.wicket.extensions.markup.html.bootstrap.icon.FontAwesome5I
 import de.tudarmstadt.ukp.clarin.webanno.api.CasProvider;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.action.AnnotationActionHandler;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.AnnotationPage;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar.AnnotationSidebarFactory_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar.AnnotationSidebar_ImplBase;
@@ -54,15 +55,28 @@ public class ExternalSearchAnnotationSidebarFactory
     }
 
     @Override
+    public String getDescription()
+    {
+        return "Allows searching document repositories and importing documents. Only available if "
+                + "there are document repositories defined in the project.";
+    }
+
+    @Override
     public IconType getIcon()
     {
         return FontAwesome5IconType.database_s;
     }
 
     @Override
+    public boolean available(Project aProject)
+    {
+        return externalSearchService.existsEnabledDocumentRepository(aProject);
+    }
+
+    @Override
     public boolean applies(AnnotatorState aState)
     {
-        return externalSearchService.existsEnabledDocumentRepository(aState.getProject());
+        return available(aState.getProject());
     }
 
     @Override

--- a/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchAnnotationSidebarFactory.java
+++ b/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchAnnotationSidebarFactory.java
@@ -45,6 +45,12 @@ public class SearchAnnotationSidebarFactory
     }
 
     @Override
+    public String getDescription()
+    {
+        return "Allows searching for text and annotations.";
+    }
+
+    @Override
     public IconType getIcon()
     {
         return FontAwesome5IconType.search_s;


### PR DESCRIPTION
**What's in the PR**
- Added a new project settings page for "Annotation" and there the project manager can configure a default sidebar
- Added a description to sidebar factories
- Added available(...) method allowing to check if a sidebar factory in general is available in the current project or not
- Added option to use a default preference which is used as the fallback for a user preference if the user does not have a preference yet

**How to test manually**
* Try setting a default sidebar. Note that one a user opens the annotation page, a sidebar preference is saved and this means the user won't fall back to the default preference. So either you need to try with a new user, a new project or you'd have to delete the user preference from the DB to test the fallback.

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [x] PR updates documentation
