### PR TITLE
#2650 - Multi-platform docker image

### DIFF
--- a/inception/inception-docker/README.md
+++ b/inception/inception-docker/README.md
@@ -28,12 +28,15 @@ For a release build:
         
     docker run -p8080:8080 -v inception-data:/export -it inceptionproject/inception
 
-## Cross-platform build for AMD64
+## Multi-platform build for ARM46 and AMD64
 
-If you are e.g. on a ARM machine and wish to create a cross-platform build targeting AMD64, use:
+To build a docker images which runs on AMD64 as well as ARM64 machines, use:
 
-    mvn -Pdocker-buildx-amd64 clean package
-    mvn -Pdocker docker:push   (only if the build should be published)
+    docker buildx create --use          (need to do this only once!)
+    mvn -Pdocker-buildx clean package   (will be pushed immediately!)
+
+Mind that you may have to log in to DockerHub before being able to publish. This can be done e.g.
+via Docker Desktop or on the command line via `docker login`.
 
 ## Options
 If you want to keep the application data easily accessible in a folder on your host (e.g. if you

--- a/inception/inception-docker/pom.xml
+++ b/inception/inception-docker/pom.xml
@@ -39,7 +39,7 @@
   </dependencies>
   <profiles>
     <profile>
-      <id>docker-buildx-amd64</id>
+      <id>docker-buildx</id>
       <properties>
         <!-- This property us referenced in the Dockerfile -->
         <docker.jarfile>inception-app-webapp-${project.version}-standalone.jar</docker.jarfile>
@@ -105,7 +105,7 @@
                 <configuration>
                   <workingDirectory>${project.build.directory}/buildx</workingDirectory>
                   <executable>docker</executable>
-                  <commandlineArgs>buildx build --platform=linux/amd64 -t ${docker.image.name}:latest -t ${docker.image.name}:${project.version} .</commandlineArgs>
+                  <commandlineArgs>buildx build --push --platform=linux/amd64,linux/arm64 -t ${docker.image.name}:latest -t ${docker.image.name}:${project.version} .</commandlineArgs>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
**What's in the PR**
- Change buildx profile such that a multi-platform image is built and immediately pushed to DockerHub (loading multi-platform images into `docker images` is not suppported by Docker)
- Update README for the multi-platform image

**How to test manually**
* See README

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
