### PR TITLE
#1778 - Make tokenization editable

### DIFF
--- a/inception/inception-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/initializers/SentenceLayerInitializer.java
+++ b/inception/inception-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/initializers/SentenceLayerInitializer.java
@@ -20,9 +20,9 @@ package de.tudarmstadt.ukp.clarin.webanno.project.initializers;
 import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.SPAN_TYPE;
 import static de.tudarmstadt.ukp.clarin.webanno.model.OverlapMode.NO_OVERLAP;
 import static de.tudarmstadt.ukp.clarin.webanno.model.ValidationMode.NEVER;
-import static java.util.Arrays.asList;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -56,9 +56,7 @@ public class SentenceLayerInitializer
     @Override
     public List<Class<? extends ProjectInitializer>> getDependencies()
     {
-        return asList(
-                // Because locks to token boundaries
-                TokenLayerInitializer.class);
+        return Collections.emptyList();
     }
 
     @Override
@@ -71,7 +69,7 @@ public class SentenceLayerInitializer
     public void configure(Project aProject) throws IOException
     {
         AnnotationLayer sentenceLayer = new AnnotationLayer(Sentence.class.getName(), "Sentence",
-                SPAN_TYPE, aProject, true, AnchoringMode.TOKENS, NO_OVERLAP);
+                SPAN_TYPE, aProject, true, AnchoringMode.CHARACTERS, NO_OVERLAP);
 
         // Since the user cannot turn off validation for the sentence layer if there is any kind of
         // problem with the validation functionality we are conservative here and disable validation

--- a/inception/inception-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/initializers/TokenLayerInitializer.java
+++ b/inception/inception-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/initializers/TokenLayerInitializer.java
@@ -21,9 +21,9 @@ import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.SPAN_TYPE;
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.CHARACTERS;
 import static de.tudarmstadt.ukp.clarin.webanno.model.OverlapMode.NO_OVERLAP;
 import static de.tudarmstadt.ukp.clarin.webanno.model.ValidationMode.NEVER;
+import static java.util.Arrays.asList;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -61,7 +61,9 @@ public class TokenLayerInitializer
     @Override
     public List<Class<? extends ProjectInitializer>> getDependencies()
     {
-        return Collections.emptyList();
+        return asList(
+                // Because tokens are not allowed to cross sentence boundaries
+                SentenceLayerInitializer.class);
     }
 
     @Override

--- a/inception/inception-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/initializers/config/ProjectInitializersAutoConfiguration.java
+++ b/inception/inception-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/initializers/config/ProjectInitializersAutoConfiguration.java
@@ -38,6 +38,7 @@ import de.tudarmstadt.ukp.clarin.webanno.project.initializers.OrthographyLayerIn
 import de.tudarmstadt.ukp.clarin.webanno.project.initializers.PartOfSpeechLayerInitializer;
 import de.tudarmstadt.ukp.clarin.webanno.project.initializers.PartOfSpeechTagSetInitializer;
 import de.tudarmstadt.ukp.clarin.webanno.project.initializers.SemPredArgLayerInitializer;
+import de.tudarmstadt.ukp.clarin.webanno.project.initializers.SentenceLayerInitializer;
 import de.tudarmstadt.ukp.clarin.webanno.project.initializers.SofaChangeOperationTagSetInitializer;
 import de.tudarmstadt.ukp.clarin.webanno.project.initializers.SurfaceFormLayerInitializer;
 import de.tudarmstadt.ukp.clarin.webanno.project.initializers.TokenLayerInitializer;
@@ -169,5 +170,11 @@ public class ProjectInitializersAutoConfiguration
     public TokenLayerInitializer tokenLayerInitializer(AnnotationSchemaService aSchemaService)
     {
         return new TokenLayerInitializer(aSchemaService);
+    }
+
+    @Bean
+    public SentenceLayerInitializer sentenceLayerInitializer(AnnotationSchemaService aSchemaService)
+    {
+        return new SentenceLayerInitializer(aSchemaService);
     }
 }


### PR DESCRIPTION
**What's in the PR**
- Sentences are currently expected to be the "first" unit - that is because we define that tokens respect sentence boundaries. Maybe that's going to change again, i.e. such that tokens do not respect sentence boundaries but sentences lock to token boundaries
- Add sentence initializer as a dependency to the token initializer
- Change the sentence anchoring mode to characters

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
