### PR TITLE
#2655 - Curated CASes are exported to the wrong spot

### DIFF
--- a/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/exporters/CuratedDocumentsExporter.java
+++ b/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/exporters/CuratedDocumentsExporter.java
@@ -128,7 +128,7 @@ public class CuratedDocumentsExporter
                     if (documentService.existsCas(sourceDocument, CURATION_USER)) {
                         // Copy CAS - this is used when importing the project again
                         try (OutputStream os = new FileOutputStream(
-                                new File(curationDir, CURATION_USER + ".ser"))) {
+                                new File(curationCasDir, CURATION_USER + ".ser"))) {
                             documentService.exportCas(sourceDocument, CURATION_USER, os);
                         }
 


### PR DESCRIPTION
**What's in the PR**
- Fix export spot in ZIP file

**How to test manually**
* Export a project with curated documents
* Check exported ZIP file
* Re-import and check that curations are still in place

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
