### PR TITLE
#2691 - Make confirm dialog when finishing documents configurable required

### DIFF
--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/annotation/DynamicAnnotatorWorkflowActionBarItemGroup.java
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/annotation/DynamicAnnotatorWorkflowActionBarItemGroup.java
@@ -21,6 +21,7 @@ package de.tudarmstadt.ukp.inception.workload.dynamic.annotation;
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState.FINISHED;
 import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.enabledWhen;
 
+import java.io.IOException;
 import java.util.Optional;
 
 import javax.persistence.EntityManager;
@@ -45,8 +46,10 @@ import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.clarin.webanno.support.dialog.ConfirmationDialog;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxLink;
 import de.tudarmstadt.ukp.inception.workload.dynamic.DynamicWorkloadExtension;
+import de.tudarmstadt.ukp.inception.workload.dynamic.trait.DynamicWorkloadTraits;
 import de.tudarmstadt.ukp.inception.workload.dynamic.workflow.WorkflowExtensionPoint;
 import de.tudarmstadt.ukp.inception.workload.model.WorkloadManagementService;
+import de.tudarmstadt.ukp.inception.workload.model.WorkloadManager;
 
 /**
  * This is only enabled for annotators of a project with the dynamic workload enabled. An annotator
@@ -63,7 +66,6 @@ public class DynamicAnnotatorWorkflowActionBarItemGroup
 
     protected ConfirmationDialog finishDocumentDialog;
 
-    private final AnnotatorState annotatorState;
     private final LambdaAjaxLink finishDocumentLink;
 
     // SpringBeans
@@ -74,15 +76,11 @@ public class DynamicAnnotatorWorkflowActionBarItemGroup
     private @SpringBean WorkloadManagementService workloadManagementService;
     private @SpringBean WorkflowExtensionPoint workflowExtensionPoint;
 
-    /**
-     * Constructor of the ActionBar
-     */
     public DynamicAnnotatorWorkflowActionBarItemGroup(String aId, AnnotationPageBase aPage)
     {
         super(aId);
 
         page = aPage;
-        annotatorState = aPage.getModelObject();
 
         add(finishDocumentDialog = new ConfirmationDialog("finishDocumentDialog",
                 new StringResourceModel("FinishDocumentDialog.title", this, null),
@@ -95,6 +93,11 @@ public class DynamicAnnotatorWorkflowActionBarItemGroup
         finishDocumentLink.add(enabledWhen(page::isEditable));
         finishDocumentLink.add(new Label("state")
                 .add(new CssClassNameModifier(LambdaModel.of(this::getStateClass))));
+    }
+
+    public AnnotatorState getModelObject()
+    {
+        return page.getModelObject();
     }
 
     protected AnnotationPageBase getAnnotationPage()
@@ -110,40 +113,51 @@ public class DynamicAnnotatorWorkflowActionBarItemGroup
     /**
      * This method represents the opening dialog upon clicking "Finish" for the current document.
      */
-    protected void actionFinishDocument(AjaxRequestTarget aTarget)
+    private void actionFinishDocument(AjaxRequestTarget aTarget) throws IOException
     {
-        finishDocumentDialog.setConfirmAction((_target) -> {
-            page.actionValidateDocument(_target, page.getEditorCas());
+        WorkloadManager manager = workloadManagementService
+                .loadOrCreateWorkloadManagerConfiguration(getModelObject().getProject());
+        DynamicWorkloadTraits traits = dynamicWorkloadExtension.readTraits(manager);
 
-            // Needed often, therefore assigned in the beginning of the method
-            User user = annotatorState.getUser();
-            Project project = annotatorState.getProject();
-            SourceDocument document = annotatorState.getDocument();
-
-            // On finishing, the current AnnotationDocument is put to the new state FINISHED
-            AnnotationDocument annotationDocument = documentService.getAnnotationDocument(document,
-                    user);
-            documentService.setAnnotationDocumentState(annotationDocument, FINISHED);
-
-            _target.add(page);
-
-            // Assign a new document with actionLoadDocument
-            Optional<SourceDocument> nextDocument = dynamicWorkloadExtension
-                    .nextDocumentToAnnotate(project, user);
-            if (nextDocument.isPresent()) {
-                // This was the case, so load the document and return
-                page.getModelObject().setDocument(nextDocument.get(),
-                        documentService.listSourceDocuments(nextDocument.get().getProject()));
-                page.actionLoadDocument(_target);
-            }
-            else {
-                // Nothing left, so returning to homepage and showing hint
-                page.getSession()
-                        .info("There are no more documents to annotate available for you.");
-                page.setResponsePage(getAnnotationPage().getApplication().getHomePage());
-            }
-        });
+        if (traits.isConfirmFinishingDocuments()) {
+            finishDocumentDialog
+                    .setConfirmAction(_target -> this.actionFinishDocumentConfirmed(_target));
+        }
+        else {
+            this.actionFinishDocumentConfirmed(aTarget);
+        }
 
         finishDocumentDialog.show(aTarget);
+    }
+
+    private void actionFinishDocumentConfirmed(AjaxRequestTarget aTarget) throws IOException
+    {
+        page.actionValidateDocument(aTarget, page.getEditorCas());
+
+        AnnotatorState state = getModelObject();
+        User user = state.getUser();
+        Project project = state.getProject();
+
+        // On finishing, the current AnnotationDocument is put to the new state FINISHED
+        AnnotationDocument annotationDocument = documentService
+                .getAnnotationDocument(state.getDocument(), user);
+        documentService.setAnnotationDocumentState(annotationDocument, FINISHED);
+
+        aTarget.add(page);
+
+        Optional<SourceDocument> nextDocument = dynamicWorkloadExtension
+                .nextDocumentToAnnotate(project, user);
+
+        if (!nextDocument.isPresent()) {
+            // Nothing left, so returning to homepage and showing hint
+            page.getSession().info("There are no more documents to annotate available for you.");
+            page.setResponsePage(getAnnotationPage().getApplication().getHomePage());
+            return;
+        }
+
+        // Assign a new document with actionLoadDocument
+        page.getModelObject().setDocument(nextDocument.get(),
+                documentService.listSourceDocuments(nextDocument.get().getProject()));
+        page.actionLoadDocument(aTarget);
     }
 }

--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/management/DynamicWorkloadManagementPage.html
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/management/DynamicWorkloadManagementPage.html
@@ -213,6 +213,16 @@
                     </div>
                     <div class="row form-row">
                       <label class="col-form-label col-sm-7">
+                        <wicket:message key="confirmFinishingDocuments" />
+                      </label>
+                      <div class="col-sm-5">
+                        <div class="form-check">
+                          <input class="form-check-input" type="checkbox" wicket:id="confirmFinishingDocuments">
+                        </div>
+                      </div>
+                    </div>
+                    <div class="row form-row">
+                      <label class="col-form-label col-sm-7">
                         <wicket:message key="workflow" />
                         <a wicket:id="workflowHelpLink"/>
                       </label>

--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/management/DynamicWorkloadManagementPage.java
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/management/DynamicWorkloadManagementPage.java
@@ -434,6 +434,8 @@ public class DynamicWorkloadManagementPage
 
         settingsForm.add(new DocLink("workflowHelpLink", "sect_dynamic_workload"));
 
+        settingsForm.add(new CheckBox("confirmFinishingDocuments"));
+
         settingsForm.add(new NumberTextField<>("defaultNumberOfAnnotations", Integer.class) //
                 .setMinimum(1) //
                 .setConvertEmptyInputStringToNull(false) //

--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/management/DynamicWorkloadManagementPage.properties
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/management/DynamicWorkloadManagementPage.properties
@@ -69,6 +69,7 @@ resetDocument=Change document status
 assignDocument=Assign document(s)
 unassignDocument=Delete a document
 stateFilter=Document state
+confirmFinishingDocuments=Confirm finishing documents
 
 assignDocument.null=Please select a document
 unassignDocument.null=Please select a document

--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/trait/DynamicWorkloadTraits.java
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/trait/DynamicWorkloadTraits.java
@@ -35,6 +35,7 @@ public class DynamicWorkloadTraits
 
     private String workflowType;
     private int defaultNumberOfAnnotations;
+    private boolean confirmFinishingDocuments = true;
 
     private Duration abandonationTimeout;
     private AnnotationDocumentState abandonationState = IGNORE;
@@ -97,5 +98,15 @@ public class DynamicWorkloadTraits
     public void setAbandonationState(AnnotationDocumentState aAbandonationState)
     {
         abandonationState = aAbandonationState;
+    }
+
+    public boolean isConfirmFinishingDocuments()
+    {
+        return confirmFinishingDocuments;
+    }
+
+    public void setConfirmFinishingDocuments(boolean aConfirmFinishingDocuments)
+    {
+        confirmFinishingDocuments = aConfirmFinishingDocuments;
     }
 }


### PR DESCRIPTION
**What's in the PR**
- Added option to disable the confirmation dialog when finishing a document in dynamic mode

**How to test manually**
* Enable dynamic workload
* Go to the workload management page
* Turn off the confirmation dialog in the settings on that page and save
* Visit the annotation page as an annotation user (curation users get the default workflow management action bar, not the dynamic one which doesn't consider the new setting)

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
