### PR TITLE
#2714 - Make "any" the default setting for "allowed values"

### DIFF
--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/ConceptFeatureTraits.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/ConceptFeatureTraits.java
@@ -64,7 +64,7 @@ public class ConceptFeatureTraits
 
     public ConceptFeatureValueType getAllowedValueType()
     {
-        return allowedValueType != null ? allowedValueType : ConceptFeatureValueType.INSTANCE;
+        return allowedValueType != null ? allowedValueType : ConceptFeatureValueType.ANY_OBJECT;
     }
 
     public void setAllowedValueType(ConceptFeatureValueType aAllowedType)


### PR DESCRIPTION
**What's in the PR**
- Changed default object type for concept features from "instance" to "any"

**How to test manually**
* Create a new project
* Check if the "identifier" feature on the named entity layer has "any" as the setting for the permitted object types

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
