### PR TITLE
#2683 - Improve query performance for long mentions

### DIFF
--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
@@ -886,8 +886,10 @@ public class SPARQLQueryBuilder
     @Override
     public SPARQLQueryBuilder withLabelMatchingAnyOf(String... aValues)
     {
-        String[] values = Arrays.stream(aValues).map(SPARQLQueryBuilder::trimQueryString)
-                .filter(StringUtils::isNotBlank).toArray(String[]::new);
+        String[] values = Arrays.stream(aValues) //
+                .map(SPARQLQueryBuilder::trimQueryString) //
+                .filter(StringUtils::isNotBlank) //
+                .toArray(String[]::new);
 
         if (values.length == 0) {
             returnEmptyResult = true;
@@ -2045,14 +2047,16 @@ public class SPARQLQueryBuilder
     public static String convertToFuzzyMatchingQuery(String aQuery)
     {
         StringJoiner joiner = new StringJoiner(" ");
-        for (String term : aQuery.split(" ")) {
-            if (term.length() > 4) {
+        String[] terms = aQuery.split("\\s");
+        for (String term : terms) {
+            // We only do the fuzzy search if there are few terms because if there are many terms,
+            // the search becomes too slow if we do a fuzzy match for each of them.
+            if (term.length() > 4 && terms.length <= 3) {
                 joiner.add(term + "~");
             }
             // REC: excluding terms of 3 or less characters helps reducing the problem that a
             // mention of "Counties of Catherlagh" matches "Anne of Austria", but actually
-            // this should be handled by stopwords and not be excluding any short words...
-            // I think
+            // I think this should be handled by stopwords and not be excluding any short words...
             else if (term.length() >= 3) {
                 joiner.add(term);
             }


### PR DESCRIPTION
**What's in the PR**
- Do not use fuzzy searches for very long queries because that makes things waaaay to slow
- If there was an exact IRI match, do not bother trying to search by label
- Break candidate generation up into smaller methods it is easier to see in the profiler which part takes longest

**How to test manually**
* Use a reasonably-sized KB local, annotate a long mention and try to link it against a concept either by label search or by IRI

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
