### PR TITLE
#2697 - Curation Overview list reset

### DIFF
--- a/inception/inception-workload-dynamic/pom.xml
+++ b/inception/inception-workload-dynamic/pom.xml
@@ -216,7 +216,6 @@
       <artifactId>dkpro-core-api-ner-asl</artifactId>
       <scope>test</scope>
     </dependency>
-    
   </dependencies>
   
   <build>

--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/DynamicWorkloadExtensionImpl.java
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/DynamicWorkloadExtensionImpl.java
@@ -308,6 +308,12 @@ public class DynamicWorkloadExtensionImpl
     @Transactional
     public void updateDocumentState(SourceDocument aDocument, int aRequiredAnnotatorCount)
     {
+        // If the SOURCE document is already in curation, we do not touch the state anymore
+        if (aDocument.getState() == CURATION_FINISHED
+                || aDocument.getState() == CURATION_IN_PROGRESS) {
+            return;
+        }
+
         Map<AnnotationDocumentState, Long> stats = documentService
                 .getAnnotationDocumentStats(aDocument);
         long finishedCount = stats.get(AnnotationDocumentState.FINISHED);

--- a/inception/inception-workload-dynamic/src/test/java/de/tudarmstadt/ukp/inception/workload/dynamic/DynamicWorkloadExtensionImplTest.java
+++ b/inception/inception-workload-dynamic/src/test/java/de/tudarmstadt/ukp/inception/workload/dynamic/DynamicWorkloadExtensionImplTest.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package de.tudarmstadt.ukp.inception.workload.dynamic.workflow.types;
+package de.tudarmstadt.ukp.inception.workload.dynamic;
 
 import static java.lang.Thread.sleep;
 import static java.time.temporal.ChronoUnit.SECONDS;
@@ -67,10 +67,9 @@ import de.tudarmstadt.ukp.clarin.webanno.text.TextFormatSupport;
 import de.tudarmstadt.ukp.clarin.webanno.text.config.TextFormatsAutoConfiguration;
 import de.tudarmstadt.ukp.inception.scheduling.config.SchedulingServiceAutoConfiguration;
 import de.tudarmstadt.ukp.inception.workload.config.WorkloadManagementAutoConfiguration;
-import de.tudarmstadt.ukp.inception.workload.dynamic.DynamicWorkloadExtension;
-import de.tudarmstadt.ukp.inception.workload.dynamic.Fixtures;
 import de.tudarmstadt.ukp.inception.workload.dynamic.config.DynamicWorkloadManagerAutoConfiguration;
 import de.tudarmstadt.ukp.inception.workload.dynamic.trait.DynamicWorkloadTraits;
+import de.tudarmstadt.ukp.inception.workload.dynamic.workflow.types.DefaultWorkflowExtension;
 import de.tudarmstadt.ukp.inception.workload.model.WorkloadManagementService;
 import de.tudarmstadt.ukp.inception.workload.model.WorkloadManager;
 

--- a/inception/inception-workload-matrix/pom.xml
+++ b/inception/inception-workload-matrix/pom.xml
@@ -135,5 +135,67 @@
       <groupId>org.danekja</groupId>
       <artifactId>jdk-serializable-functional</artifactId>
     </dependency>
+    
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-project</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-api-dao</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-io-text</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-test-autoconfigure</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.dkpro.core</groupId>
+      <artifactId>dkpro-core-api-ner-asl</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
-</project>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <configuration>
+            <ignoredDependencies>
+              <!--
+               - Test dependencies used via auto-configuration and reflection
+               -->
+              <ignoredDependency>org.springframework.boot:spring-boot-test</ignoredDependency>
+              <ignoredDependency>org.springframework.boot:spring-boot-starter-data-jpa</ignoredDependency>
+              <ignoredDependency>com.h2database:h2</ignoredDependency>
+            </ignoredDependencies>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build></project>

--- a/inception/inception-workload-matrix/pom.xml
+++ b/inception/inception-workload-matrix/pom.xml
@@ -32,6 +32,10 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-api-annotation</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-model</artifactId>
     </dependency>
     <dependency>
@@ -60,8 +64,21 @@
     </dependency>
     
     <dependency>
+      <groupId>org.apache.uima</groupId>
+      <artifactId>uimaj-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.uima</groupId>
+      <artifactId>uimafit-core</artifactId>
+    </dependency>
+    
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
     </dependency>
 
     <dependency>
@@ -92,7 +109,15 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-core</artifactId>
     </dependency>
 
     <dependency>

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/MatrixWorkloadExtension.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/MatrixWorkloadExtension.java
@@ -21,10 +21,10 @@ import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.ProjectState;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.workload.extension.WorkloadManagerExtension;
-import de.tudarmstadt.ukp.inception.workload.matrix.trait.MatrixWorkloadTrait;
+import de.tudarmstadt.ukp.inception.workload.matrix.trait.MatrixWorkloadTraits;
 
 public interface MatrixWorkloadExtension
-    extends WorkloadManagerExtension<MatrixWorkloadTrait>
+    extends WorkloadManagerExtension<MatrixWorkloadTraits>
 {
     static final String MATRIX_WORKLOAD_MANAGER_EXTENSION_ID = "matrix";
 

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/trait/MatrixWorkloadTraits.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/trait/MatrixWorkloadTraits.java
@@ -22,7 +22,7 @@ import java.io.Serializable;
 /**
  * Trait class for default matrix workload
  */
-public class MatrixWorkloadTrait
+public class MatrixWorkloadTraits
     implements Serializable
 {
     private static final long serialVersionUID = 6984531953353384507L;
@@ -30,7 +30,7 @@ public class MatrixWorkloadTrait
 
     private int defaultNumberOfAnnotations;
 
-    public MatrixWorkloadTrait()
+    public MatrixWorkloadTraits()
     {
     }
 

--- a/inception/inception-workload-matrix/src/test/java/de/tudarmstadt/ukp/inception/workload/matrix/Fixtures.java
+++ b/inception/inception-workload-matrix/src/test/java/de/tudarmstadt/ukp/inception/workload/matrix/Fixtures.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.workload.matrix;
+
+import static de.tudarmstadt.ukp.clarin.webanno.support.uima.FeatureStructureBuilder.buildFS;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.commons.io.IOUtils.toInputStream;
+
+import org.apache.uima.cas.CAS;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
+import de.tudarmstadt.ukp.clarin.webanno.api.dao.casstorage.CasStorageSession;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
+import de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity;
+
+public class Fixtures
+{
+    public static void importTestSourceDocumentAndAddNamedEntity(DocumentService documentService,
+            AnnotationDocument annotationDocument)
+        throws Exception
+    {
+        try (var session = CasStorageSession.open()) {
+            documentService.uploadSourceDocument(toInputStream("This is a test.", UTF_8),
+                    annotationDocument.getDocument());
+            CAS cas = documentService.readAnnotationCas(annotationDocument);
+            buildFS(cas, NamedEntity.class.getName()) //
+                    .withFeature("value", "test") //
+                    .buildAndAddToIndexes();
+            documentService.writeAnnotationCas(cas, annotationDocument, true);
+        }
+    }
+}

--- a/inception/inception-workload-matrix/src/test/java/de/tudarmstadt/ukp/inception/workload/matrix/MatrixWorkloadExtensionImplTest.java
+++ b/inception/inception-workload-matrix/src/test/java/de/tudarmstadt/ukp/inception/workload/matrix/MatrixWorkloadExtensionImplTest.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.workload.matrix;
+
+import static org.apache.uima.fit.factory.TypeSystemDescriptionFactory.createTypeSystemDescription;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+
+import org.apache.uima.util.CasCreationUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.session.SessionRegistry;
+import org.springframework.util.FileSystemUtils;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
+import de.tudarmstadt.ukp.clarin.webanno.api.DocumentImportExportService;
+import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
+import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
+import de.tudarmstadt.ukp.clarin.webanno.api.config.RepositoryAutoConfiguration;
+import de.tudarmstadt.ukp.clarin.webanno.api.dao.annotationservice.config.AnnotationSchemaServiceAutoConfiguration;
+import de.tudarmstadt.ukp.clarin.webanno.api.dao.casstorage.config.CasStorageServiceAutoConfiguration;
+import de.tudarmstadt.ukp.clarin.webanno.api.dao.documentservice.config.DocumentServiceAutoConfiguration;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState;
+import de.tudarmstadt.ukp.clarin.webanno.project.config.ProjectServiceAutoConfiguration;
+import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
+import de.tudarmstadt.ukp.clarin.webanno.security.config.SecurityAutoConfiguration;
+import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
+import de.tudarmstadt.ukp.clarin.webanno.text.TextFormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.text.config.TextFormatsAutoConfiguration;
+import de.tudarmstadt.ukp.inception.scheduling.config.SchedulingServiceAutoConfiguration;
+import de.tudarmstadt.ukp.inception.workload.config.WorkloadManagementAutoConfiguration;
+import de.tudarmstadt.ukp.inception.workload.matrix.config.MatrixWorkloadManagerAutoConfiguration;
+import de.tudarmstadt.ukp.inception.workload.matrix.trait.MatrixWorkloadTraits;
+import de.tudarmstadt.ukp.inception.workload.model.WorkloadManagementService;
+import de.tudarmstadt.ukp.inception.workload.model.WorkloadManager;
+
+@EnableAutoConfiguration
+@DataJpaTest(excludeAutoConfiguration = LiquibaseAutoConfiguration.class, showSql = false, //
+        properties = { //
+                "spring.main.banner-mode=off", //
+                "workload.dynamic.enabled=true", //
+                "repository.path=" + MatrixWorkloadExtensionImplTest.TEST_OUTPUT_FOLDER })
+@EntityScan({ //
+        "de.tudarmstadt.ukp.inception", //
+        "de.tudarmstadt.ukp.clarin.webanno" })
+@Import({ //
+        TextFormatsAutoConfiguration.class, //
+        DocumentServiceAutoConfiguration.class, //
+        ProjectServiceAutoConfiguration.class, //
+        CasStorageServiceAutoConfiguration.class, //
+        RepositoryAutoConfiguration.class, //
+        AnnotationSchemaServiceAutoConfiguration.class, //
+        SecurityAutoConfiguration.class, //
+        SchedulingServiceAutoConfiguration.class, //
+        WorkloadManagementAutoConfiguration.class, //
+        MatrixWorkloadManagerAutoConfiguration.class })
+public class MatrixWorkloadExtensionImplTest
+{
+    static final String TEST_OUTPUT_FOLDER = "target/test-output/MatrixWorkloadExtensionImplTest";
+
+    private @Autowired ProjectService projectService;
+    private @Autowired DocumentService documentService;
+    private @Autowired UserDao userService;
+    private @Autowired WorkloadManagementService workloadManagementService;
+    private @Autowired MatrixWorkloadExtension matrixWorkloadExtension;
+    private @Autowired SessionRegistry sessionRegistry;
+
+    private User annotator;
+    private Project project;
+    private SourceDocument sourceDocument;
+    private AnnotationDocument annotationDocument;
+    private MatrixWorkloadTraits traits;
+
+    @BeforeAll
+    public static void setupClass()
+    {
+        FileSystemUtils.deleteRecursively(new File(TEST_OUTPUT_FOLDER));
+    }
+
+    @BeforeEach
+    public void setup() throws Exception
+    {
+        annotator = userService.create(new User("anno1"));
+        project = projectService.createProject(new Project("test"));
+
+        sourceDocument = documentService
+                .createSourceDocument(new SourceDocument("doc.txt", project, TextFormatSupport.ID));
+        annotationDocument = documentService.createAnnotationDocument(
+                new AnnotationDocument(annotator.getUsername(), sourceDocument));
+
+        Fixtures.importTestSourceDocumentAndAddNamedEntity(documentService, annotationDocument);
+
+        WorkloadManager workloadManager = workloadManagementService
+                .loadOrCreateWorkloadManagerConfiguration(project);
+        workloadManager.setType(MatrixWorkloadExtension.MATRIX_WORKLOAD_MANAGER_EXTENSION_ID);
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception
+    {
+        projectService.removeProject(project);
+    }
+
+    @Test
+    public void thatRecalculatingStateDoesNotFallBacKBehindCuration() throws Exception
+    {
+        documentService.setSourceDocumentState(sourceDocument,
+                SourceDocumentState.CURATION_IN_PROGRESS);
+
+        matrixWorkloadExtension.recalculate(project);
+
+        sourceDocument = documentService.getSourceDocument(project.getId(), sourceDocument.getId());
+
+        assertThat(sourceDocument.getState()).isEqualTo(SourceDocumentState.CURATION_IN_PROGRESS);
+    }
+
+    @SpringBootConfiguration
+    public static class TestContext
+    {
+        @Bean
+        DocumentImportExportService documentImportExportService(
+                AnnotationSchemaService aSchemaService)
+            throws Exception
+        {
+            var tsd = createTypeSystemDescription();
+            var importService = mock(DocumentImportExportService.class);
+            when(importService.importCasFromFile(any(), any(), any(), any()))
+                    .thenReturn(CasCreationUtils.createCas(tsd, null, null, null));
+            return importService;
+        }
+    }
+}


### PR DESCRIPTION
**What's in the PR**
- Added condition to not change document state that is already in curation or with curation finished
- Added a test checking that

**How to test manually**
1) Created a new project
2) Imported a document into the project
3) Added a few annotations to the project as the admin user
4) Marked the document as "finished"
5) Opened the document for curation as the admin user
6) Removed one of the pre-merged annotations from the curation view (to see if manual curation actions are preseved)
7) Marked the curation document as finished
8) Added a new annotation user to the project
9) Check that state is still "curation finished"

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
