### PR TITLE
#2671 - Make tagsets order aware

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/AnnotationSchemaService.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/AnnotationSchemaService.java
@@ -74,6 +74,8 @@ public interface AnnotationSchemaService
     @PreAuthorize("hasAnyRole('ROLE_ADMIN','ROLE_USER')")
     void createTags(Tag... tag);
 
+    void updateTagRanks(TagSet aTagSet, List<Tag> aTags);
+
     /**
      * creates a {@link TagSet} object in the database
      *

--- a/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/exporters/TagSetExporter.java
+++ b/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/exporters/TagSetExporter.java
@@ -185,9 +185,10 @@ public class TagSetExporter
             }
 
             Tag tag = new Tag();
-            tag.setDescription(exTag.getDescription());
             tag.setTagSet(aTagSet);
             tag.setName(exTag.getName());
+            tag.setDescription(exTag.getDescription());
+            tag.setRank(tags.size());
             tags.add(tag);
         }
 

--- a/inception/inception-model-export/src/main/java/de/tudarmstadt/ukp/clarin/webanno/export/model/ExportedTag.java
+++ b/inception/inception-model-export/src/main/java/de/tudarmstadt/ukp/clarin/webanno/export/model/ExportedTag.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
  * Gets only tag name and tag description to be exported. No need to get the tag ID and other
  * details from the persistent entity
  */
-@JsonPropertyOrder(value = { "tag_name", "tag_description" })
+@JsonPropertyOrder(value = { "tag_name", "tag_description", "rank" })
 public class ExportedTag
 {
     @JsonProperty("tag_name")

--- a/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/Tag.java
+++ b/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/Tag.java
@@ -54,6 +54,9 @@ public class Tag
     @JoinColumn(name = "tagset")
     private TagSet tagSet;
 
+    @Column(nullable = false)
+    private int rank;
+
     public Tag()
     {
         // Nothing to do
@@ -109,6 +112,16 @@ public class Tag
     public void setTagSet(TagSet aTagSet)
     {
         tagSet = aTagSet;
+    }
+
+    public int getRank()
+    {
+        return rank;
+    }
+
+    public void setRank(int aRank)
+    {
+        rank = aRank;
     }
 
     @Override

--- a/inception/inception-model/src/main/resources/de/tudarmstadt/ukp/clarin/webanno/model/db-changelog.xml
+++ b/inception/inception-model/src/main/resources/de/tudarmstadt/ukp/clarin/webanno/model/db-changelog.xml
@@ -1326,4 +1326,17 @@
       tableName="project"
       constraintName="UK3k75vvu7mevyvvb5may5lj8k7" />
   </changeSet>  
+
+  <changeSet author="INCEpTION Team" id="20211212-1">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="tag" columnName="rank"/>
+      </not>
+    </preConditions>
+    <addColumn tableName="tag">
+      <column name="rank" type="INT" defaultValueNumeric="0">
+        <constraints nullable="false"/>
+      </column>
+    </addColumn>
+  </changeSet>
 </databaseChangeLog>

--- a/inception/inception-project-initializers/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/initializers/JsonImportUtil.java
+++ b/inception/inception-project-initializers/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/initializers/JsonImportUtil.java
@@ -72,13 +72,17 @@ public class JsonImportUtil
         tagsetInUse.setLanguage(importedTagSet.getLanguage());
         tagsetInUse.setProject(project);
         aAnnotationService.createTagSet(tagsetInUse);
+        
         // Add all tags from imported tagset
+        int rank = 0;
         for (ExportedTag tag : importedTagSet.getTags()) {
             Tag newTag = new Tag();
             newTag.setDescription(tag.getDescription());
             newTag.setName(tag.getName());
+            newTag.setRank(rank);
             newTag.setTagSet(tagsetInUse);
             aAnnotationService.createTag(newTag);
+            rank++;
         }
 
         return tagsetInUse;
@@ -118,6 +122,7 @@ public class JsonImportUtil
             tag.setDescription(exTag.getDescription());
             tag.setTagSet(newTagSet);
             tag.setName(exTag.getName());
+            tag.setRank(tags.size());
             tags.add(tag);
         }
 

--- a/inception/inception-ui-tagsets/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/tagsets/ProjectTagSetsPanel.html
+++ b/inception/inception-ui-tagsets/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/tagsets/ProjectTagSetsPanel.html
@@ -27,7 +27,7 @@
         <div wicket:id="tagSetEditor" class="flex-v-container flex-no-gutter"></div>
         
         <div class="flex-content flex-h-container flex-gutter">
-          <div wicket:id="tagSelector" class="flex-h-container flex-no-gutter" style="flex: .3;"></div>
+          <div wicket:id="tagSelector" class="flex-h-container flex-no-gutter" style="flex: .4;"></div>
           <div wicket:id="tagEditor" class="flex-content flex-h-container flex-no-gutter"></div>
         </div>
       </div>

--- a/inception/inception-ui-tagsets/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/tagsets/ProjectTagSetsPanel.properties
+++ b/inception/inception-ui-tagsets/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/tagsets/ProjectTagSetsPanel.properties
@@ -27,3 +27,6 @@ tagDetailForm.save.label=Save tag
 tagDetailForm.cancel.label=Cancel
 
 tagSelectionForm.new.label=Create tag
+
+moveUp=Up
+moveDown=Down

--- a/inception/inception-ui-tagsets/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/tagsets/TagSelectionPanel.html
+++ b/inception/inception-ui-tagsets/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/tagsets/TagSelectionPanel.html
@@ -23,7 +23,13 @@
       <div class="card-header">
         <wicket:message key="tags" />
         <div class="actions">
-          <button wicket:id="create" class="btn btn-primary">
+          <button wicket:id="moveUp" class="btn btn-secondary" type="button" wicket:message="title:moveUp">
+            <i class="fas fa-arrow-up"></i>
+          </button>
+          <button wicket:id="moveDown" class="btn btn-secondary" type="button" wicket:message="title:moveDown">
+            <i class="fas fa-arrow-down"></i>
+          </button>
+          <button wicket:id="create" class="btn btn-primary" type="button">
             <i class="fas fa-plus-square"></i>&nbsp;
             <wicket:message key="create"/>
           </button>

--- a/inception/inception-ui-tagsets/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/tagsets/TagSetEditorPanel.java
+++ b/inception/inception-ui-tagsets/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/tagsets/TagSetEditorPanel.java
@@ -208,7 +208,6 @@ public class TagSetEditorPanel
                     exportedTag.setDescription(tag.getDescription());
                     exportedTag.setName(tag.getName());
                     exportedTags.add(exportedTag);
-
                 }
                 exTagSet.setTags(exportedTags);
 

--- a/inception/inception-ui-tagsets/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/tagsets/TagSetImportPanel.java
+++ b/inception/inception-ui-tagsets/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/tagsets/TagSetImportPanel.java
@@ -184,8 +184,9 @@ public class TagSetImportPanel
                         // to the tagset
                         else {
                             Tag tag = new Tag();
-                            tag.setDescription(tabbedTagsetFromFile.get(key).replace("\\n", "\n"));
                             tag.setName(key);
+                            tag.setDescription(tabbedTagsetFromFile.get(key).replace("\\n", "\n"));
+                            tag.setRank(i);
                             tag.setTagSet(tagSet);
                             annotationService.createTag(tag);
                         }


### PR DESCRIPTION
**What's in the PR**
- Added new column "rank" to the tags
- Added new call to re-order tags in the annotation schema service without genrating tons of "tag updated" events
- Added buttons to move tags up and down to the tag selection panel
- Set rank on tags while importing tagsets

**How to test manually**
* Re-order tags in the tagset editor
* See if re-ordering and making changes in the tag detail editor are independent
* Check if the tags appear in the right order on the annotation page

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
