### PR TITLE
#2747 - Depends_on in docker compose 3 not supported

### DIFF
--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/scripts/docker-compose-mysql5.yml
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/scripts/docker-compose-mysql5.yml
@@ -2,7 +2,7 @@
 # docker-compose up [-d]
 # docker-compose down
 ##
-version: '3.5'
+version: '2.4'
 
 networks:
   inception-net:

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/scripts/docker-compose.yml
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/scripts/docker-compose.yml
@@ -2,7 +2,7 @@
 # docker-compose up [-d]
 # docker-compose down
 ##
-version: '3.5'
+version: '2.4'
 
 networks:
   inception-net:


### PR DESCRIPTION
**What's in the PR**
- Set version back to 2.4

**How to test manually**
* Try running the compose script

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
