### PR TITLE
#2750 - Upgrade dependencies

### DIFF
--- a/inception/inception-app-webapp/pom.xml
+++ b/inception/inception-app-webapp/pom.xml
@@ -40,6 +40,10 @@
   
     <!-- INCEPTION - CORE DEPENDENCIES -->
     <dependency>
+      <groupId>org.dkpro.core</groupId>
+      <artifactId>dkpro-core-api-resources-asl</artifactId>
+    </dependency>
+    <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-ui-core</artifactId>
     </dependency>

--- a/inception/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/INCEpTION.java
+++ b/inception/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/INCEpTION.java
@@ -31,6 +31,7 @@ import javax.validation.Validator;
 import org.apache.catalina.Context;
 import org.apache.catalina.connector.Connector;
 import org.apache.catalina.webresources.StandardRoot;
+import org.dkpro.core.api.resources.ResourceObjectProviderBase;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -168,8 +169,11 @@ public class INCEpTION
 
     private static void init(SpringApplicationBuilder aBuilder)
     {
-        // WebAnno relies on FS IDs being stable, so we need to enable this
+        // We rely on FS IDs being stable, so we need to enable this
         System.setProperty(ALWAYS_HOLD_ONTO_FSS, "true");
+
+        // We do not want DKPro Core to try and auto-download anything
+        System.setProperty(ResourceObjectProviderBase.PROP_REPO_OFFLINE, "true");
 
         aBuilder.banner(new InceptionBanner());
         aBuilder.initializers(new InceptionApplicationContextInitializer());

--- a/inception/inception-brat-editor/.gitignore
+++ b/inception/inception-brat-editor/.gitignore
@@ -1,0 +1,3 @@
+src/main/ts/node_modules
+src/main/ts/package.json
+src/main/ts/package-lock.json

--- a/inception/inception-html-recogito-editor/.gitignore
+++ b/inception/inception-html-recogito-editor/.gitignore
@@ -1,0 +1,3 @@
+src/main/ts/node_modules
+src/main/ts/package.json
+src/main/ts/package-lock.json

--- a/inception/inception-image/pom.xml
+++ b/inception/inception-image/pom.xml
@@ -116,19 +116,10 @@
     <dependency>
       <groupId>org.webjars.npm</groupId>
       <artifactId>color-thief</artifactId>
-      <version>2.2.1</version>
-      <exclusions>
-        <!-- The versions of canvas referenced by color-thief are not available on Maven Central -->
-        <exclusion>
-          <groupId>org.webjars.npm</groupId>
-          <artifactId>canvas</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.webjars.npm</groupId>
       <artifactId>canvas</artifactId>
-      <version>1.4.0</version>
     </dependency>
   </dependencies>
   <build>

--- a/inception/inception-ui-dashboard/pom.xml
+++ b/inception/inception-ui-dashboard/pom.xml
@@ -137,7 +137,6 @@
     <dependency>
       <groupId>org.webjars.npm</groupId>
       <artifactId>axios</artifactId>
-      <version>0.21.1</version>
     </dependency>
 
     <dependency>
@@ -171,10 +170,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-extensions</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.wicketstuff</groupId>
-      <artifactId>wicket-datetime</artifactId>
     </dependency>
     <dependency>
       <groupId>org.wicketstuff</groupId>

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/projectlist/ProjectsOverviewPage.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/projectlist/ProjectsOverviewPage.java
@@ -35,6 +35,8 @@ import static org.apache.wicket.authroles.authorization.strategies.role.metadata
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -65,7 +67,6 @@ import org.apache.wicket.util.lang.Classes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wicketstuff.annotation.mount.MountPath;
-import org.wicketstuff.datetime.markup.html.basic.DateLabel;
 import org.wicketstuff.event.annotation.OnEvent;
 
 import com.github.rjeschke.txtmark.Processor;
@@ -114,6 +115,8 @@ public class ProjectsOverviewPage
     private static final long serialVersionUID = -2159246322262294746L;
 
     private static final Logger LOG = LoggerFactory.getLogger(ProjectsOverviewPage.class);
+
+    private static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
 
     private @SpringBean ProjectService projectService;
     private @SpringBean UserDao userRepository;
@@ -296,11 +299,14 @@ public class ProjectsOverviewPage
                 projectLink.add(new Label(MID_NAME, aItem.getModelObject().getName()));
                 aItem.add(new Label(MID_DESCRIPTION, aItem.getModelObject().getShortDescription())
                         .setEscapeModelStrings(false));
-                DateLabel createdLabel = DateLabel.forDatePattern(MID_CREATED,
-                        () -> project.getCreated(), "yyyy-MM-dd");
+
+                Label createdLabel = new Label(MID_CREATED,
+                        () -> project.getCreated() != null
+                                ? DATE_FORMAT.format(project.getCreated())
+                                : null);
                 addActionsDropdown(aItem);
                 aItem.add(projectLink);
-                createdLabel.add(visibleWhen(() -> createdLabel.getModelObject() != null));
+                createdLabel.add(visibleWhen(() -> createdLabel.getDefaultModelObject() != null));
                 aItem.add(createdLabel);
                 aItem.add(createRoleBadges(aItem.getModelObject()));
                 Label projectId = new Label(MID_ID, () -> project.getId());

--- a/inception/pom.xml
+++ b/inception/pom.xml
@@ -15,7 +15,9 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>de.tudarmstadt.ukp.inception.app</groupId>
@@ -69,23 +71,23 @@
     <uima.version>3.2.0</uima.version>
     <uimafit.version>3.2.0</uimafit.version>
 
-    <spring.version>5.3.9</spring.version>
-    <spring.boot.version>2.5.4</spring.boot.version>
-    <spring.security.version>5.5.2</spring.security.version>
-    <springdoc.version>1.5.10</springdoc.version>
-    <swagger.version>2.1.10</swagger.version>
+    <spring.version>5.3.13</spring.version>
+    <spring.boot.version>2.5.7</spring.boot.version>
+    <spring.security.version>5.5.3</spring.security.version>
+    <springdoc.version>1.5.13</springdoc.version>
+    <swagger.version>2.1.11</swagger.version>
 
     <slf4j.version>1.7.32</slf4j.version>
-    <log4j.version>2.15.0</log4j.version>
-    <jboss.logging.version>3.4.1.Final</jboss.logging.version>
+    <log4j.version>2.16.0</log4j.version>
+    <jboss.logging.version>3.4.2.Final</jboss.logging.version>
 
-    <groovy.version>3.0.3</groovy.version>
+    <groovy.version>3.0.9</groovy.version>
 
-    <tomcat.version>9.0.52</tomcat.version>
+    <tomcat.version>9.0.56</tomcat.version>
     <servlet-api.version>4.0.1</servlet-api.version>
 
     <mariadb.driver.version>2.7.4</mariadb.driver.version>
-    <hibernate.version>5.5.7.Final</hibernate.version>
+    <hibernate.version>5.5.8.Final</hibernate.version>
     <hibernate.validator.version>6.2.0.Final</hibernate.validator.version>
 
     <wicket.version>9.4.0</wicket.version>
@@ -105,10 +107,10 @@
       - At the moment (2020-FEB-09), there are no versions of RDF4J and Jena (Fuseki) which
       - are built against Lucene 8.x.
       -->
-    <lucene.version>7.7.3</lucene.version> <!-- 8.7.0 -->
-    <solr.version>7.7.3</solr.version> <!-- 8.5.1 / 8.7.0 -->
-    <mtas.version>7.7.1.0</mtas.version> <!-- 8.7.0.0 -->
-    <elasticsearch.version>6.8.17</elasticsearch.version> <!-- 7.10.2 -->
+    <lucene.version>7.7.3</lucene.version> <!-- 9.0.0 -->
+    <solr.version>7.7.3</solr.version> <!-- 8.11.0 -->
+    <mtas.version>7.7.1.0</mtas.version> <!-- 8.9.0.0 -->
+    <elasticsearch.version>6.8.21</elasticsearch.version> <!-- 7.16.1 -->
     <rdf4j.version>3.7.2</rdf4j.version>
     <jena.version>3.17.0</jena.version>
 
@@ -866,6 +868,18 @@
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>org.webjars</groupId>
+            <artifactId>tempusdominus-bootstrap-4</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.webjars</groupId>
+            <artifactId>jquerypp</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.webjars.bower</groupId>
+            <artifactId>summernote</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -907,6 +921,11 @@
         <groupId>com.giffing.wicket.spring.boot.starter</groupId>
         <artifactId>wicket-spring-boot-context</artifactId>
         <version>${wicket-spring-boot.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.webjars.npm</groupId>
+        <artifactId>axios</artifactId>
+        <version>0.24.0</version>
       </dependency>
       <dependency>
         <groupId>org.webjars</groupId>
@@ -969,6 +988,13 @@
         <artifactId>txtmark</artifactId>
         <version>0.13</version>
       </dependency>
+
+      <dependency>
+        <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
+        <artifactId>owasp-java-html-sanitizer</artifactId>
+        <version>20211018.2</version>
+      </dependency>
+
       <dependency>
         <groupId>commons-beanutils</groupId>
         <artifactId>commons-beanutils</artifactId>
@@ -1658,6 +1684,23 @@
         <artifactId>kinetic</artifactId>
         <version>5.2.0</version>
       </dependency>
+      <dependency>
+        <groupId>org.webjars.npm</groupId>
+        <artifactId>color-thief</artifactId>
+        <version>2.2.5</version>
+        <exclusions>
+        <!-- The versions of canvas referenced by color-thief are not available on Maven Central -->
+          <exclusion>
+            <groupId>org.webjars.npm</groupId>
+            <artifactId>canvas</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.webjars.npm</groupId>
+        <artifactId>canvas</artifactId>
+        <version>1.4.0</version>
+      </dependency>
 
       <dependency>
         <groupId>org.mariadb.jdbc</groupId>
@@ -1697,6 +1740,12 @@
       </dependency>
 
       <dependency>
+        <groupId>org.apache.ant</groupId>
+        <artifactId>ant</artifactId>
+        <version>1.10.12</version>
+      </dependency>
+
+      <dependency>
         <!-- Import dependency management from Spring Boot -->
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
@@ -1721,6 +1770,26 @@
         <version>${dkpro.version}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.dkpro.core</groupId>
+        <artifactId>dkpro-core-api-resources-asl</artifactId>
+        <version>${dkpro.version}</version>
+        <exclusions>
+          <!-- We do not use model-downloading -->
+          <exclusion>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-model</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.ivy</groupId>
+            <artifactId>ivy</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/inception/pom.xml
+++ b/inception/pom.xml
@@ -1687,7 +1687,7 @@
       <dependency>
         <groupId>org.webjars.npm</groupId>
         <artifactId>color-thief</artifactId>
-        <version>2.2.5</version>
+        <version>2.2.1</version>
         <exclusions>
         <!-- The versions of canvas referenced by color-thief are not available on Maven Central -->
           <exclusion>

--- a/inception/pom.xml
+++ b/inception/pom.xml
@@ -1776,11 +1776,13 @@
         <artifactId>dkpro-core-api-resources-asl</artifactId>
         <version>${dkpro.version}</version>
         <exclusions>
-          <!-- We do not use model-downloading -->
+          <!-- We do not use DKPro Core model-downloading -->
           <exclusion>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-model</artifactId>
           </exclusion>
+          <!--  
+          Cannot exclude until https://github.com/dkpro/dkpro-core/issues/1511 is fixed
           <exclusion>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
@@ -1789,6 +1791,7 @@
             <groupId>org.apache.ivy</groupId>
             <artifactId>ivy</artifactId>
           </exclusion>
+          -->
         </exclusions>
       </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.dkpro</groupId>
     <artifactId>dkpro-parent-pom</artifactId>
-    <version>25</version>
+    <version>26</version>
   </parent>
 
   <groupId>de.tudarmstadt.ukp.inception.app</groupId>


### PR DESCRIPTION
**What's in the PR**
- Move a few more versions to the parent POM
- Dropped dependency on wicket-datetime
- Spring 5.3.9 -> 5.3.13
- Spring Boot 2.5.4 -> 2.5.7
- Spring Security 5.5.2 -> 5.5.3
- SpringDoc 1.5.10 -> 1.5.13
- Swagger 2.1.10 -> 2.1.11
- Log4j 2.15.0 -> 2.16.0
- JBoss Logging 3.4.1 -> 3.4.2
- Groovy 3.0.3 -> 3.0.9
- Tomcat 9.0.52 -> 9.0.56
- Hibernate 5.5.7 -> 5.5.8
- owasp-java-html-sanitizer -> 20211018.2
- ant -> 1.10.12
- ElasticSearch 6.8.17 -> 6.8.21
- Added exclusion for tempusdominus-bootstrap-4
- Added exclusion for jquerypp
- Added exclusion for summernote
- Added exclusion for maven-model

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
