### PR TITLE
#2630 - Upgrade dependencies

### DIFF
--- a/inception/inception-api-dao/pom.xml
+++ b/inception/inception-api-dao/pom.xml
@@ -184,8 +184,8 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
+      <groupId>org.hsqldb</groupId>
+      <artifactId>hsqldb</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -218,7 +218,7 @@
                -->
               <ignoredDependency>org.springframework.boot:spring-boot-test</ignoredDependency>
               <ignoredDependency>org.springframework.boot:spring-boot-starter-data-jpa</ignoredDependency>
-              <ignoredDependency>com.h2database:h2</ignoredDependency>
+              <ignoredDependency>org.hsqldb:hsqldb</ignoredDependency>
             </ignoredDependencies>
           </configuration>
         </plugin>

--- a/inception/inception-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentServiceImplDatabaseTest.java
+++ b/inception/inception-api-dao/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentServiceImplDatabaseTest.java
@@ -19,9 +19,10 @@ package de.tudarmstadt.ukp.clarin.webanno.api.dao;
 
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentStateChangeFlag.EXPLICIT_ANNOTATOR_USER_ACTION;
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.ANNOTATOR;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.commons.io.IOUtils.toInputStream;
 import static org.apache.uima.fit.factory.TypeSystemDescriptionFactory.createTypeSystemDescription;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.h2.util.IOUtils.getInputStreamFromString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -203,7 +204,7 @@ public class DocumentServiceImplDatabaseTest
                 .createAnnotationDocument(new AnnotationDocument(annotator1.getUsername(), doc));
 
         try (var session = CasStorageSession.open()) {
-            sut.uploadSourceDocument(getInputStreamFromString("This is a test."), doc);
+            sut.uploadSourceDocument(toInputStream("This is a test.", UTF_8), doc);
         }
 
         sut.setAnnotationDocumentState(ann, AnnotationDocumentState.IN_PROGRESS,

--- a/inception/inception-concept-linking/pom.xml
+++ b/inception/inception-concept-linking/pom.xml
@@ -186,8 +186,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
+      <groupId>org.hsqldb</groupId>
+      <artifactId>hsqldb</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -222,7 +222,7 @@
           <configuration>
             <usedDependencies>
               <!-- Testing - used via reflection -->
-              <usedDependency>com.h2database:h2</usedDependency>
+              <usedDependency>org.hsqldb:hsqldb</usedDependency>
               <usedDependency>com.jayway.jsonpath:json-path</usedDependency>
               <usedDependency>org.springframework.boot:spring-boot-starter-data-jpa</usedDependency>
             </usedDependencies>

--- a/inception/inception-curation/pom.xml
+++ b/inception/inception-curation/pom.xml
@@ -233,8 +233,8 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
+      <groupId>org.hsqldb</groupId>
+      <artifactId>hsqldb</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -262,7 +262,7 @@
                -->
               <ignoredDependency>org.springframework.boot:spring-boot-test</ignoredDependency>
               <ignoredDependency>org.springframework.boot:spring-boot-starter-data-jpa</ignoredDependency>
-              <ignoredDependency>com.h2database:h2</ignoredDependency>
+              <ignoredDependency>org.hsqldb:hsqldb</ignoredDependency>
             </ignoredDependencies>
           </configuration>
         </plugin>

--- a/inception/inception-diam/pom.xml
+++ b/inception/inception-diam/pom.xml
@@ -210,8 +210,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
+      <groupId>org.hsqldb</groupId>
+      <artifactId>hsqldb</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/inception/inception-imls-stringmatch/pom.xml
+++ b/inception/inception-imls-stringmatch/pom.xml
@@ -196,8 +196,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
+      <groupId>org.hsqldb</groupId>
+      <artifactId>hsqldb</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -214,7 +214,7 @@
           <configuration>
             <usedDependencies>
               <!-- Testing - used via reflection -->
-              <usedDependency>com.h2database:h2</usedDependency>
+              <usedDependency>org.hsqldb:hsqldb</usedDependency>
               <usedDependency>org.springframework.boot:spring-boot-starter-test</usedDependency>
               <usedDependency>org.springframework.boot:spring-boot-starter-data-jpa</usedDependency>
             </usedDependencies>

--- a/inception/inception-kb/pom.xml
+++ b/inception/inception-kb/pom.xml
@@ -244,8 +244,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
+      <groupId>org.hsqldb</groupId>
+      <artifactId>hsqldb</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -309,7 +309,7 @@
               <usedDependency>org.eclipse.rdf4j:rdf4j-queryresultio-api</usedDependency>
               <usedDependency>org.eclipse.rdf4j:rdf4j-sail-inferencer</usedDependency>
               <!-- Testing - used via reflection -->
-              <usedDependency>com.h2database:h2</usedDependency>
+              <usedDependency>org.hsqldb:hsqldb</usedDependency>
               <usedDependency>com.jayway.jsonpath:json-path</usedDependency>
               <usedDependency>org.springframework.boot:spring-boot-starter-data-jpa</usedDependency>
             </usedDependencies>

--- a/inception/inception-log/pom.xml
+++ b/inception/inception-log/pom.xml
@@ -143,8 +143,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
+      <groupId>org.hsqldb</groupId>
+      <artifactId>hsqldb</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/inception/inception-preferences/pom.xml
+++ b/inception/inception-preferences/pom.xml
@@ -106,8 +106,8 @@
 
     <!-- DEPENDENCIES FOR TESTING -->
     <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
+      <groupId>org.hsqldb</groupId>
+      <artifactId>hsqldb</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/inception/inception-project-export/pom.xml
+++ b/inception/inception-project-export/pom.xml
@@ -246,8 +246,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
+      <groupId>org.hsqldb</groupId>
+      <artifactId>hsqldb</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/inception/inception-project/pom.xml
+++ b/inception/inception-project/pom.xml
@@ -15,7 +15,9 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>de.tudarmstadt.ukp.inception.app</groupId>
@@ -99,51 +101,48 @@
     
     <!-- DEPENDENCIES FOR TESTING -->
     <dependency>
-    	<groupId>org.springframework.boot</groupId>
-    	<artifactId>spring-boot</artifactId>
-    	<scope>test</scope>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
-    	<groupId>org.springframework.boot</groupId>
-    	<artifactId>spring-boot-test-autoconfigure</artifactId>
-    	<scope>test</scope>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-test-autoconfigure</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
-    	<groupId>org.springframework.boot</groupId>
-    	<artifactId>spring-boot-starter-data-jpa</artifactId>
-    	<scope>test</scope>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
-    	<groupId>com.h2database</groupId>
-    	<artifactId>h2</artifactId>
-    	<scope>test</scope>
+      <groupId>org.hsqldb</groupId>
+      <artifactId>hsqldb</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>
     <plugins>
-	  <plugin>
-	    <groupId>org.apache.maven.plugins</groupId>
-		<artifactId>maven-dependency-plugin</artifactId>
-		<executions>
-		  <execution>
-		    <id>default</id>
-			<phase>verify</phase>
-			<goals>
-			  <goal>analyze-only</goal>
-			</goals>
-		  </execution>
-		</executions>
-		<configuration>
-		  <failOnWarning>true</failOnWarning>
-		  <ignoredDependencies>
-			<!-- - h2database and data-jpa, used via reflection in tests, cannot 
-			     -be detected by Maven 
-			-->
-			<dependency>com.h2database:h2</dependency>
-			<dependency>org.springframework.boot:spring-boot-starter-data-jpa</dependency>
-		  </ignoredDependencies>
-		</configuration>
-	  </plugin>
-	</plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>default</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>analyze-only</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <failOnWarning>true</failOnWarning>
+          <ignoredDependencies>
+            <ignoredDependency>org.hsqldb:hsqldb</ignoredDependency>
+            <ignoredDependency>org.springframework.boot:spring-boot-starter-data-jpa</ignoredDependency>
+          </ignoredDependencies>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
 </project>

--- a/inception/inception-project/src/test/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImplTest.java
+++ b/inception/inception-project/src/test/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImplTest.java
@@ -52,7 +52,9 @@ import de.tudarmstadt.ukp.clarin.webanno.model.ProjectPermission;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.Role;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 
-@DataJpaTest(excludeAutoConfiguration = LiquibaseAutoConfiguration.class, showSql = false, //
+@DataJpaTest( //
+        excludeAutoConfiguration = LiquibaseAutoConfiguration.class, //
+        showSql = false, //
         properties = { //
                 "spring.main.banner-mode=off" })
 @ExtendWith(SpringExtension.class)

--- a/inception/inception-recommendation/pom.xml
+++ b/inception/inception-recommendation/pom.xml
@@ -243,8 +243,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
+      <groupId>org.hsqldb</groupId>
+      <artifactId>hsqldb</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/inception/inception-remote/pom.xml
+++ b/inception/inception-remote/pom.xml
@@ -230,8 +230,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
+      <groupId>org.hsqldb</groupId>
+      <artifactId>hsqldb</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -271,7 +271,7 @@
               <ignoredDependency>org.springframework.boot:spring-boot-starter-web</ignoredDependency>
               <ignoredDependency>org.springframework.boot:spring-boot-starter-data-jpa</ignoredDependency>
               <ignoredDependency>com.jayway.jsonpath:json-path</ignoredDependency>
-              <ignoredDependency>com.h2database:h2</ignoredDependency>
+              <ignoredDependency>org.hsqldb:hsqldb</ignoredDependency>
               <ignoredDependency>de.tudarmstadt.ukp.inception.app:webanno-io-text</ignoredDependency>
               <ignoredDependency>de.tudarmstadt.ukp.inception.app:webanno-project</ignoredDependency>
               <ignoredDependency>de.tudarmstadt.ukp.inception.app:webanno-api-dao</ignoredDependency>

--- a/inception/inception-search-mtas/pom.xml
+++ b/inception/inception-search-mtas/pom.xml
@@ -153,8 +153,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
+      <groupId>org.hsqldb</groupId>
+      <artifactId>hsqldb</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/inception/inception-sharing/pom.xml
+++ b/inception/inception-sharing/pom.xml
@@ -159,8 +159,8 @@
 
     <!-- DEPENDENCIES FOR TESTING -->
     <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
+      <groupId>org.hsqldb</groupId>
+      <artifactId>hsqldb</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/inception/inception-ui-curation/pom.xml
+++ b/inception/inception-ui-curation/pom.xml
@@ -206,8 +206,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
+      <groupId>org.hsqldb</groupId>
+      <artifactId>hsqldb</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/inception/inception-versioning/pom.xml
+++ b/inception/inception-versioning/pom.xml
@@ -162,8 +162,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
+      <groupId>org.hsqldb</groupId>
+      <artifactId>hsqldb</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/inception/inception-websocket/pom.xml
+++ b/inception/inception-websocket/pom.xml
@@ -190,8 +190,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
+      <groupId>org.hsqldb</groupId>
+      <artifactId>hsqldb</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/inception/inception-workload-dynamic/pom.xml
+++ b/inception/inception-workload-dynamic/pom.xml
@@ -203,8 +203,8 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
+      <groupId>org.hsqldb</groupId>
+      <artifactId>hsqldb</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -227,7 +227,7 @@
                -->
               <ignoredDependency>org.springframework.boot:spring-boot-test</ignoredDependency>
               <ignoredDependency>org.springframework.boot:spring-boot-starter-data-jpa</ignoredDependency>
-              <ignoredDependency>com.h2database:h2</ignoredDependency>
+              <ignoredDependency>org.hsqldb:hsqldb</ignoredDependency>
             </ignoredDependencies>
           </configuration>
         </plugin>

--- a/inception/inception-workload-matrix/pom.xml
+++ b/inception/inception-workload-matrix/pom.xml
@@ -193,8 +193,8 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
+      <groupId>org.hsqldb</groupId>
+      <artifactId>hsqldb</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -217,7 +217,7 @@
                -->
               <ignoredDependency>org.springframework.boot:spring-boot-test</ignoredDependency>
               <ignoredDependency>org.springframework.boot:spring-boot-starter-data-jpa</ignoredDependency>
-              <ignoredDependency>com.h2database:h2</ignoredDependency>
+              <ignoredDependency>org.hsqldb:hsqldb</ignoredDependency>
             </ignoredDependencies>
           </configuration>
         </plugin>

--- a/inception/pom.xml
+++ b/inception/pom.xml
@@ -70,7 +70,7 @@
     <uimafit.version>3.2.0</uimafit.version>
 
     <spring.version>5.3.14</spring.version>
-    <spring.boot.version>2.6.1</spring.boot.version>
+    <spring.boot.version>2.5.7</spring.boot.version>
     <spring.security.version>5.6.0</spring.security.version>
     <springdoc.version>1.6.1</springdoc.version>
     <swagger.version>2.1.11</swagger.version>

--- a/inception/pom.xml
+++ b/inception/pom.xml
@@ -1552,11 +1552,6 @@
         <artifactId>caffeine</artifactId>
         <version>2.9.3</version>
       </dependency>
-      <dependency>
-        <groupId>com.h2database</groupId>
-        <artifactId>h2</artifactId>
-        <version>2.0.202</version>
-      </dependency>
 
       <!-- JAXB DEPENDENCIES -->
       <dependency>
@@ -2020,10 +2015,10 @@
             <dependency>com.sun.xml.bind:jaxb-impl</dependency>
             <dependency>javax.activation:javax.activation-api</dependency>
             <!--
-              - h2database and data-jpa, used via reflection in tests in search-mtas,
+              - hsqldb and data-jpa, used via reflection in tests in search-mtas,
               - cannot be detected by Maven
             -->
-            <dependency>com.h2database:h2</dependency>
+            <usedDependency>org.hsqldb:hsqldb</usedDependency>
             <dependency>org.springframework.boot:spring-boot-starter-data-jpa</dependency>
             <!--
               - Common test dependencies
@@ -2330,7 +2325,7 @@
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>build-helper-maven-plugin</artifactId>
-            <version>3.0.0</version>
+            <version>3.2.0</version>
             <executions>
               <execution>
                 <id>addToSourceFolder</id>

--- a/inception/pom.xml
+++ b/inception/pom.xml
@@ -61,22 +61,22 @@
     <dkpro.core.testCachePath>${session.executionRootDirectory}/cache/dkpro-core-datasets</dkpro.core.testCachePath>
     <excludedTestCategories>slow</excludedTestCategories>
 
-    <junit.version>5.8.1</junit.version>
+    <junit.version>5.8.2</junit.version>
     <mockito.version>3.12.4</mockito.version>
-    <assertj.version>3.20.2</assertj.version>
+    <assertj.version>3.21.0</assertj.version>
 
     <dkpro.version>2.2.0</dkpro.version>
     <uima.version>3.2.0</uima.version>
     <uimafit.version>3.2.0</uimafit.version>
 
-    <spring.version>5.3.13</spring.version>
-    <spring.boot.version>2.5.7</spring.boot.version>
-    <spring.security.version>5.5.3</spring.security.version>
-    <springdoc.version>1.5.13</springdoc.version>
+    <spring.version>5.3.14</spring.version>
+    <spring.boot.version>2.6.1</spring.boot.version>
+    <spring.security.version>5.6.0</spring.security.version>
+    <springdoc.version>1.6.1</springdoc.version>
     <swagger.version>2.1.11</swagger.version>
 
     <slf4j.version>1.7.32</slf4j.version>
-    <log4j.version>2.16.0</log4j.version>
+    <log4j.version>2.17.0</log4j.version>
     <jboss.logging.version>3.4.2.Final</jboss.logging.version>
 
     <groovy.version>3.0.9</groovy.version>
@@ -85,17 +85,17 @@
     <servlet-api.version>4.0.1</servlet-api.version>
 
     <mariadb.driver.version>2.7.4</mariadb.driver.version>
-    <hibernate.version>5.5.8.Final</hibernate.version>
+    <hibernate.version>5.6.3.Final</hibernate.version>
     <hibernate.validator.version>6.2.0.Final</hibernate.validator.version>
 
-    <wicket.version>9.6.0</wicket.version>
-    <wicketstuff.version>9.6.0</wicketstuff.version>
+    <wicket.version>9.7.0</wicket.version>
+    <wicketstuff.version>9.7.0</wicketstuff.version>
     <wicket-jquery-ui.version>9.5.0</wicket-jquery-ui.version>
     <wicket-bootstrap.version>6.0.0-M4</wicket-bootstrap.version>
     <wicket-jquery-selectors.version>3.0.3</wicket-jquery-selectors.version>
     <wicket-webjars.version>3.0.3</wicket-webjars.version>
     <wicket-spring-boot.version>3.0.4</wicket-spring-boot.version>
-    <bootstrap.version>5.1.2</bootstrap.version>
+    <bootstrap.version>5.1.3</bootstrap.version>
     <hover.version>2.0.2</hover.version>
 
     <!--
@@ -1171,6 +1171,12 @@
       </dependency>
 
       <dependency>
+        <groupId>it.unimi.dsi</groupId>
+        <artifactId>fastutil</artifactId>
+        <version>8.5.6</version>
+      </dependency>
+
+      <dependency>
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-core</artifactId>
         <version>${hibernate.version}</version>
@@ -1378,7 +1384,7 @@
       <dependency>
         <groupId>org.hsqldb</groupId>
         <artifactId>hsqldb</artifactId>
-        <version>2.5.0</version>
+        <version>2.6.1</version>
       </dependency>
 
       <dependency>
@@ -1396,30 +1402,7 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-
-      <!-- LOG4J -->
-
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-api</artifactId>
-        <version>${log4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-core</artifactId>
-        <version>${log4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-slf4j-impl</artifactId>
-        <version>${log4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-layout-template-json</artifactId>
-        <version>${log4j.version}</version>
-      </dependency>
-
+  
       <!-- Weblicht -->
 
       <dependency>
@@ -1537,17 +1520,17 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.7</version>
+        <version>2.11.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-text</artifactId>
-        <version>1.8</version>
+        <version>1.9</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.11</version>
+        <version>3.12.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -1562,17 +1545,17 @@
       <dependency>
         <groupId>commons-validator</groupId>
         <artifactId>commons-validator</artifactId>
-        <version>1.6</version>
+        <version>1.7</version>
       </dependency>
       <dependency>
         <groupId>com.github.ben-manes.caffeine</groupId>
         <artifactId>caffeine</artifactId>
-        <version>2.8.0</version>
+        <version>2.9.3</version>
       </dependency>
       <dependency>
         <groupId>com.h2database</groupId>
         <artifactId>h2</artifactId>
-        <version>1.4.197</version>
+        <version>2.0.202</version>
       </dependency>
 
       <!-- JAXB DEPENDENCIES -->
@@ -1795,6 +1778,15 @@
         <groupId>org.apache.wicket</groupId>
         <artifactId>wicket-parent</artifactId>
         <version>${wicket.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
+        <!-- Import dependency management from LOG4J -->
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j</artifactId>
+        <version>${log4j.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -2128,16 +2120,18 @@
         <plugin>
           <groupId>io.fabric8</groupId>
           <artifactId>docker-maven-plugin</artifactId>
-          <version>0.34.1</version>
+          <version>0.38.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>versions-maven-plugin</artifactId>
-          <version>2.7</version>
+          <version>2.8.1</version>
           <configuration>
             <rulesUri>file:${maven.multiModuleProjectDirectory}/inception/inception-build/src/main/resources/inception/rules.xml</rulesUri>
+            <!--
             <allowAnyUpdates>false</allowAnyUpdates>
             <allowMajorUpdates>false</allowMajorUpdates>
+            -->
           </configuration>
         </plugin>
       </plugins>
@@ -2387,7 +2381,7 @@
                 <dependency>
                   <groupId>com.puppycrawl.tools</groupId>
                   <artifactId>checkstyle</artifactId>
-                  <version>8.29</version>
+                  <version>8.45.1</version>
                 </dependency>
               </dependencies>
               <configuration>

--- a/inception/pom.xml
+++ b/inception/pom.xml
@@ -2370,7 +2370,7 @@
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-checkstyle-plugin</artifactId>
-              <version>3.1.0</version>
+              <version>3.1.2</version>
               <inherited>true</inherited>
               <dependencies>
                 <dependency>


### PR DESCRIPTION
**What's in the PR**
- JUnit 5.8.1 -> 5.8.2
- AssertJ 3.20.3 -> 3.21.0
- Spring 5.3.13 -> 5.3.14
- Spring Security 5.5.3 -> 5.6.0
- SpringDoc 1.5.11 -> 1.6.1
- Log4J 2.16.0 -> 2.17.0
- Hibernate 5.5.8 -> 5.6.3
- Wicket 9.6.0 -> 9.7.0
- Wicketstuff 9.6.0 -> 9.7.0
- Bootstrap 5.1.2 -> 5.1.3
- FastUtil -> 8.5.6
- HSQLDB 2.5.0 -> 2.6.1
- Commons IO 2.7 -> 2.11.0
- Commons Text 1.8 -> 1.9
- Commons Lang3 3.11 -> 3.12.0
- Commons Validator 1.6 -> 1.7
- Caffeine 2.8.0 -> 2.9.3
- H2 1.4.197 -> 2.0.202
- Docker Maven Plugin 0.34.1 -> 0.38.0
- Maven Versions Plugin 2.7 -> 2.8.1
- Checkstyle 8.29 -> 8.45.1

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
