### PR TITLE
#2775 - Ability to work with really large tagsets for link features

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/LinkFeatureEditor.html
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/LinkFeatureEditor.html
@@ -25,7 +25,7 @@
         <span wicket:id="linkIndicator"></span>
       </span>
     </div>
-    <div class="card">
+    <div class="card g-0">
       <div wicket:id="content">
         <div class="card-body" wicket:enclosure="slots">
           <div wicket:id="slots">

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/LinkFeatureEditor.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/LinkFeatureEditor.java
@@ -19,6 +19,7 @@ package de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor;
 
 import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.selectFsByAddr;
 import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.wicket.event.Broadcast.BUBBLE;
 
@@ -30,7 +31,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.uima.UIMAException;
 import org.apache.uima.cas.CAS;
@@ -203,7 +203,7 @@ public class LinkFeatureEditor
                 Map<String, String> renderedFeatures = renderer.renderLabelFeatureValues(adapter,
                         fs, features);
 
-                String roleLabel = TypeUtil.getUiLabelText(adapter, renderedFeatures);
+                String roleLabel = TypeUtil.getUiLabelText(renderedFeatures);
                 if (isEmpty(roleLabel)) {
                     roleLabel = aModel.role + ": " + layer.getUiName();
                 }
@@ -268,59 +268,12 @@ public class LinkFeatureEditor
         });
 
         if (getModelObject().feature.getTagset() != null) {
-            field = new StyledComboBox<Tag>("newRole", PropertyModel.of(this, "newRole"),
-                    PropertyModel.of(getModel(), "tagset"))
-            {
-                private static final long serialVersionUID = 1L;
-
-                @Override
-                protected void onInitialize()
-                {
-                    super.onInitialize();
-
-                    // Ensure proper order of the initializing JS header items: first combo box
-                    // behavior (in super.onInitialize()), then tooltip.
-                    Options options = new Options(DescriptionTooltipBehavior.makeTooltipOptions());
-                    options.set("content",
-                            ClassicKendoComboboxTextFeatureEditor.FUNCTION_FOR_TOOLTIP);
-                    add(new TooltipBehavior("#" + field.getMarkupId() + "_listbox *[title]",
-                            options)
-                    {
-                        private static final long serialVersionUID = -7207021885475073279L;
-
-                        @Override
-                        protected String $()
-                        {
-                            // REC: It takes a moment for the KendoDatasource to load the data and
-                            // for the Combobox to render the hidden dropdown. I did not find
-                            // a way to hook into this process and to get notified when the
-                            // data is available in the dropdown, so trying to handle this
-                            // with a slight delay hopeing that all is set up after 1 second.
-                            return "try {setTimeout(function () { " + super.$()
-                                    + " }, 1000); } catch (err) {}; ";
-                        }
-                    });
-                }
-
-                @Override
-                public void onConfigure(JQueryBehavior aBehavior)
-                {
-                    super.onConfigure(aBehavior);
-
-                    aBehavior.setOption("placeholder", Options.asString("Select role"));
-
-                    // Trigger a re-loading of the tagset from the server as constraints may have
-                    // changed the ordering
-                    Optional<AjaxRequestTarget> target = RequestCycle.get()
-                            .find(AjaxRequestTarget.class);
-                    if (target.isPresent()) {
-                        target.get()
-                                .appendJavaScript(WicketUtil.wrapInTryCatch(String.format(
-                                        "var $w = %s; if ($w) { $w.dataSource.read(); }",
-                                        KendoUIBehavior.widget(this, ComboBoxBehavior.METHOD))));
-                    }
-                }
-            };
+            if (getModelObject().tagset.size() > 100) {
+                field = makeAutoComplete("newRole");
+            }
+            else {
+                field = makeComboBox("newRole");
+            }
         }
         else {
             field = new TextField<String>("newRole", PropertyModel.of(this, "newRole"));
@@ -418,6 +371,81 @@ public class LinkFeatureEditor
                         .equals(state.getArmedFeature().feature));
             }
         });
+    }
+
+    private AbstractTextComponent makeAutoComplete(String aId)
+    {
+        return new ReorderableTagAutoCompleteField(aId, PropertyModel.of(this, "newRole"))
+        {
+            private static final long serialVersionUID = 311286735004237737L;
+
+            @Override
+            protected List<ReorderableTag> getChoices(String aTerm)
+            {
+                FeatureState state = LinkFeatureEditor.this.getModelObject();
+
+                TagRanker ranker = new TagRanker();
+                ranker.setMaxResults(100);
+                ranker.setTagCreationAllowed(state.getFeature().getTagset().isCreateTag());
+
+                return ranker.rank(aTerm, state.tagset);
+            }
+        };
+    }
+
+    private AbstractTextComponent makeComboBox(String aId)
+    {
+        return new StyledComboBox<Tag>(aId, PropertyModel.of(this, "newRole"),
+                PropertyModel.of(getModel(), "tagset"))
+        {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            protected void onInitialize()
+            {
+                super.onInitialize();
+
+                // Ensure proper order of the initializing JS header items: first combo box
+                // behavior (in super.onInitialize()), then tooltip.
+                Options options = new Options(DescriptionTooltipBehavior.makeTooltipOptions());
+                options.set("content", ClassicKendoComboboxTextFeatureEditor.FUNCTION_FOR_TOOLTIP);
+                add(new TooltipBehavior("#" + field.getMarkupId() + "_listbox *[title]", options)
+                {
+                    private static final long serialVersionUID = -7207021885475073279L;
+
+                    @Override
+                    protected String $()
+                    {
+                        // REC: It takes a moment for the KendoDatasource to load the data and
+                        // for the Combobox to render the hidden dropdown. I did not find
+                        // a way to hook into this process and to get notified when the
+                        // data is available in the dropdown, so trying to handle this
+                        // with a slight delay hoping that all is set up after 1 second.
+                        return "try {setTimeout(function () { " + super.$()
+                                + " }, 1000); } catch (err) {}; ";
+                    }
+                });
+            }
+
+            @Override
+            public void onConfigure(JQueryBehavior aBehavior)
+            {
+                super.onConfigure(aBehavior);
+
+                aBehavior.setOption("placeholder", Options.asString("Select role"));
+
+                // Trigger a re-loading of the tagset from the server as constraints may have
+                // changed the ordering
+                Optional<AjaxRequestTarget> target = RequestCycle.get()
+                        .find(AjaxRequestTarget.class);
+                if (target.isPresent()) {
+                    target.get()
+                            .appendJavaScript(WicketUtil.wrapInTryCatch(String.format(
+                                    "var $w = %s; if ($w) { $w.dataSource.read(); }",
+                                    KendoUIBehavior.widget(this, ComboBoxBehavior.METHOD))));
+                }
+            }
+        };
     }
 
     private void removeAutomaticallyAddedUnusedEntries()
@@ -539,56 +567,67 @@ public class LinkFeatureEditor
 
     private void actionAdd(AjaxRequestTarget aTarget)
     {
-        if (StringUtils.isBlank((String) field.getModelObject())
-                && getTraits().isEnableRoleLabels()) {
+        if (isBlank((String) field.getModelObject()) && getTraits().isEnableRoleLabels()) {
             error("Must set slot label before adding!");
             aTarget.addChildren(getPage(), IFeedback.class);
+            return;
         }
-        else {
-            @SuppressWarnings("unchecked")
-            List<LinkWithRoleModel> links = (List<LinkWithRoleModel>) LinkFeatureEditor.this
-                    .getModelObject().value;
-            AnnotatorState state = LinkFeatureEditor.this.stateModel.getObject();
 
-            LinkWithRoleModel m = new LinkWithRoleModel();
-            m.role = (String) field.getModelObject();
-            links.add(m);
-            state.setArmedSlot(getModelObject(), links.size() - 1);
+        @SuppressWarnings("unchecked")
+        List<LinkWithRoleModel> links = (List<LinkWithRoleModel>) LinkFeatureEditor.this
+                .getModelObject().value;
+        AnnotatorState state = LinkFeatureEditor.this.stateModel.getObject();
 
-            // Need to re-render the whole form because a slot in another
-            // link editor might get unarmed
-            aTarget.add(getOwner());
+        LinkWithRoleModel m = new LinkWithRoleModel();
+        m.role = (String) field.getModelObject();
+        int insertionPoint = findInsertionPoint(links);
+        links.add(insertionPoint, m);
+        state.setArmedSlot(getModelObject(), insertionPoint);
+
+        // Need to re-render the whole form because a slot in another link editor might get unarmed
+        aTarget.add(getOwner());
+    }
+
+    private int findInsertionPoint(List<LinkWithRoleModel> aLinks)
+    {
+        if (aLinks.isEmpty()) {
+            return 0;
         }
+
+        int i = aLinks.size();
+        while (i > 0 && aLinks.get(i - 1).autoCreated) {
+            i--;
+        }
+
+        return i;
     }
 
     private void actionSet(AjaxRequestTarget aTarget)
     {
-        if (StringUtils.isBlank((String) field.getModelObject())
-                && getTraits().isEnableRoleLabels()) {
+        if (isBlank((String) field.getModelObject()) && getTraits().isEnableRoleLabels()) {
             error("Must set slot label before changing!");
             aTarget.addChildren(getPage(), IFeedback.class);
+            return;
         }
-        else {
-            @SuppressWarnings("unchecked")
-            List<LinkWithRoleModel> links = (List<LinkWithRoleModel>) LinkFeatureEditor.this
-                    .getModelObject().value;
-            AnnotatorState state = LinkFeatureEditor.this.stateModel.getObject();
-            FeatureState fs = state.getArmedFeature();
 
-            // Update the slot
-            LinkWithRoleModel m = links.get(state.getArmedSlot());
-            m.role = (String) field.getModelObject();
-            links.set(state.getArmedSlot(), m); // avoid reordering
+        @SuppressWarnings("unchecked")
+        List<LinkWithRoleModel> links = (List<LinkWithRoleModel>) LinkFeatureEditor.this
+                .getModelObject().value;
+        AnnotatorState state = LinkFeatureEditor.this.stateModel.getObject();
 
-            aTarget.add(content);
+        // Update the slot
+        LinkWithRoleModel m = links.get(state.getArmedSlot());
+        m.role = (String) field.getModelObject();
+        links.set(state.getArmedSlot(), m); // avoid reordering
 
-            // Send event - but only if we set the label on a slot which was already filled/saved.
-            // Unset slots only exist in the link editor and if we commit the change here, we
-            // trigger a reload of the feature editors from the CAS which makes the unfilled slots
-            // disappear and leaves behind an armed slot pointing to a removed slot.
-            if (m.targetAddr != -1) {
-                send(this, Broadcast.BUBBLE, new FeatureEditorValueChangedEvent(this, aTarget));
-            }
+        aTarget.add(content);
+
+        // Send event - but only if we set the label on a slot which was already filled/saved.
+        // Unset slots only exist in the link editor and if we commit the change here, we
+        // trigger a reload of the feature editors from the CAS which makes the unfilled slots
+        // disappear and leaves behind an armed slot pointing to a removed slot.
+        if (m.targetAddr != -1) {
+            send(this, Broadcast.BUBBLE, new FeatureEditorValueChangedEvent(this, aTarget));
         }
     }
 
@@ -598,7 +637,6 @@ public class LinkFeatureEditor
         List<LinkWithRoleModel> links = (List<LinkWithRoleModel>) LinkFeatureEditor.this
                 .getModelObject().value;
         AnnotatorState state = LinkFeatureEditor.this.stateModel.getObject();
-        FeatureState fs = state.getArmedFeature();
 
         LinkWithRoleModel linkWithRoleModel = links.get(state.getArmedSlot());
         links.remove(state.getArmedSlot());

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/ReorderableTagAutoCompleteField.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/ReorderableTagAutoCompleteField.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor;
+
+import java.util.List;
+import java.util.Locale;
+
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.util.convert.ConversionException;
+import org.apache.wicket.util.convert.IConverter;
+
+import com.googlecode.wicket.jquery.core.JQueryBehavior;
+import com.googlecode.wicket.jquery.core.Options;
+import com.googlecode.wicket.jquery.core.template.IJQueryTemplate;
+import com.googlecode.wicket.kendo.ui.form.autocomplete.AutoCompleteTextField;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.ReorderableTag;
+import de.tudarmstadt.ukp.clarin.webanno.model.Tag;
+
+public abstract class ReorderableTagAutoCompleteField
+    extends AutoCompleteTextField<ReorderableTag>
+{
+    private static final long serialVersionUID = 311286735004237737L;
+
+    protected ReorderableTagAutoCompleteField(String aId)
+    {
+        super(aId);
+    }
+
+    public ReorderableTagAutoCompleteField(String aId, IModel<ReorderableTag> aModel)
+    {
+        super(aId, aModel);
+    }
+
+    @Override
+    public void onConfigure(JQueryBehavior behavior)
+    {
+        super.onConfigure(behavior);
+
+        behavior.setOption("delay", 500);
+        behavior.setOption("animation", false);
+        behavior.setOption("footerTemplate",
+                Options.asString("#: instance.dataSource.total() # items found"));
+        // Prevent scrolling action from closing the dropdown while the focus is on the
+        // input field
+        behavior.setOption("close",
+                String.join(" ", "function(e) {",
+                        "  if (document.activeElement == e.sender.element[0]) {",
+                        "    e.preventDefault();" + "  }", "}"));
+        behavior.setOption("select", " function (e) { this.trigger('change'); }");
+    }
+
+    @Override
+    protected abstract List<ReorderableTag> getChoices(String aTerm);
+
+    /*
+     * Below is a hack which is required because all the text feature editors are expected to write
+     * a plain string into the feature state. However, we cannot have an {@code
+     * AutoCompleteTextField<String>} field because then we would loose easy access to the tag
+     * description which we show in the tooltips. So we hack the converter to return strings on the
+     * way out into the model. This is a very evil hack and we need to avoid declaring generic types
+     * because we work against them!
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @Override
+    public <C> IConverter<C> getConverter(Class<C> aType)
+    {
+        IConverter originalConverter = super.getConverter(aType);
+
+        return new IConverter()
+        {
+            private static final long serialVersionUID = -6505569244789767066L;
+
+            @Override
+            public Object convertToObject(String aValue, Locale aLocale) throws ConversionException
+            {
+                Object value = originalConverter.convertToObject(aValue, aLocale);
+                if (value instanceof String) {
+                    return value;
+                }
+                else if (value instanceof Tag) {
+                    return ((Tag) value).getName();
+                }
+                else if (value instanceof ReorderableTag) {
+                    return ((ReorderableTag) value).getName();
+                }
+                else {
+                    return null;
+                }
+            }
+
+            @Override
+            public String convertToString(Object aValue, Locale aLocale)
+            {
+                return originalConverter.convertToString(aValue, aLocale);
+            }
+        };
+    }
+
+    @Override
+    protected IJQueryTemplate newTemplate()
+    {
+        return KendoChoiceDescriptionScriptReference.templateReorderable();
+    }
+}

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/StyledComboBox.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/StyledComboBox.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.model.IModel;
 
+import com.googlecode.wicket.jquery.core.renderer.IChoiceRenderer;
 import com.googlecode.wicket.jquery.core.template.IJQueryTemplate;
 import com.googlecode.wicket.kendo.ui.form.combobox.ComboBox;
 
@@ -44,6 +45,12 @@ public class StyledComboBox<T>
     public StyledComboBox(String aId, IModel<String> aModel, IModel<List<T>> aChoices)
     {
         super(aId, aModel, aChoices);
+    }
+
+    public StyledComboBox(String aId, IModel<String> aModel, IModel<List<T>> aChoices,
+            IChoiceRenderer<? super T> aRenderer)
+    {
+        super(aId, aModel, aChoices, aRenderer);
     }
 
     public StyledComboBox(String string, List<T> choices)


### PR DESCRIPTION
**What's in the PR**
- Extract tag auto-complete field into a re-usable class
- Use it also in the link feature editor for the roles if there are more than 100 tags in the tagset
- Slight UI layout fix in the link feature editor
- Fix issue that wrong slot could be selected when adding a new slot and there are default or "important" slots

**How to test manually**
* Try using link features with a really large tagset
* Try using the regular string feature with a large tagset

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
