### PR TITLE
#2775 - Ability to work with really large tagsets for link features

### DIFF
--- a/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/AgreementMeasureTestSuite_ImplBase.java
+++ b/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/AgreementMeasureTestSuite_ImplBase.java
@@ -51,8 +51,8 @@ import org.mockito.Mock;
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.BooleanFeatureSupport;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRegistryImpl;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.LinkFeatureSupport;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.NumberFeatureSupport;
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.SlotFeatureSupport;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.StringFeatureSupport;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.layer.ChainLayerSupport;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.layer.LayerBehaviorRegistryImpl;
@@ -87,7 +87,7 @@ public class AgreementMeasureTestSuite_ImplBase
 
         FeatureSupportRegistryImpl featureSupportRegistry = new FeatureSupportRegistryImpl(
                 asList(new StringFeatureSupport(), new BooleanFeatureSupport(),
-                        new NumberFeatureSupport(), new SlotFeatureSupport(annotationService)));
+                        new NumberFeatureSupport(), new LinkFeatureSupport(annotationService)));
         featureSupportRegistry.init();
 
         LayerBehaviorRegistryImpl layerBehaviorRegistry = new LayerBehaviorRegistryImpl(asList());

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/LinkFeatureSupport.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/LinkFeatureSupport.java
@@ -63,7 +63,7 @@ import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
  * {@code AnnotationServiceAutoConfiguration#slotFeatureSupport}.
  * </p>
  */
-public class SlotFeatureSupport
+public class LinkFeatureSupport
     implements FeatureSupport<LinkFeatureTraits>
 {
     private final Logger log = LoggerFactory.getLogger(getClass());
@@ -73,7 +73,7 @@ public class SlotFeatureSupport
     private String featureSupportId;
 
     @Autowired
-    public SlotFeatureSupport(AnnotationSchemaService aAnnotationService)
+    public LinkFeatureSupport(AnnotationSchemaService aAnnotationService)
     {
         annotationService = aAnnotationService;
     }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/StringFeatureSupport.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/StringFeatureSupport.java
@@ -35,7 +35,8 @@ import org.slf4j.LoggerFactory;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.action.AnnotationActionHandler;
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.config.PrimitiveUimaFeatureSupportProperties;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.config.StringFeatureSupportProperties;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.config.StringFeatureSupportPropertiesImpl;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor.DynamicTextAreaFeatureEditor;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor.FeatureEditor;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor.InputFieldTextFeatureEditor;
@@ -67,7 +68,7 @@ public class StringFeatureSupport
 
     private List<FeatureType> primitiveTypes;
 
-    private final PrimitiveUimaFeatureSupportProperties properties;
+    private final StringFeatureSupportProperties properties;
 
     private final AnnotationSchemaService schemaService;
 
@@ -76,10 +77,10 @@ public class StringFeatureSupport
      */
     public StringFeatureSupport()
     {
-        this(new PrimitiveUimaFeatureSupportProperties(), null);
+        this(new StringFeatureSupportPropertiesImpl(), null);
     }
 
-    public StringFeatureSupport(PrimitiveUimaFeatureSupportProperties aProperties,
+    public StringFeatureSupport(StringFeatureSupportProperties aProperties,
             AnnotationSchemaService aSchemaService)
     {
         properties = aProperties;

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/config/LinkFeatureSupportProperties.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/config/LinkFeatureSupportProperties.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.config;
+
+public interface LinkFeatureSupportProperties
+{
+    /**
+     * If the tagset is larger than the threshold, an auto-complete field is used instead of a
+     * standard combobox.
+     */
+    int getAutoCompleteThreshold();
+
+    /**
+     * When an auto-complete field is used, this determines the maximum number of items shown in the
+     * dropdown menu.
+     */
+    int getAutoCompleteMaxResults();
+}

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/config/LinkFeatureSupportPropertiesImpl.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/config/LinkFeatureSupportPropertiesImpl.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * <p>
+ * This class is exposed as a Spring Component via {@code AnnotationSchemaServiceAutoConfiguration}.
+ * </p>
+ */
+@ConfigurationProperties("annotation.feature-support.link")
+public class LinkFeatureSupportPropertiesImpl
+    implements LinkFeatureSupportProperties
+{
+    private int autoCompleteThreshold = 75;
+
+    private int autoCompleteMaxResults = 100;
+
+    @Override
+    public int getAutoCompleteThreshold()
+    {
+        return autoCompleteThreshold;
+    }
+
+    public void setAutoCompleteThreshold(int aAutoCompleteThreshold)
+    {
+        autoCompleteThreshold = aAutoCompleteThreshold;
+    }
+
+    @Override
+    public int getAutoCompleteMaxResults()
+    {
+        return autoCompleteMaxResults;
+    }
+
+    public void setAutoCompleteMaxResults(int aAutoCompleteMaxResults)
+    {
+        autoCompleteMaxResults = aAutoCompleteMaxResults;
+    }
+}

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/config/StringFeatureSupportProperties.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/config/StringFeatureSupportProperties.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.config;
+
+public interface StringFeatureSupportProperties
+{
+    /**
+     * If the tagset is larger than the threshold, a combo-box is used instead of a radio choice.
+     */
+    int getComboBoxThreshold();
+
+    /**
+     * If the tagset is larger than the threshold, an auto-complete field is used instead of a
+     * standard combobox.
+     */
+    int getAutoCompleteThreshold();
+
+    /**
+     * When an auto-complete field is used, this determines the maximum number of items shown in the
+     * dropdown menu.
+     */
+    int getAutoCompleteMaxResults();
+}

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/config/StringFeatureSupportPropertiesImpl.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/config/StringFeatureSupportPropertiesImpl.java
@@ -25,25 +25,16 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * </p>
  */
 @ConfigurationProperties("annotation.feature-support.string")
-public class PrimitiveUimaFeatureSupportProperties
+public class StringFeatureSupportPropertiesImpl
+    implements StringFeatureSupportProperties
 {
-    /**
-     * If the tagset is larger than the threshold, a combo-box is used instead of a radio choice.
-     */
     private int comboBoxThreshold = 6;
 
-    /**
-     * If the tagset is larger than the threshold, an auto-complete field is used instead of a
-     * standard combobox.
-     */
     private int autoCompleteThreshold = 75;
 
-    /**
-     * When an auto-complete field is used, this determines the maximum number of items shown in the
-     * dropdown menu.
-     */
     private int autoCompleteMaxResults = 100;
 
+    @Override
     public int getComboBoxThreshold()
     {
         return comboBoxThreshold;
@@ -54,6 +45,7 @@ public class PrimitiveUimaFeatureSupportProperties
         comboBoxThreshold = aComboBoxThreshold;
     }
 
+    @Override
     public int getAutoCompleteThreshold()
     {
         return autoCompleteThreshold;
@@ -64,6 +56,7 @@ public class PrimitiveUimaFeatureSupportProperties
         autoCompleteThreshold = aAutoCompleteThreshold;
     }
 
+    @Override
     public int getAutoCompleteMaxResults()
     {
         return autoCompleteMaxResults;

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/LinkFeatureEditor.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/LinkFeatureEditor.java
@@ -74,6 +74,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.event.AnnotationDeletedE
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.AnnotationException;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupport;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRegistry;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.config.LinkFeatureSupportProperties;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.event.FeatureEditorValueChangedEvent;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.event.LinkFeatureDeletedEvent;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.layer.LayerSupportRegistry;
@@ -106,6 +107,7 @@ public class LinkFeatureEditor
     private @SpringBean AnnotationSchemaService annotationService;
     private @SpringBean FeatureSupportRegistry featureSupportRegistry;
     private @SpringBean LayerSupportRegistry layerSupportRegistry;
+    private @SpringBean LinkFeatureSupportProperties properties;
 
     private WebMarkupContainer content;
 
@@ -268,7 +270,7 @@ public class LinkFeatureEditor
         });
 
         if (getModelObject().feature.getTagset() != null) {
-            if (getModelObject().tagset.size() > 100) {
+            if (getModelObject().tagset.size() > properties.getAutoCompleteThreshold()) {
                 field = makeAutoComplete("newRole");
             }
             else {
@@ -385,7 +387,7 @@ public class LinkFeatureEditor
                 FeatureState state = LinkFeatureEditor.this.getModelObject();
 
                 TagRanker ranker = new TagRanker();
-                ranker.setMaxResults(100);
+                ranker.setMaxResults(properties.getAutoCompleteMaxResults());
                 ranker.setTagCreationAllowed(state.getFeature().getTagset().isCreateTag());
 
                 return ranker.rank(aTerm, state.tagset);

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/LinkFeatureTraitsEditor.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/LinkFeatureTraitsEditor.java
@@ -41,7 +41,7 @@ import com.googlecode.wicket.kendo.ui.form.multiselect.MultiSelect;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRegistry;
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.SlotFeatureSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.LinkFeatureSupport;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.Tag;
 import de.tudarmstadt.ukp.clarin.webanno.model.TagSet;
@@ -62,7 +62,7 @@ public class LinkFeatureTraitsEditor
     private IModel<AnnotationFeature> feature;
     private IModel<Traits> traits;
 
-    public LinkFeatureTraitsEditor(String aId, SlotFeatureSupport aFS,
+    public LinkFeatureTraitsEditor(String aId, LinkFeatureSupport aFS,
             IModel<AnnotationFeature> aFeatureModel)
     {
         super(aId, aFeatureModel);
@@ -184,9 +184,9 @@ public class LinkFeatureTraitsEditor
         getFeatureSupport().writeTraits(feature.getObject(), t);
     }
 
-    private SlotFeatureSupport getFeatureSupport()
+    private LinkFeatureSupport getFeatureSupport()
     {
-        return (SlotFeatureSupport) featureSupportRegistry.getExtension(featureSupportId)
+        return (LinkFeatureSupport) featureSupportRegistry.getExtension(featureSupportId)
                 .orElseThrow();
     }
 

--- a/inception/inception-api-annotation/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/LinkFeatureSupportTest.java
+++ b/inception/inception-api-annotation/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/LinkFeatureSupportTest.java
@@ -49,11 +49,11 @@ import de.tudarmstadt.ukp.clarin.webanno.model.MultiValueMode;
 import de.tudarmstadt.ukp.clarin.webanno.model.Tag;
 import de.tudarmstadt.ukp.clarin.webanno.model.TagSet;
 
-public class SlotFeatureSupportTest
+public class LinkFeatureSupportTest
 {
     private @Mock AnnotationSchemaService schemaService;
 
-    private SlotFeatureSupport sut;
+    private LinkFeatureSupport sut;
 
     private AnnotationFeature slotFeature;
 
@@ -67,7 +67,7 @@ public class SlotFeatureSupportTest
     {
         initMocks(this);
 
-        sut = new SlotFeatureSupport(schemaService);
+        sut = new LinkFeatureSupport(schemaService);
 
         slotFeature = new AnnotationFeature("links", "webanno.custom.SimpleSpan");
         slotFeature.setLinkTypeName("webanno.custom.LinkType");

--- a/inception/inception-api-annotation/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/StringFeatureSupportTest.java
+++ b/inception/inception-api-annotation/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/StringFeatureSupportTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.config.PrimitiveUimaFeatureSupportProperties;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.config.StringFeatureSupportPropertiesImpl;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.Tag;
 import de.tudarmstadt.ukp.clarin.webanno.model.TagSet;
@@ -54,7 +54,7 @@ public class StringFeatureSupportTest
     {
         initMocks(this);
 
-        sut = new StringFeatureSupport(new PrimitiveUimaFeatureSupportProperties(), schemaService);
+        sut = new StringFeatureSupport(new StringFeatureSupportPropertiesImpl(), schemaService);
 
         valueFeature = new AnnotationFeature("value", CAS.TYPE_NAME_STRING);
 

--- a/inception/inception-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/annotationservice/config/AnnotationSchemaServiceAutoConfiguration.java
+++ b/inception/inception-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/annotationservice/config/AnnotationSchemaServiceAutoConfiguration.java
@@ -41,10 +41,12 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.BooleanFeatureSu
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupport;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRegistry;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRegistryImpl;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.LinkFeatureSupport;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.NumberFeatureSupport;
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.SlotFeatureSupport;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.StringFeatureSupport;
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.config.PrimitiveUimaFeatureSupportProperties;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.config.LinkFeatureSupportPropertiesImpl;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.config.StringFeatureSupportProperties;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.config.StringFeatureSupportPropertiesImpl;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.layer.ChainLayerSupport;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.layer.LayerBehaviorRegistry;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.layer.LayerBehaviorRegistryImpl;
@@ -57,7 +59,8 @@ import de.tudarmstadt.ukp.clarin.webanno.api.dao.AnnotationSchemaServiceImpl;
 
 @Configuration
 @EnableConfigurationProperties({ //
-        PrimitiveUimaFeatureSupportProperties.class, //
+        StringFeatureSupportPropertiesImpl.class, //
+        LinkFeatureSupportPropertiesImpl.class, //
         AnnotationEditorPropertiesImpl.class })
 public class AnnotationSchemaServiceAutoConfiguration
 {
@@ -93,17 +96,16 @@ public class AnnotationSchemaServiceAutoConfiguration
     }
 
     @Bean
-    public StringFeatureSupport stringFeaturesupport(
-            PrimitiveUimaFeatureSupportProperties aProperties,
+    public StringFeatureSupport stringFeaturesupport(StringFeatureSupportProperties aProperties,
             AnnotationSchemaService aSchemaService)
     {
         return new StringFeatureSupport(aProperties, aSchemaService);
     }
 
     @Bean
-    public SlotFeatureSupport slotFeaturesupport(AnnotationSchemaService aAnnotationService)
+    public LinkFeatureSupport linkFeatureSupport(AnnotationSchemaService aAnnotationService)
     {
-        return new SlotFeatureSupport(aAnnotationService);
+        return new LinkFeatureSupport(aAnnotationService);
     }
 
     @Bean

--- a/inception/inception-brat-editor/src/test/java/de/tudarmstadt/ukp/clarin/webanno/brat/message/BratRendererTest.java
+++ b/inception/inception-brat-editor/src/test/java/de/tudarmstadt/ukp/clarin/webanno/brat/message/BratRendererTest.java
@@ -47,8 +47,8 @@ import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.coloring.ColoringServiceImpl;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.BooleanFeatureSupport;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRegistryImpl;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.LinkFeatureSupport;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.NumberFeatureSupport;
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.SlotFeatureSupport;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.StringFeatureSupport;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.layer.ChainLayerSupport;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.layer.LayerBehaviorRegistryImpl;
@@ -125,7 +125,7 @@ public class BratRendererTest
 
         FeatureSupportRegistryImpl featureSupportRegistry = new FeatureSupportRegistryImpl(
                 asList(new StringFeatureSupport(), new BooleanFeatureSupport(),
-                        new NumberFeatureSupport(), new SlotFeatureSupport(schemaService)));
+                        new NumberFeatureSupport(), new LinkFeatureSupport(schemaService)));
         featureSupportRegistry.init();
 
         LayerBehaviorRegistryImpl layerBehaviorRegistry = new LayerBehaviorRegistryImpl(asList());

--- a/inception/inception-curation/src/test/java/de/tudarmstadt/ukp/inception/curation/merge/CasMergeTestBase.java
+++ b/inception/inception-curation/src/test/java/de/tudarmstadt/ukp/inception/curation/merge/CasMergeTestBase.java
@@ -45,8 +45,8 @@ import org.mockito.Mock;
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.BooleanFeatureSupport;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRegistryImpl;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.LinkFeatureSupport;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.NumberFeatureSupport;
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.SlotFeatureSupport;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.StringFeatureSupport;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.layer.ChainLayerSupport;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.layer.LayerBehaviorRegistryImpl;
@@ -67,7 +67,6 @@ import de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
 import de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.Dependency;
-import de.tudarmstadt.ukp.inception.curation.merge.CasMerge;
 
 public class CasMergeTestBase
 {
@@ -365,7 +364,7 @@ public class CasMergeTestBase
 
         featureSupportRegistry = new FeatureSupportRegistryImpl(
                 asList(new StringFeatureSupport(), new BooleanFeatureSupport(),
-                        new NumberFeatureSupport(), new SlotFeatureSupport(schemaService)));
+                        new NumberFeatureSupport(), new LinkFeatureSupport(schemaService)));
         featureSupportRegistry.init();
 
         LayerBehaviorRegistryImpl layerBehaviorRegistry = new LayerBehaviorRegistryImpl(asList());

--- a/inception/inception-curation/src/test/java/de/tudarmstadt/ukp/inception/curation/merge/strategy/ThresholdBasedMergeStrategyTest.java
+++ b/inception/inception-curation/src/test/java/de/tudarmstadt/ukp/inception/curation/merge/strategy/ThresholdBasedMergeStrategyTest.java
@@ -27,7 +27,6 @@ import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.Configuration;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.ConfigurationSet;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.internal.AID;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.span.SpanPosition;
-import de.tudarmstadt.ukp.inception.curation.merge.strategy.ThresholdBasedMergeStrategy;
 
 class ThresholdBasedMergeStrategyTest
 {

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/config/DiamEditorAutoConfig.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/config/DiamEditorAutoConfig.java
@@ -38,7 +38,6 @@ import de.tudarmstadt.ukp.inception.diam.editor.actions.ExtensionActionHandler;
 import de.tudarmstadt.ukp.inception.diam.editor.actions.FillSlotWithExistingAnnotationHandler;
 import de.tudarmstadt.ukp.inception.diam.editor.actions.FillSlotWithNewAnnotationHandler;
 import de.tudarmstadt.ukp.inception.diam.editor.actions.ImplicitUnarmSlotHandler;
-import de.tudarmstadt.ukp.inception.diam.editor.actions.ImplicitUnarmSlotHandler;
 import de.tudarmstadt.ukp.inception.diam.editor.actions.LazyDetailsHandler;
 import de.tudarmstadt.ukp.inception.diam.editor.actions.SelectAnnotationHandler;
 import de.tudarmstadt.ukp.inception.diam.editor.lazydetails.LazyDetailsLookupService;

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/settings_annotation-editor.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/settings_annotation-editor.adoc
@@ -17,6 +17,22 @@
 [[sect_settings_annotation]]
 = Annotation editor
 
+.Settings related to all annotation editors
+[cols="4*", options="header"]
+|===
+| Setting
+| Description
+| Default
+| Example
+
+| annotation.default-preferences.remember-layer
+| Whether "remember layer" is activated by default
+| false
+| 
+|===
+
+
+.Settings related to the brat editor
 [cols="4*", options="header"]
 |===
 | Setting
@@ -34,29 +50,52 @@
 | 5
 | 
 
-| annotation.default-preferences.remember-layer
-| Whether "remember layer" is activated by default
+| ui.brat.single-click-selection
+| Whether to select annotations with a single click
 | false
-| 
+|
+|===
 
-| annotation.feature-support.string.comboBoxThreshold
+.Settings related to string features
+[cols="4*", options="header"]
+|===
+| Setting
+| Description
+| Default
+| Example
+
+| annotation.feature-support.string.combo-box-threshold
 | If the tagset is larger than the threshold, an combo-box field is used instead of a radio-choice.
 | 6
 | 16
 
-| annotation.feature-support.string.autoCompleteThreshold
+| annotation.feature-support.string.auto-complete-threshold
 | If the tagset is larger than the threshold, an auto-complete field is used instead of a standard combobox.
 | 75
 | 100
 
-| annotation.feature-support.string.autoCompleteMaxResults
+| annotation.feature-support.string.auto-complete-max-results
 | When an auto-complete field is used, this determines the maximum number of items shown in the dropdown menu.
 | 100
 | 1000
+|===
 
-| ui.brat.singleClickSelection
-| Whether to select annotations with a single click
-| false
-|
+.Settings related to link features
+[cols="4*", options="header"]
+|===
+| Setting
+| Description
+| Default
+| Example
+
+| annotation.feature-support.link.auto-complete-threshold
+| If the tagset is larger than the threshold, an auto-complete field is used instead of a standard combobox.
+| 75
+| 100
+
+| annotation.feature-support.link.auto-complete-max-results
+| When an auto-complete field is used, this determines the maximum number of items shown in the dropdown menu.
+| 100
+| 1000
 |===
 

--- a/inception/inception-pdf-editor/src/test/java/de/tudarmstadt/ukpinception/pdfeditor/pdfanno/model/PdfAnnoRendererTest.java
+++ b/inception/inception-pdf-editor/src/test/java/de/tudarmstadt/ukpinception/pdfeditor/pdfanno/model/PdfAnnoRendererTest.java
@@ -47,8 +47,8 @@ import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.coloring.ColoringServiceImpl;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.BooleanFeatureSupport;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRegistryImpl;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.LinkFeatureSupport;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.NumberFeatureSupport;
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.SlotFeatureSupport;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.StringFeatureSupport;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.layer.ChainLayerSupport;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.layer.LayerBehaviorRegistryImpl;
@@ -125,7 +125,7 @@ public class PdfAnnoRendererTest
 
         FeatureSupportRegistryImpl featureSupportRegistry = new FeatureSupportRegistryImpl(
                 asList(new StringFeatureSupport(), new BooleanFeatureSupport(),
-                        new NumberFeatureSupport(), new SlotFeatureSupport(schemaService)));
+                        new NumberFeatureSupport(), new LinkFeatureSupport(schemaService)));
         featureSupportRegistry.init();
 
         LayerBehaviorRegistryImpl layerBehaviorRegistry = new LayerBehaviorRegistryImpl(asList());

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/extensionpoint/ExtensionPoint_ImplBase.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/extensionpoint/ExtensionPoint_ImplBase.java
@@ -65,7 +65,7 @@ public abstract class ExtensionPoint_ImplBase<C, E extends Extension<C>>
             }
         }
 
-        log.debug("Found [{}] {} extensions", extensions.size(), getClass().getSimpleName());
+        log.info("Found [{}] {} extensions", extensions.size(), getClass().getSimpleName());
 
         extensionsList = unmodifiableList(extensions);
     }

--- a/inception/inception-ui-annotation/src/main/resources/META-INF/asciidoc/user-guide/annotation_create-annotations_link-features.adoc
+++ b/inception/inception-ui-annotation/src/main/resources/META-INF/asciidoc/user-guide/annotation_create-annotations_link-features.adoc
@@ -35,8 +35,15 @@ annotation owning the slow is shown in the annotation detail panel. Here, the cr
 .Role labels
 If role labels are enabled they can be changed by the user at any time.
 To change a previously selected role label, no prior deletion is needed.
-Just double-click on the instance you want to change, it will be highlighted in orange, and chose
+Just click on the slot you want to change, it will be highlighted in orange, and chose
 another role label.
+
+If there is a large number of tags in the tagset associated with the link feature, the the role 
+combobox is replaced with an auto-complete field. The difference is that in the auto-complete field, there is no button to open the dropdown to select a role. Instead, you can press space or use the cursor-down keys to cause the dropdown menu for the role to open. Also, the dropdown only shows up
+to a configurable maximum of matching tags. You can type in something (e.g. `action`) to filter for
+items containing `action`. The threshold for displaying an auto-complete field and the maximum number
+of tags shown in the dropdown can be configured globally. The settings are documented in the 
+administrators guide.
 
 If role labels are disabled for the link feature layer they cannot be manually set by the user.
 Instead the UI label of the linked annotation is displayed.


### PR DESCRIPTION
**What's in the PR**
- Rename SlotFeatureSupport to LinkFeatureSupport
- Added auto-complete threshold settings for the role selector in the link feature editor
- Updated documentation

**How to test manually**
* See issue description / documentation

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
