### PR TITLE
#2803 - invitation link behind reverse proxy

### DIFF
--- a/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/InviteServiceImpl.java
+++ b/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/InviteServiceImpl.java
@@ -327,9 +327,14 @@ public class InviteServiceImpl
             while (url.charAt(url.length() - 1) == '/') {
                 url.setLength(url.length() - 1);
             }
+
+            Project project = aInvite.getProject();
+            String projectSegment = project.getSlug() != null ? project.getSlug()
+                    : String.valueOf(project.getId());
+
             url.append(NS_PROJECT);
             url.append("/");
-            url.append(aInvite.getProject().getId());
+            url.append(projectSegment);
             url.append("/");
             url.append("join-project");
             url.append("/");

--- a/inception/inception-sharing/src/main/resources/META-INF/asciidoc/admin-guide/settings_sharing.adoc
+++ b/inception/inception-sharing/src/main/resources/META-INF/asciidoc/admin-guide/settings_sharing.adoc
@@ -51,5 +51,10 @@ instances.
 | enable/disable guest annotators
 | false
 | true
+
+| sharing.invites.invite-base-url
+| base URL used to generate invite links, e.g. when running behind a reverse proxy
+| _unset_
+| https://public.mydomain.com/inception
 |===
 


### PR DESCRIPTION
**What's in the PR**
- Use the project slug in the generated invite link
- Document the invite link base URL setting

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
