### PR TITLE
#2819 - Cannot import CoNLL file

### DIFF
--- a/inception/inception-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/Conll2000FormatSupport.java
+++ b/inception/inception-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/Conll2000FormatSupport.java
@@ -25,8 +25,8 @@ import org.apache.uima.cas.CAS;
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
-import org.dkpro.core.io.conll.Conll2002Reader;
-import org.dkpro.core.io.conll.Conll2002Writer;
+import org.dkpro.core.io.conll.Conll2000Reader;
+import org.dkpro.core.io.conll.Conll2000Writer;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
 import de.tudarmstadt.ukp.clarin.webanno.conll.config.ConllFormatsAutoConfiguration;
@@ -72,7 +72,7 @@ public class Conll2000FormatSupport
     public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
         throws ResourceInitializationException
     {
-        return createReaderDescription(Conll2002Reader.class, aTSD);
+        return createReaderDescription(Conll2000Reader.class, aTSD);
     }
 
     @Override
@@ -80,6 +80,6 @@ public class Conll2000FormatSupport
             TypeSystemDescription aTSD, CAS aCAS)
         throws ResourceInitializationException
     {
-        return createEngineDescription(Conll2002Writer.class, aTSD);
+        return createEngineDescription(Conll2000Writer.class, aTSD);
     }
 }

--- a/inception/inception-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/Conll2002FormatSupport.java
+++ b/inception/inception-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/Conll2002FormatSupport.java
@@ -25,8 +25,8 @@ import org.apache.uima.cas.CAS;
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
-import org.dkpro.core.io.conll.Conll2000Reader;
-import org.dkpro.core.io.conll.Conll2000Writer;
+import org.dkpro.core.io.conll.Conll2002Reader;
+import org.dkpro.core.io.conll.Conll2002Writer;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
 import de.tudarmstadt.ukp.clarin.webanno.conll.config.ConllFormatsAutoConfiguration;
@@ -72,7 +72,7 @@ public class Conll2002FormatSupport
     public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
         throws ResourceInitializationException
     {
-        return createReaderDescription(Conll2000Reader.class, aTSD);
+        return createReaderDescription(Conll2002Reader.class, aTSD);
     }
 
     @Override
@@ -80,6 +80,6 @@ public class Conll2002FormatSupport
             TypeSystemDescription aTSD, CAS aCAS)
         throws ResourceInitializationException
     {
-        return createEngineDescription(Conll2000Writer.class, aTSD);
+        return createEngineDescription(Conll2002Writer.class, aTSD);
     }
 }

--- a/inception/pom.xml
+++ b/inception/pom.xml
@@ -1755,7 +1755,7 @@
       <dependency>
         <!-- Import dependency management from LOG4J -->
         <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j</artifactId>
+        <artifactId>log4j-bom</artifactId>
         <version>${log4j.version}</version>
         <type>pom</type>
         <scope>import</scope>
@@ -1775,10 +1775,12 @@
         <version>${dkpro.version}</version>
         <exclusions>
           <!-- We do not use DKPro Core model-downloading -->
+          <!--  
           <exclusion>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-model</artifactId>
           </exclusion>
+          -->
           <!--  
           Cannot exclude until https://github.com/dkpro/dkpro-core/issues/1511 is fixed
           <exclusion>


### PR DESCRIPTION
**What's in the PR**
- Readers and writers in CoNLL 2000 and CoNLL 2002 support were mixed up
- Remove exclusion of dependency which can cause a ClassNotFoundException at runtime when importing files with readers that support tagset mapping
- Fixed Log4J BOM import which moved some dependencies wrongly to the test scope - because we imported "log4j" instead of "log4j-bom"...

**How to test manually**
* Try importing a CoNLL 2000, 2002, 2003 file

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
