### PR TITLE
#2822 - Clean up (brat) rendering code

### DIFF
--- a/inception/inception-brat-editor/src/main/ts/brat/annotator_ui/AnnotatorUI.ts
+++ b/inception/inception-brat-editor/src/main/ts/brat/annotator_ui/AnnotatorUI.ts
@@ -49,8 +49,6 @@ import { EntityTypeDto } from "../protocol/Protocol";
 
 export class AnnotatorUI {
   private data: DocumentData = null;
-  private coll = null;
-  private doc = null;
 
   private arcDragOrigin = null;
   private arcDragOriginBox = null;
@@ -98,7 +96,6 @@ export class AnnotatorUI {
       on('dataReady', this, this.rememberData).
       on('spanAndAttributeTypesLoaded', this, this.spanAndAttributeTypesLoaded).
       on('user', this, this.userReceived).
-      on('current', this, this.gotCurrent).
       on('isReloadOkay', this, this.isReloadOkay).
       on('keydown', this, this.onKeyDown).
       on('click', this, this.onClick).
@@ -266,8 +263,6 @@ export class AnnotatorUI {
       old_target: targetSpanId,
       type: type,
       old_type: type,
-      collection: this.coll,
-      'document': this.doc
     };
 
     const eventDescId = evt.target.getAttribute('data-arc-ed');
@@ -734,8 +729,6 @@ export class AnnotatorUI {
             action: 'createArc',
             origin: originSpan.id,
             target: targetSpan.id,
-            collection: this.coll,
-            'document': this.doc
           };
 
           this.ajax.createRelationAnnotation(originSpan.id, targetSpan.id);
@@ -886,23 +879,8 @@ export class AnnotatorUI {
     }
   }
 
-  tagCurrentDocument(taggerId) {
-    const tagOptions = {
-      action: 'tag',
-      collection: this.coll,
-      'document': this.doc,
-      tagger: taggerId,
-    };
-    this.dispatcher.post('ajax', [tagOptions, 'edited']);
-  }
-
   spanAndAttributeTypesLoaded(_spanTypes, _entityAttributeTypes, _eventAttributeTypes, _relationTypesHash) {
     this.spanTypes = _spanTypes;
-  }
-
-  gotCurrent(_coll, _doc, _args) {
-    this.coll = _coll;
-    this.doc = _doc;
   }
 
   // WEBANNO EXTENSION BEGIN - #1388 Support context menu

--- a/inception/inception-brat-editor/src/main/ts/brat/protocol/Protocol.ts
+++ b/inception/inception-brat-editor/src/main/ts/brat/protocol/Protocol.ts
@@ -267,16 +267,6 @@ export type EquivDto = [
    * @deprecated INCEpTION does not use events
    */
   events: Array<EventDto>; // deprecated?
-
-  /**
-   * @deprecated INCEpTION does not use the collection name.
-   */
-  collection: string;
-
-  /**
-   * @deprecated INCEpTION does not use the document name.
-   */
-  document: string;
 }
 
 

--- a/inception/inception-brat-editor/src/main/ts/brat/visualizer/Visualizer.ts
+++ b/inception/inception-brat-editor/src/main/ts/brat/visualizer/Visualizer.ts
@@ -145,16 +145,6 @@ export class Visualizer {
   private sourceData: SourceData = null;
   private requestedData: SourceData = null; // FIXME Do we really need requestedData AND sourceData?
 
-  /**
-   * @deprecated INCEpTION does not use the collection name.
-   */
-  private coll: string = undefined;
-
-  /**
-   * @deprecated INCEpTION does not use the document name.
-   */
-  private doc: string = undefined;
-
   private args: Record<MarkerType, MarkerDto> = null;
 
   private isRenderRequested = false;
@@ -3244,14 +3234,14 @@ export class Visualizer {
     Util.profileStart('render');
 
     if (!sourceData && !this.data) {
-      this.dispatcher.post('doneRendering', [this.coll, this.doc, this.args]);
+      this.dispatcher.post('doneRendering', [this.args]);
       return;
     }
 
     this.svgContainer.style.visibility = 'visible';
-    if ((this.sourceData && this.sourceData.collection && (this.sourceData.document !== this.doc || this.sourceData.collection !== this.coll)) || this.drawing) {
+    if (this.drawing) {
       this.redraw = true;
-      this.dispatcher.post('doneRendering', [this.coll, this.doc, this.args]);
+      this.dispatcher.post('doneRendering', [this.args]);
       return;
     }
 
@@ -3365,7 +3355,7 @@ export class Visualizer {
       this.redraw = false;
     }
 
-    this.dispatcher.post('doneRendering', [this.coll, this.doc, this.args]);
+    this.dispatcher.post('doneRendering', [this.args]);
   }
 
   private renderAdjustMargin(y: number, sentNumGroup: SVGTypeMapping<SVGGElement>) {
@@ -3392,7 +3382,7 @@ export class Visualizer {
       setSourceDataDefaults(sourceData);
     }
 
-    this.dispatcher.post('startedRendering', [this.coll, this.doc, this.args]);
+    this.dispatcher.post('startedRendering', [this.args]);
     this.dispatcher.post('spin');
 
     setTimeout(() => {
@@ -3414,7 +3404,7 @@ export class Visualizer {
    * due to a partial update from the server.
    */
   rerender() {
-    this.dispatcher.post('startedRendering', [this.coll, this.doc, this.args]);
+    this.dispatcher.post('startedRendering', [this.args]);
     this.dispatcher.post('spin');
 
     try {
@@ -3443,14 +3433,9 @@ export class Visualizer {
 
   renderDocument() {
     Util.profileStart('invoke getDocument');
-    this.dispatcher.post('ajax', [{
-      action: 'getDocument',
-      collection: this.coll,
-      'document': this.doc,
-    }, 'renderData', {
-      collection: this.coll,
-      'document': this.doc
-    }]);
+    this.dispatcher.post('ajax', [
+      { action: 'getDocument' }, 
+      'renderData' ]);
   }
 
   triggerRender() {
@@ -3464,14 +3449,10 @@ export class Visualizer {
         return;
       }
 
-      if (this.doc.length) {
-        Util.profileClear();
-        Util.profileStart('before render');
-        this.renderDocument();
-        return;
-      }
-
-      this.dispatcher.post(0, 'renderError:noFileSpecified');
+      Util.profileClear();
+      Util.profileStart('before render');
+      this.renderDocument();
+      return;
     }
   }
 
@@ -3484,9 +3465,7 @@ export class Visualizer {
     this.isCollectionLoaded = false;
   }
 
-  gotCurrent(coll, doc, args, reloadData) {
-    this.coll = coll;
-    this.doc = doc;
+  gotCurrent(args, reloadData) {
     this.args = args;
 
     if (reloadData) {

--- a/inception/inception-brat-editor/src/main/ts/brat/visualizer_ui/VisualizerUI.ts
+++ b/inception/inception-brat-editor/src/main/ts/brat/visualizer_ui/VisualizerUI.ts
@@ -455,7 +455,7 @@ export class VisualizerUI {
     });
   }
 
-  onDoneRendering(coll, doc, args) {
+  onDoneRendering(args) {
     if (args && !args.edited) {
       // FIXME REC 2021-11-21 - Good idea but won't work in INCEpTION since there could 
       // be multiple SVGs on screen. Should be removed or done differently.


### PR DESCRIPTION
**What's in the PR**
- Pull code that cancels rendering if an editor was already rendered or that's already part of the AJAX target out into the AnnotationEditorBase class
- Pull error handling code into AnnotationEditorBase
- Remove collection and document information from brat

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
