### PR TITLE
#2833 - Enhance (external) editors API

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/rendering/DocumentViewFactory.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/rendering/DocumentViewFactory.java
@@ -26,5 +26,5 @@ import de.tudarmstadt.ukp.clarin.webanno.support.extensionpoint.Extension;
 public interface DocumentViewFactory
     extends Extension<AnnotationDocument>
 {
-    Component createView(String aId, IModel<AnnotationDocument> aDocument);
+    Component createView(String aId, IModel<AnnotationDocument> aDocument, String aEditorFactoryId);
 }

--- a/inception/inception-api-formats/pom.xml
+++ b/inception/inception-api-formats/pom.xml
@@ -37,5 +37,9 @@
       <groupId>org.apache.uima</groupId>
       <artifactId>uimafit-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.wicket</groupId>
+      <artifactId>wicket-core</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/inception/inception-api-formats/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/format/FormatSupport.java
+++ b/inception/inception-api-formats/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/format/FormatSupport.java
@@ -17,11 +17,15 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.api.format;
 
+import java.util.Collections;
+import java.util.List;
+
 import org.apache.uima.analysis_engine.AnalysisEngineDescription;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
+import org.apache.wicket.request.resource.CssResourceReference;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
@@ -55,6 +59,14 @@ public interface FormatSupport
     default boolean isWritable()
     {
         return false;
+    }
+
+    /**
+     * @return format-specific CSS style-sheets that styleable editors should load.
+     */
+    default List<CssResourceReference> getCssStylesheets()
+    {
+        return Collections.emptyList();
     }
 
     /**

--- a/inception/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/htmleditor/docview/HtmlDocumentIFrameViewFactory.java
+++ b/inception/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/htmleditor/docview/HtmlDocumentIFrameViewFactory.java
@@ -49,7 +49,8 @@ public class HtmlDocumentIFrameViewFactory
     }
 
     @Override
-    public Component createView(String aId, IModel<AnnotationDocument> aDoc)
+    public Component createView(String aId, IModel<AnnotationDocument> aDoc,
+            String aEditorFactoryId)
     {
         return new HtmlDocumentIFrameView(aId, aDoc);
     }

--- a/inception/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/htmleditor/docview/HtmlDocumentViewFactory.java
+++ b/inception/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/htmleditor/docview/HtmlDocumentViewFactory.java
@@ -49,7 +49,8 @@ public class HtmlDocumentViewFactory
     }
 
     @Override
-    public Component createView(String aId, IModel<AnnotationDocument> aDoc)
+    public Component createView(String aId, IModel<AnnotationDocument> aDoc,
+            String aEditorFactoryId)
     {
         return new HtmlDocumentView(aId, aDoc);
     }

--- a/inception/inception-html-recogito-editor/src/main/java/de/tudarmstadt/ukp/inception/recogitojseditor/RecogitoHtmlAnnotationEditor.java
+++ b/inception/inception-html-recogito-editor/src/main/java/de/tudarmstadt/ukp/inception/recogitojseditor/RecogitoHtmlAnnotationEditor.java
@@ -65,7 +65,7 @@ public class RecogitoHtmlAnnotationEditor
                 aModel.getObject().getDocument(), aModel.getObject().getUser());
 
         vis = documentViewExtensionPoint.getExtension(VIEW_FORMAT) //
-                .map(ext -> ext.createView("vis", Model.of(annDoc))) //
+                .map(ext -> ext.createView("vis", Model.of(annDoc), null)) //
                 .orElseGet(() -> new Label("Unsupported view"));
         add(vis);
 

--- a/inception/inception-imls-elg/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/elg/ElgCatalogClientImplTest.java
+++ b/inception/inception-imls-elg/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/elg/ElgCatalogClientImplTest.java
@@ -17,8 +17,8 @@
  */
 package de.tudarmstadt.ukp.inception.recommendation.imls.elg;
 
-import org.junit.Ignore;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import de.tudarmstadt.ukp.inception.recommendation.imls.elg.client.ElgCatalogClient;
@@ -37,7 +37,7 @@ public class ElgCatalogClientImplTest
         sut = new ElgCatalogClientImpl();
     }
 
-    @Ignore("Not really a test")
+    @Disabled("Not really a test")
     @Test
     public void testCatalogQuery() throws Exception
     {
@@ -46,7 +46,7 @@ public class ElgCatalogClientImplTest
         // System.out.println(JSONUtil.toPrettyJsonString(response));
     }
 
-    @Ignore("Not really a test")
+    @Disabled("Not really a test")
     @Test
     public void testRetrievingDetails() throws Exception
     {
@@ -56,7 +56,7 @@ public class ElgCatalogClientImplTest
         // System.out.println(JSONUtil.toPrettyJsonString(response));
     }
     
-    @Ignore("Not really a test")
+    @Disabled("Not really a test")
     @Test
     public void findNonExecutableServices() throws Exception {
         ElgCatalogSearchResponse response = sut.search("");

--- a/inception/inception-js-api/src/main/ts/src/editor/AnnotationEditorFactory.ts
+++ b/inception/inception-js-api/src/main/ts/src/editor/AnnotationEditorFactory.ts
@@ -19,7 +19,7 @@ import { DiamClientFactory } from "../diam";
 import { AnnotationEditor, AnnotationEditorProperties } from ".";
 
 export interface AnnotationEditorFactory {
-  getOrInitialize(element: HTMLElement | string, diam: DiamClientFactory, props: AnnotationEditorProperties): Promise<AnnotationEditor>;
+  getOrInitialize(element: Node, diam: DiamClientFactory, props: AnnotationEditorProperties): Promise<AnnotationEditor>;
 
-  destroy(element: HTMLElement | string): void;
+  destroy(element: Node): void;
 }


### PR DESCRIPTION
**What's in the PR**
- Allow sending the editor ID to the view
- Allow formats to specify CSS stylesheets that should be used when being rendered in styleable editors
- Pass target element to external editor only as element and not as ID
- Improve CSS and JavaScript injection in external editor factory

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
