### PR TITLE
#878 - Unhide annotation suggestions immediately if an overlapping annotation is deleted

### DIFF
--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/SuggestionGroup.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/SuggestionGroup.java
@@ -363,6 +363,16 @@ public class SuggestionGroup<T extends AnnotationSuggestion>
         return suggestions.add(aSuggestion);
     }
 
+    public void showAll(int aFlags)
+    {
+        stream().forEach(span -> span.show(aFlags));
+    }
+
+    public void hideAll(int aFlags)
+    {
+        stream().forEach(span -> span.hide(aFlags));
+    }
+
     @Override
     public Iterator<T> iterator()
     {

--- a/inception/inception-recommendation/pom.xml
+++ b/inception/inception-recommendation/pom.xml
@@ -271,6 +271,11 @@
       <artifactId>dkpro-core-api-ner-asl</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.dkpro.core</groupId>
+      <artifactId>dkpro-core-api-syntax-asl</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/Fixtures.java
+++ b/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/Fixtures.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.service;
+
+import static java.util.stream.Collectors.toList;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import de.tudarmstadt.ukp.inception.recommendation.api.model.AnnotationSuggestion;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.RelationSuggestion;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.SpanSuggestion;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.SuggestionDocumentGroup;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.SuggestionGroup;
+
+public class Fixtures
+{
+    // AnnotationSuggestion
+    private final static long RECOMMENDER_ID = 1;
+    private final static String RECOMMENDER_NAME = "TestEntityRecommender";
+    private final static String DOC_NAME = "TestDocument";
+    private final static String UI_LABEL = "TestUiLabel";
+    private final static double CONFIDENCE = 0.2;
+    private final static String CONFIDENCE_EXPLANATION = "Predictor A: 0.05 | Predictor B: 0.15";
+    private final static String COVERED_TEXT = "TestText";
+
+    static <T extends AnnotationSuggestion> List<T> getInvisibleSuggestions(
+            Collection<SuggestionGroup<T>> aSuggestions)
+    {
+        return aSuggestions.stream() //
+                .flatMap(SuggestionGroup::stream) //
+                .filter(s -> !s.isVisible()) //
+                .collect(toList());
+    }
+
+    static <T extends AnnotationSuggestion> List<T> getVisibleSuggestions(
+            Collection<SuggestionGroup<T>> aSuggestions)
+    {
+        return aSuggestions.stream() //
+                .flatMap(SuggestionGroup::stream) //
+                .filter(s -> s.isVisible()) //
+                .collect(toList());
+    }
+
+    static SuggestionDocumentGroup<SpanSuggestion> makeSpanSuggestionGroup(long layerId,
+            String feature, int[][] vals)
+    {
+        List<SpanSuggestion> suggestions = new ArrayList<>();
+        for (int[] val : vals) {
+            suggestions.add(new SpanSuggestion(val[0], RECOMMENDER_ID, RECOMMENDER_NAME, layerId,
+                    feature, DOC_NAME, val[1], val[2], COVERED_TEXT, null, UI_LABEL, CONFIDENCE,
+                    CONFIDENCE_EXPLANATION));
+        }
+
+        return new SuggestionDocumentGroup<>(suggestions);
+    }
+
+    static SuggestionDocumentGroup<RelationSuggestion> makeRelationSuggestionGroup(long layerId,
+            String feature, int[][] vals)
+    {
+        List<RelationSuggestion> suggestions = new ArrayList<>();
+        for (int[] val : vals) {
+            suggestions.add(new RelationSuggestion(val[0], RECOMMENDER_ID, RECOMMENDER_NAME,
+                    layerId, feature, DOC_NAME, val[1], val[2], val[3], val[4], null, UI_LABEL,
+                    CONFIDENCE, CONFIDENCE_EXPLANATION));
+        }
+
+        return new SuggestionDocumentGroup<>(suggestions);
+    }
+}

--- a/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RelationSuggestionVisibilityCalculationTest.java
+++ b/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RelationSuggestionVisibilityCalculationTest.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.service;
+
+import static de.tudarmstadt.ukp.inception.recommendation.service.Fixtures.getInvisibleSuggestions;
+import static de.tudarmstadt.ukp.inception.recommendation.service.Fixtures.getVisibleSuggestions;
+import static de.tudarmstadt.ukp.inception.recommendation.service.Fixtures.makeRelationSuggestionGroup;
+import static java.util.stream.Collectors.toList;
+import static org.apache.uima.cas.CAS.TYPE_NAME_STRING;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.EntityManager;
+
+import org.apache.uima.cas.CAS;
+import org.apache.uima.fit.factory.JCasFactory;
+import org.apache.uima.jcas.JCas;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
+import de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.Dependency;
+import de.tudarmstadt.ukp.inception.recommendation.api.LearningRecordService;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.AnnotationSuggestion;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.RelationSuggestion;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.SuggestionDocumentGroup;
+
+public class RelationSuggestionVisibilityCalculationTest
+{
+    private @Mock LearningRecordService recordService;
+    private @Mock AnnotationSchemaService annoService;
+
+    private Project project;
+    private AnnotationLayer layer;
+    private String user;
+    private long layerId;
+
+    private RecommendationServiceImpl sut;
+
+    @BeforeEach
+    public void setUp() throws Exception
+    {
+        initMocks(this);
+
+        user = "Testuser";
+
+        layer = new AnnotationLayer();
+        layer.setName(Dependency._TypeName);
+        layer.setId(42l);
+        layerId = layer.getId();
+
+        project = new Project();
+        project.setName("Test Project");
+
+        List<AnnotationFeature> featureList = new ArrayList<AnnotationFeature>();
+        featureList
+                .add(new AnnotationFeature(Dependency._FeatName_DependencyType, TYPE_NAME_STRING));
+        when(annoService.listAnnotationFeature(layer)).thenReturn(featureList);
+        when(annoService.listSupportedFeatures(layer)).thenReturn(featureList);
+
+        sut = new RecommendationServiceImpl(null, null, null, null, annoService, null,
+                recordService, (EntityManager) null);
+    }
+
+    @Test
+    public void testCalculateVisibilityNoRecordsAllHidden() throws Exception
+    {
+        when(recordService.listRecords(user, layer)).thenReturn(new ArrayList<>());
+
+        CAS cas = getTestCas();
+        SuggestionDocumentGroup<RelationSuggestion> suggestions = makeRelationSuggestionGroup(
+                layerId, Dependency._FeatName_DependencyType, new int[][] { { 1, 0, 3, 13, 20 } });
+        sut.calculateRelationSuggestionVisibility(cas, user, layer, suggestions, 0, 25);
+
+        assertThat(getVisibleSuggestions(suggestions)) //
+                .as("No suggestions are visible as they overlap with annotations") //
+                .isEmpty();
+        // FIXME find out why suggestions are repeated/doubled
+        assertThat(getInvisibleSuggestions(suggestions)) //
+                .as("Invisible suggestions are hidden because of overlapping") //
+                .extracting(AnnotationSuggestion::getReasonForHiding) //
+                .extracting(String::trim) //
+                .containsExactly("overlapping");
+    }
+
+    @Test
+    public void thatVisibilityIsRestoredWhenOverlappingAnnotationIsRemoved() throws Exception
+    {
+        when(recordService.listRecords(user, layer)).thenReturn(new ArrayList<>());
+
+        CAS cas = getTestCas();
+        SuggestionDocumentGroup<RelationSuggestion> suggestions = makeRelationSuggestionGroup(
+                layerId, Dependency._FeatName_DependencyType, new int[][] { { 1, 0, 3, 13, 20 } });
+        sut.calculateRelationSuggestionVisibility(cas, user, layer, suggestions, 0, 25);
+
+        assertThat(getVisibleSuggestions(suggestions)) //
+                .as("No suggestions are visible as they overlap with annotations") //
+                .isEmpty();
+        assertThat(getInvisibleSuggestions(suggestions)) //
+                .as("All suggestions are hidden as the overlap with annotations") //
+                .isNotEmpty();
+
+        cas.select(Dependency.class).forEach(Dependency::removeFromIndexes);
+
+        sut.calculateRelationSuggestionVisibility(cas, user, layer, suggestions, 0, 25);
+
+        assertThat(getInvisibleSuggestions(suggestions)) //
+                .as("No suggestions are hidden as they no longer overlap with annotations") //
+                .containsExactly();
+        assertThat(getVisibleSuggestions(suggestions)) //
+                .as("All suggestions are visible as they no longer overlap with annotations") //
+                .containsExactlyInAnyOrderElementsOf(
+                        suggestions.stream().flatMap(g -> g.stream()).collect(toList()));
+    }
+
+    private CAS getTestCas() throws Exception
+    {
+        String documentText = "Dies ist ein Testtext, ach ist der schoen, der schoenste von allen"
+                + " Testtexten.";
+        JCas jcas = JCasFactory.createText(documentText, "de");
+
+        Token governor = new Token(jcas, 0, 3);
+        governor.addToIndexes();
+
+        // the annotation's feature value is initialized as null
+        Token dependent = new Token(jcas, 13, 20);
+        dependent.addToIndexes();
+
+        Dependency dep = new Dependency(jcas, dependent.getBegin(), dependent.getEnd());
+        dep.setDependent(dependent);
+        dep.setGovernor(governor);
+        dep.setDependencyType("DEP");
+        dep.addToIndexes();
+
+        return jcas.getCas();
+    }
+}

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/KnowledgeBaseDetailsPanel.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/KnowledgeBaseDetailsPanel.java
@@ -17,6 +17,8 @@
  */
 package de.tudarmstadt.ukp.inception.ui.kb.project;
 
+import static org.apache.commons.lang3.exception.ExceptionUtils.getRootCauseMessage;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
@@ -183,7 +185,8 @@ public class KnowledgeBaseDetailsPanel
                         success("Imported: " + f.getKey());
                     }
                     catch (Exception e) {
-                        error("Failed to import: " + f.getKey());
+                        error("Failed to import [" + f.getKey() + "]: " + getRootCauseMessage(e));
+                        log.error("Failed to import [{}]: ", f.getKey(), e);
                     }
                 }
             }


### PR DESCRIPTION
**What's in the PR**
- Do not skip visibility calculation if there are no annotations
- Ensure that suggestions in the current window are un-hidden as part of visibility calculation check - and then hidden again if necessary
- Added tests

**How to test manually**
* See issue description

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
