### PR TITLE
#2855 - Exclude empty annotations from String Matcher and OpenNLP recommenders

### DIFF
--- a/inception/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/doccat/OpenNlpDoccatRecommender.java
+++ b/inception/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/doccat/OpenNlpDoccatRecommender.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.inception.recommendation.imls.opennlp.doccat;
 
 import static de.tudarmstadt.ukp.inception.recommendation.api.evaluation.EvaluationResult.toEvaluationResult;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.uima.fit.util.CasUtil.getType;
 import static org.apache.uima.fit.util.CasUtil.indexCovered;
 import static org.apache.uima.fit.util.CasUtil.select;
@@ -245,6 +246,10 @@ public class OpenNlpDoccatRecommender
                 for (AnnotationFS annotation : selectCovered(annotationType, sampleUnit)) {
                     if (samples.size() >= traits.getTrainingSetSizeLimit()) {
                         break casses;
+                    }
+
+                    if (isBlank(annotation.getCoveredText())) {
+                        continue;
                     }
 
                     String label = annotation.getFeatureValueAsString(feature);

--- a/inception/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/ner/OpenNlpNerRecommender.java
+++ b/inception/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/ner/OpenNlpNerRecommender.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.inception.recommendation.imls.opennlp.ner;
 
 import static de.tudarmstadt.ukp.inception.recommendation.api.evaluation.EvaluationResult.toEvaluationResult;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.uima.fit.util.CasUtil.getType;
 import static org.apache.uima.fit.util.CasUtil.select;
@@ -311,6 +312,10 @@ public class OpenNlpNerRecommender
             for (AnnotationFS sampleUnit : cas.<Annotation> select(sampleUnitType)) {
                 if (nameSamples.size() >= traits.getTrainingSetSizeLimit()) {
                     break casses;
+                }
+
+                if (isBlank(sampleUnit.getCoveredText())) {
+                    continue;
                 }
 
                 Collection<Annotation> tokens = cas.<Annotation> select(tokenType)

--- a/inception/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/pos/OpenNlpPosRecommender.java
+++ b/inception/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/pos/OpenNlpPosRecommender.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.inception.recommendation.imls.opennlp.pos;
 
 import static de.tudarmstadt.ukp.inception.recommendation.api.evaluation.EvaluationResult.toEvaluationResult;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNoneBlank;
 import static org.apache.uima.fit.util.CasUtil.getType;
 import static org.apache.uima.fit.util.CasUtil.select;
@@ -268,6 +269,10 @@ public class OpenNlpPosRecommender
             for (Annotation sampleUnit : cas.<Annotation> select(sampleUnitType)) {
                 if (posSamples.size() >= traits.getTrainingSetSizeLimit()) {
                     break casses;
+                }
+
+                if (isBlank(sampleUnit.getCoveredText())) {
+                    continue;
                 }
 
                 List<Annotation> tokens = cas.<Annotation> select(tokenType).coveredBy(sampleUnit)

--- a/inception/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/span/StringMatchingRecommender.java
+++ b/inception/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/span/StringMatchingRecommender.java
@@ -369,6 +369,10 @@ public class StringMatchingRecommender
 
     private void learn(Trie<DictEntry> aDict, String aText, String aLabel)
     {
+        if (isBlank(aText)) {
+            return;
+        }
+
         String label = isBlank(aLabel) ? UNKNOWN_LABEL : aLabel;
 
         String text = aText;
@@ -383,7 +387,6 @@ public class StringMatchingRecommender
         }
 
         entry.put(label);
-
     }
 
     private List<Sample> extractData(List<CAS> aCasses, String aLayerName, String aFeatureName)
@@ -403,6 +406,10 @@ public class StringMatchingRecommender
                 List<Span> spans = new ArrayList<>();
 
                 for (AnnotationFS annotation : selectCovered(annotationType, sentence)) {
+                    if (isBlank(annotation.getCoveredText())) {
+                        continue;
+                    }
+
                     String label = annotation.getFeatureValueAsString(predictedFeature);
                     if (isNotEmpty(label)) {
                         spans.add(new Span(annotation.getBegin(), annotation.getEnd(),


### PR DESCRIPTION
**What's in the PR**
- Ignore zero-width annotations and annotations on whitespace only during training/evaluation

**How to test manually**
* See issue

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
