### PR TITLE
#2861 - Towards multi-value features

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/adapter/TypeAdapter.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/adapter/TypeAdapter.java
@@ -31,6 +31,7 @@ import org.apache.uima.cas.text.AnnotationFS;
 import org.apache.uima.fit.util.CasUtil;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.AnnotationException;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.Selection;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.VID;
@@ -156,7 +157,8 @@ public interface TypeAdapter
      *            the value.
      */
     void setFeatureValue(SourceDocument aDocument, String aUsername, CAS aCas, int aAddress,
-            AnnotationFeature aFeature, Object aValue);
+            AnnotationFeature aFeature, Object aValue)
+        throws AnnotationException;
 
     /**
      * @deprecated The UI class {@link AnnotatorState} should not be passed here. Use
@@ -165,6 +167,7 @@ public interface TypeAdapter
     @Deprecated
     default void setFeatureValue(AnnotatorState aState, CAS aCas, int aAddress,
             AnnotationFeature aFeature, Object aValue)
+        throws AnnotationException
     {
         setFeatureValue(aState.getDocument(), aState.getUser().getUsername(), aCas, aAddress,
                 aFeature, aValue);

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/adapter/TypeAdapter_ImplBase.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/adapter/TypeAdapter_ImplBase.java
@@ -37,6 +37,7 @@ import org.springframework.context.ApplicationEventPublisher;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.event.FeatureValueUpdatedEvent;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.AnnotationException;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRegistry;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.layer.LayerSupportRegistry;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
@@ -115,6 +116,7 @@ public abstract class TypeAdapter_ImplBase
     @Override
     public void setFeatureValue(SourceDocument aDocument, String aUsername, CAS aCas, int aAddress,
             AnnotationFeature aFeature, Object aValue)
+        throws AnnotationException
     {
         FeatureStructure fs = selectFsByAddr(aCas, aAddress);
 

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/LinkFeatureSupport.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/LinkFeatureSupport.java
@@ -221,12 +221,11 @@ public class LinkFeatureSupport
                         throw new IllegalArgumentException("[" + link.role
                                 + "] is not in the tag list. Please choose from the existing tags");
                     }
-                    else {
-                        Tag selectedTag = new Tag();
-                        selectedTag.setName(link.role);
-                        selectedTag.setTagSet(aFeature.getTagset());
-                        annotationService.createTag(selectedTag);
-                    }
+
+                    Tag selectedTag = new Tag();
+                    selectedTag.setName(link.role);
+                    selectedTag.setTagSet(aFeature.getTagset());
+                    annotationService.createTag(selectedTag);
                 }
             }
         }
@@ -312,5 +311,12 @@ public class LinkFeatureSupport
         catch (IOException e) {
             log.error("Unable to write traits", e);
         }
+    }
+
+    @Override
+    public String renderFeatureValue(AnnotationFeature aFeature, String aLabel)
+    {
+        // Never render link feature labels
+        return null;
     }
 }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/LinkFeatureSupport.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/LinkFeatureSupport.java
@@ -40,6 +40,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.action.AnnotationActionHandler;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.AnnotationException;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor.FeatureEditor;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor.LinkFeatureEditor;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor.LinkFeatureTraits;
@@ -211,6 +212,7 @@ public class LinkFeatureSupport
 
     @Override
     public void setFeatureValue(CAS aCas, AnnotationFeature aFeature, int aAddress, Object aValue)
+        throws AnnotationException
     {
         if (aValue instanceof List && aFeature.getTagset() != null) {
             for (LinkWithRoleModel link : (List<LinkWithRoleModel>) aValue) {

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/StringFeatureSupport.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/StringFeatureSupport.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.action.AnnotationActionHandler;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.AnnotationException;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.config.StringFeatureSupportProperties;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.config.StringFeatureSupportPropertiesImpl;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor.DynamicTextAreaFeatureEditor;
@@ -109,6 +110,7 @@ public class StringFeatureSupport
 
     @Override
     public void setFeatureValue(CAS aCas, AnnotationFeature aFeature, int aAddress, Object aValue)
+        throws AnnotationException
     {
         if (aValue != null && schemaService != null && aFeature.getTagset() != null
                 && CAS.TYPE_NAME_STRING.equals(aFeature.getType())

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/UimaPrimitiveFeatureSupport_ImplBase.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/UimaPrimitiveFeatureSupport_ImplBase.java
@@ -61,20 +61,4 @@ public abstract class UimaPrimitiveFeatureSupport_ImplBase<T>
     {
         aTD.addFeature(aFeature.getName(), aFeature.getDescription(), aFeature.getType());
     }
-
-    @Override
-    public String renderFeatureValue(AnnotationFeature aFeature, String aLabel)
-    {
-        if (CAS.TYPE_NAME_BOOLEAN.equals(aFeature.getType()) && aLabel != null) {
-            if ("true".equals(aLabel)) {
-                return "+" + aFeature.getUiName();
-            }
-            else {
-                return "-" + aFeature.getUiName();
-            }
-        }
-        else {
-            return FeatureSupport.super.renderFeatureValue(aFeature, aLabel);
-        }
-    }
 }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/KendoAutoCompleteTextFeatureEditor.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/KendoAutoCompleteTextFeatureEditor.java
@@ -20,8 +20,6 @@ package de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor;
 import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
 import static org.apache.wicket.markup.head.JavaScriptHeaderItem.forReference;
 
-import java.util.List;
-
 import org.apache.wicket.MarkupContainer;
 import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.html.form.AbstractTextComponent;
@@ -31,7 +29,6 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.action.AnnotationActionH
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.keybindings.KeyBindingsPanel;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.FeatureState;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
-import de.tudarmstadt.ukp.clarin.webanno.model.ReorderableTag;
 
 /**
  * String feature editor using a Kendo AutoComplete field.
@@ -91,21 +88,6 @@ public class KendoAutoCompleteTextFeatureEditor
     @Override
     protected AbstractTextComponent createInputField()
     {
-        return new ReorderableTagAutoCompleteField("value")
-        {
-            private static final long serialVersionUID = 311286735004237737L;
-
-            @Override
-            protected List<ReorderableTag> getChoices(String aTerm)
-            {
-                FeatureState state = KendoAutoCompleteTextFeatureEditor.this.getModelObject();
-
-                TagRanker ranker = new TagRanker();
-                ranker.setMaxResults(maxResults);
-                ranker.setTagCreationAllowed(state.getFeature().getTagset().isCreateTag());
-
-                return ranker.rank(aTerm, state.tagset);
-            }
-        };
+        return new ReorderableTagAutoCompleteField("value", getModel(), maxResults);
     }
 }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/LinkFeatureEditor.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/LinkFeatureEditor.java
@@ -390,22 +390,8 @@ public class LinkFeatureEditor
 
     private AbstractTextComponent makeAutoComplete(String aId)
     {
-        return new ReorderableTagAutoCompleteField(aId, PropertyModel.of(this, "newRole"))
-        {
-            private static final long serialVersionUID = 311286735004237737L;
-
-            @Override
-            protected List<ReorderableTag> getChoices(String aTerm)
-            {
-                FeatureState state = LinkFeatureEditor.this.getModelObject();
-
-                TagRanker ranker = new TagRanker();
-                ranker.setMaxResults(properties.getAutoCompleteMaxResults());
-                ranker.setTagCreationAllowed(state.getFeature().getTagset().isCreateTag());
-
-                return ranker.rank(aTerm, state.tagset);
-            }
-        };
+        return new ReorderableTagAutoCompleteField(aId, PropertyModel.of(this, "newRole"),
+                getModel(), properties.getAutoCompleteMaxResults());
     }
 
     private AbstractTextComponent makeComboBox(String aId)

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/StringFeatureTraitsEditor.html
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/StringFeatureTraitsEditor.html
@@ -24,7 +24,7 @@
         <div class="form-check">
           <input wicket:id="multipleRows" class="form-check-input" type="checkbox">
           <label wicket:for="multipleRows" class="form-check-label">
-            Multiple Rows
+            Multiple rows
           </label>
         </div>
       </div>
@@ -34,14 +34,14 @@
         <div class="form-check">
           <input wicket:id="dynamicSize" class="form-check-input" type="checkbox">
           <label wicket:for="dynamicSize" class="form-check-label">
-            Dynamic Size
+            Dynamic size
           </label>
         </div>
       </div>
     </div>
     <div class="row form-row" wicket:enclosure="collapsedRows">
       <label wicket:for="collapsedRows" class="col-sm-4 col-form-label">
-        Collapsed Rows
+        Collapsed rows
       </label>
       <div class="col-sm-8">
         <input type="number" style="width:100%;" wicket:id="collapsedRows" data-container="body"></input>
@@ -49,7 +49,7 @@
     </div>
     <div class="row form-row" wicket:enclosure="expandedRows">
       <label wicket:for="expandedRows" class="col-sm-4 col-form-label">
-        Expanded Rows
+        Expanded rows
       </label>
       <div class="col-sm-8">
         <input type="number" style="width:100%;" wicket:id="expandedRows" data-container="body"></input>

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/StringFeatureTraitsEditor.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/StringFeatureTraitsEditor.java
@@ -65,9 +65,6 @@ public class StringFeatureTraitsEditor
     {
         super(aId, aFeature);
 
-        // We cannot retain a reference to the actual SlotFeatureSupport instance because that
-        // is not serializable, but we can retain its ID and look it up again from the registry
-        // when required.
         featureSupportId = aFS.getId();
         feature = aFeature;
 

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/rendering/Renderer.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/rendering/Renderer.java
@@ -83,8 +83,7 @@ public interface Renderer
         Map<String, String> features = new LinkedHashMap<>();
 
         for (AnnotationFeature feature : aFeatures) {
-            if (!feature.isEnabled() || !feature.isVisible()
-                    || !MultiValueMode.NONE.equals(feature.getMultiValueMode())) {
+            if (!feature.isEnabled() || !feature.isVisible()) {
                 continue;
             }
 

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/util/WebAnnoCasUtil.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/util/WebAnnoCasUtil.java
@@ -819,9 +819,7 @@ public class WebAnnoCasUtil
             // remove duplicate links
             Set<LinkWithRoleModel> links = new HashSet<>(aValue);
             for (LinkWithRoleModel e : links) {
-                // Skip links that have been added in the UI but where the target has not
-                // yet been
-                // set
+                // Skip empty slots that have been added where the target has not yet been set
                 if (e.targetAddr == -1) {
                     continue;
                 }

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationDetailPanel.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationDetailPanel.java
@@ -272,7 +272,8 @@ public class DocumentMetadataAnnotationDetailPanel
         }
     }
 
-    private void writeFeatureEditorModelsToCas(TypeAdapter aAdapter, CAS aCas) throws IOException
+    private void writeFeatureEditorModelsToCas(TypeAdapter aAdapter, CAS aCas)
+        throws IOException, AnnotationException
     {
         List<FeatureState> featureStates = featureList.getModelObject();
 

--- a/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/MultiValueMode.java
+++ b/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/MultiValueMode.java
@@ -25,7 +25,8 @@ import de.tudarmstadt.ukp.clarin.webanno.support.PersistentEnum;
 public enum MultiValueMode
     implements PersistentEnum
 {
-    NONE("none"), ARRAY("array");
+    NONE("none"), //
+    ARRAY("array");
 
     private final String id;
 

--- a/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchAnnotationSidebar.java
+++ b/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchAnnotationSidebar.java
@@ -683,6 +683,7 @@ public class SearchAnnotationSidebar
 
     private void setFeatureValues(SourceDocument aDocument, CAS aCas, SpanAdapter aAdapter,
             AnnotatorState state, AnnotationFS annoFS)
+        throws AnnotationException
     {
         int addr = getAddr(annoFS);
         List<FeatureState> featureStates = state.getFeatureStates();


### PR DESCRIPTION
**What's in the PR**
- Boolean feature rendering is handled in the boolean feature support - no need to do it in the base class
- Allow rendering feature values of multi-value features
- Link features are multi-value features but they should never be rendered in the label - so always return null
- Change setFeatureValue such that it may throw an AnnotationException
- Better factoring out of the ReorderableTagAutoCompleteField

**How to test manually**
* No particular test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
