### PR TITLE
#898 - Annotators should be able to reopen a finished document

### DIFF
--- a/inception/inception-app-webapp/pom.xml
+++ b/inception/inception-app-webapp/pom.xml
@@ -730,6 +730,7 @@
                 <toc>left</toc>
                 <include-dir>./admin-guide/</include-dir>
                 <source-dir>${project.basedir}/../</source-dir>
+                <imagesDir>./admin-guide/images</imagesDir>
               </attributes>
             </configuration>
           </execution>

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/actionbar/CurationWorkflowActionBarExtension.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/actionbar/CurationWorkflowActionBarExtension.java
@@ -25,8 +25,8 @@ import org.springframework.stereotype.Component;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.actionbar.ActionBarExtension;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
-import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.DefaultWorkflowActionBarExtension;
 import de.tudarmstadt.ukp.clarin.webanno.ui.curation.page.CurationPage;
+import de.tudarmstadt.ukp.inception.workload.extension.WorkloadManagerExtension;
 
 @Order(1000)
 @Component
@@ -36,7 +36,7 @@ public class CurationWorkflowActionBarExtension
     @Override
     public String getRole()
     {
-        return DefaultWorkflowActionBarExtension.class.getName();
+        return WorkloadManagerExtension.WORKLOAD_ACTION_BAR_ROLE;
     }
 
     @Override

--- a/inception/inception-workload-dynamic/pom.xml
+++ b/inception/inception-workload-dynamic/pom.xml
@@ -43,10 +43,6 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
-      <artifactId>inception-ui-annotation</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-api</artifactId>
     </dependency>
     <dependency>
@@ -73,6 +69,11 @@
     <dependency>
       <groupId>javax.persistence</groupId>
       <artifactId>javax.persistence-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
     </dependency>
 
     <dependency>

--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/annotation/DynamicWorkflowActionBarExtension.java
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/annotation/DynamicWorkflowActionBarExtension.java
@@ -25,8 +25,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.actionbar.ActionBarExtension;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
-import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.DefaultWorkflowActionBarExtension;
 import de.tudarmstadt.ukp.inception.workload.dynamic.config.DynamicWorkloadManagerAutoConfiguration;
+import de.tudarmstadt.ukp.inception.workload.extension.WorkloadManagerExtension;
 import de.tudarmstadt.ukp.inception.workload.model.WorkloadManagementService;
 
 /**
@@ -52,7 +52,7 @@ public class DynamicWorkflowActionBarExtension
     @Override
     public String getRole()
     {
-        return DefaultWorkflowActionBarExtension.class.getName();
+        return WorkloadManagerExtension.WORKLOAD_ACTION_BAR_ROLE;
     }
 
     @Override

--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/trait/DynamicWorkloadTraits.java
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/trait/DynamicWorkloadTraits.java
@@ -22,12 +22,15 @@ import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState.IG
 import java.io.Serializable;
 import java.time.Duration;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
 import de.tudarmstadt.ukp.inception.workload.dynamic.workflow.types.DefaultWorkflowExtension;
 
 /**
  * Trait class for dynamic workload
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class DynamicWorkloadTraits
     implements Serializable
 {

--- a/inception/inception-workload-matrix/pom.xml
+++ b/inception/inception-workload-matrix/pom.xml
@@ -87,6 +87,11 @@
     </dependency>
     
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/annotation/MatrixWorkflowActionBarExtension.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/annotation/MatrixWorkflowActionBarExtension.java
@@ -15,24 +15,35 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package de.tudarmstadt.ukp.clarin.webanno.ui.annotation;
+package de.tudarmstadt.ukp.inception.workload.matrix.annotation;
 
 import org.apache.wicket.markup.html.panel.Panel;
 import org.springframework.core.annotation.Order;
-import org.springframework.stereotype.Component;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.actionbar.ActionBarExtension;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
-import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.AnnotatorWorkflowActionBarItemGroup;
+import de.tudarmstadt.ukp.inception.workload.extension.WorkloadManagerExtension;
+import de.tudarmstadt.ukp.inception.workload.matrix.config.MatrixWorkloadManagerAutoConfiguration;
 
+/**
+ * <p>
+ * This class is exposed as a Spring Component via
+ * {@link MatrixWorkloadManagerAutoConfiguration#matrixWorkflowActionBarExtension}
+ * </p>
+ */
 @Order(1000)
-@Component
-public class DefaultWorkflowActionBarExtension
+public class MatrixWorkflowActionBarExtension
     implements ActionBarExtension
 {
     @Override
     public Panel createActionBarItem(String aId, AnnotationPageBase aPage)
     {
-        return new AnnotatorWorkflowActionBarItemGroup(aId, aPage);
+        return new MatrixWorkflowActionBarItemGroup(aId, aPage);
+    }
+
+    @Override
+    public String getRole()
+    {
+        return WorkloadManagerExtension.WORKLOAD_ACTION_BAR_ROLE;
     }
 }

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/annotation/MatrixWorkflowActionBarItemGroup.html
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/annotation/MatrixWorkflowActionBarItemGroup.html
@@ -26,7 +26,7 @@
         <button wicket:id="showResetDocumentDialog" class="btn btn-light" type="button" title="Reset document">
           <i class="fas fa-recycle"></i>
         </button>
-        <button wicket:id="showFinishDocumentDialog" class="btn btn-light" type="button" title="Finish document">
+        <button wicket:id="toggleDocumentState" class="btn btn-light" type="button" title="Finish document">
           <i wicket:id="state"></i>
         </button>
       </div>

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/annotation/MatrixWorkflowActionBarItemGroup.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/annotation/MatrixWorkflowActionBarItemGroup.java
@@ -15,10 +15,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar;
+package de.tudarmstadt.ukp.inception.workload.matrix.annotation;
 
+import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.CURATION_USER;
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState.FINISHED;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState.IN_PROGRESS;
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentStateChangeFlag.EXPLICIT_ANNOTATOR_USER_ACTION;
+import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.CURATION_FINISHED;
+import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.CURATION_IN_PROGRESS;
 import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.enabledWhen;
 
 import java.io.IOException;
@@ -36,33 +40,35 @@ import org.apache.wicket.spring.injection.annot.SpringBean;
 import de.agilecoders.wicket.core.markup.html.bootstrap.behavior.CssClassNameModifier;
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.icon.FontAwesome5IconType;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
-import de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.AnnotationException;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.ValidationException;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
-import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
-import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentStateTransition;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.support.dialog.ChallengeResponseDialog;
 import de.tudarmstadt.ukp.clarin.webanno.support.dialog.ConfirmationDialog;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxLink;
+import de.tudarmstadt.ukp.inception.workload.matrix.MatrixWorkloadExtension;
+import de.tudarmstadt.ukp.inception.workload.matrix.trait.MatrixWorkloadTraits;
+import de.tudarmstadt.ukp.inception.workload.model.WorkloadManagementService;
 
-public class AnnotatorWorkflowActionBarItemGroup
+public class MatrixWorkflowActionBarItemGroup
     extends Panel
 {
     private static final long serialVersionUID = 4139817495914347777L;
 
     private @SpringBean DocumentService documentService;
     private @SpringBean UserDao userRepository;
+    private @SpringBean WorkloadManagementService workloadManagementService;
+    private @SpringBean MatrixWorkloadExtension matrixWorkloadExtension;
 
     private final AnnotationPageBase page;
-    protected final ConfirmationDialog finishDocumentDialog;
-    private final LambdaAjaxLink finishDocumentLink;
-    private ChallengeResponseDialog resetDocumentDialog;
-    private LambdaAjaxLink resetDocumentLink;
+    private final ConfirmationDialog finishDocumentDialog;
+    private final ChallengeResponseDialog resetDocumentDialog;
+    private final LambdaAjaxLink resetDocumentLink;
 
-    public AnnotatorWorkflowActionBarItemGroup(String aId, AnnotationPageBase aPage)
+    public MatrixWorkflowActionBarItemGroup(String aId, AnnotationPageBase aPage)
     {
         super(aId);
 
@@ -72,17 +78,13 @@ public class AnnotatorWorkflowActionBarItemGroup
                 new StringResourceModel("FinishDocumentDialog.title", this, null),
                 new StringResourceModel("FinishDocumentDialog.text", this, null)));
 
-        add(finishDocumentLink = new LambdaAjaxLink("showFinishDocumentDialog",
-                this::actionFinishDocument));
-        finishDocumentLink.setOutputMarkupId(true);
-        finishDocumentLink.add(enabledWhen(() -> page.isEditable()));
-        finishDocumentLink.add(new Label("state")
-                .add(new CssClassNameModifier(LambdaModel.of(this::getStateClass))));
+        add(createToggleDocumentStateLink("toggleDocumentState"));
 
         IModel<String> documentNameModel = PropertyModel.of(page.getModel(), "document.name");
         add(resetDocumentDialog = new ChallengeResponseDialog("resetDocumentDialog",
                 new StringResourceModel("ResetDocumentDialog.title", this),
-                new StringResourceModel("ResetDocumentDialog.text", this).setModel(page.getModel())
+                new StringResourceModel("ResetDocumentDialog.text", this) //
+                        .setModel(page.getModel()) //
                         .setParameters(documentNameModel),
                 documentNameModel));
         resetDocumentDialog.setConfirmAction(this::actionResetDocument);
@@ -90,6 +92,25 @@ public class AnnotatorWorkflowActionBarItemGroup
         add(resetDocumentLink = new LambdaAjaxLink("showResetDocumentDialog",
                 resetDocumentDialog::show));
         resetDocumentLink.add(enabledWhen(() -> page.isEditable()));
+    }
+
+    private LambdaAjaxLink createToggleDocumentStateLink(String aId)
+    {
+        MatrixWorkloadTraits traits = matrixWorkloadExtension.readTraits(workloadManagementService
+                .loadOrCreateWorkloadManagerConfiguration(page.getModelObject().getProject()));
+
+        LambdaAjaxLink link;
+        if (traits.isReopenableByAnnotator()) {
+            link = new LambdaAjaxLink(aId, this::actionToggleDocumentState);
+        }
+        else {
+            link = new LambdaAjaxLink(aId, this::actionRequestFinishDocumentConfirmation);
+        }
+        link.setOutputMarkupId(true);
+        link.add(enabledWhen(() -> page.isEditable() || traits.isReopenableByAnnotator()));
+        link.add(new Label("state")
+                .add(new CssClassNameModifier(LambdaModel.of(this::getStateClass))));
+        return link;
     }
 
     protected AnnotationPageBase getAnnotationPage()
@@ -109,7 +130,7 @@ public class AnnotatorWorkflowActionBarItemGroup
         }
     }
 
-    protected void actionFinishDocument(AjaxRequestTarget aTarget)
+    protected void actionRequestFinishDocumentConfirmation(AjaxRequestTarget aTarget)
         throws IOException, AnnotationException
     {
         try {
@@ -121,27 +142,55 @@ public class AnnotatorWorkflowActionBarItemGroup
             return;
         }
 
-        finishDocumentDialog.setConfirmAction((_target) -> {
-            AnnotatorState state = page.getModelObject();
-            AnnotationDocument annotationDocument = documentService
-                    .getAnnotationDocument(state.getDocument(), state.getUser());
-
-            documentService.setAnnotationDocumentState(annotationDocument, FINISHED,
-                    EXPLICIT_ANNOTATOR_USER_ACTION);
-
-            // manually update state change!! No idea why it is not updated in the DB
-            // without calling createAnnotationDocument(...)
-            documentService.createAnnotationDocument(annotationDocument);
-
-            // curation sidebar: need to update source doc state as well to finished
-            if (state.getUser().getUsername().equals(WebAnnoConst.CURATION_USER)) {
-                documentService.transitionSourceDocumentState(state.getDocument(),
-                        SourceDocumentStateTransition.CURATION_IN_PROGRESS_TO_CURATION_FINISHED);
-            }
-
-            _target.add(page);
-        });
+        finishDocumentDialog.setConfirmAction(this::actionToggleDocumentState);
         finishDocumentDialog.show(aTarget);
+    }
+
+    private void actionToggleDocumentState(AjaxRequestTarget aTarget)
+    {
+        AnnotatorState state = page.getModelObject();
+        SourceDocument document = state.getDocument();
+        var annDoc = documentService.getAnnotationDocument(document, state.getUser());
+
+        if (annDoc.getAnnotatorState() != annDoc.getState()) {
+            error("Annotation state has been overridden by a project manager or curator. "
+                    + "You cannot change it.");
+            aTarget.addChildren(getPage(), IFeedback.class);
+            return;
+        }
+
+        // We look at the annotator state here because annotators should only be able to re-open
+        // documents that they closed themselves - not documents that were closed e.g. by a manager
+        var annState = annDoc.getAnnotatorState();
+        switch (annState) {
+        case IN_PROGRESS:
+            // curation sidebar: need to update source doc state as well to finished
+            if (state.getUser().getUsername().equals(CURATION_USER)) {
+                documentService.setSourceDocumentState(document, CURATION_FINISHED);
+            }
+            else {
+                documentService.setAnnotationDocumentState(annDoc, FINISHED,
+                        EXPLICIT_ANNOTATOR_USER_ACTION);
+            }
+            aTarget.add(page);
+            break;
+        case FINISHED:
+            // curation sidebar: need to update source doc state as well to finished
+            if (state.getUser().getUsername().equals(CURATION_USER)) {
+                documentService.setSourceDocumentState(document, CURATION_IN_PROGRESS);
+            }
+            else {
+                documentService.setAnnotationDocumentState(annDoc, IN_PROGRESS,
+                        EXPLICIT_ANNOTATOR_USER_ACTION);
+            }
+            aTarget.add(page);
+            break;
+        default:
+            error("Can only change document state for documents that are finished or in progress, "
+                    + "but document is in state [" + annState + "]");
+            aTarget.addChildren(getPage(), IFeedback.class);
+            break;
+        }
     }
 
     protected void actionResetDocument(AjaxRequestTarget aTarget) throws Exception

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/config/MatrixWorkloadManagerAutoConfiguration.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/config/MatrixWorkloadManagerAutoConfiguration.java
@@ -26,6 +26,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
 import de.tudarmstadt.ukp.inception.scheduling.SchedulingService;
 import de.tudarmstadt.ukp.inception.workload.matrix.MatrixWorkloadExtension;
 import de.tudarmstadt.ukp.inception.workload.matrix.MatrixWorkloadExtensionImpl;
+import de.tudarmstadt.ukp.inception.workload.matrix.annotation.MatrixWorkflowActionBarExtension;
 import de.tudarmstadt.ukp.inception.workload.matrix.event.MatrixWorkloadStateWatcher;
 import de.tudarmstadt.ukp.inception.workload.model.WorkloadManagementService;
 
@@ -47,5 +48,11 @@ public class MatrixWorkloadManagerAutoConfiguration
             SchedulingService aSchedulingService)
     {
         return new MatrixWorkloadStateWatcher(aSchedulingService);
+    }
+
+    @Bean
+    public MatrixWorkflowActionBarExtension matrixWorkflowActionBarExtension()
+    {
+        return new MatrixWorkflowActionBarExtension();
     }
 }

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/MatrixWorkloadManagementPage.html
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/MatrixWorkloadManagementPage.html
@@ -56,6 +56,39 @@
                   <div wicket:id="filterPanel"/>
                 </div>
               </span> 
+              <span class="dropdown sticky-dropdown" aria-haspopup="true" aria-expanded="false">
+                <button class="btn btn-action btn-secondary dropdown-toggle flex-content"
+                  type="button" data-bs-toggle="dropdown">
+                  <i class="fas fa-cog"></i>
+                  <span class="d-none d-lg-inline">
+                    &nbsp;<wicket:message key="settings" />
+                  </span>
+                </button>
+                <div class="dropdown-menu shadow-lg pt-0 pb-0" role="menu" style="min-width: 600px;">
+                  <form wicket:id="settingsForm">
+                    <div class="card-header">
+                      <wicket:message key="settings" />
+                    </div>
+                    <div class="card-body">
+                      <div class="row form-row">
+                        <label class="col-form-label col-sm-7">
+                          <wicket:message key="reopenableByAnnotator" />
+                        </label>
+                        <div class="col-sm-5">
+                          <div class="form-check">
+                            <input class="form-check-input" type="checkbox" wicket:id="reopenableByAnnotator">
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="card-footer">
+                      <button class="btn btn-primary" wicket:id="save">
+                        <wicket:message key="save" />
+                      </button>
+                    </div>
+                  </form>
+                </div>
+              </span>
               <button wicket:id="refresh" class="btn btn-action btn-secondary">
                 <i class="fas fa-redo"></i>
                 <span class="d-none d-lg-inline">

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/MatrixWorkloadManagementPage.properties
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/MatrixWorkloadManagementPage.properties
@@ -16,7 +16,10 @@
 page.title=Monitoring
 page.help.link=sect_matrix_workload
 
+#Cards header
+settings=Settings
 refresh=Refresh
+reopenableByAnnotator=Reopenable by annotators
 
 INPROGRESS=in progress
 NEW=new

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/trait/MatrixWorkloadTraits.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/trait/MatrixWorkloadTraits.java
@@ -19,33 +19,26 @@ package de.tudarmstadt.ukp.inception.workload.matrix.trait;
 
 import java.io.Serializable;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 /**
- * Trait class for default matrix workload
+ * Trait class for matrix workload
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class MatrixWorkloadTraits
     implements Serializable
 {
     private static final long serialVersionUID = 6984531953353384507L;
-    private static final String MATRIX_WORKLOAD_TRAIT = "matrix";
 
-    private int defaultNumberOfAnnotations;
+    private boolean reopenableByAnnotator;
 
-    public MatrixWorkloadTraits()
+    public boolean isReopenableByAnnotator()
     {
+        return reopenableByAnnotator;
     }
 
-    public String getType()
+    public void setReopenableByAnnotator(boolean aReopenableByAnnotator)
     {
-        return MATRIX_WORKLOAD_TRAIT;
-    }
-
-    public int getDefaultNumberOfAnnotations()
-    {
-        return defaultNumberOfAnnotations;
-    }
-
-    public void setDefaultNumberOfAnnotations(int defaultNumberOfAnnotations)
-    {
-        this.defaultNumberOfAnnotations = defaultNumberOfAnnotations;
+        reopenableByAnnotator = aReopenableByAnnotator;
     }
 }

--- a/inception/inception-workload-matrix/src/main/resources/META-INF/asciidoc/user-guide/workload_matrix.adoc
+++ b/inception/inception-workload-matrix/src/main/resources/META-INF/asciidoc/user-guide/workload_matrix.adoc
@@ -110,4 +110,15 @@ filter text field. For example, with the checkbox enabled, you could search for 
 all documents whose name starts with `chapter01` or for `train|test` to match all documents containing
 `train` or `test` in their name.
 
- 
+== Allow annotators to re-open documents
+
+When an annotator marks a document as **Finished**, the document becomes uneditable for them. 
+By default, the only way to re-open a document for further annotation is that a curator or project manager opens the workload management page and changes the state of the document there.
+
+However, in some cases, it is more convenient if annotators themselves can re-open a document and continue editing it. 
+The option **Reopenable by annotators** in the **Settings** dialog on the workload management can be enabled to allow annotators put finished documents back into the **in progress** state directly from the annotation page by clicking on the **Finish/lock** button in the action bar. 
+If this option is enabled, the dialog that asks users to confirm that they wish to mark a document is finished is not shown.
+
+NOTE: This option only allows annotators to re-open documents that they have closed themselves. 
+    If a document has been marked as finished by a project manager or curator, the annotators can not re-open it. 
+    On the workload management page, documents that have been explicitly closed by a curator/manager bear a double icon in their state column (e.g. **finished (in progress)**).

--- a/inception/inception-workload/src/main/java/de/tudarmstadt/ukp/inception/workload/extension/WorkloadManagerExtension.java
+++ b/inception/inception-workload/src/main/java/de/tudarmstadt/ukp/inception/workload/extension/WorkloadManagerExtension.java
@@ -29,6 +29,8 @@ import de.tudarmstadt.ukp.inception.workload.model.WorkloadManager;
 public interface WorkloadManagerExtension<T>
     extends Extension<Project>
 {
+    public static final String WORKLOAD_ACTION_BAR_ROLE = "Workload";
+
     @Override
     default boolean accepts(Project project)
     {


### PR DESCRIPTION
**What's in the PR**
- Added a trait to the matrix workload which should allow annotators to re-open a document - settable in the workload management page, but has no effect yet

**How to test manually**
* Enable the setting on the matrix workload management page
* Try closing and then re-opening a document on the annotation page

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
