### PR TITLE
#2411 - Possibility to reopen documents of an annotator in the curation

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/page/AnnotationPageBase.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/page/AnnotationPageBase.java
@@ -43,6 +43,7 @@ import org.apache.wicket.feedback.IFeedback;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.LoadableDetachableModel;
 import org.apache.wicket.request.IRequestParameters;
+import org.apache.wicket.request.RequestHandlerExecutor.ReplaceHandlerException;
 import org.apache.wicket.request.Url;
 import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.request.flow.RedirectToUrlException;
@@ -266,6 +267,11 @@ public abstract class AnnotationPageBase
 
     protected void handleException(AjaxRequestTarget aTarget, Exception aException)
     {
+        if (aException instanceof ReplaceHandlerException) {
+            // Let Wicket redirects still work
+            throw (ReplaceHandlerException) aException;
+        }
+
         LoggerFactory.getLogger(getClass()).error("Error: " + aException.getMessage(), aException);
         error("Error: " + aException.getMessage());
         if (aTarget != null) {

--- a/inception/inception-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentServiceImpl.java
+++ b/inception/inception-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/DocumentServiceImpl.java
@@ -346,8 +346,10 @@ public class DocumentServiceImpl
         return entityManager
                 .createQuery("FROM AnnotationDocument WHERE document = :document AND "
                         + "user =:user" + " AND project = :project", AnnotationDocument.class)
-                .setParameter("document", aDocument).setParameter("user", aUser)
-                .setParameter("project", aDocument.getProject()).getSingleResult();
+                .setParameter("document", aDocument) //
+                .setParameter("user", aUser) //
+                .setParameter("project", aDocument.getProject()) //
+                .getSingleResult();
     }
 
     @Override

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/dialog/ConfirmationDialog.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/dialog/ConfirmationDialog.java
@@ -30,6 +30,7 @@ import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.model.StringResourceModel;
+import org.apache.wicket.request.RequestHandlerExecutor.ReplaceHandlerException;
 import org.slf4j.LoggerFactory;
 
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.AjaxCallback;
@@ -182,6 +183,10 @@ public class ConfirmationDialog
         if (confirmAction != null) {
             try {
                 confirmAction.accept(aTarget);
+            }
+            catch (ReplaceHandlerException e) {
+                // Let Wicket redirects still work
+                throw e;
             }
             catch (Exception e) {
                 LoggerFactory.getLogger(getPage().getClass()).error("Error: " + e.getMessage(), e);

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/lambda/LambdaAjaxButton.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/lambda/LambdaAjaxButton.java
@@ -21,6 +21,7 @@ import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.markup.html.form.AjaxButton;
 import org.apache.wicket.feedback.IFeedback;
 import org.apache.wicket.markup.html.form.Form;
+import org.apache.wicket.request.RequestHandlerExecutor.ReplaceHandlerException;
 import org.slf4j.LoggerFactory;
 
 public class LambdaAjaxButton<T>
@@ -81,6 +82,10 @@ public class LambdaAjaxButton<T>
 
         try {
             action.accept(aTarget, (Form<T>) getForm());
+        }
+        catch (ReplaceHandlerException e) {
+            // Let Wicket redirects still work
+            throw e;
         }
         catch (Exception e) {
             if (exceptionHandler != null) {

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/lambda/LambdaAjaxEventBehavior.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/lambda/LambdaAjaxEventBehavior.java
@@ -21,6 +21,7 @@ import org.apache.wicket.ajax.AjaxEventBehavior;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.attributes.AjaxRequestAttributes;
 import org.apache.wicket.feedback.IFeedback;
+import org.apache.wicket.request.RequestHandlerExecutor.ReplaceHandlerException;
 import org.slf4j.LoggerFactory;
 
 public class LambdaAjaxEventBehavior
@@ -50,6 +51,10 @@ public class LambdaAjaxEventBehavior
     {
         try {
             action.accept(aTarget);
+        }
+        catch (ReplaceHandlerException e) {
+            // Let Wicket redirects still work
+            throw e;
         }
         catch (Exception e) {
             if (exceptionHandler != null) {

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/lambda/LambdaAjaxFormChoiceComponentUpdatingBehavior.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/lambda/LambdaAjaxFormChoiceComponentUpdatingBehavior.java
@@ -21,6 +21,7 @@ import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.form.AjaxFormChoiceComponentUpdatingBehavior;
 import org.apache.wicket.feedback.IFeedback;
+import org.apache.wicket.request.RequestHandlerExecutor.ReplaceHandlerException;
 import org.slf4j.LoggerFactory;
 
 public class LambdaAjaxFormChoiceComponentUpdatingBehavior
@@ -56,6 +57,10 @@ public class LambdaAjaxFormChoiceComponentUpdatingBehavior
             if (action != null) {
                 action.accept(aTarget);
             }
+        }
+        catch (ReplaceHandlerException e) {
+            // Let Wicket redirects still work
+            throw e;
         }
         catch (Exception e) {
             if (exceptionHandler != null) {

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/lambda/LambdaAjaxFormComponentUpdatingBehavior.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/lambda/LambdaAjaxFormComponentUpdatingBehavior.java
@@ -21,6 +21,7 @@ import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.form.AjaxFormComponentUpdatingBehavior;
 import org.apache.wicket.feedback.IFeedback;
+import org.apache.wicket.request.RequestHandlerExecutor.ReplaceHandlerException;
 import org.slf4j.LoggerFactory;
 
 public class LambdaAjaxFormComponentUpdatingBehavior
@@ -61,6 +62,10 @@ public class LambdaAjaxFormComponentUpdatingBehavior
             if (action != null) {
                 action.accept(aTarget);
             }
+        }
+        catch (ReplaceHandlerException e) {
+            // Let Wicket redirects still work
+            throw e;
         }
         catch (Exception e) {
             if (exceptionHandler != null) {

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/lambda/LambdaAjaxFormSubmittingBehavior.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/lambda/LambdaAjaxFormSubmittingBehavior.java
@@ -22,6 +22,7 @@ import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.form.AjaxFormSubmitBehavior;
 import org.apache.wicket.feedback.IFeedback;
 import org.apache.wicket.markup.html.form.Form;
+import org.apache.wicket.request.RequestHandlerExecutor.ReplaceHandlerException;
 import org.slf4j.LoggerFactory;
 
 public class LambdaAjaxFormSubmittingBehavior
@@ -82,6 +83,10 @@ public class LambdaAjaxFormSubmittingBehavior
             if (action != null) {
                 action.accept(aTarget);
             }
+        }
+        catch (ReplaceHandlerException e) {
+            // Let Wicket redirects still work
+            throw e;
         }
         catch (Exception e) {
             if (exceptionHandler != null) {

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/lambda/LambdaAjaxLink.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/lambda/LambdaAjaxLink.java
@@ -20,6 +20,7 @@ package de.tudarmstadt.ukp.clarin.webanno.support.lambda;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.markup.html.AjaxLink;
 import org.apache.wicket.feedback.IFeedback;
+import org.apache.wicket.request.RequestHandlerExecutor.ReplaceHandlerException;
 import org.slf4j.LoggerFactory;
 
 public class LambdaAjaxLink
@@ -65,6 +66,10 @@ public class LambdaAjaxLink
     {
         try {
             action.accept(aTarget);
+        }
+        catch (ReplaceHandlerException e) {
+            // Let Wicket redirects still work
+            throw e;
         }
         catch (Exception e) {
             if (exceptionHandler != null) {

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/lambda/LambdaAjaxSubmitLink.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/lambda/LambdaAjaxSubmitLink.java
@@ -23,6 +23,7 @@ import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.markup.html.form.AjaxSubmitLink;
 import org.apache.wicket.feedback.IFeedback;
 import org.apache.wicket.markup.html.form.Form;
+import org.apache.wicket.request.RequestHandlerExecutor.ReplaceHandlerException;
 import org.slf4j.LoggerFactory;
 
 @SuppressWarnings({ "unchecked", "rawtypes" })
@@ -65,6 +66,10 @@ public class LambdaAjaxSubmitLink<T extends Serializable>
     {
         try {
             action.accept(aTarget, getForm());
+        }
+        catch (ReplaceHandlerException e) {
+            // Let Wicket redirects still work
+            throw e;
         }
         catch (Exception e) {
             if (exceptionHandler != null) {

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/lambda/LambdaButton.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/lambda/LambdaButton.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.clarin.webanno.support.lambda;
 
 import org.apache.wicket.markup.html.form.Button;
+import org.apache.wicket.request.RequestHandlerExecutor.ReplaceHandlerException;
 import org.danekja.java.misc.serializable.SerializableRunnable;
 import org.danekja.java.util.function.serializable.SerializableConsumer;
 import org.slf4j.LoggerFactory;
@@ -70,6 +71,10 @@ public class LambdaButton
     {
         try {
             action.run();
+        }
+        catch (ReplaceHandlerException e) {
+            // Let Wicket redirects still work
+            throw e;
         }
         catch (Exception e) {
             if (exceptionHandler != null) {

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/lambda/LambdaForm.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/lambda/LambdaForm.java
@@ -21,6 +21,7 @@ import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.feedback.IFeedback;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.model.IModel;
+import org.apache.wicket.request.RequestHandlerExecutor.ReplaceHandlerException;
 import org.apache.wicket.request.cycle.RequestCycle;
 import org.slf4j.LoggerFactory;
 
@@ -56,6 +57,10 @@ public class LambdaForm<T>
         try {
             submitAction.accept(RequestCycle.get().find(AjaxRequestTarget.class).orElse(null),
                     this);
+        }
+        catch (ReplaceHandlerException e) {
+            // Let Wicket redirects still work
+            throw e;
         }
         catch (Exception e) {
             LoggerFactory.getLogger(getPage().getClass()).error("Error: " + e.getMessage(), e);

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/lambda/LambdaMenuItem.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/lambda/LambdaMenuItem.java
@@ -20,6 +20,7 @@ package de.tudarmstadt.ukp.clarin.webanno.support.lambda;
 import org.apache.wicket.Page;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.feedback.IFeedback;
+import org.apache.wicket.request.RequestHandlerExecutor.ReplaceHandlerException;
 import org.apache.wicket.request.cycle.PageRequestHandlerTracker;
 import org.apache.wicket.request.cycle.RequestCycle;
 import org.slf4j.LoggerFactory;
@@ -45,6 +46,10 @@ public class LambdaMenuItem
     {
         try {
             action.accept(aTarget);
+        }
+        catch (ReplaceHandlerException e) {
+            // Let Wicket redirects still work
+            throw e;
         }
         catch (Exception e) {
             Page page = (Page) PageRequestHandlerTracker.getLastHandler(RequestCycle.get())

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/actionbar/CuratorWorkflowActionBarItemGroup.html
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/actionbar/CuratorWorkflowActionBarItemGroup.html
@@ -21,12 +21,12 @@
   <wicket:panel>
     <div class="action-bar-group">
       <div wicket:id="resetDocumentDialog"></div>
-      <div wicket:id="finishDocumentDialog"></div>
+      <!-- <div wicket:id="finishDocumentDialog"></div> -->
       <div class="btn-group">
         <button wicket:id="showResetDocumentDialog" class="btn btn-light" type="button">
           <i class="fas fa-recycle"></i>
         </button>
-        <button wicket:id="showFinishDocumentDialog" class="btn btn-light" type="button">
+        <button wicket:id="toggleCurationState" class="btn btn-light" type="button">
           <i wicket:id="state"></i>
         </button>
       </div>

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/model/BratSuggestionVisualizer.html
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/model/BratSuggestionVisualizer.html
@@ -20,8 +20,12 @@
 <body>
   <wicket:panel>
     <div class="flex-content card">
+      <div wicket:id="stateChangeConfirmationDialog"></div>
       <div class="card-header">
         <wicket:container wicket:id="username"/>
+        <a wicket:id="stateToggle" class="btn btn-sm p-0 float-end">
+          <i wicket:id="state"></i>
+        </a>
       </div>
       <div class="card-body text-center" style="overflow-x: auto">
         <div wicket:id="vis" class="brat"></div>

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/model/BratSuggestionVisualizer.properties
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/model/BratSuggestionVisualizer.properties
@@ -1,0 +1,25 @@
+# Licensed to the Technische Universität Darmstadt under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The Technische Universität Darmstadt 
+# licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.
+#  
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+StateChangeConfirmationDialog.title=Change state
+StateChangeConfirmationDialog.text=Are you sure you want to put this annotator back into progress?\
+  <p>The annotator will be able to edit it the annotations again, but you won't see them anymore on \
+  the curation page until the annotations are marked as finished again. If you re-open the last \
+  finished annotations for a document, you will be force to curate another document or stop \
+  curation. \
+  <p><b>Note:</b> The document will still stay in the state "curation in progress" and any \
+  curations that you may already have performed will not be discarded, but you will not be able to \
+  access them until at least one annotator is back in the "finished" state. If you wish to restart \
+  curation for this document later, use the e.g. "re-merge" button.

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/CurationPage.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/CurationPage.java
@@ -53,6 +53,7 @@ import java.util.Set;
 import org.apache.uima.UIMAException;
 import org.apache.uima.cas.CAS;
 import org.apache.wicket.AttributeModifier;
+import org.apache.wicket.RestartResponseException;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.feedback.IFeedback;
 import org.apache.wicket.markup.head.IHeaderResponse;
@@ -575,7 +576,9 @@ public class CurationPage
                     + "administration dashboard and if none of the imported users have been "
                     + "enabled via the users management page after the import (also something "
                     + "that only administrators can do).");
-            backToProjectPage();
+            PageParameters pageParameters = new PageParameters();
+            setProjectPageParameter(pageParameters, getProject());
+            throw new RestartResponseException(CurationPage.class, pageParameters);
         }
 
         Map<String, CAS> casses = documentService

--- a/inception/inception-ui-curation/src/main/resources/META-INF/asciidoc/user-guide/curation.adoc
+++ b/inception/inception-ui-curation/src/main/resources/META-INF/asciidoc/user-guide/curation.adoc
@@ -64,9 +64,11 @@ wrong and misplaced).
 image::curation_1.png[align="center"]
 
 The center part of the annotation page is divided into the *Annotation* pane which is a full-scale
-annotation editor and contains the final data from the curation step. Below it are multiple read-only
-panes containing the annotations from individual annotators. Clicking on an annotation in any of the
-annotator's panes transfers the respective annotation to the *Annotation* pane.
+annotation editor and contains the final data from the curation step. 
+
+Below it are multiple read-only panes containing the annotations from individual annotators. 
+Clicking on an annotation in any of the annotator's panes transfers the respective annotation to the *Annotation* pane.
+There is also a small state icon for each annotator. If you click on that icon, you can change the state, e.g. from *finished* back to *in progress*. Note if you do that, the respective annotators document will no longer be available for curation. When the last finished annotation for a document is reopened, you will be forced to leave curation.
 
 When a document is opened for the first time in the curation page, the application analyzes agreements
 and disagreements between annotators. All annotations on which all annotators agree are automatically


### PR DESCRIPTION
**What's in the PR**
- Added option to re-open document directly from the curation page
- Documented the new feature
- Fixed issue that redirecting to another page would not work in many cases because the exception handles would catch the Wicket redirect exception

**How to test manually**
* See documentation

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
