### PR TITLE
#2891 - Predictions are not cleared after deleting the last annotation

### DIFF
--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/TrainingTask.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/TrainingTask.java
@@ -222,6 +222,11 @@ public class TrainingTask
                             logMessages.add(warn(this,
                                     "There are no [%s] annotations available to train on.",
                                     layer.getUiName()));
+                            // This can happen if there were already predictions based on existing
+                            // annotations, but all annotations have been removed/deleted. To ensure
+                            // that the prediction run removes the stale predictions, we need to
+                            // call it a success here.
+                            seenSuccessfulTraining = true;
                             continue;
                         }
 


### PR DESCRIPTION
**What's in the PR**
- Lack of training annotations is no reason to skip prediction

**How to test manually**
* Should be reproducible using a string recommender

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
