### PR TITLE
#2912 - Upgrade dependencies (24.0)

### DIFF
--- a/inception/pom.xml
+++ b/inception/pom.xml
@@ -61,36 +61,38 @@
     <dkpro.core.testCachePath>${session.executionRootDirectory}/cache/dkpro-core-datasets</dkpro.core.testCachePath>
     <excludedTestCategories>slow</excludedTestCategories>
 
-    <junit.version>5.8.2</junit.version>
-    <mockito.version>3.12.4</mockito.version>
+    <junit-jupiter.version>5.8.2</junit-jupiter.version>
+    <mockito.version>4.4.0</mockito.version>
     <assertj.version>3.21.0</assertj.version>
+    <awaitility.version>4.2.0</awaitility.version>
+    <xmlunit.version>1.6</xmlunit.version>
 
     <dkpro.version>2.2.0</dkpro.version>
     <uima.version>3.2.0</uima.version>
     <uimafit.version>3.2.0</uimafit.version>
 
-    <spring.version>5.3.15</spring.version>
-    <spring.boot.version>2.6.3</spring.boot.version>
-    <spring.security.version>5.6.1</spring.security.version>
-    <springdoc.version>1.6.5</springdoc.version>
-    <swagger.version>2.1.12</swagger.version>
+    <spring.version>5.3.17</spring.version>
+    <spring.boot.version>2.6.5</spring.boot.version>
+    <spring.security.version>5.6.2</spring.security.version>
+    <springdoc.version>1.6.6</springdoc.version>
+    <swagger.version>2.1.13</swagger.version>
 
-    <slf4j.version>1.7.35</slf4j.version>
-    <log4j.version>2.17.1</log4j.version>
+    <slf4j.version>1.7.36</slf4j.version>
+    <log4j2.version>2.17.2</log4j2.version>
     <jboss.logging.version>3.4.2.Final</jboss.logging.version>
 
-    <groovy.version>3.0.9</groovy.version>
+    <groovy.version>3.0.10</groovy.version>
 
-    <tomcat.version>9.0.58</tomcat.version>
+    <tomcat.version>9.0.60</tomcat.version>
     <servlet-api.version>4.0.1</servlet-api.version>
 
     <mariadb.driver.version>2.7.4</mariadb.driver.version>
     <hibernate.version>5.6.5.Final</hibernate.version>
     <hibernate.validator.version>6.2.0.Final</hibernate.validator.version>
 
-    <wicket.version>9.7.0</wicket.version>
-    <wicketstuff.version>9.7.0</wicketstuff.version>
-    <wicket-jquery-ui.version>9.7.0</wicket-jquery-ui.version>
+    <wicket.version>9.8.0</wicket.version>
+    <wicketstuff.version>9.8.0</wicketstuff.version>
+    <wicket-jquery-ui.version>9.8.0</wicket-jquery-ui.version>
     <wicket-bootstrap.version>6.0.0-M6</wicket-bootstrap.version>
     <wicket-jquery-selectors.version>3.0.4</wicket-jquery-selectors.version>
     <wicket-webjars.version>3.0.4</wicket-webjars.version>
@@ -113,13 +115,13 @@
     <jena.version>3.17.0</jena.version>
 
     <asciidoctor.plugin.version>2.2.1</asciidoctor.plugin.version>
-    <asciidoctor.version>2.5.2</asciidoctor.version>
+    <asciidoctor.version>2.5.3</asciidoctor.version>
     <asciidoctor-diagram.version>2.2.1</asciidoctor-diagram.version>
 
     <json.version>20180813</json.version>
     <pf4j.version>2.6.0</pf4j.version>
-    <jackson.version>2.13.1</jackson.version>
-    <okhttp.version>4.9.1</okhttp.version>
+    <jackson.version>2.13.2</jackson.version>
+    <okhttp.version>4.9.3</okhttp.version>
   </properties>
   <repositories>
     <!-- For RELEASEes of WebAnno / DKPro Core -->
@@ -762,7 +764,7 @@
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>${junit.version}</version>
+        <version>${junit-jupiter.version}</version>
       </dependency>
 
       <dependency>
@@ -798,7 +800,12 @@
       <dependency>
         <groupId>org.awaitility</groupId>
         <artifactId>awaitility</artifactId>
-        <version>3.1.3</version>
+        <version>${awaitility.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>xmlunit</groupId>
+        <artifactId>xmlunit</artifactId>
+        <version>${xmlunit.version}</version>
       </dependency>
 
       <!-- Wicket jQuery -->
@@ -1113,6 +1120,17 @@
         <version>${slf4j.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-simple</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-jdk14</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+      
+      <dependency>
         <groupId>org.jboss.logging</groupId>
         <artifactId>jboss-logging</artifactId>
         <version>${jboss.logging.version}</version>
@@ -1139,7 +1157,7 @@
       <dependency>
         <groupId>it.unimi.dsi</groupId>
         <artifactId>fastutil</artifactId>
-        <version>8.5.6</version>
+        <version>8.5.8</version>
       </dependency>
 
       <dependency>
@@ -1186,12 +1204,12 @@
       <dependency>
         <groupId>org.javassist</groupId>
         <artifactId>javassist</artifactId>
-        <version>3.27.0-GA</version>
+        <version>3.28.0-GA</version>
       </dependency>
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy</artifactId>
-        <version>1.10.22</version>
+        <version>1.12.8</version>
       </dependency>
       <dependency>
         <groupId>org.wicketstuff</groupId>
@@ -1525,7 +1543,7 @@
       <dependency>
         <groupId>com.github.ben-manes.caffeine</groupId>
         <artifactId>caffeine</artifactId>
-        <version>3.0.5</version>
+        <version>3.0.6</version>
       </dependency>
 
       <!-- JAXB DEPENDENCIES -->
@@ -1786,7 +1804,7 @@
         <!-- Import dependency management from LOG4J -->
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>${log4j.version}</version>
+        <version>${log4j2.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
**What's in the PR**
- Mockito 3.12.4 -> 4.4.0
- Awaitility 3.1.3 -> 4.2.0
- Spring 5.3.15 -> 5.3.17
- Spring Boot 2.6.3 -> 2.6.5
- Spring Security 5.6.1 -> 5.6.2
- SpringDoc 1.6.5 -> 1.6.6
- Swagger 2.1.12 -> 2.1.13
- SLF4J 1.7.35 -> 1.7.36
- LOG4J 2.17.1 -> 2.17.2
- Groovy 3.0.9 -> 3.0.10
- Tomcat 9.0.58 -> 9.0.60
- Wicket 9.7.0 -> 9.8.0
- Wicketstuff 9.7.0 -> 9.8.0
- Wicket JQuery 9.7.0 -> 9.8.0
- Asciidoctor 2.5.2 -> 2.5.3
- Jackson 2.13.1 -> 2.13.2
- okhttp 4.9.1 -> 4.9.3
- fastutil 8.5.6 -> 8.5.8
- javassist 3.27.0 -> 3.28.0
- bytebuddy 1.10.22 -> 1.12.8
- caffeine 3.0.5 -> 3.0.6

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
