### PR TITLE
#2924 - Filling in slots via DIAM-based editors does not work

### DIFF
--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/DiamAjaxBehavior.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/DiamAjaxBehavior.java
@@ -50,8 +50,7 @@ public class DiamAjaxBehavior
         LOG.trace("AJAX request recieved");
 
         Request request = RequestCycle.get().getRequest();
-        handlers.getExtensions(request).stream() //
-                .findFirst() //
-                .ifPresent(handler -> handler.handle(aTarget, request));
+        handlers.getHandler(request) //
+                .ifPresent(h -> h.handle(aTarget, request));
     }
 }

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/EditorAjaxRequestHandlerExtensionPointImpl.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/EditorAjaxRequestHandlerExtensionPointImpl.java
@@ -50,4 +50,16 @@ public class EditorAjaxRequestHandlerExtensionPointImpl
                 .filter(handler -> handler.accepts(aRequest)) //
                 .findFirst();
     }
+
+    @Override
+    public List<EditorAjaxRequestHandler> getExtensions(Request aContext)
+    {
+        // EditorAjaxRequestHandler::accept may have side-effects! In particular the
+        // ImplicitUnarmSlotHandler. You do not want this side effect to unarm a slot while
+        // filtering the list of potentially matching extensions.
+        // log.warn("EditorAjaxRequestHandler::accept may have side-effects! Do not use this
+        // method.");
+        // return super.getExtensions(aContext);
+        throw new UnsupportedOperationException("Use getExtensions() instead!");
+    }
 }

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/extensionpoint/ExtensionPoint_ImplBase.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/extensionpoint/ExtensionPoint_ImplBase.java
@@ -79,14 +79,17 @@ public abstract class ExtensionPoint_ImplBase<C, E extends Extension<C>>
     @Override
     public List<E> getExtensions(C aContext)
     {
-        return getExtensions().stream().filter(e -> e.accepts(aContext)).collect(toList());
+        return getExtensions().stream() //
+                .filter(e -> e.accepts(aContext)) //
+                .collect(toList());
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public <X extends E> Optional<X> getExtension(String aId)
     {
-        return (Optional<X>) getExtensions().stream().filter(fs -> fs.getId().equals(aId))
+        return (Optional<X>) getExtensions().stream() //
+                .filter(fs -> fs.getId().equals(aId)) //
                 .findFirst();
     }
 }


### PR DESCRIPTION
**What's in the PR**
- Fix iteration through request handlers to allow for the side-effect of the ImplicitUnarmSlotHandler

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
