### PR TITLE
#2943 - Duplicate key error in active learning

### DIFF
--- a/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.java
+++ b/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.java
@@ -29,16 +29,14 @@ import static de.tudarmstadt.ukp.inception.recommendation.api.model.LearningReco
 import static de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordType.REJECTED;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
-import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toMap;
 import static org.apache.uima.fit.util.CasUtil.selectAt;
 
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -561,9 +559,10 @@ public class ActiveLearningSidebar
         AnnotationFeature feat = annotationService.getFeature(aCurrentRecommendation.getFeature(),
                 alState.getLayer());
         FeatureSupport<?> featureSupport = featureSupportRegistry.findExtension(feat).orElseThrow();
-        // We get away with passing "null" here instead of the CAS because we currently
-        // have no recommenders for any feature types that actually need the CAS (i.e.
-        // link feature types and the likes).
+
+        // We get away with passing "null" here instead of the CAS because we currently have no
+        // recommenders for any feature types that actually need the CAS (i.e. link feature types
+        // and the likes).
         Object wrappedFeatureValue = featureSupport.wrapFeatureValue(feat, null,
                 aCurrentRecommendation.getLabel());
         FeatureState featureState = new FeatureState(aCurrentRecommendation.getVID(), feat,
@@ -573,7 +572,7 @@ public class ActiveLearningSidebar
         List<ReorderableTag> tagList = annotationService.listTagsReorderable(feat.getTagset());
         List<ReorderableTag> reorderedTagList = new ArrayList<>();
         if (tagList.size() > 0) {
-            Predictions predictions = recommendationService.getPredictions(state.getUser(),
+            var predictions = recommendationService.getPredictions(state.getUser(),
                     state.getProject());
             // get all the predictions
             List<SpanSuggestion> allRecommendations = predictions.getPredictionsByTokenAndFeature(
@@ -581,17 +580,34 @@ public class ActiveLearningSidebar
                     aCurrentRecommendation.getBegin(), aCurrentRecommendation.getEnd(),
                     aCurrentRecommendation.getFeature());
 
-            // get all the label of the predictions (e.g. "NN")
-            Map<String, SpanSuggestion> allRecommendationLabels = allRecommendations.stream() //
+            // Get all the label of the predictions (e.g. "NN").
+            var allLabels = new LinkedHashMap<String, SpanSuggestion>();
+            allRecommendations.stream() //
                     .filter(AnnotationSuggestion::isVisible) //
-                    .collect(toMap(AnnotationSuggestion::getLabel, identity()));
+                    // We filter for recommendations from the same recommender as the current
+                    // suggestion to assess comes from because scores may not be comparable
+                    // across recommenders
+                    .filter(rec -> rec.getRecommenderId() == aCurrentRecommendation
+                            .getRecommenderId())
+                    .forEachOrdered(rec -> {
+                        if (Objects.equals(rec.getLabel(), aCurrentRecommendation.getLabel())) {
+                            allLabels.put(rec.getLabel(), aCurrentRecommendation);
+                        }
+                        else {
+                            var existingSuggestion = allLabels.get(rec.getLabel());
+                            if (existingSuggestion == null
+                                    || rec.getScore() > existingSuggestion.getScore()) {
+                                allLabels.put(rec.getLabel(), rec);
+                            }
+                        }
+                    });
 
             for (ReorderableTag tag : tagList) {
                 // add the tags which contain the prediction-labels to the beginning of a tagset
-                SpanSuggestion suggestion = allRecommendationLabels.get(tag.getName());
+                SpanSuggestion suggestion = allLabels.get(tag.getName());
                 if (suggestion != null) {
                     tag.setReordered(true);
-                    tag.setDetail(format("%.2f", suggestion.getScore()));
+                    tag.setScore(format("%.3f", suggestion.getScore()));
                     reorderedTagList.add(tag);
                 }
             }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/KendoChoiceDescriptionScriptReference.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/KendoChoiceDescriptionScriptReference.java
@@ -17,10 +17,10 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor;
 
+import static java.util.Arrays.asList;
 import static org.apache.wicket.markup.head.JavaScriptHeaderItem.forReference;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.apache.wicket.markup.head.HeaderItem;
@@ -86,7 +86,7 @@ public class KendoChoiceDescriptionScriptReference
             @Override
             public List<String> getTextProperties()
             {
-                return Arrays.asList("name", "description");
+                return asList("name", "description");
             }
         };
     }
@@ -100,22 +100,31 @@ public class KendoChoiceDescriptionScriptReference
             @Override
             public String getText()
             {
-                // Some docs on how the templates work in Kendo, in case we need
-                // more fancy dropdowns
+                // Docs on how the templates work in Kendo, in case we need more fancy dropdowns
                 // http://docs.telerik.com/kendo-ui/framework/templates/overview
-                return "# if (data.reordered == 'true') { #"
-                        + "<div title=\"#: data.description #\" "
-                        + "onmouseover=\"javascript:applyTooltip(this)\">"
-                        + "<b>#: data.name #</b></div>\n" + "# } else { #"
-                        + "<div title=\"#: data.description #\" "
-                        + "onmouseover=\"javascript:applyTooltip(this)\">"
-                        + "#: data.name #</div>\n" + "# } #";
+                // @formatter:off
+                StringBuilder sb = new StringBuilder();
+                sb.append("<div title='#: data.description #' onmouseover='javascript:applyTooltip(this)'>");
+                sb.append("# if (data.reordered == 'true') { #");
+                sb.append("  <b>#: data.name #</b>");
+                sb.append("# } else { #");
+                sb.append("  #: data.name #");
+                sb.append("# } #");
+                sb.append("# if (data.score) { #");
+                sb.append("  <div class='item-description'>");
+                sb.append("    Score: ${ data.score }");
+                sb.append("  </div>");
+                sb.append("# } #");
+                sb.append("</div>");
+                // @formatter:on
+
+                return sb.toString();
             }
 
             @Override
             public List<String> getTextProperties()
             {
-                return Arrays.asList("name", "description", "reordered");
+                return asList("name", "description", "reordered", "score");
             }
         };
     }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/KendoComboboxTextFeatureEditor.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/KendoComboboxTextFeatureEditor.java
@@ -18,10 +18,11 @@
 package de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.editor;
 
 import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
+import static de.tudarmstadt.ukp.clarin.webanno.support.wicket.WicketUtil.wrapInTryCatch;
+import static java.lang.String.format;
 import static org.apache.wicket.markup.head.JavaScriptHeaderItem.forReference;
 
 import java.util.Objects;
-import java.util.Optional;
 
 import org.apache.wicket.MarkupContainer;
 import org.apache.wicket.ajax.AjaxRequestTarget;
@@ -46,7 +47,6 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.FeatureState;
 import de.tudarmstadt.ukp.clarin.webanno.api.event.TagEvent;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.Tag;
-import de.tudarmstadt.ukp.clarin.webanno.support.wicket.WicketUtil;
 
 /**
  * String feature editor using a Kendo ComboBox field.
@@ -149,13 +149,11 @@ public class KendoComboboxTextFeatureEditor
 
                 // Trigger a re-loading of the tagset from the server as constraints may have
                 // changed the ordering
-                Optional<AjaxRequestTarget> target = RequestCycle.get()
-                        .find(AjaxRequestTarget.class);
+                var target = RequestCycle.get().find(AjaxRequestTarget.class);
                 if (target.isPresent()) {
-                    target.get()
-                            .appendJavaScript(WicketUtil.wrapInTryCatch(String.format(
-                                    "var $w = %s; if ($w) { $w.dataSource.read(); }",
-                                    KendoUIBehavior.widget(this, ComboBoxBehavior.METHOD))));
+                    target.get().appendJavaScript(wrapInTryCatch(format( //
+                            "var $w = %s; if ($w) { $w.dataSource.read(); }",
+                            KendoUIBehavior.widget(this, ComboBoxBehavior.METHOD))));
                 }
             }
         };

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/RadioGroupStringFeatureEditor.html
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/RadioGroupStringFeatureEditor.html
@@ -34,7 +34,7 @@
         <div class="radio-button-group">
           <div wicket:id="radios" class="radio-button" style="position: relative;">
             <span style="position: absolute; right: 0; z-index: 10;" class="pt-1 pe-1">
-              <span wicket:id="detail" class="badge bg-secondary"/>
+              <span wicket:id="score" class="badge bg-secondary"/>
               <span wicket:id="description">
                 <i class="fas fa-info-circle"/>
               </span>

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/RadioGroupStringFeatureEditor.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/feature/editor/RadioGroupStringFeatureEditor.java
@@ -156,7 +156,7 @@ public class RadioGroupStringFeatureEditor
 
                 String descriptionText = item.getModel().getObject().getDescription();
 
-                Label detail = new Label("detail", item.getModel().map(ReorderableTag::getDetail));
+                Label score = new Label("score", item.getModel().map(ReorderableTag::getScore));
 
                 WebMarkupContainer description = new WebMarkupContainer("description");
                 description.add(visibleWhen(() -> isNotBlank(descriptionText)));
@@ -171,7 +171,7 @@ public class RadioGroupStringFeatureEditor
 
                 add(description);
 
-                item.add(radio, label, detail, description);
+                item.add(radio, label, score, description);
             }
         };
     }

--- a/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/ReorderableTag.java
+++ b/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/ReorderableTag.java
@@ -27,7 +27,7 @@ public class ReorderableTag
 
     private final ImmutableTag tag;
     private boolean reordered;
-    private String detail;
+    private String score;
 
     public ReorderableTag(ImmutableTag aTag)
     {
@@ -76,14 +76,14 @@ public class ReorderableTag
         return tag.getName();
     }
 
-    public String getDetail()
+    public String getScore()
     {
-        return detail;
+        return score;
     }
 
-    public void setDetail(String aDetail)
+    public void setScore(String aScore)
     {
-        detail = aDetail;
+        score = aScore;
     }
 
     @Override


### PR DESCRIPTION
**What's in the PR**
- Filter suggestions to reorder by the recommender which provided the currently active-learning-selected suggestion because scores may not be comparable across recommenders
- Display score (detail) in dropdown in the combo box
- Handle case that there may be multiple recommendations for the same label (which might actually not be necessary anymore due to the change above)

**How to test manually**
* Configure two recommenders e.g. Token Sequence Classifier and String Matcher on a POS-annotated document
* In active learning mode, find a location where both suggest the same label
* There should not be an error

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
