### PR TITLE
#2937 - Value shown as 0-1 decimal number instead of 0-100 percentage

### DIFF
--- a/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/merge/ThresholdBasedMergeStrategyTraitsEditor.java
+++ b/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/merge/ThresholdBasedMergeStrategyTraitsEditor.java
@@ -24,6 +24,7 @@ import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 
+import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaModelAdapter;
 import de.tudarmstadt.ukp.inception.curation.model.CurationWorkflow;
 
 public class ThresholdBasedMergeStrategyTraitsEditor
@@ -57,8 +58,11 @@ public class ThresholdBasedMergeStrategyTraitsEditor
 
         form.add(new NumberTextField<>("userThreshold", Integer.class).setMinimum(0));
 
-        form.add(new NumberTextField<>("confidenceThreshold", Double.class).setMinimum(0.0d)
-                .setMaximum(1.0d).setStep(0.1d));
+        form.add(new NumberTextField<>("confidenceThreshold", Double.class) //
+                .setMinimum(0.0d).setMaximum(100.0d).setStep(0.1d) //
+                .setModel(LambdaModelAdapter.of( //
+                        () -> traits.getConfidenceThreshold() * 100.0d,
+                        (v) -> traits.setConfidenceThreshold(v / 100.0d))));
 
         add(form);
     }


### PR DESCRIPTION
**What's in the PR**
- Scale the confidence threshold to a value between 0 and 100 on screen.

**How to test manually**
* Set a confidence threshold value

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
