### PR TITLE
#2957 - Search can't find all tokens of a layer

### DIFF
--- a/inception/inception-search-mtas/src/main/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndex.java
+++ b/inception/inception-search-mtas/src/main/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndex.java
@@ -705,40 +705,37 @@ public class MtasDocumentIndex
 
     private String preprocessQuery(String aQuery)
     {
-        String result;
-
-        if (!(aQuery.contains("\"") || aQuery.contains("[") || aQuery.contains("]"))) {
-            // Convert raw words query to a Mtas CQP query
-
-            result = "";
-            BreakIterator words = BreakIterator.getWordInstance();
-            words.setText(aQuery);
-
-            int start = words.first();
-            int end = words.next();
-            while (end != BreakIterator.DONE) {
-                String word = aQuery.substring(start, end);
-                if (!word.trim().isEmpty()) {
-                    word = word.replace("&", "\\&");
-                    word = word.replace("(", "\\(");
-                    word = word.replace(")", "\\)");
-                    word = word.replace("#", "\\#");
-                    word = word.replace("{", "\\{");
-                    word = word.replace("}", "\\}");
-                    word = word.replace("<", "\\<");
-                    word = word.replace(">", "\\>");
-                    // Add the word to the query
-                    result += "\"" + word + "\"";
-                }
-                start = end;
-                end = words.next();
-                if (end != BreakIterator.DONE) {
-                    result += " ";
-                }
-            }
+        if (aQuery.contains("\"") || aQuery.contains("[") || aQuery.contains("]")
+                || aQuery.contains("<") || aQuery.contains(">")) {
+            return aQuery;
         }
-        else {
-            result = aQuery;
+
+        // Convert raw words query to a Mtas CQP query
+        String result = "";
+        BreakIterator words = BreakIterator.getWordInstance();
+        words.setText(aQuery);
+
+        int start = words.first();
+        int end = words.next();
+        while (end != BreakIterator.DONE) {
+            String word = aQuery.substring(start, end);
+            if (!word.trim().isEmpty()) {
+                word = word.replace("&", "\\&");
+                word = word.replace("(", "\\(");
+                word = word.replace(")", "\\)");
+                word = word.replace("#", "\\#");
+                word = word.replace("{", "\\{");
+                word = word.replace("}", "\\}");
+                word = word.replace("<", "\\<");
+                word = word.replace(">", "\\>");
+                // Add the word to the query
+                result += "\"" + word + "\"";
+            }
+            start = end;
+            end = words.next();
+            if (end != BreakIterator.DONE) {
+                result += " ";
+            }
         }
 
         return result;

--- a/inception/inception-search-mtas/src/main/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasUtils.java
+++ b/inception/inception-search-mtas/src/main/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasUtils.java
@@ -33,22 +33,28 @@ public final class MtasUtils
         // No instances
     }
 
-    public static void print(MtasTokenCollection aTC) throws MtasParserException
+    public static void print(MtasTokenCollection aTC)
     {
-        String[][] dump = aTC.getList();
-        int[] widths = new int[dump[0].length];
-        for (int n = 0; n < dump.length; n++) {
-            for (int i = 0; i < widths.length; i++) {
-                widths[i] = Math.max(widths[i], String.valueOf(dump[n][i]).length());
+        try {
+            String[][] dump = aTC.getList();
+
+            int[] widths = new int[dump[0].length];
+            for (int n = 0; n < dump.length; n++) {
+                for (int i = 0; i < widths.length; i++) {
+                    widths[i] = Math.max(widths[i], String.valueOf(dump[n][i]).length());
+                }
+            }
+
+            for (int n = 0; n < dump.length; n++) {
+                for (int i = 0; i < dump[n].length; i++) {
+                    System.out.print(StringUtils.rightPad(String.valueOf(dump[n][i]), widths[i]));
+                    System.out.print(" | ");
+                }
+                System.out.println();
             }
         }
-
-        for (int n = 0; n < dump.length; n++) {
-            for (int i = 0; i < dump[n].length; i++) {
-                System.out.print(StringUtils.rightPad(String.valueOf(dump[n][i]), widths[i]));
-                System.out.print(" | ");
-            }
-            System.out.println();
+        catch (MtasParserException e) {
+            e.printStackTrace();
         }
     }
 

--- a/inception/inception-search-mtas/src/test/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndexTest.java
+++ b/inception/inception-search-mtas/src/test/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndexTest.java
@@ -545,6 +545,41 @@ public class MtasDocumentIndexTest
     }
 
     @Test
+    public void testAnnotationQueryMultiTokenWithoutConditions() throws Exception
+    {
+        Project project = new Project("annotation-query-multi-token-no-cond");
+
+        createProject(project);
+
+        SourceDocument sourceDocument = new SourceDocument("Annotation document", project, "text");
+
+        String fileContent = "The capital of Galicia is Santiago de Compostela.";
+
+        uploadDocument(Pair.of(sourceDocument, fileContent));
+        annotateDocument(project, user, sourceDocument);
+
+        String query = "<Named_entity/>";
+
+        List<SearchResult> results = searchService.query(user, project, query);
+
+        // Test results
+        SearchResult expectedResult = new SearchResult();
+        expectedResult.setDocumentId(sourceDocument.getId());
+        expectedResult.setDocumentTitle("Annotation document");
+        // When searching for an annotation, we don't get the matching
+        // text back... not sure why...
+        expectedResult.setText("");
+        expectedResult.setLeftContext("");
+        expectedResult.setRightContext("");
+        expectedResult.setOffsetStart(15);
+        expectedResult.setOffsetEnd(22);
+        expectedResult.setTokenStart(3);
+        expectedResult.setTokenLength(1);
+
+        assertThat(results).containsExactly(expectedResult);
+    }
+
+    @Test
     public void testKeepResultsOrdering() throws Exception
     {
         Project project = new Project("keep-results-ordering");


### PR DESCRIPTION
**What's in the PR**
- Fix the issue by including `<` and `>` in the "simple query" detection
- Bit of cleaning up
- Added unit test checking for a regex matching in a query and for a multi-token query without conditions

**How to test manually**
* See issue description

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
