### PR TITLE
#2967 - Schema validation fails on MySQL 8

### DIFF
--- a/inception/inception-app-webapp/src/main/resources/application.yml
+++ b/inception/inception-app-webapp/src/main/resources/application.yml
@@ -61,6 +61,8 @@ spring:
             mode: NONE
       hibernate:
         dialect: ${database.dialect:${INCEPTION_DB_DIALECT:}}
+        # See https://github.com/inception-project/inception/issues/2967
+        globally_quoted_identifiers: true
         # Enable SQL statements formatting.
         # format_sql: true
         # L2 CACHE: generate statistics to check if L2/query cache is actually being used.

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/scripts/docker-compose-mysql8.yml
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/scripts/docker-compose-mysql8.yml
@@ -9,7 +9,7 @@ networks:
 
 services:
   db:
-    image: "mysql:5"
+    image: "mysql:8"
     environment:
       - MYSQL_RANDOM_ROOT_PASSWORD=yes
       - MYSQL_DATABASE=inception
@@ -18,7 +18,7 @@ services:
       - MYSQL_PASSWORD=${DBPASSWORD:-inception}
     volumes:
       - ${INCEPTION_DB_HOME:-db-data}:/var/lib/mysql
-    command: ["--character-set-server=utf8", "--collation-server=utf8_bin"]
+    command: ["--character-set-server=utf8mb4", "--collation-server=utf8mb4_bin"]
     healthcheck:
       test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost", "-p${DBPASSWORD:-inception}", "-u${DBUSER:-inception}"]
       interval: 20s
@@ -32,13 +32,13 @@ services:
     ports:
       - "${INCEPTION_PORT:-8080}:8080"
     environment:
-      - INCEPTION_DB_DIALECT=org.hibernate.dialect.MySQL5InnoDBDialect
-      - INCEPTION_DB_DRIVER=com.mysql.jdbc.Driver
+      - INCEPTION_DB_DIALECT=org.hibernate.dialect.MySQL8Dialect
+      - INCEPTION_DB_DRIVER=org.mariadb.jdbc.Driver
       - INCEPTION_DB_URL=jdbc:mysql://db:3306/inception?useSSL=false&useUnicode=true&characterEncoding=UTF-8
       - INCEPTION_DB_USERNAME=${DBUSER:-inception}
       - INCEPTION_DB_PASSWORD=${DBPASSWORD:-inception}
     volumes:
-      - ${INCEPTION_HOME:-app-data⁄}:/export
+      - ${INCEPTION_HOME:-app-data}:/export
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
**What's in the PR**
- Update MySQL docker compose example from MySQL 5 to MySQL 8
- Add global quoting of identifiers for hibernate so we do not run into problems with case sensitivity on different types/versions of database backends

**How to test manually**
* Try running INCEpTION against MySQL 8

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
