### PR TITLE
#1778 - Make tokenization editable

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/AnnotationSchemaService.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/AnnotationSchemaService.java
@@ -567,5 +567,7 @@ public interface AnnotationSchemaService
     void importUimaTypeSystem(Project aProject, TypeSystemDescription aTSD)
         throws ResourceInitializationException;
 
-    boolean isSentencesEditable(Project aProject);
+    boolean isSentenceLayerEditable(Project aProject);
+
+    boolean isTokenLayerEditable(Project aProject);
 }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/model/AnnotatorStateImpl.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/model/AnnotatorStateImpl.java
@@ -19,6 +19,7 @@ package de.tudarmstadt.ukp.clarin.webanno.api.annotation.model;
 
 import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.CHAIN_TYPE;
 import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.SPAN_TYPE;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.unmodifiableList;
 import static org.apache.wicket.event.Broadcast.BREADTH;
 
@@ -38,7 +39,6 @@ import org.apache.wicket.core.request.handler.IPageRequestHandler;
 import org.apache.wicket.core.request.handler.IPartialPageRequestHandler;
 import org.apache.wicket.request.cycle.RequestCycle;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.config.AnnotationEditorProperties;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.paging.PagingStrategy;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.paging.Unit;
@@ -185,7 +185,7 @@ public class AnnotatorStateImpl
 
     private PagingStrategy pagingStrategy;
 
-    private List<Unit> visibleUnits;
+    private List<Unit> visibleUnits = emptyList();
 
     private Map<AnnotatorStateMetaDataKey<?>, Object> metaData = new HashMap<>();
 
@@ -389,8 +389,9 @@ public class AnnotatorStateImpl
 
         // Make sure the currently selected layer is actually visible/exists
         if (!annotationLayers.contains(selectedAnnotationLayer)) {
-            selectedAnnotationLayer = annotationLayers.stream()
-                    .filter(layer -> layer.getType().equals(WebAnnoConst.SPAN_TYPE)).findFirst()
+            selectedAnnotationLayer = annotationLayers.stream() //
+                    .filter(layer -> layer.getType().equals(SPAN_TYPE)) //
+                    .findFirst() //
                     .orElse(null);
             defaultAnnotationLayer = selectedAnnotationLayer;
         }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/paging/PagingStrategy.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/paging/PagingStrategy.java
@@ -57,8 +57,10 @@ public interface PagingStrategy
             List<Unit> units = units(aCas);
 
             // Find the unit containing the given offset
-            Unit unit = units.stream().filter(u -> u.getBegin() <= aOffset && aOffset <= u.getEnd())
-                    .findFirst().orElseThrow(() -> new IllegalArgumentException(
+            Unit unit = units.stream() //
+                    .filter(u -> u.getBegin() <= aOffset && aOffset <= u.getEnd()) //
+                    .findFirst() //
+                    .orElseThrow(() -> new IllegalArgumentException(
                             "No unit contains character offset [" + aOffset + "]"));
 
             // How many rows to display before the unit such that the unit is centered?

--- a/inception/inception-api-annotation/src/main/resources/META-INF/asciidoc/user-guide/editable-segmentation.adoc
+++ b/inception/inception-api-annotation/src/main/resources/META-INF/asciidoc/user-guide/editable-segmentation.adoc
@@ -39,13 +39,20 @@ careful, ready to face unexpected situations and make regular backups of course.
 
 Once the feature has been enabled, new projects get a **Sentence** layer. It is also possible to
 add a sentence layer to existing project from the dropdown menu of the **create layer** button where
-other built-in layers can also be added to a project that does not yet contain them. The layer is
-by default **read-only** which means that you can see the sentence annotations in the annotation
-editor but not create or delete sentence annotations. To make the sentences really editable for the
-annotators, un-check the **read-only** checkbox and save the layer settings.
+other built-in layers can also be added to a project that does not yet contain them. By default, the
+layer is **not enabled** and **read-only** which means that you can neither see the sentence 
+annotations in the annotation editor nor create or delete sentence annotations. To make the sentences 
+visible and editable for the annotators, check the **enabled** checkbox and un-check the 
+**read-only** checkbox and save the layer settings.
 
-While the sentence layer is editable (i.e. while the *read-only* checkbox is unchecked), the
-annotation page and the curation page default to a line-oriented editor instead of the usual
-sentence-oriented editor. In the line-oriented editor, the sentences can be safely shown and edited
-because the editor does not rely on sentence boundaries to control the rendering process.
+While the sentence layer is editable (i.e. enabled and not read-only), the annotation page and the curation page default to a line-oriented editor instead of the usual sentence-oriented editor. In
+the line-oriented editor, the sentences can be safely shown and edited because the editor does not
+rely on sentence boundaries to control the rendering process. It is then possible to curate the
+sentence boundaries.
+
+NOTE: If you start curating a document while the sentence layer is editable but then switch it back
+      not being editable, then it could happen that different annotators have different segmentations and/or that the curation
+      document does not contain all sentence boundaries. This means that some sentences may be invisible because the 
+      the sentence-oriented visualization does not display them!
+
 

--- a/inception/inception-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/annotationservice/config/AnnotationSchemaServiceAutoConfiguration.java
+++ b/inception/inception-api-dao/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/dao/annotationservice/config/AnnotationSchemaServiceAutoConfiguration.java
@@ -37,6 +37,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.adapter.RelationOverlapB
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.adapter.SpanAnchoringModeBehavior;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.adapter.SpanCrossSentenceBehavior;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.adapter.SpanOverlapBehavior;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.config.AnnotationEditorProperties;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.BooleanFeatureSupport;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupport;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRegistry;
@@ -71,10 +72,11 @@ public class AnnotationSchemaServiceAutoConfiguration
     public AnnotationSchemaService annotationSchemaService(
             LayerSupportRegistry aLayerSupportRegistry,
             FeatureSupportRegistry aFeatureSupportRegistry,
+            AnnotationEditorProperties aAnnotationEditorProperties,
             ApplicationEventPublisher aApplicationEventPublisher)
     {
         return new AnnotationSchemaServiceImpl(aLayerSupportRegistry, aFeatureSupportRegistry,
-                aApplicationEventPublisher, entityManager);
+                aApplicationEventPublisher, aAnnotationEditorProperties, entityManager);
     }
 
     @Bean

--- a/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/annotation/BratSentenceOrientedAnnotationEditorFactory.java
+++ b/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/annotation/BratSentenceOrientedAnnotationEditorFactory.java
@@ -55,7 +55,7 @@ public class BratSentenceOrientedAnnotationEditorFactory
     @Override
     public int accepts(Project aProject, String aFormat)
     {
-        if (annotationService.isSentencesEditable(aProject)) {
+        if (annotationService.isSentenceLayerEditable(aProject)) {
             return NOT_SUITABLE;
         }
 

--- a/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/merge/CasMerge.java
+++ b/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/merge/CasMerge.java
@@ -89,6 +89,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.LinkMode;
 import de.tudarmstadt.ukp.clarin.webanno.model.MultiValueMode;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.support.logging.LogMessage;
 import de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData;
@@ -183,7 +184,7 @@ public class CasMerge
         Set<LogMessage> messages = new LinkedHashSet<>();
 
         // Remove any annotations from the target CAS - keep type system, sentences and tokens
-        clearAnnotations(aTargetCas);
+        clearAnnotations(aTargetDocument.getProject(), aTargetCas);
 
         // If there is nothing to merge, bail out
         if (aCases.isEmpty()) {
@@ -375,12 +376,15 @@ public class CasMerge
      * Removes all annotations except {@link Token} and {@link Sentence} annotations - but from
      * these also only the offsets are kept and all other features are cleared.
      * 
+     * @param aProject
+     *            the project to which the CAS belongs.
+     * 
      * @param aCas
      *            the CAS to clear.
      * @throws UIMAException
      *             if there was a problem clearing the CAS.
      */
-    private void clearAnnotations(CAS aCas) throws UIMAException
+    private void clearAnnotations(Project aProject, CAS aCas) throws UIMAException
     {
         // Copy the CAS - basically we do this just to keep the full type system information
         CAS backup = WebAnnoCasUtil.createCasCopy(aCas);
@@ -398,14 +402,23 @@ public class CasMerge
         aCas.setDocumentLanguage(backup.getDocumentLanguage()); // DKPro Core Issue 435
         aCas.setDocumentText(backup.getDocumentText());
 
-        if (!annotationEditorProperties.isTokenLayerEditable()) {
+        transferSegmentation(aProject, aCas, backup);
+    }
+
+    /**
+     * If tokens and/or sentences are not editable, then they are not part of the curation process
+     * and we transfer them from the template CAS.
+     */
+    private void transferSegmentation(Project aProject, CAS aCas, CAS backup)
+    {
+        if (!schemaService.isTokenLayerEditable(aProject)) {
             // Transfer token boundaries
             for (AnnotationFS t : selectTokens(backup)) {
                 aCas.addFsToIndexes(createToken(aCas, t.getBegin(), t.getEnd()));
             }
         }
 
-        if (!annotationEditorProperties.isSentenceLayerEditable()) {
+        if (!schemaService.isSentenceLayerEditable(aProject)) {
             // Transfer sentence boundaries
             for (AnnotationFS s : selectSentences(backup)) {
                 aCas.addFsToIndexes(createSentence(aCas, s.getBegin(), s.getEnd()));

--- a/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/service/CurationMergeServiceImpl.java
+++ b/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/service/CurationMergeServiceImpl.java
@@ -20,6 +20,7 @@ package de.tudarmstadt.ukp.inception.curation.service;
 import static de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.doDiffSingle;
 import static de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.getDiffAdapters;
 import static de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.LinkCompareBehavior.LINK_ROLE_AS_LABEL;
+import static java.lang.Integer.MAX_VALUE;
 import static java.lang.invoke.MethodHandles.lookup;
 import static java.util.stream.Collectors.toList;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -93,17 +94,20 @@ public class CurationMergeServiceImpl
     {
         List<DiffAdapter> adapters = getDiffAdapters(annotationService, aLayers);
 
-        if (!annotationEditorProperties.isSentenceLayerEditable()) {
+        // If the token/sentence layer is not editable, we do not offer curation of the tokens.
+        // Instead the tokens are obtained from a random template CAS when initializing the CAS - we
+        // assume here that the tokens have never been modified.
+        if (!annotationService.isSentenceLayerEditable(aDocument.getProject())) {
             adapters.removeIf(adapter -> Sentence._TypeName.equals(adapter.getType()));
         }
 
-        if (!annotationEditorProperties.isTokenLayerEditable()) {
+        if (!annotationService.isTokenLayerEditable(aDocument.getProject())) {
             adapters.removeIf(adapter -> Token._TypeName.equals(adapter.getType()));
         }
 
         DiffResult diff;
         try (StopWatch watch = new StopWatch(LOG, "CasDiff")) {
-            diff = doDiffSingle(adapters, LINK_ROLE_AS_LABEL, aCassesToMerge, 0, Integer.MAX_VALUE)
+            diff = doDiffSingle(adapters, LINK_ROLE_AS_LABEL, aCassesToMerge, 0, MAX_VALUE)
                     .toResult();
         }
 

--- a/inception/inception-project-initializers/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/initializers/SentenceLayerInitializer.java
+++ b/inception/inception-project-initializers/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/initializers/SentenceLayerInitializer.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.clarin.webanno.project.initializers;
 
 import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.SPAN_TYPE;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.TOKENS;
 import static de.tudarmstadt.ukp.clarin.webanno.model.OverlapMode.NO_OVERLAP;
 import static de.tudarmstadt.ukp.clarin.webanno.model.ValidationMode.NEVER;
 
@@ -29,7 +30,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.project.ProjectInitializer;
-import de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.project.initializers.config.ProjectInitializersAutoConfiguration;
@@ -74,7 +74,7 @@ public class SentenceLayerInitializer
     public void configure(Project aProject) throws IOException
     {
         AnnotationLayer sentenceLayer = new AnnotationLayer(Sentence.class.getName(), "Sentence",
-                SPAN_TYPE, aProject, true, AnchoringMode.TOKENS, NO_OVERLAP);
+                SPAN_TYPE, aProject, true, TOKENS, NO_OVERLAP);
 
         // Since the user cannot turn off validation for the sentence layer if there is any kind of
         // problem with the validation functionality we are conservative here and disable validation
@@ -82,6 +82,7 @@ public class SentenceLayerInitializer
         sentenceLayer.setValidationMode(NEVER);
         sentenceLayer.setReadonly(true);
         sentenceLayer.setCrossSentence(true);
+        sentenceLayer.setEnabled(false);
 
         annotationSchemaService.createOrUpdateLayer(sentenceLayer);
     }

--- a/inception/inception-project-initializers/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/initializers/SentenceLayerInitializer.java
+++ b/inception/inception-project-initializers/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/initializers/SentenceLayerInitializer.java
@@ -21,9 +21,9 @@ import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.SPAN_TYPE;
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.TOKENS;
 import static de.tudarmstadt.ukp.clarin.webanno.model.OverlapMode.NO_OVERLAP;
 import static de.tudarmstadt.ukp.clarin.webanno.model.ValidationMode.NEVER;
+import static java.util.Arrays.asList;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -61,7 +61,9 @@ public class SentenceLayerInitializer
     @Override
     public List<Class<? extends ProjectInitializer>> getDependencies()
     {
-        return Collections.emptyList();
+        return asList(
+                // Because sentences locked to tokens
+                TokenLayerInitializer.class);
     }
 
     @Override

--- a/inception/inception-project-initializers/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/initializers/TokenLayerInitializer.java
+++ b/inception/inception-project-initializers/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/initializers/TokenLayerInitializer.java
@@ -23,10 +23,13 @@ import static de.tudarmstadt.ukp.clarin.webanno.model.OverlapMode.NO_OVERLAP;
 import static de.tudarmstadt.ukp.clarin.webanno.model.ValidationMode.NEVER;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
+import de.tudarmstadt.ukp.clarin.webanno.api.project.ProjectInitializer;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.project.initializers.config.ProjectInitializersAutoConfiguration;
@@ -53,6 +56,12 @@ public class TokenLayerInitializer
     public String getName()
     {
         return "Tokens";
+    }
+
+    @Override
+    public List<Class<? extends ProjectInitializer>> getDependencies()
+    {
+        return Collections.emptyList();
     }
 
     @Override

--- a/inception/inception-project-initializers/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/initializers/TokenLayerInitializer.java
+++ b/inception/inception-project-initializers/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/initializers/TokenLayerInitializer.java
@@ -21,15 +21,12 @@ import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.SPAN_TYPE;
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.CHARACTERS;
 import static de.tudarmstadt.ukp.clarin.webanno.model.OverlapMode.NO_OVERLAP;
 import static de.tudarmstadt.ukp.clarin.webanno.model.ValidationMode.NEVER;
-import static java.util.Arrays.asList;
 
 import java.io.IOException;
-import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
-import de.tudarmstadt.ukp.clarin.webanno.api.project.ProjectInitializer;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.project.initializers.config.ProjectInitializersAutoConfiguration;
@@ -56,14 +53,6 @@ public class TokenLayerInitializer
     public String getName()
     {
         return "Tokens";
-    }
-
-    @Override
-    public List<Class<? extends ProjectInitializer>> getDependencies()
-    {
-        return asList(
-                // Because tokens are not allowed to cross sentence boundaries
-                SentenceLayerInitializer.class);
     }
 
     @Override

--- a/inception/inception-project-initializers/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/initializers/TokenLayerInitializer.java
+++ b/inception/inception-project-initializers/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/initializers/TokenLayerInitializer.java
@@ -84,6 +84,7 @@ public class TokenLayerInitializer
         tokenLayer.setValidationMode(NEVER);
         tokenLayer.setReadonly(true);
         tokenLayer.setCrossSentence(false);
+        tokenLayer.setEnabled(false);
 
         annotationSchemaService.createOrUpdateLayer(tokenLayer);
     }


### PR DESCRIPTION
**What's in the PR**
- Disable sentence layer by default
- Better checking if sentence/token layer are editable
- Better handling of curation CAS initialization when sentence layer is present but not editable

**How to test manually**
* Try re-merging when sentence editing is not enabled

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
