### PR TITLE
#2997 - Editing PDFs no longer works

### DIFF
--- a/inception/inception-pdf-editor/src/main/js/pdfanno/src/core/src/render/renderSpan.ts
+++ b/inception/inception-pdf-editor/src/main/js/pdfanno/src/core/src/render/renderSpan.ts
@@ -1,8 +1,5 @@
 import { renderKnob } from './renderKnob'
 import { hex2rgba } from '../utils/color'
-import { ANNO_VERSION } from '../version'
-
-console.log('ANNO_VERSION:', ANNO_VERSION)
 
 /**
  * Create a Span element.

--- a/inception/inception-pdf-editor/src/main/js/pdfanno/src/core/src/version.ts
+++ b/inception/inception-pdf-editor/src/main/js/pdfanno/src/core/src/version.ts
@@ -1,7 +1,0 @@
-const packageJson = require('../../../package.json')
-/**
- * Paper Anno Version.
- * This is overwritten at build.
- */
-export let ANNO_VERSION = packageJson.version
-export let PDFEXTRACT_VERSION = packageJson.pdfextract.version


### PR DESCRIPTION
**What's in the PR**
- Remove reference to undeclared version in package.json which causes client-side code to crash and PDF annotations to not work anymore

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
