### PR TITLE
#3001 - Error when PDF has a blank page inside

### DIFF
--- a/inception/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/PdfAnnotationEditor.java
+++ b/inception/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/PdfAnnotationEditor.java
@@ -89,9 +89,8 @@ public class PdfAnnotationEditor
 
     private PdfExtractFile pdfExtractFile;
     private DocumentModel documentModel;
-    private int page;
-    private Offset pageOffset;
     private Map<Integer, Offset> pageOffsetCache;
+    private int page;
 
     private @SpringBean DocumentService documentService;
     private @SpringBean AnnotationSchemaService annotationService;
@@ -152,7 +151,13 @@ public class PdfAnnotationEditor
      */
     public void renderPdfAnnoModel(AjaxRequestTarget aTarget)
     {
-        if (getModelObject().getProject() == null || pageOffset == null) {
+        if (getModelObject().getProject() == null) {
+            return;
+        }
+
+        Offset pageOffset = pageOffsetCache.computeIfAbsent(page, this::calculatePageOffsets);
+
+        if (pageOffset == null) {
             return;
         }
 
@@ -367,7 +372,6 @@ public class PdfAnnotationEditor
     private void getAnnotations(AjaxRequestTarget aTarget, IRequestParameters aParams)
     {
         page = aParams.getParameterValue("page").toInt();
-        pageOffset = pageOffsetCache.computeIfAbsent(page, this::calculatePageOffsets);
         renderPdfAnnoModel(aTarget);
     }
 
@@ -379,8 +383,8 @@ public class PdfAnnotationEditor
         int beginPage = Math.min(Math.max(1, aPage - 1), maxPageNumber);
         int endPage = Math.min(Math.max(1, aPage + 1), maxPageNumber);
 
-        int begin = pdfExtractFile.getPageOffset(beginPage).getBegin();
-        int end = pdfExtractFile.getPageOffset(endPage).getEnd() + 1;
+        int begin = pdfExtractFile.getBeginPageOffset(beginPage);
+        int end = pdfExtractFile.getEndPageOffset(endPage);
 
         List<Offset> offsets = new ArrayList<>();
         offsets.add(new Offset(begin, begin));

--- a/inception/inception-pdf-editor/src/main/js/pdfanno/src/core/index.ts
+++ b/inception/inception-pdf-editor/src/main/js/pdfanno/src/core/index.ts
@@ -110,6 +110,7 @@ function renderAnno () {
     left       : `${leftMargin}px`,
     width      : `${width}px`,
     height     : `${height}px`,
+    visibility : 'hidden',
     'z-index'  : 2
   })
   // Add an annotation layer.
@@ -119,6 +120,7 @@ function renderAnno () {
     left       : `${leftMargin}px`,
     width      : `${width}px`,
     height     : `${height}px`,
+    visibility : 'hidden',
     'z-index'  : 2
   })
 

--- a/inception/inception-pdf-editor/src/main/js/pdfanno/src/core/src/render/renderRelation.ts
+++ b/inception/inception-pdf-editor/src/main/js/pdfanno/src/core/src/render/renderRelation.ts
@@ -49,6 +49,7 @@ export function renderRelation (a) {
     stroke : a.color
   })
   group.style.visibility = 'visible'
+  group.style.pointerEvents = 'auto'
   group.setAttribute('read-only', a.readOnly === true)
 
   $svg[0].appendChild(group)
@@ -130,6 +131,7 @@ function createSVGElement (top, left, width, height) {
     left       : `${left - margin}px`,
     width      : `${width + margin * 2}px`,
     height     : `${height + margin * 2}px`,
+    'pointer-events' : 'none',
     'z-index'  : 2
   }).attr({
     x : 0,

--- a/inception/inception-pdf-editor/src/main/js/pdfanno/src/page/util/analyzer.ts
+++ b/inception/inception-pdf-editor/src/main/js/pdfanno/src/page/util/analyzer.ts
@@ -12,11 +12,15 @@
  *   position page type char x y w h ? ? ? ?
  *   9426<TAB>4<TAB>TEXT<TAB>G<TAB>435.29147 62.84513 7.7976065 13.014011<TAB>435.6371 65.52354 7.3116064 7.4520063
  *   9427<TAB>4<TAB>DRAW<TAB>MOVE_TO<TAB>129.75435<TAB>79.0188
- *
  */
-export function customizeAnalyzeResult (pdftxt) {
+export interface Page {
+  body;
+  meta;
+  page : number;
+}
 
-  let pages = []
+export function customizeAnalyzeResult (pdftxt) : Page[] {
+  let pages : Page[] = []
   let page
   let body
   let meta


### PR DESCRIPTION
**What's in the PR**
- Server-side: if a page cannot be found, look for the start/end of the next/prev existing page instead.
- Client-side: look for page by page number, not by index in page array

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
