### PR TITLE
#2912 - Upgrade dependencies (24.0)

### DIFF
--- a/inception/pom.xml
+++ b/inception/pom.xml
@@ -137,11 +137,13 @@
     <jackson.version>2.13.2</jackson.version>
     <okhttp.version>4.9.3</okhttp.version>
     
+    <node.version>16.14.2</node.version>
+    <npm.version>8.5.0</npm.version>
     <typescript.version>^4.6.3</typescript.version>
-    <typescript-eslint.version>^5.17.0</typescript-eslint.version>
-    <esbuild.version>^0.14.29</esbuild.version>
+    <typescript-eslint.version>^5.20.0</typescript-eslint.version>
+    <esbuild.version>^0.14.38</esbuild.version>
     <esbuild-sass-plugin.version>^2.2.6</esbuild-sass-plugin.version>
-    <eslint.version>^8.12.0</eslint.version>
+    <eslint.version>^8.13.0</eslint.version>
   </properties>
   <repositories>
     <!-- For RELEASEes of WebAnno / DKPro Core -->
@@ -2017,7 +2019,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>buildnumber-maven-plugin</artifactId>
-        <version>1.4</version>
+        <version>3.0.0</version>
         <executions>
           <execution>
             <phase>validate</phase>
@@ -2139,7 +2141,7 @@
         <plugin>
           <groupId>com.github.eirslett</groupId>
           <artifactId>frontend-maven-plugin</artifactId>
-          <version>1.11.3</version>
+          <version>1.12.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -2153,7 +2155,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M5</version>
+          <version>3.0.0-M6</version>
           <configuration>
             <systemPropertyVariables>
               <dkpro.core.testCachePath>${dkpro.core.testCachePath}</dkpro.core.testCachePath>
@@ -2169,12 +2171,12 @@
         <plugin>
           <groupId>io.fabric8</groupId>
           <artifactId>docker-maven-plugin</artifactId>
-          <version>0.38.0</version>
+          <version>0.39.1</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>versions-maven-plugin</artifactId>
-          <version>2.8.1</version>
+          <version>2.10.0</version>
           <configuration>
             <rulesUri>file:${maven.multiModuleProjectDirectory}/inception/inception-build/src/main/resources/inception/rules.xml</rulesUri>
             <!--
@@ -2573,8 +2575,8 @@
             <configuration>
               <workingDirectory>src/main/ts</workingDirectory>
               <installDirectory>../../node</installDirectory>
-              <nodeVersion>v16.13.0</nodeVersion>
-              <npmVersion>8.1.0</npmVersion>
+              <nodeVersion>v${node.version}</nodeVersion>
+              <npmVersion>${npm.version}</npmVersion>
             </configuration>
             <executions>
               <execution>


### PR DESCRIPTION
**What's in the PR**
- node 16.13.0 -> 16.14.2
- npm 8.1.0 -> 8.5.0
- typescript-eslint 5.17.0 -> 5.20.0
- esbuild 0.14.29 -> 0.14.38
- eslint 8.12.0 -> 8.13.0
- buildnumber-maven-plugin 1.4 -> 3.0.0
- frontend-maven-plugin 1.11.3 -> 1.12.1
- maven-surefire-plugin 3.0.0-M5 -> 3.0.0-M6
- docker-maven-plugin 0.38.0 -> 0.39.1
- versions-maven-plugin 2.8.1 -> 2.10.0

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
