### PR TITLE
#3013 - Application does not start when websocket support is disabled

### DIFF
--- a/inception/inception-diam-editor/pom.xml
+++ b/inception/inception-diam-editor/pom.xml
@@ -55,6 +55,10 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.wicket</groupId>

--- a/inception/inception-diam-editor/src/main/java/de/tudarmstadt/ukp/inception/experimental/editor/diamdebugeditor/DiamDebugEditorFactory.java
+++ b/inception/inception-diam-editor/src/main/java/de/tudarmstadt/ukp/inception/experimental/editor/diamdebugeditor/DiamDebugEditorFactory.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.inception.experimental.editor.diamdebugeditor;
 
 import org.apache.wicket.model.IModel;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Component;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.CasProvider;
@@ -27,6 +28,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.action.AnnotationActionH
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.model.AnnotatorState;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.paging.NoPagingStrategy;
 
+@ConditionalOnExpression("${websocket.enabled:true}")
 @Component("diamDebugEditor")
 public class DiamDebugEditorFactory
     extends AnnotationEditorFactoryImplBase

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/model/websocket/ViewportDefinition.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/model/websocket/ViewportDefinition.java
@@ -27,7 +27,7 @@ import org.apache.uima.cas.text.AnnotationPredicates;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
-import de.tudarmstadt.ukp.inception.diam.service.DiamController;
+import de.tudarmstadt.ukp.inception.diam.service.DiamWebsocketController;
 import de.tudarmstadt.ukp.inception.websocket.config.WebSocketConstants;
 
 public class ViewportDefinition
@@ -105,10 +105,10 @@ public class ViewportDefinition
         properties.setProperty(WebSocketConstants.PARAM_PROJECT, String.valueOf(projectId));
         properties.setProperty(WebSocketConstants.PARAM_DOCUMENT, String.valueOf(documentId));
         properties.setProperty(WebSocketConstants.PARAM_USER, user);
-        properties.setProperty(DiamController.PARAM_FROM, String.valueOf(begin));
-        properties.setProperty(DiamController.PARAM_TO, String.valueOf(end));
-        return DiamController.PLACEHOLDER_RESOLVER
-                .replacePlaceholders(DiamController.DOCUMENT_VIEWPORT_TOPIC_TEMPLATE, properties);
+        properties.setProperty(DiamWebsocketController.PARAM_FROM, String.valueOf(begin));
+        properties.setProperty(DiamWebsocketController.PARAM_TO, String.valueOf(end));
+        return DiamWebsocketController.PLACEHOLDER_RESOLVER
+                .replacePlaceholders(DiamWebsocketController.DOCUMENT_VIEWPORT_TOPIC_TEMPLATE, properties);
     }
 
     @Override

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/service/DiamWebsocketController.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/service/DiamWebsocketController.java
@@ -39,6 +39,7 @@ import org.apache.uima.cas.CAS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.event.EventListener;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
@@ -80,8 +81,9 @@ import de.tudarmstadt.ukp.inception.diam.model.websocket.ViewportState;
 /**
  * Differential INCEpTION Annotation Messaging (DIAM) protocol controller.
  */
+@ConditionalOnExpression("${websocket.enabled:true}")
 @Controller
-public class DiamController
+public class DiamWebsocketController
 {
     private final Logger log = LoggerFactory.getLogger(getClass());
 
@@ -120,7 +122,7 @@ public class DiamController
 
     private final LoadingCache<ViewportDefinition, ViewportState> activeViewports;
 
-    public DiamController(SimpMessagingTemplate aMsgTemplate, PreRenderer aPreRenderer,
+    public DiamWebsocketController(SimpMessagingTemplate aMsgTemplate, PreRenderer aPreRenderer,
             DocumentService aDocumentService, RepositoryProperties aRepositoryProperties,
             AnnotationSchemaService aSchemaService, ProjectService aProjectService,
             UserDao aUserRepository)

--- a/inception/inception-diam/src/test/java/de/tudarmstadt/ukp/inception/diam/service/DiamWebsocketController_ViewportRoutingTest.java
+++ b/inception/inception-diam/src/test/java/de/tudarmstadt/ukp/inception/diam/service/DiamWebsocketController_ViewportRoutingTest.java
@@ -132,7 +132,7 @@ import de.tudarmstadt.ukp.inception.websocket.config.stomp.LoggingStompSessionHa
         "de.tudarmstadt.ukp.clarin.webanno.model", //
         "de.tudarmstadt.ukp.clarin.webanno.security.model", //
         "de.tudarmstadt.ukp.inception.log.model" })
-public class DiamController_ViewportRoutingTest
+public class DiamWebsocketController_ViewportRoutingTest
 {
     private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
@@ -143,7 +143,7 @@ public class DiamController_ViewportRoutingTest
     private @LocalServerPort int port;
     private String websocketUrl;
 
-    private @Autowired DiamController sut;
+    private @Autowired DiamWebsocketController sut;
 
     private @Autowired ProjectService projectService;
     private @Autowired DocumentService documentService;

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/footer/RecommendationEventFooterPanel.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/footer/RecommendationEventFooterPanel.java
@@ -66,7 +66,7 @@ public class RecommendationEventFooterPanel
         super.onConfigure();
         // model will be added as props to vue component
         setDefaultModel(Model.ofMap(Map.of("wsEndpoint", constructEndpointUrl(), "topicChannel",
-                RecommendationEventMessageControllerImpl.REC_EVENTS, "feedbackPanelId",
+                RecommendationEventWebsocketControllerImpl.REC_EVENTS, "feedbackPanelId",
                 feedback.retrieveFeedbackPanelId(this), "projectId", getProjectId())));
     }
 

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/footer/RecommendationEventWebsocketController.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/footer/RecommendationEventWebsocketController.java
@@ -15,30 +15,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package de.tudarmstadt.ukp.inception.websocket.controller;
+package de.tudarmstadt.ukp.inception.recommendation.footer;
 
-import java.security.Principal;
-import java.util.List;
+import de.tudarmstadt.ukp.inception.recommendation.event.RecommenderTaskEvent;
 
-import org.springframework.context.ApplicationEvent;
-
-import de.tudarmstadt.ukp.inception.websocket.model.LoggedEventMessage;
-
-public interface LoggedEventMessageController
+public interface RecommendationEventWebsocketController
 {
-    /***
-     * Push messages on received application events to named user
-     */
-    public void onApplicationEvent(ApplicationEvent aEvent);
+    String handleException(Throwable exception);
 
-    /**
-     * Return the most recent logged events to the subscribing client
-     * 
-     * @param aPrincipal
-     *            the subscribing client
-     * @return the most recent events
-     */
-    public List<LoggedEventMessage> getMostRecentLoggedEvents(Principal aPrincipal);
-
-    public String handleException(Throwable exception);
+    void onRecommenderErrorEvent(RecommenderTaskEvent aEvent);
 }

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/footer/RecommendationEventWebsocketControllerImpl.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/footer/RecommendationEventWebsocketControllerImpl.java
@@ -20,7 +20,7 @@ package de.tudarmstadt.ukp.inception.recommendation.footer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.event.EventListener;
 import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -32,20 +32,20 @@ import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
 import de.tudarmstadt.ukp.inception.recommendation.event.RecommenderTaskEvent;
 import de.tudarmstadt.ukp.inception.websocket.model.LoggedEventMessage;
 
-@ConditionalOnBean(SimpMessagingTemplate.class)
+@ConditionalOnExpression("${websocket.enabled:true} and ${websocket.recommender-events.enabled:true}")
 @Controller
-public class RecommendationEventMessageControllerImpl
-    implements RecommendationEventMessageController
+public class RecommendationEventWebsocketControllerImpl
+    implements RecommendationEventWebsocketController
 {
     private final Logger log = LoggerFactory
-            .getLogger(RecommendationEventMessageControllerImpl.class);
+            .getLogger(RecommendationEventWebsocketControllerImpl.class);
 
     public static final String REC_EVENTS = "/recEvents";
     public static final String REC_EVENTS_TOPIC = "/queue" + REC_EVENTS;
 
     private final SimpMessagingTemplate msgTemplate;
 
-    public RecommendationEventMessageControllerImpl(@Autowired SimpMessagingTemplate aMsgTemplate)
+    public RecommendationEventWebsocketControllerImpl(@Autowired SimpMessagingTemplate aMsgTemplate)
     {
         msgTemplate = aMsgTemplate;
     }

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/config/DashboardAutoConfiguration.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/config/DashboardAutoConfiguration.java
@@ -20,6 +20,7 @@ package de.tudarmstadt.ukp.inception.ui.core.dashboard.config;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -52,14 +53,14 @@ public class DashboardAutoConfiguration
     }
 
     @Bean
-    @ConditionalOnProperty(prefix = "dashboard", name = "legacy-export", havingValue = "false", matchIfMissing = true)
+    @ConditionalOnExpression("${websocket.enabled:true} and !${dashboard.legacy-export.enabled:false}")
     public ProjectExportMenuItem projectExportMenuItem()
     {
         return new ProjectExportMenuItem();
     }
 
     @Bean
-    @ConditionalOnProperty(prefix = "dashboard", name = "legacy-export", havingValue = "true", matchIfMissing = false)
+    @ConditionalOnExpression("!${websocket.enabled:true} or ${dashboard.legacy-export.enabled:false}")
     @Deprecated
     public LegacyProjectExportMenuItem legacyProjectExportMenuItem()
     {

--- a/inception/inception-websocket/src/main/java/de/tudarmstadt/ukp/inception/websocket/config/WebsocketAutoConfiguration.java
+++ b/inception/inception-websocket/src/main/java/de/tudarmstadt/ukp/inception/websocket/config/WebsocketAutoConfiguration.java
@@ -28,7 +28,7 @@ import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBr
 import com.giffing.wicket.spring.boot.starter.configuration.extensions.core.csrf.CsrfAttacksPreventionProperties;
 
 import de.tudarmstadt.ukp.inception.log.config.EventLoggingAutoConfiguration;
-import de.tudarmstadt.ukp.inception.websocket.controller.LoggedEventMessageController;
+import de.tudarmstadt.ukp.inception.websocket.controller.LoggedEventsWebsocketController;
 import de.tudarmstadt.ukp.inception.websocket.footer.LoggedEventFooterItem;
 
 @Configuration
@@ -38,7 +38,7 @@ import de.tudarmstadt.ukp.inception.websocket.footer.LoggedEventFooterItem;
 @EnableConfigurationProperties(CsrfAttacksPreventionProperties.class)
 public class WebsocketAutoConfiguration
 {
-    @ConditionalOnBean(LoggedEventMessageController.class)
+    @ConditionalOnBean(LoggedEventsWebsocketController.class)
     @ConditionalOnProperty(name = "websocket.loggedevent.enabled", havingValue = "true")
     @Bean
     public LoggedEventFooterItem loggedEventFooterItem()

--- a/inception/inception-websocket/src/main/java/de/tudarmstadt/ukp/inception/websocket/controller/LoggedEventsWebsocketController.java
+++ b/inception/inception-websocket/src/main/java/de/tudarmstadt/ukp/inception/websocket/controller/LoggedEventsWebsocketController.java
@@ -15,13 +15,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package de.tudarmstadt.ukp.inception.recommendation.footer;
+package de.tudarmstadt.ukp.inception.websocket.controller;
 
-import de.tudarmstadt.ukp.inception.recommendation.event.RecommenderTaskEvent;
+import java.security.Principal;
+import java.util.List;
 
-public interface RecommendationEventMessageController
+import org.springframework.context.ApplicationEvent;
+
+import de.tudarmstadt.ukp.inception.websocket.model.LoggedEventMessage;
+
+public interface LoggedEventsWebsocketController
 {
-    String handleException(Throwable exception);
+    /***
+     * Push messages on received application events to named user
+     */
+    public void onApplicationEvent(ApplicationEvent aEvent);
 
-    void onRecommenderErrorEvent(RecommenderTaskEvent aEvent);
+    /**
+     * Return the most recent logged events to the subscribing client
+     * 
+     * @param aPrincipal
+     *            the subscribing client
+     * @return the most recent events
+     */
+    public List<LoggedEventMessage> getMostRecentLoggedEvents(Principal aPrincipal);
+
+    public String handleException(Throwable exception);
 }

--- a/inception/inception-websocket/src/main/java/de/tudarmstadt/ukp/inception/websocket/controller/LoggedEventsWebsocketControllerImpl.java
+++ b/inception/inception-websocket/src/main/java/de/tudarmstadt/ukp/inception/websocket/controller/LoggedEventsWebsocketControllerImpl.java
@@ -40,9 +40,9 @@ import de.tudarmstadt.ukp.inception.log.adapter.EventLoggingAdapterRegistry;
 import de.tudarmstadt.ukp.inception.websocket.model.LoggedEventMessage;
 
 @Controller
-@ConditionalOnExpression("${websocket.enabled:true} and ${websocket.loggedevent.enabled:false}")
-public class LoggedEventMessageControllerImpl
-    implements LoggedEventMessageController
+@ConditionalOnExpression("${websocket.enabled:true} and ${websocket.logged-events.enabled:false}")
+public class LoggedEventsWebsocketControllerImpl
+    implements LoggedEventsWebsocketController
 {
     private static final int MAX_EVENTS = 5;
 
@@ -56,7 +56,7 @@ public class LoggedEventMessageControllerImpl
     private final EventLoggingAdapterRegistry adapterRegistry;
 
     @Autowired
-    public LoggedEventMessageControllerImpl(SimpMessagingTemplate aMsgTemplate,
+    public LoggedEventsWebsocketControllerImpl(SimpMessagingTemplate aMsgTemplate,
             EventLoggingAdapterRegistry aAdapterRegistry, DocumentService aDocService,
             ProjectService aProjectService, EventRepository aEventRepository)
     {

--- a/inception/inception-websocket/src/main/java/de/tudarmstadt/ukp/inception/websocket/footer/LoggedEventFooterPanel.java
+++ b/inception/inception-websocket/src/main/java/de/tudarmstadt/ukp/inception/websocket/footer/LoggedEventFooterPanel.java
@@ -37,8 +37,8 @@ import de.agilecoders.wicket.webjars.request.resource.WebjarsJavaScriptResourceR
 import de.tudarmstadt.ukp.inception.support.dayjs.DayJsResourceReference;
 import de.tudarmstadt.ukp.inception.support.vue.VueComponent;
 import de.tudarmstadt.ukp.inception.websocket.config.WebsocketConfig;
-import de.tudarmstadt.ukp.inception.websocket.controller.LoggedEventMessageController;
-import de.tudarmstadt.ukp.inception.websocket.controller.LoggedEventMessageControllerImpl;
+import de.tudarmstadt.ukp.inception.websocket.controller.LoggedEventsWebsocketController;
+import de.tudarmstadt.ukp.inception.websocket.controller.LoggedEventsWebsocketControllerImpl;
 import de.tudarmstadt.ukp.inception.websocket.feedback.FeedbackPanelExtensionBehavior;
 
 @AuthorizeAction(action = Action.RENDER, roles = "ROLE_ADMIN")
@@ -47,7 +47,7 @@ public class LoggedEventFooterPanel
 {
     private static final long serialVersionUID = -9006607500867612027L;
 
-    private @SpringBean LoggedEventMessageController loggedEventService;
+    private @SpringBean LoggedEventsWebsocketController loggedEventService;
     private @SpringBean ServletContext servletContext;
     private FeedbackPanelExtensionBehavior feedback;
 
@@ -65,7 +65,7 @@ public class LoggedEventFooterPanel
         super.onConfigure();
         // model will be added as props to vue component
         setDefaultModel(Model.ofMap(Map.of("wsEndpoint", constructEndpointUrl(), "topicChannel",
-                LoggedEventMessageControllerImpl.LOGGED_EVENTS, "feedbackPanelId",
+                LoggedEventsWebsocketControllerImpl.LOGGED_EVENTS, "feedbackPanelId",
                 feedback.retrieveFeedbackPanelId(this))));
     }
 

--- a/inception/inception-websocket/src/main/resources/META-INF/asciidoc/admin-guide/settings_websocket.adoc
+++ b/inception/inception-websocket/src/main/resources/META-INF/asciidoc/admin-guide/settings_websocket.adoc
@@ -36,8 +36,13 @@ You can enable websocket support for your instance which allows to push messages
 | false
 | true
 
-| websocket.loggedevent.enabled
+| websocket.logged-events.enabled
 | enable/disable push messages for logged events
 | false
 | true
+
+| websocket.recommender-events.enabled
+| enable/disable push messages for recommender events
+| true
+| false
 |===

--- a/inception/inception-websocket/src/test/java/de/tudarmstadt/ukp/inception/websocket/LoggedEventsWebsocketControllerImplTest.java
+++ b/inception/inception-websocket/src/test/java/de/tudarmstadt/ukp/inception/websocket/LoggedEventsWebsocketControllerImplTest.java
@@ -45,11 +45,11 @@ import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.inception.log.EventRepository;
 import de.tudarmstadt.ukp.inception.log.adapter.EventLoggingAdapterRegistryImpl;
 import de.tudarmstadt.ukp.inception.log.adapter.SpanEventAdapter;
-import de.tudarmstadt.ukp.inception.websocket.controller.LoggedEventMessageControllerImpl;
+import de.tudarmstadt.ukp.inception.websocket.controller.LoggedEventsWebsocketControllerImpl;
 import de.tudarmstadt.ukp.inception.websocket.model.LoggedEventMessage;
 
 @ExtendWith(SpringExtension.class)
-public class LoggedEventMessageControllerImplTest
+public class LoggedEventsWebsocketControllerImplTest
 {
     private static final String TEST_ADMIN_USERNAME = "testAdmin";
     private @Mock DocumentService docService;
@@ -62,7 +62,7 @@ public class LoggedEventMessageControllerImplTest
     private SourceDocument testDoc;
     private User testAdmin;
 
-    private LoggedEventMessageControllerImpl sut;
+    private LoggedEventsWebsocketControllerImpl sut;
 
     @BeforeEach
     public void setup()
@@ -79,7 +79,7 @@ public class LoggedEventMessageControllerImplTest
         when(projectService.getProject(1L)).thenReturn(testProject);
         when(docService.getSourceDocument(1L, 2L)).thenReturn(testDoc);
 
-        sut = new LoggedEventMessageControllerImpl(new SimpMessagingTemplate(outboundChannel),
+        sut = new LoggedEventsWebsocketControllerImpl(new SimpMessagingTemplate(outboundChannel),
                 adapterRegistry, docService, projectService, eventRepository);
     }
 

--- a/inception/inception-websocket/src/test/java/de/tudarmstadt/ukp/inception/websocket/WebSocketIntegrationTest.java
+++ b/inception/inception-websocket/src/test/java/de/tudarmstadt/ukp/inception/websocket/WebSocketIntegrationTest.java
@@ -81,7 +81,7 @@ import de.tudarmstadt.ukp.inception.websocket.model.LoggedEventMessage;
         properties = { //
                 "spring.main.banner-mode=off", //
                 "websocket.enabled=true", //
-                "websocket.loggedevent.enabled=true", //
+                "websocket.logged-events.enabled=true", //
                 "event-logging.enabled=true" })
 @SpringBootApplication( //
         exclude = { //


### PR DESCRIPTION
**What's in the PR**
- Renamed controller classes to make clearer they use Websocket
- Added a @ConditionalOnExpression to the DiamWebsocketController
- Automatically switch back to the legacy export page when WebSocket is disabled
- Disable the DIAM debug editor when WebSocket is disabled

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
