### PR TITLE
#3049 - Can add empty IRI as additional property

### DIFF
--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/AdditionalMatchingPropertiesPanel.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/AdditionalMatchingPropertiesPanel.java
@@ -17,6 +17,8 @@
  */
 package de.tudarmstadt.ukp.inception.ui.kb.project;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
 import java.util.ArrayList;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
@@ -102,16 +104,17 @@ public class AdditionalMatchingPropertiesPanel
     private void actionAddProperty(AjaxRequestTarget aTarget)
     {
         String concept = newPropertyIRIString.getObject();
-        if (isPropertyValid(kbModel.getObject().getKb(), concept, true)) {
-            properties.getObject().add(concept);
-            kbModel.getObject().getKb().setAdditionalMatchingProperties(properties.getObject());
-            newPropertyIRIString.setObject(null);
-        }
-        else {
+
+        if (!isPropertyValid(kbModel.getObject().getKb(), concept, true)) {
             error("Property [" + newPropertyIRIString.getObject()
-                    + "] does not exist or has already been specified");
+                    + "] is not an (absolute) IRI, does not exist, or has already been specified");
             aTarget.addChildren(getPage(), IFeedback.class);
+            return;
         }
+
+        properties.getObject().add(concept);
+        kbModel.getObject().getKb().setAdditionalMatchingProperties(properties.getObject());
+        newPropertyIRIString.setObject(null);
         aTarget.add(this);
     }
 
@@ -125,6 +128,15 @@ public class AdditionalMatchingPropertiesPanel
     public boolean isPropertyValid(KnowledgeBase aKb, String aPropertyIri, boolean aAll)
         throws QueryEvaluationException
     {
+        if (isBlank(aPropertyIri)) {
+            return false;
+        }
+
+        // Check if it looks like an (absolute) IRI
+        if (aPropertyIri.indexOf(':') < 0) {
+            return false;
+        }
+
         return !properties.getObject().contains(aPropertyIri);
         // KBs tend to not declare all their properties, so we do not try to check if it actually
         // exist...

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/RootConceptsPanel.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/RootConceptsPanel.java
@@ -17,6 +17,8 @@
  */
 package de.tudarmstadt.ukp.inception.ui.kb.project;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
 import java.util.ArrayList;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
@@ -97,16 +99,17 @@ public class RootConceptsPanel
     private void actionNewRootConcept(AjaxRequestTarget aTarget)
     {
         String concept = newConceptIRIString.getObject();
-        if (isConceptValid(kbModel.getObject().getKb(), concept, true)) {
-            concepts.getObject().add(concept);
-            kbModel.getObject().getKb().setAdditionalMatchingProperties(concepts.getObject());
-            newConceptIRIString.setObject(null);
-        }
-        else {
+        if (!isConceptValid(kbModel.getObject().getKb(), concept, true)) {
             error("Concept [" + newConceptIRIString.getObject()
-                    + "] does not exist or has already been specified");
+                    + "]  is not an (absolute) IRI, does not exist, or has already been specified");
             aTarget.addChildren(getPage(), IFeedback.class);
+            return;
         }
+
+        concepts.getObject().add(concept);
+        kbModel.getObject().getKb().setAdditionalMatchingProperties(concepts.getObject());
+        newConceptIRIString.setObject(null);
+
         aTarget.add(this);
     }
 
@@ -120,6 +123,10 @@ public class RootConceptsPanel
     public boolean isConceptValid(KnowledgeBase kb, String conceptIRI, boolean aAll)
         throws QueryEvaluationException
     {
+        if (isBlank(conceptIRI)) {
+            return false;
+        }
+
         return !concepts.getObject().contains(conceptIRI)
                 && kbService.readConcept(kbModel.getObject().getKb(), conceptIRI, true).isPresent();
     }


### PR DESCRIPTION
**What's in the PR**
- Reject empty root concepts and matching properties
- Improve error message
- Reject property IRIs that do not look like (absolute) IRIs

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
