### PR TITLE
#3052 - Cannot export project when websocket is disabled

### DIFF
--- a/inception/inception-project-export/src/main/java/de/tudarmstadt/ukp/inception/project/export/task/ProjectExportTask_ImplBase.java
+++ b/inception/inception-project-export/src/main/java/de/tudarmstadt/ukp/inception/project/export/task/ProjectExportTask_ImplBase.java
@@ -62,7 +62,7 @@ public abstract class ProjectExportTask_ImplBase<R extends ProjectExportRequest_
 
     private @Autowired ServletContext servletContext;
     private @Autowired DocumentService documentService;
-    private @Autowired SimpMessagingTemplate msgTemplate;
+    private @Autowired(required = false) SimpMessagingTemplate msgTemplate;
 
     public ProjectExportTask_ImplBase(Project aProject, R aRequest, String aUsername)
     {
@@ -76,8 +76,13 @@ public abstract class ProjectExportTask_ImplBase<R extends ProjectExportRequest_
     @Override
     public void afterPropertiesSet() throws Exception
     {
-        monitor = new NotifyingProjectExportTaskMonitor(project, handle, request.getTitle(),
-                msgTemplate);
+        if (msgTemplate != null) {
+            monitor = new NotifyingProjectExportTaskMonitor(project, handle, request.getTitle(),
+                    msgTemplate);
+        }
+        else {
+            monitor = new ProjectExportTaskMonitor(project, handle, request.getTitle());
+        }
         monitor.setCreateTime(System.currentTimeMillis());
     }
 


### PR DESCRIPTION
**What's in the PR**
- Make the SimpMessagingTemplate optional in the export task base class
- Use the non-notifying monitor when WebSocket is not available

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
