### PR TITLE
#3055 - Some logged events to not contain document/project information

### DIFF
--- a/inception/inception-layer-docmetadata/pom.xml
+++ b/inception/inception-layer-docmetadata/pom.xml
@@ -49,6 +49,10 @@
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-model</artifactId>
     </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-log</artifactId>
+    </dependency>
     
     <dependency>
       <groupId>org.apache.uima</groupId>

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/log/DocumentMetadataEventAdapter.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/log/DocumentMetadataEventAdapter.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.core.docanno.log;
+
+import java.io.IOException;
+
+import org.springframework.stereotype.Component;
+
+import de.tudarmstadt.ukp.clarin.webanno.support.JSONUtil;
+import de.tudarmstadt.ukp.inception.log.adapter.EventLoggingAdapter;
+import de.tudarmstadt.ukp.inception.log.model.AnnotationDetails;
+import de.tudarmstadt.ukp.inception.ui.core.docanno.event.DocumentMetadataEvent;
+
+@Component
+public class DocumentMetadataEventAdapter
+    implements EventLoggingAdapter<DocumentMetadataEvent>
+{
+    @Override
+    public boolean accepts(Object aEvent)
+    {
+        return aEvent instanceof DocumentMetadataEvent;
+    }
+
+    @Override
+    public long getDocument(DocumentMetadataEvent aEvent)
+    {
+        return aEvent.getDocument().getId();
+    }
+
+    @Override
+    public long getProject(DocumentMetadataEvent aEvent)
+    {
+        return aEvent.getProject().getId();
+    }
+
+    @Override
+    public String getAnnotator(DocumentMetadataEvent aEvent)
+    {
+        return aEvent.getUser();
+    }
+
+    @Override
+    public String getDetails(DocumentMetadataEvent aEvent) throws IOException
+    {
+        AnnotationDetails details = new AnnotationDetails(aEvent.getAnnotation());
+        return JSONUtil.toJsonString(details);
+    }
+}

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/BulkAnnotationEventAdapter.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/BulkAnnotationEventAdapter.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.log.adapter;
+
+import org.springframework.stereotype.Component;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.event.BulkAnnotationEvent;
+
+@Component
+public class BulkAnnotationEventAdapter
+    implements EventLoggingAdapter<BulkAnnotationEvent>
+{
+    @Override
+    public boolean accepts(Object aEvent)
+    {
+        return aEvent instanceof BulkAnnotationEvent;
+    }
+
+    @Override
+    public long getDocument(BulkAnnotationEvent aEvent)
+    {
+        var document = aEvent.getDocument();
+        return document != null ? document.getId() : -1;
+    }
+
+    @Override
+    public long getProject(BulkAnnotationEvent aEvent)
+    {
+        var project = aEvent.getProject();
+        return project != null ? project.getId() : -1;
+    }
+
+    @Override
+    public String getAnnotator(BulkAnnotationEvent aEvent)
+    {
+        return aEvent.getUser();
+    }
+}


### PR DESCRIPTION
**What's in the PR**
- Added event logging adpaters for DocumentMetadataEvent and BulkAnnotationEvent

**How to test manually**
* Create annotations and check the events table in the database or the event log in an exported project

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
