### PR TITLE
#3057 - Exception in activities dashlet

### DIFF
--- a/inception/inception-ui-dashboard-activity/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/activity/ActivitiesDashletControllerImpl.java
+++ b/inception/inception-ui-dashboard-activity/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/activity/ActivitiesDashletControllerImpl.java
@@ -137,6 +137,7 @@ public class ActivitiesDashletControllerImpl
                 user.getUsername(), annotationEvents, 10);
         return recentEvents.stream() //
                 .filter(Objects::nonNull) //
+                .filter(event -> event.getDocument() == -1l) //
                 // Filter out documents which are not annotatable or curatable
                 .filter(event -> {
                     if (CURATION_USER.equals(event.getAnnotator())) {
@@ -154,7 +155,7 @@ public class ActivitiesDashletControllerImpl
                 .map(event -> {
                     if (CURATION_USER.equals(event.getAnnotator())) {
                         return new Activity(event,
-                                annotatableSourceDocuments.get(event.getDocument()),
+                                curatableSourceDocuments.get(event.getDocument()),
                                 curationPageMenuItem.getUrl(project, event.getDocument()));
                     }
                     else {


### PR DESCRIPTION
**What's in the PR**
- Filter out events without documents
- When picking out curated documents, we should probably use the "curatableSourceDocuments" list and not the "annotatableSourceDocuments" list?

**How to test manually**
* Check if the activities dashlet works ok

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
