### PR TITLE
#3059 - Add support for the Stardog SPARQL FTS service 

### DIFF
--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/IriConstants.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/IriConstants.java
@@ -47,6 +47,7 @@ public class IriConstants
     public static final String PREFIX_SCHEMA = "http://schema.org/";
     public static final String PREFIX_LUCENE_SEARCH = "http://www.openrdf.org/contrib/lucenesail#";
     public static final String PREFIX_MWAPI = "https://www.mediawiki.org/ontology#API/";
+    public static final String PREFIX_STARDOG = "tag:stardog:api:search:";
 
     public static final String UKP_WIKIDATA_SPARQL_ENDPOINT = "http://knowledgebase.ukp.informatik.tu-darmstadt.de:8890/sparql";
     public static final Set<String> IMPLICIT_NAMESPACES = Collections
@@ -87,6 +88,7 @@ public class IriConstants
     public static final IRI FTS_LUCENE;
     public static final IRI FTS_VIRTUOSO;
     public static final IRI FTS_WIKIDATA;
+    public static final IRI FTS_STARDOG;
     public static final IRI FTS_NONE;
 
     public static final List<IRI> CLASS_IRIS;
@@ -114,6 +116,7 @@ public class IriConstants
         FTS_VIRTUOSO = vf.createIRI("bif:contains");
         FTS_LUCENE = vf.createIRI(PREFIX_LUCENE_SEARCH, "matches");
         FTS_WIKIDATA = vf.createIRI(PREFIX_MWAPI, "search");
+        FTS_STARDOG = vf.createIRI(PREFIX_STARDOG, "textMatch");
         FTS_NONE = vf.createIRI("FTS:NONE");
 
         CLASS_IRIS = asList(RDFS.CLASS, OWL.CLASS, WIKIDATA_CLASS, SKOS.CONCEPT);
@@ -125,7 +128,7 @@ public class IriConstants
         PROPERTY_TYPE_IRIS = asList(RDF.PROPERTY, WIKIDATA_PROPERTY_TYPE);
         PROPERTY_LABEL_IRIS = asList(RDFS.LABEL, SKOS.PREF_LABEL);
         PROPERTY_DESCRIPTION_IRIS = asList(RDFS.COMMENT, SCHEMA_DESCRIPTION);
-        FTS_IRIS = asList(FTS_FUSEKI, FTS_VIRTUOSO, FTS_WIKIDATA, FTS_LUCENE);
+        FTS_IRIS = asList(FTS_FUSEKI, FTS_VIRTUOSO, FTS_WIKIDATA, FTS_LUCENE, FTS_STARDOG);
     }
 
     public static boolean hasImplicitNamespace(KnowledgeBase kb, String s)

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/StardogEntitySearchService.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/StardogEntitySearchService.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.kb.querybuilder;
+
+import static de.tudarmstadt.ukp.inception.kb.IriConstants.PREFIX_STARDOG;
+import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.prefix;
+import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.bNode;
+import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.eclipse.rdf4j.sparqlbuilder.core.Prefix;
+import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
+import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPattern;
+import org.eclipse.rdf4j.sparqlbuilder.graphpattern.TriplePattern;
+import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
+import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf;
+
+public class StardogEntitySearchService
+    implements GraphPattern
+{
+    private static final Prefix FTS = prefix("fts", iri(PREFIX_STARDOG));
+
+    private static final Iri FTS_TEXT_MATCH = FTS.iri("textMatch");
+    private static final Iri FTS_QUERY = FTS.iri("query");
+    private static final Iri FTS_THRESHOLD = FTS.iri("threshold");
+    private static final Iri FTS_LIMIT = FTS.iri("limit");
+    private static final Iri FTS_OFFSET = FTS.iri("offset");
+    private static final Iri FTS_SCORE = FTS.iri("score");
+    private static final Iri FTS_RESULT = FTS.iri("result");
+
+    // service fts:textMatch {
+    // [] fts:query 'Mexico AND city' ;
+    // fts:threshold 0.6 ;
+    // fts:limit 10 ;
+    // fts:offset 5 ;
+    // fts:score ?score ;
+    // fts:result ?res ;
+    private final Collection<TriplePattern> patterns;
+
+    /**
+     * Provides access to the Stardog search service.
+     * 
+     * @param aResult
+     *            the variable to which the matching values are to be bound.
+     * @param aQuery
+     *            the query term.
+     */
+    public StardogEntitySearchService(Variable aResult, String aQuery)
+    {
+        patterns = new ArrayList<>();
+        patterns.add(bNode() //
+                .has(FTS_QUERY, Rdf.literalOf(aQuery)) //
+                .andHas(FTS_RESULT, aResult));
+    }
+
+    @Override
+    public String getQueryString()
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append("SERVICE ");
+        sb.append(FTS_TEXT_MATCH.getQueryString());
+        sb.append(" { \n");
+        for (TriplePattern pattern : patterns) {
+            sb.append(pattern.getQueryString());
+            sb.append(" \n");
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @Override
+    public boolean isEmpty()
+    {
+        return false;
+    }
+}

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FusekiRepositoryTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FusekiRepositoryTest.java
@@ -109,7 +109,7 @@ public class FusekiRepositoryTest
     }
 
     @Test
-    public void testWithLabelStartingWith_RDF4J_withLanguage_noFTS() throws Exception
+    public void testWithLabelStartingWith_withLanguage_noFTS() throws Exception
     {
         SPARQLQueryBuilderTest.testWithLabelStartingWith_withLanguage_noFTS(repository, kb);
     }

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FusekiRepositoryTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FusekiRepositoryTest.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.kb.querybuilder;
+
+import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_FUSEKI;
+import static de.tudarmstadt.ukp.inception.kb.http.PerThreadSslCheckingHttpClientUtils.restoreSslVerification;
+import static de.tudarmstadt.ukp.inception.kb.http.PerThreadSslCheckingHttpClientUtils.suspendSslVerification;
+import static de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilderTest.buildSparqlRepository;
+
+import java.lang.reflect.Method;
+
+import org.apache.jena.fuseki.main.FusekiServer;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.query.text.EntityDefinition;
+import org.apache.jena.query.text.TextDatasetFactory;
+import org.apache.jena.query.text.TextIndex;
+import org.apache.jena.query.text.TextIndexConfig;
+import org.apache.jena.query.text.TextIndexLucene;
+import org.apache.jena.tdb.TDBFactory;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.RAMDirectory;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import de.tudarmstadt.ukp.inception.kb.RepositoryType;
+import de.tudarmstadt.ukp.inception.kb.model.KnowledgeBase;
+
+public class FusekiRepositoryTest
+{
+    private FusekiServer fusekiServer;
+    private Repository repository;
+    private KnowledgeBase kb;
+
+    @BeforeEach
+    public void setUp(TestInfo aTestInfo)
+    {
+        String methodName = aTestInfo.getTestMethod().map(Method::getName).orElse("<unknown>");
+        System.out.printf("\n=== %s === %s =====================\n", methodName,
+                aTestInfo.getDisplayName());
+
+        suspendSslVerification();
+
+        // Local Fuseki in-memory story
+        fusekiServer = FusekiServer.create() //
+                .add("/fuseki", createFusekiFTSDataset()) //
+                .build();
+        fusekiServer.start();
+
+        kb = new KnowledgeBase();
+        kb.setDefaultLanguage("en");
+        kb.setType(RepositoryType.LOCAL);
+        kb.setFullTextSearchIri(FTS_FUSEKI.stringValue());
+        kb.setMaxResults(100);
+
+        SPARQLQueryBuilderTest.initRdfsMapping(kb);
+
+        repository = buildSparqlRepository(
+                "http://localhost:" + fusekiServer.getPort() + "/fuseki");
+
+        try (RepositoryConnection conn = repository.getConnection()) {
+            conn.clear();
+        }
+    }
+
+    @AfterEach
+    public void tearDown()
+    {
+        restoreSslVerification();
+
+        fusekiServer.stop();
+    }
+
+    @Test
+    public void testWithLabelStartingWith_withLanguage_FTS_1() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelStartingWith_withLanguage_FTS_1(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelStartingWith_withLanguage_FTS_2() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelStartingWith_withLanguage_FTS_2(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelStartingWith_withLanguage_FTS_3() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelStartingWith_withLanguage_FTS_3(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelStartingWith_RDF4J_withLanguage_noFTS() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelStartingWith_withLanguage_noFTS(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelContainingAnyOf_pets_ttl_noFTS() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelContainingAnyOf_pets_ttl_noFTS(repository, kb);
+    }
+
+    @Test
+    public void thatRootsCanBeRetrieved_ontolex() throws Exception
+    {
+        SPARQLQueryBuilderTest.thatRootsCanBeRetrieved_ontolex(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelContainingAnyOf_withLanguage_noFTS() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelContainingAnyOf_withLanguage_noFTS(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelContainingAnyOf_withLanguage_FTS() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelContainingAnyOf_withLanguage(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelMatchingAnyOf_withLanguage_FTS() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelMatchingAnyOf_withLanguage(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelMatchingAnyOf_withLanguage_noFTS() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelMatchingAnyOf_withLanguage_noFTS(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelStartingWith_withoutLanguage_FTS() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelStartingWith_withoutLanguage(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelStartingWith_withoutLanguage_noFTS() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelStartingWith_withoutLanguage_noFTS(repository, kb);
+    }
+
+    @Disabled("Requires addition Fuseki FTS configuration")
+    @Test
+    public void testWithLabelMatchingExactlyAnyOf_subproperty_FTS() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelMatchingExactlyAnyOf_subproperty(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelMatchingExactlyAnyOf_subproperty_noFTS() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelMatchingExactlyAnyOf_subproperty_noFTS(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelMatchingExactlyAnyOf_withLanguage_noFTS() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelMatchingExactlyAnyOf_withLanguage_noFTS(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelMatchingExactlyAnyOf_withLanguage_FTS() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelMatchingExactlyAnyOf_withLanguage(repository, kb);
+    }
+
+    /**
+     * Creates a dataset description with FTS support for the RDFS label property.
+     */
+    static Dataset createFusekiFTSDataset()
+    {
+        Dataset ds1 = TDBFactory.createDataset();
+        Directory dir = new RAMDirectory();
+        EntityDefinition eDef = new EntityDefinition("iri", "text");
+        eDef.setPrimaryPredicate(org.apache.jena.vocabulary.RDFS.label);
+        TextIndexConfig tidxCfg = new TextIndexConfig(eDef);
+        tidxCfg.setValueStored(true);
+        tidxCfg.setMultilingualSupport(true);
+        TextIndex tidx = new TextIndexLucene(dir, tidxCfg);
+        Dataset ds = TextDatasetFactory.create(ds1, tidx);
+        return ds;
+    }
+}

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/Rdf4JRepositoryTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/Rdf4JRepositoryTest.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.kb.querybuilder;
+
+import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_LUCENE;
+import static de.tudarmstadt.ukp.inception.kb.http.PerThreadSslCheckingHttpClientUtils.restoreSslVerification;
+import static de.tudarmstadt.ukp.inception.kb.http.PerThreadSslCheckingHttpClientUtils.suspendSslVerification;
+
+import java.lang.reflect.Method;
+
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.sail.lucene.LuceneSail;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import de.tudarmstadt.ukp.inception.kb.RepositoryType;
+import de.tudarmstadt.ukp.inception.kb.model.KnowledgeBase;
+
+public class Rdf4JRepositoryTest
+{
+    private Repository repository;
+    private KnowledgeBase kb;
+
+    @BeforeEach
+    public void setUp(TestInfo aTestInfo)
+    {
+        String methodName = aTestInfo.getTestMethod().map(Method::getName).orElse("<unknown>");
+        System.out.printf("\n=== %s === %s =====================\n", methodName,
+                aTestInfo.getDisplayName());
+
+        suspendSslVerification();
+
+        // Local RDF4J in-memory store - this should be used for most tests because we can
+        // a) rely on its availability
+        // b) import custom test data
+        LuceneSail lucenesail = new LuceneSail();
+        lucenesail.setParameter(LuceneSail.LUCENE_RAMDIR_KEY, "true");
+        lucenesail.setBaseSail(new MemoryStore());
+        repository = new SailRepository(lucenesail);
+        repository.init();
+
+        kb = new KnowledgeBase();
+        kb.setDefaultLanguage("en");
+        kb.setType(RepositoryType.LOCAL);
+        kb.setFullTextSearchIri(FTS_LUCENE.stringValue());
+        kb.setMaxResults(100);
+
+        SPARQLQueryBuilderTest.initRdfsMapping(kb);
+
+        try (RepositoryConnection conn = repository.getConnection()) {
+            conn.clear();
+        }
+    }
+
+    @AfterEach
+    public void tearDown()
+    {
+        restoreSslVerification();
+
+        repository.shutDown();
+    }
+
+    @Test
+    public void testWithLabelStartingWith_withLanguage_FTS_1() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelStartingWith_withLanguage_FTS_1(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelStartingWith_withLanguage_FTS_2() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelStartingWith_withLanguage_FTS_2(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelStartingWith_withLanguage_FTS_3() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelStartingWith_withLanguage_FTS_3(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelStartingWith_RDF4J_withLanguage_noFTS() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelStartingWith_withLanguage_noFTS(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelContainingAnyOf_pets_ttl_noFTS() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelContainingAnyOf_pets_ttl_noFTS(repository, kb);
+    }
+
+    @Test
+    public void thatRootsCanBeRetrieved_ontolex() throws Exception
+    {
+        SPARQLQueryBuilderTest.thatRootsCanBeRetrieved_ontolex(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelContainingAnyOf_withLanguage_noFTS() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelContainingAnyOf_withLanguage_noFTS(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelContainingAnyOf_withLanguage_FTS() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelContainingAnyOf_withLanguage(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelMatchingAnyOf_withLanguage_FTS() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelMatchingAnyOf_withLanguage(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelMatchingAnyOf_withLanguage_noFTS() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelMatchingAnyOf_withLanguage_noFTS(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelStartingWith_withoutLanguage_FTS() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelStartingWith_withoutLanguage(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelStartingWith_withoutLanguage_noFTS() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelStartingWith_withoutLanguage_noFTS(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelMatchingExactlyAnyOf_subproperty_FTS() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelMatchingExactlyAnyOf_subproperty(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelMatchingExactlyAnyOf_subproperty_noFTS() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelMatchingExactlyAnyOf_subproperty_noFTS(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelMatchingExactlyAnyOf_withLanguage_noFTS() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelMatchingExactlyAnyOf_withLanguage_noFTS(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelMatchingExactlyAnyOf_withLanguage_FTS() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelMatchingExactlyAnyOf_withLanguage(repository, kb);
+    }
+}

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/Rdf4JRepositoryTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/Rdf4JRepositoryTest.java
@@ -99,7 +99,7 @@ public class Rdf4JRepositoryTest
     }
 
     @Test
-    public void testWithLabelStartingWith_RDF4J_withLanguage_noFTS() throws Exception
+    public void testWithLabelStartingWith_withLanguage_noFTS() throws Exception
     {
         SPARQLQueryBuilderTest.testWithLabelStartingWith_withLanguage_noFTS(repository, kb);
     }

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/StardogRepositoryTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/StardogRepositoryTest.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.kb.querybuilder;
+
+import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_STARDOG;
+import static de.tudarmstadt.ukp.inception.kb.http.PerThreadSslCheckingHttpClientUtils.restoreSslVerification;
+import static de.tudarmstadt.ukp.inception.kb.http.PerThreadSslCheckingHttpClientUtils.suspendSslVerification;
+
+import java.lang.reflect.Method;
+
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.junit.Ignore;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import de.tudarmstadt.ukp.inception.kb.RepositoryType;
+import de.tudarmstadt.ukp.inception.kb.model.KnowledgeBase;
+
+// The repository has to exist and stardoc has to be running for this test to run.
+// To create the repository, use the following command:
+// stardog-admin db create -n test -o search.enabled=true --
+@Ignore("Requires manually setting up a test server")
+public class StardogRepositoryTest
+{
+    private Repository repository;
+    private KnowledgeBase kb;
+
+    @BeforeEach
+    public void setUp(TestInfo aTestInfo)
+    {
+        String methodName = aTestInfo.getTestMethod().map(Method::getName).orElse("<unknown>");
+        System.out.printf("\n=== %s === %s =====================\n", methodName,
+                aTestInfo.getDisplayName());
+
+        suspendSslVerification();
+
+        kb = new KnowledgeBase();
+        kb.setDefaultLanguage("en");
+        kb.setType(RepositoryType.LOCAL);
+        kb.setFullTextSearchIri(FTS_STARDOG.stringValue());
+        kb.setMaxResults(100);
+
+        SPARQLQueryBuilderTest.initRdfsMapping(kb);
+
+        repository = SPARQLQueryBuilderTest.buildSparqlRepository(
+                "http://admin:admin@localhost:5820/test/query",
+                "http://admin:admin@localhost:5820/test/update");
+
+        try (RepositoryConnection conn = repository.getConnection()) {
+            conn.clear();
+        }
+    }
+
+    @AfterEach
+    public void tearDown()
+    {
+        restoreSslVerification();
+    }
+
+    @Test
+    public void testWithLabelStartingWith_withLanguage_FTS_1() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelStartingWith_withLanguage_FTS_1(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelStartingWith_withLanguage_FTS_2() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelStartingWith_withLanguage_FTS_2(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelStartingWith_withLanguage_FTS_3() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelStartingWith_withLanguage_FTS_3(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelStartingWith_RDF4J_withLanguage_noFTS() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelStartingWith_withLanguage_noFTS(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelContainingAnyOf_pets_ttl_noFTS() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelContainingAnyOf_pets_ttl_noFTS(repository, kb);
+    }
+
+    @Test
+    public void thatRootsCanBeRetrieved_ontolex() throws Exception
+    {
+        SPARQLQueryBuilderTest.thatRootsCanBeRetrieved_ontolex(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelContainingAnyOf_withLanguage_noFTS() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelContainingAnyOf_withLanguage_noFTS(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelContainingAnyOf_withLanguage_FTS() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelContainingAnyOf_withLanguage(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelMatchingAnyOf_withLanguage_FTS() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelMatchingAnyOf_withLanguage(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelMatchingAnyOf_withLanguage_noFTS() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelMatchingAnyOf_withLanguage_noFTS(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelStartingWith_withoutLanguage_FTS() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelStartingWith_withoutLanguage(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelStartingWith_withoutLanguage_noFTS() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelStartingWith_withoutLanguage_noFTS(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelMatchingExactlyAnyOf_subproperty_FTS() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelMatchingExactlyAnyOf_subproperty(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelMatchingExactlyAnyOf_subproperty_noFTS() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelMatchingExactlyAnyOf_subproperty_noFTS(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelMatchingExactlyAnyOf_withLanguage_noFTS() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelMatchingExactlyAnyOf_withLanguage_noFTS(repository, kb);
+    }
+
+    @Test
+    public void testWithLabelMatchingExactlyAnyOf_withLanguage_FTS() throws Exception
+    {
+        SPARQLQueryBuilderTest.testWithLabelMatchingExactlyAnyOf_withLanguage(repository, kb);
+    }
+}

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/StardogRepositoryTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/StardogRepositoryTest.java
@@ -25,9 +25,9 @@ import java.lang.reflect.Method;
 
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
-import org.junit.Ignore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
@@ -37,7 +37,7 @@ import de.tudarmstadt.ukp.inception.kb.model.KnowledgeBase;
 // The repository has to exist and stardoc has to be running for this test to run.
 // To create the repository, use the following command:
 // stardog-admin db create -n test -o search.enabled=true --
-@Ignore("Requires manually setting up a test server")
+@Disabled("Requires manually setting up a test server")
 public class StardogRepositoryTest
 {
     private Repository repository;
@@ -94,7 +94,7 @@ public class StardogRepositoryTest
     }
 
     @Test
-    public void testWithLabelStartingWith_RDF4J_withLanguage_noFTS() throws Exception
+    public void testWithLabelStartingWith_withLanguage_noFTS() throws Exception
     {
         SPARQLQueryBuilderTest.testWithLabelStartingWith_withLanguage_noFTS(repository, kb);
     }

--- a/inception/inception-kb/src/test/resources/data/wordnet-ontolex-ontology.owl
+++ b/inception/inception-kb/src/test/resources/data/wordnet-ontolex-ontology.owl
@@ -17,8 +17,8 @@
        <vann:preferredNamespaceUri>http://wordnet-rdf.princeton.edu/ontology#</vann:preferredNamespaceUri>
        <dc:title xml:lang="en">WordNet RDF Ontology</dc:title>
        <dc:description xml:lang="en">An ontology describing the data types used in the WordNet RDF model</dc:description>
-       <dc:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2014-3-3</dc:issued>
-       <dc:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2011-4-17</dc:modified>
+       <dc:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2014-03-03</dc:issued>
+       <dc:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2011-04-17</dc:modified>
        <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">3.1</owl:versionInfo>
        <dc:license rdf:resource="http://wordnet-rdf.princeton.edu/license.html"/>
        <dc:contributor>

--- a/inception/inception-ui-kb/src/main/resources/META-INF/asciidoc/user-guide/projects_knowledge-base.adoc
+++ b/inception/inception-ui-kb/src/main/resources/META-INF/asciidoc/user-guide/projects_knowledge-base.adoc
@@ -38,6 +38,12 @@ The remote knowledge bases, there are the following settings:
   RDF4J-based servers. Note that full-text search must be enabled on the server by the server 
   operator.
 
+NOTE: **Changing the URL of a remote KB currently only takes affect after {product-name} is restarted!**
+      The updated URL will be shown in the settings, but queries will still be sent to the old URL until you restart {product-name}.
+      This also means that if you add, remove or change HTTP "Basic" authentication that are part of the URL, they will not
+      take effect until you restart. It is usually easier to delete the remote KB configuration and create it from scratch
+      with the new URL.
+
 
 === Schema mapping
 
@@ -223,15 +229,51 @@ NOTE: Not all remote SPARQL knowledge bases may support additional matching prop
 
 Full text search in knowledge bases enables searching for entities by their textual context, e.g. their label. This is a prerequisite for some advanced features such as re-ranking linking candidates during entity linking. Two full text search modes are supported:
 
+* `http://www.openrdf.org/contrib/lucenesail#matches`: use with local knowledge bases or possibly with remote knowledge bases using the link:https://rdf4j.org/documentation/programming/lucene/[RDF4J Lucene SAIL].
 * `bif:contains`: use with remote link:https://virtuoso.openlinksw.com[Virtuoso SPARQL] endpoints.
-* `text:query`: use with remote link:https://jena.apache.org/documentation/fuseki2/[Apache Jena Fuseki] SPARQL endpoints. Note that on the side of the Fuseki server, the full text index must be configured with the options `text:storeValues` and `text:multilingualSupport` both set to `true` (cf. link:https://jena.apache.org/documentation/query/text-query.html[Text Dataset Assembler documentation]).
-* `\https://www.mediawiki.org/ontology#API/`: use with the link:https://www.wikidata.org/wiki/Wikidata:SPARQL_query_service/queries[official Wikidata SPARQL endpoint].
-* `lucenesail#matches`: use with local knowledge bases or possibly with remote knowledge bases using the link:https://rdf4j.org/documentation/programming/lucene/[RDF4J Lucene SAIL].
+* `text:query`: use with remote link:https://jena.apache.org/documentation/fuseki2/[Apache Jena Fuseki] SPARQL endpoints.
+* `tag:stardog:api:search:textMatch`: use with link:https://www.stardog.com[Stardog].
+* `https://www.mediawiki.org/ontology#API/`: use with the link:https://www.wikidata.org/wiki/Wikidata:SPARQL_query_service/queries[official Wikidata SPARQL endpoint].
 * `FTS:NONE`: use if there is no full text search support in the triple store - this will be very slow in particular for large KBs.
+
+==== Apache Jena Fuseki
+
+To enable the full text index on the Fuseki server side, set the options options `text:storeValues` and
+`text:multilingualSupport` both to `true` (cf. link:https://jena.apache.org/documentation/query/text-query.html[Text Dataset Assembler documentation]).
+
+Fuseki databases are usually accessible via SPARQL at `http://localhost:3030/DATABASE-NAME/sparql` or
+`http://localhost:3030/DATABASE-NAME/query`.
+
+==== Stardog
+
+To enable full text search in a Stardog database, create the database with the option 
+`search.enabled=true`.
+
+.Example creation of FTS-enabled Stardog database
+----
+stardog-admin db create -n DATABASE-NAME -o search.enabled=true -- knowledgebase.ttl
+----
+
+Stardog databases are usually accessible via SPARQL at `http://localhost:5820/DATABASE-NAME/query`.
+You may have to specify credentials as part of the URL to gain access.
+
+==== SPARQL Endpoint Authentication
+
+{product-name} supports endpoints that use HTTP "Basic" authentication. You can simply add the
+username and password required to access the remote SPARQL endpoint as part of the URL. However,
+note that the credentials are visible to anybody visiting the KB settings and are also stored
+unencrypted.
+
+.HTTP "Basic" authenticated SPARQL URL
+----
+http://USERNAME:PASSWORD@localhost:5820/mock/query
+----
 
 === Importing RDF
 
-KBs can be populated by importing RDF files. Several formats are supported. The type of the file is determined by the file extension. So make sure the files have the correct extension when you import them, otherwise nothing might be imported from them despite a potentially long waiting time. The application suppports GZIP compressed files (ending in `.gz`, so e.g. `.ttl.gz`), so we recommend compressing the files before uploading them as this can significantly improve the import time due to a reduced transfer time across the network.
+NOTE: You can only import data into local KBs. Remote KBs are always read-only.
+
+KBs can be populated by importing RDF files. Several formats are supported. The type of the file is determined by the file extension. So make sure the files have the correct extension when you import them, otherwise nothing might be imported from them despite a potentially long waiting time. The application supports GZIP compressed files (ending in `.gz`, so e.g. `.ttl.gz`), so we recommend compressing the files before uploading them as this can significantly improve the import time due to a reduced transfer time across the network.
 
 |====
 | Format | Extension


### PR DESCRIPTION
**What's in the PR**
- Added Stardog FTS option

**How to test manually**
* Install stardog in a way that provides the CLI interface
* Create a database with search enabled: `stardog-admin db create -n myDatabase -o search.enabled=true -- file.ttl`
* Configure a KB accessing that database `http://USERNAME:PASSWORD@localhost:5820/myDatabase/query`
* Configure the KB to use the `tag:stardog:api:search:textMatch`
* Configure a layer with a concept feature
* Test accessing and searching the KB on the knowledge base page
* Test entity linking on the annotation page

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
