### PR TITLE
#3064 - Refactor KB tests

### DIFF
--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
@@ -1083,7 +1083,11 @@ public class SPARQLQueryBuilder
                     .has(FTS_LUCENE,
                             bNode(LUCENE_QUERY, literalOf(fuzzyQuery)).andHas(LUCENE_PROPERTY,
                                     VAR_MATCH_TERM_PROPERTY))
-                    .andHas(VAR_MATCH_TERM_PROPERTY, VAR_MATCH_TERM));
+                    .andHas(VAR_MATCH_TERM_PROPERTY, VAR_MATCH_TERM)
+                    // if an item has multiple labels, return a label that matches the query
+                    .filter(and(Stream.of(sanitizedValue.split("\\s"))
+                            .map(term -> containsPattern(VAR_MATCH_TERM, term)) //
+                            .toArray(Expression[]::new))));
         }
 
         return and( //

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
@@ -35,6 +35,7 @@ import static java.lang.System.currentTimeMillis;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Stream.concat;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions.and;
 import static org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions.function;
 import static org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions.notEquals;
@@ -47,8 +48,11 @@ import static org.eclipse.rdf4j.sparqlbuilder.constraint.SparqlFunction.STRSTART
 import static org.eclipse.rdf4j.sparqlbuilder.core.PropertyPaths.oneOrMore;
 import static org.eclipse.rdf4j.sparqlbuilder.core.PropertyPaths.path;
 import static org.eclipse.rdf4j.sparqlbuilder.core.PropertyPaths.zeroOrMore;
+import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.dataset;
+import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.from;
 import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.prefix;
 import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.var;
+import static org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns.and;
 import static org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns.filterExists;
 import static org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns.filterNotExists;
 import static org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns.optional;
@@ -71,6 +75,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.rdf4j.model.IRI;
@@ -91,7 +96,6 @@ import org.eclipse.rdf4j.sparqlbuilder.constraint.Operand;
 import org.eclipse.rdf4j.sparqlbuilder.constraint.SparqlFunction;
 import org.eclipse.rdf4j.sparqlbuilder.core.Prefix;
 import org.eclipse.rdf4j.sparqlbuilder.core.Projectable;
-import org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder;
 import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
 import org.eclipse.rdf4j.sparqlbuilder.core.query.Queries;
 import org.eclipse.rdf4j.sparqlbuilder.core.query.SelectQuery;
@@ -857,7 +861,7 @@ public class SPARQLQueryBuilder
         for (String value : aValues) {
             String sanitizedValue = sanitizeQueryString_FTS(value);
 
-            if (StringUtils.isBlank(sanitizedValue)) {
+            if (isBlank(sanitizedValue)) {
                 continue;
             }
 
@@ -876,7 +880,7 @@ public class SPARQLQueryBuilder
         for (String value : aValues) {
             String sanitizedValue = sanitizeQueryString_FTS(value);
 
-            if (StringUtils.isBlank(sanitizedValue)) {
+            if (isBlank(sanitizedValue)) {
                 continue;
             }
 
@@ -999,7 +1003,7 @@ public class SPARQLQueryBuilder
         for (String value : aValues) {
             String sanitizedValue = sanitizeQueryString_FTS(value);
 
-            if (StringUtils.isBlank(sanitizedValue)) {
+            if (isBlank(sanitizedValue)) {
                 continue;
             }
 
@@ -1007,7 +1011,8 @@ public class SPARQLQueryBuilder
                     .and(VAR_SUBJECT.has(VAR_MATCH_TERM_PROPERTY, VAR_MATCH_TERM)));
         }
 
-        return GraphPatterns.and(bindMatchTermProperties(VAR_MATCH_TERM_PROPERTY),
+        return and( //
+                bindMatchTermProperties(VAR_MATCH_TERM_PROPERTY),
                 union(valuePatterns.toArray(new GraphPattern[valuePatterns.size()])));
     }
 
@@ -1017,7 +1022,7 @@ public class SPARQLQueryBuilder
         for (String value : aValues) {
             String sanitizedValue = sanitizeQueryString_FTS(value);
 
-            if (StringUtils.isBlank(sanitizedValue)) {
+            if (isBlank(sanitizedValue)) {
                 continue;
             }
 
@@ -1025,7 +1030,8 @@ public class SPARQLQueryBuilder
                     VAR_MATCH_TERM.has(FTS_VIRTUOSO, literalOf("\"" + sanitizedValue + "\""))));
         }
 
-        return GraphPatterns.and(bindMatchTermProperties(VAR_MATCH_TERM_PROPERTY),
+        return and( //
+                bindMatchTermProperties(VAR_MATCH_TERM_PROPERTY),
                 union(valuePatterns.toArray(new GraphPattern[valuePatterns.size()])));
     }
 
@@ -1038,7 +1044,7 @@ public class SPARQLQueryBuilder
             String sanitizedValue = sanitizeQueryString_FTS(value);
             String fuzzyQuery = convertToFuzzyMatchingQuery(sanitizedValue);
 
-            if (StringUtils.isBlank(sanitizedValue) || StringUtils.isBlank(fuzzyQuery)) {
+            if (isBlank(sanitizedValue) || isBlank(fuzzyQuery)) {
                 continue;
             }
 
@@ -1054,8 +1060,8 @@ public class SPARQLQueryBuilder
                     collectionOf(VAR_MATCH_TERM_PROPERTY, literalOf(fuzzyQuery))));
         }
 
-        return GraphPatterns.and(bindMatchTermProperties(VAR_MATCH_TERM_PROPERTY),
-                union(valuePatterns.toArray(new GraphPattern[valuePatterns.size()])));
+        return and(bindMatchTermProperties(VAR_MATCH_TERM_PROPERTY),
+                union(valuePatterns.toArray(GraphPattern[]::new)));
     }
 
     private GraphPattern withLabelMatchingAnyOf_RDF4J_FTS(String[] aValues)
@@ -1069,7 +1075,7 @@ public class SPARQLQueryBuilder
 
             String fuzzyQuery = convertToFuzzyMatchingQuery(sanitizedValue);
 
-            if (StringUtils.isBlank(sanitizedValue) || StringUtils.isBlank(fuzzyQuery)) {
+            if (isBlank(sanitizedValue) || isBlank(fuzzyQuery)) {
                 continue;
             }
 
@@ -1080,15 +1086,18 @@ public class SPARQLQueryBuilder
                     .andHas(VAR_MATCH_TERM_PROPERTY, VAR_MATCH_TERM));
         }
 
-        return GraphPatterns.and(bindMatchTermProperties(VAR_MATCH_TERM_PROPERTY),
-                union(valuePatterns.toArray(new GraphPattern[valuePatterns.size()])));
+        return and( //
+                bindMatchTermProperties(VAR_MATCH_TERM_PROPERTY),
+                union(valuePatterns.toArray(GraphPattern[]::new)));
     }
 
     @Override
     public SPARQLQueryBuilder withLabelContainingAnyOf(String... aValues)
     {
-        String[] values = Arrays.stream(aValues).map(SPARQLQueryBuilder::trimQueryString)
-                .filter(StringUtils::isNotBlank).toArray(String[]::new);
+        String[] values = Arrays.stream(aValues) //
+                .map(SPARQLQueryBuilder::trimQueryString) //
+                .filter(StringUtils::isNotBlank) //
+                .toArray(String[]::new);
 
         if (values.length == 0) {
             returnEmptyResult = true;
@@ -1686,13 +1695,13 @@ public class SPARQLQueryBuilder
         // so it can be discovered by selectQuery() and be lifted if necessary.
         addPattern(PRIMARY_RESTRICTIONS,
                 new PromotableExistsFilter(VAR_SUBJECT.has(typeOfProperty, bNode())));
-                // ... it is not explicitly defined as being a class
+        // ... it is not explicitly defined as being a class
         addPattern(PRIMARY_RESTRICTIONS,
                 filterNotExists(VAR_SUBJECT.has(typeOfProperty, classIri)));
-                // ... it does not have any subclass
+        // ... it does not have any subclass
         addPattern(PRIMARY_RESTRICTIONS,
                 filterNotExists(bNode().has(subClassProperty, VAR_SUBJECT)));
-                // ... it does not have any superclass
+        // ... it does not have any superclass
         addPattern(PRIMARY_RESTRICTIONS,
                 filterNotExists(VAR_SUBJECT.has(subClassProperty, bNode())));
     }
@@ -1831,15 +1840,15 @@ public class SPARQLQueryBuilder
         // property paths FILTERS and OPTIONALS (which we do a lot). It seems to help when we put
         // the FILTERS together with the primary part of the query into a group.
         // See: https://github.com/openlink/virtuoso-opensource/issues/831
-        query.where(() -> SparqlBuilderUtils.getBracedString(
-                GraphPatterns.and(concat(primaryPatterns.stream(), primaryRestrictions.stream())
+        query.where(() -> SparqlBuilderUtils
+                .getBracedString(and(concat(primaryPatterns.stream(), primaryRestrictions.stream())
                         .toArray(GraphPattern[]::new)).getQueryString()));
 
         // Then add the optional or lower-prio elements
         secondaryPatterns.stream().forEach(query::where);
 
         if (kb.getDefaultDatasetIri() != null) {
-            query.from(SparqlBuilder.dataset(SparqlBuilder.from(iri(kb.getDefaultDatasetIri()))));
+            query.from(dataset(from(iri(kb.getDefaultDatasetIri()))));
         }
 
         int actualLimit = getLimit();

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FusekiRepositoryTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FusekiRepositoryTest.java
@@ -21,8 +21,11 @@ import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_FUSEKI;
 import static de.tudarmstadt.ukp.inception.kb.http.PerThreadSslCheckingHttpClientUtils.restoreSslVerification;
 import static de.tudarmstadt.ukp.inception.kb.http.PerThreadSslCheckingHttpClientUtils.suspendSslVerification;
 import static de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilderTest.buildSparqlRepository;
+import static java.util.Arrays.asList;
 
 import java.lang.reflect.Method;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.jena.fuseki.main.FusekiServer;
 import org.apache.jena.query.Dataset;
@@ -38,12 +41,14 @@ import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import de.tudarmstadt.ukp.inception.kb.RepositoryType;
 import de.tudarmstadt.ukp.inception.kb.model.KnowledgeBase;
+import de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilderTest.Scenario;
 
 public class FusekiRepositoryTest
 {
@@ -90,101 +95,25 @@ public class FusekiRepositoryTest
         fusekiServer.stop();
     }
 
-    @Test
-    public void testWithLabelStartingWith_withLanguage_FTS_1() throws Exception
+    private static List<Arguments> tests() throws Exception
     {
-        SPARQLQueryBuilderTest.testWithLabelStartingWith_withLanguage_FTS_1(repository, kb);
+        // These require additional configuration in Fuseki FTS
+        var exclusions = asList( //
+                "thatMatchingAgainstAdditionalSearchPropertiesWorks", //
+                "testWithLabelMatchingExactlyAnyOf_subproperty", //
+                "testWithLabelStartingWith_OLIA");
+
+        return SPARQLQueryBuilderTest.tests().stream() //
+                .filter(scenario -> !exclusions.contains(scenario.name))
+                .map(scenario -> Arguments.of(scenario.name, scenario))
+                .collect(Collectors.toList());
     }
 
-    @Test
-    public void testWithLabelStartingWith_withLanguage_FTS_2() throws Exception
+    @ParameterizedTest(name = "{index}: test {0}")
+    @MethodSource("tests")
+    public void runTests(String aScenarioName, Scenario aScenario) throws Exception
     {
-        SPARQLQueryBuilderTest.testWithLabelStartingWith_withLanguage_FTS_2(repository, kb);
-    }
-
-    @Test
-    public void testWithLabelStartingWith_withLanguage_FTS_3() throws Exception
-    {
-        SPARQLQueryBuilderTest.testWithLabelStartingWith_withLanguage_FTS_3(repository, kb);
-    }
-
-    @Test
-    public void testWithLabelStartingWith_withLanguage_noFTS() throws Exception
-    {
-        SPARQLQueryBuilderTest.testWithLabelStartingWith_withLanguage_noFTS(repository, kb);
-    }
-
-    @Test
-    public void testWithLabelContainingAnyOf_pets_ttl_noFTS() throws Exception
-    {
-        SPARQLQueryBuilderTest.testWithLabelContainingAnyOf_pets_ttl_noFTS(repository, kb);
-    }
-
-    @Test
-    public void thatRootsCanBeRetrieved_ontolex() throws Exception
-    {
-        SPARQLQueryBuilderTest.thatRootsCanBeRetrieved_ontolex(repository, kb);
-    }
-
-    @Test
-    public void testWithLabelContainingAnyOf_withLanguage_noFTS() throws Exception
-    {
-        SPARQLQueryBuilderTest.testWithLabelContainingAnyOf_withLanguage_noFTS(repository, kb);
-    }
-
-    @Test
-    public void testWithLabelContainingAnyOf_withLanguage_FTS() throws Exception
-    {
-        SPARQLQueryBuilderTest.testWithLabelContainingAnyOf_withLanguage(repository, kb);
-    }
-
-    @Test
-    public void testWithLabelMatchingAnyOf_withLanguage_FTS() throws Exception
-    {
-        SPARQLQueryBuilderTest.testWithLabelMatchingAnyOf_withLanguage(repository, kb);
-    }
-
-    @Test
-    public void testWithLabelMatchingAnyOf_withLanguage_noFTS() throws Exception
-    {
-        SPARQLQueryBuilderTest.testWithLabelMatchingAnyOf_withLanguage_noFTS(repository, kb);
-    }
-
-    @Test
-    public void testWithLabelStartingWith_withoutLanguage_FTS() throws Exception
-    {
-        SPARQLQueryBuilderTest.testWithLabelStartingWith_withoutLanguage(repository, kb);
-    }
-
-    @Test
-    public void testWithLabelStartingWith_withoutLanguage_noFTS() throws Exception
-    {
-        SPARQLQueryBuilderTest.testWithLabelStartingWith_withoutLanguage_noFTS(repository, kb);
-    }
-
-    @Disabled("Requires addition Fuseki FTS configuration")
-    @Test
-    public void testWithLabelMatchingExactlyAnyOf_subproperty_FTS() throws Exception
-    {
-        SPARQLQueryBuilderTest.testWithLabelMatchingExactlyAnyOf_subproperty(repository, kb);
-    }
-
-    @Test
-    public void testWithLabelMatchingExactlyAnyOf_subproperty_noFTS() throws Exception
-    {
-        SPARQLQueryBuilderTest.testWithLabelMatchingExactlyAnyOf_subproperty_noFTS(repository, kb);
-    }
-
-    @Test
-    public void testWithLabelMatchingExactlyAnyOf_withLanguage_noFTS() throws Exception
-    {
-        SPARQLQueryBuilderTest.testWithLabelMatchingExactlyAnyOf_withLanguage_noFTS(repository, kb);
-    }
-
-    @Test
-    public void testWithLabelMatchingExactlyAnyOf_withLanguage_FTS() throws Exception
-    {
-        SPARQLQueryBuilderTest.testWithLabelMatchingExactlyAnyOf_withLanguage(repository, kb);
+        aScenario.implementation.accept(repository, kb);
     }
 
     /**

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/Rdf4JRepositoryTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/Rdf4JRepositoryTest.java
@@ -20,8 +20,11 @@ package de.tudarmstadt.ukp.inception.kb.querybuilder;
 import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_LUCENE;
 import static de.tudarmstadt.ukp.inception.kb.http.PerThreadSslCheckingHttpClientUtils.restoreSslVerification;
 import static de.tudarmstadt.ukp.inception.kb.http.PerThreadSslCheckingHttpClientUtils.suspendSslVerification;
+import static java.util.Arrays.asList;
 
 import java.lang.reflect.Method;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
@@ -30,11 +33,14 @@ import org.eclipse.rdf4j.sail.lucene.LuceneSail;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import de.tudarmstadt.ukp.inception.kb.RepositoryType;
 import de.tudarmstadt.ukp.inception.kb.model.KnowledgeBase;
+import de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilderTest.Scenario;
 
 public class Rdf4JRepositoryTest
 {
@@ -80,99 +86,20 @@ public class Rdf4JRepositoryTest
         repository.shutDown();
     }
 
-    @Test
-    public void testWithLabelStartingWith_withLanguage_FTS_1() throws Exception
+    private static List<Arguments> tests() throws Exception
     {
-        SPARQLQueryBuilderTest.testWithLabelStartingWith_withLanguage_FTS_1(repository, kb);
+        var exclusions = asList();
+
+        return SPARQLQueryBuilderTest.tests().stream() //
+                .filter(scenario -> !exclusions.contains(scenario.name))
+                .map(scenario -> Arguments.of(scenario.name, scenario))
+                .collect(Collectors.toList());
     }
 
-    @Test
-    public void testWithLabelStartingWith_withLanguage_FTS_2() throws Exception
+    @ParameterizedTest(name = "{index}: test {0}")
+    @MethodSource("tests")
+    public void runTests(String aScenarioName, Scenario aScenario) throws Exception
     {
-        SPARQLQueryBuilderTest.testWithLabelStartingWith_withLanguage_FTS_2(repository, kb);
-    }
-
-    @Test
-    public void testWithLabelStartingWith_withLanguage_FTS_3() throws Exception
-    {
-        SPARQLQueryBuilderTest.testWithLabelStartingWith_withLanguage_FTS_3(repository, kb);
-    }
-
-    @Test
-    public void testWithLabelStartingWith_withLanguage_noFTS() throws Exception
-    {
-        SPARQLQueryBuilderTest.testWithLabelStartingWith_withLanguage_noFTS(repository, kb);
-    }
-
-    @Test
-    public void testWithLabelContainingAnyOf_pets_ttl_noFTS() throws Exception
-    {
-        SPARQLQueryBuilderTest.testWithLabelContainingAnyOf_pets_ttl_noFTS(repository, kb);
-    }
-
-    @Test
-    public void thatRootsCanBeRetrieved_ontolex() throws Exception
-    {
-        SPARQLQueryBuilderTest.thatRootsCanBeRetrieved_ontolex(repository, kb);
-    }
-
-    @Test
-    public void testWithLabelContainingAnyOf_withLanguage_noFTS() throws Exception
-    {
-        SPARQLQueryBuilderTest.testWithLabelContainingAnyOf_withLanguage_noFTS(repository, kb);
-    }
-
-    @Test
-    public void testWithLabelContainingAnyOf_withLanguage_FTS() throws Exception
-    {
-        SPARQLQueryBuilderTest.testWithLabelContainingAnyOf_withLanguage(repository, kb);
-    }
-
-    @Test
-    public void testWithLabelMatchingAnyOf_withLanguage_FTS() throws Exception
-    {
-        SPARQLQueryBuilderTest.testWithLabelMatchingAnyOf_withLanguage(repository, kb);
-    }
-
-    @Test
-    public void testWithLabelMatchingAnyOf_withLanguage_noFTS() throws Exception
-    {
-        SPARQLQueryBuilderTest.testWithLabelMatchingAnyOf_withLanguage_noFTS(repository, kb);
-    }
-
-    @Test
-    public void testWithLabelStartingWith_withoutLanguage_FTS() throws Exception
-    {
-        SPARQLQueryBuilderTest.testWithLabelStartingWith_withoutLanguage(repository, kb);
-    }
-
-    @Test
-    public void testWithLabelStartingWith_withoutLanguage_noFTS() throws Exception
-    {
-        SPARQLQueryBuilderTest.testWithLabelStartingWith_withoutLanguage_noFTS(repository, kb);
-    }
-
-    @Test
-    public void testWithLabelMatchingExactlyAnyOf_subproperty_FTS() throws Exception
-    {
-        SPARQLQueryBuilderTest.testWithLabelMatchingExactlyAnyOf_subproperty(repository, kb);
-    }
-
-    @Test
-    public void testWithLabelMatchingExactlyAnyOf_subproperty_noFTS() throws Exception
-    {
-        SPARQLQueryBuilderTest.testWithLabelMatchingExactlyAnyOf_subproperty_noFTS(repository, kb);
-    }
-
-    @Test
-    public void testWithLabelMatchingExactlyAnyOf_withLanguage_noFTS() throws Exception
-    {
-        SPARQLQueryBuilderTest.testWithLabelMatchingExactlyAnyOf_withLanguage_noFTS(repository, kb);
-    }
-
-    @Test
-    public void testWithLabelMatchingExactlyAnyOf_withLanguage_FTS() throws Exception
-    {
-        SPARQLQueryBuilderTest.testWithLabelMatchingExactlyAnyOf_withLanguage(repository, kb);
+        aScenario.implementation.accept(repository, kb);
     }
 }

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/RepositoryTestSuite.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/RepositoryTestSuite.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.kb.querybuilder;
+
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@SelectClasses({ //
+        FusekiRepositoryTest.class, //
+        Rdf4JRepositoryTest.class, //
+        StardogRepositoryTest.class //
+})
+public class RepositoryTestSuite
+{
+
+}

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/StardogRepositoryTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/StardogRepositoryTest.java
@@ -22,17 +22,22 @@ import static de.tudarmstadt.ukp.inception.kb.http.PerThreadSslCheckingHttpClien
 import static de.tudarmstadt.ukp.inception.kb.http.PerThreadSslCheckingHttpClientUtils.suspendSslVerification;
 
 import java.lang.reflect.Method;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import de.tudarmstadt.ukp.inception.kb.RepositoryType;
 import de.tudarmstadt.ukp.inception.kb.model.KnowledgeBase;
+import de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilderTest.Scenario;
 
 // The repository has to exist and stardoc has to be running for this test to run.
 // To create the repository, use the following command:
@@ -75,99 +80,17 @@ public class StardogRepositoryTest
         restoreSslVerification();
     }
 
-    @Test
-    public void testWithLabelStartingWith_withLanguage_FTS_1() throws Exception
+    private static List<Arguments> tests() throws Exception
     {
-        SPARQLQueryBuilderTest.testWithLabelStartingWith_withLanguage_FTS_1(repository, kb);
+        return SPARQLQueryBuilderTest.tests().stream() //
+                .map(scenario -> Arguments.of(scenario.name, scenario))
+                .collect(Collectors.toList());
     }
 
-    @Test
-    public void testWithLabelStartingWith_withLanguage_FTS_2() throws Exception
+    @ParameterizedTest(name = "{index}: test {0}")
+    @MethodSource("tests")
+    public void runTests(String aScenarioName, Scenario aScenario) throws Exception
     {
-        SPARQLQueryBuilderTest.testWithLabelStartingWith_withLanguage_FTS_2(repository, kb);
-    }
-
-    @Test
-    public void testWithLabelStartingWith_withLanguage_FTS_3() throws Exception
-    {
-        SPARQLQueryBuilderTest.testWithLabelStartingWith_withLanguage_FTS_3(repository, kb);
-    }
-
-    @Test
-    public void testWithLabelStartingWith_withLanguage_noFTS() throws Exception
-    {
-        SPARQLQueryBuilderTest.testWithLabelStartingWith_withLanguage_noFTS(repository, kb);
-    }
-
-    @Test
-    public void testWithLabelContainingAnyOf_pets_ttl_noFTS() throws Exception
-    {
-        SPARQLQueryBuilderTest.testWithLabelContainingAnyOf_pets_ttl_noFTS(repository, kb);
-    }
-
-    @Test
-    public void thatRootsCanBeRetrieved_ontolex() throws Exception
-    {
-        SPARQLQueryBuilderTest.thatRootsCanBeRetrieved_ontolex(repository, kb);
-    }
-
-    @Test
-    public void testWithLabelContainingAnyOf_withLanguage_noFTS() throws Exception
-    {
-        SPARQLQueryBuilderTest.testWithLabelContainingAnyOf_withLanguage_noFTS(repository, kb);
-    }
-
-    @Test
-    public void testWithLabelContainingAnyOf_withLanguage_FTS() throws Exception
-    {
-        SPARQLQueryBuilderTest.testWithLabelContainingAnyOf_withLanguage(repository, kb);
-    }
-
-    @Test
-    public void testWithLabelMatchingAnyOf_withLanguage_FTS() throws Exception
-    {
-        SPARQLQueryBuilderTest.testWithLabelMatchingAnyOf_withLanguage(repository, kb);
-    }
-
-    @Test
-    public void testWithLabelMatchingAnyOf_withLanguage_noFTS() throws Exception
-    {
-        SPARQLQueryBuilderTest.testWithLabelMatchingAnyOf_withLanguage_noFTS(repository, kb);
-    }
-
-    @Test
-    public void testWithLabelStartingWith_withoutLanguage_FTS() throws Exception
-    {
-        SPARQLQueryBuilderTest.testWithLabelStartingWith_withoutLanguage(repository, kb);
-    }
-
-    @Test
-    public void testWithLabelStartingWith_withoutLanguage_noFTS() throws Exception
-    {
-        SPARQLQueryBuilderTest.testWithLabelStartingWith_withoutLanguage_noFTS(repository, kb);
-    }
-
-    @Test
-    public void testWithLabelMatchingExactlyAnyOf_subproperty_FTS() throws Exception
-    {
-        SPARQLQueryBuilderTest.testWithLabelMatchingExactlyAnyOf_subproperty(repository, kb);
-    }
-
-    @Test
-    public void testWithLabelMatchingExactlyAnyOf_subproperty_noFTS() throws Exception
-    {
-        SPARQLQueryBuilderTest.testWithLabelMatchingExactlyAnyOf_subproperty_noFTS(repository, kb);
-    }
-
-    @Test
-    public void testWithLabelMatchingExactlyAnyOf_withLanguage_noFTS() throws Exception
-    {
-        SPARQLQueryBuilderTest.testWithLabelMatchingExactlyAnyOf_withLanguage_noFTS(repository, kb);
-    }
-
-    @Test
-    public void testWithLabelMatchingExactlyAnyOf_withLanguage_FTS() throws Exception
-    {
-        SPARQLQueryBuilderTest.testWithLabelMatchingExactlyAnyOf_withLanguage(repository, kb);
+        aScenario.implementation.accept(repository, kb);
     }
 }

--- a/inception/pom.xml
+++ b/inception/pom.xml
@@ -15,7 +15,9 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>de.tudarmstadt.ukp.inception.app</groupId>
@@ -106,12 +108,12 @@
     <mtas.version>7.7.1.0</mtas.version> 
     <!--   7.7.1.0  depends on Lucene 7.7.1 -->
     <!-- * 8.11.1.0 depends on Lucene 8.11.1 -->
-    
+
     <elasticsearch.version>6.8.23</elasticsearch.version> 
     <!--   6.8.23   depends on Lucene 7.7.3 -->
     <!-- * 7.17.1   depends on Lucene 8.11.1 -->
     <!--   8.1.1    depends on Lucene 9.0.0 -->
- 
+
     <rdf4j.version>3.7.7</rdf4j.version> 
     <!--   3.7.6    depends on Lucene 7.7.3 -->
     <!-- * 4.0.0-M2 depends on Lucene 8.5.1 -->
@@ -119,7 +121,7 @@
     <!-- * 4.0.0-M2 depends on Solr 8.4.1 (but we don't use that dependency)-->
     <!--   3.7.6    depends on ElasticSearch 7.7.3 (but we don't use that dependency) -->
     <!-- * 4.0.0-M2 depends on ElasticSearch 7.8.1 (but we don't use that dependency) -->
- 
+
     <jena.version>3.17.0</jena.version>
     <!--   3.17.0   depends on Lucene 7.7.3 -->
     <!-- * 4.4.0    depends on Lucene 8.11.1 -->
@@ -272,6 +274,16 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-suite-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-suite-api</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -780,7 +792,16 @@
         <artifactId>junit-bom</artifactId>
         <version>${junit.version}</version>
       </dependency>
-
+      <dependency>
+        <groupId>org.junit.platform</groupId>
+        <artifactId>junit-platform-suite-engine</artifactId>
+        <version>1.8.2</version>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.platform</groupId>
+        <artifactId>junit-platform-suite-api</artifactId>
+        <version>1.8.2</version>
+      </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
@@ -2024,7 +2045,8 @@
         </executions>
         <configuration>
           <failOnWarning>true</failOnWarning>
-          <ignoredUnusedDeclaredDependencies combine.children="append">
+          <ignoredUnusedDeclaredDependencies
+            combine.children="append">
             <!--
               - Logging is used via reflection and cannot be detected by Maven
             -->
@@ -2052,6 +2074,8 @@
             -->
             <dependency>org.junit.jupiter:junit-jupiter-api</dependency>
             <dependency>org.junit.jupiter:junit-jupiter-params</dependency>
+            <dependency>org.junit.platform:junit-platform-suite-engine</dependency>
+            <dependency>org.junit.platform:junit-platform-suite-api</dependency>
             <dependency>org.mockito:mockito-core</dependency>
             <dependency>org.mockito:mockito-junit-jupiter</dependency>
             <dependency>org.assertj:assertj-core</dependency>


### PR DESCRIPTION
**What's in the PR**
- Refactor the tests to be reusable across different backends
- Separate test classes for each backend
- Bit of cleaning up in the SPARQLQueryBuilder
- Fix RDF4J FTS potentially returning labels not matching the query if an item has multiple labels

**How to test manually**
* No particular test procedure

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
