### PR TITLE
#3038 - Search on large local knowledge base is much slower than expected

### DIFF
--- a/inception/inception-concept-linking/pom.xml
+++ b/inception/inception-concept-linking/pom.xml
@@ -80,6 +80,10 @@
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-recommendation</artifactId>
     </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-support</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>

--- a/inception/inception-kb/NOTICE.txt
+++ b/inception/inception-kb/NOTICE.txt
@@ -1,0 +1,4 @@
+de.tudarmstadt.ukp.inception.kb.querybuilder.backport.Bind:
+
+  Copied from RDF4J 4.0.0 (https://github.com/eclipse/rdf4j)
+  License: Eclipse Distribution License v1.0

--- a/inception/inception-kb/pom.xml
+++ b/inception/inception-kb/pom.xml
@@ -149,6 +149,10 @@
       <artifactId>rdfbeans</artifactId>
       <version>2.2</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.lucene</groupId>
+      <artifactId>lucene-core</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>
@@ -287,11 +291,6 @@
       <groupId>org.apache.jena</groupId>
       <artifactId>jena-core</artifactId>
       <version>${jena.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.lucene</groupId>
-      <artifactId>lucene-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/inception/inception-kb/pom.xml
+++ b/inception/inception-kb/pom.xml
@@ -317,4 +317,29 @@
       </plugins>
     </pluginManagement>
   </build>
+  <profiles>
+    <profile>
+      <id>rat-check</id>
+      <activation>
+        <file>
+          <exists>src/main/java</exists>
+        </file>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.rat</groupId>
+              <artifactId>apache-rat-plugin</artifactId>
+              <configuration>
+                <excludes combine.children="append">
+                  <exclude>**/de/tudarmstadt/ukp/inception/kb/querybuilder/backport/Bind.java</exclude>
+                </excludes>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/config/KnowledgeBasePropertiesImpl.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/config/KnowledgeBasePropertiesImpl.java
@@ -49,8 +49,6 @@ public class KnowledgeBasePropertiesImpl
     private @DurationUnit(MINUTES) Duration renderCacheExpireDelay = ofMinutes(10);
     private @DurationUnit(MINUTES) Duration renderCacheRefreshDelay = ofMinutes(1);
 
-    private int fuzzyQueryPrefix = 2;
-
     @Override
     public int getDefaultMaxResults()
     {
@@ -148,15 +146,5 @@ public class KnowledgeBasePropertiesImpl
     public void setRenderCacheRefreshDelay(Duration aRenderCacheRefreshDelay)
     {
         renderCacheRefreshDelay = aRenderCacheRefreshDelay;
-    }
-
-    public int getFuzzyQueryPrefix()
-    {
-        return fuzzyQueryPrefix;
-    }
-
-    public void setFuzzyQueryPrefix(int aFuzzyQueryPrefix)
-    {
-        fuzzyQueryPrefix = aFuzzyQueryPrefix;
     }
 }

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/config/KnowledgeBasePropertiesImpl.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/config/KnowledgeBasePropertiesImpl.java
@@ -49,6 +49,8 @@ public class KnowledgeBasePropertiesImpl
     private @DurationUnit(MINUTES) Duration renderCacheExpireDelay = ofMinutes(10);
     private @DurationUnit(MINUTES) Duration renderCacheRefreshDelay = ofMinutes(1);
 
+    private int fuzzyQueryPrefix = 2;
+
     @Override
     public int getDefaultMaxResults()
     {
@@ -146,5 +148,15 @@ public class KnowledgeBasePropertiesImpl
     public void setRenderCacheRefreshDelay(Duration aRenderCacheRefreshDelay)
     {
         renderCacheRefreshDelay = aRenderCacheRefreshDelay;
+    }
+
+    public int getFuzzyQueryPrefix()
+    {
+        return fuzzyQueryPrefix;
+    }
+
+    public void setFuzzyQueryPrefix(int aFuzzyQueryPrefix)
+    {
+        fuzzyQueryPrefix = aFuzzyQueryPrefix;
     }
 }

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/exporter/ExportedKnowledgeBase.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/exporter/ExportedKnowledgeBase.java
@@ -66,6 +66,9 @@ public class ExportedKnowledgeBase
     @JsonProperty("read_only")
     private boolean readOnly;
 
+    @JsonProperty("use_fuzzy")
+    private boolean useFuzzy;
+
     @JsonProperty("enabled")
     private boolean enabled;
 
@@ -343,5 +346,15 @@ public class ExportedKnowledgeBase
     public void setDefaultDatasetIri(String aDefaultDatasetIri)
     {
         defaultDatasetIri = aDefaultDatasetIri;
+    }
+
+    public void setUseFuzzy(boolean aUseFuzzy)
+    {
+        useFuzzy = aUseFuzzy;
+    }
+
+    public boolean isUseFuzzy()
+    {
+        return useFuzzy;
     }
 }

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/exporter/KnowledgeBaseExporter.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/exporter/KnowledgeBaseExporter.java
@@ -125,6 +125,7 @@ public class KnowledgeBaseExporter
             exportedKB.setPropertyDescriptionIri(kb.getPropertyDescriptionIri());
             exportedKB.setFullTextSearchIri(kb.getFullTextSearchIri());
             exportedKB.setReadOnly(kb.isReadOnly());
+            exportedKB.setUseFuzzy(kb.isUseFuzzy());
             exportedKB.setEnabled(kb.isEnabled());
             exportedKB.setReification(kb.getReification().toString());
             exportedKB.setSupportConceptLinking(kb.isSupportConceptLinking());
@@ -224,6 +225,7 @@ public class KnowledgeBaseExporter
                             : null);
 
             kb.setEnabled(exportedKB.isEnabled());
+            kb.setUseFuzzy(exportedKB.isUseFuzzy());
             kb.setReification(Reification.valueOf(exportedKB.getReification()));
             kb.setBasePrefix(exportedKB.getBasePrefix());
 

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/model/KnowledgeBase.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/model/KnowledgeBase.java
@@ -158,6 +158,9 @@ public class KnowledgeBase
     @Column(nullable = false)
     private boolean readOnly;
 
+    @Column(nullable = false)
+    private boolean useFuzzy;
+
     /**
      * Whether the kb is available in the UI (outside of the project settings).
      */
@@ -491,6 +494,16 @@ public class KnowledgeBase
     public Set<String> getAdditionalMatchingProperties()
     {
         return additionalMatchingProperties;
+    }
+
+    public boolean isUseFuzzy()
+    {
+        return useFuzzy;
+    }
+
+    public void setUseFuzzy(boolean aUseFuzzy)
+    {
+        useFuzzy = aUseFuzzy;
     }
 
     @Override

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
@@ -31,8 +31,10 @@ import static de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilder.Pr
 import static de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilder.Priority.SECONDARY;
 import static java.lang.Character.isWhitespace;
 import static java.lang.Integer.toHexString;
+import static java.lang.String.CASE_INSENSITIVE_ORDER;
 import static java.lang.System.currentTimeMillis;
 import static java.util.Collections.emptyList;
+import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Stream.concat;
 import static org.apache.commons.lang3.StringUtils.isBlank;
@@ -40,10 +42,12 @@ import static org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions.and;
 import static org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions.function;
 import static org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions.notEquals;
 import static org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions.or;
+import static org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions.str;
 import static org.eclipse.rdf4j.sparqlbuilder.constraint.SparqlFunction.CONTAINS;
 import static org.eclipse.rdf4j.sparqlbuilder.constraint.SparqlFunction.LANG;
 import static org.eclipse.rdf4j.sparqlbuilder.constraint.SparqlFunction.LANGMATCHES;
 import static org.eclipse.rdf4j.sparqlbuilder.constraint.SparqlFunction.REGEX;
+import static org.eclipse.rdf4j.sparqlbuilder.constraint.SparqlFunction.REPLACE;
 import static org.eclipse.rdf4j.sparqlbuilder.constraint.SparqlFunction.STRSTARTS;
 import static org.eclipse.rdf4j.sparqlbuilder.core.PropertyPaths.oneOrMore;
 import static org.eclipse.rdf4j.sparqlbuilder.core.PropertyPaths.path;
@@ -65,7 +69,6 @@ import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.literalOfLanguage;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -75,7 +78,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.rdf4j.model.IRI;
@@ -114,6 +116,7 @@ import org.slf4j.LoggerFactory;
 import de.tudarmstadt.ukp.inception.kb.graph.KBHandle;
 import de.tudarmstadt.ukp.inception.kb.graph.KBObject;
 import de.tudarmstadt.ukp.inception.kb.model.KnowledgeBase;
+import de.tudarmstadt.ukp.inception.kb.querybuilder.backport.Bind;
 
 /**
  * Build queries against the KB.
@@ -210,7 +213,7 @@ public class SPARQLQueryBuilder
 
     private boolean includeInferred = true;
 
-    private boolean forceDisableFTS = false;
+    private Set<String> forceDisableFTS = new LinkedHashSet<>();
 
     /**
      * This flag controls whether we attempt to drop duplicate labels and descriptions on the side
@@ -536,7 +539,7 @@ public class SPARQLQueryBuilder
         // this the old-fashioned way...
         if (Mode.PROPERTY.equals(mode)
                 && FTS_WIKIDATA.stringValue().equals(aKB.getFullTextSearchIri())) {
-            forceDisableFTS = true;
+            forceDisableFTS.add("Wikidata property query");
         }
     }
 
@@ -670,7 +673,7 @@ public class SPARQLQueryBuilder
     @Override
     public SPARQLQueryPrimaryConditions withIdentifier(String... aIdentifiers)
     {
-        forceDisableFTS = true;
+        forceDisableFTS.add("identifier query");
 
         addPattern(PRIMARY, new ValuesPattern(VAR_SUBJECT,
                 Arrays.stream(aIdentifiers).map(Rdf::iri).toArray(RdfValue[]::new)));
@@ -681,7 +684,7 @@ public class SPARQLQueryBuilder
     @Override
     public SPARQLQueryPrimaryConditions matchingDomain(String aIdentifier)
     {
-        forceDisableFTS = true;
+        forceDisableFTS.add("domain query");
 
         // The original code considered owl:unionOf in the domain definition... we do not do this
         // at the moment, but to see how it was before and potentially restore that behavior, we
@@ -765,11 +768,45 @@ public class SPARQLQueryBuilder
 
     private IRI getFtsMode()
     {
-        if (forceDisableFTS || kb.getFullTextSearchIri() == null) {
+        if (kb.getFullTextSearchIri() == null) {
+            return FTS_NONE;
+        }
+
+        if (isFtsLimited() && !forceDisableFTS.isEmpty()) {
+            LOG.debug("FTS force-disabled because it limits its results: {}", forceDisableFTS);
             return FTS_NONE;
         }
 
         return SimpleValueFactory.getInstance().createIRI(kb.getFullTextSearchIri());
+    }
+
+    /**
+     * When working with queries using any of {@link #roots()}, @link
+     * #withIdentifier(String)}, @link #childrenOf(String)}, {@link #descendantsOf(String)},
+     * {@link #parentsOf(String)} or {@link #ancestorsOf(String)}}, the FTS must be disabled. These
+     * methods must be called <b>before</b> any label-restricting methods like
+     * {@link #withLabelStartingWith(String)} This is because the FTS part of the query pre-filters
+     * the potential candidates, but the FTS may not return all candidates. Let's consider a large
+     * KB (e.g. Wikidata) and a query for <i>all humans named Amanda in the Star Trek universe</i>
+     * (there is a category for <i>humans in the Star Trek universe</i> in Wikidata). First the FTS
+     * would try to retrieve all entities named <i>Amanda</i>, but it does not really return all,
+     * just the top 50 (which is what Wikidata seems to be hard-coded to despite the documentation
+     * for <i>wikidata:limit</i> saying otherwise). None of these Amandas, however, is part of the
+     * Star Trek universe, so the final result of the query is empty. Here, the FTS restricts too
+     * much and too early. For such cases, we should rely on the scope sufficiently limiting the
+     * returned results such that the regex-based filtering does not get too slow.
+     * 
+     * @returns {@code true} if the FTS does not return all hits but only a e.g. the first 50 or 100
+     *          matches.
+     */
+    private boolean isFtsLimited()
+    {
+        if (kb.getFullTextSearchIri() == null) {
+            return false;
+        }
+
+        IRI ftsMode = SimpleValueFactory.getInstance().createIRI(kb.getFullTextSearchIri());
+        return FTS_WIKIDATA.equals(ftsMode);
     }
 
     private GraphPattern withLabelMatchingExactlyAnyOf_No_FTS(String[] aValues)
@@ -1079,15 +1116,25 @@ public class SPARQLQueryBuilder
                 continue;
             }
 
-            valuePatterns.add(VAR_SUBJECT
-                    .has(FTS_LUCENE,
-                            bNode(LUCENE_QUERY, literalOf(fuzzyQuery)).andHas(LUCENE_PROPERTY,
-                                    VAR_MATCH_TERM_PROPERTY))
-                    .andHas(VAR_MATCH_TERM_PROPERTY, VAR_MATCH_TERM)
-                    // if an item has multiple labels, return a label that matches the query
-                    .filter(and(Stream.of(sanitizedValue.split("\\s"))
-                            .map(term -> containsPattern(VAR_MATCH_TERM, term)) //
-                            .toArray(Expression[]::new))));
+            // If a KB item has multiple labels, we want to return only the ones which actually
+            // match the query term such that the user is not confused that the results contain
+            // items that don't match the query (even though they do through a label that is not
+            // returned). RDF4J only provides access to the matched term in a "highlighed" form
+            // where "<B>" and "</B>" match the search term. So we have to strip these markers
+            // out as part of the query.
+            valuePatterns.add(VAR_SUBJECT //
+                    .has(FTS_LUCENE, bNode(LUCENE_QUERY, literalOf(fuzzyQuery)) //
+                            .andHas(LUCENE_PROPERTY, VAR_MATCH_TERM_PROPERTY)
+                            .andHas(LUCENE_SNIPPET, var("snippet")))
+                    .and(new Bind(
+                            function(REPLACE,
+                                    function(REPLACE, var("snippet"), literalOf("</B>"),
+                                            literalOf("")),
+                                    literalOf("<B>"), literalOf("")),
+                            var("label")))
+                    .and(VAR_SUBJECT.has(VAR_MATCH_TERM_PROPERTY, VAR_MATCH_TERM))
+                    .filter(and(Expressions.equals(str(var("label")), str(VAR_MATCH_TERM)),
+                            matchLanguage(VAR_MATCH_TERM, kb.getDefaultLanguage()))));
         }
 
         return and( //
@@ -1220,7 +1267,7 @@ public class SPARQLQueryBuilder
         for (String value : aValues) {
             String sanitizedValue = sanitizeQueryString_FTS(value);
 
-            if (StringUtils.isBlank(sanitizedValue)) {
+            if (isBlank(sanitizedValue)) {
                 continue;
             }
 
@@ -1534,15 +1581,15 @@ public class SPARQLQueryBuilder
         // Match exactly
         String value = "^" + asRegexp(aValue) + "$";
 
-        // Match with default language
         if (language != null) {
-            expressions.add(and(function(REGEX, variable, literalOf(value), literalOf(regexFlags)),
-                    function(LANGMATCHES, function(LANG, aVariable), literalOf(language)))
-                            .parenthesize());
-
-            // Match without language
-            expressions.add(and(function(REGEX, variable, literalOf(value), literalOf(regexFlags)),
-                    Expressions.equals(function(LANG, aVariable), EMPTY_STRING)).parenthesize());
+            expressions.add(and( //
+                    function(REGEX, variable, literalOf(value), literalOf(regexFlags)), //
+                    or( // Match with default language
+                            function(LANGMATCHES, function(LANG, aVariable), literalOf(language)),
+                            // Match without language
+                            Expressions.equals(function(LANG, aVariable), EMPTY_STRING) //
+                    ).parenthesize() //
+            ).parenthesize());
         }
         else {
             // Match ignoring language
@@ -1554,8 +1601,6 @@ public class SPARQLQueryBuilder
 
     private Expression<?> matchString(SparqlFunction aFunction, Variable aVariable, String aValue)
     {
-        String language = kb.getDefaultLanguage();
-
         List<Expression<?>> expressions = new ArrayList<>();
 
         Operand variable = aVariable;
@@ -1581,15 +1626,11 @@ public class SPARQLQueryBuilder
                     "Only STRSTARTS and CONTAINS are supported, but got [" + aFunction + "]");
         }
 
+        String language = kb.getDefaultLanguage();
         if (language != null) {
-            // Match with default language
-            expressions.add(and(function(REGEX, variable, literalOf(value), literalOf(regexFlags)),
-                    function(LANGMATCHES, function(LANG, aVariable), literalOf(language)))
-                            .parenthesize());
-
-            // Match without language
-            expressions.add(and(function(REGEX, variable, literalOf(value), literalOf(regexFlags)),
-                    Expressions.equals(function(LANG, aVariable), EMPTY_STRING)).parenthesize());
+            expressions.add(and( //
+                    function(REGEX, variable, literalOf(value), literalOf(regexFlags)), //
+                    matchLanguage(aVariable, language)).parenthesize());
         }
         else {
             // Match ignoring language
@@ -1602,10 +1643,18 @@ public class SPARQLQueryBuilder
         return or(expressions.toArray(new Expression<?>[expressions.size()]));
     }
 
+    private Expression<?> matchLanguage(Variable aVariable, String language)
+    {
+        return or(// Match with default language
+                function(LANGMATCHES, function(LANG, aVariable), literalOf(language)),
+                // Match without language
+                Expressions.equals(function(LANG, aVariable), EMPTY_STRING)).parenthesize(); //
+    }
+
     @Override
     public SPARQLQueryPrimaryConditions roots()
     {
-        forceDisableFTS = true;
+        forceDisableFTS.add("roots query");
 
         addPattern(PRIMARY, mode.rootsPattern(kb));
 
@@ -1615,7 +1664,7 @@ public class SPARQLQueryBuilder
     @Override
     public SPARQLQueryPrimaryConditions ancestorsOf(String aItemIri)
     {
-        forceDisableFTS = true;
+        forceDisableFTS.add("ancestorOf query");
 
         Iri contextIri = iri(aItemIri);
 
@@ -1627,7 +1676,7 @@ public class SPARQLQueryBuilder
     @Override
     public SPARQLQueryPrimaryConditions descendantsOf(String aClassIri)
     {
-        forceDisableFTS = true;
+        forceDisableFTS.add("descendantsOf query");
 
         Iri contextIri = iri(aClassIri);
 
@@ -1639,7 +1688,7 @@ public class SPARQLQueryBuilder
     @Override
     public SPARQLQueryPrimaryConditions childrenOf(String aClassIri)
     {
-        forceDisableFTS = true;
+        forceDisableFTS.add("childrenOf query");
 
         Iri contextIri = iri(aClassIri);
 
@@ -1651,7 +1700,7 @@ public class SPARQLQueryBuilder
     @Override
     public SPARQLQueryPrimaryConditions parentsOf(String aClassIri)
     {
-        forceDisableFTS = true;
+        forceDisableFTS.add("parentsOf query");
 
         Iri contextIri = iri(aClassIri);
 
@@ -1746,7 +1795,7 @@ public class SPARQLQueryBuilder
         if (!mode.getAdditionalMatchingProperties(kb).isEmpty()) {
             addPreferredLabelProjections(projections);
             addPattern(SECONDARY, bindPrefLabelProperties(VAR_PREF_LABEL_PROPERTY));
-            retrieveOptional(VAR_PREF_LABEL_PROPERTY, VAR_PREF_LABEL);
+            retrieveOptionalWithLanguage(VAR_PREF_LABEL_PROPERTY, VAR_PREF_LABEL);
         }
 
         // If the label is already retrieved, do nothing
@@ -1756,7 +1805,7 @@ public class SPARQLQueryBuilder
 
         addMatchTermProjections(projections);
         addPattern(SECONDARY, bindMatchTermProperties(VAR_MATCH_TERM_PROPERTY));
-        retrieveOptional(VAR_MATCH_TERM_PROPERTY, VAR_MATCH_TERM);
+        retrieveOptionalWithLanguage(VAR_MATCH_TERM_PROPERTY, VAR_MATCH_TERM);
 
         return this;
     }
@@ -1768,25 +1817,19 @@ public class SPARQLQueryBuilder
         projections.add(getDescriptionProjection());
 
         Iri descProperty = mode.getDescriptionProperty(kb);
-        retrieveOptional(descProperty, VAR_DESC_CANDIDATE);
+        retrieveOptionalWithLanguage(descProperty, VAR_DESC_CANDIDATE);
 
         return this;
     }
 
-    private void retrieveOptional(RdfPredicate aProperty, Variable aVariable)
+    private void retrieveOptionalWithLanguage(RdfPredicate aProperty, Variable aVariable)
     {
-        String language = kb.getDefaultLanguage();
-
         List<GraphPattern> patterns = new ArrayList<>();
 
-        // Find all labels corresponding to the KB language
+        String language = kb.getDefaultLanguage();
         if (language != null) {
-            // Find all labels without any language
-            patterns.add(VAR_SUBJECT.has(aProperty, aVariable)
-                    .filter(Expressions.equals(function(LANG, aVariable), EMPTY_STRING)));
-
-            patterns.add(VAR_SUBJECT.has(aProperty, aVariable)
-                    .filter(function(LANGMATCHES, function(LANG, aVariable), literalOf(language))));
+            patterns.add(VAR_SUBJECT.has(aProperty, aVariable) //
+                    .filter(matchLanguage(aVariable, language)));
         }
         else {
             // Find all labels ignoring any language
@@ -1890,10 +1933,11 @@ public class SPARQLQueryBuilder
             TupleQuery tupleQuery = aConnection.prepareTupleQuery(queryString);
             tupleQuery.setIncludeInferred(includeInferred);
             results = evaluateListQuery(tupleQuery, aAll);
-            results.sort(Comparator.comparing(KBObject::getUiLabel, String.CASE_INSENSITIVE_ORDER));
+            results.sort(comparing(KBObject::getUiLabel, CASE_INSENSITIVE_ORDER));
 
             LOG.debug("[{}] Query returned {} results in {}ms", queryId, results.size(),
                     currentTimeMillis() - startTime);
+
             return results;
         }
         catch (QueryEvaluationException e) {

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryPrimaryConditions.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryPrimaryConditions.java
@@ -17,21 +17,6 @@
  */
 package de.tudarmstadt.ukp.inception.kb.querybuilder;
 
-/**
- * When working with queries using any of {@link #roots()}, @link #withIdentifier(String)}, @link
- * #childrenOf(String)}, {@link #descendantsOf(String)}, {@link #parentsOf(String)} or
- * {@link #ancestorsOf(String)}}, the FTS is internally disabled. These methods must be called
- * <b>before</b> any label-restricting methods like {@link #withLabelStartingWith(String)} This is
- * because the FTS part of the query pre-filters the potential candidates, but the FTS may not
- * return all candidates. Let's consider a large KB (e.g. Wikidata) and a query for <i>all humans
- * named Amanda in the Star Trek universe</i> (there is a category for <i>humans in the Star Trek
- * universe</i> in Wikidata). First the FTS would try to retrieve all entities named <i>Amanda</i>,
- * but it does not really return all, just the top 50 (which is what Wikidata seems to be hard-coded
- * to despite the documentation for <i>wikidata:limit</i> saying otherwise). None of these Amandas,
- * however, is part of the Star Trek universe, so the final result of the query is empty. Here, the
- * FTS restricts too much and too early. For such cases, we should rely on the scope sufficiently
- * limiting the returned results such that the regex-based filtering does not get too slow.
- */
 public interface SPARQLQueryPrimaryConditions
     extends SPARQLQuery, SPARQLQueryOptionalElements
 {
@@ -93,7 +78,7 @@ public interface SPARQLQueryPrimaryConditions
     /**
      * Match all the roots of the class hierarchy.
      * <p>
-     * <b>NOTE:</b> this method implicitly disables FTS for the query and must be called before
+     * <b>NOTE:</b> this method may implicitly disable FTS for the query and must be called before
      * {@link #withLabelStartingWith(String)} or any other label-matching methods. Failure to do so
      * may result in queries returning fewer than expected results (in the worst case, no results).
      */
@@ -101,9 +86,9 @@ public interface SPARQLQueryPrimaryConditions
 
     /**
      * Limits results to ancestors of the given item. If the item is an instance, its classes are
-     * considered to be its parents. If the item is a class, then the superclasses are the parents.
+     * considered to be its parents. If the item is a class, then the super-classes are the parents.
      * <p>
-     * <b>NOTE:</b> this method implicitly disables FTS for the query and must be called before
+     * <b>NOTE:</b> this method may implicitly disable FTS for the query and must be called before
      * {@link #withLabelStartingWith(String)} or any other label-matching methods. Failure to do so
      * may result in queries returning fewer than expected results (in the worst case, no results).
      * 
@@ -116,7 +101,7 @@ public interface SPARQLQueryPrimaryConditions
      * subclasses and instances (of subclasses). Depending on which kind if items the query is built
      * for, either one of them or both are returned.
      * <p>
-     * <b>NOTE:</b> this method implicitly disables FTS for the query and must be called before
+     * <b>NOTE:</b> this method may implicitly disable FTS for the query and must be called before
      * {@link #withLabelStartingWith(String)} or any other label-matching methods. Failure to do so
      * may result in queries returning fewer than expected results (in the worst case, no results).
      * 
@@ -129,7 +114,7 @@ public interface SPARQLQueryPrimaryConditions
      * instances. Depending on which kind if items the query is built for, either one of them or
      * both are returned.
      * <p>
-     * <b>NOTE:</b> this method implicitly disables FTS for the query and must be called before
+     * <b>NOTE:</b> this method may implicitly disable FTS for the query and must be called before
      * {@link #withLabelStartingWith(String)} or any other label-matching methods. Failure to do so
      * may result in queries returning fewer than expected results (in the worst case, no results).
      * 
@@ -140,7 +125,7 @@ public interface SPARQLQueryPrimaryConditions
     /**
      * Limits results to parents of the given class.
      * <p>
-     * <b>NOTE:</b> this method implicitly disables FTS for the query and must be called before
+     * <b>NOTE:</b> this method may implicitly disable FTS for the query and must be called before
      * {@link #withLabelStartingWith(String)} or any other label-matching methods. Failure to do so
      * may result in queries returning fewer than expected results (in the worst case, no results).
      * 
@@ -153,7 +138,7 @@ public interface SPARQLQueryPrimaryConditions
      * inheritance hierarchy, so if A has a property x and B is a subclass of A, then B also has the
      * property x.
      * <p>
-     * <b>NOTE:</b> this method implicitly disables FTS for the query and must be called before
+     * <b>NOTE:</b> this method may implicitly disable FTS for the query and must be called before
      * {@link #withLabelStartingWith(String)} or any other label-matching methods. Failure to do so
      * may result in queries returning fewer than expected results (in the worst case, no results).
      * 

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/backport/Bind.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/backport/Bind.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2021 Eclipse RDF4J contributors.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+package de.tudarmstadt.ukp.inception.kb.querybuilder.backport;
+
+import org.eclipse.rdf4j.sparqlbuilder.core.Assignable;
+import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
+import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPattern;
+import org.eclipse.rdf4j.sparqlbuilder.util.SparqlBuilderUtils;
+
+/**
+ * @since 4.0.0
+ * @author Florian Kleedorfer
+ */
+public class Bind
+    implements GraphPattern
+{
+    private static final String AS = " AS ";
+    private Assignable expression;
+    private Variable var;
+
+    public Bind(Assignable exp, Variable var)
+    {
+        this.expression = exp;
+        this.var = var;
+    }
+
+    @Override
+    public String getQueryString()
+    {
+        return "BIND" + SparqlBuilderUtils
+                .getParenthesizedString(expression.getQueryString() + AS + var.getQueryString());
+    }
+}

--- a/inception/inception-kb/src/main/resources/de/tudarmstadt/ukp/inception/kb/model/db-changelog.xml
+++ b/inception/inception-kb/src/main/resources/de/tudarmstadt/ukp/inception/kb/model/db-changelog.xml
@@ -432,4 +432,17 @@
       </column>
     </createTable>
   </changeSet>
+  
+  <changeSet author="INCEpTION Team" id="20220527-1">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="knowledgebase" columnName="useFuzzy"/>
+      </not>
+    </preConditions>
+    <addColumn tableName="knowledgebase">
+      <column name="useFuzzy" type="BOOLEAN" defaultValueBoolean="false">
+        <constraints nullable="false" />
+      </column>
+    </addColumn>
+  </changeSet>
 </databaseChangeLog>

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderGenericTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderGenericTest.java
@@ -110,8 +110,11 @@ public class SPARQLQueryBuilderGenericTest
                         .asHandles(conn, true);
 
                 return children.stream().map(KBHandle::getIdentifier)
-                        .allMatch(_child -> SPARQLQueryBuilder.forClasses(kb).parentsOf(_child)
-                                .limit(5).asHandles(conn, true).stream()
+                        .allMatch(_child -> SPARQLQueryBuilder.forClasses(kb) //
+                                .parentsOf(_child) //
+                                .limit(5) //
+                                .asHandles(conn, true) //
+                                .stream() //
                                 .map(KBHandle::getIdentifier)
                                 // .map(v -> {
                                 // System.out.printf("C: %s%n", v);

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/ProjectKnowledgeBasePanel.properties
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/ProjectKnowledgeBasePanel.properties
@@ -81,6 +81,7 @@ kb.details.local.contents.clear.feedback="${name}" cleared.
 kb.details.permissions.writeprotection=Write protection
 kb.details.contents.permissions= Read only
 kb.details.contents.maxQueryLimit=Set to max value
+kb.details.contents.useFuzzy=Use fuzzy matching (slower)
 
 kb.details.delete.confirmation.title=Confirmation
 kb.details.delete.confirmation.content=Are you sure you want to <strong>delete the knowledge base "${name}"</strong>?

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/QuerySettingsPanel.html
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/QuerySettingsPanel.html
@@ -26,6 +26,16 @@
     </h4>
   </div>
 
+  <div class="row form-row" wicket:enclosure="useFuzzy">
+    <div class="offset-sm-3 col-sm-9">
+      <div class="form-check">
+        <input wicket:id="useFuzzy" class="form-check-input" type="checkbox">
+        <label wicket:for="useFuzzy" class="form-check-label">
+          <wicket:label key="kb.details.contents.useFuzzy"/>
+        </label>
+      </div>
+    </div>
+  </div>
   <div class="row form-row">
     <label class="col-form-label col-sm-3">
       <wicket:message key="kb.queryLimit"/>

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/QuerySettingsPanel.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/QuerySettingsPanel.java
@@ -48,6 +48,7 @@ public class QuerySettingsPanel
 
     private final TextField<Integer> queryLimitField;
     private final CheckBox maxQueryLimitCheckBox;
+    private final CheckBox useFuzzyCheckBox;
     private final CompoundPropertyModel<KnowledgeBaseWrapper> kbModel;
 
     public QuerySettingsPanel(String id, CompoundPropertyModel<KnowledgeBaseWrapper> aModel)
@@ -59,6 +60,9 @@ public class QuerySettingsPanel
 
         queryLimitField = queryLimitField("maxResults", kbModel.bind("kb.maxResults"));
         add(queryLimitField);
+        useFuzzyCheckBox = new CheckBox("useFuzzy", kbModel.bind("kb.useFuzzy"));
+        useFuzzyCheckBox.setOutputMarkupId(true);
+        add(useFuzzyCheckBox);
         maxQueryLimitCheckBox = maxQueryLimitCheckbox("maxQueryLimit", Model.of(false));
         add(maxQueryLimitCheckBox);
         add(ftsField("fullTextSearchIri", "kb.fullTextSearchIri"));

--- a/inception/inception-ui-kb/src/main/resources/META-INF/asciidoc/user-guide/projects_knowledge-base.adoc
+++ b/inception/inception-ui-kb/src/main/resources/META-INF/asciidoc/user-guide/projects_knowledge-base.adoc
@@ -23,20 +23,23 @@ There are various settings for knowledge bases.
 [.thumb]
 image::kb3.png[align="center"]
 
+=== Local KBs
+
+* **Read only:** Whether the KB can be modified. This setting is disabled by default. Enabling it
+  prevents making changes to the KB and allows for more effective query caching.
+
 === Remote KBs
 
 The remote knowledge bases, there are the following settings:
 
 * **SPARQL endpoint URL:** The SPARQL URL used to access the knowledge base
+* **Skip SSL certificate checks:** Enable to skip the verification of SSL certificates. This can
+  help if the remote server is using a self-signed certificate. It should be avoided to use this
+  option in production. Instead, better install the remote certificate into your Java environment
+  so it can be validated. 
 * **Default dataset:** A SPARQL endpoint may server multiple datasets. This setting can be used to
   restrict queries to a specific one. Consult with the operator of the SPARQL server to see which
   datasets are available.
-* **Result limit for SPARQL queries:** this is used to limit the amount of data retrieved from the
-  remote server, e.g when populating dropdown boxes for concept search.
-* **Full text search mode:** a SPARQL endpoint capable of full-text searching makes the knowledge
-  based considerably more responsive. Use `bif:contains` for Virtuoso servers and `lucenesail` for
-  RDF4J-based servers. Note that full-text search must be enabled on the server by the server 
-  operator.
 
 NOTE: **Changing the URL of a remote KB currently only takes affect after {product-name} is restarted!**
       The updated URL will be shown in the settings, but queries will still be sent to the old URL until you restart {product-name}.
@@ -45,9 +48,22 @@ NOTE: **Changing the URL of a remote KB currently only takes affect after {produ
       with the new URL.
 
 
+=== Query settings
+
+* **Use fuzzy matching:** enables fuzzy matching when searching the knowledge base. The effect is
+  slightly different depending on the backend being used and it can **significantly slow down** the
+  retrieval process. It is normally a good idea to leave this feature off. If you would like to 
+  retrieve items from the knowledge base which only approximately match a query (e.g. you would 
+  like that an entry `John` is matched if you enter `Johan` or vice versa), then you could try
+  this out. 
+* **Result limit for SPARQL queries:** this is used to limit the amount of data retrieved from the
+  remote server, e.g when populating dropdown boxes for concept search.
+
+
 === Schema mapping
 
-Different types of knowledge base schemata are supported via a configurable mapping mechanism. The user can choose one of the pre-configured mapping or provide a custom mapping.
+Different types of knowledge base schemata are supported via a configurable mapping mechanism. The
+user can choose one of the pre-configured mapping or provide a custom mapping.
 
 
 [cols="1,1,3a"]


### PR DESCRIPTION
**What's in the PR**
- Added option to disable fuzzy search (off by default)
- Improve timing logging/reporting in the concept linking service
- Improve information on why FTS is disabled when performing certain kinds of queries
- Fix fuzzy label matching for RDF4J when an item has multiple labels potentially with different languages
- Factor language matching out into a separate method and simplify the query by removing a redundant/duplicate regex condition
- Update KB settings documentation

**How to test manually**
* Compare in particular entity linking without fuzzy matching to entity linking with fuzzy matching
* Check if matching results are ok

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
