### PR TITLE
#3076 - Items matching text entered in to concept feature editor often appear late

### DIFF
--- a/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/config/EntityLinkingServiceAutoConfiguration.java
+++ b/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/config/EntityLinkingServiceAutoConfiguration.java
@@ -30,6 +30,7 @@ import org.springframework.context.annotation.Lazy;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRegistry;
 import de.tudarmstadt.ukp.clarin.webanno.api.config.RepositoryProperties;
+import de.tudarmstadt.ukp.inception.conceptlinking.feature.CasingFeatureGenerator;
 import de.tudarmstadt.ukp.inception.conceptlinking.feature.EntityRankingFeatureGenerator;
 import de.tudarmstadt.ukp.inception.conceptlinking.feature.FrequencyFeatureGenerator;
 import de.tudarmstadt.ukp.inception.conceptlinking.feature.LevenshteinFeatureGenerator;
@@ -66,6 +67,12 @@ public class EntityLinkingServiceAutoConfiguration
     public EntityLinkingProperties entityLinkingProperties()
     {
         return new EntityLinkingPropertiesImpl();
+    }
+
+    @Bean
+    public CasingFeatureGenerator casingFeatureGenerator()
+    {
+        return new CasingFeatureGenerator();
     }
 
     @Bean

--- a/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/feature/CasingFeatureGenerator.java
+++ b/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/feature/CasingFeatureGenerator.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.conceptlinking.feature;
+
+import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_QUERY;
+import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_QUERY_IS_LOWER_CASE;
+import static java.lang.Character.isAlphabetic;
+import static java.lang.Character.isLowerCase;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+
+import de.tudarmstadt.ukp.inception.conceptlinking.config.EntityLinkingServiceAutoConfiguration;
+import de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity;
+
+/**
+ * <p>
+ * This class is exposed as a Spring Component via
+ * {@link EntityLinkingServiceAutoConfiguration#casingFeatureGenerator()}.
+ * </p>
+ */
+public class CasingFeatureGenerator
+    implements EntityRankingFeatureGenerator
+{
+    @Override
+    public void apply(CandidateEntity aCandidate)
+    {
+        aCandidate.get(KEY_QUERY) //
+                .map(query -> allAlphabeticCharactersAreLowerCase(query)) //
+                .ifPresent(isLower -> aCandidate.put(KEY_QUERY_IS_LOWER_CASE, isLower));
+    }
+
+    public static boolean allAlphabeticCharactersAreLowerCase(final CharSequence cs)
+    {
+        if (isEmpty(cs)) {
+            return false;
+        }
+
+        int len = cs.length();
+        for (int i = 0; i < len; i++) {
+            if (isAlphabetic(i) && !isLowerCase(cs.charAt(i))) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/feature/LevenshteinFeatureGenerator.java
+++ b/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/feature/LevenshteinFeatureGenerator.java
@@ -19,12 +19,14 @@ package de.tudarmstadt.ukp.inception.conceptlinking.feature;
 
 import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_LEVENSHTEIN_MENTION;
 import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_LEVENSHTEIN_MENTION_CONTEXT;
+import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_LEVENSHTEIN_MENTION_NC;
 import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_LEVENSHTEIN_QUERY;
+import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_LEVENSHTEIN_QUERY_NC;
 import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_MENTION;
 import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_MENTION_CONTEXT;
 import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_QUERY;
+import static org.apache.commons.lang3.StringUtils.join;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.similarity.LevenshteinDistance;
 
 import de.tudarmstadt.ukp.inception.conceptlinking.config.EntityLinkingServiceAutoConfiguration;
@@ -45,15 +47,26 @@ public class LevenshteinFeatureGenerator
     public void apply(CandidateEntity aCandidate)
     {
         String label = aCandidate.getLabel();
+        String labelNC = aCandidate.getLabel().toLowerCase(aCandidate.getLocale());
 
-        aCandidate.get(KEY_MENTION).map(mention -> lev.apply(label, mention))
+        aCandidate.get(KEY_MENTION) //
+                .map(mention -> lev.apply(label, mention)) //
                 .ifPresent(score -> aCandidate.put(KEY_LEVENSHTEIN_MENTION, score));
 
-        aCandidate.get(KEY_QUERY).map(query -> lev.apply(label, query))
+        aCandidate.get(KEY_MENTION) //
+                .map(mention -> lev.apply(labelNC, mention)) //
+                .ifPresent(score -> aCandidate.put(KEY_LEVENSHTEIN_MENTION_NC, score));
+
+        aCandidate.get(KEY_QUERY) //
+                .map(query -> lev.apply(label, query)) //
                 .ifPresent(score -> aCandidate.put(KEY_LEVENSHTEIN_QUERY, score));
 
-        aCandidate.get(KEY_MENTION_CONTEXT)
-                .map(context -> lev.apply(label, StringUtils.join(context, ' ')))
+        aCandidate.get(KEY_QUERY) //
+                .map(query -> lev.apply(labelNC, query)) //
+                .ifPresent(score -> aCandidate.put(KEY_LEVENSHTEIN_QUERY_NC, score));
+
+        aCandidate.get(KEY_MENTION_CONTEXT) //
+                .map(context -> lev.apply(label, join(context, ' '))) //
                 .ifPresent(score -> aCandidate.put(KEY_LEVENSHTEIN_MENTION_CONTEXT, score));
     }
 }

--- a/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/model/CandidateEntity.java
+++ b/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/model/CandidateEntity.java
@@ -41,11 +41,20 @@ public class CandidateEntity
      * The query entered by the user.
      */
     public static final Key<String> KEY_QUERY = new Key<>("query");
+    public static final Key<String> KEY_QUERY_NC = new Key<>("queryNC");
+
+    /**
+     * Whether the query entered by the user is completely in lower case.
+     */
+    public static final Key<Boolean> KEY_QUERY_IS_LOWER_CASE = new Key<>("queryIsLowerCase");
 
     /**
      * The mention in the text which is to be linked.
      */
     public static final Key<String> KEY_MENTION = new Key<>("mention");
+    public static final Key<String> KEY_MENTION_NC = new Key<>("mentionNC");
+
+    public static final Key<String> KEY_LABEL_NC = new Key<>("labelNC");
 
     /**
      * The context of the mention.
@@ -60,6 +69,9 @@ public class CandidateEntity
      * be calculated.
      */
     public static final Key<Integer> KEY_LEVENSHTEIN_MENTION = new Key<>("levMention",
+            Integer.MAX_VALUE);
+
+    public static final Key<Integer> KEY_LEVENSHTEIN_MENTION_NC = new Key<>("levMentionNC",
             Integer.MAX_VALUE);
 
     /**
@@ -80,6 +92,9 @@ public class CandidateEntity
      * be calculated.
      */
     public static final Key<Integer> KEY_LEVENSHTEIN_QUERY = new Key<>("levQuery",
+            Integer.MAX_VALUE);
+
+    public static final Key<Integer> KEY_LEVENSHTEIN_QUERY_NC = new Key<>("levQueryNC",
             Integer.MAX_VALUE);
 
     /**

--- a/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/ranking/BaselineRankingStrategy.java
+++ b/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/ranking/BaselineRankingStrategy.java
@@ -19,11 +19,15 @@ package de.tudarmstadt.ukp.inception.conceptlinking.ranking;
 
 import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_FREQUENCY;
 import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_ID_RANK;
+import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_LABEL_NC;
 import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_LEVENSHTEIN_MENTION;
 import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_LEVENSHTEIN_MENTION_CONTEXT;
 import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_LEVENSHTEIN_QUERY;
+import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_LEVENSHTEIN_QUERY_NC;
 import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_NUM_RELATIONS;
 import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_QUERY;
+import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_QUERY_IS_LOWER_CASE;
+import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_QUERY_NC;
 import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_SIGNATURE_OVERLAP_SCORE;
 
 import java.util.Comparator;
@@ -37,14 +41,19 @@ public class BaselineRankingStrategy
     private static final Comparator<CandidateEntity> INSTANCE = (e1, e2) -> new CompareToBuilder()
             // Did the user enter an URI and does the candidate exactly match it?
             // Note that the comparator sorts ascending by value, so a match is represented using
-            // a 0 while a mistmatch is represented using 1. The typical case is that neither
+            // a 0 while a mismatch is represented using 1. The typical case is that neither
             // candidate matches the query which causes the next ranking criteria to be evaluated
-            .append(e1.get(KEY_QUERY).map(q -> q.equals(e1.getIRI()) ? 0 : 1).orElse(1),
-                    e2.get(KEY_QUERY).map(q -> q.equals(e2.getIRI()) ? 0 : 1).orElse(1))
+            .append(queryMatchesIri(e1), queryMatchesIri(e2))
+            // Prefer matches where the query appears in the label
+            .append(labelMatchesQueryNC(e1), labelMatchesQueryNC(e2))
             // Compare geometric mean of the Levenshtein distance to query and mention
             // since both are important and a very close similarity in say the mention outweighs
             // a not so close similarity in the query
             .append(weightedLevenshteinDistance(e1), weightedLevenshteinDistance(e2))
+            // Prefer good matches on the query over good matches on the mention
+            .append(queryOverMention(e1), queryOverMention(e2))
+            // Cased over caseless
+            .append(casedOverCaseless(e1), casedOverCaseless(e2))
             // A high signature overlap score is preferred.
             .append(e2.get(KEY_SIGNATURE_OVERLAP_SCORE).get(),
                     e1.get(KEY_SIGNATURE_OVERLAP_SCORE).get())
@@ -62,9 +71,42 @@ public class BaselineRankingStrategy
                     e2.getLabel().toLowerCase(e2.getLocale()))
             .toComparison();
 
+    private static double queryMatchesIri(CandidateEntity aCandidate)
+    {
+        return aCandidate.get(KEY_QUERY).map(q -> q.equals(aCandidate.getIRI()) ? 0 : 1).orElse(1);
+    }
+
+    private static double labelMatchesQueryNC(CandidateEntity aCandidate)
+    {
+        return aCandidate.get(KEY_QUERY_NC)
+                .map(q -> aCandidate.get(KEY_LABEL_NC).map(l -> l.contains(q) ? 0 : 1).orElse(1))
+                .orElse(1);
+    }
+
+    private static double casedOverCaseless(CandidateEntity aCandidate)
+    {
+        int queryNC = aCandidate.get(KEY_LEVENSHTEIN_QUERY_NC).get();
+        int query = aCandidate.get(KEY_LEVENSHTEIN_QUERY).get();
+
+        return queryNC <= query ? 0 : 1;
+    }
+
+    private static double queryOverMention(CandidateEntity aCandidate)
+    {
+        boolean caseInsensitive = aCandidate.get(KEY_QUERY_IS_LOWER_CASE).orElse(true);
+        int query = aCandidate
+                .get(caseInsensitive ? KEY_LEVENSHTEIN_QUERY_NC : KEY_LEVENSHTEIN_QUERY).get();
+        int mention = aCandidate.get(KEY_LEVENSHTEIN_MENTION).get();
+
+        return query <= mention ? 0 : 1;
+    }
+
     private static double weightedLevenshteinDistance(CandidateEntity aCandidate)
     {
-        int query = aCandidate.get(KEY_LEVENSHTEIN_QUERY).get();
+        boolean caseInsensitive = aCandidate.get(KEY_QUERY_IS_LOWER_CASE).orElse(true);
+
+        int query = aCandidate
+                .get(caseInsensitive ? KEY_LEVENSHTEIN_QUERY_NC : KEY_LEVENSHTEIN_QUERY).get();
         int mention = aCandidate.get(KEY_LEVENSHTEIN_MENTION).get();
 
         if (query == Integer.MAX_VALUE && mention == Integer.MAX_VALUE) {
@@ -77,12 +119,6 @@ public class BaselineRankingStrategy
 
         if (mention == Integer.MAX_VALUE) {
             return Math.sqrt(query);
-        }
-
-        // If the distance of the query and mention is the same, then give the query a slight
-        // benefit so the user see's items matching the query he/she entered first
-        if (query > 0 && query == mention) {
-            query = query - 1;
         }
 
         return Math.sqrt(query * mention);

--- a/inception/inception-concept-linking/src/test/java/de/tudarmstadt/ukp/inception/conceptlinking/service/ConceptLinkingServiceImplTest.java
+++ b/inception/inception-concept-linking/src/test/java/de/tudarmstadt/ukp/inception/conceptlinking/service/ConceptLinkingServiceImplTest.java
@@ -102,7 +102,8 @@ public class ConceptLinkingServiceImplTest
         List<KBHandle> handles = sut.disambiguate(kb, null, ANY_OBJECT, "soc", null, 0, null);
 
         assertThat(handles.stream().map(KBHandle::getName))
-                .as("Check whether \"Socke\" has been retrieved.").contains("Socke");
+                .as("Check whether \"Socke\" has been retrieved.") //
+                .contains("Socke");
 
         kbService.removeKnowledgeBase(kb);
     }
@@ -119,7 +120,8 @@ public class ConceptLinkingServiceImplTest
         List<KBHandle> handles = sut.disambiguate(kb, null, ANY_OBJECT, "man", null, 0, null);
 
         assertThat(handles.stream().map(KBHandle::getName))
-                .as("Check whether \"manatee\" has been retrieved.").contains("manatee");
+                .as("Check whether \"manatee\" has been retrieved.") //
+                .contains("manatee");
 
         kbService.removeKnowledgeBase(kb);
     }


### PR DESCRIPTION
**What's in the PR**
- Modify ranking algorithm to put more weight on the query entered by the user
- Added unit tests

**How to test manually**
* Search for entities to link, in paricular such that do not match the annotated text

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
