### PR TITLE
#3083 - KB test class for Virtuoso

### DIFF
--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/IriConstants.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/IriConstants.java
@@ -45,6 +45,7 @@ public class IriConstants
     public static final String PREFIX_WIKIDATA_ENTITY = "http://www.wikidata.org/entity/";
     public static final String PREFIX_WIKIDATA_DIRECT = "http://www.wikidata.org/prop/direct/";
     public static final String PREFIX_SCHEMA = "http://schema.org/";
+    public static final String PREFIX_VIRTUOSO = "http://www.openlinksw.com/schemas/bif#";
     public static final String PREFIX_LUCENE_SEARCH = "http://www.openrdf.org/contrib/lucenesail#";
     public static final String PREFIX_MWAPI = "https://www.mediawiki.org/ontology#API/";
     public static final String PREFIX_STARDOG = "tag:stardog:api:search:";
@@ -113,7 +114,7 @@ public class IriConstants
         SCHEMA_DESCRIPTION = vf.createIRI(PREFIX_SCHEMA, "description");
 
         FTS_FUSEKI = vf.createIRI("text:query");
-        FTS_VIRTUOSO = vf.createIRI("bif:contains");
+        FTS_VIRTUOSO = vf.createIRI(PREFIX_VIRTUOSO, "contains");
         FTS_LUCENE = vf.createIRI(PREFIX_LUCENE_SEARCH, "matches");
         FTS_WIKIDATA = vf.createIRI(PREFIX_MWAPI, "search");
         FTS_STARDOG = vf.createIRI(PREFIX_STARDOG, "textMatch");

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderTest.java
@@ -45,6 +45,7 @@ import java.util.List;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.function.FailableBiConsumer;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.OWL;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
@@ -1787,7 +1788,13 @@ public class SPARQLQueryBuilderTest
             // To avoid having two hashes here, we drop the hash from the base prefix configured
             // by the user.
             String prefix = StringUtils.removeEnd(aKB.getBasePrefix(), "#");
-            conn.add(aIS, prefix, aFormat);
+            if (aKB.getDefaultDatasetIri() != null) {
+                var ctx = SimpleValueFactory.getInstance().createIRI(aKB.getDefaultDatasetIri());
+                conn.add(aIS, prefix, aFormat, ctx);
+            }
+            else {
+                conn.add(aIS, prefix, aFormat);
+            }
         }
     }
 

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/VirtuosoRepositoryTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/VirtuosoRepositoryTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.kb.querybuilder;
+
+import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_VIRTUOSO;
+import static de.tudarmstadt.ukp.inception.kb.http.PerThreadSslCheckingHttpClientUtils.restoreSslVerification;
+import static de.tudarmstadt.ukp.inception.kb.http.PerThreadSslCheckingHttpClientUtils.suspendSslVerification;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.repository.Repository;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import de.tudarmstadt.ukp.inception.kb.RepositoryType;
+import de.tudarmstadt.ukp.inception.kb.model.KnowledgeBase;
+import de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilderTest.Scenario;
+
+// The repository has to exist and Virtuoso has to be running for this test to run.
+// To create the repository, use the following steps:
+// Install Virtuoso, e.g. `brew install virtuoso`
+// Start Virtuoso, e.g. `virtuoso-t +foreground +configfile /opt/homebrew/Cellar/virtuoso/7.2.7/var/lib/virtuoso/db/virtuoso.ini`
+// Go to http://localhost:8890/conductor -> System Admin -> User Accounts -> SPARQL and add account role SPARQL_UPDATE
+// Check if FTS is enabled: `SELECT * from DB.DBA.RDF_OBJ_FT_RULES;`
+// Enable FTS: `DB.DBA.RDF_OBJ_FT_RULE_ADD (null, null, 'ALL');`
+@Disabled("Requires manually setting up a test server")
+public class VirtuosoRepositoryTest
+{
+    private Repository repository;
+    private KnowledgeBase kb;
+
+    @BeforeEach
+    public void setUp(TestInfo aTestInfo)
+    {
+        String methodName = aTestInfo.getTestMethod().map(Method::getName).orElse("<unknown>");
+        System.out.printf("\n=== %s === %s =====================\n", methodName,
+                aTestInfo.getDisplayName());
+
+        suspendSslVerification();
+
+        kb = new KnowledgeBase();
+        kb.setDefaultLanguage("en");
+        kb.setDefaultDatasetIri("http://testgraph");
+        kb.setType(RepositoryType.REMOTE);
+        kb.setFullTextSearchIri(FTS_VIRTUOSO.stringValue());
+        kb.setMaxResults(100);
+
+        SPARQLQueryBuilderTest.initRdfsMapping(kb);
+
+        repository = SPARQLQueryBuilderTest.buildSparqlRepository("http://localhost:8890/sparql/");
+
+        try (RepositoryConnection conn = repository.getConnection()) {
+            var ctx = SimpleValueFactory.getInstance().createIRI(kb.getDefaultDatasetIri());
+            conn.clear(ctx);
+        }
+    }
+
+    @AfterEach
+    public void tearDown()
+    {
+        restoreSslVerification();
+    }
+
+    private static List<Arguments> tests() throws Exception
+    {
+        return SPARQLQueryBuilderTest.tests().stream() //
+                .map(scenario -> Arguments.of(scenario.name, scenario))
+                .collect(Collectors.toList());
+    }
+
+    @ParameterizedTest(name = "{index}: test {0}")
+    @MethodSource("tests")
+    public void runTests(String aScenarioName, Scenario aScenario) throws Exception
+    {
+        aScenario.implementation.accept(repository, kb);
+    }
+}


### PR DESCRIPTION
**What's in the PR**
- Add test class for Virtuoso
- Adjust Virtuoso FTS because Virtuoso does not like `<bif:contains>` - since the IRI is stored in the KB table, this could be an issue for existing Virtuoso KBs where `bif:contains` is stored in the KB
- Consider the default graph from the KB when loading test data into the KB

**How to test manually**
* No specific test procedure

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
