### PR TITLE
#3113 - Option to wait for recommendations before showing document

### DIFF
--- a/inception/inception-recommendation-api/pom.xml
+++ b/inception/inception-recommendation-api/pom.xml
@@ -46,6 +46,10 @@
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-support</artifactId>
     </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-preferences</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.uima</groupId>

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/RecommendationService.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/RecommendationService.java
@@ -31,11 +31,13 @@ import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.clarin.webanno.support.logging.LogMessageGroup;
+import de.tudarmstadt.ukp.inception.preferences.Key;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.EvaluatedRecommender;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Predictions;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Preferences;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Progress;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.RecommenderGeneralSettings;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.RelationSuggestion;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.SpanSuggestion;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.SuggestionGroup;
@@ -43,11 +45,14 @@ import de.tudarmstadt.ukp.inception.recommendation.api.recommender.Recommendatio
 import de.tudarmstadt.ukp.inception.recommendation.api.recommender.RecommenderContext;
 
 /**
- * The main contact point of the Recommendation module. This interface can be injected in the wicket
+ * The main contact point of the Recommendation module. This interface can be injected in the Wicket
  * pages. It is used to pull the latest recommendations for an annotation layer and render them.
  */
 public interface RecommendationService
 {
+    Key<RecommenderGeneralSettings> KEY_RECOMMENDER_GENERAL_SETTINGS = new Key<>(
+            RecommenderGeneralSettings.class, "recommendation/general");
+
     String FEATURE_NAME_IS_PREDICTION = "inception_internal_predicted";
     String FEATURE_NAME_SCORE_SUFFIX = "_score";
     String FEATURE_NAME_SCORE_EXPLANATION_SUFFIX = "_score_explanation";

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/RecommenderGeneralSettings.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/RecommenderGeneralSettings.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.api.model;
+
+import java.io.Serializable;
+
+public class RecommenderGeneralSettings
+    implements Serializable
+{
+    private static final long serialVersionUID = -1889889346307217345L;
+
+    private boolean waitForRecommendersOnOpenDocument = false;
+
+    public boolean isWaitForRecommendersOnOpenDocument()
+    {
+        return waitForRecommendersOnOpenDocument;
+    }
+
+    public void setWaitForRecommendersOnOpenDocument(boolean aWaitForRecommendersOnOpenDocument)
+    {
+        waitForRecommendersOnOpenDocument = aWaitForRecommendersOnOpenDocument;
+    }
+}

--- a/inception/inception-recommendation/pom.xml
+++ b/inception/inception-recommendation/pom.xml
@@ -93,6 +93,10 @@
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-log</artifactId>
     </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-preferences</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.dkpro.core</groupId>

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/config/RecommenderServiceAutoConfiguration.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/config/RecommenderServiceAutoConfiguration.java
@@ -36,6 +36,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRegistry;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
+import de.tudarmstadt.ukp.inception.preferences.PreferencesService;
 import de.tudarmstadt.ukp.inception.recommendation.RecommendationEditorExtension;
 import de.tudarmstadt.ukp.inception.recommendation.api.LearningRecordService;
 import de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService;
@@ -70,13 +71,14 @@ public class RecommenderServiceAutoConfiguration
 
     @Bean
     @Autowired
-    public RecommendationService recommendationService(SessionRegistry aSessionRegistry,
-            UserDao aUserRepository, RecommenderFactoryRegistry aRecommenderFactoryRegistry,
+    public RecommendationService recommendationService(PreferencesService aPreferencesService,
+            SessionRegistry aSessionRegistry, UserDao aUserRepository,
+            RecommenderFactoryRegistry aRecommenderFactoryRegistry,
             SchedulingService aSchedulingService, AnnotationSchemaService aAnnoService,
             DocumentService aDocumentService, LearningRecordService aLearningRecordService,
             ProjectService aProjectService, ApplicationEventPublisher aApplicationEventPublisher)
     {
-        return new RecommendationServiceImpl(aSessionRegistry, aUserRepository,
+        return new RecommendationServiceImpl(aPreferencesService, aSessionRegistry, aUserRepository,
                 aRecommenderFactoryRegistry, aSchedulingService, aAnnoService, aDocumentService,
                 aLearningRecordService, aProjectService, entityManager, aApplicationEventPublisher);
     }

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/ProjectRecommendersPanel.html
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/ProjectRecommendersPanel.html
@@ -20,11 +20,12 @@
 <wicket:panel>
   <div class="scrolling flex-content flex-v-container flex-gutter">
     <div class="flex-content flex-h-container flex-gutter">
-      <div wicket:id="recommenders"
-        class="flex-sidebar flex-v-container flex-gutter"
-        style="flex-basis: 30%;"></div>
+      <div wicket:id="recommenders" class="flex-sidebar flex-v-container flex-gutter"
+        style="flex-basis: 30%;">
+      </div>
       <div wicket:id="recommenderEditor"
-        class="flex-content flex-v-container flex-only-internal-gutter"></div>
+        class="flex-content flex-v-container flex-only-internal-gutter">
+      </div>
     </div>
   </div>
 </wicket:panel>

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/ProjectRecommendersPanel.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/ProjectRecommendersPanel.java
@@ -36,7 +36,6 @@ public class ProjectRecommendersPanel
     private static final long serialVersionUID = 3042218455285633439L;
 
     private static final String MID_RECOMMENDERS = "recommenders";
-    private static final String MID_CREATE_BUTTON = "create";
     private static final String MID_RECOMMENDER_EDITOR = "recommenderEditor";
 
     private IModel<Project> projectModel;

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderListPanel.html
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderListPanel.html
@@ -23,9 +23,35 @@
       <div class="card-header">
         <wicket:message key="recommenders"/>
         <div class="actions">
+          <span class="dropdown" aria-haspopup="true" aria-expanded="false">
+            <button class="btn btn-action btn-secondary dropdown-toggle flex-content" type="button" data-bs-toggle="dropdown">
+              <i class="fas fa-cog"></i>
+            </button>
+            <div class="dropdown-menu shadow-lg pt-0 pb-0" role="menu" style="min-width: 440px;">
+              <form wicket:id="form" class="card">
+                <div class="card-body">
+                  <div class="row form-row" wicket:enclosure="waitForRecommendersOnOpenDocument">
+                    <div class="col-sm-12">
+                      <div class="form-check">
+                        <input wicket:id="waitForRecommendersOnOpenDocument" class="form-check-input" type="checkbox"/>
+                        <label wicket:for="waitForRecommendersOnOpenDocument">
+                          <wicket:message key="waitForRecommendersOnOpenDocument"/>
+                        </label>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="card-footer text-end">
+                  <button wicket:id="save" class="btn btn-primary">
+                    <i class="fas fa-save"></i>&nbsp;
+                    <wicket:message key="save"/>
+                  </button> 
+                </div>
+              </form>
+            </div>
+          </span>
           <button wicket:id="create" class="btn btn-primary">
-            <i class="fas fa-plus-square"></i>&nbsp;
-            <wicket:message key="create"/>
+            <i class="fas fa-plus-square"></i>&nbsp;<wicket:message key="create"/>
           </button>
         </div>
       </div>

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderListPanel.properties
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderListPanel.properties
@@ -15,3 +15,4 @@
 # limitations under the License.
 
 recommenders=Recommenders
+waitForRecommendersOnOpenDocument=Wait for suggestions from pre-trained recommenders when opening document

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommendationSidebar.html
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommendationSidebar.html
@@ -81,7 +81,6 @@
       </div>
       <div class="scrolling card-body flex-v-container">
         <span class="flex-content no-data-notice" wicket:id="noRecommendersLabel"></span>
-        <!-- <div wicket:id="learningCurve" class="mb-3"></div> -->
         <div wicket:id="recommenders" ></div>
       </div>
     </div>

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/NonTrainableRecommenderActivationTask.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/NonTrainableRecommenderActivationTask.java
@@ -1,0 +1,210 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.tasks;
+
+import static de.tudarmstadt.ukp.inception.recommendation.api.recommender.TrainingCapability.TRAINING_NOT_SUPPORTED;
+import static java.lang.System.currentTimeMillis;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import javax.persistence.NoResultException;
+
+import org.apache.commons.lang3.concurrent.ConcurrentException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
+import de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.EvaluatedRecommender;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
+import de.tudarmstadt.ukp.inception.recommendation.api.recommender.RecommendationEngine;
+import de.tudarmstadt.ukp.inception.recommendation.api.recommender.RecommendationException;
+import de.tudarmstadt.ukp.inception.recommendation.api.recommender.RecommenderContext;
+import de.tudarmstadt.ukp.inception.recommendation.event.RecommenderEvaluationResultEvent;
+import de.tudarmstadt.ukp.inception.recommendation.event.SelectionTaskEvent;
+
+/**
+ * This task activates all non-trainable recommenders.
+ */
+public class NonTrainableRecommenderActivationTask
+    extends RecommendationTask_ImplBase
+{
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    private @Autowired AnnotationSchemaService annoService;
+    private @Autowired RecommendationService recommendationService;
+    private @Autowired ApplicationEventPublisher appEventPublisher;
+
+    public NonTrainableRecommenderActivationTask(User aUser, Project aProject, String aTrigger)
+    {
+        super(aUser, aProject, aTrigger);
+    }
+
+    @Override
+    public void execute()
+    {
+        User user = getUser().orElseThrow();
+
+        for (AnnotationLayer layer : annoService.listAnnotationLayer(getProject())) {
+            if (!layer.isEnabled()) {
+                continue;
+            }
+
+            List<Recommender> recommenders = recommendationService.listRecommenders(layer);
+            if (recommenders == null || recommenders.isEmpty()) {
+                continue;
+            }
+
+            List<EvaluatedRecommender> evaluatedRecommenders = new ArrayList<>();
+            for (Recommender r : recommenders) {
+                // Make sure we have the latest recommender config from the DB - the one from
+                // the active recommenders list may be outdated
+                Optional<Recommender> optRecommender = freshenRecommender(user, r);
+                if (optRecommender.isEmpty()) {
+                    continue;
+                }
+
+                Recommender recommender = optRecommender.get();
+                String recommenderName = recommender.getName();
+
+                try {
+                    long start = System.currentTimeMillis();
+
+                    considerRecommender(user, recommender).ifPresent(evaluatedRecommender -> {
+                        var result = evaluatedRecommender.getEvaluationResult();
+
+                        evaluatedRecommenders.add(evaluatedRecommender);
+                        appEventPublisher.publishEvent(new RecommenderEvaluationResultEvent(this,
+                                recommender, user.getUsername(), result,
+                                currentTimeMillis() - start, evaluatedRecommender.isActive()));
+
+                        var evalEvent = new SelectionTaskEvent(this, recommender,
+                                user.getUsername(), result);
+                        result.getErrorMsg().ifPresent(evalEvent::setErrorMsg);
+                        appEventPublisher.publishEvent(evalEvent);
+                    });
+                }
+                catch (Throwable e) {
+                    // Catching Throwable is intentional here as we want to continue the execution
+                    // even if a particular recommender fails.
+                    log.error("[{}][{}]: Failed", user.getUsername(), recommenderName, e);
+                    appEventPublisher.publishEvent(new SelectionTaskEvent(this, recommender,
+                            user.getUsername(), e.getMessage()));
+                }
+            }
+
+            recommendationService.setEvaluatedRecommenders(user, layer, evaluatedRecommenders);
+        }
+    }
+
+    private Optional<EvaluatedRecommender> considerRecommender(User user, Recommender recommender)
+        throws RecommendationException, ConcurrentException
+    {
+        var optFactory = recommendationService.getRecommenderFactory(recommender);
+        if (optFactory.isEmpty()) {
+            sendMissingFactoryNotification(user, recommender);
+            return Optional.empty();
+        }
+
+        var factory = optFactory.get();
+        if (!factory.accepts(recommender.getLayer(), recommender.getFeature())) {
+            return Optional.of(skipRecommenderWithInvalidSettings(user, recommender));
+        }
+
+        RecommendationEngine engine = factory.build(recommender);
+        if (TRAINING_NOT_SUPPORTED == engine.getTrainingCapability()) {
+            return Optional.of(activateNonTrainableRecommender(user, recommender, engine));
+        }
+
+        return Optional.of(skipTrainableRecommender(user, recommender));
+    }
+
+    private EvaluatedRecommender activateNonTrainableRecommender(User user, Recommender recommender,
+            RecommendationEngine aEngine)
+    {
+        RecommenderContext ctx = aEngine.newContext(recommendationService
+                .getContext(user, recommender).orElse(RecommenderContext.EMPTY_CONTEXT));
+        ctx.setUser(user);
+        ctx.close();
+        recommendationService.putContext(user, recommender, ctx);
+
+        String recommenderName = recommender.getName();
+        log.debug("[{}][{}]: Activating [{}] non-trainable recommender", user.getUsername(),
+                recommenderName, recommenderName);
+        info("Recommender [%s] activated because it is not trainable", recommenderName);
+        return EvaluatedRecommender.makeActiveWithoutEvaluation(recommender);
+    }
+
+    private EvaluatedRecommender skipTrainableRecommender(User user, Recommender recommender)
+    {
+        String recommenderName = recommender.getName();
+        log.info("[{}][{}]: Recommender requires training " + "- skipping recommender",
+                user.getUsername(), recommenderName);
+        info("Recommender [%s] requires training - skipping recommender", recommenderName);
+        return EvaluatedRecommender.makeInactiveWithoutEvaluation(recommender, "Requires training");
+    }
+
+    private EvaluatedRecommender skipRecommenderWithInvalidSettings(User user,
+            Recommender recommender)
+    {
+        String recommenderName = recommender.getName();
+        log.info("[{}][{}]: Recommender configured with invalid layer or feature "
+                + "- skipping recommender", user.getUsername(), recommenderName);
+        info("Recommender [%s] configured with invalid layer or feature - skipping recommender",
+                recommenderName);
+        return EvaluatedRecommender.makeInactiveWithoutEvaluation(recommender,
+                "Invalid layer or feature");
+    }
+
+    private void sendMissingFactoryNotification(User user, Recommender recommender)
+    {
+        log.error("[{}][{}]: No recommender factory available for [{}]", user.getUsername(),
+                recommender.getName(), recommender.getTool());
+        appEventPublisher.publishEvent(new SelectionTaskEvent(this, recommender, user.getUsername(),
+                String.format("No recommender factory available for %s", recommender.getTool())));
+    }
+
+    private Optional<Recommender> freshenRecommender(User aUser, Recommender r)
+    {
+        // Make sure we have the latest recommender config from the DB - the one from
+        // the active recommenders list may be outdated
+        Recommender recommender;
+        try {
+            recommender = recommendationService.getRecommender(r.getId());
+        }
+        catch (NoResultException e) {
+            log.info("[{}][{}]: Recommender no longer available... skipping", aUser.getUsername(),
+                    r.getName());
+            return Optional.empty();
+        }
+
+        if (!recommender.isEnabled()) {
+            log.debug("[{}][{}]: Disabled - skipping", aUser.getUsername(), recommender.getName());
+            return Optional.empty();
+        }
+
+        return Optional.of(recommender);
+    }
+}

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/RecommendationTask_ImplBase.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/RecommendationTask_ImplBase.java
@@ -1,4 +1,23 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.tudarmstadt.ukp.inception.recommendation.tasks;
+
+import static java.util.Collections.unmodifiableList;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,7 +54,7 @@ public abstract class RecommendationTask_ImplBase
 
     public List<LogMessage> getLogMessages()
     {
-        return logMessages;
+        return unmodifiableList(logMessages);
     }
 
     public void info(String aFormat, Object... aValues)

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/RecommendationTask_ImplBase.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/RecommendationTask_ImplBase.java
@@ -1,0 +1,55 @@
+package de.tudarmstadt.ukp.inception.recommendation.tasks;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
+import de.tudarmstadt.ukp.clarin.webanno.support.logging.LogMessage;
+import de.tudarmstadt.ukp.inception.scheduling.Task;
+
+public abstract class RecommendationTask_ImplBase
+    extends Task
+{
+    private final List<LogMessage> logMessages = new ArrayList<>();
+
+    public RecommendationTask_ImplBase(Project aProject, String aTrigger)
+    {
+        super(aProject, aTrigger);
+    }
+
+    public RecommendationTask_ImplBase(User aUser, Project aProject, String aTrigger)
+    {
+        super(aUser, aProject, aTrigger);
+    }
+
+    public void inheritLog(List<LogMessage> aLogMessages)
+    {
+        logMessages.addAll(aLogMessages);
+    }
+
+    public void inheritLog(RecommendationTask_ImplBase aOther)
+    {
+        logMessages.addAll(aOther.logMessages);
+    }
+
+    public List<LogMessage> getLogMessages()
+    {
+        return logMessages;
+    }
+
+    public void info(String aFormat, Object... aValues)
+    {
+        logMessages.add(LogMessage.info(this, aFormat, aValues));
+    }
+
+    public void warn(String aFormat, Object... aValues)
+    {
+        logMessages.add(LogMessage.warn(this, aFormat, aValues));
+    }
+
+    public void error(String aFormat, Object... aValues)
+    {
+        logMessages.add(LogMessage.error(this, aFormat, aValues));
+    }
+}

--- a/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImplIntegrationTest.java
+++ b/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImplIntegrationTest.java
@@ -85,7 +85,7 @@ public class RecommendationServiceImplIntegrationTest
     {
         openMocks(this);
 
-        sut = new RecommendationServiceImpl(null, null, recommenderFactoryRegistry, null,
+        sut = new RecommendationServiceImpl(null, null, null, recommenderFactoryRegistry, null,
                 annoService, null, null, testEntityManager.getEntityManager());
 
         project = createProject(PROJECT_NAME);

--- a/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RelationSuggestionVisibilityCalculationTest.java
+++ b/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RelationSuggestionVisibilityCalculationTest.java
@@ -82,8 +82,8 @@ public class RelationSuggestionVisibilityCalculationTest
         when(annoService.listAnnotationFeature(layer)).thenReturn(featureList);
         when(annoService.listSupportedFeatures(layer)).thenReturn(featureList);
 
-        sut = new RecommendationServiceImpl(null, null, null, null, annoService, null,
-                recordService, (EntityManager) null);
+        sut = new RecommendationServiceImpl(null, null, null, null, null, annoService, null,
+                recordService, null, (EntityManager) null, null);
     }
 
     @Test

--- a/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/SpanSuggestionVisibilityCalculationTest.java
+++ b/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/SpanSuggestionVisibilityCalculationTest.java
@@ -82,7 +82,7 @@ public class SpanSuggestionVisibilityCalculationTest
         when(annoService.listAnnotationFeature(layer)).thenReturn(featureList);
         when(annoService.listSupportedFeatures(layer)).thenReturn(featureList);
 
-        sut = new RecommendationServiceImpl(null, null, null, null, annoService, null,
+        sut = new RecommendationServiceImpl(null, null, null, null, null, annoService, null,
                 recordService, (EntityManager) null);
     }
 

--- a/inception/inception-scheduling/src/main/java/de/tudarmstadt/ukp/inception/scheduling/SchedulingService.java
+++ b/inception/inception-scheduling/src/main/java/de/tudarmstadt/ukp/inception/scheduling/SchedulingService.java
@@ -76,4 +76,6 @@ public interface SchedulingService
      *            The project whose tasks will be removed.
      */
     void stopAllTasksForProject(Project aProject);
+
+    void executeSync(Task aTask);
 }

--- a/inception/inception-scheduling/src/main/java/de/tudarmstadt/ukp/inception/scheduling/SchedulingServiceImpl.java
+++ b/inception/inception-scheduling/src/main/java/de/tudarmstadt/ukp/inception/scheduling/SchedulingServiceImpl.java
@@ -369,4 +369,13 @@ public class SchedulingServiceImpl
         getScheduledTasks().forEach(t -> log.debug("Scheduled: {}", t));
         getRunningTasks().forEach(t -> log.debug("Running  : {}", t));
     }
+
+    @Override
+    public void executeSync(Task aTask)
+    {
+        AutowireCapableBeanFactory factory = applicationContext.getAutowireCapableBeanFactory();
+        factory.autowireBean(aTask);
+        factory.initializeBean(aTask, "transientTask");
+        aTask.execute(); // Execute synchronously - blocking
+    }
 }


### PR DESCRIPTION
**What's in the PR**
- Added a per-project option to wait for non-trainable recommenders to provide suggestions before accessing a document (off by default)
- Refactoring of the recommender tasks
- Refactoring of the selection task to be more readable

**How to test manually**
* Configure a non-trainable recommender, e.g. a non-trainable external recommender or an ELG recommender
* Access the annotation page with the option disabled - access should be immediate, recommendations may appear only later
* Log out - log back in
* Enable the wait option and then access the annotation page - access should be blocked until recommendations have been retrieved (or until ELG runs into a timeout...)

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
