### PR TITLE
#1778 - Make tokenization editable

### DIFF
--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/layers/ProjectLayersPanel.java
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/layers/ProjectLayersPanel.java
@@ -88,6 +88,8 @@ import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.TagSet;
 import de.tudarmstadt.ukp.clarin.webanno.project.initializers.LayerInitializer;
+import de.tudarmstadt.ukp.clarin.webanno.project.initializers.SentenceLayerInitializer;
+import de.tudarmstadt.ukp.clarin.webanno.project.initializers.TokenLayerInitializer;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.clarin.webanno.support.JSONUtil;
@@ -293,6 +295,10 @@ public class ProjectLayersPanel
             return repository.listProjectInitializers().stream()
                     .filter(initializer -> initializer instanceof LayerInitializer)
                     .filter(initializer -> !initializer.alreadyApplied(getModelObject()))
+                    .filter(initializer -> !(initializer instanceof TokenLayerInitializer)
+                            || annotationEditorProperties.isTokenLayerEditable())
+                    .filter(initializer -> !(initializer instanceof SentenceLayerInitializer)
+                            || annotationEditorProperties.isSentenceLayerEditable())
                     .sorted(comparing(ProjectInitializer::getName)) //
                     .collect(toList());
         }


### PR DESCRIPTION
**What's in the PR**
- Do not offer adding a token or sentence layer via the layer initializers menu on the project layers panel unless token/sentence editing is actually enabled

**How to test manually**
* Go to the project layers pane on a new project and see if adding "Sentence" is offered

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
