### PR TITLE
#2912 - Upgrade dependencies (24.0)

### DIFF
--- a/inception/pom.xml
+++ b/inception/pom.xml
@@ -71,13 +71,13 @@
 
     <dkpro.version>2.2.0</dkpro.version>
     <uima.version>3.3.0</uima.version>
-    <uimafit.version>3.2.0</uimafit.version>
+    <uimafit.version>3.3.0</uimafit.version>
 
-    <spring.version>5.3.20</spring.version>
-    <spring.boot.version>2.6.8</spring.boot.version>
-    <spring.security.version>5.6.5</spring.security.version>
-    <springdoc.version>1.6.8</springdoc.version>
-    <swagger.version>2.2.0</swagger.version>
+    <spring.version>5.3.21</spring.version>
+    <spring.boot.version>2.7.0</spring.boot.version>
+    <spring.security.version>5.7.1</spring.security.version>
+    <springdoc.version>1.6.9</springdoc.version>
+    <swagger.version>2.2.1</swagger.version>
 
     <slf4j.version>1.7.36</slf4j.version>
     <log4j2.version>2.17.2</log4j2.version>
@@ -85,7 +85,7 @@
 
     <groovy.version>3.0.10</groovy.version>
 
-    <tomcat.version>9.0.63</tomcat.version>
+    <tomcat.version>9.0.64</tomcat.version>
     <servlet-api.version>4.0.1</servlet-api.version>
 
     <mariadb.driver.version>2.7.5</mariadb.driver.version>
@@ -94,10 +94,10 @@
 
     <wicket.version>9.10.0</wicket.version>
     <wicketstuff.version>9.10.0</wicketstuff.version>
-    <wicket-jquery-ui.version>9.8.0</wicket-jquery-ui.version>
-    <wicket-bootstrap.version>6.0.0-M6</wicket-bootstrap.version>
+    <wicket-jquery-ui.version>9.8.1</wicket-jquery-ui.version>
+    <wicket-bootstrap.version>6.0.0-M7</wicket-bootstrap.version>
     <wicket-jquery-selectors.version>3.0.4</wicket-jquery-selectors.version>
-    <wicket-webjars.version>3.0.4</wicket-webjars.version>
+    <wicket-webjars.version>3.0.6</wicket-webjars.version>
     <wicket-spring-boot.version>3.1.6</wicket-spring-boot.version>
     <bootstrap.version>5.1.3</bootstrap.version>
     <hover.version>2.0.2</hover.version>


### PR DESCRIPTION
**What's in the PR**
- Apache UIMA uimaFIT 3.2.0 -> 3.3.0
- Spring 5.3.20 -> 5.3.21
- Spring Boot 2.6.8 -> 2.7.0
- Spring Security 5.6.5 -> 5.7.1
- Springdoc 1.6.8 -> 1.6.9
- Swagger API 2.2.0 -> 2.2.1
- Tomcat 9.0.63 -> 9.0.64
- Wicket Query 9.8.0 -> 9.8.1
- Wicket Bootstrap 6.0.0-M6 -> 6.0.0-M7
- Wicket Webjars 3.0.4 -> 3.0.6

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
