### PR TITLE
#3136 - Support reading compressed CASes from 24.0

### DIFF
--- a/inception/inception-api-dao/pom.xml
+++ b/inception/inception-api-dao/pom.xml
@@ -161,6 +161,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.xerial.snappy</groupId>
+      <artifactId>snappy-java</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <scope>provided</scope>
@@ -204,7 +209,7 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  
+
   <build>
     <pluginManagement>
       <plugins>

--- a/inception/pom.xml
+++ b/inception/pom.xml
@@ -1562,6 +1562,11 @@
         <artifactId>caffeine</artifactId>
         <version>3.0.5</version>
       </dependency>
+      <dependency>
+        <groupId>org.xerial.snappy</groupId>
+        <artifactId>snappy-java</artifactId>
+        <version>1.1.8.4</version>
+      </dependency>
 
       <!-- JAXB DEPENDENCIES -->
       <dependency>


### PR DESCRIPTION
**What's in the PR**
- Backport the code for detecting and reading compressed CASes from 24.x

**How to test manually**
* Run 24.x and update annotations in some document
* Go back to 23.x and check if the annotation document can be loaded

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
