### PR TITLE
#3142 - Ability to add/remove project permissions via remote API

### DIFF
--- a/inception/inception-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
+++ b/inception/inception-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
@@ -273,7 +273,7 @@ public class ProjectServiceImpl
         String query = String.join("\n", //
                 "FROM ProjectPermission ", //
                 "WHERE user =:user AND project =:project ", //
-                "ORDER BY level");
+                "ORDER BY user, level");
 
         return entityManager.createQuery(query, ProjectPermission.class) //
                 .setParameter("user", aUser) //
@@ -496,7 +496,8 @@ public class ProjectServiceImpl
     {
         String query = String.join("\n", //
                 "FROM ProjectPermission ", //
-                "WHERE project = :project");
+                "WHERE project = :project", //
+                "ORDER BY user, level");
         return entityManager.createQuery(query, ProjectPermission.class) //
                 .setParameter("project", aProject) //
                 .getResultList();

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/model/RPermission.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/model/RPermission.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.aero.model;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.ProjectPermission;
+
+public class RPermission
+{
+    public long project;
+    public String user;
+    public String role;
+
+    public RPermission(ProjectPermission aPermission)
+    {
+        project = aPermission.getProject().getId();
+        user = aPermission.getUser();
+        role = aPermission.getLevel().name();
+    }
+
+    public RPermission(long aProject, String aUser, String aRole)
+    {
+        project = aProject;
+        user = aUser;
+        role = aRole;
+    }
+}

--- a/inception/inception-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/AeroRemoteApiControllerTest.java
+++ b/inception/inception-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/AeroRemoteApiControllerTest.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi;
 
 import static de.tudarmstadt.ukp.clarin.webanno.security.model.Role.ROLE_ADMIN;
+import static de.tudarmstadt.ukp.clarin.webanno.security.model.Role.ROLE_USER;
 import static de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.aero.AeroRemoteApiController.API_BASE;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -131,6 +132,7 @@ public class AeroRemoteApiControllerTest
 
         if (!initialized) {
             userRepository.create(new User("admin", ROLE_ADMIN));
+            userRepository.create(new User("user", ROLE_USER));
             initialized = true;
         }
     }
@@ -291,6 +293,93 @@ public class AeroRemoteApiControllerTest
             .andExpect(jsonPath("$.body[0].id").value("1"))
             .andExpect(jsonPath("$.body[0].name").value("test.txt"))
             .andExpect(jsonPath("$.body[0].state").value("ANNOTATION-IN-PROGRESS"));
+        // @formatter:on
+    }
+
+    @Test
+    public void t006_testPermissionCreate() throws Exception
+    {
+        // @formatter:off
+        mvc.perform(post(API_BASE + "/projects/1/permissions/user")
+                .with(csrf().asHeader())
+                .with(user("admin").roles("ADMIN"))
+                .param("projectId", "1")
+                .param("userId", "user")
+                .param("roles", "ANNOTATOR", "CURATOR"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+            .andExpect(jsonPath("$.body[0].project").value("1"))
+            .andExpect(jsonPath("$.body[0].user").value("user"))
+            .andExpect(jsonPath("$.body[0].role").value("CURATOR"))
+            .andExpect(jsonPath("$.body[1].project").value("1"))
+            .andExpect(jsonPath("$.body[1].user").value("user"))
+            .andExpect(jsonPath("$.body[1].role").value("ANNOTATOR"));
+        // @formatter:on
+    }
+
+    @Test
+    public void t007_testPermissionListForUser() throws Exception
+    {
+        // @formatter:off
+        mvc.perform(get(API_BASE + "/projects/1/permissions/user")
+                .with(csrf().asHeader())
+                .with(user("admin").roles("ADMIN"))
+                .param("projectId", "1")
+                .param("userId", "user"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+            .andExpect(jsonPath("$.body[0].project").value("1"))
+            .andExpect(jsonPath("$.body[0].user").value("user"))
+            .andExpect(jsonPath("$.body[0].role").value("CURATOR"))
+            .andExpect(jsonPath("$.body[1].project").value("1"))
+            .andExpect(jsonPath("$.body[1].user").value("user"))
+            .andExpect(jsonPath("$.body[1].role").value("ANNOTATOR"));
+        // @formatter:on
+    }
+
+    @Test
+    public void t008_testPermissionListAll() throws Exception
+    {
+        // @formatter:off
+        mvc.perform(get(API_BASE + "/projects/1/permissions")
+                .with(csrf().asHeader())
+                .with(user("admin").roles("ADMIN"))
+                .param("projectId", "1"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+            .andExpect(jsonPath("$.body[0].project").value("1"))
+            .andExpect(jsonPath("$.body[0].user").value("admin"))
+            .andExpect(jsonPath("$.body[0].role").value("MANAGER"))
+            .andExpect(jsonPath("$.body[1].project").value("1"))
+            .andExpect(jsonPath("$.body[1].user").value("admin"))
+            .andExpect(jsonPath("$.body[1].role").value("CURATOR"))
+            .andExpect(jsonPath("$.body[2].project").value("1"))
+            .andExpect(jsonPath("$.body[2].user").value("admin"))
+            .andExpect(jsonPath("$.body[2].role").value("ANNOTATOR"))
+            .andExpect(jsonPath("$.body[3].project").value("1"))
+            .andExpect(jsonPath("$.body[3].user").value("user"))
+            .andExpect(jsonPath("$.body[3].role").value("CURATOR"))
+            .andExpect(jsonPath("$.body[4].project").value("1"))
+            .andExpect(jsonPath("$.body[4].user").value("user"))
+            .andExpect(jsonPath("$.body[4].role").value("ANNOTATOR"));
+        // @formatter:on
+    }
+
+    @Test
+    public void t009_testPermissionDelete() throws Exception
+    {
+        // @formatter:off
+        mvc.perform(delete(API_BASE + "/projects/1/permissions/user")
+                .with(csrf().asHeader())
+                .with(user("admin").roles("ADMIN"))
+                .param("projectId", "1")
+                .param("userId", "user")
+                .param("roles", "CURATOR"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+            .andExpect(jsonPath("$.body[0].project").value("1"))
+            .andExpect(jsonPath("$.body[0].user").value("user"))
+            .andExpect(jsonPath("$.body[0].role").value("ANNOTATOR"));
         // @formatter:on
     }
 


### PR DESCRIPTION
**What's in the PR**
- Added calls to manage project permissions

**How to test manually**
* Use the Swagger UI to test the calls

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
