### PR TITLE
#3146 - Bad credentials to remote API redirect to login HTML page

### DIFF
--- a/inception/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/app/config/InceptionSecurity.java
+++ b/inception/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/app/config/InceptionSecurity.java
@@ -193,6 +193,7 @@ public class InceptionSecurity
                     .antMatchers("/assets/**").permitAll()
                     .antMatchers("/images/**").permitAll()
                     .antMatchers("/resources/**").permitAll()
+                    .antMatchers("/whoops").permitAll()
                     .antMatchers("/about/**").permitAll()
                     .antMatchers("/wicket/resource/**").permitAll()
                     .antMatchers("/" + NS_PROJECT + "/*/join-project/**").permitAll()

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/ErrorPage.html
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/ErrorPage.html
@@ -67,7 +67,7 @@
             <td><span wicket:id="appVersion" /></td>
           </tr>
 
-          <tr>
+          <tr wicket:enclosure="javaVendor">
             <th>Java&nbsp;version</th>
             <td>
               <span wicket:id="javaVendor" />
@@ -75,7 +75,7 @@
             </td>
           </tr>
 
-          <tr>
+          <tr wicket:enclosure="javaVendor">
             <th>Operating&nbsp;system</th>
             <td>
               <span wicket:id="osName" />


### PR DESCRIPTION
**What's in the PR**
- Allow access to error page without login (thus avoiding the redirection to the login page when trying to render the error page to an anonymous user)
- Do not render OS, Java, etc. details to unauthorized users on the error page
- When the client says to accept JSON or the request URL looks like an API url, return a JSON response instead of rendering the page as HTML

**How to test manually**
* Try providing bad credentials to the remote API

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
