### PR TITLE
#3164 - Include additional information in webhook notification

### DIFF
--- a/inception/inception-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/event/AnnotationStateChangeEvent.java
+++ b/inception/inception-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/event/AnnotationStateChangeEvent.java
@@ -18,6 +18,8 @@
 package de.tudarmstadt.ukp.clarin.webanno.api.event;
 
 import org.springframework.context.ApplicationEvent;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
@@ -28,6 +30,7 @@ public class AnnotationStateChangeEvent
 {
     private static final long serialVersionUID = 2369088588078065027L;
 
+    private String user;
     private AnnotationDocument annotationDocument;
     private AnnotationDocumentState previousState;
     private AnnotationDocumentState newState;
@@ -39,6 +42,14 @@ public class AnnotationStateChangeEvent
         annotationDocument = aAnnotation;
         newState = aAnnotation.getState();
         previousState = aPreviousState;
+
+        SecurityContext context = SecurityContextHolder.getContext();
+        if (context.getAuthentication() != null) {
+            user = context.getAuthentication().getName();
+        }
+        else {
+            user = "<SYSTEM>";
+        }
     }
 
     public SourceDocument getDocument()
@@ -59,5 +70,10 @@ public class AnnotationStateChangeEvent
     public AnnotationDocumentState getNewState()
     {
         return newState;
+    }
+
+    public String getUser()
+    {
+        return user;
     }
 }

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/AnnotationStateChangedEventAdapter.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/AnnotationStateChangedEventAdapter.java
@@ -59,6 +59,12 @@ public class AnnotationStateChangedEventAdapter
     }
 
     @Override
+    public String getUser(AnnotationStateChangeEvent aEvent)
+    {
+        return aEvent.getUser();
+    }
+
+    @Override
     public String getDetails(AnnotationStateChangeEvent aEvent) throws IOException
     {
         StateChangeDetails details = new StateChangeDetails();

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/webhooks/WebhookService.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/webhooks/WebhookService.java
@@ -176,13 +176,25 @@ public class WebhookService
                 }
                 catch (Exception e) {
                     if (hookAndCount.getValue().get() < configuration.getRetryCount()) {
-                        log.error("Unable to send webhook [{}] ... retrying in a moment",
-                                hookAndCount.getKey(), e);
+                        if (log.isDebugEnabled()) {
+                            log.error("Unable to send webhook [{}]: {} - retrying in a moment",
+                                    hookAndCount.getKey().getUrl(), e.getMessage(), e);
+                        }
+                        else {
+                            log.error("Unable to send webhook [{}]: {} - retrying in a moment",
+                                    hookAndCount.getKey().getUrl(), e.getMessage());
+                        }
                         hookAndCount.getValue().incrementAndGet();
                     }
                     else {
-                        log.error("Unable to invoke webhook [{}] - giving up",
-                                hookAndCount.getKey(), e);
+                        if (log.isDebugEnabled()) {
+                            log.error("Unable to invoke webhook [{}]: {} - giving up",
+                                    hookAndCount.getKey().getUrl(), e.getMessage(), e);
+                        }
+                        else {
+                            log.error("Unable to invoke webhook [{}]: {} - giving up",
+                                    hookAndCount.getKey().getUrl(), e.getMessage());
+                        }
                         i.remove();
                     }
                 }

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/webhooks/json/AnnotationStateChangeMessage.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/webhooks/json/AnnotationStateChangeMessage.java
@@ -17,11 +17,16 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.webhooks.json;
 
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
 import de.tudarmstadt.ukp.clarin.webanno.api.event.AnnotationStateChangeEvent;
 import de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.aero.AeroRemoteApiController;
 
 public class AnnotationStateChangeMessage
 {
+    private long timestamp;
+
     private long projectId;
     private String projectName;
 
@@ -40,6 +45,8 @@ public class AnnotationStateChangeMessage
 
     public AnnotationStateChangeMessage(AnnotationStateChangeEvent aEvent)
     {
+        timestamp = aEvent.getTimestamp();
+
         projectId = aEvent.getDocument().getProject().getId();
         projectName = aEvent.getDocument().getProject().getName();
 
@@ -52,6 +59,16 @@ public class AnnotationStateChangeMessage
                 .annotationDocumentStateToString(aEvent.getNewState());
         annotationPreviousState = AeroRemoteApiController
                 .annotationDocumentStateToString(aEvent.getPreviousState());
+    }
+
+    public long getTimestamp()
+    {
+        return timestamp;
+    }
+
+    public void setTimestamp(long aTimestamp)
+    {
+        timestamp = aTimestamp;
     }
 
     public long getProjectId()
@@ -122,5 +139,16 @@ public class AnnotationStateChangeMessage
     public void setAnnotationUser(String aAnnotationUser)
     {
         annotationUser = aAnnotationUser;
+    }
+
+    @Override
+    public String toString()
+    {
+        return new ToStringBuilder(this, ToStringStyle.JSON_STYLE).append("timestamp", timestamp)
+                .append("projectId", projectId).append("projectName", projectName)
+                .append("documentId", documentId).append("documentName", documentName)
+                .append("annotationUser", annotationUser)
+                .append("annotationPreviousState", annotationPreviousState)
+                .append("annotationState", annotationState).toString();
     }
 }

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/webhooks/json/AnnotationStateChangeMessage.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/webhooks/json/AnnotationStateChangeMessage.java
@@ -33,10 +33,12 @@ public class AnnotationStateChangeMessage
     private long documentId;
     private String documentName;
 
+    private String user;
     private String annotationUser;
 
     private String annotationPreviousState;
     private String annotationState;
+    private String annotatorAnnotationState;
 
     public AnnotationStateChangeMessage()
     {
@@ -53,12 +55,15 @@ public class AnnotationStateChangeMessage
         documentId = aEvent.getDocument().getId();
         documentName = aEvent.getDocument().getName();
 
+        user = aEvent.getUser();
         annotationUser = aEvent.getAnnotationDocument().getUser();
 
         annotationState = AeroRemoteApiController
                 .annotationDocumentStateToString(aEvent.getNewState());
         annotationPreviousState = AeroRemoteApiController
                 .annotationDocumentStateToString(aEvent.getPreviousState());
+        annotatorAnnotationState = AeroRemoteApiController.annotationDocumentStateToString(
+                aEvent.getAnnotationDocument().getAnnotatorState());
     }
 
     public long getTimestamp()
@@ -141,14 +146,35 @@ public class AnnotationStateChangeMessage
         annotationUser = aAnnotationUser;
     }
 
+    public String getUser()
+    {
+        return user;
+    }
+
+    public void setUser(String aUser)
+    {
+        user = aUser;
+    }
+
+    public String getAnnotatorAnnotationState()
+    {
+        return annotatorAnnotationState;
+    }
+
+    public void setAnnotatorAnnotationState(String aAnnotatorAnnotationState)
+    {
+        annotatorAnnotationState = aAnnotatorAnnotationState;
+    }
+
     @Override
     public String toString()
     {
         return new ToStringBuilder(this, ToStringStyle.JSON_STYLE).append("timestamp", timestamp)
                 .append("projectId", projectId).append("projectName", projectName)
                 .append("documentId", documentId).append("documentName", documentName)
-                .append("annotationUser", annotationUser)
+                .append("user", user).append("annotationUser", annotationUser)
                 .append("annotationPreviousState", annotationPreviousState)
-                .append("annotationState", annotationState).toString();
+                .append("annotationState", annotationState)
+                .append("annotatorAnnotationState", annotatorAnnotationState).toString();
     }
 }

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/webhooks/json/DocumentStateChangeMessage.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/webhooks/json/DocumentStateChangeMessage.java
@@ -17,11 +17,16 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.webhooks.json;
 
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+
 import de.tudarmstadt.ukp.clarin.webanno.api.event.DocumentStateChangedEvent;
 import de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.aero.AeroRemoteApiController;
 
 public class DocumentStateChangeMessage
 {
+    private long timestamp;
+
     private long projectId;
     private String projectName;
 
@@ -38,6 +43,8 @@ public class DocumentStateChangeMessage
 
     public DocumentStateChangeMessage(DocumentStateChangedEvent aEvent)
     {
+        timestamp = aEvent.getTimestamp();
+
         projectId = aEvent.getDocument().getProject().getId();
         projectName = aEvent.getDocument().getProject().getName();
 
@@ -47,6 +54,16 @@ public class DocumentStateChangeMessage
         documentState = AeroRemoteApiController.sourceDocumentStateToString(aEvent.getNewState());
         documentPreviousState = AeroRemoteApiController
                 .sourceDocumentStateToString(aEvent.getPreviousState());
+    }
+
+    public long getTimestamp()
+    {
+        return timestamp;
+    }
+
+    public void setTimestamp(long aTimestamp)
+    {
+        timestamp = aTimestamp;
     }
 
     public long getProjectId()
@@ -107,5 +124,15 @@ public class DocumentStateChangeMessage
     public void setDocumentState(String aDocumentState)
     {
         documentState = aDocumentState;
+    }
+
+    @Override
+    public String toString()
+    {
+        return new ToStringBuilder(this, ToStringStyle.JSON_STYLE).append("timestamp", timestamp)
+                .append("projectId", projectId).append("projectName", projectName)
+                .append("documentId", documentId).append("documentName", documentName)
+                .append("documentPreviousState", documentPreviousState)
+                .append("documentState", documentState).toString();
     }
 }

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/webhooks/json/ProjectStateChangeMessage.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/webhooks/json/ProjectStateChangeMessage.java
@@ -26,6 +26,8 @@ import de.tudarmstadt.ukp.clarin.webanno.api.event.ProjectStateChangedEvent;
 
 public class ProjectStateChangeMessage
 {
+    private long timestamp;
+
     private long projectId;
     private String projectName;
 
@@ -39,11 +41,23 @@ public class ProjectStateChangeMessage
 
     public ProjectStateChangeMessage(ProjectStateChangedEvent aEvent)
     {
+        timestamp = aEvent.getTimestamp();
+
         projectId = aEvent.getProject().getId();
         projectName = aEvent.getProject().getName();
 
         projectState = projectStateToString(aEvent.getNewState());
         projectPreviousState = projectStateToString(aEvent.getPreviousState());
+    }
+
+    public long getTimestamp()
+    {
+        return timestamp;
+    }
+
+    public void setTimestamp(long aTimestamp)
+    {
+        timestamp = aTimestamp;
     }
 
     public long getProjectId()
@@ -89,7 +103,8 @@ public class ProjectStateChangeMessage
     @Override
     public String toString()
     {
-        return new ToStringBuilder(this, ToStringStyle.SIMPLE_STYLE) //
+        return new ToStringBuilder(this, ToStringStyle.JSON_STYLE) //
+                .append("timestamp", timestamp) //
                 .append("projectId", projectId) //
                 .append("projectName", projectName) //
                 .append("projectPreviousState", projectPreviousState) //

--- a/inception/inception-remote/src/main/resources/META-INF/asciidoc/admin-guide/remote-api-webhooks.adoc
+++ b/inception/inception-remote/src/main/resources/META-INF/asciidoc/admin-guide/remote-api-webhooks.adoc
@@ -69,6 +69,13 @@ webhooks.retry-delay=5000
 
 NOTE: Events being triggered while {product-name} is being shut down may not trigger any webhook deliveries.
 
+== Bulk changes
+
+When performing bulk changes of annotation states (i.e. via the workload management page), no 
+individual `ANNOTATION_STATE` events are  generated. The document and project states are re-calculated
+after the bulk change and depending on whether the bulk action had any effect on them,
+`DOCUMENT_STATE` and/or `PROJECT_STATE` events are generated.
+
 == Message examples
 
 When a webhook is triggered, it sends a HTTP `POST` request to the configured URL. The `X-AERO-Notification` header indicates the topic and the body of the request is a JSON structure providing
@@ -78,6 +85,7 @@ convenient - the actual messages are not pretty-printed.
 .Example `PROJECT_STATE`
 ----
 {
+  "timestamp": 1234567890,
   "projectId": 123,
   "projectName": "Example project",
   "projectPreviousState": "CURATION-IN-PROGRESS",
@@ -88,6 +96,7 @@ convenient - the actual messages are not pretty-printed.
 .Example `DOCUMENT_STATE`
 ----
 {
+  "timestamp": 1234567890,
   "projectId": 123,
   "projectName": "Example project",
   "documentId": 565,
@@ -100,12 +109,26 @@ convenient - the actual messages are not pretty-printed.
 .Example `ANNOTATION_STATE`
 ----
 {
+  "timestamp": 1234567890,
   "projectId": 123,
   "projectName": "Example project",
   "documentId": 565,
   "documentName": "document.txt",
+  "user": "annotator1",
   "annotationUser": "annotator1",
   "annotationPreviousState": "COMPLETE",
-  "annotationState": "LOCKED"
+  "annotationState": "COMPLETE",
+  "annotatorAnnotationState": "IN_PROGRESS"
 }
 ----
+
+In the `ANNOTATION_STATE` message, we have two fields containing a user name: `user` and `annotationUser`.
+Usually, these two fields will be the same. They differ if a user changes the state of a document
+of another user. An example is when a curator marks the curation of a document as finished. In this
+case, the curator's username is in the field `user` while the `annotationUser` field has the value
+`CURATION_USER`.
+
+The effective annotation state can be found in the `annotationState` field. However, it can be the
+case that a manager has overridden the state, e.g. because an annotator forgot to mark a document
+as finished. The `annotatorAnnotationState` field contains the state that was  (implicitly) set by the
+annotator.

--- a/inception/inception-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/webhooks/WebhookServiceTest.java
+++ b/inception/inception-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/webhooks/WebhookServiceTest.java
@@ -137,6 +137,7 @@ public class WebhookServiceTest
         ann.setId(3l);
         ann.setDocument(doc);
         ann.setState(AnnotationDocumentState.FINISHED);
+        ann.setAnnotatorState(AnnotationDocumentState.IN_PROGRESS);
     }
 
     @Test

--- a/inception/inception-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/webhooks/WebhookServiceTest.java
+++ b/inception/inception-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/webhooks/WebhookServiceTest.java
@@ -25,17 +25,23 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.client.RestTemplateAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.servlet.DispatcherServletAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.servlet.ServletWebServerFactoryAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
@@ -59,17 +65,27 @@ import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.ProjectState;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState;
+import de.tudarmstadt.ukp.clarin.webanno.security.config.SecurityAutoConfiguration;
 import de.tudarmstadt.ukp.clarin.webanno.support.ApplicationContextProvider;
+import de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.config.RemoteApiAutoConfiguration;
+import de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.webhooks.WebhookServiceTest.TestService;
 import de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.webhooks.json.AnnotationStateChangeMessage;
 import de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.webhooks.json.DocumentStateChangeMessage;
 import de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.webhooks.json.ProjectStateChangeMessage;
-import de.tudarmstadt.ukp.inception.log.config.EventLoggingAutoConfiguration;
 
-@SpringBootApplication(exclude = { //
-        EventLoggingAutoConfiguration.class, //
-        SecurityAutoConfiguration.class, //
-        LiquibaseAutoConfiguration.class })
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, //
+@ImportAutoConfiguration( //
+        exclude = { //
+                SecurityAutoConfiguration.class, //
+                LiquibaseAutoConfiguration.class }, //
+        classes = { //
+                ServletWebServerFactoryAutoConfiguration.class, //
+                RestTemplateAutoConfiguration.class, //
+                DispatcherServletAutoConfiguration.class, //
+                WebMvcAutoConfiguration.class, //
+                RemoteApiAutoConfiguration.class, //
+                TestService.class })
+@SpringBootTest( //
+        webEnvironment = WebEnvironment.RANDOM_PORT, //
         properties = { //
                 "spring.main.banner-mode=off",
                 "repository.path=" + WebhookServiceTest.TEST_OUTPUT_FOLDER })
@@ -79,6 +95,8 @@ import de.tudarmstadt.ukp.inception.log.config.EventLoggingAutoConfiguration;
 public class WebhookServiceTest
 {
     static final String TEST_OUTPUT_FOLDER = "target/test-output/WebhookServiceTest";
+
+    private final static Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private @LocalServerPort int port;
     private @Autowired ApplicationEventPublisher applicationEventPublisher;
@@ -227,6 +245,7 @@ public class WebhookServiceTest
                 @RequestBody ProjectStateChangeMessage aMsg)
             throws Exception
         {
+            LOG.info("Recieved: {}", aMsg);
             projectStateChangeMsgs.add(Pair.of(aMsg, aHeaders));
             return ResponseEntity.ok().build();
         }
@@ -240,6 +259,7 @@ public class WebhookServiceTest
                 @RequestBody DocumentStateChangeMessage aMsg)
             throws Exception
         {
+            LOG.info("Recieved: {}", aMsg);
             docStateChangeMsgs.add(Pair.of(aMsg, aHeaders));
             return ResponseEntity.ok().build();
         }
@@ -253,6 +273,7 @@ public class WebhookServiceTest
                 @RequestBody AnnotationStateChangeMessage aMsg)
             throws Exception
         {
+            LOG.info("Recieved: {}", aMsg);
             annStateChangeMsgs.add(Pair.of(aMsg, aHeaders));
             return ResponseEntity.ok().build();
         }

--- a/inception/inception-remote/src/test/resources/log4j2.xml
+++ b/inception/inception-remote/src/test/resources/log4j2.xml
@@ -6,7 +6,7 @@
     </Console>
   </Appenders>
   <Loggers>
-    <Logger name="de.tudarmstadt" level="DEBUG"/>
+    <Logger name="de.tudarmstadt" level="INFO"/>
     <Root level="warn">
       <AppenderRef ref="ConsoleAppender" />
     </Root>


### PR DESCRIPTION
**What's in the PR**
- Include timestamp information
- Triggering user in the `ANNOTATION_STATE` events
- State set by annotator in the `ANNOTATION_STATE` events

**How to test manually**
* Configure a webhook and check if the notifications you get contain the additional information

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [x] PR updates documentation
