### PR TITLE
#3167 - Ability to set default admin username

### DIFF
--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/installation_unsupervised.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/installation_unsupervised.adoc
@@ -22,10 +22,12 @@ To perform an unsupervised installations of {product-name}, you can:
 * create the `admin` account with the `ROLE_REMOTE`
 * enable/disable telemetry support to avoid the admin being asked on the first login
 
-.Custom default admin password
-To set a custom default admin password, add the following line to the `settings.properties` file:
+.Custom default admin user/password
+To set a custom default admin user name and password, add the following line to the `settings.properties` 
+file. If no custom user name is set, the default `admin` is used.:
 
 ```
+security.default-admin-username=mastermind
 security.default-admin-password={bcrypt}XXXXXX
 ```
 

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/NameUtil.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/NameUtil.java
@@ -15,18 +15,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package de.tudarmstadt.ukp.clarin.webanno.ui.core.page;
+package de.tudarmstadt.ukp.clarin.webanno.security;
 
 import static org.apache.commons.lang3.StringUtils.containsNone;
 
 public class NameUtil
 {
-    public static final String WEBANNO_ILLEGAL_CHARACTERS = "^/\\&*?+$![]";
+    public static final String WEBANNO_ILLEGAL_CHARACTERS = "^/\\&*?+$![] ";
 
     public static final String BAD_FOR_FILENAMES = "#%&{}\\<>*?/ $!'\":@+`|=";
 
     /**
-     * Check if the name is valid, SPecial characters are not allowed as a project/user name as it
+     * Check if the name is valid, special characters are not allowed as a project/user name as it
      * will conflict with file naming system
      * 
      * @param aName

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/config/SecurityProperties.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/config/SecurityProperties.java
@@ -22,9 +22,9 @@ import de.tudarmstadt.ukp.clarin.webanno.security.model.Role;
 public interface SecurityProperties
 {
     /**
-     * @return encoded default password for the admin user. If this is set, the system will create
-     *         the admin user with the given encoded password on startup unless the user already
-     *         exists.
+     * @return encoded default password for the default admin user. If this is set, the system will
+     *         create the admin user with the given encoded password on startup unless the user
+     *         already exists.
      */
     String getDefaultAdminPassword();
 
@@ -34,4 +34,9 @@ public interface SecurityProperties
      *         also set.
      */
     boolean isDefaultAdminRemoteAccess();
+
+    /**
+     * @return username for the default admin user.
+     */
+    String getDefaultAdminUsername();
 }

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/config/SecurityPropertiesImpl.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/config/SecurityPropertiesImpl.java
@@ -26,9 +26,22 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class SecurityPropertiesImpl
     implements SecurityProperties
 {
+    private String defaultAdminUsername;
+
     private String defaultAdminPassword;
 
     private boolean defaultAdminRemoteAccess = false;
+
+    @Override
+    public String getDefaultAdminUsername()
+    {
+        return defaultAdminUsername;
+    }
+
+    public void setDefaultAdminUsername(String aDefaultAdminUsername)
+    {
+        defaultAdminUsername = aDefaultAdminUsername;
+    }
 
     @Override
     public String getDefaultAdminPassword()

--- a/inception/inception-security/src/test/java/de/tudarmstadt/ukp/clarin/webanno/security/UserDaoImplTest.java
+++ b/inception/inception-security/src/test/java/de/tudarmstadt/ukp/clarin/webanno/security/UserDaoImplTest.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+
+import de.tudarmstadt.ukp.clarin.webanno.security.config.SecurityAutoConfiguration;
+import de.tudarmstadt.ukp.clarin.webanno.security.config.SecurityPropertiesImpl;
+import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
+
+@DataJpaTest(showSql = false)
+@EnableAutoConfiguration
+@ImportAutoConfiguration( //
+        exclude = { LiquibaseAutoConfiguration.class }, //
+        classes = { SecurityAutoConfiguration.class })
+@EntityScan({ //
+        "de.tudarmstadt.ukp.clarin.webanno.security.model" })
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+class UserDaoImplTest
+{
+    @Autowired
+    SecurityPropertiesImpl securityProperties;
+
+    @Autowired
+    UserDaoImpl userDao;
+
+    @Test
+    void thatInvalidDefaultUserNameIsRejected()
+    {
+        securityProperties.setDefaultAdminUsername("blörg $[]");
+        securityProperties.setDefaultAdminPassword("blah");
+
+        assertThat(NameUtil.isNameValidUserName(securityProperties.getDefaultAdminUsername()))
+                .isFalse();
+        assertThatIllegalStateException() //
+                .isThrownBy(() -> userDao.installDefaultAdminUser());
+    }
+
+    @Test
+    void thatCustomAdminUserIsCreated()
+    {
+        var username = "overlord";
+        var password = "super-secret";
+        securityProperties.setDefaultAdminUsername(username);
+        securityProperties.setDefaultAdminPassword(password);
+
+        userDao.installDefaultAdminUser();
+
+        User user = userDao.get(username);
+        assertThat(user).isNotNull();
+        assertThat(user.getUsername()).isEqualTo(username);
+        assertThat(user.getPassword()).isEqualTo(password);
+    }
+
+    @Test
+    void thatCustomAdminUserIsCreatedWithDefaultUsername()
+    {
+        var username = "admin";
+        var password = "super-secret";
+        securityProperties.setDefaultAdminUsername(null);
+        securityProperties.setDefaultAdminPassword(password);
+
+        userDao.installDefaultAdminUser();
+
+        User user = userDao.get(username);
+        assertThat(user).isNotNull();
+        assertThat(user.getUsername()).isEqualTo(username);
+        assertThat(user.getPassword()).isEqualTo(password);
+    }
+
+    @Test
+    void thatCustomAdminUserIsOnlyCreatedWhenPasswordIsSet()
+    {
+        var username = "overlord";
+        securityProperties.setDefaultAdminUsername(username);
+        securityProperties.setDefaultAdminPassword(null);
+
+        userDao.installDefaultAdminUser();
+
+        assertThat(userDao.get(username)).isNull();
+        assertThat(userDao.get("admin")).isNull();
+    }
+
+    @SpringBootConfiguration
+    public static class SpringConfig
+    {
+        // No content
+    }
+}

--- a/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/InviteServiceImpl.java
+++ b/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/InviteServiceImpl.java
@@ -18,10 +18,10 @@
 package de.tudarmstadt.ukp.inception.sharing;
 
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.ANNOTATOR;
+import static de.tudarmstadt.ukp.clarin.webanno.security.NameUtil.isNameValidUserName;
 import static de.tudarmstadt.ukp.clarin.webanno.security.UserDao.EMPTY_PASSWORD;
 import static de.tudarmstadt.ukp.clarin.webanno.security.UserDao.REALM_PROJECT_PREFIX;
 import static de.tudarmstadt.ukp.clarin.webanno.security.model.Role.ROLE_USER;
-import static de.tudarmstadt.ukp.clarin.webanno.ui.core.page.NameUtil.isNameValidUserName;
 import static de.tudarmstadt.ukp.clarin.webanno.ui.core.page.ProjectPageBase.NS_PROJECT;
 import static de.tudarmstadt.ukp.inception.sharing.model.Mandatoriness.NOT_ALLOWED;
 

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/users/ManageUsersPage.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/users/ManageUsersPage.java
@@ -17,10 +17,10 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.ui.core.users;
 
+import static de.tudarmstadt.ukp.clarin.webanno.security.NameUtil.isNameValidUserName;
 import static de.tudarmstadt.ukp.clarin.webanno.security.UserDao.isProfileSelfServiceAllowed;
 import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.enabledWhen;
 import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
-import static de.tudarmstadt.ukp.clarin.webanno.ui.core.page.NameUtil.isNameValidUserName;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/inception/pom.xml
+++ b/inception/pom.xml
@@ -343,6 +343,32 @@
       <artifactId>spring-boot-starter-validation</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-test-autoconfigure</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.hsqldb</groupId>
+      <artifactId>hsqldb</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <dependencyManagement>
@@ -2186,9 +2212,12 @@
             <dependency>org.awaitility:awaitility</dependency>
             <dependency>org.springframework:spring-test</dependency>
             <dependency>org.springframework.boot:spring-boot-starter-web</dependency>
+            <dependency>org.springframework.boot:spring-boot-test</dependency>
             <dependency>org.springframework.boot:spring-boot-test-autoconfigure</dependency>
-            <dependency>org.springframework.security:spring-security-test</dependency>
             <dependency>org.springframework.boot:spring-boot-starter-validation</dependency>
+            <dependency>org.springframework.boot:spring-boot-starter-data-jpa</dependency>
+            <dependency>org.springframework.security:spring-security-test</dependency>
+            <dependency>org.hsqldb:hsqldb</dependency>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
         <dependencies>


### PR DESCRIPTION
**What's in the PR**
- Added ability to set the default admin username
- Update documentation
- Added test
- Moved NameUtil to the security module
- Add space to the list of characters excluded for usernames

**How to test manually**
* See documentation

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [x] PR updates documentation
