### PR TITLE
#3096 - New PDF editor

### DIFF
--- a/inception/inception-js-api/src/main/ts/src/model/compact/CompactAnnotatedText.ts
+++ b/inception/inception-js-api/src/main/ts/src/model/compact/CompactAnnotatedText.ts
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 import { Offsets } from "../Offsets";
+import { VID } from "../VID";
 import { CompactAnnotationMarker } from "./CompactAnnotationMarker";
 import { CompactRelation } from "./CompactRelation";
 import { CompactSpan } from "./CompactSpan";
@@ -28,4 +29,28 @@ export interface CompactAnnotatedText {
   spans?: Array<CompactSpan>;
   annotationMarkers?: Array<CompactAnnotationMarker>;
   textMarkers?: Array<CompactTextMarker>;
+}
+
+/**
+ * Converts a list of {@link CompactAnnotationMarker}s to an easily accessible map using the {@link VID} 
+ * as key and the set of markers on that annotation as values.
+ * 
+ * @param markerList a list of {@link CompactAnnotationMarker}s
+ * @returns the map
+ */
+export function makeMarkerMap<T>(markerList: T[] | undefined): Map<VID, Array<T>> {
+  const markerMap = new Map<VID, Array<T>>();
+  if (markerList) {
+    markerList.forEach(marker => {
+      marker[1].forEach(vid => {
+        let ms = markerMap.get(vid);
+        if (!ms) {
+          ms = [];
+          markerMap.set(vid, ms);
+        }
+        ms.push(marker);
+      })
+    });
+  }
+  return markerMap;
 }

--- a/inception/inception-pdf-editor2/src/main/ts/src/PdfAnnotationEditor.css
+++ b/inception/inception-pdf-editor2/src/main/ts/src/PdfAnnotationEditor.css
@@ -15,4 +15,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+ .marker-matchfocus {
+ 	background-color: rgba(255, 165, 0, 0.4);
+  border-color: rgba(255, 165, 0, 1.0);
+ }
+
+.anno-span__area.marker-focus {
+  box-shadow: 0 2px 0px 0px rgba(255,165,0) !important;
+}
+

--- a/inception/inception-pdf-editor2/src/main/ts/src/PdfAnnotationEditor.css
+++ b/inception/inception-pdf-editor2/src/main/ts/src/PdfAnnotationEditor.css
@@ -24,3 +24,7 @@
   box-shadow: 0 2px 0px 0px rgba(255,165,0) !important;
 }
 
+.anno-knob.marker-focus {
+  box-shadow: 0 0px 2px 2px rgba(255,165,0) !important;
+}
+

--- a/inception/inception-pdf-editor2/src/main/ts/src/PdfAnnotationEditor.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/PdfAnnotationEditor.ts
@@ -50,10 +50,6 @@ export class PdfAnnotationEditor implements AnnotationEditor {
   onAnnotationSelected (ev: Event) {
     if (ev instanceof CustomEvent) {
       const ann = ev.detail as AbstractAnnotation
-      if (!ann.selected) {
-        return
-      }
-
       this.ajax.selectAnnotation(ann.vid)
     }
   }

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/UI/span.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/UI/span.ts
@@ -153,9 +153,7 @@ function handleMouseUp (e: MouseEvent) {
 
   if (mouseDown) {
     makeSelections(e)
-    if (currentSelectionHighlight) {
-      currentSelectionHighlight.deselect()
-    }
+
     if (selectionBegin !== null && selectionEnd !== null) {
       const event = new CustomEvent('createSpanAnnotation', {
         bubbles: true,
@@ -170,6 +168,7 @@ function handleMouseUp (e: MouseEvent) {
       }, 1000)
     }
   }
+
   mouseDown = false
 }
 
@@ -219,12 +218,11 @@ function selectionHighlight (textRange: [number, number], page: number): SpanAnn
   hl.border = false
   hl.rectangles = mergeRects(getGlyphsInRange(textRange).map(g => g.bbox))
 
-  if (hl.rectangles.length == 0) {
+  if (hl.rectangles.length === 0) {
     return null
   }
 
   hl.render()
-  hl.select()
   hl.disable()
   return hl
 }

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/annotation/abstract.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/annotation/abstract.ts
@@ -19,6 +19,7 @@ export default abstract class AbstractAnnotation extends EventEmitter {
   element: HTMLElement = null
   exportId: any
   type: 'span' | 'relation'
+  classList: string[] = []
 
   /**
    * Constructor.

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/annotation/abstract.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/annotation/abstract.ts
@@ -12,7 +12,6 @@ export default abstract class AbstractAnnotation extends EventEmitter {
   color: string = null
   deleted = false
   disabled = false
-  selected = false
   readOnly = false
   hoverEventDisable = false
   selectedTime = null
@@ -59,8 +58,6 @@ export default abstract class AbstractAnnotation extends EventEmitter {
       this.setHoverEvent()
     }
 
-    this.selected && this.element.classList.remove('--selected')
-
     this.disabled && this.disable()
 
     return true
@@ -93,16 +90,9 @@ export default abstract class AbstractAnnotation extends EventEmitter {
    * Handle a click event.
    */
   handleSingleClickEvent (e: Event) {
-    if (!this.selected) {
-      this.toggleSelect()
-    }
-
-    if (this.selected) {
-      // TODO Use common function.
-      const event = document.createEvent('CustomEvent')
-      event.initCustomEvent('annotationSelected', true, true, this)
-      this.element.dispatchEvent(event)
-    }
+    const event = document.createEvent('CustomEvent')
+    event.initCustomEvent('annotationSelected', true, true, this)
+    this.element.dispatchEvent(event)
   }
 
   /**
@@ -137,56 +127,6 @@ export default abstract class AbstractAnnotation extends EventEmitter {
    */
   dehighlight () {
     this.element.classList.remove('--hover')
-  }
-
-  /**
-   * Select the annotation.
-   */
-  select () {
-    this.selected = true
-    this.selectedTime = Date.now()
-    this.element.classList.add('--selected')
-  }
-
-  /**
-   * Deselect the annotation.
-   */
-  deselect () {
-    console.log('deselect')
-    this.selected = false
-    this.selectedTime = null
-    this.element.classList.remove('--selected')
-  }
-
-  /**
-   * Toggle the selected state.
-   */
-  toggleSelect () {
-    if (this.selected) {
-      this.deselect()
-    } else {
-      this.select()
-    }
-  }
-
-  /**
-   * Delete the annotation if selected.
-   */
-  deleteSelectedAnnotation (): boolean {
-    if (this.isSelected()) {
-      this.destroy().then(() => {
-        dispatchWindowEvent('annotationDeleted', { vid: this.vid })
-      })
-      return true
-    }
-    return false
-  }
-
-  /**
-   * Check whether the annotation is selected.
-   */
-  isSelected () {
-    return this.element.classList.contains('--selected')
   }
 
   /**

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/annotation/container.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/annotation/container.ts
@@ -42,13 +42,6 @@ export default class AnnotationContainer {
   }
 
   /**
-   * Get annotations which user select.
-   */
-  getSelectedAnnotations () : AbstractAnnotation[] {
-    return this.getAllAnnotations().filter(a => a.selected)
-  }
-
-  /**
    * Find an annotation by the id which an annotation has.
    */
   findById (vid: VID) : AbstractAnnotation {

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/annotation/relation.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/annotation/relation.ts
@@ -14,7 +14,6 @@ export default class RelationAnnotation extends AbstractAnnotation {
   zIndex: number
   _rel1Annotation: SpanAnnotation
   _rel2Annotation: SpanAnnotation
-  selected: boolean
 
   /**
    * Constructor.
@@ -41,9 +40,7 @@ export default class RelationAnnotation extends AbstractAnnotation {
     this.handleHoverInEvent = this.handleHoverInEvent.bind(this)
     this.handleHoverOutEvent = this.handleHoverOutEvent.bind(this)
 
-    window.globalEvent.on('deleteSelectedAnnotation', this.deleteSelectedAnnotation)
     window.globalEvent.on('enableViewMode', this.enableViewMode)
-    // window.globalEvent.on('rectmoveend', this.handleRelMoveEnd)
   }
 
   /**
@@ -64,7 +61,6 @@ export default class RelationAnnotation extends AbstractAnnotation {
     if (this._rel1Annotation) {
       this._rel1Annotation.on('hoverin', this.handleRelHoverIn)
       this._rel1Annotation.on('hoverout', this.handleRelHoverOut)
-      // this._rel1Annotation.on('rectmove', this.handleRelMove)
       this._rel1Annotation.on('delete', this.handleRelDelete)
     }
   }
@@ -109,12 +105,14 @@ export default class RelationAnnotation extends AbstractAnnotation {
    */
   destroy () {
     const promise = super.destroy()
+
     if (this._rel1Annotation) {
       this._rel1Annotation.removeListener('hoverin', this.handleRelHoverIn)
       this._rel1Annotation.removeListener('hoverout', this.handleRelHoverOut)
       this._rel1Annotation.removeListener('delete', this.handleRelDelete)
       delete this._rel1Annotation
     }
+
     if (this._rel2Annotation) {
       this._rel2Annotation.removeListener('hoverin', this.handleRelHoverIn)
       this._rel2Annotation.removeListener('hoverout', this.handleRelHoverOut)
@@ -122,7 +120,6 @@ export default class RelationAnnotation extends AbstractAnnotation {
       delete this._rel2Annotation
     }
 
-    window.globalEvent.removeListener('deleteSelectedAnnotation', this.deleteSelectedAnnotation)
     window.globalEvent.removeListener('enableViewMode', this.enableViewMode)
 
     return promise
@@ -150,20 +147,6 @@ export default class RelationAnnotation extends AbstractAnnotation {
     if (this.rel2Annotation) {
       this.rel2Annotation.dehighlight()
     }
-  }
-
-  /**
-   * Handle a selected event on a text.
-   */
-  handleTextSelected () {
-    this.select()
-  }
-
-  /**
-   * Handle a deselected event on a text.
-   */
-  handleTextDeselected () {
-    this.deselect()
   }
 
   /**
@@ -271,9 +254,6 @@ export default class RelationAnnotation extends AbstractAnnotation {
     }
   }
 
-  /**
-   * @{inheritDoc}
-   */
   equalTo (anno: RelationAnnotation) {
     if (!anno || this.type !== anno.type) {
       return false

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/annotation/span.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/annotation/span.ts
@@ -3,6 +3,10 @@ import { getGlyphsInRange } from '../../../page/textLayer'
 import { Rectangle } from '../../../../vmodel/Rectangle'
 import { mergeRects } from '../UI/span'
 
+let clickCount = 0
+let timer = null
+const CLICK_DELAY = 300
+
 /**
  * Span Annotation.
  */
@@ -11,7 +15,7 @@ export default class SpanAnnotation extends AbstractAnnotation {
   readOnly = false
   knob = true
   border = true
-  text = null
+  text: string
   textRange: [number, number]
   page: number = -1
   zIndex = 10
@@ -22,7 +26,6 @@ export default class SpanAnnotation extends AbstractAnnotation {
 
     this.type = 'span'
     this.vid = null
-    this.text = null
     this.color = null
     this.textRange = null
     this.page = null
@@ -186,7 +189,3 @@ export default class SpanAnnotation extends AbstractAnnotation {
       e.removeEventListener('click', this.handleClickEvent))
   }
 }
-
-var clickCount = 0
-var timer = null
-var CLICK_DELAY = 300

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/annotation/span.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/annotation/span.ts
@@ -36,7 +36,6 @@ export default class SpanAnnotation extends AbstractAnnotation {
     this.handleHoverInEvent = this.handleHoverInEvent.bind(this)
     this.handleHoverOutEvent = this.handleHoverOutEvent.bind(this)
 
-    window.globalEvent.on('deleteSelectedAnnotation', this.deleteSelectedAnnotation)
     window.globalEvent.on('enableViewMode', this.enableViewMode)
   }
 
@@ -80,7 +79,6 @@ export default class SpanAnnotation extends AbstractAnnotation {
     const promise = super.destroy()
     this.emit('delete')
 
-    window.globalEvent.removeListener('deleteSelectedAnnotation', this.deleteSelectedAnnotation)
     window.globalEvent.removeListener('enableViewMode', this.enableViewMode)
     return promise
   }
@@ -99,27 +97,6 @@ export default class SpanAnnotation extends AbstractAnnotation {
     }
 
     return p
-  }
-
-  /**
-   * Delete the annotation if selected.
-   */
-  deleteSelectedAnnotation (): boolean {
-    return super.deleteSelectedAnnotation()
-  }
-
-  /**
-   * Handle a selected event on a text.
-   */
-  handleTextSelected () {
-    this.select()
-  }
-
-  /**
-   * Handle a deselected event on a text.
-   */
-  handleTextDeselected () {
-    this.deselect()
   }
 
   /**

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/render/renderKnob.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/render/renderKnob.ts
@@ -7,21 +7,24 @@ export const DEFAULT_RADIUS = 7
  * Create a bounding circle.
  * @param {Object} the data for rendering.
  */
-export function renderKnob ({ x, y, readOnly, text, color }): HTMLElement {
+export function renderKnob ({ a, x, y, readOnly, text }): HTMLElement {
   // Adjust the position.
   [x, y] = adjustPoint(x, (y - (DEFAULT_RADIUS + 2)), DEFAULT_RADIUS)
 
   const knob = document.createElement('div')
   knob.setAttribute('title', text)
   knob.classList.add('anno-knob')
+  a.classList.forEach(c => knob.classList.add(c))
   if (readOnly) {
     knob.classList.add('is-readonly')
   }
   knob.style.top = `${y}px`
-  knob.style.left = `${x}px`,
-  knob.style.width = DEFAULT_RADIUS + 'px',
-  knob.style.height = DEFAULT_RADIUS + 'px',
-  knob.style.backgroundColor = color
+  knob.style.left = `${x}px`
+  knob.style.width = DEFAULT_RADIUS + 'px'
+  knob.style.height = DEFAULT_RADIUS + 'px'
+  if (a.color) {
+    knob.style.backgroundColor = a.color
+  }
   return knob
 }
 

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/render/renderRelation.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/render/renderRelation.ts
@@ -91,15 +91,18 @@ export function renderRelation (a: RelationAnnotation): HTMLDivElement {
   group.appendChild(outline)
 
   /*
-      <path d="M 25 25 Q 175 25 175 175" stroke="blue" fill="none"/>
-  */
+   * <path d="M 25 25 Q 175 25 175 175" stroke="blue" fill="none"/>
+   */
+  const classlist = ['anno-relation']
+  a?.classList.forEach(c => classlist.push(c))
+
   const relation = document.createElementNS('http://www.w3.org/2000/svg', 'path')
   setAttributes(relation, {
     d: `M ${a.x1} ${a.y1} Q ${control.x} ${control.y} ${a.x2} ${a.y2}`,
     stroke: a.color,
     strokeWidth: 1,
     fill: 'none',
-    class: 'anno-relation'
+    class: classlist.join(' ')
   })
 
   // Triangle for the end point.

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/render/renderSpan.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/render/renderSpan.ts
@@ -44,36 +44,27 @@ export function mapToDocumentCoordinates (aRectangles: Rectangle[], page: number
  * @return a html element describing a span annotation.
  */
 export function renderSpan (span: SpanAnnotation): HTMLElement | undefined {
-  // REC: This should not be needed
-  // if (!span.page) {
-  //   if (span.rectangles.length > 0) {
-  //     span.page = span.rectangles[0].page
-  //   }
-  // }
-
   const rectangles = mapToDocumentCoordinates(span.rectangles, span.page)
 
   if (!rectangles) {
     return undefined
   }
 
-  const color = span.color || '#FF0'
-
   const base = document.createElement('div')
   base.classList.add('anno-span')
   base.style.zIndex = '10'
 
   rectangles.forEach(r => {
-    base.appendChild(createRect(span, r, color, span.readOnly))
+    base.appendChild(createRect(span, r, span.color, span.readOnly))
   })
 
   if (span.knob) {
     base.appendChild(renderKnob({
+      a: span,
       x: rectangles[0].x,
       y: rectangles[0].y,
       readOnly: span.readOnly,
-      text: span.text,
-      color
+      text: span.text
     }))
   }
 
@@ -88,14 +79,16 @@ export function createRect (a: SpanAnnotation | undefined, r: Rectangle, color?:
     rect.classList.add('no-border')
   }
 
-  const actualColor = color || '#FF0'
+  a?.classList.forEach(c => rect.classList.add(c))
 
   rect.style.top = r.y + 'px'
   rect.style.left = r.x + 'px'
   rect.style.width = r.w + 'px'
   rect.style.height = r.h + 'px'
-  rect.style.backgroundColor = hex2rgba(actualColor, 0.4)
-  rect.style.borderColor = actualColor
+  if (color) {
+    rect.style.backgroundColor = hex2rgba(color, 0.4)
+    rect.style.borderColor = color
+  }
   rect.style.pointerEvents = 'none'
   return rect
 }

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/page/textLayer.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/page/textLayer.ts
@@ -22,6 +22,32 @@ export function getPage (num: number): VPage | undefined {
   return pages.find(p => p.index === num)
 }
 
+export function getPageBefore (num: number): VPage | undefined {
+  let pageBefore : VPage | undefined
+  for (const page of pages) {
+    if (page.index === num) {
+      return pageBefore
+    }
+    pageBefore = page
+  }
+  return pageBefore
+}
+
+export function getPageAfter(num: number): VPage | undefined {
+  let stop = false
+  for (const page of pages) {
+    if (stop) {
+      return page
+    }
+
+    if (page.index === num) {
+      stop = true
+    }
+  }
+
+  return undefined
+}
+
 export function findPageForOffset (offset: number): VPage | undefined {
   const page = pages.find(p => p.range[0] <= offset && offset < p.range[1])
   if (!page) {

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/pdfanno.css
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/pdfanno.css
@@ -1,47 +1,10 @@
 @charset "utf-8";
 
-/* Loading */
-.loader-container {
-    position: absolute;
-    top: 100px;
-    left: 50%;
-    width: 200px;
-    height: 200px;
-    margin-left: -150px;
-    /*margin-top: -150px;*/
-    background-color: #333;
-    padding: 16px;
-    box-shadow: 0 0 10px rgba(0,0,0,.5);
-    transition: opacity .3s ease-in-out;
-}
-.loader-container.close {
-    opacity: 0;
-}
-.loader {
-    border: 16px solid #f3f3f3; /* Light grey */
-    border-top: 16px solid #3498db; /* Blue */
-    border-radius: 50%;
-    width: 120px;
-    height: 120px;
-    animation: spin 1.5s ease-in-out infinite;
-    margin-left: auto;
-    margin-right: auto;
-}
-@keyframes spin {
-    0% { transform: rotate(0deg); }
-    100% { transform: rotate(360deg); }
-}
-.loader-container p {
-    margin-top: 16px;
-    font-size: 16px;
-    text-align: center;
-    color: white;
-}
-
 /*
   viewer.css
  */
-.dropdown, .dropup {
+.dropdown,
+.dropup {
   z-index: 10000;
 }
 
@@ -63,40 +26,45 @@
  * Text Layer.
  */
 .pdfanno-text-layer {
-    position: absolute;
-    text-align: center;
+  position: absolute;
+  text-align: center;
 }
 
 /**
  * Annotation Layer.
  */
-.annoLayer > * {
+.annoLayer>* {
   opacity: 0.5;
 }
-.annoLayer > *.--hover,
-.annoLayer > *.--selected {
+
+.annoLayer>*.--hover,
+.annoLayer>*.--selected {
   opacity: 1;
 }
 
 /**
-    Annotation Knob for control.
-*/
+ * Annotation Knob for control.
+ */
 .anno-knob {
-    position: absolute;
-    background-color: blue;
-    border-radius: 50%;
-    transition: 0.2s;
-    transform-origin: center center;
+  position: absolute;
+  background-color: blue;
+  border-radius: 50%;
+  transition: 0.2s;
+  transform-origin: center center;
+  cursor: pointer;
 }
+
 .--hover .anno-knob,
 .--selected .anno-knob {
-  box-shadow: rgba(113,135,164,.2) 1px 1px 1px;
+  box-shadow: rgba(113, 135, 164, .2) 1px 1px 1px;
   transform: scale(2);
 }
+
 .anno-knob.is-readonly {
-    border-radius: 0;
-    transform: rotate(45deg) scale(0.7);
+  border-radius: 0;
+  transform: rotate(45deg) scale(0.7);
 }
+
 .--hover .anno-knob.is-readonly,
 .--selected .anno-knob.is-readonly {
   transform: rotate(45deg) scale(1.4);
@@ -106,30 +74,38 @@
  * Span Annotation.
  */
 .anno-span {
-    position: absolute;
-    top: 0;
-    left: 0;
-    visibility: visible;
+  position: absolute;
+  top: 0;
+  left: 0;
+  visibility: visible;
 }
+
 .anno-span__area {
-    position: absolute;
-    border: 1px solid black;
+  position: absolute;
+  border-bottom: 2px solid black;
 }
+
 .--hover .anno-span__area,
 .--selected .anno-span__area {
   border: 1px dashed black !important;
   box-sizing: border-box;
 }
+
 .anno-span__area.no-border,
 .--hover .anno-span__area.no-border,
 .--selected .anno-span__area.no-border {
   border-width: 0 !important;
 }
+
 .anno-span__border {
   position: absolute;
   border: 1px solid black;
 }
 
+.anno-span rect {
+  /* Enable the hover event on circles and text even if they are overwraped other spans. */
+  pointer-events: none;
+}
 /**
   Relation Annotation.
 */
@@ -137,22 +113,16 @@
 .--selected .anno-relation {
   stroke-width: 2px;
 }
+
 .anno-relation-outline {
   fill: none;
   visibility: hidden;
 }
+
 .--selected .anno-relation-outline {
   visibility: visible;
   stroke: black;
   stroke-width: 3px;
   pointer-events: stroke;
   stroke-dasharray: 5;
-}
-
-/**
- * Span Annotation.
- */
-.anno-span rect {
-    /* Enable the hover event on circles and text even if they are overwraped other spans. */
-    pointer-events: none;
 }

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/pdfanno.css
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/pdfanno.css
@@ -33,10 +33,6 @@
 /**
  * Annotation Layer.
  */
-.annoLayer>* {
-  opacity: 0.5;
-}
-
 .annoLayer>*.--hover,
 .annoLayer>*.--selected {
   opacity: 1;
@@ -46,6 +42,7 @@
  * Annotation Knob for control.
  */
 .anno-knob {
+  opacity: 0.5;
   position: absolute;
   background-color: blue;
   border-radius: 50%;

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/pdfanno.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/pdfanno.ts
@@ -24,7 +24,7 @@ export const annoLayer2Id = 'annoLayer2'
 let annoPage: PDFAnnoPage
 let annotationContainer: AnnotationContainer
 let diamAjax: DiamAjax
-let pageRender: number
+let currentFocusPage: number
 let pagechangeEventCounter: number
 
 export async function initPdfAnno (ajax: DiamAjax): Promise<void> {
@@ -238,8 +238,20 @@ export function scrollTo (offset: number, position: string): void {
 }
 
 export function getAnnotations () {
+  const focusPage = textLayer.getPage(currentFocusPage)
+
+  if (!focusPage) {
+    console.error(`Cannot find page ${currentFocusPage}`)
+    return
+  }
+
+  const pageBefore = textLayer.getPageBefore(currentFocusPage)
+  const extendedBegin = (pageBefore || focusPage)?.range[0]
+  const pageAfter = textLayer.getPageAfter(currentFocusPage)
+  const extendedEnd = (pageAfter || focusPage)?.range[1]
+
   const options : DiamLoadAnnotationsOptions = {
-    range: textLayer.getPage(pageRender).range,
+    range: [extendedBegin, extendedEnd],
     includeText: false
   }
 
@@ -309,7 +321,7 @@ async function displayViewer (): Promise<void> {
         textLayer.setup(vModel)
 
         pagechangeEventCounter = 0
-        pageRender = 1
+        currentFocusPage = 1
         const initAnnotations = function (e) {
           try {
             getAnnotations()
@@ -320,12 +332,12 @@ async function displayViewer (): Promise<void> {
         window.PDFViewerApplication.eventBus.on('pagerendered', initAnnotations)
         window.PDFViewerApplication.eventBus.on('pagechanging', function (e) {
           pagechangeEventCounter++
-          if (e.pageNumber !== pageRender) {
+          if (e.pageNumber !== currentFocusPage) {
             const snapshot = pagechangeEventCounter
             const renderTimeout = 500
             setTimeout(() => {
-              if (snapshot === pagechangeEventCounter && e.pageNumber !== pageRender) {
-                pageRender = e.pageNumber
+              if (snapshot === pagechangeEventCounter && e.pageNumber !== currentFocusPage) {
+                currentFocusPage = e.pageNumber
                 pagechangeEventCounter = 0
                 getAnnotations()
               }

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/pdfanno.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/pdfanno.ts
@@ -16,6 +16,7 @@ import { getGlyphsInRange } from './page/textLayer'
 import RelationAnnotation from './core/src/annotation/relation'
 import { createRect, mapToDocumentCoordinates } from './core/src/render/renderSpan'
 import { transform } from './core/src/render/appendChild'
+import { makeMarkerMap } from '@inception-project/inception-js-api/src/model/compact/CompactAnnotatedText'
 
 // TODO make it a global const.
 // const svgLayerId = 'annoLayer'
@@ -258,6 +259,8 @@ export function getAnnotations () {
   diamAjax.loadAnnotations(options).then((doc: CompactAnnotatedText) => {
     annotationContainer.clear()
 
+    const annotationMarkers = makeMarkerMap(doc.annotationMarkers)
+
     if (doc.spans) {
       console.log(`Loaded ${doc.spans.length} span annotations`)
       for (const s of doc.spans) {
@@ -265,9 +268,10 @@ export function getAnnotations () {
         span.vid = `${s[0]}`
         span.textRange = [s[1][0][0] + doc.window[0], s[1][0][1] + doc.window[0]]
         span.page = textLayer.findPageForOffset(span.textRange[0]).index
-        span.color = s[2].c
-        span.text = s[2].l
+        span.color = s[2]?.c || '#FFF'
+        span.text = s[2]?.l || ''
         span.rectangles = mergeRects(getGlyphsInRange(span.textRange).map(g => g.bbox))
+        annotationMarkers.get(s[0])?.forEach(m => span.classList.push(`marker-${m[0]}`))
         span.save()
       }
     }
@@ -281,6 +285,7 @@ export function getAnnotations () {
         rel.rel2Annotation = annotationContainer.findById(r[1][1][0])
         rel.color = r[2].c
         rel.text = r[2].l
+        annotationMarkers.get(r[0])?.forEach(m => rel.classList.push(`marker-${m[0]}`))
         rel.save()
       }
     }
@@ -290,10 +295,10 @@ export function getAnnotations () {
         const span = new SpanAnnotation()
         span.textRange = [m[1][0][0] + doc.window[0], m[1][0][1] + doc.window[0]]
         span.page = textLayer.findPageForOffset(span.textRange[0]).index
-        span.color = 'blue'
         span.knob = false
         span.border = false
         span.rectangles = mergeRects(getGlyphsInRange(span.textRange).map(g => g.bbox))
+        span.classList = [`marker-${m[0]}`]
         span.save()
       }
     }


### PR DESCRIPTION
**What's in the PR**
- Also render annotations on the page before and after the current page if possible
- Slightly change the rendering style for annotations to only a border below
- Pointer cursor over knobs
- Remove opacity setting from annotation highlights and rely on the semitransparent highlight background
- The knob should always be halt-transparent
- Add selection highlight to the currently selected annotation
- Improve support for annotation/text markers
- Removed unused code for client-side selection management
- Add selection highlight to the knob of the selected annotation

**How to test manually**
* Use PDF editor to test it

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
