### PR TITLE
#1606 - Search result list jumps back to top

### DIFF
--- a/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchAnnotationSidebar.html
+++ b/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchAnnotationSidebar.html
@@ -113,6 +113,11 @@
                     class="d-none d-xl-inline">&nbsp;<wicket:message
                       key="search" /></span>
                 </button>
+                <button wicket:id="export" 
+                  class="btn btn-sm btn-outline-primary flex-grow-0" 
+                  wicket:message="title:export">
+                  <i class="fas fa-download" aria-hidden="true"></i>
+                </button>
                 <button wicket:id="clearButton"
                   class="btn btn-outline-secondary flex-grow-0"
                   wicket:message="title:clear">
@@ -126,113 +131,118 @@
         <div class="d-flex flex-wrap justify-content-between mb-1">
           <ul wicket:id="pagingNavigator" class="mb-1"/>
           
-          <div class="input-group input-group-sm w-auto d-none d-xl-inline mb-1">
+          <div class="input-group input-group-sm w-auto d-none d-xxl-inline mb-1">
             <span wicket:id="numberOfResults" class="input-group-text"/> 
           </div>
-          
-          <div class="btn-group mb-1" role="group">
-            <button wicket:id="export"
-              class="btn btn-sm btn-outline-primary">
-              <i class="fas fa-download" aria-hidden="true"></i>
-              <span class="d-none d-xxl-inline ms-1"><wicket:message key="export" /></span>
-            </button>
-          </div>
         </div>
         
-        <div class="scrolling flex-content">
-          <table wicket:id="resultsGroupContainer"
-            class="table table-striped table-sm">
-            <wicket:container wicket:id="searchResultGroups">
-              <tr valign="middle" style="line-height: 2em;">
-                <th class="ssb-group-header-control headers" colspan="1">
-                  <label wicket:for="selectAllInGroup"> <input
-                    wicket:id="selectAllInGroup" type="checkbox">
-                </label>
-                </th>
-                <th class="ssb-group-header-title headers" colspan="1">
-                  <wicket:container wicket:id="groupTitle" />
-                </th>
-              </tr>
-              <wicket:container wicket:id="group" />
-            </wicket:container>
-          </table>
-        </div>
-        
-        <form wicket:id="annotateForm" style="margin-top: 5px">
-          <div class="mb-2 d-flex">
-            <div class="btn-group flex-content flex-h-container"
-              role="group">
-              <button wicket:id="annotateAllButton" type="submit"
-                class="btn btn-primary flex-content"
-                wicket:message="title:create">
-                <i class="fas fa-plus" aria-hidden="true"></i> <span
-                  class="d-none d-xl-inline">&nbsp;<wicket:message
-                    key="create" /></span>
-              </button>
-              <button wicket:id="toggleCreateOptionsVisibility"
-                type="button"
-                class="btn btn-secondary border-start flex-static-item">
-                <i class="fas fa-cog" aria-hidden="true"></i>
-              </button>
-            </div>
-          </div>
-          
-          <form wicket:id="createOptions" class="card mb-2">
-            <div class="card-header small">
-              <wicket:message key="options" />
-            </div>
-            <div class="card-body small">
-              <div class="form-row"
-                wicket:enclosure="overrideExistingAnnotations">
-                <div class="form-check">
-                  <input wicket:id="overrideExistingAnnotations"
-                    class="form-check-input" type="checkbox"> <label
-                    wicket:for="overrideExistingAnnotations"
-                    class="form-check-label"> <wicket:label
-                      key="overrideMode" />
-                  </label>
+        <div class="flex-content flex-v-container">
+          <div wicket:enclosure="noDataNotice" class="flex-content flex-v-container">
+            <div wicket:id="noDataNotice" class="card flex-content flex-v-container">
+              <div class="card-body flex-content flex-v-container">
+                <div class="no-data-notice flex-content">
+                  No results
                 </div>
               </div>
             </div>
-          </form>
+          </div>
 
-          <div class="mb-2 d-flex">
-            <div class="btn-group flex-content flex-h-container"
-              role="group">
-              <button wicket:id="deleteButton" type="submit"
-                class="btn btn-danger flex-content"
-                wicket:message="title:delete">
-                <i class="fas fa-trash" aria-hidden="true"></i> <span
-                  class="d-none d-xl-inline">&nbsp;<wicket:message
-                    key="delete" /></span>
-              </button>
-              <button wicket:id="toggleDeleteOptionsVisibility"
-                type="button"
-                class="btn btn-secondary border-start flex-static-item">
-                <i class="fas fa-cog" aria-hidden="true"></i>
-              </button>
-            </div>
+          <div class="scrolling flex-content" wicket:id="resultsTable">
+            <table class="table table-striped table-sm">
+              <tbody wicket:id="resultsGroupContainer">
+                <wicket:container wicket:id="searchResultGroups">
+                  <tr valign="middle" style="line-height: 2em;">
+                    <th class="ssb-group-header-control headers" colspan="1">
+                      <label wicket:for="selectAllInGroup"> <input
+                        wicket:id="selectAllInGroup" type="checkbox">
+                    </label>
+                    </th>
+                    <th class="ssb-group-header-title headers" colspan="1">
+                      <wicket:container wicket:id="groupTitle" />
+                    </th>
+                  </tr>
+                  <wicket:container wicket:id="group" />
+                </wicket:container>
+              </tbody>
+            </table>
           </div>
           
-          <form wicket:id="deleteOptions" class="card mb-2">
-            <div class="card-header small">
-              <wicket:message key="options" />
-            </div>
-            <div class="card-body small">
-              <div class="form-row"
-                wicket:enclosure="deleteOnlyMatchingFeatureValues">
-                <div class="form-check">
-                  <input wicket:id="deleteOnlyMatchingFeatureValues"
-                    class="form-check-input" type="checkbox"> <label
-                    wicket:for="deleteOnlyMatchingFeatureValues"
-                    class="form-check-label"> <wicket:label
-                      key="deleteOnlyMatchingFeatureValues" />
-                  </label>
-                </div>
+          <form wicket:id="annotateForm" style="margin-top: 5px">
+            <div class="mb-2 d-flex">
+              <div class="btn-group flex-content flex-h-container"
+                role="group">
+                <button wicket:id="annotateAllButton" type="submit"
+                  class="btn btn-primary flex-content"
+                  wicket:message="title:create">
+                  <i class="fas fa-plus" aria-hidden="true"></i> <span
+                    class="d-none d-xl-inline">&nbsp;<wicket:message
+                      key="create" /></span>
+                </button>
+                <button wicket:id="toggleCreateOptionsVisibility"
+                  type="button"
+                  class="btn btn-secondary border-start flex-static-item">
+                  <i class="fas fa-cog" aria-hidden="true"></i>
+                </button>
               </div>
             </div>
+            
+            <form wicket:id="createOptions" class="card mb-2">
+              <div class="card-header small">
+                <wicket:message key="options" />
+              </div>
+              <div class="card-body small">
+                <div class="form-row"
+                  wicket:enclosure="overrideExistingAnnotations">
+                  <div class="form-check">
+                    <input wicket:id="overrideExistingAnnotations"
+                      class="form-check-input" type="checkbox"> <label
+                      wicket:for="overrideExistingAnnotations"
+                      class="form-check-label"> <wicket:label
+                        key="overrideMode" />
+                    </label>
+                  </div>
+                </div>
+              </div>
+            </form>
+  
+            <div class="mb-2 d-flex">
+              <div class="btn-group flex-content flex-h-container"
+                role="group">
+                <button wicket:id="deleteButton" type="submit"
+                  class="btn btn-danger flex-content"
+                  wicket:message="title:delete">
+                  <i class="fas fa-trash" aria-hidden="true"></i> <span
+                    class="d-none d-xl-inline">&nbsp;<wicket:message
+                      key="delete" /></span>
+                </button>
+                <button wicket:id="toggleDeleteOptionsVisibility"
+                  type="button"
+                  class="btn btn-secondary border-start flex-static-item">
+                  <i class="fas fa-cog" aria-hidden="true"></i>
+                </button>
+              </div>
+            </div>
+            
+            <form wicket:id="deleteOptions" class="card mb-2">
+              <div class="card-header small">
+                <wicket:message key="options" />
+              </div>
+              <div class="card-body small">
+                <div class="form-row"
+                  wicket:enclosure="deleteOnlyMatchingFeatureValues">
+                  <div class="form-check">
+                    <input wicket:id="deleteOnlyMatchingFeatureValues"
+                      class="form-check-input" type="checkbox"> <label
+                      wicket:for="deleteOnlyMatchingFeatureValues"
+                      class="form-check-label"> <wicket:label
+                        key="deleteOnlyMatchingFeatureValues" />
+                    </label>
+                  </div>
+                </div>
+              </div>
+            </form>
           </form>
-        </form>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
**What's in the PR**
- Fixes jumping to the top when (un)selecting a checkbox in the results list after scrolling down - when clicking on a result triggers a switch of the document, it still jumps
- Only show group-level checkbox if there are any editable results in the group
- Ignore non-editable results in a group when determining the group-level checkbox state

**How to test manually**
* Use the sidebar

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
