### PR TITLE
#3209 - Reactivity lost after creating an annotation

### DIFF
--- a/inception/inception-brat-editor/src/main/ts/brat/annotator_ui/AnnotatorUI.ts
+++ b/inception/inception-brat-editor/src/main/ts/brat/annotator_ui/AnnotatorUI.ts
@@ -851,8 +851,9 @@ export class AnnotatorUI {
         }
 
         // normal span select in standard annotation mode or reselect: show selector
-        const spanText = this.data.text.substring(selectedFrom, selectedTo);
-        this.ajax.createSpanAnnotation(this.spanOptions.offsets, spanText);
+        this.spanDragJustStarted = false
+        const spanText = this.data.text.substring(selectedFrom, selectedTo)
+        this.ajax.createSpanAnnotation(this.spanOptions.offsets, spanText)
       }
     }
   }


### PR DESCRIPTION
**What's in the PR**
- Clear spanDragJustStarted flag when a span annotation is created to avoid mouse move after span creation registering as drag action

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
