### PR TITLE
#2433 - Case Insensitive Token Search

### DIFF
--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchQueryRequest.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchQueryRequest.java
@@ -24,12 +24,14 @@ import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
+import de.tudarmstadt.ukp.inception.search.model.AnnotationSearchState;
 
 public class SearchQueryRequest
 {
     private final Project project;
     private final User user;
     private final String query;
+    private final AnnotationSearchState prefs;
 
     private final SourceDocument limitedToDocument;
 
@@ -39,20 +41,22 @@ public class SearchQueryRequest
     private final long offset;
     private final long count;
 
-    public SearchQueryRequest(Project aProject, User aUser, String aQuery)
+    public SearchQueryRequest(Project aProject, User aUser, String aQuery,
+            AnnotationSearchState aPrefs)
     {
-        this(aProject, aUser, aQuery, null);
+        this(aProject, aUser, aQuery, null, aPrefs);
     }
 
     public SearchQueryRequest(Project aProject, User aUser, String aQuery,
-            SourceDocument aLimitedToDocument)
+            SourceDocument aLimitedToDocument, AnnotationSearchState aPrefs)
     {
-        this(aProject, aUser, aQuery, aLimitedToDocument, null, null, 0, Integer.MAX_VALUE);
+        this(aProject, aUser, aQuery, aLimitedToDocument, null, null, 0, Integer.MAX_VALUE, aPrefs);
     }
 
     public SearchQueryRequest(Project aProject, User aUser, String aQuery,
             SourceDocument aLimitedToDocument, AnnotationLayer aAnnotationLayer,
-            AnnotationFeature aAnnotationFeature, long aOffset, long aCount)
+            AnnotationFeature aAnnotationFeature, long aOffset, long aCount,
+            AnnotationSearchState aPrefs)
     {
         super();
         project = aProject;
@@ -63,6 +67,7 @@ public class SearchQueryRequest
         annotationFeature = aAnnotationFeature;
         offset = aOffset;
         count = aCount;
+        prefs = aPrefs;
     }
 
     public Project getProject()
@@ -103,5 +108,10 @@ public class SearchQueryRequest
     public long getCount()
     {
         return count;
+    }
+
+    public AnnotationSearchState getSearchSettings()
+    {
+        return prefs;
     }
 }

--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchServiceImpl.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchServiceImpl.java
@@ -26,7 +26,6 @@ import static java.lang.System.currentTimeMillis;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toUnmodifiableSet;
-import static org.apache.commons.lang3.StringUtils.toRootLowerCase;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -563,11 +562,9 @@ public class SearchServiceImpl
             Index index = pooledIndex.get();
             ensureIndexIsCreatedAndValid(aProject, index);
 
-            var query = preferencesService.loadDefaultTraitsForProject(KEY_SEARCH_STATE, aProject)
-                    .isCaseSensitive() ? aQuery : toRootLowerCase(aQuery);
-
+            var prefs = preferencesService.loadDefaultTraitsForProject(KEY_SEARCH_STATE, aProject);
             return index.getPhysicalIndex().executeQuery(new SearchQueryRequest(aProject, aUser,
-                    query, aDocument, aAnnotationLayer, aAnnotationFeature, offset, count));
+                    aQuery, aDocument, aAnnotationLayer, aAnnotationFeature, offset, count, prefs));
         }
     }
 
@@ -581,8 +578,9 @@ public class SearchServiceImpl
             Index index = pooledIndex.get();
             ensureIndexIsCreatedAndValid(aProject, index);
 
+            var prefs = preferencesService.loadDefaultTraitsForProject(KEY_SEARCH_STATE, aProject);
             return index.getPhysicalIndex().getAnnotationStatistics(new StatisticRequest(aProject,
-                    aUser, aMinTokenPerDoc, aMaxTokenPerDoc, aFeatures, null));
+                    aUser, aMinTokenPerDoc, aMaxTokenPerDoc, aFeatures, null, prefs));
         }
     }
 
@@ -597,8 +595,9 @@ public class SearchServiceImpl
             ensureIndexIsCreatedAndValid(aProject, index);
             PhysicalIndex physicalIndex = index.getPhysicalIndex();
 
+            var prefs = preferencesService.loadDefaultTraitsForProject(KEY_SEARCH_STATE, aProject);
             StatisticRequest statRequest = new StatisticRequest(aProject, aUser, aMinTokenPerDoc,
-                    aMaxTokenPerDoc, aFeatures, aQuery);
+                    aMaxTokenPerDoc, aFeatures, aQuery, prefs);
             LayerStatistics statistics = physicalIndex.getLayerStatistics(statRequest,
                     statRequest.getQuery(), physicalIndex.getUniqueDocuments(statRequest));
 
@@ -766,12 +765,10 @@ public class SearchServiceImpl
 
             ensureIndexIsCreatedAndValid(aProject, index);
 
-            var query = preferencesService.loadDefaultTraitsForProject(KEY_SEARCH_STATE, aProject)
-                    .isCaseSensitive() ? aQuery : toRootLowerCase(aQuery);
-
             // Index is valid, try to execute the query
+            var prefs = preferencesService.loadDefaultTraitsForProject(KEY_SEARCH_STATE, aProject);
             return index.getPhysicalIndex().numberOfQueryResults(new SearchQueryRequest(aProject,
-                    aUser, query, aDocument, aAnnotationLayer, aAnnotationFeature, 0L, 0L));
+                    aUser, aQuery, aDocument, aAnnotationLayer, aAnnotationFeature, 0L, 0L, prefs));
         }
     }
 

--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/StatisticRequest.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/StatisticRequest.java
@@ -23,11 +23,13 @@ import java.util.Set;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
+import de.tudarmstadt.ukp.inception.search.model.AnnotationSearchState;
 
 public class StatisticRequest
 {
     private final Project project;
     private final User user;
+    private final AnnotationSearchState prefs;
 
     private final OptionalInt minTokenPerDoc;
     private final OptionalInt maxTokenPerDoc;
@@ -36,7 +38,8 @@ public class StatisticRequest
     private final String query;
 
     public StatisticRequest(Project aProject, User aUser, OptionalInt aMinTokenPerDoc,
-            OptionalInt aMaxTokenPerDoc, Set<AnnotationFeature> aFeatures, String aQuery)
+            OptionalInt aMaxTokenPerDoc, Set<AnnotationFeature> aFeatures, String aQuery,
+            AnnotationSearchState aPrefs)
     {
         project = aProject;
         user = aUser;
@@ -45,6 +48,7 @@ public class StatisticRequest
         maxTokenPerDoc = aMaxTokenPerDoc;
         query = aQuery;
         features = aFeatures;
+        prefs = aPrefs;
     }
 
     public Project getProject()
@@ -82,4 +86,8 @@ public class StatisticRequest
         return query;
     }
 
+    public AnnotationSearchState getSearchSettings()
+    {
+        return prefs;
+    }
 }

--- a/inception/inception-search-mtas/src/main/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndex.java
+++ b/inception/inception-search-mtas/src/main/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndex.java
@@ -34,6 +34,7 @@ import static mtas.analysis.util.MtasTokenizerFactory.ARGUMENT_PARSER;
 import static mtas.analysis.util.MtasTokenizerFactory.ARGUMENT_PARSER_ARGS;
 import static mtas.codec.MtasCodec.MTAS_CODEC_NAME;
 import static org.apache.commons.io.FileUtils.deleteDirectory;
+import static org.apache.commons.lang3.StringUtils.toRootLowerCase;
 import static org.apache.lucene.search.ScoreMode.COMPLETE_NO_SCORES;
 
 import java.io.File;
@@ -114,6 +115,7 @@ import de.tudarmstadt.ukp.inception.search.StatisticRequest;
 import de.tudarmstadt.ukp.inception.search.StatisticsResult;
 import de.tudarmstadt.ukp.inception.search.index.IndexRebuildRequiredException;
 import de.tudarmstadt.ukp.inception.search.index.PhysicalIndex;
+import de.tudarmstadt.ukp.inception.search.model.AnnotationSearchState;
 import de.tudarmstadt.ukp.inception.search.model.BulkIndexingContext;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
@@ -512,17 +514,16 @@ public class MtasDocumentIndex
         return fullDocSet;
     }
 
-    public MtasSpanQuery parseQuery(String aQuery) throws ExecutionException, IOException
+    private MtasSpanQuery parseQuery(String aQuery, AnnotationSearchState aPrefs)
+        throws ExecutionException, IOException
     {
         final MtasSpanQuery mtasSpanQuery;
         try {
-            String modifiedQuery = preprocessQuery(aQuery);
-            MtasSpanQuery mtasSpanQuery1;
+            String modifiedQuery = preprocessQuery(aQuery, aPrefs);
             try (Reader queryReader = new StringReader(modifiedQuery)) {
                 MtasCQLParser parser = new MtasCQLParser(queryReader);
-                mtasSpanQuery1 = parser.parse(FIELD_CONTENT, DEFAULT_PREFIX, null, null, null);
+                mtasSpanQuery = parser.parse(FIELD_CONTENT, DEFAULT_PREFIX, null, null, null);
             }
-            mtasSpanQuery = mtasSpanQuery1;
         }
         catch (ParseException | Error e) {
             // The exceptions thrown by the MTAS CQL Parser are inheriting from
@@ -582,7 +583,8 @@ public class MtasDocumentIndex
             String[] functionTypes = new String[2];
 
             // Add the preprocessed query to the spanQueryList
-            MtasSpanQuery parsedQuery = parseQuery(aFeatureQuery);
+            MtasSpanQuery parsedQuery = parseQuery(aFeatureQuery,
+                    aStatisticRequest.getSearchSettings());
             fieldStats.spanQueryList.add(parsedQuery);
 
             // maybe using a function for this simple case is too slow...
@@ -595,7 +597,8 @@ public class MtasDocumentIndex
             functionTypes[0] = LayerStatistics.STATS;
 
             // A query which counts sentences
-            MtasSpanQuery parsedSentQuery = parseQuery("<s=\"\"/>");
+            MtasSpanQuery parsedSentQuery = parseQuery("<s=\"\"/>",
+                    aStatisticRequest.getSearchSettings());
             fieldStats.spanQueryList.add(parsedSentQuery);
 
             spanQuerys[1] = parsedSentQuery;
@@ -680,13 +683,12 @@ public class MtasDocumentIndex
 
         final MtasSpanQuery mtasSpanQuery;
         try {
-            String modifiedQuery = preprocessQuery(aRequest.getQuery());
-            MtasSpanQuery mtasSpanQuery1;
+            String modifiedQuery = preprocessQuery(aRequest.getQuery(),
+                    aRequest.getSearchSettings());
             try (Reader reader = new StringReader(modifiedQuery)) {
                 MtasCQLParser parser = new MtasCQLParser(reader);
-                mtasSpanQuery1 = parser.parse(FIELD_CONTENT, DEFAULT_PREFIX, null, null, null);
+                mtasSpanQuery = parser.parse(FIELD_CONTENT, DEFAULT_PREFIX, null, null, null);
             }
-            mtasSpanQuery = mtasSpanQuery1;
         }
         catch (ParseException | Error e) {
             // The exceptions thrown by the MTAS CQL Parser are inheriting from java.lang.Error...
@@ -715,7 +717,7 @@ public class MtasDocumentIndex
         }
     }
 
-    private String preprocessQuery(String aQuery)
+    private String preprocessQuery(String aQuery, AnnotationSearchState aPrefs)
     {
         if (aQuery.contains("\"") || aQuery.contains("[") || aQuery.contains("]")
                 || aQuery.contains("<") || aQuery.contains(">")) {
@@ -731,6 +733,11 @@ public class MtasDocumentIndex
         int end = words.next();
         while (end != BreakIterator.DONE) {
             String word = aQuery.substring(start, end);
+
+            if (!aPrefs.isCaseSensitive()) {
+                word = toRootLowerCase(word);
+            }
+
             if (!word.trim().isEmpty()) {
                 word = word.replace("&", "\\&");
                 word = word.replace("(", "\\(");

--- a/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchAnnotationSidebar.html
+++ b/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchAnnotationSidebar.html
@@ -33,13 +33,6 @@
               <form wicket:id="searchOptionsForm">
                 <div class="card-header small">
                   <wicket:message key="options" />
-                  <div class="actions">
-                    <button wicket:id="reindexProject" type="button"
-                      class="btn btn-sm btn-secondary">
-                      <i class="fas fa-sync" aria-hidden="true"></i>
-                      <wicket:message key="reindex" />
-                    </button>
-                  </div>
                 </div>
                 <div class="card-body small">
                   <div class="row form-row" wicket:enclosure="limitedToCurrentDocument">

--- a/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchAnnotationSidebar.java
+++ b/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchAnnotationSidebar.java
@@ -121,7 +121,6 @@ import de.tudarmstadt.ukp.inception.search.model.Progress;
 public class SearchAnnotationSidebar
     extends AnnotationSidebar_ImplBase
 {
-    private static final String MID_REINDEX_PROJECT = "reindexProject";
     private static final String MID_EXPORT = "export";
     private static final String MID_CLEAR_BUTTON = "clearButton";
     private static final String MID_TOGGLE_DELETE_OPTIONS_VISIBILITY = "toggleDeleteOptionsVisibility";
@@ -362,14 +361,8 @@ public class SearchAnnotationSidebar
         searchOptionsForm.add(createResultsPerPageSelection("itemsPerPage"));
         searchOptionsForm.add(lowLevelPagingCheckBox = createLowLevelPagingCheckBox());
         searchOptionsForm.setOutputMarkupPlaceholderTag(true);
-        searchOptionsForm.add(new LambdaAjaxLink(MID_REINDEX_PROJECT, this::actionRebuildIndex));
 
         return searchOptionsForm;
-    }
-
-    private void actionRebuildIndex(AjaxRequestTarget aTarget)
-    {
-        searchService.enqueueReindexTask(getAnnotationPage().getModelObject().getProject(), "user");
     }
 
     @Override


### PR DESCRIPTION
**What's in the PR**
- Handle lower-casing of the query differently such that layer names and feature names are not affected
- When writing a CQL query against a case-insensitive index, the user needs to take case of not upper-casing search terms
- For simple text queries, we do lower-case automatically

**How to test manually**
* Switch to a case-insensitive index configuration
* Try CQL query against layers that have upper-case characters in their names

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
