### PR TITLE
#2972 - Simplify search for boolean values

### DIFF
--- a/inception/inception-model/pom.xml
+++ b/inception/inception-model/pom.xml
@@ -33,6 +33,11 @@
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-security</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.uima</groupId>
+      <artifactId>uimaj-core</artifactId>
+    </dependency>
     
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/AnnotationFeature.java
+++ b/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/AnnotationFeature.java
@@ -17,6 +17,9 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.model;
 
+import static de.tudarmstadt.ukp.clarin.webanno.model.MultiValueMode.ARRAY;
+import static de.tudarmstadt.ukp.clarin.webanno.support.uima.JCasClassUtil.getUimaTypeName;
+
 import java.io.Serializable;
 
 import javax.persistence.Cacheable;
@@ -33,6 +36,9 @@ import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 
+import org.apache.uima.cas.Feature;
+import org.apache.uima.jcas.cas.CommonPrimitiveArray;
+import org.apache.uima.jcas.cas.TOP;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.NotFound;
@@ -171,6 +177,31 @@ public class AnnotationFeature
         type = aType;
         description = aDescription;
         tagset = aTagSet;
+    }
+
+    private AnnotationFeature(Builder builder)
+    {
+        this.id = builder.id;
+        this.type = builder.type;
+        this.layer = builder.layer;
+        this.project = builder.project;
+        this.tagset = builder.tagset;
+        this.uiName = builder.uiName;
+        this.description = builder.description;
+        this.enabled = builder.enabled;
+        this.name = builder.name;
+        this.visible = builder.visible;
+        this.includeInHover = builder.includeInHover;
+        this.remember = builder.remember;
+        this.hideUnconstraintFeature = builder.hideUnconstraintFeature;
+        this.required = builder.required;
+        this.multiValueMode = builder.multiValueMode;
+        this.linkMode = builder.linkMode;
+        this.linkTypeName = builder.linkTypeName;
+        this.linkTypeRoleFeatureName = builder.linkTypeRoleFeatureName;
+        this.linkTypeTargetFeatureName = builder.linkTypeTargetFeatureName;
+        this.traits = builder.traits;
+        this.curatable = builder.curatable;
     }
 
     public Long getId()
@@ -583,5 +614,192 @@ public class AnnotationFeature
             return false;
         }
         return true;
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static final class Builder
+    {
+        private Long id;
+        private String type;
+        private AnnotationLayer layer;
+        private Project project;
+        private TagSet tagset;
+        private String uiName;
+        private String description;
+        private boolean enabled = true;
+        private String name;
+        private boolean visible = true;
+        private boolean includeInHover = false;
+        private boolean remember;
+        private boolean hideUnconstraintFeature;
+        private boolean required;
+        private MultiValueMode multiValueMode = MultiValueMode.NONE;
+        private LinkMode linkMode = LinkMode.NONE;
+        private String linkTypeName;
+        private String linkTypeRoleFeatureName;
+        private String linkTypeTargetFeatureName;
+        private String traits;
+        private boolean curatable = true;
+
+        private Builder()
+        {
+        }
+
+        public Builder forFeature(Feature aFeature)
+        {
+            withType(aFeature.getRange().getName());
+            withName(aFeature.getShortName());
+            withUiName(aFeature.getShortName());
+            return this;
+        }
+
+        public Builder withId(Long id)
+        {
+            this.id = id;
+            return this;
+        }
+
+        public Builder withType(String type)
+        {
+            this.type = type;
+            return this;
+        }
+
+        public Builder withRange(String type)
+        {
+            return withType(type);
+        }
+
+        public Builder withRange(Class<? extends TOP> aClazz)
+        {
+            if (CommonPrimitiveArray.class.isAssignableFrom(aClazz)) {
+                withMultiValueMode(ARRAY);
+            }
+            return withType(getUimaTypeName(aClazz));
+        }
+
+        public Builder withLayer(AnnotationLayer layer)
+        {
+            this.layer = layer;
+            this.project = layer.getProject();
+            return this;
+        }
+
+        public Builder withProject(Project project)
+        {
+            this.project = project;
+            return this;
+        }
+
+        public Builder withTagset(TagSet tagset)
+        {
+            this.tagset = tagset;
+            return this;
+        }
+
+        public Builder withUiName(String uiName)
+        {
+            this.uiName = uiName;
+            return this;
+        }
+
+        public Builder withDescription(String description)
+        {
+            this.description = description;
+            return this;
+        }
+
+        public Builder withEnabled(boolean enabled)
+        {
+            this.enabled = enabled;
+            return this;
+        }
+
+        public Builder withName(String name)
+        {
+            this.name = name;
+            return this;
+        }
+
+        public Builder withVisible(boolean visible)
+        {
+            this.visible = visible;
+            return this;
+        }
+
+        public Builder withIncludeInHover(boolean includeInHover)
+        {
+            this.includeInHover = includeInHover;
+            return this;
+        }
+
+        public Builder withRemember(boolean remember)
+        {
+            this.remember = remember;
+            return this;
+        }
+
+        public Builder withHideUnconstraintFeature(boolean hideUnconstraintFeature)
+        {
+            this.hideUnconstraintFeature = hideUnconstraintFeature;
+            return this;
+        }
+
+        public Builder withRequired(boolean required)
+        {
+            this.required = required;
+            return this;
+        }
+
+        public Builder withMultiValueMode(MultiValueMode multiValueMode)
+        {
+            this.multiValueMode = multiValueMode;
+            return this;
+        }
+
+        public Builder withLinkMode(LinkMode linkMode)
+        {
+            this.linkMode = linkMode;
+            return this;
+        }
+
+        public Builder withLinkTypeName(String linkTypeName)
+        {
+            this.linkTypeName = linkTypeName;
+            return this;
+        }
+
+        public Builder withLinkTypeRoleFeatureName(String linkTypeRoleFeatureName)
+        {
+            this.linkTypeRoleFeatureName = linkTypeRoleFeatureName;
+            return this;
+        }
+
+        public Builder withLinkTypeTargetFeatureName(String linkTypeTargetFeatureName)
+        {
+            this.linkTypeTargetFeatureName = linkTypeTargetFeatureName;
+            return this;
+        }
+
+        public Builder withTraits(String traits)
+        {
+            this.traits = traits;
+            return this;
+        }
+
+        public Builder withCuratable(boolean curatable)
+        {
+            this.curatable = curatable;
+            return this;
+        }
+
+        public AnnotationFeature build()
+        {
+            return new AnnotationFeature(this);
+        }
     }
 }

--- a/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/AnnotationLayer.java
+++ b/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/AnnotationLayer.java
@@ -35,6 +35,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 
+import org.apache.uima.jcas.cas.TOP;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.Type;
@@ -145,6 +146,29 @@ public class AnnotationLayer
         setType(aType);
         setAnchoringMode(aAnchoringMode);
         setOverlapMode(aOverlapMode);
+    }
+
+    private AnnotationLayer(Builder builder)
+    {
+        this.id = builder.id;
+        this.uiName = builder.uiName;
+        this.type = builder.type;
+        this.description = builder.description;
+        this.enabled = builder.enabled;
+        this.builtIn = builder.builtIn;
+        this.readonly = builder.readonly;
+        this.onClickJavascriptAction = builder.onClickJavascriptAction;
+        this.name = builder.name;
+        this.attachType = builder.attachType;
+        this.attachFeature = builder.attachFeature;
+        this.project = builder.project;
+        this.crossSentence = builder.crossSentence;
+        this.showTextInHover = builder.showTextInHover;
+        this.linkedListBehavior = builder.linkedListBehavior;
+        this.anchoringMode = builder.anchoringMode;
+        this.overlapMode = builder.overlapMode;
+        this.validationMode = builder.validationMode;
+        this.traits = builder.traits;
     }
 
     /**
@@ -542,5 +566,165 @@ public class AnnotationLayer
     public String toString()
     {
         return "[" + name + "](" + id + ")";
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static final class Builder
+    {
+        private Long id;
+        private String uiName;
+        private String type;
+        private String description;
+        private boolean enabled = true;
+        private boolean builtIn = false;
+        private boolean readonly = false;
+        private String onClickJavascriptAction;
+        private String name;
+        private AnnotationLayer attachType;
+        private AnnotationFeature attachFeature;
+        private Project project;
+        private boolean crossSentence;
+        private boolean showTextInHover = true;
+        private boolean linkedListBehavior;
+        private AnchoringMode anchoringMode = AnchoringMode.TOKENS;
+        private OverlapMode overlapMode = OverlapMode.NO_OVERLAP;
+        private ValidationMode validationMode = ValidationMode.ALWAYS;
+        private String traits;
+
+        private Builder()
+        {
+            // Nothing to do
+        }
+
+        public Builder forJCasClass(Class<? extends TOP> aClazz)
+        {
+            withName(aClazz.getName());
+            withUiName(aClazz.getSimpleName());
+            return this;
+        }
+
+        public Builder withId(Long id)
+        {
+            this.id = id;
+            return this;
+        }
+
+        public Builder withUiName(String uiName)
+        {
+            this.uiName = uiName;
+            return this;
+        }
+
+        public Builder withType(String type)
+        {
+            this.type = type;
+            return this;
+        }
+
+        public Builder withDescription(String description)
+        {
+            this.description = description;
+            return this;
+        }
+
+        public Builder withEnabled(boolean enabled)
+        {
+            this.enabled = enabled;
+            return this;
+        }
+
+        public Builder withBuiltIn(boolean builtIn)
+        {
+            this.builtIn = builtIn;
+            return this;
+        }
+
+        public Builder withReadonly(boolean readonly)
+        {
+            this.readonly = readonly;
+            return this;
+        }
+
+        public Builder withOnClickJavascriptAction(String onClickJavascriptAction)
+        {
+            this.onClickJavascriptAction = onClickJavascriptAction;
+            return this;
+        }
+
+        public Builder withName(String name)
+        {
+            this.name = name;
+            return this;
+        }
+
+        public Builder withAttachType(AnnotationLayer attachType)
+        {
+            this.attachType = attachType;
+            return this;
+        }
+
+        public Builder withAttachFeature(AnnotationFeature attachFeature)
+        {
+            this.attachType = attachFeature.getLayer();
+            this.attachFeature = attachFeature;
+            return this;
+        }
+
+        public Builder withProject(Project project)
+        {
+            this.project = project;
+            return this;
+        }
+
+        public Builder withCrossSentence(boolean crossSentence)
+        {
+            this.crossSentence = crossSentence;
+            return this;
+        }
+
+        public Builder withShowTextInHover(boolean showTextInHover)
+        {
+            this.showTextInHover = showTextInHover;
+            return this;
+        }
+
+        public Builder withLinkedListBehavior(boolean linkedListBehavior)
+        {
+            this.linkedListBehavior = linkedListBehavior;
+            return this;
+        }
+
+        public Builder withAnchoringMode(AnchoringMode anchoringMode)
+        {
+            this.anchoringMode = anchoringMode;
+            return this;
+        }
+
+        public Builder withOverlapMode(OverlapMode overlapMode)
+        {
+            this.overlapMode = overlapMode;
+            return this;
+        }
+
+        public Builder withValidationMode(ValidationMode validationMode)
+        {
+            this.validationMode = validationMode;
+            return this;
+        }
+
+        public Builder withTraits(String traits)
+        {
+            this.traits = traits;
+            return this;
+        }
+
+        public AnnotationLayer build()
+        {
+            return new AnnotationLayer(this);
+        }
     }
 }

--- a/inception/inception-search-core/pom.xml
+++ b/inception/inception-search-core/pom.xml
@@ -77,6 +77,10 @@
       <groupId>org.apache.uima</groupId>
       <artifactId>uimaj-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.uima</groupId>
+      <artifactId>uimafit-core</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>info.picocli</groupId>

--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/PrimitiveUimaIndexingSupport.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/PrimitiveUimaIndexingSupport.java
@@ -17,12 +17,18 @@
  */
 package de.tudarmstadt.ukp.inception.search;
 
-import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static de.tudarmstadt.ukp.clarin.webanno.model.MultiValueMode.ARRAY;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.apache.uima.cas.CAS.TYPE_NAME_BOOLEAN;
+import static org.apache.uima.cas.CAS.TYPE_NAME_FLOAT;
+import static org.apache.uima.cas.CAS.TYPE_NAME_INTEGER;
+import static org.apache.uima.cas.CAS.TYPE_NAME_STRING;
+import static org.apache.uima.cas.CAS.TYPE_NAME_STRING_ARRAY;
 
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.multimap.HashSetValuedHashMap;
-import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.text.AnnotationFS;
+import org.apache.uima.fit.util.FSUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupport;
@@ -65,15 +71,21 @@ public class PrimitiveUimaIndexingSupport
         switch (aFeature.getMultiValueMode()) {
         case NONE:
             switch (aFeature.getType()) {
-            case CAS.TYPE_NAME_INTEGER: // fallthrough
-            case CAS.TYPE_NAME_FLOAT: // fallthrough
-            case CAS.TYPE_NAME_BOOLEAN: // fallthrough
-            case CAS.TYPE_NAME_STRING:
+            case TYPE_NAME_INTEGER: // fall-through
+            case TYPE_NAME_FLOAT: // fall-through
+            case TYPE_NAME_BOOLEAN: // fall-through
+            case TYPE_NAME_STRING:
                 return true;
             default:
                 return false;
             }
-        case ARRAY: // fallthrough
+        case ARRAY: // fall-through
+            switch (aFeature.getType()) {
+            case TYPE_NAME_STRING_ARRAY:
+                return true;
+            default:
+                return false;
+            }
         default:
             return false;
         }
@@ -84,13 +96,35 @@ public class PrimitiveUimaIndexingSupport
             AnnotationFS aAnnotation, String aFeaturePrefix, AnnotationFeature aFeature)
     {
         FeatureSupport<?> featSup = featureSupportRegistry.findExtension(aFeature).orElseThrow();
-        String featureValue = featSup.renderFeatureValue(aFeature, aAnnotation);
-        MultiValuedMap<String, String> values = new HashSetValuedHashMap<String, String>();
-        if (isEmpty(featureValue)) {
-            return values;
+
+        String featureIndexName = featureIndexName(aFieldPrefix, aFeaturePrefix, aFeature);
+        if (aFeature.getMultiValueMode() == ARRAY) {
+            var valuesMap = new HashSetValuedHashMap<String, String>();
+            var values = FSUtil.getFeature(aAnnotation, aFeature.getName(), String[].class);
+            if (values != null) {
+                for (String value : values) {
+                    String featureValue = featSup.renderFeatureValue(aFeature, value);
+                    if (isNotBlank(featureValue)) {
+                        valuesMap.put(featureIndexName, featureValue);
+                    }
+                }
+            }
+            return valuesMap;
         }
-        values.put(featureIndexName(aFieldPrefix, aFeaturePrefix, aFeature), featureValue);
-        return values;
+        if (TYPE_NAME_BOOLEAN.equals(aFeature.getType())) {
+            var value = FSUtil.getFeature(aAnnotation, aFeature.getName(), Boolean.class);
+            var valuesMap = new HashSetValuedHashMap<String, String>();
+            valuesMap.put(featureIndexName, value ? "true" : "false");
+            return valuesMap;
+        }
+        else {
+            var valuesMap = new HashSetValuedHashMap<String, String>();
+            String featureValue = featSup.renderFeatureValue(aFeature, aAnnotation);
+            if (isNotBlank(featureValue)) {
+                valuesMap.put(featureIndexName, featureValue);
+            }
+            return valuesMap;
+        }
     }
 
     @Override

--- a/inception/inception-search-mtas/pom.xml
+++ b/inception/inception-search-mtas/pom.xml
@@ -246,4 +246,28 @@
         </plugin>
       </plugins>
     </pluginManagement>
-  </build></project>
+    <plugins>
+      <plugin>
+        <!--generate types dynamically -->
+        <groupId>org.apache.uima</groupId>
+        <artifactId>jcasgen-maven-plugin</artifactId>
+        <version>${uima.version}</version>
+        <configuration>
+          <limitToProject>true</limitToProject>
+          <outputDirectory>${project.build.directory}/generated-test-sources/jcasgen</outputDirectory>
+          <typeSystemIncludes>
+            <include>src/test/resources/desc/type/**/*.xml</include>
+          </typeSystemIncludes>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/inception/inception-search-mtas/pom.xml
+++ b/inception/inception-search-mtas/pom.xml
@@ -268,6 +268,26 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>addToSourceFolder</id>
+            <goals>
+              <!--add the generated sources -->
+              <goal>add-test-source</goal>
+            </goals>
+            <phase>process-test-sources</phase>
+            <configuration>
+              <sources>
+                <!--default path to generated sources -->
+                <source>${project.build.directory}/generated-test-sources/jcasgen</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/inception/inception-search-mtas/src/main/resources/META-INF/asciidoc/user-guide/search-mtas.adoc
+++ b/inception/inception-search-mtas/src/main/resources/META-INF/asciidoc/user-guide/search-mtas.adoc
@@ -168,7 +168,7 @@ The capital of Galicia
 (<Named_entity.value="OTH"/> | <Named_entity.value="LOC"/>) intersecting <SemArg/>
 ----
 
-=== Relation queries
+=== Relation layer queries
 
 When relations are index, they are indexed by their target span.
 
@@ -207,7 +207,12 @@ Both layers have a string feature called `value`.
 ----
 
 
-=== Concept Annotation queries
+=== Boolean feature queries
+
+The values of boolean features are indexed as `true` and `false`.
+
+
+=== Concept feature queries
 
 .Generic Search over annotated KB entities : all occurrences for KB entity *Bordeaux*
 ----

--- a/inception/inception-search-mtas/src/test/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasUimaParserTest.java
+++ b/inception/inception-search-mtas/src/test/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasUimaParserTest.java
@@ -20,16 +20,13 @@ package de.tudarmstadt.ukp.inception.search.index.mtas;
 import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.FEAT_REL_SOURCE;
 import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.FEAT_REL_TARGET;
 import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.RELATION_TYPE;
-import static de.tudarmstadt.ukp.clarin.webanno.api.WebAnnoConst.SPAN_TYPE;
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.SINGLE_TOKEN;
-import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.TOKENS;
-import static de.tudarmstadt.ukp.clarin.webanno.model.OverlapMode.NO_OVERLAP;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
+import static org.apache.uima.cas.CAS.TYPE_NAME_BOOLEAN;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,17 +36,21 @@ import org.apache.uima.fit.factory.JCasBuilder;
 import org.apache.uima.fit.factory.JCasFactory;
 import org.apache.uima.fit.testing.factory.TokenBuilder;
 import org.apache.uima.jcas.JCas;
+import org.apache.uima.jcas.cas.StringArray;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.adapter.RelationAdapter;
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.adapter.SpanAdapter;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.BooleanFeatureSupport;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.FeatureSupportRegistryImpl;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.MultiValueStringFeatureSupport;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.NumberFeatureSupport;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.StringFeatureSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.feature.config.StringFeatureSupportPropertiesImpl;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.layer.LayerSupportRegistryImpl;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
@@ -62,9 +63,13 @@ import de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.Dependency;
 import de.tudarmstadt.ukp.inception.search.FeatureIndexingSupportRegistryImpl;
 import de.tudarmstadt.ukp.inception.search.PrimitiveUimaIndexingSupport;
 import de.tudarmstadt.ukp.inception.search.model.AnnotationSearchState;
+import inception.test.MultiValueHost;
+import inception.test.PrimitiveHost;
 import mtas.analysis.token.MtasToken;
 import mtas.analysis.token.MtasTokenCollection;
+import mtas.analysis.util.MtasParserException;
 
+@ExtendWith(MockitoExtension.class)
 public class MtasUimaParserTest
 {
     private @Mock AnnotationSchemaService annotationSchemaService;
@@ -77,25 +82,137 @@ public class MtasUimaParserTest
     private Project project;
     private JCas jcas;
 
+    private AnnotationLayer namedEntityLayer;
+    private AnnotationFeature namedEntityValueFeature;
+    private AnnotationFeature namedEntityIdentifierFeature;
+
+    private AnnotationLayer tokenLayer;
+    private AnnotationFeature tokenLayerPos;
+
+    private AnnotationLayer posLayer;
+    private AnnotationFeature posLayerValue;
+
+    private AnnotationLayer depLayer;
+    private AnnotationFeature dependencyLayerGovernor;
+    private AnnotationFeature dependencyLayerDependent;
+
+    private AnnotationLayer multiValueHostLayer;
+    private AnnotationFeature multiValueHostStringArrayFeature;
+
+    private AnnotationLayer primitiveHostLayer;
+    private AnnotationFeature primitiveHostBooleanFeature;
+
     @BeforeEach
     public void setup() throws Exception
     {
-        initMocks(this);
-
         project = new Project();
         project.setId(1l);
         project.setName("test project");
+
+        namedEntityLayer = AnnotationLayer.builder() //
+                .forJCasClass(NamedEntity.class) //
+                .withProject(project) //
+                .build();
+
+        namedEntityValueFeature = AnnotationFeature.builder() //
+                .withLayer(namedEntityLayer) //
+                .withName(NamedEntity._FeatName_value) //
+                .withUiName(NamedEntity._FeatName_value) //
+                .withType(CAS.TYPE_NAME_STRING) //
+                .build();
+
+        namedEntityIdentifierFeature = AnnotationFeature.builder() //
+                .withLayer(namedEntityLayer) //
+                .withName(NamedEntity._FeatName_identifier) //
+                .withUiName(NamedEntity._FeatName_identifier) //
+                .withRange(CAS.TYPE_NAME_STRING) //
+                .build();
+
+        tokenLayer = AnnotationLayer.builder() //
+                .forJCasClass(Token.class) //
+                .withProject(project) //
+                .withAnchoringMode(SINGLE_TOKEN) //
+                .build();
+
+        tokenLayerPos = AnnotationFeature.builder() //
+                .withLayer(tokenLayer) //
+                .withName(Token._FeatName_pos) //
+                .withRange(POS.class) //
+                .build();
+
+        posLayer = AnnotationLayer.builder() //
+                .forJCasClass(POS.class) //
+                .withProject(project) //
+                .withAnchoringMode(SINGLE_TOKEN) //
+                .build();
+
+        posLayerValue = AnnotationFeature.builder() //
+                .withLayer(posLayer) //
+                .withName(POS._FeatName_PosValue) //
+                .withUiName(POS._FeatName_PosValue) //
+                .withRange(CAS.TYPE_NAME_STRING) //
+                .build();
+
+        depLayer = AnnotationLayer.builder() //
+                .forJCasClass(Dependency.class) //
+                .withType(RELATION_TYPE) //
+                .withProject(project) //
+                .withAnchoringMode(SINGLE_TOKEN) //
+                .withAttachFeature(tokenLayerPos) //
+                .build();
+
+        dependencyLayerGovernor = AnnotationFeature.builder() //
+                .withLayer(depLayer) //
+                .withName(FEAT_REL_SOURCE) //
+                .withUiName(FEAT_REL_SOURCE) //
+                .withRange(Token.class) //
+                .build();
+
+        dependencyLayerDependent = AnnotationFeature.builder() //
+                .withLayer(depLayer) //
+                .withName(FEAT_REL_TARGET) //
+                .withUiName(FEAT_REL_TARGET) //
+                .withRange(Token.class) //
+                .build();
+
+        multiValueHostLayer = AnnotationLayer.builder() //
+                .forJCasClass(MultiValueHost.class) //
+                .withProject(project) //
+                .build();
+
+        multiValueHostStringArrayFeature = AnnotationFeature.builder() //
+                .withLayer(multiValueHostLayer) //
+                .withName(MultiValueHost._FeatName_stringArray) //
+                .withUiName(MultiValueHost._FeatName_stringArray) //
+                .withRange(StringArray.class) //
+                .build();
+
+        primitiveHostLayer = AnnotationLayer.builder() //
+                .forJCasClass(PrimitiveHost.class) //
+                .withProject(project) //
+                .build();
+
+        primitiveHostBooleanFeature = AnnotationFeature.builder() //
+                .withLayer(primitiveHostLayer) //
+                .withName(PrimitiveHost._FeatName_booleanFeature) //
+                .withUiName(PrimitiveHost._FeatName_booleanFeature) //
+                .withRange(TYPE_NAME_BOOLEAN) //
+                .build();
 
         prefs = new AnnotationSearchState();
 
         layerSupportRegistry = new LayerSupportRegistryImpl(emptyList());
 
-        featureSupportRegistry = new FeatureSupportRegistryImpl(asList(new StringFeatureSupport(),
-                new BooleanFeatureSupport(), new NumberFeatureSupport()));
+        featureSupportRegistry = new FeatureSupportRegistryImpl(asList( //
+                new StringFeatureSupport(), //
+                new BooleanFeatureSupport(), //
+                new NumberFeatureSupport(), //
+                new MultiValueStringFeatureSupport(new StringFeatureSupportPropertiesImpl(),
+                        null)));
         featureSupportRegistry.init();
 
-        featureIndexingSupportRegistry = new FeatureIndexingSupportRegistryImpl(
-                asList(new PrimitiveUimaIndexingSupport(featureSupportRegistry)));
+        featureIndexingSupportRegistry = new FeatureIndexingSupportRegistryImpl(asList( //
+                new PrimitiveUimaIndexingSupport(featureSupportRegistry)));
         featureIndexingSupportRegistry.init();
 
         // Resetting the JCas is faster than re-creating it
@@ -113,17 +230,13 @@ public class MtasUimaParserTest
         TokenBuilder<Token, Sentence> builder = TokenBuilder.create(Token.class, Sentence.class);
         builder.buildTokens(jcas, "This is a test . \n This is sentence two .");
 
-        // Only tokens and sentences here, no extra layers
-        when(annotationSchemaService.listAnnotationLayer(project)).thenReturn(asList());
-
         var sut = new MtasUimaParser(asList(), annotationSchemaService,
                 featureIndexingSupportRegistry, prefs);
         MtasTokenCollection tc = sut.createTokenCollection(jcas.getCas());
 
         MtasUtils.print(tc);
 
-        List<MtasToken> tokens = new ArrayList<>();
-        tc.iterator().forEachRemaining(tokens::add);
+        List<MtasToken> tokens = toList(tc);
 
         assertThat(tokens) //
                 .filteredOn(t -> "Token".equals(t.getPrefix())) //
@@ -155,31 +268,81 @@ public class MtasUimaParserTest
         builder.add(" ");
         builder.add(".", Token.class);
 
-        AnnotationLayer layer = new AnnotationLayer(NamedEntity.class.getName(), "Named Entity",
-                SPAN_TYPE, project, true, TOKENS, NO_OVERLAP);
-        when(annotationSchemaService.listAnnotationLayer(any(Project.class)))
-                .thenReturn(asList(layer));
-
         MtasUimaParser sut = new MtasUimaParser(
-                asList(new AnnotationFeature(1l, layer, "value", CAS.TYPE_NAME_STRING),
-                        new AnnotationFeature(2l, layer, "identifier", CAS.TYPE_NAME_STRING)),
+                asList(namedEntityValueFeature, namedEntityIdentifierFeature),
                 annotationSchemaService, featureIndexingSupportRegistry, prefs);
-        MtasTokenCollection tc = sut.createTokenCollection(jcas.getCas());
 
+        MtasTokenCollection tc = sut.createTokenCollection(jcas.getCas());
         MtasUtils.print(tc);
 
         List<MtasToken> tokens = new ArrayList<>();
         tc.iterator().forEachRemaining(tokens::add);
 
         assertThat(tokens) //
-                .filteredOn(t -> t.getPrefix().startsWith("Named_Entity"))
-                .extracting(MtasToken::getPrefix) //
-                .containsExactly("Named_Entity", "Named_Entity.value");
+                .filteredOn(t -> t.getPrefix().startsWith(namedEntityLayer.getUiName()))
+                .extracting(MtasToken::getPrefix, MtasToken::getPostfix) //
+                .containsExactly( //
+                        tuple("NamedEntity", ""), //
+                        tuple("NamedEntity.value", "PER"));
+    }
+
+    @Test
+    void testMultiValueStringFeature() throws Exception
+    {
+        TokenBuilder<Token, Sentence> builder = TokenBuilder.create(Token.class, Sentence.class);
+        builder.buildTokens(jcas, "test");
+
+        var mvh = new MultiValueHost(jcas, 0, 4);
+        mvh.setStringArray(StringArray.create(jcas, new String[] { "a", "b" }));
+        mvh.addToIndexes();
+
+        MtasUimaParser sut = new MtasUimaParser(asList(multiValueHostStringArrayFeature),
+                annotationSchemaService, featureIndexingSupportRegistry, prefs);
+        MtasTokenCollection result = sut.createTokenCollection(jcas.getCas());
+
+        MtasUtils.print(result);
+
+        List<MtasToken> tokens = toList(result);
 
         assertThat(tokens) //
-                .filteredOn(t -> t.getPrefix().startsWith("Named_Entity")) //
-                .extracting(MtasToken::getPostfix) //
-                .containsExactly("", "PER");
+                .filteredOn(t -> t.getPrefix().startsWith(multiValueHostLayer.getUiName())) //
+                .extracting(MtasToken::getPrefix, MtasToken::getPostfix) //
+                .containsExactly( //
+                        tuple("MultiValueHost", "test"), //
+                        tuple("MultiValueHost.stringArray", "a"), //
+                        tuple("MultiValueHost.stringArray", "b"));
+    }
+
+    @Test
+    void testBooleanFeature() throws Exception
+    {
+        TokenBuilder<Token, Sentence> builder = TokenBuilder.create(Token.class, Sentence.class);
+        builder.buildTokens(jcas, "test");
+
+        var ph1 = new PrimitiveHost(jcas, 0, 4);
+        ph1.setBooleanFeature(true);
+        ph1.addToIndexes();
+
+        var ph2 = new PrimitiveHost(jcas, 0, 4);
+        ph2.setBooleanFeature(false);
+        ph2.addToIndexes();
+
+        MtasUimaParser sut = new MtasUimaParser(asList(primitiveHostBooleanFeature),
+                annotationSchemaService, featureIndexingSupportRegistry, prefs);
+        MtasTokenCollection result = sut.createTokenCollection(jcas.getCas());
+
+        MtasUtils.print(result);
+
+        List<MtasToken> tokens = toList(result);
+
+        assertThat(tokens) //
+                .filteredOn(t -> t.getPrefix().startsWith(primitiveHostLayer.getUiName())) //
+                .extracting(MtasToken::getPrefix, MtasToken::getPostfix) //
+                .containsExactly( //
+                        tuple("PrimitiveHost", "test"), //
+                        tuple("PrimitiveHost", "test"), //
+                        tuple("PrimitiveHost.booleanFeature", "false"), //
+                        tuple("PrimitiveHost.booleanFeature", "true"));
     }
 
     @Test
@@ -192,24 +355,18 @@ public class MtasUimaParserTest
         zeroWidthNe.setValue("OTH");
         zeroWidthNe.addToIndexes();
 
-        AnnotationLayer layer = new AnnotationLayer(NamedEntity.class.getName(), "Named Entity",
-                SPAN_TYPE, project, true, TOKENS, NO_OVERLAP);
-        when(annotationSchemaService.listAnnotationLayer(any(Project.class)))
-                .thenReturn(asList(layer));
-
         MtasUimaParser sut = new MtasUimaParser(
-                asList(new AnnotationFeature(1l, layer, "value", CAS.TYPE_NAME_STRING),
-                        new AnnotationFeature(2l, layer, "identifier", CAS.TYPE_NAME_STRING)),
+                asList(namedEntityValueFeature, namedEntityIdentifierFeature),
                 annotationSchemaService, featureIndexingSupportRegistry, prefs);
-        MtasTokenCollection tc = sut.createTokenCollection(jcas.getCas());
+        MtasTokenCollection result = sut.createTokenCollection(jcas.getCas());
 
-        MtasUtils.print(tc);
+        MtasUtils.print(result);
 
         List<MtasToken> tokens = new ArrayList<>();
-        tc.iterator().forEachRemaining(tokens::add);
+        result.iterator().forEachRemaining(tokens::add);
 
         assertThat(tokens) //
-                .filteredOn(t -> t.getPrefix().startsWith("Named_Entity")) //
+                .filteredOn(t -> t.getPrefix().startsWith(namedEntityLayer.getUiName())) //
                 .isEmpty();
     }
 
@@ -239,40 +396,11 @@ public class MtasUimaParserTest
         d1.setGovernor(t1);
         d1.addToIndexes();
 
-        // Set up annotation schema with POS and Dependency
-        AnnotationLayer tokenLayer = new AnnotationLayer(Token.class.getName(), "Token", SPAN_TYPE,
-                project, true, SINGLE_TOKEN, NO_OVERLAP);
-        tokenLayer.setId(1l);
-        AnnotationFeature tokenLayerPos = new AnnotationFeature(1l, tokenLayer, "pos",
-                POS.class.getName());
-
-        AnnotationLayer posLayer = new AnnotationLayer(POS.class.getName(), "POS", SPAN_TYPE,
-                project, true, SINGLE_TOKEN, NO_OVERLAP);
-        posLayer.setId(2l);
-        AnnotationFeature posLayerValue = new AnnotationFeature(1l, posLayer, "PosValue",
-                CAS.TYPE_NAME_STRING);
-
-        AnnotationLayer depLayer = new AnnotationLayer(Dependency.class.getName(), "Dependency",
-                RELATION_TYPE, project, true, SINGLE_TOKEN, NO_OVERLAP);
-        depLayer.setId(3l);
-        depLayer.setAttachType(tokenLayer);
-        depLayer.setAttachFeature(tokenLayerPos);
-        AnnotationFeature dependencyLayerGovernor = new AnnotationFeature(2l, depLayer,
-                FEAT_REL_SOURCE, Token.class.getName());
-        AnnotationFeature dependencyLayerDependent = new AnnotationFeature(3l, depLayer,
-                FEAT_REL_TARGET, Token.class.getName());
-
-        when(annotationSchemaService.listAnnotationLayer(any(Project.class)))
-                .thenReturn(asList(tokenLayer, posLayer, depLayer));
-
-        when(annotationSchemaService.getAdapter(posLayer))
-                .thenReturn(new SpanAdapter(layerSupportRegistry, featureSupportRegistry, null,
-                        posLayer, () -> asList(posLayerValue), null));
-
-        when(annotationSchemaService.getAdapter(depLayer)).thenReturn(new RelationAdapter(
-                layerSupportRegistry, featureSupportRegistry, null, depLayer, FEAT_REL_TARGET,
-                FEAT_REL_SOURCE, () -> asList(dependencyLayerGovernor, dependencyLayerDependent),
-                emptyList()));
+        when(annotationSchemaService.getAdapter(depLayer)) //
+                .thenReturn(new RelationAdapter(layerSupportRegistry, featureSupportRegistry, null,
+                        depLayer, FEAT_REL_TARGET, FEAT_REL_SOURCE,
+                        () -> asList(dependencyLayerGovernor, dependencyLayerDependent),
+                        emptyList()));
 
         MtasUimaParser sut = new MtasUimaParser(
                 asList(tokenLayerPos, posLayerValue, dependencyLayerGovernor,
@@ -294,5 +422,12 @@ public class MtasUimaParserTest
                         "Dependency-source.PosValue=A", //
                         "Dependency-target=b", //
                         "Dependency-target.PosValue=B");
+    }
+
+    private List<MtasToken> toList(MtasTokenCollection result) throws MtasParserException
+    {
+        List<MtasToken> tokens = new ArrayList<>();
+        result.iterator().forEachRemaining(tokens::add);
+        return tokens;
     }
 }

--- a/inception/inception-search-mtas/src/test/resources/META-INF/org.apache.uima.fit/types.txt
+++ b/inception/inception-search-mtas/src/test/resources/META-INF/org.apache.uima.fit/types.txt
@@ -1,0 +1,1 @@
+classpath*:desc/type/TestTypes.xml

--- a/inception/inception-search-mtas/src/test/resources/desc/type/TestTypes.xml
+++ b/inception/inception-search-mtas/src/test/resources/desc/type/TestTypes.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<typeSystemDescription xmlns="http://uima.apache.org/resourceSpecifier">
+  <name>TestTypes</name>
+  <description/>
+  <version>1.0</version>
+  <vendor/>
+  <types>
+    <typeDescription>
+      <name>inception.test.MultiValueHost</name>
+      <description/>
+      <supertypeName>uima.tcas.Annotation</supertypeName>
+      <features>
+        <featureDescription>
+          <name>stringArray</name>
+          <description/>
+          <rangeTypeName>uima.cas.StringArray</rangeTypeName>
+        </featureDescription>
+      </features>
+    </typeDescription>
+    <typeDescription>
+      <name>inception.test.PrimitiveHost</name>
+      <description/>
+      <supertypeName>uima.tcas.Annotation</supertypeName>
+      <features>
+        <featureDescription>
+          <name>booleanFeature</name>
+          <description/>
+          <rangeTypeName>uima.cas.Boolean</rangeTypeName>
+        </featureDescription>
+      </features>
+    </typeDescription>
+  </types>
+</typeSystemDescription>

--- a/inception/inception-search-mtas/suppressions.xml
+++ b/inception/inception-search-mtas/suppressions.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+"-//Puppy Crawl//DTD Suppressions 1.1//EN"
+"http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+    <suppress files=".*[/\\]target[/\\].*" checks=".*"/>
+</suppressions>

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/uima/JCasClassUtil.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/uima/JCasClassUtil.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.support.uima;
+
+import org.apache.uima.cas.CAS;
+import org.apache.uima.cas.FeatureStructure;
+import org.apache.uima.cas.text.AnnotationFS;
+import org.apache.uima.jcas.cas.TOP;
+
+public class JCasClassUtil
+{
+    public static final String UIMA_BUILTIN_JCAS_PREFIX = "org.apache.uima.jcas.";
+
+    public static String getUimaTypeName(Class<? extends TOP> aClazz)
+    {
+        String typeName = aClazz.getName();
+        if (typeName.startsWith(UIMA_BUILTIN_JCAS_PREFIX)) {
+            typeName = "uima." + typeName.substring(UIMA_BUILTIN_JCAS_PREFIX.length());
+        }
+        else if (FeatureStructure.class.getName().equals(typeName)) {
+            typeName = CAS.TYPE_NAME_TOP;
+        }
+        else if (AnnotationFS.class.getName().equals(typeName)) {
+            typeName = CAS.TYPE_NAME_ANNOTATION;
+        }
+        return typeName;
+    }
+}


### PR DESCRIPTION
**What's in the PR**
- Add builders to AnnotationLayer and AnnotationFeature
- Add support for indexing multi-value string features
- Index boolean feature values as true/false
- Added tests
- Updated documentation

**How to test manually**
* Define a layer with a boolean feature and search for it e.g. as `[MyLayer.boolFeature="true"]`
* Define a layer with a multi-value string feature, then search for one value or more values, e.g. `[MyLayer.value="a" & MyLayer.value="b"]`

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
