### PR TITLE
#3185 - Two guest users with same UI name

### DIFF
--- a/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/AcceptInvitePage.java
+++ b/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/AcceptInvitePage.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.wicket.AttributeModifier;
+import org.apache.wicket.RestartResponseException;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.feedback.IFeedback;
 import org.apache.wicket.markup.html.WebMarkupContainer;
@@ -108,6 +109,13 @@ public class AcceptInvitePage
         if (user != null && invitationIsValid.getObject()) {
             if (projectService.existsProjectPermissionLevel(user, getProject(), ANNOTATOR)) {
                 backToProjectPage();
+            }
+            else if (user.getRealm() != null) {
+                // It the current user is a project-bound user and does not already exist in the
+                // project, then the user belongs to a different project. In this case, the user
+                // must not join another project to which they are not bound
+                ApplicationSession.get().signOut();
+                throw new RestartResponseException(getClass(), aPageParameters);
             }
         }
 


### PR DESCRIPTION
**What's in the PR**
- Force-logout a project-bound users when they try to join another project so a new identity is created when joining the new project

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
