### PR TITLE
#3223 - Search sidebar can bypass workload management

### DIFF
--- a/inception/inception-ui-search/pom.xml
+++ b/inception/inception-ui-search/pom.xml
@@ -43,6 +43,10 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-workload</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-security</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
**What's in the PR**
- Hide option to search all documents when random access is disabled
- Always limited to the current document when random access is disabled

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
