### PR TITLE
#1088 - Create spans across page boundaries in PDF editor

### DIFF
--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/annotation/span.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/annotation/span.ts
@@ -56,7 +56,7 @@ export default class SpanAnnotation extends AbstractAnnotation {
         console.error('ERROR: span missing page or textRange. span=', this)
         return false
       }
-      this.rectangles = mergeRects(getGlyphsInRange(this.textRange).map(g => g.bbox))
+      this.rectangles = mergeRects(getGlyphsInRange(this.textRange))
     }
 
     return super.render()

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/pdfanno.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/pdfanno.ts
@@ -212,7 +212,7 @@ export function scrollTo (offset: number, position: string): void {
     return
   }
 
-  const rectangles = mapToDocumentCoordinates(getGlyphsInRange([offset, offset + 1]).map(g => g.bbox), page)
+  const rectangles = mapToDocumentCoordinates(getGlyphsInRange([offset, offset + 1]).map(g => g.bbox))
   const annoLayer = document.getElementById('annoLayer2')
   if (!annoLayer) {
     console.error('No annoLayer found.')
@@ -270,7 +270,7 @@ export function getAnnotations () {
         span.page = textLayer.findPageForOffset(span.textRange[0]).index
         span.color = s[2]?.c || '#FFF'
         span.text = s[2]?.l || ''
-        span.rectangles = mergeRects(getGlyphsInRange(span.textRange).map(g => g.bbox))
+        span.rectangles = mergeRects(getGlyphsInRange(span.textRange))
         annotationMarkers.get(s[0])?.forEach(m => span.classList.push(`marker-${m[0]}`))
         span.save()
       }
@@ -297,7 +297,7 @@ export function getAnnotations () {
         span.page = textLayer.findPageForOffset(span.textRange[0]).index
         span.knob = false
         span.border = false
-        span.rectangles = mergeRects(getGlyphsInRange(span.textRange).map(g => g.bbox))
+        span.rectangles = mergeRects(getGlyphsInRange(span.textRange))
         span.classList = [`marker-${m[0]}`]
         span.save()
       }

--- a/inception/inception-pdf-editor2/src/main/ts/src/vmodel/Rectangle.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/vmodel/Rectangle.ts
@@ -19,12 +19,14 @@
 import { Point } from './Point'
 
 export class Rectangle {
+  p: number
   x: number
   y: number
   w: number
   h: number
 
-  constructor (aRectangle: {x: number, y: number, w: number, h: number}) {
+  constructor (aRectangle: {p: number, x: number, y: number, w: number, h: number}) {
+    this.p = aRectangle.p
     this.x = aRectangle.x
     this.y = aRectangle.y
     this.w = aRectangle.w

--- a/inception/inception-pdf-editor2/src/main/ts/src/vmodel/VGlyph.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/vmodel/VGlyph.ts
@@ -33,9 +33,9 @@ export class VGlyph {
     this.end = aGlyph[1]
     this.unicode = aGlyph[2]
     if (aLine[0] === 0 || aLine[0] === 180) {
-      this.bbox = new Rectangle({ x: aGlyph[3], y: aLine[2], w: aGlyph[4], h: aLine[4] })
+      this.bbox = new Rectangle({ p: aPage.index, x: aGlyph[3], y: aLine[2], w: aGlyph[4], h: aLine[4] })
     } else {
-      this.bbox = new Rectangle({ x: aLine[1], y: aGlyph[3], w: aLine[3], h: aGlyph[4] })
+      this.bbox = new Rectangle({ p: aPage.index, x: aLine[1], y: aGlyph[3], w: aLine[3], h: aGlyph[4] })
     }
   }
 }


### PR DESCRIPTION
**What's in the PR**
- Consider the page of each glyph when merging rectangles
- Consider the page of rectangles when rendering
- Fixes rendering of annotations that go across page boundaries
- Also fixes selection of text across page boundaries (#1087)

**How to test manually**
* Create an annotation in the brat view that goes across a page boundary, then look at it in the PDF view
* Drag a selection across a page boundary to create  a cross-page annotation

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
