### PR TITLE
#3281 - Support the new UIMA JSON CAS format

### DIFF
--- a/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/CasStorageSession.java
+++ b/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/CasStorageSession.java
@@ -346,6 +346,7 @@ public class CasStorageSession
 
         Optional<SessionManagedCas> result = managedCases.values().stream()
                 .flatMap(casByUser -> casByUser.values().stream()
+                        .filter(metadata -> metadata.isCasSet())
                         .filter(metadata -> metadata.getCas() == aCas))
                 .findFirst();
 

--- a/inception/inception-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/DocumentImportExportService.java
+++ b/inception/inception-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/DocumentImportExportService.java
@@ -240,4 +240,6 @@ public interface DocumentImportExportService
      */
     TypeSystemDescription getTypeSystemForExport(Project aProject)
         throws ResourceInitializationException;
+
+    TypeSystemDescription getExportSpecificTypes();
 }

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/user-guide.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/user-guide.adoc
@@ -247,6 +247,10 @@ include::{include-dir}formats-text.adoc[leveloffset=+2]
 
 include::{include-dir}formats-uimabinarycas.adoc[leveloffset=+2]
 
+include::{include-dir}formats-uimajson.adoc[leveloffset=+2]
+
+include::{include-dir}formats-uimajson-legacy.adoc[leveloffset=+2]
+
 include::{include-dir}formats-uimaxmi.adoc[leveloffset=+2]
 
 include::{include-dir}formats-webannotsv1.adoc[leveloffset=+2]

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/user-guide/formats-uimajson-legacy.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/user-guide/formats-uimajson-legacy.adoc
@@ -1,0 +1,37 @@
+// Licensed to the Technische Universität Darmstadt under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The Technische Universität Darmstadt 
+// licenses this file to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.
+//  
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+[[sect_formats_uimajson_legacy]]
+= UIMA CAS JSON (legacy)
+
+This is an old and deprecated UIMA CAS JSON format which can be exported but not imported.
+It should no longer be used. Instead, one should turn to <<sect_formats_uimajson>>.
+
+The format does support custom layers.
+
+For more details on this format, please refer to the link:https://uima.apache.org/d/uimaj-current/references.html#ugr.ref.json[UIMA Reference Guide].
+
+[cols="2,1,1,1,3"]
+|====
+| Format | Read | Write | Custom Layers | Description
+
+| link:https://uima.apache.org/d/uimaj-current/references.html#ugr.ref.json[UIMA CAS JSON (legacy)] (`json`)
+| no
+| yes
+| yes
+| UIMA CAS JSON (legacy)
+|====
+

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/user-guide/formats-uimajson.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/user-guide/formats-uimajson.adoc
@@ -1,0 +1,43 @@
+// Licensed to the Technische Universität Darmstadt under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The Technische Universität Darmstadt 
+// licenses this file to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.
+//  
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+[[sect_formats_uimajson]]
+= UIMA CAS JSON (experimental)
+
+This is a new and still experimental UIMA CAS JSON format which is able to capture not only the
+annotations but also the type system. As such, it is self-contained like the <<sect_formats_uimabinarycas>>
+format while at the same time being more readable than the <<sect_formats_uimaxmi>> format.
+
+Support for this format is available in the following implementations:
+
+* link:https://github.com/apache/uima-uimaj-io-jsoncas[Apache UIMA Java SDK JSON CAS Support] (Java).
+  This is the implementation we use here.
+* link:https://github.com/dkpro/dkpro-cassis[DKPro Cassis] (Python)
+
+The current draft specification of the format is available link:https://github.com/apache/uima-uimaj-io-jsoncas/blob/main/SPECIFICATION.adoc[here].
+
+[cols="2,1,1,1,3"]
+|====
+| Format | Read | Write | Custom Layers | Description
+
+| link:https://github.com/apache/uima-uimaj-io-jsoncas/blob/main/SPECIFICATION.adoc[UIMA CAS JSON (experimental)] (`jsoncas`)
+| yes
+| yes
+| yes
+| UIMA CAS JSON 0.4.0
+
+|====
+

--- a/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/DocumentImportExportServiceImpl.java
+++ b/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/DocumentImportExportServiceImpl.java
@@ -32,6 +32,7 @@ import static de.tudarmstadt.ukp.clarin.webanno.support.WebAnnoConst.CURATION_US
 import static java.io.File.createTempFile;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
+import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.io.FileUtils.forceDelete;
@@ -499,6 +500,12 @@ public class DocumentImportExportServiceImpl
     }
 
     @Override
+    public TypeSystemDescription getExportSpecificTypes()
+    {
+        return (TypeSystemDescription) schemaTypeSystem.clone();
+    }
+
+    @Override
     public TypeSystemDescription getTypeSystemForExport(Project aProject)
         throws ResourceInitializationException
     {
@@ -587,7 +594,8 @@ public class DocumentImportExportServiceImpl
                 .collect(groupingBy(AnnotationFeature::getLayer));
 
         List<AnnotationLayer> layers = featuresGroupedByLayer.keySet().stream()
-                .sorted(Comparator.comparing(AnnotationLayer::getName)).collect(toList());
+                .sorted(comparing(AnnotationLayer::getName)) //
+                .collect(toList());
 
         for (var layer : layers) {
             final var layerDefFs = aCas.createFS(layerDefType);

--- a/inception/inception-io-json/pom.xml
+++ b/inception/inception-io-json/pom.xml
@@ -37,7 +37,7 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
-      <artifactId>inception-export</artifactId>
+      <artifactId>inception-api</artifactId>
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
@@ -62,6 +62,14 @@
     <dependency>
       <groupId>org.dkpro.core</groupId>
       <artifactId>dkpro-core-io-json-asl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.dkpro.core</groupId>
+      <artifactId>dkpro-core-api-io-asl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/inception/inception-io-json/pom.xml
+++ b/inception/inception-io-json/pom.xml
@@ -15,7 +15,9 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>de.tudarmstadt.ukp.inception.app</groupId>
@@ -34,6 +36,14 @@
       <artifactId>inception-model</artifactId>
     </dependency>
     <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-export</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-schema</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>
@@ -44,6 +54,10 @@
     <dependency>
       <groupId>org.apache.uima</groupId>
       <artifactId>uimafit-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.uima</groupId>
+      <artifactId>uimaj-io-json</artifactId>
     </dependency>
     <dependency>
       <groupId>org.dkpro.core</groupId>

--- a/inception/inception-io-json/src/main/java/de/tudarmstadt/ukp/inception/io/jsoncas/LegacyUimaJsonFormatSupport.java
+++ b/inception/inception-io-json/src/main/java/de/tudarmstadt/ukp/inception/io/jsoncas/LegacyUimaJsonFormatSupport.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package de.tudarmstadt.ukp.clarin.webanno.json;
+package de.tudarmstadt.ukp.inception.io.jsoncas;
 
 import static org.apache.uima.fit.factory.AnalysisEngineFactory.createEngineDescription;
 
@@ -30,11 +30,11 @@ import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 
 @Component
-public class JsonFormatSupport
+public class LegacyUimaJsonFormatSupport
     implements FormatSupport
 {
     public static final String ID = "json";
-    public static final String NAME = "UIMA CAS JSON";
+    public static final String NAME = "UIMA CAS JSON (legacy)";
 
     @Override
     public String getId()

--- a/inception/inception-io-json/src/main/java/de/tudarmstadt/ukp/inception/io/jsoncas/UimaJsonCasFormatSupport.java
+++ b/inception/inception-io-json/src/main/java/de/tudarmstadt/ukp/inception/io/jsoncas/UimaJsonCasFormatSupport.java
@@ -38,7 +38,6 @@ import org.springframework.stereotype.Component;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
-import de.tudarmstadt.ukp.inception.schema.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.service.AnnotationSchemaServiceImpl;
 
 @Component
@@ -49,14 +48,11 @@ public class UimaJsonCasFormatSupport
     public static final String NAME = "UIMA CAS JSON 0.4.0 (experimental)";
 
     private final DocumentImportExportService documentImportExportService;
-    private final AnnotationSchemaService annotationSchemaService;
 
     @Autowired
-    public UimaJsonCasFormatSupport(DocumentImportExportService aDocumentImportExportService,
-            AnnotationSchemaService aAnnotationSchemaService)
+    public UimaJsonCasFormatSupport(DocumentImportExportService aDocumentImportExportService)
     {
         documentImportExportService = aDocumentImportExportService;
-        annotationSchemaService = aAnnotationSchemaService;
     }
 
     @Override

--- a/inception/inception-io-json/src/main/java/de/tudarmstadt/ukp/inception/io/jsoncas/UimaJsonCasFormatSupport.java
+++ b/inception/inception-io-json/src/main/java/de/tudarmstadt/ukp/inception/io/jsoncas/UimaJsonCasFormatSupport.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.io.jsoncas;
+
+import static java.util.Arrays.asList;
+import static org.apache.uima.fit.factory.AnalysisEngineFactory.createEngineDescription;
+import static org.apache.uima.fit.factory.CollectionReaderFactory.createReaderDescription;
+import static org.apache.uima.util.CasCreationUtils.mergeTypeSystems;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.uima.analysis_engine.AnalysisEngineDescription;
+import org.apache.uima.cas.CAS;
+import org.apache.uima.collection.CollectionException;
+import org.apache.uima.collection.CollectionReaderDescription;
+import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
+import org.apache.uima.util.TypeSystemUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.DocumentImportExportService;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.inception.schema.AnnotationSchemaService;
+import de.tudarmstadt.ukp.inception.schema.service.AnnotationSchemaServiceImpl;
+
+@Component
+public class UimaJsonCasFormatSupport
+    implements FormatSupport
+{
+    public static final String ID = "jsoncas";
+    public static final String NAME = "UIMA CAS JSON 0.4.0 (experimental)";
+
+    private final DocumentImportExportService documentImportExportService;
+    private final AnnotationSchemaService annotationSchemaService;
+
+    @Autowired
+    public UimaJsonCasFormatSupport(DocumentImportExportService aDocumentImportExportService,
+            AnnotationSchemaService aAnnotationSchemaService)
+    {
+        documentImportExportService = aDocumentImportExportService;
+        annotationSchemaService = aAnnotationSchemaService;
+    }
+
+    @Override
+    public String getId()
+    {
+        return ID;
+    }
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public boolean isReadable()
+    {
+        return true;
+    }
+
+    @Override
+    public boolean isWritable()
+    {
+        return true;
+    }
+
+    @Override
+    public AnalysisEngineDescription getWriterDescription(Project aProject,
+            TypeSystemDescription aTSD, CAS aCAS)
+        throws ResourceInitializationException
+    {
+        return createEngineDescription(UimaJsonCasWriter.class, aTSD);
+    }
+
+    @Override
+    public void read(CAS aCas, File aFile)
+        throws ResourceInitializationException, IOException, CollectionException
+    {
+        // We need to perform a little hack here because the JSON CAS IO does not support lenient
+        // deserialization yet. INCEpTION includes some types in exports that are specific only to
+        // exports. They are usually discarded by the lenient XMI import, but here they bite us.
+        var tsd = mergeTypeSystems(asList( //
+                TypeSystemUtil.typeSystem2TypeSystemDescription(aCas.getTypeSystem()),
+                documentImportExportService.getExportSpecificTypes()));
+
+        upgradeCas(aCas, tsd);
+
+        FormatSupport.super.read(aCas, aFile);
+
+        // No need to go back to the original CAS TS because another upgrade happens after
+        // project import anyway.
+    }
+
+    private void upgradeCas(CAS aCas, TypeSystemDescription tsd)
+        throws IOException, ResourceInitializationException, CollectionException
+    {
+        try {
+            AnnotationSchemaServiceImpl._upgradeCas(aCas, aCas, tsd);
+        }
+        catch (ResourceInitializationException e) {
+            throw e;
+        }
+    }
+
+    @Override
+    public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
+        throws ResourceInitializationException
+    {
+        return createReaderDescription(UimaJsonCasReader.class, aTSD);
+    }
+}

--- a/inception/inception-io-json/src/main/java/de/tudarmstadt/ukp/inception/io/jsoncas/UimaJsonCasReader.java
+++ b/inception/inception-io-json/src/main/java/de/tudarmstadt/ukp/inception/io/jsoncas/UimaJsonCasReader.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.io.jsoncas;
+
+import java.io.IOException;
+
+import org.apache.uima.collection.CollectionException;
+import org.apache.uima.jcas.JCas;
+import org.apache.uima.json.jsoncas2.JsonCas2Deserializer;
+import org.apache.uima.json.jsoncas2.mode.FeatureStructuresMode;
+import org.dkpro.core.api.io.JCasResourceCollectionReader_ImplBase;
+
+/**
+ * UIMA JSON CAS format reader.
+ */
+public class UimaJsonCasReader
+    extends JCasResourceCollectionReader_ImplBase
+{
+    @Override
+    public void getNext(JCas aJCas) throws IOException, CollectionException
+    {
+        Resource res = nextFile();
+        initCas(aJCas, res);
+
+        var jds = new JsonCas2Deserializer();
+        jds.setFsMode(FeatureStructuresMode.AS_ARRAY);
+
+        try (var is = res.getInputStream()) {
+            jds.deserialize(is, aJCas.getCas());
+        }
+    }
+}

--- a/inception/inception-io-json/src/main/java/de/tudarmstadt/ukp/inception/io/jsoncas/UimaJsonCasWriter.java
+++ b/inception/inception-io-json/src/main/java/de/tudarmstadt/ukp/inception/io/jsoncas/UimaJsonCasWriter.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.io.jsoncas;
+
+import java.io.OutputStream;
+
+import org.apache.uima.UimaContext;
+import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
+import org.apache.uima.jcas.JCas;
+import org.apache.uima.json.jsoncas2.JsonCas2Serializer;
+import org.apache.uima.json.jsoncas2.mode.FeatureStructuresMode;
+import org.apache.uima.json.jsoncas2.mode.OffsetConversionMode;
+import org.apache.uima.json.jsoncas2.mode.SofaMode;
+import org.apache.uima.json.jsoncas2.mode.TypeSystemMode;
+import org.apache.uima.json.jsoncas2.ref.FullyQualifiedTypeRefGenerator;
+import org.apache.uima.json.jsoncas2.ref.SequentialIdRefGenerator;
+import org.apache.uima.resource.ResourceInitializationException;
+import org.dkpro.core.api.io.JCasFileWriter_ImplBase;
+
+/**
+ * UIMA JSON CAS format writer.
+ */
+public class UimaJsonCasWriter
+    extends JCasFileWriter_ImplBase
+{
+    private JsonCas2Serializer jcs;
+
+    @Override
+    public void initialize(UimaContext aContext) throws ResourceInitializationException
+    {
+        super.initialize(aContext);
+
+        jcs = new JsonCas2Serializer();
+        jcs.setFsMode(FeatureStructuresMode.AS_ARRAY);
+        jcs.setSofaMode(SofaMode.AS_REGULAR_FEATURE_STRUCTURE);
+        jcs.setTypeRefGeneratorSupplier(FullyQualifiedTypeRefGenerator::new);
+        jcs.setIdRefGeneratorSupplier(SequentialIdRefGenerator::new);
+        jcs.setOffsetConversionMode(OffsetConversionMode.UTF_16);
+        jcs.setTypeSystemMode(TypeSystemMode.MINIMAL);
+    }
+
+    @Override
+    public void process(JCas aJCas) throws AnalysisEngineProcessException
+    {
+        try (OutputStream docOS = getOutputStream(aJCas, ".json")) {
+            jcs.serialize(aJCas.getCas(), docOS);
+        }
+        catch (Exception e) {
+            throw new AnalysisEngineProcessException(e);
+        }
+    }
+}

--- a/inception/inception-pdf-editor/src/main/ts/build.js
+++ b/inception/inception-pdf-editor/src/main/ts/build.js
@@ -2,13 +2,13 @@
  * Licensed to the Technische Universität Darmstadt under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
- * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * regarding copyright ownership.  The Technische Universität Darmstadt
  * licenses this file to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.
- *  
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,11 +18,11 @@
 const yargs = require('yargs/yargs')
 const { hideBin } = require('yargs/helpers')
 const esbuild = require('esbuild')
-const fs = require('fs-extra');
+const fs = require('fs-extra')
 
 const argv = yargs(hideBin(process.argv)).argv
 
-let outbase = "../../../target/js/de/tudarmstadt/ukp/inception/pdfeditor/resources/";
+let outbase = '../../../target/js/de/tudarmstadt/ukp/inception/pdfeditor/resources/'
 
 if (!argv.live) {
   fs.emptyDirSync(outbase)
@@ -33,25 +33,25 @@ defaults = {
   bundle: true,
   sourcemap: true,
   minify: !argv.live,
-  target: "es6",
-  loader: { ".ts": "ts" },
+  target: 'es6',
+  loader: { '.ts': 'ts' },
   logLevel: 'info'
 }
 
 if (argv.live) {
-  defaults['watch'] = {
-    onRebuild(error, result) {
+  defaults.watch = {
+    onRebuild (error, result) {
       if (error) console.error('watch build failed:', error)
       else console.log('watch build succeeded:', result)
-    },
-  };
-  outbase = "../../../target/classes/de/tudarmstadt/ukp/inception/pdfeditor/resources/";
+    }
+  }
+  outbase = '../../../target/classes/de/tudarmstadt/ukp/inception/pdfeditor/resources/'
 }
 
 esbuild.build(Object.assign({
-  entryPoints: ["src/main.ts"],
+  entryPoints: ['src/main.ts'],
   outfile: `${outbase}/PdfAnnotationEditor.min.js`,
-  globalName: "PdfAnnotationEditor",
+  globalName: 'PdfAnnotationEditor'
 }, defaults))
 
 fs.copySync('pdfjs-web', `${outbase}`)

--- a/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/service/AnnotationSchemaServiceImpl.java
+++ b/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/service/AnnotationSchemaServiceImpl.java
@@ -1242,7 +1242,10 @@ public class AnnotationSchemaServiceImpl
         _upgradeCas(aSourceCas, aTargetCas, aTargetTypeSystem);
     }
 
-    static void _upgradeCas(CAS aSourceCas, CAS aTargetCas, TypeSystemDescription aTargetTypeSystem)
+    // TODO: This method should be come private again ASAP. It is only public to work around
+    // the fact that the JSON CAS deserializer does not support lenient deserialization yet!
+    public static void _upgradeCas(CAS aSourceCas, CAS aTargetCas,
+            TypeSystemDescription aTargetTypeSystem)
         throws IOException, ResourceInitializationException
     {
         // Save source CAS type system (do this early since we might do an in-place upgrade)

--- a/inception/pom.xml
+++ b/inception/pom.xml
@@ -70,6 +70,7 @@
     <dkpro.version>2.2.0</dkpro.version>
     <uima.version>3.3.0</uima.version>
     <uimafit.version>3.3.0</uimafit.version>
+    <uima-json.version>0.4.0</uima-json.version>
 
     <spring.version>5.3.22</spring.version>
     <spring.boot.version>2.7.2</spring.boot.version>
@@ -419,6 +420,11 @@
         <groupId>org.apache.uima</groupId>
         <artifactId>uimafit-cpe</artifactId>
         <version>${uimafit.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.uima</groupId>
+        <artifactId>uimaj-io-json</artifactId>
+        <version>${uima-json.version}</version>
       </dependency>
       <dependency>
         <groupId>org.json</groupId>


### PR DESCRIPTION
**What's in the PR**
- Added r/w support for new UIMA CAS JSON format (marked as experimental but active by default)
- Marked old CAS JSON format as legacy
- Fixed issue in CasStorageSession that may cause a misleading error message if the session contains a CasHolder which does not yet have a CAS set
- Made a package-private method in AnnotationSchemaServiceImpl public to enable a workaround for missing lenient deserialization in new CAS JSON library

**How to test manually**
* Import some document, make some annotations and then export as UIMA JSON CAS (experimental)
* Import the exported JSON back as UIMA JSON CAS (experimental)

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
