### PR TITLE
#3265 - Wrong character encoding in the page footer

### DIFF
--- a/inception/inception-app-webapp/src/main/resources/application.yml
+++ b/inception/inception-app-webapp/src/main/resources/application.yml
@@ -103,6 +103,10 @@ server:
     path: /whoops
 
 wicket:
+  core:
+    settings:
+      markup:
+        default-markup-encoding: UTF-8
   web:
     servlet:
       dispatcher-types: request, error, async, forward


### PR DESCRIPTION
**What's in the PR**
- Try setting the Wicket markup encoding to UTF-8 so it does not fall back to the system encoding

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
