### PR TITLE
#3294 - Support OAuth (client credentials) when accessing SPARQL endpoints

### DIFF
--- a/inception/inception-kb/pom.xml
+++ b/inception/inception-kb/pom.xml
@@ -54,6 +54,10 @@
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-support</artifactId>
     </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-security</artifactId>
+    </dependency>
     
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -159,6 +163,10 @@
       <artifactId>caffeine</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-beans</artifactId>

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
@@ -528,8 +528,13 @@ public class KnowledgeBaseServiceImpl
                 .build();
 
         // Check if there is already a session we can use
-        var session = oAuthSessionRepository.get(kb,
-                _kb -> new OAuthSessionImpl(client.getToken()));
+        var session = oAuthSessionRepository.get(kb, _kb -> {
+            log.debug("[{}] Creating new OAuth session as [{}]...", _kb, auth.getClientId());
+            var _session = new OAuthSessionImpl(client.getToken());
+            log.debug("[{}] OAuth session as [{}] will expire in [{}]", _kb, auth.getClientId(),
+                    _session.getAccessTokenExpiresIn());
+            return _session;
+        });
 
         try {
             client.refreshSessionIfNecessary(session);

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
@@ -23,6 +23,7 @@ import static de.tudarmstadt.ukp.inception.kb.http.PerThreadSslCheckingHttpClien
 import static de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilder.DEFAULT_LIMIT;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static java.util.stream.Collectors.toList;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.substringAfter;
 import static org.apache.commons.lang3.StringUtils.substringBefore;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
@@ -100,6 +101,7 @@ import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
+import org.springframework.http.HttpHeaders;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
@@ -108,6 +110,7 @@ import com.github.benmanes.caffeine.cache.LoadingCache;
 import de.tudarmstadt.ukp.clarin.webanno.api.config.RepositoryProperties;
 import de.tudarmstadt.ukp.clarin.webanno.api.event.BeforeProjectRemovedEvent;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.support.JSONUtil;
 import de.tudarmstadt.ukp.clarin.webanno.support.SettingsUtil;
 import de.tudarmstadt.ukp.clarin.webanno.support.StopWatch;
 import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBaseProperties;
@@ -122,12 +125,18 @@ import de.tudarmstadt.ukp.inception.kb.graph.KBQualifier;
 import de.tudarmstadt.ukp.inception.kb.graph.KBStatement;
 import de.tudarmstadt.ukp.inception.kb.http.PerThreadSslCheckingHttpClientUtils;
 import de.tudarmstadt.ukp.inception.kb.model.KnowledgeBase;
+import de.tudarmstadt.ukp.inception.kb.model.RemoteRepositoryTraits;
 import de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQuery;
 import de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilder;
 import de.tudarmstadt.ukp.inception.kb.reification.NoReification;
 import de.tudarmstadt.ukp.inception.kb.reification.ReificationStrategy;
 import de.tudarmstadt.ukp.inception.kb.reification.WikiDataReification;
 import de.tudarmstadt.ukp.inception.kb.yaml.KnowledgeBaseProfile;
+import de.tudarmstadt.ukp.inception.security.client.auth.basic.BasicAuthenticationTraits;
+import de.tudarmstadt.ukp.inception.security.client.auth.oauth.MemoryOAuthSessionRepository;
+import de.tudarmstadt.ukp.inception.security.client.auth.oauth.OAuthAuthenticationClientImpl;
+import de.tudarmstadt.ukp.inception.security.client.auth.oauth.OAuthClientCredentialsAuthenticationTraits;
+import de.tudarmstadt.ukp.inception.security.client.auth.oauth.OAuthSessionImpl;
 
 /**
  * <p>
@@ -146,6 +155,7 @@ public class KnowledgeBaseServiceImpl
     private final KnowledgeBaseProperties properties;
 
     private final LoadingCache<QueryKey, List<KBHandle>> queryCache;
+    private final MemoryOAuthSessionRepository<KnowledgeBase> oAuthSessionRepository;
 
     @Autowired
     public KnowledgeBaseServiceImpl(RepositoryProperties aRepoProperties,
@@ -153,17 +163,8 @@ public class KnowledgeBaseServiceImpl
     {
         properties = aKBProperties;
 
-        Caffeine<QueryKey, List<KBHandle>> cacheBuilder = Caffeine.newBuilder()
-                .maximumWeight(aKBProperties.getCacheSize())
-                .expireAfterAccess(aKBProperties.getCacheExpireDelay())
-                .refreshAfterWrite(aKBProperties.getCacheRefreshDelay())
-                .weigher((QueryKey key, List<KBHandle> value) -> value.size());
-
-        if (log.isTraceEnabled()) {
-            cacheBuilder.recordStats();
-        }
-
-        queryCache = cacheBuilder.build(this::runQuery);
+        queryCache = createQueryCache(aKBProperties);
+        oAuthSessionRepository = new MemoryOAuthSessionRepository<>();
 
         kbRepositoriesRoot = new File(aRepoProperties.getPath(), "kb");
 
@@ -197,6 +198,22 @@ public class KnowledgeBaseServiceImpl
                 .newPerThreadSslCheckingHttpClientBuilder().build());
 
         log.info("Knowledge base repository path: {}", kbRepositoriesRoot);
+    }
+
+    private LoadingCache<QueryKey, List<KBHandle>> createQueryCache(
+            KnowledgeBaseProperties aKBProperties)
+    {
+        Caffeine<QueryKey, List<KBHandle>> queryCacheBuilder = Caffeine.newBuilder()
+                .maximumWeight(aKBProperties.getCacheSize())
+                .expireAfterAccess(aKBProperties.getCacheExpireDelay())
+                .refreshAfterWrite(aKBProperties.getCacheRefreshDelay())
+                .weigher((QueryKey key, List<KBHandle> value) -> value.size());
+
+        if (log.isTraceEnabled()) {
+            queryCacheBuilder.recordStats();
+        }
+
+        return queryCacheBuilder.build(this::runQuery);
     }
 
     public KnowledgeBaseServiceImpl(RepositoryProperties aRepoProperties,
@@ -349,6 +366,9 @@ public class KnowledgeBaseServiceImpl
         throws RepositoryException, RepositoryConfigException
     {
         assertRegistration(kb);
+        // We clear any current OAuth session on the repository because we do not know if maybe
+        // the user has changed the repository URL / credentials as part of the update...
+        oAuthSessionRepository.clear(kb);
         entityManager.merge(kb);
     }
 
@@ -359,7 +379,7 @@ public class KnowledgeBaseServiceImpl
     {
         assertRegistration(kb);
         repoManager.addRepositoryConfig(new RepositoryConfig(kb.getRepositoryId(), cfg));
-        entityManager.merge(kb);
+        updateKnowledgeBase(kb);
     }
 
     @SuppressWarnings("unchecked")
@@ -399,6 +419,8 @@ public class KnowledgeBaseServiceImpl
         throws RepositoryException, RepositoryConfigException
     {
         assertRegistration(aKB);
+
+        oAuthSessionRepository.clear(aKB);
 
         repoManager.removeRepository(aKB.getRepositoryId());
 
@@ -441,23 +463,21 @@ public class KnowledgeBaseServiceImpl
         if (repo instanceof SPARQLRepository) {
             SPARQLRepositoryConfig sparqlRepoConfig = (SPARQLRepositoryConfig) getKnowledgeBaseConfig(
                     kb);
-            URI uri = URI.create(sparqlRepoConfig.getQueryEndpointUrl());
-            String userInfo = uri.getUserInfo();
-            if (StringUtils.isNotBlank(userInfo)) {
-                userInfo = userInfo.trim();
-                String username;
-                String password;
-                if (userInfo.contains(":")) {
-                    username = substringBefore(userInfo, ":");
-                    password = substringAfter(userInfo, ":");
-                }
-                else {
-                    username = userInfo;
-                    password = "";
-                }
+            SPARQLRepository sparqlRepo = (SPARQLRepository) repo;
+            applyBasicHttpAuthenticationConfigurationFromUrl(sparqlRepoConfig, sparqlRepo);
+            RemoteRepositoryTraits traits = readTraits(kb);
 
-                SPARQLRepository sparqlRepo = (SPARQLRepository) repo;
-                sparqlRepo.setUsernameAndPassword(username, password);
+            if (traits != null && traits.getAuthentication() != null) {
+                switch (traits.getAuthentication().getType()) {
+                case BASIC: {
+                    applyBasicHttpAuthenticationConfiguration(sparqlRepo, traits);
+                    break;
+                }
+                case OAUTH_CLIENT_CREDENTIALS: {
+                    applyOAuthConfiguration(kb, sparqlRepo, traits);
+                    break;
+                }
+                }
             }
         }
 
@@ -478,6 +498,70 @@ public class KnowledgeBaseServiceImpl
                 }
             };
         };
+    }
+
+    private RemoteRepositoryTraits readTraits(KnowledgeBase kb)
+    {
+        try {
+            return JSONUtil.fromJsonString(RemoteRepositoryTraits.class, kb.getTraits());
+        }
+        catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private void applyBasicHttpAuthenticationConfiguration(SPARQLRepository sparqlRepo,
+            RemoteRepositoryTraits traits)
+    {
+        var auth = (BasicAuthenticationTraits) traits.getAuthentication();
+        sparqlRepo.setUsernameAndPassword(auth.getUsername(), auth.getPassword());
+    }
+
+    private void applyOAuthConfiguration(KnowledgeBase kb, SPARQLRepository sparqlRepo,
+            RemoteRepositoryTraits traits)
+    {
+        var auth = (OAuthClientCredentialsAuthenticationTraits) traits.getAuthentication();
+        var client = OAuthAuthenticationClientImpl.builder() //
+                .withClientId(auth.getClientId()) //
+                .withClientSecret(auth.getClientSecret()) //
+                .withTokenEndpointUrl(auth.getTokenEndpointUrl()) //
+                .build();
+
+        // Check if there is already a session we can use
+        var session = oAuthSessionRepository.get(kb,
+                _kb -> new OAuthSessionImpl(client.getToken()));
+
+        try {
+            client.refreshSessionIfNecessary(session);
+        }
+        catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+
+        var headers = Map.of(HttpHeaders.AUTHORIZATION, "Bearer " + session.getAccessToken());
+        sparqlRepo.setAdditionalHttpHeaders(headers);
+    }
+
+    private void applyBasicHttpAuthenticationConfigurationFromUrl(
+            SPARQLRepositoryConfig sparqlRepoConfig, SPARQLRepository sparqlRepo)
+    {
+        URI uri = URI.create(sparqlRepoConfig.getQueryEndpointUrl());
+        String userInfo = uri.getUserInfo();
+        if (isNotBlank(userInfo)) {
+            userInfo = userInfo.trim();
+            String username;
+            String password;
+            if (userInfo.contains(":")) {
+                username = substringBefore(userInfo, ":");
+                password = substringAfter(userInfo, ":");
+            }
+            else {
+                username = userInfo;
+                password = "";
+            }
+
+            sparqlRepo.setUsernameAndPassword(username, password);
+        }
     }
 
     @SuppressWarnings("resource")

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/exporter/ExportedKnowledgeBase.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/exporter/ExportedKnowledgeBase.java
@@ -106,6 +106,9 @@ public class ExportedKnowledgeBase
     @JsonProperty("remote_url")
     private String remoteURL;
 
+    @JsonProperty("traits")
+    private String traits;
+
     public String getId()
     {
         return id;
@@ -356,5 +359,15 @@ public class ExportedKnowledgeBase
     public boolean isUseFuzzy()
     {
         return useFuzzy;
+    }
+
+    public String getTraits()
+    {
+        return traits;
+    }
+
+    public void setTraits(String aTraits)
+    {
+        traits = aTraits;
     }
 }

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/exporter/KnowledgeBaseExporter.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/exporter/KnowledgeBaseExporter.java
@@ -138,6 +138,7 @@ public class KnowledgeBaseExporter
                     kb.getDefaultDatasetIri() != null ? kb.getDefaultDatasetIri() : null);
             exportedKB.setMaxResults(kb.getMaxResults());
             exportedKB.setSubPropertyIri(kb.getSubPropertyIri());
+            exportedKB.setTraits(kb.getTraits());
             exportedKnowledgeBases.add(exportedKB);
 
             if (kb.getType() == RepositoryType.REMOTE) {
@@ -228,6 +229,7 @@ public class KnowledgeBaseExporter
             kb.setUseFuzzy(exportedKB.isUseFuzzy());
             kb.setReification(Reification.valueOf(exportedKB.getReification()));
             kb.setBasePrefix(exportedKB.getBasePrefix());
+            kb.setTraits(exportedKB.getTraits());
 
             if (exportedKB.getRootConcepts() != null) {
                 kb.setRootConcepts(exportedKB.getRootConcepts());

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/model/KnowledgeBase.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/model/KnowledgeBase.java
@@ -36,6 +36,7 @@ import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
+import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
@@ -207,6 +208,10 @@ public class KnowledgeBase
      */
     @Column(nullable = false)
     private boolean skipSslValidation = false;
+
+    @Lob
+    @Column(length = 64000)
+    private String traits;
 
     public String getRepositoryId()
     {
@@ -504,6 +509,16 @@ public class KnowledgeBase
     public void setUseFuzzy(boolean aUseFuzzy)
     {
         useFuzzy = aUseFuzzy;
+    }
+
+    public String getTraits()
+    {
+        return traits;
+    }
+
+    public void setTraits(String aTraits)
+    {
+        traits = aTraits;
     }
 
     @Override

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/model/RemoteRepositoryTraits.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/model/RemoteRepositoryTraits.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.kb.model;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import de.tudarmstadt.ukp.inception.security.client.auth.AuthenticationTraits;
+
+public class RemoteRepositoryTraits
+    implements Serializable
+{
+    private static final long serialVersionUID = 5358860222920519699L;
+
+    @JsonProperty("authentication")
+    private AuthenticationTraits authentication;
+
+    public AuthenticationTraits getAuthentication()
+    {
+        return authentication;
+    }
+
+    public void setAuthentication(AuthenticationTraits aAuthentification)
+    {
+        authentication = aAuthentification;
+    }
+}

--- a/inception/inception-kb/src/main/resources/de/tudarmstadt/ukp/inception/kb/model/db-changelog.xml
+++ b/inception/inception-kb/src/main/resources/de/tudarmstadt/ukp/inception/kb/model/db-changelog.xml
@@ -445,4 +445,17 @@
       </column>
     </addColumn>
   </changeSet>
+  
+  <changeSet author="INCEpTION Team" id="20220818-1">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="knowledgebase" columnName="traits"/>
+      </not>
+    </preConditions>
+    <addColumn tableName="knowledgebase">
+      <column name="traits" type="LONGTEXT">
+        <constraints nullable="true" />
+      </column>
+    </addColumn>
+  </changeSet>
 </databaseChangeLog>

--- a/inception/inception-security/marker-wicket-module
+++ b/inception/inception-security/marker-wicket-module
@@ -1,0 +1,1 @@
+Marker file which activates the profile "wicket-module" from the parent POM.

--- a/inception/inception-security/pom.xml
+++ b/inception/inception-security/pom.xml
@@ -64,6 +64,16 @@
       <artifactId>wicket-auth-roles</artifactId>
     </dependency>
 
+    <!-- Jackson -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
     <!-- SPRING -->
     <dependency>
       <groupId>org.springframework</groupId>
@@ -116,6 +126,11 @@
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
     </dependency>
 
     <!-- LOGGING DEPENDENCIES - SLF4J -->

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/AuthenticationTraits.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/AuthenticationTraits.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.security.client.auth;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import de.tudarmstadt.ukp.inception.security.client.auth.basic.BasicAuthenticationTraits;
+import de.tudarmstadt.ukp.inception.security.client.auth.oauth.OAuthClientCredentialsAuthenticationTraits;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonSubTypes({ //
+        @Type(value = BasicAuthenticationTraits.class, //
+                name = BasicAuthenticationTraits.TYPE_ID),
+        @Type(value = OAuthClientCredentialsAuthenticationTraits.class, //
+                name = OAuthClientCredentialsAuthenticationTraits.TYPE_ID) })
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class AuthenticationTraits
+    implements Serializable
+{
+    private static final long serialVersionUID = 5358860222920519699L;
+
+    public abstract AuthenticationType getType();
+}

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/AuthenticationTraitsEditor.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/AuthenticationTraitsEditor.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.security.client.auth;
+
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.model.IModel;
+
+public abstract class AuthenticationTraitsEditor
+    extends Panel
+{
+    private static final long serialVersionUID = -5167115783065993309L;
+
+    public AuthenticationTraitsEditor(String aId)
+    {
+        super(aId);
+    }
+
+    public AuthenticationTraitsEditor(String aId, IModel<?> aModel)
+    {
+        super(aId, aModel);
+    }
+
+    public abstract void setEditMode(boolean aMode);
+
+    public abstract void commit();
+}

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/AuthenticationType.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/AuthenticationType.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.security.client.auth;
+
+import de.tudarmstadt.ukp.inception.security.client.auth.basic.BasicAuthenticationTraits;
+import de.tudarmstadt.ukp.inception.security.client.auth.oauth.OAuthClientCredentialsAuthenticationTraits;
+
+public enum AuthenticationType
+{
+    BASIC(BasicAuthenticationTraits.TYPE_ID), //
+    OAUTH_CLIENT_CREDENTIALS(OAuthClientCredentialsAuthenticationTraits.TYPE_ID);
+
+    private final String id;
+
+    AuthenticationType(String aId)
+    {
+        id = aId;
+    }
+
+    public String getId()
+    {
+        return id;
+    }
+
+    @Override
+    public String toString()
+    {
+        return id;
+    }
+}

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/NoAuthenticationTraitsEditor.html
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/NoAuthenticationTraitsEditor.html
@@ -16,14 +16,5 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-
-<html xmlns:wicket="http://wicket.apache.org">
-<body>
-<wicket:panel>
-  <div class=" col-xs-12">
-    <div wicket:id="remoteSpecificSettings" />
-    <div wicket:id="localSpecificSettings"/>
-  </div>
+<wicket:panel xmlns:wicket="http://wicket.apache.org">
 </wicket:panel>
-</body>
-</html>

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/NoAuthenticationTraitsEditor.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/NoAuthenticationTraitsEditor.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.security.client.auth;
+
+public class NoAuthenticationTraitsEditor
+    extends AuthenticationTraitsEditor
+{
+    private static final long serialVersionUID = 2314779756017515092L;
+
+    public NoAuthenticationTraitsEditor(String aId)
+    {
+        super(aId);
+    }
+
+    @Override
+    public void setEditMode(boolean aMode)
+    {
+        // Ignore
+    }
+
+    @Override
+    public void commit()
+    {
+        // Ignore
+    }
+}

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/basic/BasicAuthenticationTraits.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/basic/BasicAuthenticationTraits.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.security.client.auth.basic;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import de.tudarmstadt.ukp.inception.security.client.auth.AuthenticationTraits;
+import de.tudarmstadt.ukp.inception.security.client.auth.AuthenticationType;
+
+public class BasicAuthenticationTraits
+    extends AuthenticationTraits
+{
+    private static final long serialVersionUID = -2738799956736738180L;
+
+    public static final String TYPE_ID = "Basic";
+
+    @JsonProperty("username")
+    private String username;
+
+    @JsonProperty("password")
+    private String password;
+
+    public String getUsername()
+    {
+        return username;
+    }
+
+    public void setUsername(String aUsername)
+    {
+        username = aUsername;
+    }
+
+    public String getPassword()
+    {
+        return password;
+    }
+
+    public void setPassword(String aPassword)
+    {
+        password = aPassword;
+    }
+
+    @Override
+    public AuthenticationType getType()
+    {
+        return AuthenticationType.BASIC;
+    }
+}

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/basic/BasicAuthenticationTraitsEditor.html
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/basic/BasicAuthenticationTraitsEditor.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<!--
+  Licensed to the Technische Universität Darmstadt under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The Technische Universität Darmstadt 
+  licenses this file to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.
+   
+  http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<html xmlns:wicket="http://wicket.apache.org">
+<body>
+  <wicket:panel>
+    <div class="row form-row" wicket:enclosure="status">
+      <label class="col-form-label col-sm-3">
+        Credentials
+      </label>
+      <div class="col-sm-9">
+        <div class="input-group">
+          <span wicket:id="status" class="input-group-text flex-fill"/>
+          <button wicket:id="edit" class="btn btn-outline-secondary" type="button">
+            Edit
+          </button>
+        </div>
+      </div>
+    </div>
+    <div class="row form-row" wicket:enclosure="username">
+      <label wicket:for="username" class="col-form-label col-sm-3">
+        <wicket:message key="username" />
+      </label>
+      <div class="col-sm-9">
+        <input wicket:id="username" type="text" class="form-control" autocomplete="username"/>
+      </div>
+    </div>
+    <div class="row form-row" wicket:enclosure="password">
+      <label wicket:for="password" class="col-form-label col-sm-3">
+        <wicket:message key="password" />
+      </label>
+      <div class="col-sm-9">
+        <input wicket:id="password" type="password" class="form-control" autocomplete="new-password"/>
+      </div>
+    </div>
+  </wicket:panel>
+</body>
+</html>

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/basic/BasicAuthenticationTraitsEditor.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/basic/BasicAuthenticationTraitsEditor.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.security.client.auth.basic;
+
+import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
+import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhenNot;
+
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.form.PasswordTextField;
+import org.apache.wicket.markup.html.form.TextField;
+import org.apache.wicket.model.CompoundPropertyModel;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.LoadableDetachableModel;
+import org.apache.wicket.model.Model;
+import org.apache.wicket.model.PropertyModel;
+
+import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxLink;
+import de.tudarmstadt.ukp.inception.security.client.auth.AuthenticationTraitsEditor;
+
+public class BasicAuthenticationTraitsEditor
+    extends AuthenticationTraitsEditor
+{
+    private static final long serialVersionUID = -2171643131419507935L;
+
+    private IModel<Boolean> editMode;
+    private transient String newPassword;
+
+    public BasicAuthenticationTraitsEditor(String aId, IModel<BasicAuthenticationTraits> aModel)
+    {
+        super(aId, CompoundPropertyModel.of(aModel));
+
+        setOutputMarkupId(true);
+
+        editMode = Model.of(aModel.getObject().getUsername() == null);
+
+        queue(new Label("status", LoadableDetachableModel.of(this::getStatus))
+                .add(visibleWhenNot(editMode)));
+        queue(new LambdaAjaxLink("edit", this::actionToggleEditMode) //
+                .add(visibleWhenNot(editMode)));
+        queue(new TextField<>("username") //
+                .setRequired(true) //
+                .add(visibleWhen(editMode)));
+        queue(new PasswordTextField("password", PropertyModel.of(this, "newPassword"))
+                .add(visibleWhen(editMode)));
+    }
+
+    @SuppressWarnings("unchecked")
+    IModel<BasicAuthenticationTraits> getModel()
+    {
+        return (IModel<BasicAuthenticationTraits>) getDefaultModel();
+    }
+
+    private String getStatus()
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Username is ");
+        sb.append(getModel().map(BasicAuthenticationTraits::getUsername) //
+                .map(username -> "[" + username + "]")//
+                .orElse("not set").getObject());
+        sb.append("; password is ");
+        sb.append(getModel().map(BasicAuthenticationTraits::getPassword) //
+                .map($ -> "set")//
+                .orElse("not set").getObject());
+        return sb.toString();
+    }
+
+    private void actionToggleEditMode(AjaxRequestTarget aTarget)
+    {
+        editMode.setObject(!editMode.getObject());
+        aTarget.add(this);
+    }
+
+    @Override
+    public void setEditMode(boolean aMode)
+    {
+        editMode.setObject(aMode);
+        newPassword = null;
+    }
+
+    @Override
+    public void commit()
+    {
+        if (newPassword != null) {
+            getModel().getObject().setPassword(newPassword);
+        }
+
+        setEditMode(false);
+    }
+
+    @Override
+    protected void onModelChanged()
+    {
+        setEditMode(false);
+    }
+}

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/oauth/MemoryOAuthSessionRepository.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/oauth/MemoryOAuthSessionRepository.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.security.client.auth.oauth;
+
+import org.apache.commons.lang3.function.FailableFunction;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Expiry;
+
+public class MemoryOAuthSessionRepository<T>
+{
+    private final Cache<T, OAuthSession> sessions;
+
+    public MemoryOAuthSessionRepository()
+    {
+        sessions = Caffeine.newBuilder().expireAfter(new OAuthSessionExpiry<T>()).build();
+    }
+
+    public OAuthSession get(T aKey, FailableFunction<T, OAuthSession, Throwable> aSessionCreator)
+    {
+        return sessions.get(aKey, _key -> {
+            try {
+                return aSessionCreator.apply(aKey);
+            }
+            catch (Throwable e) {
+                throw new IllegalStateException(e);
+            }
+        });
+    }
+
+    public void clear(T aKey)
+    {
+        sessions.invalidate(aKey);
+    }
+
+    private final class OAuthSessionExpiry<K>
+        implements Expiry<K, OAuthSession>
+    {
+        @Override
+        public long expireAfterCreate(K aKey, OAuthSession aValue, long aCurrentTime)
+        {
+            if (aValue.getRefreshTokenExpiresIn() > 0) {
+                return aValue.getRefreshTokenExpiresIn();
+            }
+            return aValue.getAccessTokenExpiresIn();
+        }
+
+        @Override
+        public long expireAfterUpdate(K aKey, OAuthSession aValue, long aCurrentTime,
+                long aCurrentDuration)
+        {
+            if (aValue.getRefreshTokenExpiresIn() > 0) {
+                return aValue.getRefreshTokenExpiresIn();
+            }
+            return aValue.getAccessTokenExpiresIn();
+        }
+
+        @Override
+        public long expireAfterRead(K aKey, OAuthSession aValue, long aCurrentTime,
+                long aCurrentDuration)
+        {
+            return aCurrentDuration;
+        }
+    }
+}

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/oauth/MemoryOAuthSessionRepository.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/oauth/MemoryOAuthSessionRepository.java
@@ -29,7 +29,9 @@ public class MemoryOAuthSessionRepository<T>
 
     public MemoryOAuthSessionRepository()
     {
-        sessions = Caffeine.newBuilder().expireAfter(new OAuthSessionExpiry<T>()).build();
+        sessions = Caffeine.newBuilder() //
+                .expireAfter(new OAuthSessionExpiry<T>()) //
+                .build();
     }
 
     public OAuthSession get(T aKey, FailableFunction<T, OAuthSession, Throwable> aSessionCreator)
@@ -55,20 +57,20 @@ public class MemoryOAuthSessionRepository<T>
         @Override
         public long expireAfterCreate(K aKey, OAuthSession aValue, long aCurrentTime)
         {
-            if (aValue.getRefreshTokenExpiresIn() > 0) {
-                return aValue.getRefreshTokenExpiresIn();
+            if (aValue.getRefreshTokenExpiresIn().negated().isNegative()) {
+                return aValue.getRefreshTokenExpiresIn().toNanos();
             }
-            return aValue.getAccessTokenExpiresIn();
+            return aValue.getAccessTokenExpiresIn().toNanos();
         }
 
         @Override
         public long expireAfterUpdate(K aKey, OAuthSession aValue, long aCurrentTime,
                 long aCurrentDuration)
         {
-            if (aValue.getRefreshTokenExpiresIn() > 0) {
-                return aValue.getRefreshTokenExpiresIn();
+            if (aValue.getRefreshTokenExpiresIn().negated().isNegative()) {
+                return aValue.getRefreshTokenExpiresIn().toNanos();
             }
-            return aValue.getAccessTokenExpiresIn();
+            return aValue.getAccessTokenExpiresIn().toNanos();
         }
 
         @Override

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/oauth/OAuthAccessTokenResponse.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/oauth/OAuthAccessTokenResponse.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.security.client.auth.oauth;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class OAuthAccessTokenResponse
+{
+    private @JsonIgnore long submitTime;
+    private @JsonProperty("access_token") String accessToken;
+    private @JsonProperty("expires_in") long expiresIn;
+    private @JsonProperty("refresh_expires_in") long refreshExpiresIn;
+    private @JsonProperty("refresh_token") String refreshToken;
+    private @JsonProperty("token_type") String tokenType;
+    private @JsonProperty("not-before-policy") String notBeforePolicy;
+    private @JsonProperty("session_state") String sessionState;
+    private @JsonProperty("scope") String scope;
+
+    public void setSubmitTime(long aSubmitTime)
+    {
+        submitTime = aSubmitTime;
+    }
+
+    public long getSubmitTime()
+    {
+        return submitTime;
+    }
+
+    public String getAccessToken()
+    {
+        return accessToken;
+    }
+
+    public void setAccessToken(String aAccessToken)
+    {
+        accessToken = aAccessToken;
+    }
+
+    public long getExpiresIn()
+    {
+        return expiresIn;
+    }
+
+    public void setExpiresIn(long aExpiresIn)
+    {
+        expiresIn = aExpiresIn;
+    }
+
+    public long getRefreshExpiresIn()
+    {
+        return refreshExpiresIn;
+    }
+
+    public void setRefreshExpiresIn(long aRefreshExpiresIn)
+    {
+        refreshExpiresIn = aRefreshExpiresIn;
+    }
+
+    public String getRefreshToken()
+    {
+        return refreshToken;
+    }
+
+    public void setRefreshToken(String aRefreshToken)
+    {
+        refreshToken = aRefreshToken;
+    }
+
+    public String getTokenType()
+    {
+        return tokenType;
+    }
+
+    public void setTokenType(String aTokenType)
+    {
+        tokenType = aTokenType;
+    }
+
+    public String getNotBeforePolicy()
+    {
+        return notBeforePolicy;
+    }
+
+    public void setNotBeforePolicy(String aNotBeforePolicy)
+    {
+        notBeforePolicy = aNotBeforePolicy;
+    }
+
+    public String getSessionState()
+    {
+        return sessionState;
+    }
+
+    public void setSessionState(String aSessionState)
+    {
+        sessionState = aSessionState;
+    }
+
+    public String getScope()
+    {
+        return scope;
+    }
+
+    public void setScope(String aScope)
+    {
+        scope = aScope;
+    }
+}

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/oauth/OAuthAuthenticationClient.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/oauth/OAuthAuthenticationClient.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.security.client.auth.oauth;
+
+import java.io.IOException;
+
+public interface OAuthAuthenticationClient
+{
+    OAuthAccessTokenResponse getToken(String aCode) throws IOException;
+
+    OAuthAccessTokenResponse refreshToken(String aRefreshToken) throws IOException;
+
+    boolean refreshSessionIfNecessary(OAuthSession aSession) throws IOException;
+
+    boolean requiresRefresh(OAuthSession aSession);
+
+    boolean requiresSignIn(OAuthSession aSession);
+}

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/oauth/OAuthAuthenticationClientImpl.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/oauth/OAuthAuthenticationClientImpl.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.security.client.auth.oauth;
+
+import static de.tudarmstadt.ukp.inception.security.client.auth.oauth.OAuthGrantType.AUTHORIZATION_CODE;
+import static de.tudarmstadt.ukp.inception.security.client.auth.oauth.OAuthGrantType.CLIENT_CREDENTIALS;
+import static java.time.temporal.ChronoUnit.SECONDS;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.time.Instant;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import de.tudarmstadt.ukp.inception.support.http.HttpClientImplBase;
+
+public class OAuthAuthenticationClientImpl
+    extends HttpClientImplBase
+    implements OAuthAuthenticationClient
+{
+    private static final String REDIRECT_URI = "redirect_uri";
+    private static final String REFRESH_TOKEN = "refresh_token";
+    private static final String CLIENT_ID = "client_id";
+    private static final String CLIENT_SECRET = "client_secret";
+    private static final String GRANT_TYPE = "grant_type";
+
+    private static final String CODE = "code";
+    private static final String APPLICATION_X_WWW_FORM_URLENCODED = "application/x-www-form-urlencoded";
+
+    private String clientId;
+    private String clientSecret;
+    private String tokenEndpointUrl;
+    private String redirectUri;
+
+    private OAuthAuthenticationClientImpl(Builder builder)
+    {
+        super(builder.client);
+        this.clientId = builder.clientId;
+        this.clientSecret = builder.clientSecret;
+        this.tokenEndpointUrl = builder.tokenEndpointUrl;
+        this.redirectUri = builder.redirectUri;
+    }
+
+    @Override
+    public boolean requiresSignIn(OAuthSession aSession)
+    {
+        Date validUntil = aSession.getRefreshTokenValidUntil();
+
+        if (validUntil == null && aSession.getRefreshToken() != null) {
+            // If the services does not provide information on how long the refresh token is
+            // valid, we assume that it is valid as long as we have a token.
+            return false;
+        }
+
+        if (validUntil == null) {
+            return true;
+        }
+
+        // Refresh if the token will expire in less than 60 seconds
+        return Instant.now().isAfter(validUntil.toInstant().minus(60, SECONDS));
+    }
+
+    @Override
+    public boolean requiresRefresh(OAuthSession aSession)
+    {
+        Date validUntil = aSession.getAccessTokenValidUntil();
+        if (validUntil == null) {
+            return true;
+        }
+
+        return Instant.now().isAfter(validUntil.toInstant());
+    }
+
+    @Override
+    public boolean refreshSessionIfNecessary(OAuthSession aSession) throws IOException
+    {
+        if (!requiresRefresh(aSession)) {
+            return false;
+        }
+
+        aSession.update(refreshToken(aSession.getRefreshToken()));
+        return true;
+    }
+
+    @Override
+    public OAuthAccessTokenResponse getToken(String aCode) throws IOException
+    {
+        Map<String, String> parameters = new LinkedHashMap<>();
+        parameters.put(GRANT_TYPE, AUTHORIZATION_CODE.toHeaderValue());
+        parameters.put(CLIENT_ID, clientId);
+        if (clientSecret != null) {
+            parameters.put(CLIENT_SECRET, clientSecret);
+        }
+        parameters.put(REDIRECT_URI, redirectUri);
+        parameters.put(CODE, aCode);
+
+        HttpRequest request = HttpRequest.newBuilder() //
+                .POST(BodyPublishers.ofString(urlEncodeParameters(parameters)))
+                .uri(URI.create(tokenEndpointUrl)) //
+                .header(CONTENT_TYPE, APPLICATION_X_WWW_FORM_URLENCODED) //
+                .build();
+
+        long submitTime = System.currentTimeMillis();
+        var response = deserializeResponse(sendRequest(request), OAuthAccessTokenResponse.class);
+        response.setSubmitTime(submitTime);
+        return response;
+    }
+
+    public OAuthAccessTokenResponse getToken() throws IOException
+    {
+        Map<String, String> parameters = new LinkedHashMap<>();
+        parameters.put(GRANT_TYPE, CLIENT_CREDENTIALS.toHeaderValue());
+        parameters.put(CLIENT_ID, clientId);
+        if (clientSecret != null) {
+            parameters.put(CLIENT_SECRET, clientSecret);
+        }
+
+        HttpRequest request = HttpRequest.newBuilder() //
+                .POST(BodyPublishers.ofString(urlEncodeParameters(parameters)))
+                .uri(URI.create(tokenEndpointUrl)) //
+                .header(CONTENT_TYPE, APPLICATION_X_WWW_FORM_URLENCODED) //
+                .build();
+
+        long submitTime = System.currentTimeMillis();
+        var response = deserializeResponse(sendRequest(request), OAuthAccessTokenResponse.class);
+        response.setSubmitTime(submitTime);
+        return response;
+    }
+
+    @Override
+    public OAuthAccessTokenResponse refreshToken(String aRefreshToken) throws IOException
+    {
+        Map<String, String> parameters = new LinkedHashMap<>();
+        parameters.put(GRANT_TYPE, REFRESH_TOKEN);
+        parameters.put(CLIENT_ID, clientId);
+        parameters.put(REFRESH_TOKEN, aRefreshToken);
+
+        HttpRequest request = HttpRequest.newBuilder() //
+                .POST(BodyPublishers.ofString(urlEncodeParameters(parameters)))
+                .uri(URI.create(tokenEndpointUrl)) //
+                .header(CONTENT_TYPE, APPLICATION_X_WWW_FORM_URLENCODED) //
+                .build();
+
+        long submitTime = System.currentTimeMillis();
+        var response = deserializeResponse(sendRequest(request), OAuthAccessTokenResponse.class);
+        response.setSubmitTime(submitTime);
+        return response;
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static final class Builder
+    {
+        private HttpClient client;
+        private String clientId;
+        private String clientSecret;
+        private String tokenEndpointUrl;
+        private String redirectUri;
+
+        private Builder()
+        {
+        }
+
+        public Builder withHttpClient(HttpClient aClient)
+        {
+            this.client = aClient;
+            return this;
+        }
+
+        public Builder withClientId(String aClientId)
+        {
+            this.clientId = aClientId;
+            return this;
+        }
+
+        public Builder withClientSecret(String aClientSecret)
+        {
+            this.clientSecret = aClientSecret;
+            return this;
+        }
+
+        public Builder withTokenEndpointUrl(String aTokenEndpointUrl)
+        {
+            this.tokenEndpointUrl = aTokenEndpointUrl;
+            return this;
+        }
+
+        public Builder withRedirectUri(String aRedirectUri)
+        {
+            this.redirectUri = aRedirectUri;
+            return this;
+        }
+
+        public OAuthAuthenticationClientImpl build()
+        {
+            return new OAuthAuthenticationClientImpl(this);
+        }
+    }
+
+}

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/oauth/OAuthClientCredentialsAuthenticationTraits.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/oauth/OAuthClientCredentialsAuthenticationTraits.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.security.client.auth.oauth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import de.tudarmstadt.ukp.inception.security.client.auth.AuthenticationTraits;
+import de.tudarmstadt.ukp.inception.security.client.auth.AuthenticationType;
+
+public class OAuthClientCredentialsAuthenticationTraits
+    extends AuthenticationTraits
+{
+    private static final long serialVersionUID = -2738799956736738180L;
+
+    public static final String TYPE_ID = "OAuthClientCredentials";
+
+    @JsonProperty("clientId")
+    private String clientId;
+
+    @JsonProperty("clientSecret")
+    private String clientSecret;
+
+    @JsonProperty("tokenEndpointUrl")
+    private String tokenEndpointUrl;
+
+    public String getClientId()
+    {
+        return clientId;
+    }
+
+    public void setClientId(String aClientId)
+    {
+        clientId = aClientId;
+    }
+
+    public String getClientSecret()
+    {
+        return clientSecret;
+    }
+
+    public void setClientSecret(String aClientSecret)
+    {
+        clientSecret = aClientSecret;
+    }
+
+    @Override
+    public AuthenticationType getType()
+    {
+        return AuthenticationType.OAUTH_CLIENT_CREDENTIALS;
+    }
+
+    public void setTokenEndpointUrl(String aTokenEndpointUrl)
+    {
+        tokenEndpointUrl = aTokenEndpointUrl;
+    }
+
+    public String getTokenEndpointUrl()
+    {
+        return tokenEndpointUrl;
+    }
+}

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/oauth/OAuthClientCredentialsAuthenticationTraitsEditor.html
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/oauth/OAuthClientCredentialsAuthenticationTraitsEditor.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<!--
+  Licensed to the Technische Universität Darmstadt under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The Technische Universität Darmstadt 
+  licenses this file to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.
+   
+  http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<html xmlns:wicket="http://wicket.apache.org">
+<body>
+  <wicket:panel>
+    <div class="row form-row" wicket:enclosure="tokenEndpointUrl">
+      <label wicket:for="tokenEndpointUrl" class="col-form-label col-sm-3">
+        <wicket:message key="tokenEndpointUrl" />
+      </label>
+      <div class="col-sm-9">
+        <input wicket:id="tokenEndpointUrl" type="text" class="form-control"/>
+      </div>
+    </div>
+    <div class="row form-row" wicket:enclosure="status">
+      <label class="col-form-label col-sm-3">
+        Credentials
+      </label>
+      <div class="col-sm-9">
+        <div class="input-group">
+          <span wicket:id="status" class="input-group-text flex-fill"/>
+          <button wicket:id="edit" class="btn btn-outline-secondary" type="button">
+            Edit
+          </button>
+        </div>
+      </div>
+    </div>
+    <div class="row form-row" wicket:enclosure="clientId">
+      <label wicket:for="clientId" class="col-form-label col-sm-3">
+        <wicket:message key="clientId" />
+      </label>
+      <div class="col-sm-9">
+        <input wicket:id="clientId" type="text" class="form-control" autocomplete="username"/>
+      </div>
+    </div>
+    <div class="row form-row" wicket:enclosure="clientSecret">
+      <label wicket:for="clientSecret" class="col-form-label col-sm-3">
+        <wicket:message key="clientSecret" />
+      </label>
+      <div class="col-sm-9">
+        <input wicket:id="clientSecret" type="password" class="form-control" autocomplete="new-password"/>
+      </div>
+    </div>
+  </wicket:panel>
+</body>
+</html>

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/oauth/OAuthClientCredentialsAuthenticationTraitsEditor.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/oauth/OAuthClientCredentialsAuthenticationTraitsEditor.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.security.client.auth.oauth;
+
+import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
+import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhenNot;
+
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.form.PasswordTextField;
+import org.apache.wicket.markup.html.form.TextField;
+import org.apache.wicket.model.CompoundPropertyModel;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.LoadableDetachableModel;
+import org.apache.wicket.model.Model;
+import org.apache.wicket.model.PropertyModel;
+import org.apache.wicket.validation.validator.UrlValidator;
+
+import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxLink;
+import de.tudarmstadt.ukp.inception.security.client.auth.AuthenticationTraitsEditor;
+
+public class OAuthClientCredentialsAuthenticationTraitsEditor
+    extends AuthenticationTraitsEditor
+{
+    private static final long serialVersionUID = 6915129149290353201L;
+
+    private IModel<Boolean> editMode;
+    private transient String newClientSecret;
+
+    public OAuthClientCredentialsAuthenticationTraitsEditor(String aId,
+            IModel<OAuthClientCredentialsAuthenticationTraits> aModel)
+    {
+        super(aId, CompoundPropertyModel.of(aModel));
+
+        setOutputMarkupId(true);
+
+        editMode = Model.of(aModel.getObject().getClientId() == null);
+
+        queue(new Label("status", LoadableDetachableModel.of(this::getStatus))
+                .add(visibleWhenNot(editMode)));
+        queue(new LambdaAjaxLink("edit", this::actionToggleEditMode) //
+                .add(visibleWhenNot(editMode)));
+        queue(new TextField<String>("tokenEndpointUrl") //
+                .add(new UrlValidator(new String[] { "http", "https" })) //
+                .setRequired(true));
+        queue(new TextField<String>("clientId") //
+                .setRequired(true) //
+                .add(visibleWhen(editMode)));
+        queue(new PasswordTextField("clientSecret", PropertyModel.of(this, "newClientSecret")) //
+                .add(visibleWhen(editMode)));
+    }
+
+    @SuppressWarnings("unchecked")
+    IModel<OAuthClientCredentialsAuthenticationTraits> getModel()
+    {
+        return (IModel<OAuthClientCredentialsAuthenticationTraits>) getDefaultModel();
+    }
+
+    private String getStatus()
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Client ID is ");
+        sb.append(getModel().map(OAuthClientCredentialsAuthenticationTraits::getClientId) //
+                .map(username -> "[" + username + "]")//
+                .orElse("not set").getObject());
+        sb.append("; client secret is ");
+        sb.append(getModel().map(OAuthClientCredentialsAuthenticationTraits::getClientSecret) //
+                .map(username -> "set")//
+                .orElse("not set").getObject());
+        return sb.toString();
+    }
+
+    private void actionToggleEditMode(AjaxRequestTarget aTarget)
+    {
+        editMode.setObject(!editMode.getObject());
+        aTarget.add(this);
+    }
+
+    @Override
+    public void setEditMode(boolean aMode)
+    {
+        editMode.setObject(aMode);
+        newClientSecret = null;
+    }
+
+    @Override
+    public void commit()
+    {
+        if (newClientSecret != null) {
+            getModel().getObject().setClientSecret(newClientSecret);
+        }
+
+        setEditMode(false);
+    }
+
+    @Override
+    protected void onModelChanged()
+    {
+        setEditMode(false);
+    }
+}

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/oauth/OAuthClientCredentialsAuthenticationTraitsEditor.properties
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/oauth/OAuthClientCredentialsAuthenticationTraitsEditor.properties
@@ -1,0 +1,18 @@
+# Licensed to the Technische Universität Darmstadt under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The Technische Universität Darmstadt 
+# licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.
+#  
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+tokenEndpointUrl=Token endpoint URL
+clientId=Client ID
+clientSecret=Client secret

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/oauth/OAuthGrantType.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/oauth/OAuthGrantType.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.security.client.auth.oauth;
+
+/**
+ * @see <a href="https://auth0.com/docs/get-started/applications/application-grant-types">Grant
+ *      types</a>
+ */
+public enum OAuthGrantType
+{
+    AUTHORIZATION_CODE("authorization_code"),
+
+    IMPLICIT("implicit"),
+
+    CLIENT_CREDENTIALS("client_credentials"),
+
+    PASSWORD("password"),
+
+    REFRESH_TOKEN("refresh_token");
+
+    private final String type;
+
+    private OAuthGrantType(String aType)
+    {
+        type = aType;
+    }
+
+    public String toHeaderValue()
+    {
+        return type;
+    }
+}

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/oauth/OAuthSession.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/oauth/OAuthSession.java
@@ -17,21 +17,25 @@
  */
 package de.tudarmstadt.ukp.inception.security.client.auth.oauth;
 
+import static java.time.Duration.ZERO;
+
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Date;
 
 public interface OAuthSession
 {
-    Date getLastUpdate();
+    Instant getLastUpdate();
 
-    void setLastUpdate(Date aDate);
+    void setLastUpdate(Instant aDate);
 
-    long getAccessTokenExpiresIn();
+    Duration getAccessTokenExpiresIn();
 
-    void setAccessTokenExpiresIn(long aTime);
+    void setAccessTokenExpiresIn(Duration aTime);
 
-    long getRefreshTokenExpiresIn();
+    Duration getRefreshTokenExpiresIn();
 
-    void setRefreshTokenExpiresIn(long aTime);
+    void setRefreshTokenExpiresIn(Duration aTime);
 
     String getAccessToken();
 
@@ -51,10 +55,10 @@ public interface OAuthSession
 
     default void update(OAuthAccessTokenResponse response)
     {
-        setLastUpdate(new Date(response.getSubmitTime()));
+        setLastUpdate(Instant.ofEpochMilli(response.getSubmitTime()));
 
         setAccessToken(response.getAccessToken());
-        setAccessTokenExpiresIn(response.getExpiresIn());
+        setAccessTokenExpiresIn(Duration.ofSeconds(response.getExpiresIn()));
 
         if (response.getExpiresIn() > 0) {
             setAccessTokenValidUntil(
@@ -65,7 +69,7 @@ public interface OAuthSession
         }
 
         setRefreshToken(response.getRefreshToken());
-        setRefreshTokenExpiresIn(response.getRefreshExpiresIn());
+        setRefreshTokenExpiresIn(Duration.ofSeconds(response.getRefreshExpiresIn()));
 
         if (response.getRefreshExpiresIn() > 0) {
             setRefreshTokenValidUntil(
@@ -78,8 +82,8 @@ public interface OAuthSession
 
     default void clear()
     {
-        setAccessTokenExpiresIn(0);
-        setRefreshTokenExpiresIn(0);
+        setAccessTokenExpiresIn(ZERO);
+        setRefreshTokenExpiresIn(ZERO);
         setLastUpdate(null);
         setAccessToken(null);
         setAccessTokenValidUntil(null);

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/oauth/OAuthSession.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/oauth/OAuthSession.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.security.client.auth.oauth;
+
+import java.util.Date;
+
+public interface OAuthSession
+{
+    Date getLastUpdate();
+
+    void setLastUpdate(Date aDate);
+
+    long getAccessTokenExpiresIn();
+
+    void setAccessTokenExpiresIn(long aTime);
+
+    long getRefreshTokenExpiresIn();
+
+    void setRefreshTokenExpiresIn(long aTime);
+
+    String getAccessToken();
+
+    void setAccessToken(String aAccessToken);
+
+    Date getAccessTokenValidUntil();
+
+    void setAccessTokenValidUntil(Date aAccessTokenValidUntil);
+
+    String getRefreshToken();
+
+    void setRefreshToken(String aRefreshToken);
+
+    Date getRefreshTokenValidUntil();
+
+    void setRefreshTokenValidUntil(Date aRefreshTokenValidUntil);
+
+    default void update(OAuthAccessTokenResponse response)
+    {
+        setLastUpdate(new Date(response.getSubmitTime()));
+
+        setAccessToken(response.getAccessToken());
+        setAccessTokenExpiresIn(response.getExpiresIn());
+
+        if (response.getExpiresIn() > 0) {
+            setAccessTokenValidUntil(
+                    new Date(response.getSubmitTime() + (response.getExpiresIn() * 1000)));
+        }
+        else {
+            setAccessTokenValidUntil(null);
+        }
+
+        setRefreshToken(response.getRefreshToken());
+        setRefreshTokenExpiresIn(response.getRefreshExpiresIn());
+
+        if (response.getRefreshExpiresIn() > 0) {
+            setRefreshTokenValidUntil(
+                    new Date(response.getSubmitTime() + (response.getRefreshExpiresIn() * 1000)));
+        }
+        else {
+            setRefreshTokenValidUntil(null);
+        }
+    }
+
+    default void clear()
+    {
+        setAccessTokenExpiresIn(0);
+        setRefreshTokenExpiresIn(0);
+        setLastUpdate(null);
+        setAccessToken(null);
+        setAccessTokenValidUntil(null);
+        setRefreshToken(null);
+        setRefreshTokenValidUntil(null);
+    }
+}

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/oauth/OAuthSessionImpl.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/oauth/OAuthSessionImpl.java
@@ -18,6 +18,8 @@
 package de.tudarmstadt.ukp.inception.security.client.auth.oauth;
 
 import java.io.Serializable;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Date;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -28,11 +30,11 @@ public class OAuthSessionImpl
 {
     private static final long serialVersionUID = 5378118174761262214L;
 
-    private Date lastUpdate;
+    private Instant lastUpdate;
 
-    private long accessTokenExpiresIn;
+    private Duration accessTokenExpiresIn;
 
-    private long refreshTokenExpiresIn;
+    private Duration refreshTokenExpiresIn;
 
     private String accessToken;
 
@@ -96,37 +98,37 @@ public class OAuthSessionImpl
     }
 
     @Override
-    public Date getLastUpdate()
+    public Instant getLastUpdate()
     {
         return lastUpdate;
     }
 
     @Override
-    public void setLastUpdate(Date aLastUpdate)
+    public void setLastUpdate(Instant aLastUpdate)
     {
         lastUpdate = aLastUpdate;
     }
 
     @Override
-    public long getAccessTokenExpiresIn()
+    public Duration getAccessTokenExpiresIn()
     {
         return accessTokenExpiresIn;
     }
 
     @Override
-    public void setAccessTokenExpiresIn(long aAccessTokenExpiresIn)
+    public void setAccessTokenExpiresIn(Duration aAccessTokenExpiresIn)
     {
         accessTokenExpiresIn = aAccessTokenExpiresIn;
     }
 
     @Override
-    public long getRefreshTokenExpiresIn()
+    public Duration getRefreshTokenExpiresIn()
     {
         return refreshTokenExpiresIn;
     }
 
     @Override
-    public void setRefreshTokenExpiresIn(long aRefreshTokenExpiresIn)
+    public void setRefreshTokenExpiresIn(Duration aRefreshTokenExpiresIn)
     {
         refreshTokenExpiresIn = aRefreshTokenExpiresIn;
     }

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/oauth/OAuthSessionImpl.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/client/auth/oauth/OAuthSessionImpl.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.security.client.auth.oauth;
+
+import java.io.Serializable;
+import java.util.Date;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+@JsonSerialize
+public class OAuthSessionImpl
+    implements Serializable, OAuthSession
+{
+    private static final long serialVersionUID = 5378118174761262214L;
+
+    private Date lastUpdate;
+
+    private long accessTokenExpiresIn;
+
+    private long refreshTokenExpiresIn;
+
+    private String accessToken;
+
+    private Date accessTokenValidUntil;
+
+    private String refreshToken;
+
+    private Date refreshTokenValidUntil;
+
+    public OAuthSessionImpl(OAuthAccessTokenResponse aResponse)
+    {
+        update(aResponse);
+    }
+
+    @Override
+    public String getAccessToken()
+    {
+        return accessToken;
+    }
+
+    @Override
+    public void setAccessToken(String aAccessToken)
+    {
+        accessToken = aAccessToken;
+    }
+
+    @Override
+    public Date getAccessTokenValidUntil()
+    {
+        return accessTokenValidUntil;
+    }
+
+    @Override
+    public void setAccessTokenValidUntil(Date aAccessTokenValidUntil)
+    {
+        accessTokenValidUntil = aAccessTokenValidUntil;
+    }
+
+    @Override
+    public String getRefreshToken()
+    {
+        return refreshToken;
+    }
+
+    @Override
+    public void setRefreshToken(String aRefreshToken)
+    {
+        refreshToken = aRefreshToken;
+    }
+
+    @Override
+    public Date getRefreshTokenValidUntil()
+    {
+        return refreshTokenValidUntil;
+    }
+
+    @Override
+    public void setRefreshTokenValidUntil(Date aRefreshTokenValidUntil)
+    {
+        refreshTokenValidUntil = aRefreshTokenValidUntil;
+    }
+
+    @Override
+    public Date getLastUpdate()
+    {
+        return lastUpdate;
+    }
+
+    @Override
+    public void setLastUpdate(Date aLastUpdate)
+    {
+        lastUpdate = aLastUpdate;
+    }
+
+    @Override
+    public long getAccessTokenExpiresIn()
+    {
+        return accessTokenExpiresIn;
+    }
+
+    @Override
+    public void setAccessTokenExpiresIn(long aAccessTokenExpiresIn)
+    {
+        accessTokenExpiresIn = aAccessTokenExpiresIn;
+    }
+
+    @Override
+    public long getRefreshTokenExpiresIn()
+    {
+        return refreshTokenExpiresIn;
+    }
+
+    @Override
+    public void setRefreshTokenExpiresIn(long aRefreshTokenExpiresIn)
+    {
+        refreshTokenExpiresIn = aRefreshTokenExpiresIn;
+    }
+}

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/http/HttpClientImplBase.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/http/HttpClientImplBase.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.support.http;
+
+import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class HttpClientImplBase
+{
+    public static final int HTTP_BAD_REQUEST = 400;
+
+    public static final String CONTENT_TYPE = "Content-Type";
+
+    protected final HttpClient client;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public HttpClientImplBase()
+    {
+        this(null);
+    }
+
+    public HttpClientImplBase(HttpClient aClient)
+    {
+        if (aClient != null) {
+            client = aClient;
+        }
+        else {
+            client = HttpClient.newBuilder().build();
+        }
+    }
+
+    protected HttpResponse<String> sendRequest(HttpRequest aRequest) throws IOException
+    {
+        try {
+            HttpResponse<String> response = client.send(aRequest, BodyHandlers.ofString(UTF_8));
+
+            // If the response indicates that the request was not successful,
+            // then it does not make sense to go on and try to decode the XMI
+            if (response.statusCode() >= HTTP_BAD_REQUEST) {
+                String responseBody = getResponseBody(response);
+                String msg = format("Request was not successful: [%d] - [%s]",
+                        response.statusCode(), responseBody);
+                throw new IOException(msg);
+            }
+
+            return response;
+        }
+        catch (IOException | InterruptedException e) {
+            throw new IOException("Error while sending request: " + e.getMessage(), e);
+        }
+    }
+
+    protected String getResponseBody(HttpResponse<String> response)
+    {
+        if (response.body() != null) {
+            return response.body();
+        }
+        else {
+            return "";
+        }
+    }
+
+    protected <T> T deserializeResponse(HttpResponse<String> response, Class<T> aType)
+        throws IOException
+    {
+        try {
+            return objectMapper.readValue(response.body(), aType);
+        }
+        catch (IOException e) {
+            throw new IOException("Error while deserializing server response!", e);
+        }
+    }
+
+    protected String urlEncodeParameters(Map<String, String> aParameters)
+    {
+        if (aParameters.isEmpty()) {
+            return "";
+        }
+        StringBuilder uriBuilder = new StringBuilder();
+        for (Entry<String, String> param : aParameters.entrySet()) {
+            if (uriBuilder.length() > 0) {
+                uriBuilder.append("&");
+            }
+            uriBuilder.append(URLEncoder.encode(param.getKey(), UTF_8));
+            uriBuilder.append('=');
+            uriBuilder.append(URLEncoder.encode(param.getValue(), UTF_8));
+        }
+
+        return uriBuilder.toString();
+    }
+}

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.properties
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.properties
@@ -56,6 +56,7 @@ permissions=Permissions
 permissions.for=Permissions for
 documents=Documents
 username=Username
+password=Password
 language=Language
 tagset=Tagset
 tagset.details=Tagset Details

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/AccessSpecificSettingsPanel.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/AccessSpecificSettingsPanel.java
@@ -17,511 +17,79 @@
  */
 package de.tudarmstadt.ukp.inception.ui.kb.project;
 
-import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
+import static de.tudarmstadt.ukp.inception.kb.RepositoryType.LOCAL;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
 
-import org.apache.wicket.AttributeModifier;
-import org.apache.wicket.ClassAttributeModifier;
-import org.apache.wicket.ajax.AjaxRequestTarget;
-import org.apache.wicket.ajax.markup.html.AjaxLink;
-import org.apache.wicket.feedback.IFeedback;
-import org.apache.wicket.markup.html.WebMarkupContainer;
-import org.apache.wicket.markup.html.basic.Label;
-import org.apache.wicket.markup.html.form.CheckBox;
-import org.apache.wicket.markup.html.form.Form;
-import org.apache.wicket.markup.html.form.RequiredTextField;
-import org.apache.wicket.markup.html.form.TextField;
-import org.apache.wicket.markup.html.form.upload.FileUpload;
-import org.apache.wicket.markup.html.form.upload.FileUploadField;
-import org.apache.wicket.markup.html.link.ExternalLink;
-import org.apache.wicket.markup.html.list.ListItem;
-import org.apache.wicket.markup.html.list.ListView;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
-import org.apache.wicket.model.LoadableDetachableModel;
-import org.apache.wicket.model.Model;
-import org.apache.wicket.model.ResourceModel;
-import org.apache.wicket.model.StringResourceModel;
-import org.apache.wicket.model.util.ListModel;
-import org.apache.wicket.spring.injection.annot.SpringBean;
-import org.apache.wicket.util.resource.IResourceStream;
-import org.eclipse.rdf4j.repository.RepositoryException;
-import org.eclipse.rdf4j.rio.RDFFormat;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import com.github.rjeschke.txtmark.Processor;
-
-import de.agilecoders.wicket.extensions.markup.html.bootstrap.form.fileinput.FileInputConfig;
-import de.tudarmstadt.ukp.clarin.webanno.support.bootstrap.BootstrapFileInputField;
-import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxLink;
-import de.tudarmstadt.ukp.clarin.webanno.support.wicket.AjaxDownloadLink;
-import de.tudarmstadt.ukp.clarin.webanno.support.wicket.TempFileResource;
-import de.tudarmstadt.ukp.inception.kb.KnowledgeBaseService;
-import de.tudarmstadt.ukp.inception.kb.RepositoryType;
-import de.tudarmstadt.ukp.inception.kb.SchemaProfile;
-import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBaseProperties;
-import de.tudarmstadt.ukp.inception.kb.yaml.KnowledgeBaseInfo;
+import de.tudarmstadt.ukp.inception.kb.model.KnowledgeBase;
 import de.tudarmstadt.ukp.inception.kb.yaml.KnowledgeBaseProfile;
-import de.tudarmstadt.ukp.inception.support.io.FileUploadDownloadHelper;
-import de.tudarmstadt.ukp.inception.ui.kb.project.validators.Validators;
+import de.tudarmstadt.ukp.inception.ui.kb.project.local.LocalRepositorySettingsPanel;
+import de.tudarmstadt.ukp.inception.ui.kb.project.remote.RemoteRepositorySettingsPanel;
 
 public class AccessSpecificSettingsPanel
     extends Panel
 {
     private static final long serialVersionUID = -7834443872889805698L;
 
-    private static final Logger log = LoggerFactory.getLogger(AccessSpecificSettingsPanel.class);
-
-    private final CompoundPropertyModel<KnowledgeBaseWrapper> kbModel;
-
-    // Remote
-    private final Map<String, KnowledgeBaseProfile> knowledgeBaseProfiles;
-    private static final int MAXIMUM_REMOTE_REPO_SUGGESTIONS = 10;
-    private WebMarkupContainer infoContainerRemote;
-
-    // Local
-    private FileUploadField fileUpload;
-    private WebMarkupContainer listViewContainer;
-    private KnowledgeBaseProfile selectedKnowledgeBaseProfile;
-    private static final String CLASSPATH_PREFIX = "classpath:";
-    private final Map<String, KnowledgeBaseProfile> downloadedProfiles;
-    private final Map<String, File> uploadedFiles;
-    private WebMarkupContainer infoContainerLocal;
-
-    // Both
-    private CompoundPropertyModel<KnowledgeBaseInfo> kbInfoModel;
-
-    /**
-     * Given the default file extension of an RDF format, returns the corresponding
-     * {@link RDFFormat}. This factory method detour is necessary because {@link RDFFormat} should
-     * be used as a model, but is not serializable.
-     *
-     * @return an {@link RDFFormat}
-     */
-    private static final RDFFormat getRdfFormatForFileExt(String fileExt)
-    {
-        return EXPORT_FORMATS.stream().filter(f -> f.getDefaultFileExtension().equals(fileExt))
-                .findAny().get();
-    }
-
-    private static final List<RDFFormat> EXPORT_FORMATS = Arrays.asList(RDFFormat.RDFXML,
-            RDFFormat.NTRIPLES, RDFFormat.TURTLE);
-    private static final List<String> EXPORT_FORMAT_FILE_EXTENSIONS = EXPORT_FORMATS.stream()
-            .map(f -> f.getDefaultFileExtension()).collect(Collectors.toList());
-
-    private @SpringBean KnowledgeBaseService kbService;
-    private @SpringBean KnowledgeBaseProperties kbproperties;
-
-    private TextField<String> urlField;
-    private CheckBox skipSslValidation;
-    private TextField<String> defaultDatasetField;
+    private final LocalRepositorySettingsPanel local;
+    private final RemoteRepositorySettingsPanel remote;
 
     public AccessSpecificSettingsPanel(String id,
             CompoundPropertyModel<KnowledgeBaseWrapper> aModel,
             Map<String, KnowledgeBaseProfile> aKnowledgeBaseProfiles)
     {
-        super(id);
+        super(id, aModel);
         setOutputMarkupId(true);
 
-        kbModel = aModel;
-        knowledgeBaseProfiles = aKnowledgeBaseProfiles;
-        downloadedProfiles = new HashMap<>();
-        uploadedFiles = new HashMap<>();
-        kbModel.getObject().clearFiles();
-        kbInfoModel = CompoundPropertyModel.of(Model.of());
+        aModel.getObject().clearFiles();
 
-        boolean isHandlingLocalRepository = kbModel.getObject().getKb()
-                .getType() == RepositoryType.LOCAL;
+        boolean isHandlingLocalRepository = aModel.getObject().getKb().getType() == LOCAL;
 
         // container for form components related to local KBs
-        WebMarkupContainer local = new WebMarkupContainer("localSpecificSettings");
-        add(local);
+        local = new LocalRepositorySettingsPanel("localSpecificSettings", aModel,
+                aKnowledgeBaseProfiles);
         local.setVisibilityAllowed(isHandlingLocalRepository);
-        setUpLocalSpecificSettings(local);
+        add(local);
 
         // container for form components related to remote KBs
-        WebMarkupContainer remote = new WebMarkupContainer("remoteSpecificSettings");
-        add(remote);
+        remote = new RemoteRepositorySettingsPanel("remoteSpecificSettings", aModel,
+                aKnowledgeBaseProfiles);
         remote.setVisibilityAllowed(!isHandlingLocalRepository);
-        setUpRemoteSpecificSettings(remote);
+        add(remote);
     }
 
-    private void setUpRemoteSpecificSettings(WebMarkupContainer wmc)
+    @SuppressWarnings("unchecked")
+    public IModel<KnowledgeBaseWrapper> getModel()
     {
-        urlField = new RequiredTextField<>("url");
-        urlField.add(Validators.URL_VALIDATOR);
-        wmc.add(urlField);
-
-        skipSslValidation = new CheckBox("skipSslValidation", kbModel.bind("kb.skipSslValidation"));
-        skipSslValidation.setOutputMarkupPlaceholderTag(true);
-        wmc.add(skipSslValidation);
-
-        // for up to MAXIMUM_REMOTE_REPO_SUGGESTIONS of knowledge bases, create a link which
-        // directly fills in the URL field (convenient for both developers AND users :))
-        List<KnowledgeBaseProfile> suggestions = new ArrayList<>(knowledgeBaseProfiles.values()
-                .stream().filter(kb -> RepositoryType.REMOTE.equals(kb.getType()))
-                .collect(Collectors.toList()));
-        suggestions = suggestions.subList(0,
-                Math.min(suggestions.size(), MAXIMUM_REMOTE_REPO_SUGGESTIONS));
-
-        infoContainerRemote = createKbInfoContainer("infoContainer");
-        infoContainerRemote.setOutputMarkupId(true);
-        wmc.add(infoContainerRemote);
-        wmc.add(remoteSuggestionsList("suggestions", suggestions));
-
-        defaultDatasetField = defaultDataset("defaultDataset",
-                kbModel.bind("kb.defaultDatasetIri"));
-        wmc.add(defaultDatasetField);
+        return (IModel<KnowledgeBaseWrapper>) getDefaultModel();
     }
 
-    private TextField<String> defaultDataset(String aId, IModel<String> model)
+    public void applyState()
     {
-        TextField<String> defaultDataset = new TextField<>(aId, model);
-        defaultDataset.add(Validators.IRI_VALIDATOR);
-        return defaultDataset;
-    }
+        KnowledgeBase kb = getModel().getObject().getKb();
+        switch (kb.getType()) {
+        case LOCAL:
+            // local knowledge bases are editable by default
+            kb.setReadOnly(false);
 
-    private ListView<KnowledgeBaseProfile> remoteSuggestionsList(String aId,
-            List<KnowledgeBaseProfile> aSuggestions)
-    {
-        return new ListView<KnowledgeBaseProfile>(aId, aSuggestions)
-        {
-            private static final long serialVersionUID = 4179629475064638272L;
-
-            @Override
-            protected void populateItem(ListItem<KnowledgeBaseProfile> item)
-            {
-                // add a link for one knowledge base with proper label
-                LambdaAjaxLink link = new LambdaAjaxLink("suggestionLink", t -> {
-                    // set all the fields according to the chosen profile
-                    kbModel.getObject().setUrl(item.getModelObject().getAccess().getAccessUrl());
-                    // sets root concepts list - if null then an empty list otherwise change the
-                    // values to IRI and populate the list
-                    kbModel.getObject().getKb().applyRootConcepts(item.getModelObject());
-                    kbModel.getObject().getKb()
-                            .applyAdditionalMatchingProperties(item.getModelObject());
-                    kbModel.getObject().getKb().applyMapping(item.getModelObject().getMapping());
-                    kbInfoModel.setObject(item.getModelObject().getInfo());
-                    kbModel.getObject().getKb().setFullTextSearchIri(
-                            item.getModelObject().getAccess().getFullTextSearchIri());
-                    kbModel.getObject().getKb()
-                            .setDefaultLanguage(item.getModelObject().getDefaultLanguage());
-                    kbModel.getObject().getKb()
-                            .setDefaultDatasetIri(item.getModelObject().getDefaultDataset());
-                    kbModel.getObject().getKb()
-                            .setReification(item.getModelObject().getReification());
-                    t.add(urlField, defaultDatasetField, infoContainerRemote);
-                });
-                link.add(new Label("suggestionLabel", item.getModelObject().getName()));
-                item.add(link);
-            }
-        };
-    }
-
-    private WebMarkupContainer createKbInfoContainer(String aId)
-    {
-        WebMarkupContainer wmc = new WebMarkupContainer(aId);
-        wmc.add(new Label("description",
-                kbInfoModel.bind("description")
-                        .map(description -> Processor.process((String) description, true)))
-                                .setEscapeModelStrings(false)
-                                .add(visibleWhen(() -> kbInfoModel.getObject() != null)));
-        wmc.add(new Label("hostInstitutionName", kbInfoModel.bind("hostInstitutionName"))
-                .add(visibleWhen(() -> kbInfoModel.getObject() != null)));
-        wmc.add(new Label("authorName", kbInfoModel.bind("authorName"))
-                .add(visibleWhen(() -> kbInfoModel.getObject() != null)));
-        wmc.add(new ExternalLink("websiteURL", kbInfoModel.bind("websiteURL"),
-                kbInfoModel.bind("websiteURL"))
-                        .add(visibleWhen(() -> kbInfoModel.getObject() != null)));
-        return wmc;
-    }
-
-    private void setUpLocalSpecificSettings(WebMarkupContainer wmc)
-    {
-        wmc.add(uploadForm("uploadForm", "uploadField"));
-
-        // add link for clearing the knowledge base contents, enabled only, if there is
-        // something to clear
-        AjaxLink<Void> clearLink = clearLink("clear");
-        wmc.add(clearLink);
-
-        wmc.add(fileExtensionsExportList("exportButtons"));
-
-        List<KnowledgeBaseProfile> localKBs = knowledgeBaseProfiles.values().stream()
-                .filter(kb -> RepositoryType.LOCAL.equals(kb.getType()))
-                .collect(Collectors.toList());
-
-        listViewContainer = new WebMarkupContainer("listViewContainer");
-        ListView<KnowledgeBaseProfile> suggestions = localSuggestionsList("localKBs", localKBs);
-        listViewContainer.add(suggestions);
-        listViewContainer.setOutputMarkupPlaceholderTag(true);
-
-        LambdaAjaxLink addKbButton = new LambdaAjaxLink("addKbButton",
-                this::actionDownloadKbAndSetIRIs);
-        addKbButton.add(new Label("addKbLabel", new ResourceModel("kb.wizard.steps.local.addKb")));
-        listViewContainer.add(addKbButton);
-
-        infoContainerLocal = createKbInfoContainer("infoContainer");
-        infoContainerLocal.setOutputMarkupId(true);
-        wmc.add(infoContainerLocal);
-
-        wmc.add(listViewContainer);
-    }
-
-    private Form<Void> uploadForm(String aFormId, String aFieldId)
-    {
-        Form<Void> importProjectForm = new Form<Void>(aFormId)
-        {
-            private static final long serialVersionUID = -8284858297362896476L;
-
-            @Override
-            protected void onSubmit()
-            {
-                super.onSubmit();
-                handleUploadedFiles();
-            }
-        };
-
-        FileInputConfig config = new FileInputConfig();
-        config.initialCaption("Import knowledge base ...");
-        config.showPreview(false);
-        config.showUpload(false);
-        importProjectForm
-                .add(fileUpload = new BootstrapFileInputField(aFieldId, new ListModel<>(), config));
-        return importProjectForm;
-    }
-
-    public void handleUploadedFiles()
-    {
-        try {
-            for (FileUpload fu : fileUpload.getFileUploads()) {
-                File tmp = uploadFile(fu);
-                kbModel.getObject().putFile(fu.getClientFileName(), tmp);
-            }
-        }
-        catch (Exception e) {
-            log.error("Error while uploading files", e);
-            error("Could not upload files");
-        }
-    }
-
-    private AjaxLink<Void> clearLink(String aId)
-    {
-        AjaxLink<Void> clearLink = new LambdaAjaxLink(aId, this::actionClear)
-        {
-
-            private static final long serialVersionUID = -6272361381689154558L;
-
-            @Override
-            public boolean isEnabled()
-            {
-                return !kbService.isEmpty(kbModel.getObject().getKb());
-            }
-        };
-        return clearLink;
-    }
-
-    private ListView<String> fileExtensionsExportList(String aId)
-    {
-        ListView<String> fileExListView = new ListView<String>(aId, EXPORT_FORMAT_FILE_EXTENSIONS)
-        {
-
-            private static final long serialVersionUID = -1869762759620557362L;
-
-            @Override
-            protected void populateItem(ListItem<String> item)
-            {
-                // creates an appropriately labeled {@link AjaxDownloadLink} which triggers the
-                // download of the contents of the current KB in the given format
-                String fileExtension = item.getModelObject();
-                Model<String> exportFileNameModel = Model
-                        .of(kbModel.getObject().getKb().getName() + "." + fileExtension);
-                AjaxDownloadLink exportLink = new AjaxDownloadLink("link", exportFileNameModel,
-                        LoadableDetachableModel.of(() -> actionExport(fileExtension)));
-                exportLink.add(new Label("label", new ResourceModel("kb.export." + fileExtension)));
-                item.add(exportLink);
-            }
-        };
-        return fileExListView;
-    }
-
-    private ListView<KnowledgeBaseProfile> localSuggestionsList(String aId,
-            List<KnowledgeBaseProfile> localKBs)
-    {
-        ListView<KnowledgeBaseProfile> suggestions = new ListView<KnowledgeBaseProfile>(aId,
-                localKBs)
-        {
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            protected void populateItem(ListItem<KnowledgeBaseProfile> item)
-            {
-                LambdaAjaxLink link = new LambdaAjaxLink("suggestionLink",
-                        _target -> actionSelectPredefinedKB(_target, item.getModel()));
-
-                // Can not import the same KB more than once
-                boolean isImported = downloadedProfiles
-                        .containsKey(item.getModelObject().getName());
-                link.setEnabled(!isImported);
-
-                String itemLabel = item.getModelObject().getName();
-                // Adjust label to indicate whether the KB has already been downloaded
-                if (isImported) {
-                    // \u2714 is the checkmark symbol
-                    itemLabel = itemLabel + "  \u2714";
-                }
-                link.add(new Label("suggestionLabel", itemLabel));
-
-                link.add(new ClassAttributeModifier()
-                {
-                    private static final long serialVersionUID = -3985182168502826951L;
-
-                    @Override
-                    protected Set<String> update(Set<String> aOldClasses)
-                    {
-                        if (Objects.equals(selectedKnowledgeBaseProfile, item.getModelObject())) {
-                            aOldClasses.add("active");
-                        }
-                        else {
-                            aOldClasses.remove("active");
-                        }
-                        return aOldClasses;
-                    }
-                });
-
-                // Show schema type on mouseover
-                link.add(
-                        AttributeModifier
-                                .append("title",
-                                        new StringResourceModel(
-                                                "kb.wizard.steps.local.schemaOnMouseOver", this)
-                                                        .setParameters(
-                                                                SchemaProfile
-                                                                        .checkSchemaProfile(item
-                                                                                .getModelObject())
-                                                                        .getUiLabel(),
-                                                                getAccessTypeLabel(
-                                                                        item.getModelObject()))));
-
-                item.add(link);
-            }
-        };
-        suggestions.setOutputMarkupId(true);
-        return suggestions;
-    }
-
-    private void actionSelectPredefinedKB(AjaxRequestTarget aTarget,
-            IModel<KnowledgeBaseProfile> aModel)
-    {
-        if (Objects.equals(selectedKnowledgeBaseProfile, aModel.getObject())) {
-            selectedKnowledgeBaseProfile = null;
-        }
-        else {
-            selectedKnowledgeBaseProfile = aModel.getObject();
-            kbInfoModel.setObject(aModel.getObject().getInfo());
-        }
-        aTarget.add(listViewContainer, infoContainerLocal);
-    }
-
-    private File uploadFile(FileUpload fu) throws IOException
-    {
-        String fileName = fu.getClientFileName();
-        if (!uploadedFiles.containsKey(fileName)) {
-            FileUploadDownloadHelper fileUploadDownloadHelper = new FileUploadDownloadHelper(
-                    getApplication());
-            File tmpFile = fileUploadDownloadHelper.writeFileUploadToTemporaryFile(fu, kbModel);
-            uploadedFiles.put(fileName, tmpFile);
-        }
-        else {
-            log.debug("File [{}] already downloaded, skipping!", fileName);
-        }
-        return uploadedFiles.get(fileName);
-    }
-
-    private void actionClear(AjaxRequestTarget aTarget)
-    {
-        try {
-            kbService.clear(kbModel.getObject().getKb());
-            info(getString("kb.details.local.contents.clear.feedback", kbModel.bind("kb")));
-            aTarget.add(this);
-            aTarget.addChildren(getPage(), IFeedback.class);
-        }
-        catch (RepositoryException e) {
-            error("Error clearing KB: " + e.getMessage());
-            log.error("Error clearing KB", e);
-            aTarget.addChildren(getPage(), IFeedback.class);
-        }
-    }
-
-    private IResourceStream actionExport(String rdfFormatFileExt)
-    {
-        return new TempFileResource((os) -> kbService.exportData(kbModel.getObject().getKb(),
-                getRdfFormatForFileExt(rdfFormatFileExt), os));
-    }
-
-    private void actionDownloadKbAndSetIRIs(AjaxRequestTarget aTarget)
-    {
-        try {
-            if (selectedKnowledgeBaseProfile != null) {
-
-                String accessUrl = selectedKnowledgeBaseProfile.getAccess().getAccessUrl();
-
-                FileUploadDownloadHelper fileUploadDownloadHelper = new FileUploadDownloadHelper(
-                        getApplication());
-
-                if (!accessUrl.startsWith(CLASSPATH_PREFIX)) {
-
-                    File tmpFile = fileUploadDownloadHelper
-                            .writeFileDownloadToTemporaryFile(accessUrl, kbModel);
-                    kbModel.getObject().putFile(selectedKnowledgeBaseProfile.getName(), tmpFile);
-                }
-                else {
-                    // import from classpath
-                    File kbFile = fileUploadDownloadHelper
-                            .writeClasspathResourceToTemporaryFile(accessUrl, kbModel);
-                    kbModel.getObject().putFile(selectedKnowledgeBaseProfile.getName(), kbFile);
-                }
-
-                kbModel.getObject().getKb().applyRootConcepts(selectedKnowledgeBaseProfile);
-                kbModel.getObject().getKb().applyMapping(selectedKnowledgeBaseProfile.getMapping());
-                kbModel.getObject().getKb().setFullTextSearchIri(
-                        selectedKnowledgeBaseProfile.getAccess().getFullTextSearchIri());
-                kbModel.getObject().getKb()
-                        .setDefaultLanguage(selectedKnowledgeBaseProfile.getDefaultLanguage());
-                kbModel.getObject().getKb()
-                        .setReification(selectedKnowledgeBaseProfile.getReification());
-                downloadedProfiles.put(selectedKnowledgeBaseProfile.getName(),
-                        selectedKnowledgeBaseProfile);
-                aTarget.add(this);
-                selectedKnowledgeBaseProfile = null;
-            }
-        }
-        catch (IOException e) {
-            error("Unable to download or import knowledge base file " + e.getMessage());
-            log.error("Unable to download or import knowledge base file ", e);
-            aTarget.addChildren(getPage(), IFeedback.class);
-        }
-    }
-
-    private String getAccessTypeLabel(KnowledgeBaseProfile aProfile)
-    {
-        if (aProfile.getAccess().getAccessUrl().startsWith(CLASSPATH_PREFIX)) {
-            return "CLASSPATH";
-        }
-        else {
-            return "DOWNLOAD";
+            // We need to handle this manually here because the onSubmit method of the upload
+            // form is only called *after* the upload component has already been detached and
+            // as a consequence all uploaded files have been cleared
+            local.handleUploadedFiles();
+            break;
+        case REMOTE:
+            // MB: as of 2018-02, all remote knowledge bases are read-only, hence the
+            // PermissionsStep is currently not shown. Therefore, set read-only property here
+            // manually.
+            kb.setReadOnly(true);
+            remote.applyState();
+            break;
+        default:
+            throw new IllegalStateException("Unsupported repository type [" + kb.getType() + "]");
         }
     }
 }

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/KnowledgeBaseDetailsPanel.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/KnowledgeBaseDetailsPanel.java
@@ -17,17 +17,18 @@
  */
 package de.tudarmstadt.ukp.inception.ui.kb.project;
 
+import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
+import static de.tudarmstadt.ukp.inception.kb.RepositoryType.LOCAL;
+import static de.tudarmstadt.ukp.inception.kb.RepositoryType.REMOTE;
+import static java.util.Collections.emptyMap;
 import static org.apache.commons.lang3.exception.ExceptionUtils.getRootCauseMessage;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
-import java.util.Collections;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
-import org.apache.wicket.ajax.markup.html.form.AjaxButton;
 import org.apache.wicket.feedback.IFeedback;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.form.RequiredTextField;
@@ -45,12 +46,12 @@ import org.eclipse.rdf4j.repository.sparql.config.SPARQLRepositoryConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import de.tudarmstadt.ukp.clarin.webanno.support.JSONUtil;
 import de.tudarmstadt.ukp.clarin.webanno.support.dialog.ConfirmationDialog;
+import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxButton;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxLink;
-import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior;
 import de.tudarmstadt.ukp.clarin.webanno.support.spring.ApplicationEventPublisherHolder;
 import de.tudarmstadt.ukp.inception.kb.KnowledgeBaseService;
-import de.tudarmstadt.ukp.inception.kb.RepositoryType;
 import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBaseProperties;
 import de.tudarmstadt.ukp.inception.kb.event.KnowledgeBaseConfigurationChangedEvent;
 import de.tudarmstadt.ukp.inception.kb.model.KnowledgeBase;
@@ -60,10 +61,14 @@ public class KnowledgeBaseDetailsPanel
 {
     private static final long serialVersionUID = -3550082954966752196L;
 
-    private static final Logger log = LoggerFactory.getLogger(KnowledgeBaseDetailsPanel.class);
+    private static final Logger LOG = LoggerFactory.getLogger(KnowledgeBaseDetailsPanel.class);
 
-    private static final String TITLE_MARKUP_ID = "title";
-    private static final String CONTENT_MARKUP_ID = "content";
+    private static final String CID_FORM = "form";
+    private static final String CID_SAVE = "save";
+    private static final String CID_REINDEX = "reindex";
+    private static final String CID_DELETE = "delete";
+    private static final String CID_TITLE = "title";
+    private static final String CID_CONTENT = "content";
 
     private @SpringBean ApplicationEventPublisherHolder applicationEventPublisherHolder;
     private @SpringBean KnowledgeBaseService kbService;
@@ -72,10 +77,8 @@ public class KnowledgeBaseDetailsPanel
     private final IModel<KnowledgeBase> kbModel;
     private final CompoundPropertyModel<KnowledgeBaseWrapper> kbwModel;
 
-    private Component title;
-    private Component content;
-
-    private ConfirmationDialog confirmationDialog;
+    private final KBSettingsContent content;
+    private final ConfirmationDialog confirmationDialog;
 
     public KnowledgeBaseDetailsPanel(String aId, IModel<KnowledgeBase> aKbModel)
     {
@@ -84,12 +87,11 @@ public class KnowledgeBaseDetailsPanel
 
         kbModel = aKbModel;
 
-        KnowledgeBaseWrapper kbw = new KnowledgeBaseWrapper();
-        KnowledgeBase kb = kbModel.getObject();
-        kbw.setKb(kb);
+        KnowledgeBaseWrapper kbw = new KnowledgeBaseWrapper(kbModel.getObject());
+
         // set the URL of the KBW to the current SPARQL URL, if dealing with a remote repository
-        if (kbw.getKb().getType() == RepositoryType.REMOTE) {
-            RepositoryImplConfig cfg = kbService.getKnowledgeBaseConfig(kb);
+        if (kbw.getKb().getType() == REMOTE) {
+            RepositoryImplConfig cfg = kbService.getKnowledgeBaseConfig(kbw.getKb());
             String url = ((SPARQLRepositoryConfig) cfg).getQueryEndpointUrl();
             kbw.setUrl(url);
         }
@@ -100,44 +102,20 @@ public class KnowledgeBaseDetailsPanel
 
         // this form contains all the wicket components in this panel; not only the components used
         // for editing, but also the ones for showing information about a KB (when in ViewMode)
-        Form<KnowledgeBaseWrapper> form = new Form<>("form", kbwModel);
-        add(form);
+        queue(new Form<KnowledgeBaseWrapper>(CID_FORM, kbwModel));
 
         // title/content
-        title = new KBSettingsTitle(TITLE_MARKUP_ID, kbwModel);
-        content = new KBSettingsContent(CONTENT_MARKUP_ID, kbwModel);
-        form.add(title);
-        form.add(content);
+        queue(new KBSettingsTitle(CID_TITLE, kbwModel));
+        queue(content = new KBSettingsContent(CID_CONTENT, kbwModel));
 
         // re-index button only visible for local KBs
-        form.add(new LambdaAjaxLink("delete", KnowledgeBaseDetailsPanel.this::actionDelete));
-        form.add(new LambdaAjaxLink("reindex", KnowledgeBaseDetailsPanel.this::actionReindex)
-                .add(LambdaBehavior.visibleWhen(() -> RepositoryType.LOCAL
-                        .equals(kbwModel.getObject().getKb().getType()))));
-        form.add(new AjaxButton("save", form)
-        {
-            private static final long serialVersionUID = 3393631640806116694L;
-
-            @Override
-            protected void onError(AjaxRequestTarget aTarget)
-            {
-                aTarget.addChildren(getPage(), IFeedback.class);
-            }
-
-            @Override
-            protected void onAfterSubmit(AjaxRequestTarget aTarget)
-            {
-                KnowledgeBaseDetailsPanel.this.actionSave(aTarget, form);
-                success("Knowledge base settings saved.");
-                aTarget.addChildren(getPage(), IFeedback.class);
-                applicationEventPublisherHolder.get()
-                        .publishEvent(new KnowledgeBaseConfigurationChangedEvent(this,
-                                aKbModel.getObject().getProject()));
-            }
-        });
+        queue(new LambdaAjaxLink(CID_DELETE, this::actionDelete));
+        queue(new LambdaAjaxLink(CID_REINDEX, this::actionReindex) //
+                .add(visibleWhen(kbwModel.map($ -> $.getKb().getType() == LOCAL).orElse(false))));
+        queue(new LambdaAjaxButton<>(CID_SAVE, this::actionSave).triggerAfterSubmit());
 
         confirmationDialog = new ConfirmationDialog("confirmationDialog");
-        add(confirmationDialog);
+        queue(confirmationDialog);
     }
 
     @Override
@@ -161,7 +139,7 @@ public class KnowledgeBaseDetailsPanel
     private void actionSave(AjaxRequestTarget aTarget, Form<KnowledgeBaseWrapper> aForm)
     {
         aTarget.addChildren(getPage(), IFeedback.class);
-        aTarget.add(findParentWithAssociatedMarkup());
+        aTarget.add(this);
 
         try {
             KnowledgeBaseWrapper kbw = kbwModel.getObject();
@@ -169,15 +147,20 @@ public class KnowledgeBaseDetailsPanel
             // if dealing with a remote repository and a non-empty URL, get a new
             // RepositoryImplConfig for the new URL; otherwise keep using the existing config
             RepositoryImplConfig cfg;
-            if (kbw.getKb().getType() == RepositoryType.REMOTE && kbw.getUrl() != null) {
+            if (kbw.getKb().getType() == REMOTE && kbw.getUrl() != null) {
                 cfg = kbService.getRemoteConfig(kbw.getUrl());
             }
             else {
                 cfg = kbService.getKnowledgeBaseConfig(kbw.getKb());
             }
+
+            content.applyState();
+
             KnowledgeBase kb = kbw.getKb();
+            kb.setTraits(JSONUtil.toJsonString(kbw.getTraits()));
             kbService.updateKnowledgeBase(kb, cfg);
-            if (kb.getType() == RepositoryType.LOCAL) {
+
+            if (kb.getType() == LOCAL) {
                 kbService.defineBaseProperties(kb);
                 for (Pair<String, File> f : kbw.getFiles()) {
                     try (InputStream is = new FileInputStream(f.getValue())) {
@@ -186,16 +169,20 @@ public class KnowledgeBaseDetailsPanel
                     }
                     catch (Exception e) {
                         error("Failed to import [" + f.getKey() + "]: " + getRootCauseMessage(e));
-                        log.error("Failed to import [{}]: ", f.getKey(), e);
+                        LOG.error("Failed to import [{}]: ", f.getKey(), e);
                     }
                 }
             }
+
             modelChanged();
-            aTarget.add(this);
+
+            success("Knowledge base settings saved.");
+            applicationEventPublisherHolder.get().publishEvent(
+                    new KnowledgeBaseConfigurationChangedEvent(this, kbw.getKb().getProject()));
         }
         catch (Exception e) {
             error("Unable to save knowledge base: " + e.getLocalizedMessage());
-            log.error("Unable to save knowledge base.", e);
+            LOG.error("Unable to save knowledge base.", e);
         }
     }
 
@@ -205,14 +192,14 @@ public class KnowledgeBaseDetailsPanel
 
         KnowledgeBase kb = kbwModel.getObject().getKb();
         try {
-            log.info("Starting rebuilding full-text index of {} ... this may take a while ...", kb);
+            LOG.info("Starting rebuilding full-text index of {} ... this may take a while ...", kb);
             kbService.rebuildFullTextIndex(kb);
-            log.info("Completed rebuilding full-text index of {}", kb);
+            LOG.info("Completed rebuilding full-text index of {}", kb);
             success("Completed rebuilding full-text index");
         }
         catch (Exception e) {
             error("Unable to rebuild full text index: " + e.getLocalizedMessage());
-            log.error("Unable to rebuild full text index for KB [{}]({}) in project [{}]({})",
+            LOG.error("Unable to rebuild full text index for KB [{}]({}) in project [{}]({})",
                     kb.getName(), kb.getRepositoryId(), kb.getProject().getName(),
                     kb.getProject().getId(), e);
         }
@@ -234,7 +221,7 @@ public class KnowledgeBaseDetailsPanel
             }
             catch (RepositoryException | RepositoryConfigException e) {
                 error("Unable to remove knowledge base: " + e.getLocalizedMessage());
-                log.error("Unable to remove knowledge base.", e);
+                LOG.error("Unable to remove knowledge base.", e);
                 _target.addChildren(getPage(), IFeedback.class);
 
             }
@@ -262,7 +249,8 @@ public class KnowledgeBaseDetailsPanel
     {
         private static final long serialVersionUID = 7838564354437836375L;
 
-        private CompoundPropertyModel<KnowledgeBaseWrapper> localKbwModel;
+        private final CompoundPropertyModel<KnowledgeBaseWrapper> localKbwModel;
+        private final AccessSpecificSettingsPanel accessSpecificSettings;
 
         public KBSettingsContent(String id, CompoundPropertyModel<KnowledgeBaseWrapper> aKbwModel)
         {
@@ -270,35 +258,34 @@ public class KnowledgeBaseDetailsPanel
 
             localKbwModel = aKbwModel;
 
-            Component generalSettings = new GeneralSettingsPanel("generalSettings",
-                    Model.of(kbModel.getObject().getProject()), localKbwModel);
-            add(generalSettings);
+            var generalSettings = new GeneralSettingsPanel("generalSettings",
+                    kbModel.map(KnowledgeBase::getProject), localKbwModel);
             generalSettings.get("name").setVisible(false);
+            add(generalSettings);
 
-            Component accessSettings = new AccessSettingsPanel("accessSettings", localKbwModel);
-            add(accessSettings);
+            var accessSettings = new AccessSettingsPanel("accessSettings", localKbwModel);
             accessSettings.get("type").setEnabled(false);
             accessSettings.get("writeprotection")
-                    .setEnabled(localKbwModel.getObject().getKb().getType() == RepositoryType.LOCAL);
+                    .setEnabled(localKbwModel.getObject().getKb().getType() == LOCAL);
+            add(accessSettings);
 
-            Component accessSpecificSettings = new AccessSpecificSettingsPanel(
-                    "accessSpecificSettings", localKbwModel, Collections.emptyMap());
+            accessSpecificSettings = new AccessSpecificSettingsPanel("accessSpecificSettings",
+                    localKbwModel, emptyMap());
             add(accessSpecificSettings);
-            accessSpecificSettings.get("remoteSpecificSettings:suggestions").setVisible(false);
-            accessSpecificSettings.get("localSpecificSettings:listViewContainer").setVisible(false);
 
-            Component querySettings = new QuerySettingsPanel("querySettings", localKbwModel);
-            add(querySettings);
+            add(new QuerySettingsPanel("querySettings", localKbwModel));
 
-            Component schemaMapping = new KnowledgeBaseIriPanel("schemaMapping", localKbwModel);
-            add(schemaMapping);
+            add(new KnowledgeBaseIriPanel("schemaMapping", localKbwModel));
 
-            Component rootConcepts = new RootConceptsPanel("rootConcepts", localKbwModel);
-            add(rootConcepts);
+            add(new RootConceptsPanel("rootConcepts", localKbwModel));
 
-            Component additionalMatchingProperties = new AdditionalMatchingPropertiesPanel(
-                    "additionalMatchingProperties", localKbwModel);
-            add(additionalMatchingProperties);
+            add(new AdditionalMatchingPropertiesPanel("additionalMatchingProperties",
+                    localKbwModel));
+        }
+
+        public void applyState()
+        {
+            accessSpecificSettings.applyState();
         }
     }
 }

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/KnowledgeBaseInfoPanel.html
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/KnowledgeBaseInfoPanel.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<!--
+  Licensed to the Technische Universität Darmstadt under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The Technische Universität Darmstadt 
+  licenses this file to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.
+   
+  http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<html xmlns:wicket="http://wicket.apache.org">
+
+<body>
+  <wicket:panel>
+    <div class="row form-row" wicket:enclosure="description">
+      <label class="col-form-label col-sm-3">
+        <wicket:message key="kb.wizard.steps.accessSpecific.description" />
+      </label>
+      <label wicket:id="description" class="col-sm-9 text-muted" style="font-weight: normal;"></label>
+    </div>
+    <div class="row form-row" wicket:enclosure="hostInstitutionName">
+      <label class="col-form-label col-sm-3">
+        <wicket:message key="kb.wizard.steps.accessSpecific.hostInstitutionName" />
+      </label>
+      <label wicket:id="hostInstitutionName" class="col-sm-9 text-muted" style="font-weight: normal;"></label>
+    </div>
+    <div class="row form-row" wicket:enclosure="authorName">
+      <label class="col-form-label col-sm-3">
+        <wicket:message key="kb.wizard.steps.accessSpecific.authorName" />
+      </label>
+      <label wicket:id="authorName" class="col-sm-9 text-muted" style="font-weight: normal;"></label>
+    </div>
+    <div class="row form-row" wicket:enclosure="websiteURL">
+      <label class="col-form-label col-sm-3">
+        <wicket:message key="kb.wizard.steps.accessSpecific.homepage" />
+      </label>
+      <a wicket:id="websiteURL" class="col-sm-9" target="_blank"></a>
+    </div>
+  </wicket:panel>
+</body>
+
+</html>

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/KnowledgeBaseInfoPanel.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/KnowledgeBaseInfoPanel.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.kb.project;
+
+import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
+
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.link.ExternalLink;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.model.CompoundPropertyModel;
+
+import com.github.rjeschke.txtmark.Processor;
+
+import de.tudarmstadt.ukp.inception.kb.yaml.KnowledgeBaseInfo;
+
+public class KnowledgeBaseInfoPanel
+    extends Panel
+{
+    private static final long serialVersionUID = 7448919085704708171L;
+
+    public KnowledgeBaseInfoPanel(String aId, CompoundPropertyModel<KnowledgeBaseInfo> aModel)
+    {
+        super(aId, aModel);
+
+        queue(new Label("description",
+                aModel.bind("description")
+                        .map(description -> Processor.process((String) description, true)))
+                                .setEscapeModelStrings(false)
+                                .add(visibleWhen(() -> aModel.getObject() != null)));
+        queue(new Label("hostInstitutionName", aModel.bind("hostInstitutionName"))
+                .add(visibleWhen(() -> aModel.getObject() != null)));
+        queue(new Label("authorName", aModel.bind("authorName"))
+                .add(visibleWhen(() -> aModel.getObject() != null)));
+        queue(new ExternalLink("websiteURL", aModel.bind("websiteURL"), aModel.bind("websiteURL"))
+                .add(visibleWhen(() -> aModel.getObject() != null)));
+    }
+}

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/ProjectKnowledgeBasePanel.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/ProjectKnowledgeBasePanel.java
@@ -31,7 +31,7 @@ public class ProjectKnowledgeBasePanel
 {
     private static final long serialVersionUID = 2300684106019320208L;
 
-    private static final String DETAILS_PANEL_MARKUP_ID = "details";
+    private static final String CID_DETAILS = "details";
 
     private IModel<Project> projectModel;
     private IModel<KnowledgeBase> selectedKnowledgeBaseModel;
@@ -44,7 +44,7 @@ public class ProjectKnowledgeBasePanel
         setOutputMarkupId(true);
         projectModel = aProject;
 
-        detailsPanel = new EmptyPanel(DETAILS_PANEL_MARKUP_ID);
+        detailsPanel = new EmptyPanel(CID_DETAILS);
         add(detailsPanel);
 
         selectedKnowledgeBaseModel = Model.of();
@@ -52,7 +52,7 @@ public class ProjectKnowledgeBasePanel
                 selectedKnowledgeBaseModel);
         listPanel.setChangeAction(t -> {
             addOrReplace(detailsPanel);
-            detailsPanel.replaceWith(new KnowledgeBaseDetailsPanel(DETAILS_PANEL_MARKUP_ID,
+            detailsPanel.replaceWith(new KnowledgeBaseDetailsPanel(CID_DETAILS,
                     selectedKnowledgeBaseModel));
             t.add(this);
         });

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/ProjectKnowledgeBasePanel.properties
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/ProjectKnowledgeBasePanel.properties
@@ -20,6 +20,10 @@ kb.type=Type
 kb.url=URL
 kb.remote.url=SPARQL endpoint URL
 kb.remote.skipSslValidation=Skip SSL certificate checks
+kb.remote.authenticationType=Authentication
+authenticationType.nullValid=None
+AuthenticationType.BASIC=Basic
+AuthenticationType.OAUTH_CLIENT_CREDENTIALS=OAuth (client credentials)
 
 kb.iri=Identifiers (IRI)
 kb.iri.classIri=Class IRI

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/local/LocalRepositorySettingsPanel.html
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/local/LocalRepositorySettingsPanel.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<!--
+  Licensed to the Technische Universität Darmstadt under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The Technische Universität Darmstadt 
+  licenses this file to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.
+   
+  http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<html xmlns:wicket="http://wicket.apache.org">
+
+<body>
+  <wicket:panel>
+    <!-- Import -->
+    <div wicket:enclosure="uploadForm">
+      <div class="row form-row">
+        <label class="col-form-label col-sm-3">
+          <wicket:message key="kb.details.local.contents" />
+        </label>
+        <div class="col-sm-9">
+          <div style="flex-basis: 30%; min-width: 20em;">
+            <form wicket:id="uploadForm">
+              <input type="file" wicket:id="uploadField" multiple="multiple" />
+            </form>
+          </div>
+          <div id="supportedList">
+            <small class="text-muted">
+              <wicket:message key="kb.local.fileupload.supported.list" />
+            </small>
+          </div>
+        </div>
+      </div>
+    </div>
+    
+    <wicket:enclosure wicket:id="clear">
+      <div class="row form-row">
+        <label class="col-sm-3 col-form-label">
+          <wicket:message key="kb.details.local.contents.clear" />
+        </label>
+        <div class="col-sm-9">
+          <input type="button" wicket:id="clear" class="btn btn-danger" wicket:message="value:kb.clear" />
+        </div>
+      </div>
+    </wicket:enclosure>
+    
+    <!-- Export -->
+    <div class="row form-row" wicket:enclosure="exportButtons">
+      <label class="col-form-label col-sm-3">
+        <wicket:message key="kb.details.local.contents.export" />
+      </label>
+      <div class="col-sm-9">
+        <div class="flex-h-container flex-gutter flex-only-internal-gutter">
+          <div wicket:id="exportButtons">
+            <button wicket:id="link" type="button" class="btn btn-secondary"><i class="fas fa-download"
+                aria-hidden="true"></i>
+              <wicket:container wicket:id="label"></wicket:container>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="row form-row" wicket:id="listViewContainer" wicket:enclosure="listViewContainer">
+      <label class="col-form-label col-sm-3">
+        <wicket:message key="kb.wizard.steps.local.predefinedKBs" />
+      </label>
+      <div class="col-sm-9">
+        <div class="btn-group-vertical">
+          <wicket:container wicket:id="localKBs">
+            <button wicket:id="suggestionLink" type="button" class="btn btn-outline-secondary">
+              <wicket:container wicket:id="suggestionLabel" />
+            </button>
+          </wicket:container>
+        </div>
+        <button wicket:id="addKbButton" type="button" class="btn btn-secondary">
+          <wicket:container wicket:id="addKbLabel"></wicket:container>
+        </button>
+      </div>
+    </div>
+
+    <hr />
+
+    <div wicket:id="infoContainer" />
+  </wicket:panel>
+</body>
+
+</html>

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/local/LocalRepositorySettingsPanel.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/local/LocalRepositorySettingsPanel.java
@@ -1,0 +1,409 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.kb.project.local;
+
+import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.enabledWhen;
+import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
+import static de.tudarmstadt.ukp.inception.kb.RepositoryType.LOCAL;
+import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toList;
+import static org.eclipse.rdf4j.rio.RDFFormat.NTRIPLES;
+import static org.eclipse.rdf4j.rio.RDFFormat.RDFXML;
+import static org.eclipse.rdf4j.rio.RDFFormat.TURTLE;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.apache.wicket.AttributeModifier;
+import org.apache.wicket.ClassAttributeModifier;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.markup.html.AjaxLink;
+import org.apache.wicket.feedback.IFeedback;
+import org.apache.wicket.markup.html.WebMarkupContainer;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.form.Form;
+import org.apache.wicket.markup.html.form.upload.FileUpload;
+import org.apache.wicket.markup.html.form.upload.FileUploadField;
+import org.apache.wicket.markup.html.list.ListItem;
+import org.apache.wicket.markup.html.list.ListView;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.model.CompoundPropertyModel;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.LoadableDetachableModel;
+import org.apache.wicket.model.Model;
+import org.apache.wicket.model.ResourceModel;
+import org.apache.wicket.model.StringResourceModel;
+import org.apache.wicket.model.util.ListModel;
+import org.apache.wicket.spring.injection.annot.SpringBean;
+import org.apache.wicket.util.resource.IResourceStream;
+import org.eclipse.rdf4j.repository.RepositoryException;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import de.agilecoders.wicket.extensions.markup.html.bootstrap.form.fileinput.BootstrapFileInputField;
+import de.agilecoders.wicket.extensions.markup.html.bootstrap.form.fileinput.FileInputConfig;
+import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxLink;
+import de.tudarmstadt.ukp.clarin.webanno.support.wicket.AjaxDownloadLink;
+import de.tudarmstadt.ukp.clarin.webanno.support.wicket.TempFileResource;
+import de.tudarmstadt.ukp.inception.kb.KnowledgeBaseService;
+import de.tudarmstadt.ukp.inception.kb.SchemaProfile;
+import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBaseProperties;
+import de.tudarmstadt.ukp.inception.kb.model.KnowledgeBase;
+import de.tudarmstadt.ukp.inception.kb.yaml.KnowledgeBaseInfo;
+import de.tudarmstadt.ukp.inception.kb.yaml.KnowledgeBaseProfile;
+import de.tudarmstadt.ukp.inception.support.io.FileUploadDownloadHelper;
+import de.tudarmstadt.ukp.inception.ui.kb.project.AccessSpecificSettingsPanel;
+import de.tudarmstadt.ukp.inception.ui.kb.project.KnowledgeBaseInfoPanel;
+import de.tudarmstadt.ukp.inception.ui.kb.project.KnowledgeBaseWrapper;
+
+public class LocalRepositorySettingsPanel
+    extends Panel
+{
+    private static final long serialVersionUID = 866658729983211740L;
+
+    private static final String CID_CLEAR = "clear";
+
+    private static final String CLASSPATH_PREFIX = "classpath:";
+
+    private static final Logger LOG = LoggerFactory.getLogger(AccessSpecificSettingsPanel.class);
+
+    /**
+     * Given the default file extension of an RDF format, returns the corresponding
+     * {@link RDFFormat}. This factory method detour is necessary because {@link RDFFormat} should
+     * be used as a model, but is not serializable.
+     *
+     * @return an {@link RDFFormat}
+     */
+    private static final RDFFormat getRdfFormatForFileExt(String fileExt)
+    {
+        return EXPORT_FORMATS.stream() //
+                .filter(f -> f.getDefaultFileExtension().equals(fileExt)) //
+                .findAny().get();
+    }
+
+    private static final List<RDFFormat> EXPORT_FORMATS = asList(RDFXML, NTRIPLES, TURTLE);
+    private static final List<String> EXPORT_FORMAT_FILE_EXTENSIONS = EXPORT_FORMATS.stream()
+            .map(f -> f.getDefaultFileExtension()).collect(toList());
+
+    private @SpringBean KnowledgeBaseService kbService;
+    private @SpringBean KnowledgeBaseProperties kbproperties;
+
+    private final Map<String, KnowledgeBaseProfile> knowledgeBaseProfiles;
+    private final Map<String, KnowledgeBaseProfile> downloadedProfiles;
+    private final Map<String, File> uploadedFiles;
+
+    private final WebMarkupContainer listViewContainer;
+    private final WebMarkupContainer infoContainerLocal;
+    private final CompoundPropertyModel<KnowledgeBaseInfo> kbInfoModel;
+
+    private FileUploadField fileUpload;
+
+    private KnowledgeBaseProfile selectedKnowledgeBaseProfile;
+
+    public LocalRepositorySettingsPanel(String aId, IModel<?> aModel,
+            Map<String, KnowledgeBaseProfile> aKnowledgeBaseProfiles)
+    {
+        super(aId, aModel);
+
+        setOutputMarkupId(true);
+
+        knowledgeBaseProfiles = aKnowledgeBaseProfiles;
+        downloadedProfiles = new HashMap<>();
+        uploadedFiles = new HashMap<>();
+        kbInfoModel = CompoundPropertyModel.of(Model.of());
+
+        queue(uploadForm("uploadForm", "uploadField"));
+
+        // add link for clearing the knowledge base contents, enabled only, if there is
+        // something to clear
+        queue(clearLink(CID_CLEAR));
+
+        queue(fileExtensionsExportList("exportButtons"));
+
+        var localKBs = knowledgeBaseProfiles.values().stream() //
+                .filter(kb -> LOCAL == kb.getType()) //
+                .collect(Collectors.toList());
+
+        listViewContainer = new WebMarkupContainer("listViewContainer");
+        ListView<KnowledgeBaseProfile> suggestions = localSuggestionsList("localKBs", localKBs);
+        listViewContainer.add(suggestions);
+        listViewContainer.setOutputMarkupPlaceholderTag(true);
+        listViewContainer.add(visibleWhen(getModel().map(KnowledgeBaseWrapper::getKb) //
+                .map(kb -> kb.getRepositoryId() == null) //
+                .orElse(false)));
+
+        var addKbButton = new LambdaAjaxLink("addKbButton", this::actionDownloadKbAndSetIRIs);
+        addKbButton.add(new Label("addKbLabel", new ResourceModel("kb.wizard.steps.local.addKb")));
+        listViewContainer.add(addKbButton);
+
+        infoContainerLocal = new KnowledgeBaseInfoPanel("infoContainer", kbInfoModel);
+        infoContainerLocal.setOutputMarkupId(true);
+        queue(infoContainerLocal);
+
+        queue(listViewContainer);
+    }
+
+    @SuppressWarnings("unchecked")
+    public IModel<KnowledgeBaseWrapper> getModel()
+    {
+        return (IModel<KnowledgeBaseWrapper>) getDefaultModel();
+    }
+
+    private Form<Void> uploadForm(String aFormId, String aFieldId)
+    {
+        var form = new Form<Void>(aFormId);
+
+        FileInputConfig config = new FileInputConfig();
+        config.initialCaption("Import knowledge base ...");
+        config.showPreview(false);
+        config.showUpload(false);
+        config.removeIcon("<i class=\"fas fa-times\"></i>");
+        config.browseIcon("<i class=\"fa fa-folder-open\"></i>");
+        form.add(fileUpload = new BootstrapFileInputField(aFieldId, new ListModel<>(), config));
+
+        return form;
+    }
+
+    public void handleUploadedFiles()
+    {
+        try {
+            for (FileUpload fu : fileUpload.getFileUploads()) {
+                File tmp = uploadFile(fu);
+                getModel().getObject().putFile(fu.getClientFileName(), tmp);
+            }
+        }
+        catch (Exception e) {
+            LOG.error("Error while uploading files", e);
+            error("Could not upload files");
+        }
+    }
+
+    private AjaxLink<Void> clearLink(String aId)
+    {
+        var clearLink = new LambdaAjaxLink(aId, this::actionClear);
+        clearLink.add(visibleWhen(getModel().map(KnowledgeBaseWrapper::getKb) //
+                .map(kb -> kb.getRepositoryId() != null) //
+                .orElse(false)));
+        clearLink.add(enabledWhen(getModel().map(KnowledgeBaseWrapper::getKb) //
+                .map(kb -> kb.getRepositoryId() != null && !kbService.isEmpty(kb)) //
+                .orElse(false)));
+        return clearLink;
+
+    }
+
+    private ListView<String> fileExtensionsExportList(String aId)
+    {
+        ListView<String> fileExListView = new ListView<String>(aId, EXPORT_FORMAT_FILE_EXTENSIONS)
+        {
+            private static final long serialVersionUID = -1869762759620557362L;
+
+            @Override
+            protected void populateItem(ListItem<String> item)
+            {
+                // creates an appropriately labeled {@link AjaxDownloadLink} which triggers the
+                // download of the contents of the current KB in the given format
+                String fileExtension = item.getModelObject();
+                KnowledgeBase kb = LocalRepositorySettingsPanel.this.getModel().getObject().getKb();
+                Model<String> exportFileNameModel = Model.of(kb.getName() + "." + fileExtension);
+                AjaxDownloadLink exportLink = new AjaxDownloadLink("link", exportFileNameModel,
+                        LoadableDetachableModel.of(() -> actionExport(fileExtension)));
+                exportLink.add(new Label("label", new ResourceModel("kb.export." + fileExtension)));
+                item.add(exportLink);
+            }
+        };
+        fileExListView.add(visibleWhen(getModel().map(KnowledgeBaseWrapper::getKb) //
+                .map(kb -> kb.getRepositoryId() != null) //
+                .orElse(false)));
+        return fileExListView;
+    }
+
+    private ListView<KnowledgeBaseProfile> localSuggestionsList(String aId,
+            List<KnowledgeBaseProfile> localKBs)
+    {
+        ListView<KnowledgeBaseProfile> suggestions = new ListView<KnowledgeBaseProfile>(aId,
+                localKBs)
+        {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            protected void populateItem(ListItem<KnowledgeBaseProfile> item)
+            {
+                LambdaAjaxLink link = new LambdaAjaxLink("suggestionLink",
+                        _target -> actionSelectPredefinedKB(_target, item.getModel()));
+
+                // Can not import the same KB more than once
+                boolean isImported = downloadedProfiles
+                        .containsKey(item.getModelObject().getName());
+                link.setEnabled(!isImported);
+
+                String itemLabel = item.getModelObject().getName();
+                // Adjust label to indicate whether the KB has already been downloaded
+                if (isImported) {
+                    // \u2714 is the checkmark symbol
+                    itemLabel = itemLabel + "  \u2714";
+                }
+                link.add(new Label("suggestionLabel", itemLabel));
+
+                link.add(new ClassAttributeModifier()
+                {
+                    private static final long serialVersionUID = -3985182168502826951L;
+
+                    @Override
+                    protected Set<String> update(Set<String> aOldClasses)
+                    {
+                        if (Objects.equals(selectedKnowledgeBaseProfile, item.getModelObject())) {
+                            aOldClasses.add("active");
+                        }
+                        else {
+                            aOldClasses.remove("active");
+                        }
+                        return aOldClasses;
+                    }
+                });
+
+                // Show schema type on mouseover
+                link.add(
+                        AttributeModifier
+                                .append("title",
+                                        new StringResourceModel(
+                                                "kb.wizard.steps.local.schemaOnMouseOver", this)
+                                                        .setParameters(
+                                                                SchemaProfile
+                                                                        .checkSchemaProfile(item
+                                                                                .getModelObject())
+                                                                        .getUiLabel(),
+                                                                getAccessTypeLabel(
+                                                                        item.getModelObject()))));
+
+                item.add(link);
+            }
+        };
+        suggestions.setOutputMarkupId(true);
+        return suggestions;
+    }
+
+    private void actionSelectPredefinedKB(AjaxRequestTarget aTarget,
+            IModel<KnowledgeBaseProfile> aModel)
+    {
+        if (Objects.equals(selectedKnowledgeBaseProfile, aModel.getObject())) {
+            selectedKnowledgeBaseProfile = null;
+        }
+        else {
+            selectedKnowledgeBaseProfile = aModel.getObject();
+            kbInfoModel.setObject(aModel.getObject().getInfo());
+        }
+        aTarget.add(listViewContainer, infoContainerLocal);
+    }
+
+    private File uploadFile(FileUpload fu) throws IOException
+    {
+        String fileName = fu.getClientFileName();
+        if (!uploadedFiles.containsKey(fileName)) {
+            FileUploadDownloadHelper fileUploadDownloadHelper = new FileUploadDownloadHelper(
+                    getApplication());
+            File tmpFile = fileUploadDownloadHelper.writeFileUploadToTemporaryFile(fu, getModel());
+            uploadedFiles.put(fileName, tmpFile);
+        }
+        else {
+            LOG.debug("File [{}] already downloaded, skipping!", fileName);
+        }
+
+        return uploadedFiles.get(fileName);
+    }
+
+    private void actionClear(AjaxRequestTarget aTarget)
+    {
+        try {
+            kbService.clear(getModel().getObject().getKb());
+            info(getString("kb.details.local.contents.clear.feedback",
+                    getModel().map(KnowledgeBaseWrapper::getKb).map(KnowledgeBase::getName)));
+            aTarget.add(this);
+            aTarget.addChildren(getPage(), IFeedback.class);
+        }
+        catch (RepositoryException e) {
+            error("Error clearing KB: " + e.getMessage());
+            LOG.error("Error clearing KB", e);
+            aTarget.addChildren(getPage(), IFeedback.class);
+        }
+    }
+
+    private IResourceStream actionExport(String rdfFormatFileExt)
+    {
+        return new TempFileResource((os) -> kbService.exportData(getModel().getObject().getKb(),
+                getRdfFormatForFileExt(rdfFormatFileExt), os));
+    }
+
+    private void actionDownloadKbAndSetIRIs(AjaxRequestTarget aTarget)
+    {
+        try {
+            if (selectedKnowledgeBaseProfile != null) {
+                String accessUrl = selectedKnowledgeBaseProfile.getAccess().getAccessUrl();
+
+                FileUploadDownloadHelper fileUploadDownloadHelper = new FileUploadDownloadHelper(
+                        getApplication());
+
+                if (!accessUrl.startsWith(CLASSPATH_PREFIX)) {
+                    File tmpFile = fileUploadDownloadHelper
+                            .writeFileDownloadToTemporaryFile(accessUrl, getModel());
+                    getModel().getObject().putFile(selectedKnowledgeBaseProfile.getName(), tmpFile);
+                }
+                else {
+                    // import from classpath
+                    File kbFile = fileUploadDownloadHelper
+                            .writeClasspathResourceToTemporaryFile(accessUrl, getModel());
+                    getModel().getObject().putFile(selectedKnowledgeBaseProfile.getName(), kbFile);
+                }
+
+                KnowledgeBase kb = getModel().getObject().getKb();
+                kb.applyRootConcepts(selectedKnowledgeBaseProfile);
+                kb.applyMapping(selectedKnowledgeBaseProfile.getMapping());
+                kb.setFullTextSearchIri(
+                        selectedKnowledgeBaseProfile.getAccess().getFullTextSearchIri());
+                kb.setDefaultLanguage(selectedKnowledgeBaseProfile.getDefaultLanguage());
+                kb.setReification(selectedKnowledgeBaseProfile.getReification());
+                downloadedProfiles.put(selectedKnowledgeBaseProfile.getName(),
+                        selectedKnowledgeBaseProfile);
+                aTarget.add(this);
+
+                selectedKnowledgeBaseProfile = null;
+            }
+        }
+        catch (IOException e) {
+            error("Unable to download or import knowledge base file " + e.getMessage());
+            LOG.error("Unable to download or import knowledge base file ", e);
+            aTarget.addChildren(getPage(), IFeedback.class);
+        }
+    }
+
+    private String getAccessTypeLabel(KnowledgeBaseProfile aProfile)
+    {
+        if (aProfile.getAccess().getAccessUrl().startsWith(CLASSPATH_PREFIX)) {
+            return "CLASSPATH";
+        }
+        else {
+            return "DOWNLOAD";
+        }
+    }
+}

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/remote/RemoteRepositorySettingsPanel.html
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/remote/RemoteRepositorySettingsPanel.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<!--
+  Licensed to the Technische Universität Darmstadt under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The Technische Universität Darmstadt 
+  licenses this file to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.
+   
+  http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<html xmlns:wicket="http://wicket.apache.org">
+
+<body>
+  <wicket:panel>
+    <div class="row form-row">
+      <label wicket:for="url" class="col-form-label col-sm-3">
+        <wicket:message key="kb.remote.url" />
+      </label>
+      <div class="col-sm-9">
+        <input wicket:id="url" type="text" class="form-control" />
+      </div>
+    </div>
+    <div class="row form-row" wicket:enclosure="skipSslValidation">
+      <div class="offset-sm-3 col-sm-9">
+        <div class="form-check">
+          <input wicket:id="skipSslValidation" class="form-check-input" type="checkbox">
+          <label wicket:for="skipSslValidation" class="form-check-label">
+            <wicket:label key="kb.remote.skipSslValidation" />
+          </label>
+        </div>
+      </div>
+    </div>
+    <div class="row form-row">
+      <label wicket:for="authenticationType" class="col-form-label col-sm-3">
+        <wicket:message key="kb.remote.authenticationType" />
+      </label>
+      <div class="col-sm-9">
+        <select wicket:id="authenticationType" class="form-select" />
+      </div>
+    </div>
+    <div wicket:id="authenticationTraitsEditor"/>
+    <div class="row form-row" wicket:enclosure="defaultDataset">
+      <label class="col-form-label col-sm-3" wicket:for="defaultDataset">
+        <wicket:label key="kb.iri.defaultDataset" />
+      </label>
+      <div class="col-sm-9">
+        <input type="text" wicket:id="defaultDataset" class="form-control" />
+      </div>
+    </div>
+    <div class="row form-row" wicket:enclosure="suggestions">
+      <label class="col-form-label col-sm-3">
+        <wicket:message key="kb.wizard.steps.remote.suggestions" />
+      </label>
+      <div class="overflow-auto col-sm-9" style="height:150px">
+        <div class="list-group">
+          <wicket:container wicket:id="suggestions">
+            <button wicket:id="suggestionLink" type="button" class="list-group-item">
+              <wicket:container wicket:id="suggestionLabel" />
+            </button>
+          </wicket:container>
+        </div>
+      </div>
+    </div>
+    <div class="row form-row" wicket:id="infoContainer" style="margin-top: 20px;" />
+  </wicket:panel>
+</body>
+
+</html>

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/remote/RemoteRepositorySettingsPanel.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/remote/RemoteRepositorySettingsPanel.java
@@ -1,0 +1,240 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.kb.project.remote;
+
+import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.HtmlElementEvents.CHANGE_EVENT;
+import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
+import static de.tudarmstadt.ukp.inception.kb.RepositoryType.REMOTE;
+import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toList;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.form.CheckBox;
+import org.apache.wicket.markup.html.form.DropDownChoice;
+import org.apache.wicket.markup.html.form.EnumChoiceRenderer;
+import org.apache.wicket.markup.html.form.RequiredTextField;
+import org.apache.wicket.markup.html.form.TextField;
+import org.apache.wicket.markup.html.list.ListItem;
+import org.apache.wicket.markup.html.list.ListView;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.model.CompoundPropertyModel;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
+
+import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxFormComponentUpdatingBehavior;
+import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxLink;
+import de.tudarmstadt.ukp.inception.kb.model.KnowledgeBase;
+import de.tudarmstadt.ukp.inception.kb.yaml.KnowledgeBaseInfo;
+import de.tudarmstadt.ukp.inception.kb.yaml.KnowledgeBaseProfile;
+import de.tudarmstadt.ukp.inception.security.client.auth.AuthenticationTraitsEditor;
+import de.tudarmstadt.ukp.inception.security.client.auth.AuthenticationType;
+import de.tudarmstadt.ukp.inception.security.client.auth.NoAuthenticationTraitsEditor;
+import de.tudarmstadt.ukp.inception.security.client.auth.basic.BasicAuthenticationTraits;
+import de.tudarmstadt.ukp.inception.security.client.auth.basic.BasicAuthenticationTraitsEditor;
+import de.tudarmstadt.ukp.inception.security.client.auth.oauth.OAuthClientCredentialsAuthenticationTraits;
+import de.tudarmstadt.ukp.inception.security.client.auth.oauth.OAuthClientCredentialsAuthenticationTraitsEditor;
+import de.tudarmstadt.ukp.inception.ui.kb.project.KnowledgeBaseInfoPanel;
+import de.tudarmstadt.ukp.inception.ui.kb.project.KnowledgeBaseWrapper;
+import de.tudarmstadt.ukp.inception.ui.kb.project.validators.Validators;
+
+public class RemoteRepositorySettingsPanel
+    extends Panel
+{
+    private static final long serialVersionUID = 8523349361503121641L;
+
+    private static final String CID_AUTHENTICATION_TRAITS_EDITOR = "authenticationTraitsEditor";
+
+    private static final int MAXIMUM_REMOTE_REPO_SUGGESTIONS = 10;
+
+    private final Map<String, KnowledgeBaseProfile> knowledgeBaseProfiles;
+
+    private CompoundPropertyModel<KnowledgeBaseInfo> kbInfoModel;
+
+    private final KnowledgeBaseInfoPanel infoContainerRemote;
+    private final TextField<String> urlField;
+    private final CheckBox skipSslValidation;
+    private final TextField<String> defaultDatasetField;
+    private final DropDownChoice<AuthenticationType> authenticationType;
+
+    private AuthenticationTraitsEditor authenticationTraitsEditor;
+
+    public RemoteRepositorySettingsPanel(String aId,
+            CompoundPropertyModel<KnowledgeBaseWrapper> kbModel,
+            Map<String, KnowledgeBaseProfile> aKnowledgeBaseProfiles)
+    {
+        super(aId, kbModel);
+
+        knowledgeBaseProfiles = aKnowledgeBaseProfiles;
+
+        kbInfoModel = CompoundPropertyModel.of(Model.of());
+
+        urlField = new RequiredTextField<>("url");
+        urlField.add(Validators.URL_VALIDATOR);
+        queue(urlField);
+
+        authenticationType = new DropDownChoice<>("authenticationType",
+                asList(AuthenticationType.values()), new EnumChoiceRenderer<>(this));
+        authenticationType.add(new LambdaAjaxFormComponentUpdatingBehavior(CHANGE_EVENT,
+                this::actionAuthenticationTypeSelected));
+        authenticationType.setNullValid(true);
+        queue(authenticationType);
+
+        authenticationTraitsEditor = updateAuthenticationPanel();
+
+        skipSslValidation = new CheckBox("skipSslValidation", kbModel.bind("kb.skipSslValidation"));
+        skipSslValidation.setOutputMarkupPlaceholderTag(true);
+        queue(skipSslValidation);
+
+        infoContainerRemote = new KnowledgeBaseInfoPanel("infoContainer", kbInfoModel);
+        infoContainerRemote.setOutputMarkupId(true);
+        queue(infoContainerRemote);
+
+        queue(remoteSuggestionsList("suggestions"));
+
+        defaultDatasetField = new TextField<>("defaultDataset",
+                kbModel.bind("kb.defaultDatasetIri"));
+        defaultDatasetField.add(Validators.IRI_VALIDATOR);
+        queue(defaultDatasetField);
+    }
+
+    @SuppressWarnings("unchecked")
+    public IModel<KnowledgeBaseWrapper> getModel()
+    {
+        return (IModel<KnowledgeBaseWrapper>) getDefaultModel();
+    }
+
+    private void actionAuthenticationTypeSelected(AjaxRequestTarget aTarget)
+    {
+        updateAuthenticationPanel();
+        aTarget.add(authenticationTraitsEditor);
+    }
+
+    private AuthenticationTraitsEditor updateAuthenticationPanel()
+    {
+        AuthenticationTraitsEditor panel;
+
+        KnowledgeBaseWrapper kbw = getModel().getObject();
+        if (kbw.getAuthenticationType() != null) {
+            switch (kbw.getAuthenticationType()) {
+            case BASIC: {
+                if (!(kbw.getTraits().getAuthentication() instanceof BasicAuthenticationTraits)) {
+                    kbw.getTraits().setAuthentication(new BasicAuthenticationTraits());
+                }
+
+                panel = new BasicAuthenticationTraitsEditor(CID_AUTHENTICATION_TRAITS_EDITOR,
+                        Model.of((BasicAuthenticationTraits) kbw.getTraits().getAuthentication()));
+                break;
+            }
+            case OAUTH_CLIENT_CREDENTIALS: {
+                if (!(kbw.getTraits()
+                        .getAuthentication() instanceof OAuthClientCredentialsAuthenticationTraits)) {
+                    kbw.getTraits()
+                            .setAuthentication(new OAuthClientCredentialsAuthenticationTraits());
+                }
+                panel = new OAuthClientCredentialsAuthenticationTraitsEditor(
+                        CID_AUTHENTICATION_TRAITS_EDITOR,
+                        Model.of((OAuthClientCredentialsAuthenticationTraits) kbw.getTraits()
+                                .getAuthentication()));
+                break;
+
+            }
+            default:
+                panel = new NoAuthenticationTraitsEditor(CID_AUTHENTICATION_TRAITS_EDITOR);
+                break;
+            }
+        }
+        else {
+            panel = new NoAuthenticationTraitsEditor(CID_AUTHENTICATION_TRAITS_EDITOR);
+        }
+
+        panel.setOutputMarkupId(true);
+
+        if (authenticationTraitsEditor == null
+                || panel.getClass() != authenticationTraitsEditor.getClass()) {
+            if (authenticationTraitsEditor != null) {
+                authenticationTraitsEditor = (AuthenticationTraitsEditor) authenticationTraitsEditor
+                        .replaceWith(panel);
+            }
+            else {
+                authenticationTraitsEditor = panel;
+                queue(authenticationTraitsEditor);
+            }
+        }
+
+        return authenticationTraitsEditor;
+    }
+
+    private ListView<KnowledgeBaseProfile> remoteSuggestionsList(String aId)
+    {
+        // for up to MAXIMUM_REMOTE_REPO_SUGGESTIONS of knowledge bases, create a link which
+        // directly fills in the URL field (convenient for both developers AND users :))
+        List<KnowledgeBaseProfile> suggestions = knowledgeBaseProfiles.values().stream() //
+                .filter(kb -> REMOTE == kb.getType()) //
+                .limit(MAXIMUM_REMOTE_REPO_SUGGESTIONS) //
+                .collect(toList());
+
+        var list = new ListView<KnowledgeBaseProfile>(aId, suggestions)
+        {
+            private static final long serialVersionUID = 4179629475064638272L;
+
+            @Override
+            protected void populateItem(ListItem<KnowledgeBaseProfile> item)
+            {
+                // add a link for one knowledge base with proper label
+                var link = new LambdaAjaxLink("suggestionLink",
+                        t -> actionPopulate(t, item.getModelObject()));
+                link.add(new Label("suggestionLabel", item.getModelObject().getName()));
+                item.add(link);
+            }
+        };
+
+        list.add(visibleWhen(getModel().map(KnowledgeBaseWrapper::getKb) //
+                .map(kb -> kb.getRepositoryId() == null) //
+                .orElse(false)));
+
+        return list;
+    }
+
+    private void actionPopulate(AjaxRequestTarget aTarget, KnowledgeBaseProfile aProfile)
+    {
+        // set all the fields according to the chosen profile
+        KnowledgeBaseWrapper kbw = getModel().getObject();
+        kbw.setUrl(aProfile.getAccess().getAccessUrl());
+        // sets root concepts list - if null then an empty list otherwise change the
+        // values to IRI and populate the list
+        KnowledgeBase kb = kbw.getKb();
+        kb.applyRootConcepts(aProfile);
+        kb.applyAdditionalMatchingProperties(aProfile);
+        kb.applyMapping(aProfile.getMapping());
+        kbInfoModel.setObject(aProfile.getInfo());
+        kb.setFullTextSearchIri(aProfile.getAccess().getFullTextSearchIri());
+        kb.setDefaultLanguage(aProfile.getDefaultLanguage());
+        kb.setDefaultDatasetIri(aProfile.getDefaultDataset());
+        kb.setReification(aProfile.getReification());
+        aTarget.add(urlField, defaultDatasetField, infoContainerRemote);
+    }
+
+    public void applyState()
+    {
+        authenticationTraitsEditor.commit();
+    }
+}

--- a/inception/inception-ui-kb/src/main/resources/META-INF/asciidoc/user-guide/projects_knowledge-base.adoc
+++ b/inception/inception-ui-kb/src/main/resources/META-INF/asciidoc/user-guide/projects_knowledge-base.adoc
@@ -275,15 +275,31 @@ You may have to specify credentials as part of the URL to gain access.
 
 ==== SPARQL Endpoint Authentication
 
-{product-name} supports endpoints that use HTTP "Basic" authentication. You can simply add the
-username and password required to access the remote SPARQL endpoint as part of the URL. However,
-note that the credentials are visible to anybody visiting the KB settings and are also stored
-unencrypted.
+{product-name} supports endpoints require authentication. The following authentication mechanisms
+are supported.
 
-.HTTP "Basic" authenticated SPARQL URL
-----
-http://USERNAME:PASSWORD@localhost:5820/mock/query
-----
+* HTTP basic authentication
+* OAuth (client credentials)
+
+To enable authentication, select one of the options from the **Authenication** dropdown menu.
+
+NOTE: To protect you credentials while sending them to the remote side, it is strongly recommended
+      to use a HTTPS connection to the SPARQL endpoint and keep SSL certificate checking enabled.
+
+.HTTP "basic" authentication
+This is a simple mechanism that sends a username and password on every request. 
+
+.OAuth (client credentials) authentication
+This mechanism uses the client ID and client secret to obtain an authentication token which is then
+used for subsequent requests. Once the token expires, a new token is requested.
+
+====
+CAUTION: Legacy feature. It is also possible to use HTTP basic authentication by prefixing the 
+      SPARQL URL with the username and password (`http://USERNAME:PASSWORD@localhost:5820/mock/query`). 
+      However, this is not recommended. For example, the password will be visible to anybody being able to 
+      access the knowledge base settings. This option is only supported for backwards compatibility and will
+      be removed in future versions.
+====
 
 === Importing RDF
 

--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/management/DynamicWorkloadManagementPage.java
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/management/DynamicWorkloadManagementPage.java
@@ -32,6 +32,7 @@ import static de.tudarmstadt.ukp.inception.workload.dynamic.support.AnnotationQu
 import static java.lang.String.format;
 import static java.time.Duration.ofMinutes;
 import static java.util.Arrays.asList;
+import static java.util.Comparator.comparing;
 import static java.util.Objects.isNull;
 import static java.util.stream.Collectors.toList;
 
@@ -426,7 +427,7 @@ public class DynamicWorkloadManagementPage
         workflowChoices.setRequired(true);
         workflowChoices.setNullValid(false);
         workflowChoices.setChoices(workflowExtensionPoint.getTypes().stream() //
-                .sorted(Comparator.comparing(WorkflowType::getUiName))
+                .sorted(comparing(WorkflowType::getUiName)) //
                 .map(WorkflowType::getWorkflowExtensionId) //
                 .collect(toList()));
         settingsForm.add(workflowChoices);


### PR DESCRIPTION
**What's in the PR**
- Refactor the access-specifc settings UI of the KB to facilitate integration of the new settings
- Add new UI for configuring KB authentication for OAuth and also for HTTP basic auth
- Add handling of the new settings in the KB service code when creating new KB connections
- Clear cached OAuth sessions when removing a KB or when updating KB settings (since credentials / URL might change)
- Add traits column to KB DB entity (used to store the remote KB's authentication settings)
- Include KB traits in project export/import

**How to test manually**
* Create a new remote KB
* Point it to an OAuth-protected SPARQL endpoint
* Configure client credentials and token endpoint URL

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
