### PR TITLE
#3244 - Undo/redo feature

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/events/DocumentOpenedEvent.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/events/DocumentOpenedEvent.java
@@ -21,9 +21,11 @@ import org.apache.uima.cas.CAS;
 import org.springframework.context.ApplicationEvent;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.clarin.webanno.support.wicket.event.HybridApplicationUIEvent;
 
 public class DocumentOpenedEvent
     extends ApplicationEvent
+    implements HybridApplicationUIEvent
 {
     private static final long serialVersionUID = -2739175937794842083L;
 

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/TypeAdapter_ImplBase.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/TypeAdapter_ImplBase.java
@@ -119,14 +119,15 @@ public abstract class TypeAdapter_ImplBase
             AnnotationFeature aFeature, Object aValue)
         throws AnnotationException
     {
+        var featureSupport = featureSupportRegistry.findExtension(aFeature).orElseThrow();
+
         FeatureStructure fs = selectFsByAddr(aCas, aAddress);
 
-        Object oldValue = getValue(fs, aFeature);
+        var oldValue = featureSupport.getFeatureValue(aFeature, fs);
 
-        featureSupportRegistry.findExtension(aFeature).orElseThrow().setFeatureValue(aCas, aFeature,
-                aAddress, aValue);
+        featureSupport.setFeatureValue(aCas, aFeature, aAddress, aValue);
 
-        Object newValue = getValue(fs, aFeature);
+        var newValue = featureSupport.getFeatureValue(aFeature, fs);
 
         if (!Objects.equals(oldValue, newValue)) {
             publishEvent(new FeatureValueUpdatedEvent(this, aDocument, aUsername, getLayer(), fs,
@@ -153,6 +154,7 @@ public abstract class TypeAdapter_ImplBase
         return FSUtil.getFeature(fs, aFeature.getName(), FeatureStructure.class);
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public <T> T getFeatureValue(AnnotationFeature aFeature, FeatureStructure aFs)
     {

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/RelationAdapter.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/RelationAdapter.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.annotation.layer.relation;
 
+import static de.tudarmstadt.ukp.clarin.webanno.support.uima.ICasUtil.selectByAddr;
 import static java.lang.System.currentTimeMillis;
 import static java.util.Collections.emptyList;
 import static org.apache.uima.fit.util.CasUtil.getType;
@@ -170,6 +171,18 @@ public class RelationAdapter
         aCas.removeFsFromIndexes(fs);
         publishEvent(new RelationDeletedEvent(this, aDocument, aUsername, getLayer(), fs,
                 getTargetAnnotation(fs), getSourceAnnotation(fs)));
+    }
+
+    public AnnotationFS restore(SourceDocument aDocument, String aUsername, CAS aCas, VID aVid)
+        throws AnnotationException
+    {
+        AnnotationFS fs = selectByAddr(aCas, AnnotationFS.class, aVid.getId());
+        aCas.addFsToIndexes(fs);
+
+        publishEvent(new RelationCreatedEvent(this, aDocument, aUsername, getLayer(), fs,
+                getTargetAnnotation(fs), getSourceAnnotation(fs)));
+
+        return fs;
     }
 
     public AnnotationFS getSourceAnnotation(AnnotationFS aTargetFs)

--- a/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/model/Range.java
+++ b/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/model/Range.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.rendering.model;
 
+import java.io.Serializable;
 import java.util.Iterator;
 import java.util.Objects;
 
@@ -24,7 +25,10 @@ import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.text.AnnotationFS;
 
 public class Range
+    implements Serializable
 {
+    private static final long serialVersionUID = -6261188569647696831L;
+
     public static final Range UNDEFINED = new Range(-1, -1);
 
     private final int begin;

--- a/inception/inception-api-schema/pom.xml
+++ b/inception/inception-api-schema/pom.xml
@@ -80,5 +80,14 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
+    
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/inception/inception-api-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/feature/LinkWithRoleModel.java
+++ b/inception/inception-api-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/feature/LinkWithRoleModel.java
@@ -19,9 +19,14 @@ package de.tudarmstadt.ukp.inception.schema.feature;
 
 import java.io.Serializable;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
 /**
  * Represents a link with a role in the UI.
  */
+@JsonSerialize
+@JsonInclude(value = JsonInclude.Include.NON_DEFAULT)
 public class LinkWithRoleModel
     implements Serializable
 {

--- a/inception/inception-curation/src/test/java/de/tudarmstadt/ukp/inception/curation/export/CuratedDocumentsExporterTest.java
+++ b/inception/inception-curation/src/test/java/de/tudarmstadt/ukp/inception/curation/export/CuratedDocumentsExporterTest.java
@@ -96,8 +96,8 @@ public class CuratedDocumentsExporterTest
         CasStorageDriver driver = new FileSystemCasStorageDriver(repositoryProperties,
                 new CasStorageBackupProperties(), new CasStoragePropertiesImpl());
 
-        casStorageService = spy(new CasStorageServiceImpl(driver, new CasStorageCachePropertiesImpl(), null,
-                schemaService));
+        casStorageService = spy(new CasStorageServiceImpl(driver,
+                new CasStorageCachePropertiesImpl(), null, schemaService));
 
         importExportSerivce = new DocumentImportExportServiceImpl(repositoryProperties,
                 asList(new XmiFormatSupport()), casStorageService, schemaService, properties);

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/user-guide.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/user-guide.adoc
@@ -50,6 +50,8 @@ include::{include-dir}annotation_open.adoc[leveloffset=+2]
 
 include::{include-dir}annotation_navigation.adoc[leveloffset=+2]
 
+include::{include-dir}annotation_undo.adoc[leveloffset=+2]
+
 include::{include-dir}annotation_create-annotations.adoc[leveloffset=+2]
 
 include::{include-dir}annotation_create-annotations_span.adoc[leveloffset=+3]

--- a/inception/inception-documents/src/test/java/de/tudarmstadt/ukp/inception/documents/DocumentServiceImplConcurrencyTest.java
+++ b/inception/inception-documents/src/test/java/de/tudarmstadt/ukp/inception/documents/DocumentServiceImplConcurrencyTest.java
@@ -119,8 +119,8 @@ public class DocumentServiceImplConcurrencyTest
         CasStorageDriver driver = new FileSystemCasStorageDriver(repositoryProperties,
                 new CasStorageBackupProperties(), new CasStoragePropertiesImpl());
 
-        storageService = new CasStorageServiceImpl(driver, new CasStorageCachePropertiesImpl(), null,
-                null);
+        storageService = new CasStorageServiceImpl(driver, new CasStorageCachePropertiesImpl(),
+                null, null);
 
         sut = spy(new DocumentServiceImpl(repositoryProperties, storageService, importExportService,
                 projectService, applicationEventPublisher, entityManager));

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/KBProperty.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/KBProperty.java
@@ -181,8 +181,8 @@ public class KBProperty
             else {
                 nameLiteral = vf.createLiteral(name);
             }
-            Statement nameStmt = vf.createStatement(subject, vf.createIRI(aKb.getPropertyLabelIri()),
-                    nameLiteral);
+            Statement nameStmt = vf.createStatement(subject,
+                    vf.createIRI(aKb.getPropertyLabelIri()), nameLiteral);
             originalStatements.add(nameStmt);
             aConn.add(nameStmt);
         }

--- a/inception/inception-project-export/src/test/java/de/tudarmstadt/ukp/inception/project/export/AnnotationDocumentsExporterTest.java
+++ b/inception/inception-project-export/src/test/java/de/tudarmstadt/ukp/inception/project/export/AnnotationDocumentsExporterTest.java
@@ -92,8 +92,8 @@ public class AnnotationDocumentsExporterTest
         driver = new FileSystemCasStorageDriver(repositoryProperties,
                 new CasStorageBackupProperties(), new CasStoragePropertiesImpl());
 
-        casStorageService = new CasStorageServiceImpl(driver, new CasStorageCachePropertiesImpl(), null,
-                schemaService);
+        casStorageService = new CasStorageServiceImpl(driver, new CasStorageCachePropertiesImpl(),
+                null, schemaService);
 
         importExportSerivce = new DocumentImportExportServiceImpl(repositoryProperties,
                 asList(new XmiFormatSupport()), casStorageService, schemaService, properties);

--- a/inception/inception-project-initializers/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/initializers/JsonImportUtil.java
+++ b/inception/inception-project-initializers/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/initializers/JsonImportUtil.java
@@ -149,8 +149,8 @@ public class JsonImportUtil
      *            the project into which to import the tagset
      * @return a unique tag set name
      */
-    public static String copyTagSetName(AnnotationSchemaService aAnnotationService,
-            String aName, Project aProject)
+    public static String copyTagSetName(AnnotationSchemaService aAnnotationService, String aName,
+            Project aProject)
     {
         String betterTagSetName = "copy_of_" + aName;
         int i = 1;

--- a/inception/inception-review-editor/src/main/java/de/tudarmstadt/ukp/inception/revieweditor/AnnotationPanel.java
+++ b/inception/inception-review-editor/src/main/java/de/tudarmstadt/ukp/inception/revieweditor/AnnotationPanel.java
@@ -167,8 +167,8 @@ public abstract class AnnotationPanel
                 value = adapter.getFeatureValue(feature, fs);
             }
 
-            linkedAddr.addAll(((List<LinkWithRoleModel>) value).stream()
-                    .map(m -> m.targetAddr).collect(Collectors.toList()));
+            linkedAddr.addAll(((List<LinkWithRoleModel>) value).stream().map(m -> m.targetAddr)
+                    .collect(Collectors.toList()));
         }
 
         return linkedAddr;

--- a/inception/inception-ui-annotation/pom.xml
+++ b/inception/inception-ui-annotation/pom.xml
@@ -88,10 +88,6 @@
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-preferences</artifactId>
     </dependency>
-    <dependency>
-      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
-      <artifactId>inception-log</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>com.googlecode.wicket-jquery-ui</groupId>

--- a/inception/inception-ui-annotation/pom.xml
+++ b/inception/inception-ui-annotation/pom.xml
@@ -88,6 +88,10 @@
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-preferences</artifactId>
     </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-log</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>com.googlecode.wicket-jquery-ui</groupId>

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/AnnotationUndoActionBarExtension.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/AnnotationUndoActionBarExtension.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo;
+
+import org.apache.wicket.markup.html.panel.Panel;
+import org.springframework.core.annotation.Order;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.actionbar.ActionBarExtension;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
+import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.AnnotationPage;
+import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.config.AnnotationUIAutoConfiguration;
+
+/**
+ * <p>
+ * This class is exposed as a Spring Component via
+ * {@link AnnotationUIAutoConfiguration#annotationUndoActionBarExtension}.
+ * </p>
+ */
+@Order(0)
+public class AnnotationUndoActionBarExtension
+    implements ActionBarExtension
+{
+    @Override
+    public boolean accepts(AnnotationPageBase aPage)
+    {
+        return aPage instanceof AnnotationPage;
+    }
+
+    @Override
+    public Panel createActionBarItem(String aId, AnnotationPageBase aPage)
+    {
+        return new UndoPanel(aId, aPage);
+    }
+}

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/PerformingUndoAction.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/PerformingUndoAction.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo;
+
+import org.apache.wicket.MetaDataKey;
+
+public class PerformingUndoAction
+    extends MetaDataKey<Boolean>
+{
+    private static final long serialVersionUID = -4244853609075676915L;
+    public final static PerformingUndoAction INSTANCE = new PerformingUndoAction();
+}

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/PerformingUndoRedoAction.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/PerformingUndoRedoAction.java
@@ -19,9 +19,9 @@ package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo;
 
 import org.apache.wicket.MetaDataKey;
 
-public class PerformingUndoAction
+public class PerformingUndoRedoAction
     extends MetaDataKey<Boolean>
 {
     private static final long serialVersionUID = -4244853609075676915L;
-    public final static PerformingUndoAction INSTANCE = new PerformingUndoAction();
+    public final static PerformingUndoRedoAction INSTANCE = new PerformingUndoRedoAction();
 }

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/PostAction.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/PostAction.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo;
+
+import org.apache.wicket.Component;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+
+public interface PostAction
+{
+    void apply(Component aContextComponent, AjaxRequestTarget aTarget);
+}

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/PostActionScrollToAndHighlight.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/PostActionScrollToAndHighlight.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo;
+
+import static de.tudarmstadt.ukp.clarin.webanno.support.wicket.WicketExceptionUtil.handleException;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.wicket.Component;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.feedback.IFeedback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.inception.rendering.model.Range;
+import de.tudarmstadt.ukp.inception.schema.adapter.AnnotationException;
+
+public class PostActionScrollToAndHighlight
+    implements PostAction
+{
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    private final SourceDocument document;
+    private final Range range;
+    private final String message;
+
+    public PostActionScrollToAndHighlight(SourceDocument aDocument, Range aRange, String aMessage)
+    {
+        document = aDocument;
+        range = aRange;
+        message = aMessage;
+    }
+
+    @Override
+    public void apply(Component aContextComponent, AjaxRequestTarget aTarget)
+    {
+        try {
+            AnnotationPageBase page = aContextComponent.findParent(AnnotationPageBase.class);
+            page.getAnnotationActionHandler().actionClear(aTarget);
+            page.actionShowSelectedDocument(aTarget, document, range.getBegin(), range.getEnd());
+            // FIXME: the highlighting part is still missing...
+
+            if (StringUtils.isNotBlank(message)) {
+                aContextComponent.info(message);
+                aTarget.addChildren(page, IFeedback.class);
+            }
+        }
+        catch (IOException | AnnotationException e) {
+            handleException(LOG, aContextComponent, aTarget, e);
+        }
+    }
+}

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/PostActionScrollToAndSelect.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/PostActionScrollToAndSelect.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo;
+
+import static de.tudarmstadt.ukp.clarin.webanno.support.wicket.WicketExceptionUtil.handleException;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.wicket.Component;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.feedback.IFeedback;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
+import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
+import de.tudarmstadt.ukp.inception.schema.adapter.AnnotationException;
+
+public class PostActionScrollToAndSelect
+    implements PostAction
+{
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    private final VID vid;
+    private final String message;
+
+    public PostActionScrollToAndSelect(VID aVid, String aMessage)
+    {
+        vid = aVid;
+        message = aMessage;
+    }
+
+    @Override
+    public void apply(Component aContextComponent, AjaxRequestTarget aTarget)
+    {
+        try {
+            AnnotationPageBase page = aContextComponent.findParent(AnnotationPageBase.class);
+            page.getAnnotationActionHandler().actionSelectAndJump(aTarget, vid);
+
+            if (StringUtils.isNotBlank(message)) {
+                aContextComponent.info(message);
+                aTarget.addChildren(page, IFeedback.class);
+            }
+        }
+        catch (AnnotationException | IOException e) {
+            handleException(LOG, aContextComponent, aTarget, e);
+        }
+    }
+}

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/UndoPanel.html
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/UndoPanel.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<!--
+  Licensed to the Technische Universität Darmstadt under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The Technische Universität Darmstadt 
+  licenses this file to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.
+   
+  http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<html xmlns:wicket="http://wicket.apache.org">
+<body>
+  <wicket:panel>
+    <div class="action-bar-group">
+      <div class="btn-group">
+        <button wicket:id="undo" class="btn btn-light" type="button" wicket:message="title:undo">
+          <i class="fas fa-undo"></i>
+        </button>
+        <button wicket:id="redo" class="btn btn-light" type="button" wicket:message="title:redo">
+          <i class="fas fa-redo"></i>
+        </button>
+      </div>
+    </div>
+  </wicket:panel>
+</body>
+</html>

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/UndoPanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/UndoPanel.java
@@ -18,6 +18,9 @@
 package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo;
 
 import static de.tudarmstadt.ukp.clarin.webanno.support.wicket.WicketExceptionUtil.handleException;
+import static wicket.contrib.input.events.EventType.click;
+import static wicket.contrib.input.events.key.KeyType.Ctrl;
+import static wicket.contrib.input.events.key.KeyType.Shift;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
@@ -36,6 +39,7 @@ import org.wicketstuff.event.annotation.OnEvent;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxLink;
+import de.tudarmstadt.ukp.clarin.webanno.support.wicket.input.InputBehavior;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.actions.CreateRelationAnnotationAction;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.actions.CreateSpanAnnotationAction;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.actions.DeleteRelationAnnotationAction;
@@ -52,6 +56,7 @@ import de.tudarmstadt.ukp.inception.annotation.layer.span.SpanCreatedEvent;
 import de.tudarmstadt.ukp.inception.annotation.layer.span.SpanDeletedEvent;
 import de.tudarmstadt.ukp.inception.schema.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.adapter.AnnotationException;
+import wicket.contrib.input.events.key.KeyType;
 
 public class UndoPanel
     extends Panel
@@ -76,8 +81,11 @@ public class UndoPanel
         registerHandler(RelationDeletedEvent.class, DeleteRelationAnnotationAction::new);
         registerHandler(FeatureValueUpdatedEvent.class, UpdateFeatureValueAnnotationAction::new);
 
-        queue(new LambdaAjaxLink("undo", this::actionUndo));
-        queue(new LambdaAjaxLink("redo", this::actionRedo));
+        queue(new LambdaAjaxLink("undo", this::actionUndo)
+                .add(new InputBehavior(new KeyType[] { Ctrl, KeyType.z }, click)));
+        queue(new LambdaAjaxLink("redo", this::actionRedo)
+                .add(new InputBehavior(new KeyType[] { Shift, Ctrl, KeyType.z }, click)));
+
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/UndoPanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/UndoPanel.java
@@ -71,7 +71,9 @@ public class UndoPanel
 
     private @SpringBean AnnotationSchemaService schemaService;
 
-    private final Map<Class<? extends AnnotationEvent>, SerializableBiFunction<AnnotationSchemaService, AnnotationEvent, UndoableAnnotationAction>> undoHandlers;
+    private final Map<Class<? extends AnnotationEvent>, //
+            SerializableBiFunction<AnnotationSchemaService, AnnotationEvent, //
+                    UndoableAnnotationAction>> undoHandlers;
 
     public UndoPanel(String aId, AnnotationPageBase aPage)
     {

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/UndoPanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/UndoPanel.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo;
+
+import static de.tudarmstadt.ukp.clarin.webanno.support.wicket.WicketExceptionUtil.handleException;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.request.cycle.RequestCycle;
+import org.apache.wicket.spring.injection.annot.SpringBean;
+import org.danekja.java.util.function.serializable.SerializableFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wicketstuff.event.annotation.OnEvent;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
+import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxLink;
+import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.actions.CreateSpanAnnotationAction;
+import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.actions.RedoableAnnotationAction;
+import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.actions.UndoableAnnotationAction;
+import de.tudarmstadt.ukp.inception.annotation.events.AnnotationEvent;
+import de.tudarmstadt.ukp.inception.annotation.layer.span.SpanCreatedEvent;
+import de.tudarmstadt.ukp.inception.schema.AnnotationSchemaService;
+import de.tudarmstadt.ukp.inception.schema.adapter.AnnotationException;
+
+public class UndoPanel
+    extends Panel
+{
+    private static final long serialVersionUID = -6213541738534665790L;
+
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    private @SpringBean AnnotationSchemaService schemaService;
+
+    private final Deque<UndoableAnnotationAction> undoableActions;
+    private final Deque<RedoableAnnotationAction> redoableActions;
+    private final Map<Class<? extends AnnotationEvent>, SerializableFunction<AnnotationEvent, UndoableAnnotationAction>> undoHandlers;
+
+    public UndoPanel(String aId, AnnotationPageBase aPage)
+    {
+        super(aId);
+
+        undoableActions = new LinkedList<>();
+        redoableActions = new LinkedList<>();
+        undoHandlers = new HashMap<>();
+
+        registerHandler(SpanCreatedEvent.class, CreateSpanAnnotationAction::new);
+
+        queue(new LambdaAjaxLink("undo", this::actionUndo));
+        queue(new LambdaAjaxLink("redo", this::actionRedo));
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private <T extends AnnotationEvent> void registerHandler(Class<T> aEventClass,
+            SerializableFunction<T, UndoableAnnotationAction> aHandler)
+    {
+        undoHandlers.put(aEventClass, (SerializableFunction) aHandler);
+    }
+
+    private void actionUndo(AjaxRequestTarget aTarget)
+    {
+        if (undoableActions.isEmpty()) {
+            return;
+        }
+
+        try {
+            RequestCycle.get().setMetaData(PerformingUndoAction.INSTANCE, true);
+
+            AnnotationPageBase page = findParent(AnnotationPageBase.class);
+
+            var action = undoableActions.poll();
+
+            var cas = page.getEditorCas();
+            action.undo(schemaService, cas);
+            page.writeEditorCas(cas);
+
+            if (action instanceof RedoableAnnotationAction) {
+                redoableActions.push((RedoableAnnotationAction) action);
+            }
+
+            page.actionRefreshDocument(aTarget);
+        }
+        catch (IOException | AnnotationException e) {
+            handleException(LOG, getPage(), aTarget, e);
+        }
+        finally {
+            RequestCycle.get().setMetaData(PerformingUndoAction.INSTANCE, false);
+        }
+    }
+
+    private void actionRedo(AjaxRequestTarget aTarget)
+    {
+
+    }
+
+    @OnEvent
+    public void onAnnotationEvent(AnnotationEvent aEvent)
+    {
+        var flag = RequestCycle.get().getMetaData(PerformingUndoAction.INSTANCE);
+        if (flag != null && flag) {
+            return;
+        }
+
+        redoableActions.clear();
+
+        var handler = undoHandlers.get(aEvent.getClass());
+
+        if (handler != null) {
+            undoableActions.push(handler.apply(aEvent));
+        }
+    }
+}

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/UndoPanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/UndoPanel.java
@@ -40,6 +40,8 @@ import org.wicketstuff.event.annotation.OnEvent;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxLink;
 import de.tudarmstadt.ukp.clarin.webanno.support.wicket.input.InputBehavior;
+import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.actions.CreateChainLinkAnnotationAction;
+import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.actions.CreateChainSpanAnnotationAction;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.actions.CreateRelationAnnotationAction;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.actions.CreateSpanAnnotationAction;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.actions.DeleteRelationAnnotationAction;
@@ -50,6 +52,8 @@ import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.actions.Up
 import de.tudarmstadt.ukp.inception.annotation.events.AnnotationEvent;
 import de.tudarmstadt.ukp.inception.annotation.events.DocumentOpenedEvent;
 import de.tudarmstadt.ukp.inception.annotation.events.FeatureValueUpdatedEvent;
+import de.tudarmstadt.ukp.inception.annotation.layer.chain.ChainLinkCreatedEvent;
+import de.tudarmstadt.ukp.inception.annotation.layer.chain.ChainSpanCreatedEvent;
 import de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationCreatedEvent;
 import de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationDeletedEvent;
 import de.tudarmstadt.ukp.inception.annotation.layer.span.SpanCreatedEvent;
@@ -79,6 +83,8 @@ public class UndoPanel
         registerHandler(SpanDeletedEvent.class, DeleteSpanAnnotationAction::new);
         registerHandler(RelationCreatedEvent.class, CreateRelationAnnotationAction::new);
         registerHandler(RelationDeletedEvent.class, DeleteRelationAnnotationAction::new);
+        registerHandler(ChainSpanCreatedEvent.class, CreateChainSpanAnnotationAction::new);
+        registerHandler(ChainLinkCreatedEvent.class, CreateChainLinkAnnotationAction::new);
         registerHandler(FeatureValueUpdatedEvent.class, UpdateFeatureValueAnnotationAction::new);
 
         queue(new LambdaAjaxLink("undo", this::actionUndo)

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/UndoPanel.properties
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/UndoPanel.properties
@@ -1,0 +1,17 @@
+# Licensed to the Technische Universität Darmstadt under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The Technische Universität Darmstadt 
+# licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.
+#  
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+undo=Next document (Ctrl+z)
+redo=Previous document (Shift+Ctrl+z)

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/UndoRedoState.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/UndoRedoState.java
@@ -38,13 +38,38 @@ public class UndoRedoState
         redoableActions = new LinkedList<>();
     }
 
-    public Deque<RedoableAnnotationAction> getRedoableActions()
+    public void pushRedoable(RedoableAnnotationAction aRedo)
     {
-        return redoableActions;
+        redoableActions.push(aRedo);
     }
 
-    public Deque<UndoableAnnotationAction> getUndoableActions()
+    public RedoableAnnotationAction popRedoable()
     {
-        return undoableActions;
+        return redoableActions.pop();
+    }
+
+    public boolean hasRedoableActions()
+    {
+        return !redoableActions.isEmpty();
+    }
+
+    public void clearRedoableActions()
+    {
+        redoableActions.clear();
+    }
+
+    public void pushUndoable(UndoableAnnotationAction aRedo)
+    {
+        undoableActions.push(aRedo);
+    }
+
+    public UndoableAnnotationAction popUndoable()
+    {
+        return undoableActions.pop();
+    }
+
+    public boolean hasUndoableActions()
+    {
+        return !undoableActions.isEmpty();
     }
 }

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/UndoRedoState.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/UndoRedoState.java
@@ -27,6 +27,8 @@ import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.actions.Un
 public class UndoRedoState
     implements Serializable
 {
+    private static final int MAX_HISTORY_SIZE = 100;
+
     private static final long serialVersionUID = 6899707476888758707L;
 
     private final Deque<UndoableAnnotationAction> undoableActions;
@@ -41,6 +43,10 @@ public class UndoRedoState
     public void pushRedoable(RedoableAnnotationAction aRedo)
     {
         redoableActions.push(aRedo);
+
+        while (redoableActions.size() > MAX_HISTORY_SIZE) {
+            redoableActions.removeLast();
+        }
     }
 
     public RedoableAnnotationAction popRedoable()
@@ -61,6 +67,10 @@ public class UndoRedoState
     public void pushUndoable(UndoableAnnotationAction aRedo)
     {
         undoableActions.push(aRedo);
+
+        while (undoableActions.size() > 100) {
+            undoableActions.removeLast();
+        }
     }
 
     public UndoableAnnotationAction popUndoable()

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/UndoRedoState.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/UndoRedoState.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo;
+
+import java.io.Serializable;
+import java.util.Deque;
+import java.util.LinkedList;
+
+import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.actions.RedoableAnnotationAction;
+import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.actions.UndoableAnnotationAction;
+
+public class UndoRedoState
+    implements Serializable
+{
+    private static final long serialVersionUID = 6899707476888758707L;
+
+    private final Deque<UndoableAnnotationAction> undoableActions;
+    private final Deque<RedoableAnnotationAction> redoableActions;
+
+    public UndoRedoState()
+    {
+        undoableActions = new LinkedList<>();
+        redoableActions = new LinkedList<>();
+    }
+
+    public Deque<RedoableAnnotationAction> getRedoableActions()
+    {
+        return redoableActions;
+    }
+
+    public Deque<UndoableAnnotationAction> getUndoableActions()
+    {
+        return undoableActions;
+    }
+}

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/UndoRedoStateKey.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/UndoRedoStateKey.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo;
+
+import org.apache.wicket.MetaDataKey;
+
+public class UndoRedoStateKey
+    extends MetaDataKey<UndoRedoState>
+{
+    private static final long serialVersionUID = -4244853609075676915L;
+    public final static UndoRedoStateKey INSTANCE = new UndoRedoStateKey();
+}

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/actions/AnnotationAction_ImplBase.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/actions/AnnotationAction_ImplBase.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.actions;
+
+import java.io.Serializable;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.inception.annotation.events.AnnotationEvent;
+import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
+
+public abstract class AnnotationAction_ImplBase
+    implements Serializable
+{
+    private static final long serialVersionUID = -7723798951981402947L;
+
+    private final SourceDocument document;
+    private final String user;
+    private final VID vid;
+    private final AnnotationLayer layer;
+
+    public AnnotationAction_ImplBase(AnnotationEvent aEvent, VID aVid)
+    {
+        vid = aVid;
+        document = aEvent.getDocument();
+        user = aEvent.getUser();
+        layer = aEvent.getLayer();
+    }
+
+    public AnnotationLayer getLayer()
+    {
+        return layer;
+    }
+
+    public VID getVid()
+    {
+        return vid;
+    }
+
+    public SourceDocument getDocument()
+    {
+        return document;
+    }
+
+    public String getUser()
+    {
+        return user;
+    }
+}

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/actions/CreateChainLinkAnnotationAction.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/actions/CreateChainLinkAnnotationAction.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.actions;
+
+import java.util.Optional;
+
+import org.apache.uima.cas.CAS;
+
+import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.PostAction;
+import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.PostActionScrollToAndHighlight;
+import de.tudarmstadt.ukp.inception.annotation.layer.chain.ChainEvent;
+import de.tudarmstadt.ukp.inception.rendering.model.Range;
+import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
+import de.tudarmstadt.ukp.inception.schema.AnnotationSchemaService;
+import de.tudarmstadt.ukp.inception.schema.adapter.AnnotationException;
+
+public class CreateChainLinkAnnotationAction
+    extends AnnotationAction_ImplBase
+    implements UndoableAnnotationAction
+{
+    private static final long serialVersionUID = -6268918582061776355L;
+
+    private final Range range;
+
+    public CreateChainLinkAnnotationAction(AnnotationSchemaService aSchemaService,
+            ChainEvent aEvent)
+    {
+        super(aEvent, new VID(aEvent.getAnnotation(), 1, VID.NONE, VID.NONE));
+
+        range = new Range(aEvent.getAnnotation());
+    }
+
+    @Override
+    public Optional<PostAction> undo(AnnotationSchemaService aSchemaService, CAS aCas)
+        throws AnnotationException
+    {
+        var adapter = aSchemaService.getAdapter(getLayer());
+        adapter.delete(getDocument(), getUser(), aCas, getVid());
+        return Optional.of(new PostActionScrollToAndHighlight(getDocument(), range,
+                "[" + getLayer().getUiName() + "] link deleted"));
+    }
+}

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/actions/CreateChainSpanAnnotationAction.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/actions/CreateChainSpanAnnotationAction.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.actions;
+
+import java.util.Optional;
+
+import org.apache.uima.cas.CAS;
+
+import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.PostAction;
+import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.PostActionScrollToAndHighlight;
+import de.tudarmstadt.ukp.inception.annotation.layer.chain.ChainEvent;
+import de.tudarmstadt.ukp.inception.rendering.model.Range;
+import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
+import de.tudarmstadt.ukp.inception.schema.AnnotationSchemaService;
+import de.tudarmstadt.ukp.inception.schema.adapter.AnnotationException;
+
+public class CreateChainSpanAnnotationAction
+    extends AnnotationAction_ImplBase
+    implements UndoableAnnotationAction
+{
+    private static final long serialVersionUID = -6268918582061776355L;
+
+    private final Range range;
+
+    public CreateChainSpanAnnotationAction(AnnotationSchemaService aSchemaService,
+            ChainEvent aEvent)
+    {
+        super(aEvent, new VID(aEvent.getAnnotation()));
+
+        range = new Range(aEvent.getAnnotation());
+    }
+
+    @Override
+    public Optional<PostAction> undo(AnnotationSchemaService aSchemaService, CAS aCas)
+        throws AnnotationException
+    {
+        var adapter = aSchemaService.getAdapter(getLayer());
+        adapter.delete(getDocument(), getUser(), aCas, getVid());
+        return Optional.of(new PostActionScrollToAndHighlight(getDocument(), range,
+                "[" + getLayer().getUiName() + "] span deleted"));
+    }
+}

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/actions/CreateRelationAnnotationAction.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/actions/CreateRelationAnnotationAction.java
@@ -53,8 +53,8 @@ public class CreateRelationAnnotationAction
     {
         var adapter = aSchemaService.getAdapter(getLayer());
         adapter.delete(getDocument(), getUser(), aCas, getVid());
-        return Optional
-                .of(new PostActionScrollToAndHighlight(getDocument(), range, "Relation deleted"));
+        return Optional.of(new PostActionScrollToAndHighlight(getDocument(), range,
+                "[" + getLayer().getUiName() + "] deleted"));
     }
 
     @Override
@@ -63,6 +63,7 @@ public class CreateRelationAnnotationAction
     {
         var adapter = (RelationAdapter) aSchemaService.getAdapter(getLayer());
         adapter.restore(getDocument(), getUser(), aCas, getVid());
-        return Optional.of(new PostActionScrollToAndSelect(getVid(), "Relation restored"));
+        return Optional.of(new PostActionScrollToAndSelect(getVid(),
+                "[" + getLayer().getUiName() + "] restored"));
     }
 }

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/actions/CreateRelationAnnotationAction.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/actions/CreateRelationAnnotationAction.java
@@ -17,15 +17,37 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.actions;
 
+import static de.tudarmstadt.ukp.clarin.webanno.support.uima.ICasUtil.selectFsByAddr;
+
 import org.apache.uima.cas.CAS;
 
+import de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationCreatedEvent;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
 import de.tudarmstadt.ukp.inception.schema.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.adapter.AnnotationException;
 
-public interface UndoableAnnotationAction
+public class CreateRelationAnnotationAction
+    extends AnnotationAction_ImplBase
+    implements RedoableAnnotationAction, UndoableAnnotationAction
 {
-    VID getVid();
+    private static final long serialVersionUID = -6268918582061776355L;
 
-    void undo(AnnotationSchemaService aSchemaService, CAS aCas) throws AnnotationException;
+    public CreateRelationAnnotationAction(RelationCreatedEvent aEvent)
+    {
+        super(aEvent, new VID(aEvent.getAnnotation()));
+    }
+
+    @Override
+    public void undo(AnnotationSchemaService aSchemaService, CAS aCas) throws AnnotationException
+    {
+        var adapter = aSchemaService.getAdapter(getLayer());
+        adapter.delete(getDocument(), getUser(), aCas, getVid());
+    }
+
+    @Override
+    public void redo(AnnotationSchemaService aSchemaService, CAS aCas) throws AnnotationException
+    {
+        var fs = selectFsByAddr(aCas, getVid().getId());
+        aCas.addFsToIndexes(fs);
+    }
 }

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/actions/CreateSpanAnnotationAction.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/actions/CreateSpanAnnotationAction.java
@@ -21,7 +21,6 @@ import org.apache.uima.cas.CAS;
 
 import de.tudarmstadt.ukp.inception.annotation.layer.span.SpanAdapter;
 import de.tudarmstadt.ukp.inception.annotation.layer.span.SpanCreatedEvent;
-import de.tudarmstadt.ukp.inception.rendering.model.Range;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
 import de.tudarmstadt.ukp.inception.schema.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.adapter.AnnotationException;
@@ -32,18 +31,15 @@ public class CreateSpanAnnotationAction
 {
     private static final long serialVersionUID = -6268918582061776355L;
 
-    private Range range;
-
     public CreateSpanAnnotationAction(SpanCreatedEvent aEvent)
     {
         super(aEvent, new VID(aEvent.getAnnotation()));
-        range = aEvent.getAffectedRange();
     }
 
     @Override
     public void undo(AnnotationSchemaService aSchemaService, CAS aCas) throws AnnotationException
     {
-        var adapter = (SpanAdapter) aSchemaService.getAdapter(getLayer());
+        var adapter = aSchemaService.getAdapter(getLayer());
         adapter.delete(getDocument(), getUser(), aCas, getVid());
     }
 
@@ -51,6 +47,6 @@ public class CreateSpanAnnotationAction
     public void redo(AnnotationSchemaService aSchemaService, CAS aCas) throws AnnotationException
     {
         var adapter = (SpanAdapter) aSchemaService.getAdapter(getLayer());
-        adapter.add(getDocument(), getUser(), aCas, range.getBegin(), range.getEnd());
+        adapter.restore(getDocument(), getUser(), aCas, getVid());
     }
 }

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/actions/CreateSpanAnnotationAction.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/actions/CreateSpanAnnotationAction.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.actions;
+
+import org.apache.uima.cas.CAS;
+
+import de.tudarmstadt.ukp.inception.annotation.layer.span.SpanAdapter;
+import de.tudarmstadt.ukp.inception.annotation.layer.span.SpanCreatedEvent;
+import de.tudarmstadt.ukp.inception.rendering.model.Range;
+import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
+import de.tudarmstadt.ukp.inception.schema.AnnotationSchemaService;
+import de.tudarmstadt.ukp.inception.schema.adapter.AnnotationException;
+
+public class CreateSpanAnnotationAction
+    extends AnnotationAction_ImplBase
+    implements RedoableAnnotationAction, UndoableAnnotationAction
+{
+    private static final long serialVersionUID = -6268918582061776355L;
+
+    private Range range;
+
+    public CreateSpanAnnotationAction(SpanCreatedEvent aEvent)
+    {
+        super(aEvent, new VID(aEvent.getAnnotation()));
+        range = aEvent.getAffectedRange();
+    }
+
+    @Override
+    public void undo(AnnotationSchemaService aSchemaService, CAS aCas) throws AnnotationException
+    {
+        var adapter = (SpanAdapter) aSchemaService.getAdapter(getLayer());
+        adapter.delete(getDocument(), getUser(), aCas, getVid());
+    }
+
+    @Override
+    public void redo(AnnotationSchemaService aSchemaService, CAS aCas) throws AnnotationException
+    {
+        var adapter = (SpanAdapter) aSchemaService.getAdapter(getLayer());
+        adapter.add(getDocument(), getUser(), aCas, range.getBegin(), range.getEnd());
+    }
+}

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/actions/CreateSpanAnnotationAction.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/actions/CreateSpanAnnotationAction.java
@@ -52,8 +52,8 @@ public class CreateSpanAnnotationAction
     {
         var adapter = aSchemaService.getAdapter(getLayer());
         adapter.delete(getDocument(), getUser(), aCas, getVid());
-        return Optional
-                .of(new PostActionScrollToAndHighlight(getDocument(), range, "Span deleted"));
+        return Optional.of(new PostActionScrollToAndHighlight(getDocument(), range,
+                "[" + getLayer().getUiName() + "] deleted"));
     }
 
     @Override
@@ -62,6 +62,7 @@ public class CreateSpanAnnotationAction
     {
         var adapter = (SpanAdapter) aSchemaService.getAdapter(getLayer());
         adapter.restore(getDocument(), getUser(), aCas, getVid());
-        return Optional.of(new PostActionScrollToAndSelect(getVid(), "Span restored"));
+        return Optional.of(new PostActionScrollToAndSelect(getVid(),
+                "[" + getLayer().getUiName() + "] restored"));
     }
 }

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/actions/DeleteRelationAnnotationAction.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/actions/DeleteRelationAnnotationAction.java
@@ -17,15 +17,36 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.actions;
 
+import static de.tudarmstadt.ukp.clarin.webanno.support.uima.ICasUtil.selectFsByAddr;
+
 import org.apache.uima.cas.CAS;
 
+import de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationDeletedEvent;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
 import de.tudarmstadt.ukp.inception.schema.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.adapter.AnnotationException;
 
-public interface UndoableAnnotationAction
+public class DeleteRelationAnnotationAction
+    extends AnnotationAction_ImplBase
+    implements RedoableAnnotationAction, UndoableAnnotationAction
 {
-    VID getVid();
+    private static final long serialVersionUID = -6268918582061776355L;
 
-    void undo(AnnotationSchemaService aSchemaService, CAS aCas) throws AnnotationException;
+    public DeleteRelationAnnotationAction(RelationDeletedEvent aEvent)
+    {
+        super(aEvent, new VID(aEvent.getAnnotation()));
+    }
+
+    @Override
+    public void undo(AnnotationSchemaService aSchemaService, CAS aCas) throws AnnotationException
+    {
+        aCas.addFsToIndexes(selectFsByAddr(aCas, getVid().getId()));
+    }
+
+    @Override
+    public void redo(AnnotationSchemaService aSchemaService, CAS aCas) throws AnnotationException
+    {
+        var adapter = aSchemaService.getAdapter(getLayer());
+        adapter.delete(getDocument(), getUser(), aCas, getVid());
+    }
 }

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/actions/DeleteRelationAnnotationAction.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/actions/DeleteRelationAnnotationAction.java
@@ -17,36 +17,37 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.actions;
 
-import static de.tudarmstadt.ukp.clarin.webanno.support.uima.ICasUtil.selectFsByAddr;
+import java.util.Optional;
 
 import org.apache.uima.cas.CAS;
 
-import de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationDeletedEvent;
-import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
+import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.PostAction;
+import de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationEvent;
 import de.tudarmstadt.ukp.inception.schema.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.adapter.AnnotationException;
 
 public class DeleteRelationAnnotationAction
-    extends AnnotationAction_ImplBase
-    implements RedoableAnnotationAction, UndoableAnnotationAction
+    extends CreateRelationAnnotationAction
 {
     private static final long serialVersionUID = -6268918582061776355L;
 
-    public DeleteRelationAnnotationAction(RelationDeletedEvent aEvent)
+    public DeleteRelationAnnotationAction(AnnotationSchemaService aSchemaService,
+            RelationEvent aEvent)
     {
-        super(aEvent, new VID(aEvent.getAnnotation()));
+        super(aSchemaService, aEvent);
     }
 
     @Override
-    public void undo(AnnotationSchemaService aSchemaService, CAS aCas) throws AnnotationException
+    public Optional<PostAction> undo(AnnotationSchemaService aSchemaService, CAS aCas)
+        throws AnnotationException
     {
-        aCas.addFsToIndexes(selectFsByAddr(aCas, getVid().getId()));
+        return super.redo(aSchemaService, aCas);
     }
 
     @Override
-    public void redo(AnnotationSchemaService aSchemaService, CAS aCas) throws AnnotationException
+    public Optional<PostAction> redo(AnnotationSchemaService aSchemaService, CAS aCas)
+        throws AnnotationException
     {
-        var adapter = aSchemaService.getAdapter(getLayer());
-        adapter.delete(getDocument(), getUser(), aCas, getVid());
+        return super.undo(aSchemaService, aCas);
     }
 }

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/actions/DeleteSpanAnnotationAction.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/actions/DeleteSpanAnnotationAction.java
@@ -19,13 +19,34 @@ package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.actions;
 
 import org.apache.uima.cas.CAS;
 
+import de.tudarmstadt.ukp.inception.annotation.layer.span.SpanAdapter;
+import de.tudarmstadt.ukp.inception.annotation.layer.span.SpanDeletedEvent;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
 import de.tudarmstadt.ukp.inception.schema.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.adapter.AnnotationException;
 
-public interface UndoableAnnotationAction
+public class DeleteSpanAnnotationAction
+    extends AnnotationAction_ImplBase
+    implements RedoableAnnotationAction, UndoableAnnotationAction
 {
-    VID getVid();
+    private static final long serialVersionUID = -6268918582061776355L;
 
-    void undo(AnnotationSchemaService aSchemaService, CAS aCas) throws AnnotationException;
+    public DeleteSpanAnnotationAction(SpanDeletedEvent aEvent)
+    {
+        super(aEvent, new VID(aEvent.getAnnotation()));
+    }
+
+    @Override
+    public void undo(AnnotationSchemaService aSchemaService, CAS aCas) throws AnnotationException
+    {
+        var adapter = (SpanAdapter) aSchemaService.getAdapter(getLayer());
+        adapter.restore(getDocument(), getUser(), aCas, getVid());
+    }
+
+    @Override
+    public void redo(AnnotationSchemaService aSchemaService, CAS aCas) throws AnnotationException
+    {
+        var adapter = aSchemaService.getAdapter(getLayer());
+        adapter.delete(getDocument(), getUser(), aCas, getVid());
+    }
 }

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/actions/DeleteSpanAnnotationAction.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/actions/DeleteSpanAnnotationAction.java
@@ -17,36 +17,36 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.actions;
 
+import java.util.Optional;
+
 import org.apache.uima.cas.CAS;
 
-import de.tudarmstadt.ukp.inception.annotation.layer.span.SpanAdapter;
-import de.tudarmstadt.ukp.inception.annotation.layer.span.SpanDeletedEvent;
-import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
+import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.PostAction;
+import de.tudarmstadt.ukp.inception.annotation.layer.span.SpanEvent;
 import de.tudarmstadt.ukp.inception.schema.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.adapter.AnnotationException;
 
 public class DeleteSpanAnnotationAction
-    extends AnnotationAction_ImplBase
-    implements RedoableAnnotationAction, UndoableAnnotationAction
+    extends CreateSpanAnnotationAction
 {
     private static final long serialVersionUID = -6268918582061776355L;
 
-    public DeleteSpanAnnotationAction(SpanDeletedEvent aEvent)
+    public DeleteSpanAnnotationAction(AnnotationSchemaService aSchemaService, SpanEvent aEvent)
     {
-        super(aEvent, new VID(aEvent.getAnnotation()));
+        super(aSchemaService, aEvent);
     }
 
     @Override
-    public void undo(AnnotationSchemaService aSchemaService, CAS aCas) throws AnnotationException
+    public Optional<PostAction> undo(AnnotationSchemaService aSchemaService, CAS aCas)
+        throws AnnotationException
     {
-        var adapter = (SpanAdapter) aSchemaService.getAdapter(getLayer());
-        adapter.restore(getDocument(), getUser(), aCas, getVid());
+        return super.redo(aSchemaService, aCas);
     }
 
     @Override
-    public void redo(AnnotationSchemaService aSchemaService, CAS aCas) throws AnnotationException
+    public Optional<PostAction> redo(AnnotationSchemaService aSchemaService, CAS aCas)
+        throws AnnotationException
     {
-        var adapter = aSchemaService.getAdapter(getLayer());
-        adapter.delete(getDocument(), getUser(), aCas, getVid());
+        return super.undo(aSchemaService, aCas);
     }
 }

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/actions/RedoableAnnotationAction.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/actions/RedoableAnnotationAction.java
@@ -19,10 +19,13 @@ package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.actions;
 
 import org.apache.uima.cas.CAS;
 
+import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
 import de.tudarmstadt.ukp.inception.schema.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.adapter.AnnotationException;
 
 public interface RedoableAnnotationAction
 {
+    VID getVid();
+
     void redo(AnnotationSchemaService aSchemaService, CAS aCas) throws AnnotationException;
 }

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/actions/RedoableAnnotationAction.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/actions/RedoableAnnotationAction.java
@@ -17,15 +17,27 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.actions;
 
+import java.util.Optional;
+
 import org.apache.uima.cas.CAS;
 
-import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
+import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.PostAction;
 import de.tudarmstadt.ukp.inception.schema.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.adapter.AnnotationException;
 
 public interface RedoableAnnotationAction
 {
-    VID getVid();
-
-    void redo(AnnotationSchemaService aSchemaService, CAS aCas) throws AnnotationException;
+    /**
+     * Redo the captured action.
+     * 
+     * @param aSchemaService
+     *            a schema service used to obtain an adapter.
+     * @param aCas
+     *            the editor CAS
+     * @return an optional annotation ID to select after re-doing the captured action
+     * @throws AnnotationException
+     *             if the action cannot be re-done
+     */
+    Optional<PostAction> redo(AnnotationSchemaService aSchemaService, CAS aCas)
+        throws AnnotationException;
 }

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/actions/RedoableAnnotationAction.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/actions/RedoableAnnotationAction.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.actions;
+
+import org.apache.uima.cas.CAS;
+
+import de.tudarmstadt.ukp.inception.schema.AnnotationSchemaService;
+import de.tudarmstadt.ukp.inception.schema.adapter.AnnotationException;
+
+public interface RedoableAnnotationAction
+{
+    void redo(AnnotationSchemaService aSchemaService, CAS aCas) throws AnnotationException;
+}

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/actions/UndoableAnnotationAction.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/actions/UndoableAnnotationAction.java
@@ -17,15 +17,27 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.actions;
 
+import java.util.Optional;
+
 import org.apache.uima.cas.CAS;
 
-import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
+import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.PostAction;
 import de.tudarmstadt.ukp.inception.schema.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.adapter.AnnotationException;
 
 public interface UndoableAnnotationAction
 {
-    VID getVid();
-
-    void undo(AnnotationSchemaService aSchemaService, CAS aCas) throws AnnotationException;
+    /**
+     * Undo the captured action.
+     * 
+     * @param aSchemaService
+     *            a schema service used to obtain an adapter.
+     * @param aCas
+     *            the editor CAS
+     * @return an optional annotation ID to select after rolling back the captured action
+     * @throws AnnotationException
+     *             if the action cannot be rolled back
+     */
+    Optional<PostAction> undo(AnnotationSchemaService aSchemaService, CAS aCas)
+        throws AnnotationException;
 }

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/actions/UndoableAnnotationAction.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/actions/UndoableAnnotationAction.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.actions;
+
+import org.apache.uima.cas.CAS;
+
+import de.tudarmstadt.ukp.inception.schema.AnnotationSchemaService;
+import de.tudarmstadt.ukp.inception.schema.adapter.AnnotationException;
+
+public interface UndoableAnnotationAction
+{
+    void undo(AnnotationSchemaService aSchemaService, CAS aCas) throws AnnotationException;
+}

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/actions/UpdateFeatureValueAnnotationAction.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/actions/UpdateFeatureValueAnnotationAction.java
@@ -71,8 +71,9 @@ public class UpdateFeatureValueAnnotationAction
         var adapter = aSchemaService.getAdapter(getLayer());
         adapter.setFeatureValue(getDocument(), getUser(), aCas, getVid().getId(), feature,
                 oldValue);
-        return Optional.of(new PostActionScrollToAndSelect(getVid(),
-                "Feature value of [" + feature.getUiName() + "] restored"));
+        return Optional
+                .of(new PostActionScrollToAndSelect(getVid(), "[" + feature.getLayer().getUiName()
+                        + " feature value of [" + feature.getUiName() + "] restored"));
     }
 
     @Override
@@ -82,8 +83,9 @@ public class UpdateFeatureValueAnnotationAction
         var adapter = aSchemaService.getAdapter(getLayer());
         adapter.setFeatureValue(getDocument(), getUser(), aCas, getVid().getId(), feature,
                 newValue);
-        return Optional.of(new PostActionScrollToAndSelect(getVid(),
-                "Feature value of [" + feature.getUiName() + "] set"));
+        return Optional
+                .of(new PostActionScrollToAndSelect(getVid(), "[" + feature.getLayer().getUiName()
+                        + "] feature value of [" + feature.getUiName() + "] set"));
     }
 
 }

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/config/AnnotationUIAutoConfiguration.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/config/AnnotationUIAutoConfiguration.java
@@ -26,15 +26,22 @@ import org.springframework.context.annotation.Configuration;
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.AnnotationPageMenuItem;
+import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.AnnotationUndoActionBarExtension;
 
 @ConditionalOnWebApplication
 @Configuration
 public class AnnotationUIAutoConfiguration
 {
     @Bean
-    AnnotationPageMenuItem annotationPageMenuItem(UserDao aUserRepo, ProjectService aProjectService,
-            ServletContext aServletContext)
+    public AnnotationPageMenuItem annotationPageMenuItem(UserDao aUserRepo,
+            ProjectService aProjectService, ServletContext aServletContext)
     {
         return new AnnotationPageMenuItem(aUserRepo, aProjectService, aServletContext);
+    }
+
+    @Bean
+    public AnnotationUndoActionBarExtension annotationUndoActionBarExtension()
+    {
+        return new AnnotationUndoActionBarExtension();
     }
 }

--- a/inception/inception-ui-annotation/src/main/resources/META-INF/asciidoc/user-guide/annotation_undo.adoc
+++ b/inception/inception-ui-annotation/src/main/resources/META-INF/asciidoc/user-guide/annotation_undo.adoc
@@ -1,0 +1,39 @@
+////
+// Licensed to the Technische Universität Darmstadt under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The Technische Universität Darmstadt 
+// licenses this file to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.
+//  
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+////
+
+= Undo/re-do
+
+The undo/re-do buttons in the action bar allow to undo annotation actions or to re-do an an undone action.
+
+This functionality is only available while working on a particular document. When switching to another document, the undo/redo history is reset.
+
+.Undo/re-do key bindings
+|====
+| Key | Action 
+
+| kbd:[Ctrl-Z]
+| undo last action
+
+| kbd:[Shift-Ctrl-Z]
+| re-do last un-done action
+|====
+
+NOTE: Not all actions can be undone or redone. E.g. bulk actions are not supported. 
+      While the undoing the creation of chain span and chain link annotations is supported, 
+      re-doing these actions or undoing their deletions is not supported.
+

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.properties
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.properties
@@ -33,6 +33,8 @@ refresh=Refresh
 reset=Reset
 search=Search
 preferences=Preferences
+undo=Undo
+redo=Redo
 
 enabled=Enabled
 

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/actionbar/opendocument/CurationDocumentOpenActionColumn.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/actionbar/opendocument/CurationDocumentOpenActionColumn.java
@@ -44,8 +44,8 @@ public class CurationDocumentOpenActionColumn
 
     private MarkupContainer fragmentProvider;
 
-    public CurationDocumentOpenActionColumn(MarkupContainer aFragmentProvider, IModel<String> aTitle,
-            CurationDocumentTableSortKeys aSortProperty)
+    public CurationDocumentOpenActionColumn(MarkupContainer aFragmentProvider,
+            IModel<String> aTitle, CurationDocumentTableSortKeys aSortProperty)
     {
         super(aTitle, aSortProperty);
         fragmentProvider = aFragmentProvider;

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/KnowledgeBaseDetailsPanel.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/KnowledgeBaseDetailsPanel.java
@@ -278,8 +278,8 @@ public class KnowledgeBaseDetailsPanel
             Component accessSettings = new AccessSettingsPanel("accessSettings", localKbwModel);
             add(accessSettings);
             accessSettings.get("type").setEnabled(false);
-            accessSettings.get("writeprotection")
-                    .setEnabled(localKbwModel.getObject().getKb().getType() == RepositoryType.LOCAL);
+            accessSettings.get("writeprotection").setEnabled(
+                    localKbwModel.getObject().getKb().getType() == RepositoryType.LOCAL);
 
             Component accessSpecificSettings = new AccessSpecificSettingsPanel(
                     "accessSpecificSettings", localKbwModel, Collections.emptyMap());


### PR DESCRIPTION
**What's in the PR**
- Added undo/redo panel to the annotation page
- Support undo/redo action for spans, relations and feature updates
- Support undo for chain span/link annotations (no redo)
- History gets reset when switching documents

**How to test manually**
* Use the undo/redo buttons

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
