### PR TITLE
#3317 - Update dependencies (24.2)

### DIFF
--- a/inception/inception-html-recogito-editor/src/main/ts_template/package-lock.json
+++ b/inception/inception-html-recogito-editor/src/main/ts_template/package-lock.json
@@ -7,17 +7,18 @@
     "": {
       "name": "@inception-project/${project.artifactId}",
       "version": "${semver}",
+      "license": "Apache-2.0",
       "dependencies": {
         "@inception-project/inception-js-api": "${semver}",
-        "@recogito/recogito-client-core": "1.6.0",
-        "@recogito/recogito-js": "^1.6.0"
+        "@recogito/recogito-client-core": "1.7.4",
+        "@recogito/recogito-js": "^1.7.1"
       },
       "devDependencies": {
-        "@typescript-eslint/eslint-plugin": "^5.17.0",
-        "@typescript-eslint/parser": "^5.17.0",
-        "esbuild": "^0.14.29",
+        "@typescript-eslint/eslint-plugin": "^5.20.0",
+        "@typescript-eslint/parser": "^5.20.0",
+        "esbuild": "^0.14.38",
         "esbuild-sass-plugin": "^2.2.6",
-        "eslint": "^8.12.0",
+        "eslint": "^8.13.0",
         "typescript": "^4.6.3"
       }
     },
@@ -25,6 +26,7 @@
       "name": "@inception-project/inception-diam",
       "version": "${semver}",
       "extraneous": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@inception-project/inception-js-api": "${semver}",
         "@stomp/stompjs": "^6.1.0",
@@ -41,49 +43,1422 @@
       "version": "${semver}",
       "license": "Apache-2.0",
       "devDependencies": {
-        "esbuild": "^0.13.12",
-        "typescript": "^4.4.2"
+        "@typescript-eslint/eslint-plugin": "^5.20.0",
+        "@typescript-eslint/parser": "^5.20.0",
+        "esbuild": "^0.14.38",
+        "eslint": "^8.13.0",
+        "typescript": "^4.6.3"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/@eslint/eslintrc": {
+      "version": "1.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.3.2",
+        "globals": "^13.15.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/@humanwhocodes/config-array": {
+      "version": "0.10.4",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^1.2.1",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/@humanwhocodes/gitignore-to-minimatch": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "Apache-2.0",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/@types/json-schema": {
+      "version": "7.0.11",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "5.35.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "5.35.1",
+        "@typescript-eslint/type-utils": "5.35.1",
+        "@typescript-eslint/utils": "5.35.1",
+        "debug": "^4.3.4",
+        "functional-red-black-tree": "^1.0.1",
+        "ignore": "^5.2.0",
+        "regexpp": "^3.2.0",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^5.0.0",
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/@typescript-eslint/parser": {
+      "version": "5.35.1",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "5.35.1",
+        "@typescript-eslint/types": "5.35.1",
+        "@typescript-eslint/typescript-estree": "5.35.1",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.35.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "5.35.1",
+        "@typescript-eslint/visitor-keys": "5.35.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/@typescript-eslint/type-utils": {
+      "version": "5.35.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "5.35.1",
+        "debug": "^4.3.4",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/@typescript-eslint/types": {
+      "version": "5.35.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.35.1",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "5.35.1",
+        "@typescript-eslint/visitor-keys": "5.35.1",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/@typescript-eslint/utils": {
+      "version": "5.35.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "@typescript-eslint/scope-manager": "5.35.1",
+        "@typescript-eslint/types": "5.35.1",
+        "@typescript-eslint/typescript-estree": "5.35.1",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.35.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "5.35.1",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/acorn": {
+      "version": "8.8.0",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/ajv": {
+      "version": "6.12.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/argparse": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/array-union": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/braces": {
+      "version": "3.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/callsites": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/chalk": {
+      "version": "4.1.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/color-convert": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/color-name": {
+      "version": "1.1.4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/concat-map": {
+      "version": "0.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/debug": {
+      "version": "4.3.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/deep-is": {
+      "version": "0.1.4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/dir-glob": {
+      "version": "3.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/doctrine": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "../../../../inception-js-api/src/main/ts/node_modules/esbuild": {
-      "version": "0.13.15",
+      "version": "0.14.54",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
       },
+      "engines": {
+        "node": ">=12"
+      },
       "optionalDependencies": {
-        "esbuild-android-arm64": "0.13.15",
-        "esbuild-darwin-64": "0.13.15",
-        "esbuild-darwin-arm64": "0.13.15",
-        "esbuild-freebsd-64": "0.13.15",
-        "esbuild-freebsd-arm64": "0.13.15",
-        "esbuild-linux-32": "0.13.15",
-        "esbuild-linux-64": "0.13.15",
-        "esbuild-linux-arm": "0.13.15",
-        "esbuild-linux-arm64": "0.13.15",
-        "esbuild-linux-mips64le": "0.13.15",
-        "esbuild-linux-ppc64le": "0.13.15",
-        "esbuild-netbsd-64": "0.13.15",
-        "esbuild-openbsd-64": "0.13.15",
-        "esbuild-sunos-64": "0.13.15",
-        "esbuild-windows-32": "0.13.15",
-        "esbuild-windows-64": "0.13.15",
-        "esbuild-windows-arm64": "0.13.15"
+        "@esbuild/linux-loong64": "0.14.54",
+        "esbuild-android-64": "0.14.54",
+        "esbuild-android-arm64": "0.14.54",
+        "esbuild-darwin-64": "0.14.54",
+        "esbuild-darwin-arm64": "0.14.54",
+        "esbuild-freebsd-64": "0.14.54",
+        "esbuild-freebsd-arm64": "0.14.54",
+        "esbuild-linux-32": "0.14.54",
+        "esbuild-linux-64": "0.14.54",
+        "esbuild-linux-arm": "0.14.54",
+        "esbuild-linux-arm64": "0.14.54",
+        "esbuild-linux-mips64le": "0.14.54",
+        "esbuild-linux-ppc64le": "0.14.54",
+        "esbuild-linux-riscv64": "0.14.54",
+        "esbuild-linux-s390x": "0.14.54",
+        "esbuild-netbsd-64": "0.14.54",
+        "esbuild-openbsd-64": "0.14.54",
+        "esbuild-sunos-64": "0.14.54",
+        "esbuild-windows-32": "0.14.54",
+        "esbuild-windows-64": "0.14.54",
+        "esbuild-windows-arm64": "0.14.54"
       }
     },
-    "../../../../inception-js-api/src/main/ts/node_modules/esbuild-darwin-64": {
-      "version": "0.13.15",
+    "../../../../inception-js-api/src/main/ts/node_modules/esbuild-darwin-arm64": {
+      "version": "0.14.54",
       "cpu": [
-        "x64"
+        "arm64"
       ],
       "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/eslint": {
+      "version": "8.22.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint/eslintrc": "^1.3.0",
+        "@humanwhocodes/config-array": "^0.10.4",
+        "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.1.1",
+        "eslint-utils": "^3.0.0",
+        "eslint-visitor-keys": "^3.3.0",
+        "espree": "^9.3.3",
+        "esquery": "^1.4.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^6.0.1",
+        "globals": "^13.15.0",
+        "globby": "^11.1.0",
+        "grapheme-splitter": "^1.0.4",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "regexpp": "^3.2.0",
+        "strip-ansi": "^6.0.1",
+        "strip-json-comments": "^3.1.0",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/eslint-utils": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "engines": {
+        "node": "^10.0.0 || ^12.0.0 || >= 14.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=5"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/eslint-visitor-keys": {
+      "version": "3.3.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/eslint/node_modules/eslint-scope": {
+      "version": "7.1.1",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/eslint/node_modules/estraverse": {
+      "version": "5.3.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/espree": {
+      "version": "9.3.3",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.8.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/esquery": {
+      "version": "1.4.0",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/esquery/node_modules/estraverse": {
+      "version": "5.3.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/esrecurse": {
+      "version": "4.3.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/esrecurse/node_modules/estraverse": {
+      "version": "5.3.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/estraverse": {
+      "version": "4.3.0",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/esutils": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/fast-glob": {
+      "version": "3.2.11",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/fastq": {
+      "version": "1.13.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/fill-range": {
+      "version": "7.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/find-up": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/flat-cache": {
+      "version": "3.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/flatted": {
+      "version": "3.2.5",
+      "dev": true,
+      "license": "ISC"
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/glob": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/globals": {
+      "version": "13.17.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/globby": {
+      "version": "11.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/grapheme-splitter": {
+      "version": "1.0.4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/has-flag": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/ignore": {
+      "version": "5.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/import-fresh": {
+      "version": "3.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/inflight": {
+      "version": "1.0.6",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/inherits": {
+      "version": "2.0.4",
+      "dev": true,
+      "license": "ISC"
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/is-extglob": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/is-glob": {
+      "version": "4.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/is-number": {
+      "version": "7.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/isexe": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/levn": {
+      "version": "0.4.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/locate-path": {
+      "version": "6.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/merge2": {
+      "version": "1.4.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/micromatch": {
+      "version": "4.0.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/minimatch": {
+      "version": "3.1.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/ms": {
+      "version": "2.1.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/natural-compare": {
+      "version": "1.4.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/once": {
+      "version": "1.4.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/optionator": {
+      "version": "0.9.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/p-limit": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/p-locate": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/parent-module": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/path-exists": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/path-key": {
+      "version": "3.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/path-type": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/picomatch": {
+      "version": "2.3.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/punycode": {
+      "version": "2.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/regexpp": {
+      "version": "3.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/reusify": {
+      "version": "1.0.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/rimraf": {
+      "version": "3.0.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/run-parallel": {
+      "version": "1.2.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/semver": {
+      "version": "7.3.7",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/slash": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/supports-color": {
+      "version": "7.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/text-table": {
+      "version": "0.2.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/tslib": {
+      "version": "1.14.1",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/tsutils": {
+      "version": "3.21.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/type-check": {
+      "version": "0.4.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/type-fest": {
+      "version": "0.20.2",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "../../../../inception-js-api/src/main/ts/node_modules/typescript": {
       "version": "4.6.3",
@@ -95,6 +1470,62 @@
       },
       "engines": {
         "node": ">=4.2.0"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/uri-js": {
+      "version": "4.4.1",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/v8-compile-cache": {
+      "version": "2.3.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/which": {
+      "version": "2.0.2",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/word-wrap": {
+      "version": "1.2.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/wrappy": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "ISC"
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/yallist": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "ISC"
+    },
+    "../../../../inception-js-api/src/main/ts/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@babel/runtime": {
@@ -179,26 +1610,29 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.2.1",
+      "version": "1.3.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.3.1",
-        "globals": "^13.9.0",
+        "espree": "^9.4.0",
+        "globals": "^13.15.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.9.5",
+      "version": "0.10.4",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -208,6 +1642,27 @@
       },
       "engines": {
         "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/gitignore-to-minimatch": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "Apache-2.0",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@humanwhocodes/object-schema": {
@@ -252,7 +1707,7 @@
       }
     },
     "node_modules/@recogito/recogito-client-core": {
-      "version": "1.6.0",
+      "version": "1.7.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "core-js": "^3.18.3",
@@ -271,12 +1726,31 @@
       }
     },
     "node_modules/@recogito/recogito-js": {
-      "version": "1.6.1",
+      "version": "1.7.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@recogito/recogito-client-core": "1.6.0",
+        "@recogito/recogito-client-core": "1.7.1",
         "preact": "^10.5.13",
         "tiny-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/@recogito/recogito-js/node_modules/@recogito/recogito-client-core": {
+      "version": "1.7.1",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "core-js": "^3.18.3",
+        "fast-deep-equal": "^3.1.3",
+        "node-polyglot": "^2.4.0",
+        "react-autosize-textarea": "^7.1.0",
+        "react-draggable": "^4.4.3",
+        "react-select": "^4.3.1",
+        "react-transition-group": "^4.4.2",
+        "regenerator-runtime": "^0.13.9",
+        "timeago-react": "^3.0.2",
+        "uuid": "^8.3.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/rsimon"
       }
     },
     "node_modules/@types/json-schema": {
@@ -285,18 +1759,18 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.17.0",
+      "version": "5.35.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.17.0",
-        "@typescript-eslint/type-utils": "5.17.0",
-        "@typescript-eslint/utils": "5.17.0",
-        "debug": "^4.3.2",
+        "@typescript-eslint/scope-manager": "5.35.1",
+        "@typescript-eslint/type-utils": "5.35.1",
+        "@typescript-eslint/utils": "5.35.1",
+        "debug": "^4.3.4",
         "functional-red-black-tree": "^1.0.1",
-        "ignore": "^5.1.8",
+        "ignore": "^5.2.0",
         "regexpp": "^3.2.0",
-        "semver": "^7.3.5",
+        "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       },
       "engines": {
@@ -317,14 +1791,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.17.0",
+      "version": "5.35.1",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.17.0",
-        "@typescript-eslint/types": "5.17.0",
-        "@typescript-eslint/typescript-estree": "5.17.0",
-        "debug": "^4.3.2"
+        "@typescript-eslint/scope-manager": "5.35.1",
+        "@typescript-eslint/types": "5.35.1",
+        "@typescript-eslint/typescript-estree": "5.35.1",
+        "debug": "^4.3.4"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -343,12 +1817,12 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.17.0",
+      "version": "5.35.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "5.17.0",
-        "@typescript-eslint/visitor-keys": "5.17.0"
+        "@typescript-eslint/types": "5.35.1",
+        "@typescript-eslint/visitor-keys": "5.35.1"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -359,12 +1833,12 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.17.0",
+      "version": "5.35.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/utils": "5.17.0",
-        "debug": "^4.3.2",
+        "@typescript-eslint/utils": "5.35.1",
+        "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
       "engines": {
@@ -384,7 +1858,7 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.17.0",
+      "version": "5.35.1",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -396,16 +1870,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.17.0",
+      "version": "5.35.1",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/types": "5.17.0",
-        "@typescript-eslint/visitor-keys": "5.17.0",
-        "debug": "^4.3.2",
-        "globby": "^11.0.4",
+        "@typescript-eslint/types": "5.35.1",
+        "@typescript-eslint/visitor-keys": "5.35.1",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
         "is-glob": "^4.0.3",
-        "semver": "^7.3.5",
+        "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       },
       "engines": {
@@ -422,14 +1896,14 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.17.0",
+      "version": "5.35.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.17.0",
-        "@typescript-eslint/types": "5.17.0",
-        "@typescript-eslint/typescript-estree": "5.17.0",
+        "@typescript-eslint/scope-manager": "5.35.1",
+        "@typescript-eslint/types": "5.35.1",
+        "@typescript-eslint/typescript-estree": "5.35.1",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -445,12 +1919,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.17.0",
+      "version": "5.35.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "5.17.0",
-        "eslint-visitor-keys": "^3.0.0"
+        "@typescript-eslint/types": "5.35.1",
+        "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -461,7 +1935,7 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.7.0",
+      "version": "8.8.0",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -826,7 +2300,7 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.14.29",
+      "version": "0.14.54",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -837,32 +2311,33 @@
         "node": ">=12"
       },
       "optionalDependencies": {
-        "esbuild-android-64": "0.14.29",
-        "esbuild-android-arm64": "0.14.29",
-        "esbuild-darwin-64": "0.14.29",
-        "esbuild-darwin-arm64": "0.14.29",
-        "esbuild-freebsd-64": "0.14.29",
-        "esbuild-freebsd-arm64": "0.14.29",
-        "esbuild-linux-32": "0.14.29",
-        "esbuild-linux-64": "0.14.29",
-        "esbuild-linux-arm": "0.14.29",
-        "esbuild-linux-arm64": "0.14.29",
-        "esbuild-linux-mips64le": "0.14.29",
-        "esbuild-linux-ppc64le": "0.14.29",
-        "esbuild-linux-riscv64": "0.14.29",
-        "esbuild-linux-s390x": "0.14.29",
-        "esbuild-netbsd-64": "0.14.29",
-        "esbuild-openbsd-64": "0.14.29",
-        "esbuild-sunos-64": "0.14.29",
-        "esbuild-windows-32": "0.14.29",
-        "esbuild-windows-64": "0.14.29",
-        "esbuild-windows-arm64": "0.14.29"
+        "@esbuild/linux-loong64": "0.14.54",
+        "esbuild-android-64": "0.14.54",
+        "esbuild-android-arm64": "0.14.54",
+        "esbuild-darwin-64": "0.14.54",
+        "esbuild-darwin-arm64": "0.14.54",
+        "esbuild-freebsd-64": "0.14.54",
+        "esbuild-freebsd-arm64": "0.14.54",
+        "esbuild-linux-32": "0.14.54",
+        "esbuild-linux-64": "0.14.54",
+        "esbuild-linux-arm": "0.14.54",
+        "esbuild-linux-arm64": "0.14.54",
+        "esbuild-linux-mips64le": "0.14.54",
+        "esbuild-linux-ppc64le": "0.14.54",
+        "esbuild-linux-riscv64": "0.14.54",
+        "esbuild-linux-s390x": "0.14.54",
+        "esbuild-netbsd-64": "0.14.54",
+        "esbuild-openbsd-64": "0.14.54",
+        "esbuild-sunos-64": "0.14.54",
+        "esbuild-windows-32": "0.14.54",
+        "esbuild-windows-64": "0.14.54",
+        "esbuild-windows-arm64": "0.14.54"
       }
     },
-    "node_modules/esbuild-darwin-64": {
-      "version": "0.14.29",
+    "node_modules/esbuild-darwin-arm64": {
+      "version": "0.14.54",
       "cpu": [
-        "x64"
+        "arm64"
       ],
       "dev": true,
       "license": "MIT",
@@ -895,12 +2370,14 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.12.0",
+      "version": "8.23.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint/eslintrc": "^1.2.1",
-        "@humanwhocodes/config-array": "^0.9.2",
+        "@eslint/eslintrc": "^1.3.1",
+        "@humanwhocodes/config-array": "^0.10.4",
+        "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
+        "@humanwhocodes/module-importer": "^1.0.1",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -910,14 +2387,17 @@
         "eslint-scope": "^7.1.1",
         "eslint-utils": "^3.0.0",
         "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.3.1",
+        "espree": "^9.4.0",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^6.0.1",
-        "globals": "^13.6.0",
+        "globals": "^13.15.0",
+        "globby": "^11.1.0",
+        "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
@@ -926,14 +2406,13 @@
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
         "regexpp": "^3.2.0",
         "strip-ansi": "^6.0.1",
         "strip-json-comments": "^3.1.0",
-        "text-table": "^0.2.0",
-        "v8-compile-cache": "^2.0.3"
+        "text-table": "^0.2.0"
       },
       "bin": {
         "eslint": "bin/eslint.js"
@@ -1022,16 +2501,19 @@
       }
     },
     "node_modules/espree": {
-      "version": "9.3.1",
+      "version": "9.4.0",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.7.0",
-        "acorn-jsx": "^5.3.1",
+        "acorn": "^8.8.0",
+        "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/esquery": {
@@ -1147,6 +2629,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "3.0.4",
       "dev": true,
@@ -1247,7 +2744,7 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.13.0",
+      "version": "13.17.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1278,6 +2775,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/grapheme-splitter": {
+      "version": "1.0.4",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -1613,6 +3115,20 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "dev": true,
@@ -1776,6 +3292,34 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "dev": true,
@@ -1785,6 +3329,14 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-is-absolute": {
@@ -2076,7 +3628,7 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.5",
+      "version": "7.3.7",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -2325,11 +3877,6 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/v8-compile-cache": {
-      "version": "2.3.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/warning": {
       "version": "4.0.3",
       "license": "MIT",
@@ -2382,6 +3929,17 @@
       "version": "4.0.0",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   },
   "dependencies": {
@@ -2442,28 +4000,36 @@
       "version": "0.2.5"
     },
     "@eslint/eslintrc": {
-      "version": "1.2.1",
+      "version": "1.3.1",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.3.1",
-        "globals": "^13.9.0",
+        "espree": "^9.4.0",
+        "globals": "^13.15.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "strip-json-comments": "^3.1.1"
       }
     },
     "@humanwhocodes/config-array": {
-      "version": "0.9.5",
+      "version": "0.10.4",
       "dev": true,
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.1",
         "debug": "^4.1.1",
         "minimatch": "^3.0.4"
       }
+    },
+    "@humanwhocodes/gitignore-to-minimatch": {
+      "version": "1.0.2",
+      "dev": true
+    },
+    "@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "dev": true
     },
     "@humanwhocodes/object-schema": {
       "version": "1.2.1",
@@ -2472,40 +4038,878 @@
     "@inception-project/inception-js-api": {
       "version": "file:../../../../inception-js-api/src/main/ts",
       "requires": {
-        "esbuild": "^0.13.12",
-        "typescript": "^4.4.2"
+        "@typescript-eslint/eslint-plugin": "^5.20.0",
+        "@typescript-eslint/parser": "^5.20.0",
+        "esbuild": "^0.14.38",
+        "eslint": "^8.13.0",
+        "typescript": "^4.6.3"
       },
       "dependencies": {
-        "esbuild": {
-          "version": "0.13.15",
+        "@eslint/eslintrc": {
+          "version": "1.3.0",
           "dev": true,
           "requires": {
-            "esbuild-android-arm64": "0.13.15",
-            "esbuild-darwin-64": "0.13.15",
-            "esbuild-darwin-arm64": "0.13.15",
-            "esbuild-freebsd-64": "0.13.15",
-            "esbuild-freebsd-arm64": "0.13.15",
-            "esbuild-linux-32": "0.13.15",
-            "esbuild-linux-64": "0.13.15",
-            "esbuild-linux-arm": "0.13.15",
-            "esbuild-linux-arm64": "0.13.15",
-            "esbuild-linux-mips64le": "0.13.15",
-            "esbuild-linux-ppc64le": "0.13.15",
-            "esbuild-netbsd-64": "0.13.15",
-            "esbuild-openbsd-64": "0.13.15",
-            "esbuild-sunos-64": "0.13.15",
-            "esbuild-windows-32": "0.13.15",
-            "esbuild-windows-64": "0.13.15",
-            "esbuild-windows-arm64": "0.13.15"
+            "ajv": "^6.12.4",
+            "debug": "^4.3.2",
+            "espree": "^9.3.2",
+            "globals": "^13.15.0",
+            "ignore": "^5.2.0",
+            "import-fresh": "^3.2.1",
+            "js-yaml": "^4.1.0",
+            "minimatch": "^3.1.2",
+            "strip-json-comments": "^3.1.1"
           }
         },
-        "esbuild-darwin-64": {
-          "version": "0.13.15",
+        "@humanwhocodes/config-array": {
+          "version": "0.10.4",
+          "dev": true,
+          "requires": {
+            "@humanwhocodes/object-schema": "^1.2.1",
+            "debug": "^4.1.1",
+            "minimatch": "^3.0.4"
+          }
+        },
+        "@humanwhocodes/gitignore-to-minimatch": {
+          "version": "1.0.2",
+          "dev": true
+        },
+        "@humanwhocodes/object-schema": {
+          "version": "1.2.1",
+          "dev": true
+        },
+        "@nodelib/fs.scandir": {
+          "version": "2.1.5",
+          "dev": true,
+          "requires": {
+            "@nodelib/fs.stat": "2.0.5",
+            "run-parallel": "^1.1.9"
+          }
+        },
+        "@nodelib/fs.stat": {
+          "version": "2.0.5",
+          "dev": true
+        },
+        "@nodelib/fs.walk": {
+          "version": "1.2.8",
+          "dev": true,
+          "requires": {
+            "@nodelib/fs.scandir": "2.1.5",
+            "fastq": "^1.6.0"
+          }
+        },
+        "@types/json-schema": {
+          "version": "7.0.11",
+          "dev": true
+        },
+        "@typescript-eslint/eslint-plugin": {
+          "version": "5.35.1",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/scope-manager": "5.35.1",
+            "@typescript-eslint/type-utils": "5.35.1",
+            "@typescript-eslint/utils": "5.35.1",
+            "debug": "^4.3.4",
+            "functional-red-black-tree": "^1.0.1",
+            "ignore": "^5.2.0",
+            "regexpp": "^3.2.0",
+            "semver": "^7.3.7",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/parser": {
+          "version": "5.35.1",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/scope-manager": "5.35.1",
+            "@typescript-eslint/types": "5.35.1",
+            "@typescript-eslint/typescript-estree": "5.35.1",
+            "debug": "^4.3.4"
+          }
+        },
+        "@typescript-eslint/scope-manager": {
+          "version": "5.35.1",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.35.1",
+            "@typescript-eslint/visitor-keys": "5.35.1"
+          }
+        },
+        "@typescript-eslint/type-utils": {
+          "version": "5.35.1",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/utils": "5.35.1",
+            "debug": "^4.3.4",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "5.35.1",
+          "dev": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "5.35.1",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.35.1",
+            "@typescript-eslint/visitor-keys": "5.35.1",
+            "debug": "^4.3.4",
+            "globby": "^11.1.0",
+            "is-glob": "^4.0.3",
+            "semver": "^7.3.7",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/utils": {
+          "version": "5.35.1",
+          "dev": true,
+          "requires": {
+            "@types/json-schema": "^7.0.9",
+            "@typescript-eslint/scope-manager": "5.35.1",
+            "@typescript-eslint/types": "5.35.1",
+            "@typescript-eslint/typescript-estree": "5.35.1",
+            "eslint-scope": "^5.1.1",
+            "eslint-utils": "^3.0.0"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "5.35.1",
+          "dev": true,
+          "requires": {
+            "@typescript-eslint/types": "5.35.1",
+            "eslint-visitor-keys": "^3.3.0"
+          }
+        },
+        "acorn": {
+          "version": "8.8.0",
+          "dev": true
+        },
+        "acorn-jsx": {
+          "version": "5.3.2",
+          "dev": true,
+          "requires": {}
+        },
+        "ajv": {
+          "version": "6.12.6",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.1",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "argparse": {
+          "version": "2.0.1",
+          "dev": true
+        },
+        "array-union": {
+          "version": "2.1.0",
+          "dev": true
+        },
+        "balanced-match": {
+          "version": "1.0.2",
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.11",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "braces": {
+          "version": "3.0.2",
+          "dev": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "callsites": {
+          "version": "3.1.0",
+          "dev": true
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "dev": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "7.0.3",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "debug": {
+          "version": "4.3.4",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "deep-is": {
+          "version": "0.1.4",
+          "dev": true
+        },
+        "dir-glob": {
+          "version": "3.0.1",
+          "dev": true,
+          "requires": {
+            "path-type": "^4.0.0"
+          }
+        },
+        "doctrine": {
+          "version": "3.0.0",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2"
+          }
+        },
+        "esbuild": {
+          "version": "0.14.54",
+          "dev": true,
+          "requires": {
+            "@esbuild/linux-loong64": "0.14.54",
+            "esbuild-android-64": "0.14.54",
+            "esbuild-android-arm64": "0.14.54",
+            "esbuild-darwin-64": "0.14.54",
+            "esbuild-darwin-arm64": "0.14.54",
+            "esbuild-freebsd-64": "0.14.54",
+            "esbuild-freebsd-arm64": "0.14.54",
+            "esbuild-linux-32": "0.14.54",
+            "esbuild-linux-64": "0.14.54",
+            "esbuild-linux-arm": "0.14.54",
+            "esbuild-linux-arm64": "0.14.54",
+            "esbuild-linux-mips64le": "0.14.54",
+            "esbuild-linux-ppc64le": "0.14.54",
+            "esbuild-linux-riscv64": "0.14.54",
+            "esbuild-linux-s390x": "0.14.54",
+            "esbuild-netbsd-64": "0.14.54",
+            "esbuild-openbsd-64": "0.14.54",
+            "esbuild-sunos-64": "0.14.54",
+            "esbuild-windows-32": "0.14.54",
+            "esbuild-windows-64": "0.14.54",
+            "esbuild-windows-arm64": "0.14.54"
+          }
+        },
+        "esbuild-darwin-arm64": {
+          "version": "0.14.54",
           "dev": true,
           "optional": true
         },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "dev": true
+        },
+        "eslint": {
+          "version": "8.22.0",
+          "dev": true,
+          "requires": {
+            "@eslint/eslintrc": "^1.3.0",
+            "@humanwhocodes/config-array": "^0.10.4",
+            "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
+            "ajv": "^6.10.0",
+            "chalk": "^4.0.0",
+            "cross-spawn": "^7.0.2",
+            "debug": "^4.3.2",
+            "doctrine": "^3.0.0",
+            "escape-string-regexp": "^4.0.0",
+            "eslint-scope": "^7.1.1",
+            "eslint-utils": "^3.0.0",
+            "eslint-visitor-keys": "^3.3.0",
+            "espree": "^9.3.3",
+            "esquery": "^1.4.0",
+            "esutils": "^2.0.2",
+            "fast-deep-equal": "^3.1.3",
+            "file-entry-cache": "^6.0.1",
+            "find-up": "^5.0.0",
+            "functional-red-black-tree": "^1.0.1",
+            "glob-parent": "^6.0.1",
+            "globals": "^13.15.0",
+            "globby": "^11.1.0",
+            "grapheme-splitter": "^1.0.4",
+            "ignore": "^5.2.0",
+            "import-fresh": "^3.0.0",
+            "imurmurhash": "^0.1.4",
+            "is-glob": "^4.0.0",
+            "js-yaml": "^4.1.0",
+            "json-stable-stringify-without-jsonify": "^1.0.1",
+            "levn": "^0.4.1",
+            "lodash.merge": "^4.6.2",
+            "minimatch": "^3.1.2",
+            "natural-compare": "^1.4.0",
+            "optionator": "^0.9.1",
+            "regexpp": "^3.2.0",
+            "strip-ansi": "^6.0.1",
+            "strip-json-comments": "^3.1.0",
+            "text-table": "^0.2.0",
+            "v8-compile-cache": "^2.0.3"
+          },
+          "dependencies": {
+            "eslint-scope": {
+              "version": "7.1.1",
+              "dev": true,
+              "requires": {
+                "esrecurse": "^4.3.0",
+                "estraverse": "^5.2.0"
+              }
+            },
+            "estraverse": {
+              "version": "5.3.0",
+              "dev": true
+            }
+          }
+        },
+        "eslint-scope": {
+          "version": "5.1.1",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.3.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "eslint-utils": {
+          "version": "3.0.0",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^2.0.0"
+          },
+          "dependencies": {
+            "eslint-visitor-keys": {
+              "version": "2.1.0",
+              "dev": true
+            }
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "3.3.0",
+          "dev": true
+        },
+        "espree": {
+          "version": "9.3.3",
+          "dev": true,
+          "requires": {
+            "acorn": "^8.8.0",
+            "acorn-jsx": "^5.3.2",
+            "eslint-visitor-keys": "^3.3.0"
+          }
+        },
+        "esquery": {
+          "version": "1.4.0",
+          "dev": true,
+          "requires": {
+            "estraverse": "^5.1.0"
+          },
+          "dependencies": {
+            "estraverse": {
+              "version": "5.3.0",
+              "dev": true
+            }
+          }
+        },
+        "esrecurse": {
+          "version": "4.3.0",
+          "dev": true,
+          "requires": {
+            "estraverse": "^5.2.0"
+          },
+          "dependencies": {
+            "estraverse": {
+              "version": "5.3.0",
+              "dev": true
+            }
+          }
+        },
+        "estraverse": {
+          "version": "4.3.0",
+          "dev": true
+        },
+        "esutils": {
+          "version": "2.0.3",
+          "dev": true
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "dev": true
+        },
+        "fast-glob": {
+          "version": "3.2.11",
+          "dev": true,
+          "requires": {
+            "@nodelib/fs.stat": "^2.0.2",
+            "@nodelib/fs.walk": "^1.2.3",
+            "glob-parent": "^5.1.2",
+            "merge2": "^1.3.0",
+            "micromatch": "^4.0.4"
+          },
+          "dependencies": {
+            "glob-parent": {
+              "version": "5.1.2",
+              "dev": true,
+              "requires": {
+                "is-glob": "^4.0.1"
+              }
+            }
+          }
+        },
+        "fast-json-stable-stringify": {
+          "version": "2.1.0",
+          "dev": true
+        },
+        "fast-levenshtein": {
+          "version": "2.0.6",
+          "dev": true
+        },
+        "fastq": {
+          "version": "1.13.0",
+          "dev": true,
+          "requires": {
+            "reusify": "^1.0.4"
+          }
+        },
+        "file-entry-cache": {
+          "version": "6.0.1",
+          "dev": true,
+          "requires": {
+            "flat-cache": "^3.0.4"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "dev": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "find-up": {
+          "version": "5.0.0",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "flat-cache": {
+          "version": "3.0.4",
+          "dev": true,
+          "requires": {
+            "flatted": "^3.1.0",
+            "rimraf": "^3.0.2"
+          }
+        },
+        "flatted": {
+          "version": "3.2.5",
+          "dev": true
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "functional-red-black-tree": {
+          "version": "1.0.1",
+          "dev": true
+        },
+        "glob": {
+          "version": "7.2.0",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "glob-parent": {
+          "version": "6.0.2",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.3"
+          }
+        },
+        "globals": {
+          "version": "13.17.0",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.20.2"
+          }
+        },
+        "globby": {
+          "version": "11.1.0",
+          "dev": true,
+          "requires": {
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.2.9",
+            "ignore": "^5.2.0",
+            "merge2": "^1.4.1",
+            "slash": "^3.0.0"
+          }
+        },
+        "grapheme-splitter": {
+          "version": "1.0.4",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "dev": true
+        },
+        "ignore": {
+          "version": "5.2.0",
+          "dev": true
+        },
+        "import-fresh": {
+          "version": "3.3.0",
+          "dev": true,
+          "requires": {
+            "parent-module": "^1.0.0",
+            "resolve-from": "^4.0.0"
+          }
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "dev": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "dev": true,
+          "requires": {
+            "once": "^1.3.0",
+            "wrappy": "1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "dev": true
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "4.0.3",
+          "dev": true,
+          "requires": {
+            "is-extglob": "^2.1.1"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "dev": true
+        },
+        "isexe": {
+          "version": "2.0.0",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "dev": true
+        },
+        "json-stable-stringify-without-jsonify": {
+          "version": "1.0.1",
+          "dev": true
+        },
+        "levn": {
+          "version": "0.4.1",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "^1.2.1",
+            "type-check": "~0.4.0"
+          }
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "dev": true,
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "lodash.merge": {
+          "version": "4.6.2",
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "merge2": {
+          "version": "1.4.1",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "4.0.5",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.2",
+            "picomatch": "^2.3.1"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "dev": true
+        },
+        "natural-compare": {
+          "version": "1.4.0",
+          "dev": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "dev": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "optionator": {
+          "version": "0.9.1",
+          "dev": true,
+          "requires": {
+            "deep-is": "^0.1.3",
+            "fast-levenshtein": "^2.0.6",
+            "levn": "^0.4.1",
+            "prelude-ls": "^1.2.1",
+            "type-check": "^0.4.0",
+            "word-wrap": "^1.2.3"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "parent-module": {
+          "version": "1.0.1",
+          "dev": true,
+          "requires": {
+            "callsites": "^3.0.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "dev": true
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "dev": true
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "dev": true
+        },
+        "path-type": {
+          "version": "4.0.0",
+          "dev": true
+        },
+        "picomatch": {
+          "version": "2.3.1",
+          "dev": true
+        },
+        "prelude-ls": {
+          "version": "1.2.1",
+          "dev": true
+        },
+        "punycode": {
+          "version": "2.1.1",
+          "dev": true
+        },
+        "queue-microtask": {
+          "version": "1.2.3",
+          "dev": true
+        },
+        "regexpp": {
+          "version": "3.2.0",
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "4.0.0",
+          "dev": true
+        },
+        "reusify": {
+          "version": "1.0.4",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "run-parallel": {
+          "version": "1.2.0",
+          "dev": true,
+          "requires": {
+            "queue-microtask": "^1.2.2"
+          }
+        },
+        "semver": {
+          "version": "7.3.7",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "dev": true
+        },
+        "slash": {
+          "version": "3.0.0",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "3.1.1",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "dev": true
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "dev": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "dev": true
+        },
+        "tsutils": {
+          "version": "3.21.0",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.8.1"
+          }
+        },
+        "type-check": {
+          "version": "0.4.0",
+          "dev": true,
+          "requires": {
+            "prelude-ls": "^1.2.1"
+          }
+        },
+        "type-fest": {
+          "version": "0.20.2",
+          "dev": true
+        },
         "typescript": {
           "version": "4.6.3",
+          "dev": true
+        },
+        "uri-js": {
+          "version": "4.4.1",
+          "dev": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
+        "v8-compile-cache": {
+          "version": "2.3.0",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "word-wrap": {
+          "version": "1.2.3",
+          "dev": true
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "dev": true
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "dev": true
+        },
+        "yocto-queue": {
+          "version": "0.1.0",
           "dev": true
         }
       }
@@ -2531,7 +4935,7 @@
       }
     },
     "@recogito/recogito-client-core": {
-      "version": "1.6.0",
+      "version": "1.7.4",
       "requires": {
         "core-js": "^3.18.3",
         "fast-deep-equal": "^3.1.3",
@@ -2546,11 +4950,28 @@
       }
     },
     "@recogito/recogito-js": {
-      "version": "1.6.1",
+      "version": "1.7.1",
       "requires": {
-        "@recogito/recogito-client-core": "1.6.0",
+        "@recogito/recogito-client-core": "1.7.1",
         "preact": "^10.5.13",
         "tiny-emitter": "^2.1.0"
+      },
+      "dependencies": {
+        "@recogito/recogito-client-core": {
+          "version": "1.7.1",
+          "requires": {
+            "core-js": "^3.18.3",
+            "fast-deep-equal": "^3.1.3",
+            "node-polyglot": "^2.4.0",
+            "react-autosize-textarea": "^7.1.0",
+            "react-draggable": "^4.4.3",
+            "react-select": "^4.3.1",
+            "react-transition-group": "^4.4.2",
+            "regenerator-runtime": "^0.13.9",
+            "timeago-react": "^3.0.2",
+            "uuid": "^8.3.2"
+          }
+        }
       }
     },
     "@types/json-schema": {
@@ -2558,86 +4979,86 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.17.0",
+      "version": "5.35.1",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.17.0",
-        "@typescript-eslint/type-utils": "5.17.0",
-        "@typescript-eslint/utils": "5.17.0",
-        "debug": "^4.3.2",
+        "@typescript-eslint/scope-manager": "5.35.1",
+        "@typescript-eslint/type-utils": "5.35.1",
+        "@typescript-eslint/utils": "5.35.1",
+        "debug": "^4.3.4",
         "functional-red-black-tree": "^1.0.1",
-        "ignore": "^5.1.8",
+        "ignore": "^5.2.0",
         "regexpp": "^3.2.0",
-        "semver": "^7.3.5",
+        "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.17.0",
+      "version": "5.35.1",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.17.0",
-        "@typescript-eslint/types": "5.17.0",
-        "@typescript-eslint/typescript-estree": "5.17.0",
-        "debug": "^4.3.2"
+        "@typescript-eslint/scope-manager": "5.35.1",
+        "@typescript-eslint/types": "5.35.1",
+        "@typescript-eslint/typescript-estree": "5.35.1",
+        "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.17.0",
+      "version": "5.35.1",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.17.0",
-        "@typescript-eslint/visitor-keys": "5.17.0"
+        "@typescript-eslint/types": "5.35.1",
+        "@typescript-eslint/visitor-keys": "5.35.1"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.17.0",
+      "version": "5.35.1",
       "dev": true,
       "requires": {
-        "@typescript-eslint/utils": "5.17.0",
-        "debug": "^4.3.2",
+        "@typescript-eslint/utils": "5.35.1",
+        "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.17.0",
+      "version": "5.35.1",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.17.0",
+      "version": "5.35.1",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.17.0",
-        "@typescript-eslint/visitor-keys": "5.17.0",
-        "debug": "^4.3.2",
-        "globby": "^11.0.4",
+        "@typescript-eslint/types": "5.35.1",
+        "@typescript-eslint/visitor-keys": "5.35.1",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
         "is-glob": "^4.0.3",
-        "semver": "^7.3.5",
+        "semver": "^7.3.7",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.17.0",
+      "version": "5.35.1",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.17.0",
-        "@typescript-eslint/types": "5.17.0",
-        "@typescript-eslint/typescript-estree": "5.17.0",
+        "@typescript-eslint/scope-manager": "5.35.1",
+        "@typescript-eslint/types": "5.35.1",
+        "@typescript-eslint/typescript-estree": "5.35.1",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.17.0",
+      "version": "5.35.1",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.17.0",
-        "eslint-visitor-keys": "^3.0.0"
+        "@typescript-eslint/types": "5.35.1",
+        "eslint-visitor-keys": "^3.3.0"
       }
     },
     "acorn": {
-      "version": "8.7.0",
+      "version": "8.8.0",
       "dev": true
     },
     "acorn-jsx": {
@@ -2863,33 +5284,34 @@
       }
     },
     "esbuild": {
-      "version": "0.14.29",
+      "version": "0.14.54",
       "dev": true,
       "requires": {
-        "esbuild-android-64": "0.14.29",
-        "esbuild-android-arm64": "0.14.29",
-        "esbuild-darwin-64": "0.14.29",
-        "esbuild-darwin-arm64": "0.14.29",
-        "esbuild-freebsd-64": "0.14.29",
-        "esbuild-freebsd-arm64": "0.14.29",
-        "esbuild-linux-32": "0.14.29",
-        "esbuild-linux-64": "0.14.29",
-        "esbuild-linux-arm": "0.14.29",
-        "esbuild-linux-arm64": "0.14.29",
-        "esbuild-linux-mips64le": "0.14.29",
-        "esbuild-linux-ppc64le": "0.14.29",
-        "esbuild-linux-riscv64": "0.14.29",
-        "esbuild-linux-s390x": "0.14.29",
-        "esbuild-netbsd-64": "0.14.29",
-        "esbuild-openbsd-64": "0.14.29",
-        "esbuild-sunos-64": "0.14.29",
-        "esbuild-windows-32": "0.14.29",
-        "esbuild-windows-64": "0.14.29",
-        "esbuild-windows-arm64": "0.14.29"
+        "@esbuild/linux-loong64": "0.14.54",
+        "esbuild-android-64": "0.14.54",
+        "esbuild-android-arm64": "0.14.54",
+        "esbuild-darwin-64": "0.14.54",
+        "esbuild-darwin-arm64": "0.14.54",
+        "esbuild-freebsd-64": "0.14.54",
+        "esbuild-freebsd-arm64": "0.14.54",
+        "esbuild-linux-32": "0.14.54",
+        "esbuild-linux-64": "0.14.54",
+        "esbuild-linux-arm": "0.14.54",
+        "esbuild-linux-arm64": "0.14.54",
+        "esbuild-linux-mips64le": "0.14.54",
+        "esbuild-linux-ppc64le": "0.14.54",
+        "esbuild-linux-riscv64": "0.14.54",
+        "esbuild-linux-s390x": "0.14.54",
+        "esbuild-netbsd-64": "0.14.54",
+        "esbuild-openbsd-64": "0.14.54",
+        "esbuild-sunos-64": "0.14.54",
+        "esbuild-windows-32": "0.14.54",
+        "esbuild-windows-64": "0.14.54",
+        "esbuild-windows-arm64": "0.14.54"
       }
     },
-    "esbuild-darwin-64": {
-      "version": "0.14.29",
+    "esbuild-darwin-arm64": {
+      "version": "0.14.54",
       "dev": true,
       "optional": true
     },
@@ -2906,11 +5328,13 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.12.0",
+      "version": "8.23.0",
       "dev": true,
       "requires": {
-        "@eslint/eslintrc": "^1.2.1",
-        "@humanwhocodes/config-array": "^0.9.2",
+        "@eslint/eslintrc": "^1.3.1",
+        "@humanwhocodes/config-array": "^0.10.4",
+        "@humanwhocodes/gitignore-to-minimatch": "^1.0.2",
+        "@humanwhocodes/module-importer": "^1.0.1",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -2920,14 +5344,17 @@
         "eslint-scope": "^7.1.1",
         "eslint-utils": "^3.0.0",
         "eslint-visitor-keys": "^3.3.0",
-        "espree": "^9.3.1",
+        "espree": "^9.4.0",
         "esquery": "^1.4.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
         "functional-red-black-tree": "^1.0.1",
         "glob-parent": "^6.0.1",
-        "globals": "^13.6.0",
+        "globals": "^13.15.0",
+        "globby": "^11.1.0",
+        "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
@@ -2936,14 +5363,13 @@
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
         "regexpp": "^3.2.0",
         "strip-ansi": "^6.0.1",
         "strip-json-comments": "^3.1.0",
-        "text-table": "^0.2.0",
-        "v8-compile-cache": "^2.0.3"
+        "text-table": "^0.2.0"
       },
       "dependencies": {
         "eslint-scope": {
@@ -2993,11 +5419,11 @@
       "dev": true
     },
     "espree": {
-      "version": "9.3.1",
+      "version": "9.4.0",
       "dev": true,
       "requires": {
-        "acorn": "^8.7.0",
-        "acorn-jsx": "^5.3.1",
+        "acorn": "^8.8.0",
+        "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^3.3.0"
       }
     },
@@ -3078,6 +5504,14 @@
         "to-regex-range": "^5.0.1"
       }
     },
+    "find-up": {
+      "version": "5.0.0",
+      "dev": true,
+      "requires": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      }
+    },
     "flat-cache": {
       "version": "3.0.4",
       "dev": true,
@@ -3141,7 +5575,7 @@
       }
     },
     "globals": {
-      "version": "13.13.0",
+      "version": "13.17.0",
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"
@@ -3158,6 +5592,10 @@
         "merge2": "^1.4.1",
         "slash": "^3.0.0"
       }
+    },
+    "grapheme-splitter": {
+      "version": "1.0.4",
+      "dev": true
     },
     "has": {
       "version": "1.0.3",
@@ -3344,6 +5782,13 @@
         "computed-style": "~0.1.3"
       }
     },
+    "locate-path": {
+      "version": "6.0.0",
+      "dev": true,
+      "requires": {
+        "p-locate": "^5.0.0"
+      }
+    },
     "lodash.merge": {
       "version": "4.6.2",
       "dev": true
@@ -3450,12 +5895,30 @@
         "word-wrap": "^1.2.3"
       }
     },
+    "p-limit": {
+      "version": "3.1.0",
+      "dev": true,
+      "requires": {
+        "yocto-queue": "^0.1.0"
+      }
+    },
+    "p-locate": {
+      "version": "5.0.0",
+      "dev": true,
+      "requires": {
+        "p-limit": "^3.0.2"
+      }
+    },
     "parent-module": {
       "version": "1.0.1",
       "dev": true,
       "requires": {
         "callsites": "^3.0.0"
       }
+    },
+    "path-exists": {
+      "version": "4.0.0",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -3614,7 +6077,7 @@
       }
     },
     "semver": {
-      "version": "7.3.5",
+      "version": "7.3.7",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
@@ -3758,10 +6221,6 @@
     "uuid": {
       "version": "8.3.2"
     },
-    "v8-compile-cache": {
-      "version": "2.3.0",
-      "dev": true
-    },
     "warning": {
       "version": "4.0.3",
       "requires": {
@@ -3795,6 +6254,10 @@
     },
     "yallist": {
       "version": "4.0.0",
+      "dev": true
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
       "dev": true
     }
   }

--- a/inception/inception-html-recogito-editor/src/main/ts_template/package.json
+++ b/inception/inception-html-recogito-editor/src/main/ts_template/package.json
@@ -13,8 +13,8 @@
   },
   "dependencies": {
     "@inception-project/inception-js-api": "${semver}",
-    "@recogito/recogito-js": "^1.6.0",
-    "@recogito/recogito-client-core": "1.6.0"
+    "@recogito/recogito-js": "^1.7.1",
+    "@recogito/recogito-client-core": "1.7.4"
   },
   "devDependencies": {
     "esbuild": "${esbuild.version}",

--- a/inception/pom.xml
+++ b/inception/pom.xml
@@ -73,10 +73,10 @@
     <uima-json.version>0.4.0</uima-json.version>
 
     <spring.version>5.3.22</spring.version>
-    <spring.boot.version>2.7.2</spring.boot.version>
-    <spring.security.version>5.7.2</spring.security.version>
-    <springdoc.version>1.6.9</springdoc.version>
-    <swagger.version>2.2.1</swagger.version>
+    <spring.boot.version>2.7.3</spring.boot.version>
+    <spring.security.version>5.7.3</spring.security.version>
+    <springdoc.version>1.6.11</springdoc.version>
+    <swagger.version>2.2.2</swagger.version>
 
     <slf4j.version>1.7.36</slf4j.version>
     <log4j2.version>2.18.0</log4j2.version>


### PR DESCRIPTION
**What's in the PR**
- recogito-js 1.6.0 -> 1.7.1
- recogito-client-core 1.6.0 -> 1.7.4
- spring-boot 2.7.2 -> 2.7.3
- spring-security 5.7.2 -> 5.7.3
- springdoc 1.6.9 -> 1.6.11
- swagger 2.2.1 -> 2.2.2
 
**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
