### PR TITLE
#3321 - Fix typos in code and documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-bugfix.md
+++ b/.github/ISSUE_TEMPLATE/release-bugfix.md
@@ -9,7 +9,7 @@ about: Release checklist for feature releases (first or second digit increase)
 
 **Local**
 - [ ] Run Maven release (usually increase second digit of version, not first). Check that the JDK 
-      used to run the release is not newer than the Java version specified in the minium system
+      used to run the release is not newer than the Java version specified in the minimum system
       requirements!
 - [ ] Sign the standalone JAR
 

--- a/.github/ISSUE_TEMPLATE/release-feature.md
+++ b/.github/ISSUE_TEMPLATE/release-feature.md
@@ -9,7 +9,7 @@ about: Release checklist for bug-fix releases (third-digit increase)
 
 **Local**
 - [ ] Run Maven release (increase third digit of version). Check that the JDK 
-      used to run the release is not newer than the Java version specified in the minium system
+      used to run the release is not newer than the Java version specified in the minimum system
       requirements!
 - [ ] Sign the standalone JAR
 

--- a/inception/inception-active-learning/src/main/resources/META-INF/asciidoc/developer-guide/active-learning.adoc
+++ b/inception/inception-active-learning/src/main/resources/META-INF/asciidoc/developer-guide/active-learning.adoc
@@ -19,7 +19,7 @@
 
 The active learning module aims to guide the user through recommendations in such a way that the
 the judgements made by the user are most informative to the recommenders. The goal is to reduce
-the required user interactions to a minium. The module consists of the following classes and
+the required user interactions to a minimum. The module consists of the following classes and
 interfaces:
 
 * The `ActiveLearningService` interface and its default implementation `ActiveLearningServiceImpl`

--- a/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/CasStorageServiceImpl.java
+++ b/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/CasStorageServiceImpl.java
@@ -392,7 +392,7 @@ public class CasStorageServiceImpl
             // cache
             else if (SHARED_READ_ONLY_ACCESS.equals(aAccessMode)) {
                 if (!AUTO_CAS_UPGRADE.equals(aUpgradeMode)) {
-                    throw new IllegalArgumentException("When requsting a shared read-only CAS, the "
+                    throw new IllegalArgumentException("When requesting a shared read-only CAS, the "
                             + "access mode must be " + AUTO_CAS_UPGRADE);
                 }
 

--- a/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/CasStorageSession.java
+++ b/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/CasStorageSession.java
@@ -429,13 +429,13 @@ public class CasStorageSession
             String docId = WebAnnoCasUtil.getDocumentId(aCas);
             String docTitle = WebAnnoCasUtil.getDocumentTitle(aCas);
             throw new WriteAccessNotPermittedException(
-                    "CAS [" + docTitle + "](" + docId + ") not found in current sesssion");
+                    "CAS [" + docTitle + "](" + docId + ") not found in current session");
         }
 
         if (!mCas.map(SessionManagedCas::isWritingPermitted).orElse(false)) {
             throw new WriteAccessNotPermittedException("Write access to CAS for user ["
                     + mCas.get().getUserId() + "] for document [" + mCas.get().getSourceDocumentId()
-                    + "] is not permitted in the current sesssion");
+                    + "] is not permitted in the current session");
         }
     }
 }

--- a/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/driver/filesystem/FileSystemCasStorageDriver.java
+++ b/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/driver/filesystem/FileSystemCasStorageDriver.java
@@ -121,7 +121,7 @@ public class FileSystemCasStorageDriver
         String msgOldExists = "";
         if (oldCasFile.exists()) {
             msgOldExists = String.format(
-                    "Existance of temporary annotation file [%s] indicates that a previous "
+                    "Existence of temporary annotation file [%s] indicates that a previous "
                             + "annotation storage process did not successfully complete. Contact "
                             + "your server administator and request renaming the '%s%s' file "
                             + "to '.ser' manually on the command line. Advise the administrator to "

--- a/inception/inception-annotation-storage/src/test/java/de/tudarmstadt/ukp/inception/annotation/storage/CasStorageServiceImplTest.java
+++ b/inception/inception-annotation-storage/src/test/java/de/tudarmstadt/ukp/inception/annotation/storage/CasStorageServiceImplTest.java
@@ -628,7 +628,7 @@ public class CasStorageServiceImplTest
                     Thread.sleep(50);
                 }
                 catch (FileNotFoundException e) {
-                    // We ignore the FileNotFoundException, this could be hapening if the deleter
+                    // We ignore the FileNotFoundException, this could be happening if the deleter
                     // has just kicked in and would be perfectly normal
                 }
                 catch (Exception e) {

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/coloring/ColoringUtils.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/coloring/ColoringUtils.java
@@ -34,7 +34,7 @@ public class ColoringUtils
     }
 
     /**
-     * Filter out too light colors from the palette - those that do not show propely on a ligth
+     * Filter out too light colors from the palette - those that do not show properly on a light
      * background. The threshold controls what to filter.
      *
      * @param aPalette

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/util/WebAnnoCasUtil.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/util/WebAnnoCasUtil.java
@@ -341,7 +341,7 @@ public class WebAnnoCasUtil
 
         AnnotationFS currentToken = selectAt(aCas, tokenType, aBegin, aEnd).stream().findFirst()
                 .orElse(null);
-        // thid happens when tokens such as Dr. OR Ms. selected with double
+        // this happens when tokens such as Dr. OR Ms. selected with double
         // click, which make seletected text as Dr OR Ms
         if (currentToken == null) {
             currentToken = selectAt(aCas, tokenType, aBegin, aEnd + 1).stream().findFirst()

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/link/LinkFeatureEditor.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/link/LinkFeatureEditor.java
@@ -477,7 +477,7 @@ public class LinkFeatureEditor
             Optional<Tag> optionalTag = annotationService.getTag(id);
 
             // If a tag is missing, ignore it. We do not have foreign-key constraints in
-            // traits, so it is not an unusal situation that a user deletes a tag still
+            // traits, so it is not an unusual situation that a user deletes a tag still
             // referenced in a trait.
             if (optionalTag.isPresent()) {
                 Tag tag = optionalTag.get();

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/RelationAdapter.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/RelationAdapter.java
@@ -147,7 +147,7 @@ public class RelationAdapter
             throw new IllegalPlacementException("Relation must have a source and a target!");
         }
 
-        // Set the relation offsets in DKPro Core style - the relation recieves the offsets from
+        // Set the relation offsets in DKPro Core style - the relation receives the offsets from
         // the dependent
         // If origin and target spans are multiple tokens, dependentFS.getBegin will be the
         // the begin position of the first token and dependentFS.getEnd will be the End

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/RelationCrossSentenceBehavior.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/RelationCrossSentenceBehavior.java
@@ -70,7 +70,7 @@ public class RelationCrossSentenceBehavior
 
         if (!isBeginEndInSameSentence(aRequest.getCas(), aRequest.getOriginFs().getBegin(),
                 aRequest.getTargetFs().getEnd())) {
-            throw new MultipleSentenceCoveredException("Annotation coveres multiple sentences, "
+            throw new MultipleSentenceCoveredException("Annotation covers multiple sentences, "
                     + "limit your annotation to single sentence!");
         }
 
@@ -118,7 +118,7 @@ public class RelationCrossSentenceBehavior
             return emptyList();
         }
 
-        // Prepare feedback messsage list
+        // Prepare feedback message list
         List<Pair<LogMessage, AnnotationFS>> messages = new ArrayList<>();
 
         // Build indexes to allow quickly looking up the sentence by its begin/end offsets. Since

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanCrossSentenceBehavior.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanCrossSentenceBehavior.java
@@ -137,7 +137,7 @@ public class SpanCrossSentenceBehavior
             return emptyList();
         }
 
-        // Prepare feedback messsage list
+        // Prepare feedback message list
         List<Pair<LogMessage, AnnotationFS>> messages = new ArrayList<>();
 
         // Build indexes to allow quickly looking up the sentence by its begin/end offsets. Since

--- a/inception/inception-api-annotation/src/main/resources/META-INF/asciidoc/developer-guide/annotation-schema-feature-support-extensions.adoc
+++ b/inception/inception-api-annotation/src/main/resources/META-INF/asciidoc/developer-guide/annotation-schema-feature-support-extensions.adoc
@@ -13,7 +13,7 @@ It consists of the following classes and interfaces:
   given type of layer.
 
 To add support for a new type of feature, create a Spring component class which implements the
-`FeatureSupport` interface. Note that a single featre support class can handle multiple feature types. 
+`FeatureSupport` interface. Note that a single feature support class can handle multiple feature types.
 However, it is generally recommended to implement a separate layer support for every feature type.
 Implement the following methods:
 

--- a/inception/inception-api-annotation/src/main/resources/META-INF/asciidoc/developer-guide/annotation-schema-layer-behavior-extensions.adoc
+++ b/inception/inception-api-annotation/src/main/resources/META-INF/asciidoc/developer-guide/annotation-schema-layer-behavior-extensions.adoc
@@ -26,7 +26,7 @@ A layer behavior may have any of the following responsibilities:
   relevant method is `onRender`. If an annotation does not conform with the behavior, a error
   marker should be added for problematic annotation. This is done by creating a `VComment`
   which attaches an error message to a specified visual element, then adding that to the
-  repsonse `VDocument`. Note that `onRender` is unlike `onCreate` and `onValidate` in that it
+  response `VDocument`. Note that `onRender` is unlike `onCreate` and `onValidate` in that it
   only has indirect access to the CAS: it is passed a mapping from `AnnotationFS` instances to
   their corresponding visual elements, and can use `.getCAS()` on the FS. The annotation layer
   can be identified from the visual element with `.getLayer().getName()`.

--- a/inception/inception-api-annotation/src/test/resources/3rd-party-tsd/creta-typesystem.xml
+++ b/inception/inception-api-annotation/src/test/resources/3rd-party-tsd/creta-typesystem.xml
@@ -287,7 +287,7 @@ under which filename a CAS is stored.&lt;p&gt;
 &lt;li&gt;&lt;b&gt;document base URI / document URI:&lt;/b&gt; this system identifies a document using
   a URI. The base URI is used to derive the relative path of the document with
   respect to the base location from where it has been read. E.g. if the base
-  URI is &lt;code&gt;file:/texts&lt;/code&gt; and the document URI is &lt;code&gt;file:/texts/english/text1.txt&lt;/code&gt;, then the relativ
+  URI is &lt;code&gt;file:/texts&lt;/code&gt; and the document URI is &lt;code&gt;file:/texts/english/text1.txt&lt;/code&gt;, then the relative
   path of the document is &lt;code&gt;english/text1.txt&lt;/code&gt;. This
   information is used by writers to recreate the directory structure found
   under the base location in the target location.&lt;/li&gt;
@@ -583,7 +583,7 @@ systems.&lt;/p&gt;
                 </featureDescription>
                 <featureDescription>
                     <name>id</name>
-                    <description>If this unit had an ID in the source format from which it was imported, it may be stored here. IDs are typically not assiged by DKPro Core components. If an ID is present, it should be respected by writers.</description>
+                    <description>If this unit had an ID in the source format from which it was imported, it may be stored here. IDs are typically not assigned by DKPro Core components. If an ID is present, it should be respected by writers.</description>
                     <rangeTypeName>uima.cas.String</rangeTypeName>
                 </featureDescription>
             </features>
@@ -639,7 +639,7 @@ systems.&lt;/p&gt;
             <features>
                 <featureDescription>
                     <name>id</name>
-                    <description>If this unit had an ID in the source format from which it was imported, it may be stored here. IDs are typically not assiged by DKPro Core components. If an ID is present, it should be respected by writers.</description>
+                    <description>If this unit had an ID in the source format from which it was imported, it may be stored here. IDs are typically not assigned by DKPro Core components. If an ID is present, it should be respected by writers.</description>
                     <rangeTypeName>uima.cas.String</rangeTypeName>
                 </featureDescription>
             </features>
@@ -706,7 +706,7 @@ systems.&lt;/p&gt;
                 </featureDescription>
                 <featureDescription>
                     <name>id</name>
-                    <description>If this unit had an ID in the source format from which it was imported, it may be stored here. IDs are typically not assiged by DKPro Core components. If an ID is present, it should be respected by writers.</description>
+                    <description>If this unit had an ID in the source format from which it was imported, it may be stored here. IDs are typically not assigned by DKPro Core components. If an ID is present, it should be respected by writers.</description>
                     <rangeTypeName>uima.cas.String</rangeTypeName>
                 </featureDescription>
             </features>

--- a/inception/inception-api-annotation/src/test/resources/3rd-party-tsd/ctakes-type-system-4_0.xml
+++ b/inception/inception-api-annotation/src/test/resources/3rd-party-tsd/ctakes-type-system-4_0.xml
@@ -1023,7 +1023,7 @@ More qualifying information on how the procedure was done.</description>
     </typeDescription>
     <typeDescription>
       <name>org.apache.ctakes.typesystem.type.refsem.Attribute</name>
-      <description>The semantic encapsulation of a modifer.  E.g., for Clinical Elements, Attributes may be used to specify Body Side for a Procedure.</description>
+      <description>The semantic encapsulation of a modifier.  E.g., for Clinical Elements, Attributes may be used to specify Body Side for a Procedure.</description>
       <supertypeName>org.apache.ctakes.typesystem.type.refsem.Element</supertypeName>
     </typeDescription>
     <typeDescription>
@@ -1713,7 +1713,7 @@ This instantiates a manages/treats relation which should be marked as conditiona
         <featureDescription>
           <name>originalText</name>
           <description>The covered text of the span or the disjoint spans that resulted in the creation of this
-              IdentifiedAnnotation. If the covered text is from disjoint spans, they are separated by a delimeter.</description>
+              IdentifiedAnnotation. If the covered text is from disjoint spans, they are separated by a delimiter.</description>
           <rangeTypeName>uima.cas.FSArray</rangeTypeName>
         </featureDescription>
       </features>

--- a/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/selection/Selection.java
+++ b/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/selection/Selection.java
@@ -220,7 +220,7 @@ public class Selection
     /**
      * If an existing annotation is selected, it is returned here. Mind that a selection does not
      * have to point at an existing annotation. It can also point just at a span of text or at the
-     * endpoints of a relation. In this case, the enpoints or begin/end offsets are set, but not the
+     * endpoints of a relation. In this case, the endpoints or begin/end offsets are set, but not the
      * annotation ID.
      * 
      * @return the VID;

--- a/inception/inception-api-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/adapter/TypeUtil.java
+++ b/inception/inception-api-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/adapter/TypeUtil.java
@@ -35,7 +35,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.MultiValueMode;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VObject;
 
 /**
- * Utility Class for {@link TypeAdapter} with static methods such as geting {@link TypeAdapter}
+ * Utility Class for {@link TypeAdapter} with static methods such as getting {@link TypeAdapter}
  * based on its {@link CAS} {@link Type}
  */
 public final class TypeUtil

--- a/inception/inception-bootstrap/src/main/ts/bootstrap/inception-custom.scss
+++ b/inception/inception-bootstrap/src/main/ts/bootstrap/inception-custom.scss
@@ -117,7 +117,7 @@ span.form-control {
   vertical-align: middle !important;
 }
 
-/* Faciliate Wicket modal windows with fixed button bar at the bottom */
+/* Facilitate Wicket modal windows with fixed button bar at the bottom */
 .w_flex .w_content_container { overflow: hidden !important; }
 .w_flex .w_content_container > div { height: 100%; }
 .w_flex .w_flex_container { display: flex; flex-direction: column; height: 100%; }

--- a/inception/inception-brat-editor/src/main/ts/src/annotator_ui/AnnotatorUI.ts
+++ b/inception/inception-brat-editor/src/main/ts/src/annotator_ui/AnnotatorUI.ts
@@ -607,7 +607,7 @@ export class AnnotatorUI {
               activeSelRect.setAttributeNS(null, 'width', rw.toString())
             }
           } else {
-            // We didnt truncate anything but we have moved to a new line so we need to create a new highlight
+            // We didn't truncate anything but we have moved to a new line so we need to create a new highlight
             const lastSel = flip ? this.selRect[0] : this.selRect[this.selRect.length - 1]
             const startBox = (startsAt.parentNode as SVGGraphicsElement).getBBox()
             const endBox = (endsAt.parentNode as SVGGraphicsElement).getBBox()

--- a/inception/inception-brat-editor/src/main/ts/src/visualizer/Chunk.ts
+++ b/inception/inception-brat-editor/src/main/ts/src/visualizer/Chunk.ts
@@ -86,8 +86,8 @@ export class Chunk {
   renderText (svg: Svg, rowTextGroup: SVGTypeMapping<SVGGElement>) {
     svg.plain(this.text)
       .attr({
-        // Storing the exact position in the attributs here is an optimization because that
-        // allows us to obtain the position direcly later without the browser having to actually
+        // Storing the exact position in the attributes here is an optimization because that
+        // allows us to obtain the position directly later without the browser having to actually
         // layout stuff
         x: this.textX,
         y: this.row.textY,

--- a/inception/inception-brat-editor/src/main/ts/src/visualizer/Visualizer.ts
+++ b/inception/inception-brat-editor/src/main/ts/src/visualizer/Visualizer.ts
@@ -101,7 +101,7 @@ function setSourceDataDefaults (sourceData: SourceData) {
     sourceData.sentence_offsets = sentenceSplit(sourceData.text)
   }
 
-  // Similarily we fall back on whitespace tokenisation
+  // Similarly we fall back on whitespace tokenisation
   if (sourceData.token_offsets === undefined) {
     sourceData.token_offsets = tokenise(sourceData.text)
   }
@@ -988,7 +988,7 @@ export class Visualizer {
   }
 
   /**
-   * Populates the "data" field based on the "sourceData" JSON that we recieved from the server.
+   * Populates the "data" field based on the "sourceData" JSON that we received from the server.
    */
   setData (sourceData: SourceData) {
     this.sourceData = sourceData

--- a/inception/inception-brat-editor/src/test/java/de/tudarmstadt/ukp/clarin/webanno/brat/message/GetCollectionInformationResponseTest.java
+++ b/inception/inception-brat-editor/src/test/java/de/tudarmstadt/ukp/clarin/webanno/brat/message/GetCollectionInformationResponseTest.java
@@ -36,7 +36,7 @@ import de.tudarmstadt.ukp.clarin.webanno.support.WebAnnoConst;
 public class GetCollectionInformationResponseTest
 {
     /**
-     * generate BRAT JSON for the collection informations
+     * generate BRAT JSON for the collection information
      *
      * @throws IOException
      *             if an I/O error occurs.

--- a/inception/inception-constraints/src/main/java/de/tudarmstadt/ukp/clarin/webanno/constraints/model/Scope.java
+++ b/inception/inception-constraints/src/main/java/de/tudarmstadt/ukp/clarin/webanno/constraints/model/Scope.java
@@ -21,7 +21,7 @@ import java.io.Serializable;
 import java.util.List;
 
 /**
- * Class representating "Scope" (name) and list of "Rules" for a particular "Scope".
+ * Class representing "Scope" (name) and list of "Rules" for a particular "Scope".
  */
 public class Scope
     implements Serializable

--- a/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/CasDiff.java
+++ b/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/CasDiff.java
@@ -1331,7 +1331,7 @@ public class CasDiff
     // /**
     // * Rebuilds the diff with the current offsets and entry types. This can be used to fix the
     // diff
-    // * after reattaching to CASes that have changed. Mind that the diff results can be differnent
+    // * after reattaching to CASes that have changed. Mind that the diff results can be different
     // * due to the changes.
     // */
     // public void rebuild()

--- a/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/merge/AlreadyMergedException.java
+++ b/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/merge/AlreadyMergedException.java
@@ -20,7 +20,7 @@ package de.tudarmstadt.ukp.inception.curation.merge;
 import de.tudarmstadt.ukp.inception.schema.adapter.AnnotationException;
 
 /**
- * Indiates that a merge operation could not be performed because the annotation had already been
+ * Indicates that a merge operation could not be performed because the annotation had already been
  * merged before.
  */
 public class AlreadyMergedException

--- a/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/merge/MergeConflictException.java
+++ b/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/merge/MergeConflictException.java
@@ -20,7 +20,7 @@ package de.tudarmstadt.ukp.inception.curation.merge;
 import de.tudarmstadt.ukp.inception.schema.adapter.AnnotationException;
 
 /**
- * Indiates that a merge operation could not be performed because there was a conflict, e.g. because
+ * Indicates that a merge operation could not be performed because there was a conflict, e.g. because
  * the target CAS already contains a conflicting annotation at the same location.
  */
 public class MergeConflictException

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/DiamAjaxBehavior.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/DiamAjaxBehavior.java
@@ -58,7 +58,7 @@ public class DiamAjaxBehavior
     @Override
     protected void respond(AjaxRequestTarget aTarget)
     {
-        LOG.trace("AJAX request recieved");
+        LOG.trace("AJAX request received");
 
         Request request = RequestCycle.get().getRequest();
 

--- a/inception/inception-diam/src/test/java/de/tudarmstadt/ukp/inception/diam/service/DiamWebsocketController_ViewportRoutingTest.java
+++ b/inception/inception-diam/src/test/java/de/tudarmstadt/ukp/inception/diam/service/DiamWebsocketController_ViewportRoutingTest.java
@@ -259,7 +259,7 @@ public class DiamWebsocketController_ViewportRoutingTest
         private final CountDownLatch initDoneLatch;
         private final ViewportDefinition vpd;
 
-        private final List<String> recieved = new ArrayList<>();
+        private final List<String> received = new ArrayList<>();
 
         public SessionHandler(CountDownLatch aSubscriptionDoneLatch, CountDownLatch aInitDoneLatch,
                 ViewportDefinition aVpd)
@@ -287,12 +287,12 @@ public class DiamWebsocketController_ViewportRoutingTest
 
         public void onUpdate(StompHeaders aHeaders, MViewportUpdate aPayload)
         {
-            recieved.add(aPayload.getBegin() + "-" + aPayload.getEnd());
+            received.add(aPayload.getBegin() + "-" + aPayload.getEnd());
         }
 
         public List<String> getRecieved()
         {
-            return recieved;
+            return received;
         }
     }
 

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/developer-guide/release.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/developer-guide/release.adoc
@@ -122,7 +122,7 @@ Also, your user needs to have push rights to the `inceptionproject` Dockerhub gr
 If you have just made a release, change to `target/checkout/inception-docker`. Otherwise check out the release
 tag e.g. via `git checkout tags/inception-app-0.18.0`. 
 Make sure that in the top-level POM, the version is set to a release version (no snapshot suffix).
-Then go to the `inception-docker` module folder and there run the following commmands:
+Then go to the `inception-docker` module folder and there run the following commands:
 
 [source,xml]
 ----

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/docinfo.html
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/docinfo.html
@@ -4,7 +4,7 @@
 <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.tocify/1.9.0/javascripts/jquery.tocify.min.js"></script>
 
-<!-- We do not need the tocify CSS because the asciidoc CSS already provides most of what we neeed -->
+<!-- We do not need the tocify CSS because the asciidoc CSS already provides most of what we need -->
 
 <style>
   .tocify-header {

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/user-guide/formats-uimaxmi.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/user-guide/formats-uimaxmi.adoc
@@ -27,7 +27,7 @@ the world of XML parsers, so you may expect better interoperability with other p
 (e.g. Python) with the XML 1.0 flavor. XML 1.1 has a support for a wider range of characters, despite 
 dating back to 2006, it is still not supported by all XML parsers.
 
-The format can be processed in Java usind the link:https://github.com/apache/uima-uimaj#readme[Apache UIMA Java SDK] (both flavors) or in Python using link:https://pypi.org/project/dkpro-cassis/[DKPro Cassis] (only the XMI 1.0 flavor).
+The format can be processed in Java using the link:https://github.com/apache/uima-uimaj#readme[Apache UIMA Java SDK] (both flavors) or in Python using link:https://pypi.org/project/dkpro-cassis/[DKPro Cassis] (only the XMI 1.0 flavor).
 
 [cols="2,1,1,1,3"]
 |====

--- a/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/DocumentServiceImpl.java
+++ b/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/DocumentServiceImpl.java
@@ -539,7 +539,7 @@ public class DocumentServiceImpl
     @Override
     public List<AnnotationDocument> listFinishedAnnotationDocuments(SourceDocument aDocument)
     {
-        Validate.notNull(aDocument, "Source cocument must be specified");
+        Validate.notNull(aDocument, "Source document must be specified");
 
         // Get all annotators in the project
         List<String> users = getAllAnnotators(aDocument.getProject());

--- a/inception/inception-documents/src/main/resources/tagsets/en-dep-sd.json
+++ b/inception/inception-documents/src/main/resources/tagsets/en-dep-sd.json
@@ -149,7 +149,7 @@
     "tag_description" : "open clausal complement\r\nAn open clausal complement (xcomp) of a VP or an ADJP is a clausal complement without its own subject, whose reference is determined by an external subject. These complements are always non-finite. The name xcomp is borrowed from Lexical-Functional Grammar.\r\n“He says that you like to swim” xcomp(like, swim)\r\n“I am ready to leave” xcomp(ready, leave)"
   }, {
     "tag_name" : "xsubj",
-    "tag_description" : "controlling subject\r\nA controlling subject is the relation between the head of a open clausal complement (xcomp) and the external subject of that clause. This is an additional dependency, not a basic depedency.\r\n“Tom likes to eat fish” xsubj(eat, Tom)"
+    "tag_description" : "controlling subject\r\nA controlling subject is the relation between the head of a open clausal complement (xcomp) and the external subject of that clause. This is an additional dependency, not a basic dependency.\r\n“Tom likes to eat fish” xsubj(eat, Tom)"
   } ],
   "create_tag" : false
 }

--- a/inception/inception-documents/src/main/resources/tagsets/en-pos-ptb-tt.json
+++ b/inception/inception-documents/src/main/resources/tagsets/en-pos-ptb-tt.json
@@ -59,7 +59,7 @@
     "tag_description" : "list item marker\nExamples:  "
   }, {
     "tag_name" : "MD",
-    "tag_description" : "verb, modal auxillary\nExamples: may, should"
+    "tag_description" : "verb, modal auxiliary\nExamples: may, should"
   }, {
     "tag_name" : "NN",
     "tag_description" : "noun, singular or mass\nExamples: tiger, chair, laughter"

--- a/inception/inception-external-search-elastic/src/main/resources/META-INF/asciidoc/user-guide/external-search-repos-elasticsearch.adoc
+++ b/inception/inception-external-search-elastic/src/main/resources/META-INF/asciidoc/user-guide/external-search-repos-elasticsearch.adoc
@@ -114,4 +114,4 @@ $ docker run -p 9090:8080 cars10/elasticvue
 15. Enter `document` into the search field and press the *Search* button
 16. You should get result for the document you posted to the ElasticSearch index in step 8
 17. Click on *Import*
-18. The import button should change to *Open* now - click on it to open the documen in the annotation editor
+18. The import button should change to *Open* now - click on it to open the document in the annotation editor

--- a/inception/inception-external-search-solr/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/solr/SolrSearchProvider.java
+++ b/inception/inception-external-search-solr/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/solr/SolrSearchProvider.java
@@ -177,7 +177,7 @@ public class SolrSearchProvider
      * Convert data from SolrDocument to ExternalSearchResult
      * 
      * @param result
-     *            result has just the id complete before the methode
+     *            result has just the id complete before the method
      * @param document
      *            contain all the information about the document
      * @param aTraits
@@ -343,7 +343,7 @@ public class SolrSearchProvider
     }
 
     /**
-     * Escape special characters for standard query parser. Usefull when retrieving document with an
+     * Escape special characters for standard query parser. Useful when retrieving document with an
      * id that contain such of those characters
      * 
      * @param query

--- a/inception/inception-html-editor/src/main/ts/annotatorjs/src/annotator.ts
+++ b/inception/inception-html-editor/src/main/ts/annotatorjs/src/annotator.ts
@@ -348,7 +348,7 @@ export class Annotator extends Delegator {
 
   // Public: Initialises an annotation either from an object representation or
   // an annotation created with Annotator#createAnnotation(). It finds the
-  // selected range and higlights the selection in the DOM.
+  // selected range and highlights the selection in the DOM.
   //
   // annotation - An annotation Object to initialise.
   //
@@ -360,7 +360,7 @@ export class Annotator extends Delegator {
   //   # annotation has now been assigned the currently selected range
   //   # and a highlight appended to the DOM.
   //
-  //   # Add an existing annotation that has been stored elsewere to the DOM.
+  //   # Add an existing annotation that has been stored elsewhere to the DOM.
   //   annotation = getStoredAnnotationWithSerializedRanges()
   //   annotation = annotator.setupAnnotation(annotation)
   //

--- a/inception/inception-html-editor/src/main/ts/annotatorjs/src/class.ts
+++ b/inception/inception-html-editor/src/main/ts/annotatorjs/src/class.ts
@@ -96,7 +96,7 @@ export class Delegator {
   //   # This will bind the updateAnnotationStore() method to the custom
   //   # annotation:save event. NOTE: Because this is a custom event the
   //   # Delegator#subscribe() method will be used and updateAnnotationStore()
-  //   # will not recieve an event parameter like the previous two examples.
+  //   # will not receive an event parameter like the previous two examples.
   //   @options = {"annotation:save": "updateAnnotationStore"}
   //
   // Returns nothing.
@@ -122,7 +122,7 @@ export class Delegator {
   // can be provided in order to watch for events on a child element.
   //
   // The event can be any standard event supported by jQuery or a custom String.
-  // If a custom string is used the callback function will not recieve an
+  // If a custom string is used the callback function will not receive an
   // event object as it's first parameter.
   //
   // selector     - Selector String matching child elements. (default: '')
@@ -205,8 +205,8 @@ export class Delegator {
 
   // Public: Listens for custom event which when published will call the provided
   // callback. This is essentially a wrapper around @element.bind() but removes
-  // the event parameter that jQuery event callbacks always recieve. These
-  // parameters are unnessecary for custom events.
+  // the event parameter that jQuery event callbacks always receive. These
+  // parameters are unnecessary for custom events.
   //
   // event    - A String event name.
   // callback - A callback function called when the event is published.
@@ -275,7 +275,7 @@ export function _parseEvents(eventsObj: { [x: string]: any; }) {
 };
 
 
-// Native jQuery events that should recieve an event object. Plugins can
+// Native jQuery events that should receive an event object. Plugins can
 // add their own methods to this if required.
 Delegator.natives = (function () {
   const specials = ((() => {

--- a/inception/inception-html-editor/src/main/ts/annotatorjs/src/editor.ts
+++ b/inception/inception-html-editor/src/main/ts/annotatorjs/src/editor.ts
@@ -170,7 +170,7 @@ export class Editor extends Widget {
   //
   // Examples
   //
-  //   # Diplays the editor with the annotation loaded.
+  //   # Displays the editor with the annotation loaded.
   //   editor.load({text: 'My Annotation'})
   //
   //   editor.on('load', (annotation) ->
@@ -226,22 +226,22 @@ export class Editor extends Widget {
     return this.hide();
   }
 
-  // Public: Adds an addional form field to the editor. Callbacks can be provided
+  // Public: Adds an additional form field to the editor. Callbacks can be provided
   // to update the view and anotations on load and submission.
   //
   // options - An options Object. Options are as follows:
   //           id     - A unique id for the form element will also be set as the
-  //                    "for" attrubute of a label if there is one. Defaults to
+  //                    "for" attribute of a label if there is one. Defaults to
   //                    a timestamp. (default: "annotator-field-{timestamp}")
   //           type   - Input type String. One of "input", "textarea",
   //                    "checkbox", "select" (default: "input")
   //           label  - Label to display either in a label Element or as place-
   //                    holder text depending on the type. (default: "")
   //           load   - Callback Function called when the editor is loaded with a
-  //                    new annotation. Recieves the field <li> element and the
+  //                    new annotation. Receives the field <li> element and the
   //                    annotation to be loaded.
   //           submit - Callback Function called when the editor is submitted.
-  //                    Recieves the field <li> element and the annotation to be
+  //                    Receives the field <li> element and the annotation to be
   //                    updated.
   //
   // Examples

--- a/inception/inception-html-editor/src/main/ts/annotatorjs/src/range.ts
+++ b/inception/inception-html-editor/src/main/ts/annotatorjs/src/range.ts
@@ -327,7 +327,7 @@ export class NormalizedRange {
   }
 
   // Public: Limits the nodes within the NormalizedRange to those contained
-  // withing the bounds parameter. It returns an updated range with all
+  // within the bounds parameter. It returns an updated range with all
   // properties updated. NOTE: Method returns null if all nodes fall outside
   // of the bounds.
   //

--- a/inception/inception-html-editor/src/main/ts/annotatorjs/src/util.ts
+++ b/inception/inception-html-editor/src/main/ts/annotatorjs/src/util.ts
@@ -202,7 +202,7 @@ export function mousePosition(e: { pageY: number; pageX: number; }, offsetEl: an
 // default method. If it does it calls it.
 //
 // This is useful for methods that can be optionally used as callbacks
-// where the existance of the parameter must be checked before calling.
+// where the existence of the parameter must be checked before calling.
 export const preventEventDefault = (event: any) => __guardMethod__(event, 'preventDefault', (o: { preventDefault: () => any; }) => o.preventDefault());
 
 function __guard__(value: any, transform: { (x: any): any; (arg0: any): any; }) {

--- a/inception/inception-html-editor/src/main/ts/annotatorjs/src/viewer.ts
+++ b/inception/inception-html-editor/src/main/ts/annotatorjs/src/viewer.ts
@@ -173,7 +173,7 @@ export class Viewer extends Widget {
   //
   //   viewer.load([annotation1, annotation2, annotation3])
   //
-  // Returns itslef.
+  // Returns itself.
   load(annotations: {}) {
     this.annotations = annotations || [];
 
@@ -221,12 +221,12 @@ export class Viewer extends Widget {
     return this.show();
   }
 
-  // Public: Adds an addional field to an annotation view. A callback can be
+  // Public: Adds an additional field to an annotation view. A callback can be
   // provided to update the view on load.
   //
   // options - An options Object. Options are as follows:
   //           load - Callback Function called when the view is loaded with an
-  //                  annotation. Recieves a newly created clone of @item and
+  //                  annotation. Receives a newly created clone of @item and
   //                  the annotation to be displayed (it will be called once
   //                  for each annotation being loaded).
   //

--- a/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/v1/ExternalRecommender.java
+++ b/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/v1/ExternalRecommender.java
@@ -204,7 +204,7 @@ public class ExternalRecommender
             return out.toString();
         }
         catch (CASRuntimeException | SAXException | IOException e) {
-            throw new RecommendationException("Coud not serialize type system", e);
+            throw new RecommendationException("Could not serialize type system", e);
         }
     }
 

--- a/inception/inception-io-webanno-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebannoTsv1Reader.java
+++ b/inception/inception-io-webanno-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebannoTsv1Reader.java
@@ -219,7 +219,7 @@ public class WebannoTsv1Reader
      * The Second column is the token <br>
      * The third column is the lemma annotation <br>
      * The fourth column is the POS annotation <br>
-     * The fifth column is used for Named Entity annotations (Multiple annotations separeted by |
+     * The fifth column is used for Named Entity annotations (Multiple annotations separated by |
      * character) <br>
      * The sixth column is the origin token number of dependency parsing <br>
      * The seventh column is the function/type of the dependency parsing <br>

--- a/inception/inception-kb-fact-linking/src/main/java/de/tudarmstadt/ukp/inception/kb/factlinking/feature/QualifierFeatureEditor.java
+++ b/inception/inception-kb-fact-linking/src/main/java/de/tudarmstadt/ukp/inception/kb/factlinking/feature/QualifierFeatureEditor.java
@@ -362,7 +362,7 @@ public class QualifierFeatureEditor
 
                 // Save the CAS. This must be done explicitly here since the KBItem dropdown
                 // is not the focus-component of this editor. In fact, there could be multiple
-                // KBItem dropdowns in this feature editor since we can have multilpe modifiers.
+                // KBItem dropdowns in this feature editor since we can have multiple modifiers.
                 // For focus-components, the AnnotationFeatureForm already handles adding the
                 // saving behavior.
                 actionHandler.actionCreateOrUpdate(

--- a/inception/inception-kb-fact-linking/src/main/resources/META-INF/asciidoc/user-guide/annotation_fact-extraction.adoc
+++ b/inception/inception-kb-fact-linking/src/main/resources/META-INF/asciidoc/user-guide/annotation_fact-extraction.adoc
@@ -19,7 +19,7 @@ and a dialogue box shows as in the figure below.
 image::factExtraction1.png[align="center"]
 
 To create a local knowledge base, one needs to choose *Local* for the type. For the reification,
-*NONE* is the defaut case, but one cannot add or view qualifiers in the knowledge base with *NONE*.
+*NONE* is the default case, but one cannot add or view qualifiers in the knowledge base with *NONE*.
 So, to support qualifiers, one needs to choose *WIKIDATA* for the Reification. One can then follow
 the wizard to finish the setting.
 
@@ -35,7 +35,7 @@ enter _1988_ for this qualifier value, and click *√* to save this qualifier.
 
 image::factExtraction3.png[align="center"]
 
-One can click the pencil icon on the same line as this qualifer to edit and delete this qualifier.
+One can click the pencil icon on the same line as this qualifier to edit and delete this qualifier.
 
 == Linking a fact in the annotation page
 Assuming the project contains documents for annotation, one can now switch to the annotation page

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplIntegrationTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplIntegrationTest.java
@@ -684,7 +684,7 @@ public class KnowledgeBaseServiceImplIntegrationTest
         sut.registerKnowledgeBase(kb, sut.getNativeConfig());
 
         assertThatCode(() -> sut.deleteConcept(kb, concept))
-                .as("Check that deleting non-existant concept does nothing")
+                .as("Check that deleting non-existent concept does nothing")
                 .doesNotThrowAnyException();
     }
 
@@ -1004,7 +1004,7 @@ public class KnowledgeBaseServiceImplIntegrationTest
         sut.registerKnowledgeBase(kb, sut.getNativeConfig());
 
         assertThatCode(() -> sut.deleteProperty(kb, property))
-                .as("Check that deleting non-existant property does nothing")
+                .as("Check that deleting non-existent property does nothing")
                 .doesNotThrowAnyException();
     }
 
@@ -1336,7 +1336,7 @@ public class KnowledgeBaseServiceImplIntegrationTest
         sut.registerKnowledgeBase(kb, sut.getNativeConfig());
 
         assertThatCode(() -> sut.deleteInstance(kb, instance))
-                .as("Check that deleting non-existant instance does nothing")
+                .as("Check that deleting non-existent instance does nothing")
                 .doesNotThrowAnyException();
     }
 

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceRemoteTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceRemoteTest.java
@@ -163,7 +163,7 @@ public class KnowledgeBaseServiceRemoteTest
                 .isNotEmpty();
         for (String expectedRoot : aSutConfig.getRootIdentifier()) {
             assertThat(rootConceptKBHandle.stream().map(KBHandle::getIdentifier))
-                    .as("Check that root concept is retreived").contains(expectedRoot);
+                    .as("Check that root concept is retrieved").contains(expectedRoot);
         }
     }
 
@@ -363,7 +363,7 @@ public class KnowledgeBaseServiceRemoteTest
                             "http://zbw.eu/stw/thsys/71020", rootConcepts, parentChildConcepts));
         }
 
-        // Commenting this out for the moment becuase we expect that every ontology contains
+        // Commenting this out for the moment because we expect that every ontology contains
         // property definitions. However, this one does not include any property definitions!
         // {
         // KnowledgeBaseProfile profile = PROFILES.get("zbw-gnd");

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseSubPropertyLabelTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseSubPropertyLabelTest.java
@@ -131,7 +131,7 @@ public class KnowledgeBaseSubPropertyLabelTest
 
         assertThat(instanceKBHandle).as("Check that instance list is not empty").isNotEmpty();
         assertThat(instanceKBHandle.stream().map(KBHandle::getName))
-                .as("Check that child concept is retreived").contains("Abele, Familie");
+                .as("Check that child concept is retrieved").contains("Abele, Familie");
     }
 
     @Disabled("#1522 - GND tests not running")

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderTest.java
@@ -1767,7 +1767,7 @@ public class SPARQLQueryBuilderTest
         // Detect the file format
         RDFFormat format = Rio.getParserFormatForFileName(aFilename).orElse(RDFXML);
 
-        System.out.printf("Loading %s data fron %s%n", format, aFilename);
+        System.out.printf("Loading %s data from %s%n", format, aFilename);
 
         // Load files into the repository
         try (InputStream is = new FileInputStream(aFilename)) {

--- a/inception/inception-kb/src/test/resources/data/wildlife_ontology.ttl
+++ b/inception/inception-kb/src/test/resources/data/wildlife_ontology.ttl
@@ -237,7 +237,7 @@ wo:EcosystemRole  a      owl:Class ;
         vs:term_status   "testing" .
 
 wo:Phylum  a             owl:Class ;
-        rdfs:comment     "A phylum - also known as a division when referring to plants - is a scientfic way of grouping together related organisms. All the members of a phylum have a common ancestor and anatomical similarities. For instance, all the arthropods have external skeletons. Phlya are large groups and are further subdivided into classes, orders, families and so on."@en-gb ;
+        rdfs:comment     "A phylum - also known as a division when referring to plants - is a scientific way of grouping together related organisms. All the members of a phylum have a common ancestor and anatomical similarities. For instance, all the arthropods have external skeletons. Phlya are large groups and are further subdivided into classes, orders, families and so on."@en-gb ;
         rdfs:isDefinedBy wo:; rdfs:label       "Phylum"@en-gb ;
         rdfs:seeAlso     <http://www.bbc.co.uk/nature/phylum> , <http://en.wikipedia.org/wiki/Phylum> ;
         rdfs:subClassOf  wo:TaxonRank ;

--- a/inception/inception-kb/src/test/resources/upstream-data/1.1.ttl
+++ b/inception/inception-kb/src/test/resources/upstream-data/1.1.ttl
@@ -237,7 +237,7 @@ wo:EcosystemRole  a      owl:Class ;
         vs:term_status   "testing" .
 
 wo:Phylum  a             owl:Class ;
-        rdfs:comment     "A phylum - also known as a division when referring to plants - is a scientfic way of grouping together related organisms. All the members of a phylum have a common ancestor and anatomical similarities. For instance, all the arthropods have external skeletons. Phlya are large groups and are further subdivided into classes, orders, families and so on."@en-gb ;
+        rdfs:comment     "A phylum - also known as a division when referring to plants - is a scientific way of grouping together related organisms. All the members of a phylum have a common ancestor and anatomical similarities. For instance, all the arthropods have external skeletons. Phlya are large groups and are further subdivided into classes, orders, families and so on."@en-gb ;
         rdfs:isDefinedBy wo:; rdfs:label       "Phylum"@en-gb ;
         rdfs:seeAlso     <http://www.bbc.co.uk/nature/phylum> , <http://en.wikipedia.org/wiki/Phylum> ;
         rdfs:subClassOf  wo:TaxonRank ;

--- a/inception/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/PdfAnnotationEditor.java
+++ b/inception/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/PdfAnnotationEditor.java
@@ -292,7 +292,7 @@ public class PdfAnnotationEditor
                 getAnnotations(aTarget, aParams);
                 break;
             default:
-                handleError("Unkown action: " + action, aTarget);
+                handleError("Unknown action: " + action, aTarget);
             }
         }
         catch (IOException e) {

--- a/inception/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/pdfanno/model/PdfExtractFile.java
+++ b/inception/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/pdfanno/model/PdfExtractFile.java
@@ -138,7 +138,7 @@ public class PdfExtractFile
         stringToSanitizedSequence = new HashMap<>();
         sanitizedToStringSequence = new HashMap<>();
 
-        // build Aho-Corasick Trie to search for ligature occurences and replace them
+        // build Aho-Corasick Trie to search for ligature occurrences and replace them
         Trie.TrieBuilder trieBuilder = Trie.builder();
         substitutionTable.keySet().forEach(key -> trieBuilder.addKeyword(key));
         Trie trie = trieBuilder.build();

--- a/inception/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/pdfanno/render/PdfAnnoSerializer.java
+++ b/inception/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/pdfanno/render/PdfAnnoSerializer.java
@@ -106,7 +106,7 @@ public class PdfAnnoSerializer
         do {
             // add context before and after each span
             addContextToSpans(spans, windowSize, aDocumentText);
-            // find occurences by using Aho-Corasick algorithm
+            // find occurrences by using Aho-Corasick algorithm
             Map<String, List<Emit>> occurrenceMap = findOccurrences(spans,
                     aPdfExtractFile.getSanitizedContent());
 
@@ -220,19 +220,19 @@ public class PdfAnnoSerializer
         do {
             // add context before and after each span
             addContextToSpans(iterList, windowSize, aPdfExtractFile.getSanitizedContent());
-            // find occurences by using Aho-Corasick algorithm
+            // find occurrences by using Aho-Corasick algorithm
             Map<String, List<Emit>> occurrenceMap = findOccurrences(iterList,
                     aDocumentModel.getWhitespacelessText());
 
             for (RenderSpan renderSpan : iterList) {
-                List<Emit> occurences = occurrenceMap.get(renderSpan.getTextWithWindow());
-                if (occurences == null || occurences.size() == 0) {
+                List<Emit> occurrences = occurrenceMap.get(renderSpan.getTextWithWindow());
+                if (occurrences == null || occurrences.size() == 0) {
                     // if occurrence list is null or empty, no match was found
                     processed.add(new Offset(-1, -1));
                 }
-                else if (occurences.size() == 1) {
+                else if (occurrences.size() == 1) {
                     // if one occurrence was found produce Offset
-                    Emit emit = occurences.get(0);
+                    Emit emit = occurrences.get(0);
                     int begin = aDocumentModel.getDocumentIndex(
                             emit.getStart() + renderSpan.getWindowBeforeText().length());
                     int end = aDocumentModel.getDocumentIndex(

--- a/inception/inception-pdf-editor/src/main/ts/src/pdfanno/core/src/UI/span.ts
+++ b/inception/inception-pdf-editor/src/main/ts/src/pdfanno/core/src/UI/span.ts
@@ -22,7 +22,7 @@ function mergeRects (rects) {
     return rect
   })
 
-  // a virtical margin of error.
+  // a vertical margin of error.
   const error = 5 * scale()
 
   let tmp = convertToObject(rects[0])

--- a/inception/inception-pdf-editor/src/main/ts/src/pdfanno/core/src/render/renderKnob.ts
+++ b/inception/inception-pdf-editor/src/main/ts/src/pdfanno/core/src/render/renderKnob.ts
@@ -26,7 +26,7 @@ export function renderKnob ({ x, y, readOnly, text, color }): HTMLElement {
 }
 
 /**
- * Adjust the circle position not overlay anothers.
+ * Adjust the circle position not overlay another.
  */
 function adjustPoint (x, y, radius) {
   // Get all knobs.

--- a/inception/inception-pdf-editor/src/main/ts/src/pdfanno/page/textLayer.ts
+++ b/inception/inception-pdf-editor/src/main/ts/src/pdfanno/page/textLayer.ts
@@ -130,7 +130,7 @@ export function getGlyphsInRange (pageNum: number, startPosition: number, endPos
     var last = data
     const { position } = data
 
-    // if zero-width spans are allowed interprete ranges different from PDFAnno default
+    // if zero-width spans are allowed interpret ranges different from PDFAnno default
     // [3,3] is zero-width, [3,4] is one character
     if (allowZeroWidth) {
       if (startPosition === endPosition && startPosition === position) {
@@ -150,7 +150,7 @@ export function getGlyphsInRange (pageNum: number, startPosition: number, endPos
       }
 
       if (last.position < data.position) last = data
-      // if zero-width spans are not allowed interprete ranges as PDFAnno does usually
+      // if zero-width spans are not allowed interpret ranges as PDFAnno does usually
       // [3,3] is one character, [3,4] are two characters
     } else {
       if (startPosition <= position) {

--- a/inception/inception-pdf-editor/src/test/java/de/tudarmstadt/ukp/inception/pdfeditor/pdfanno/model/PdfAnnoRendererTest.java
+++ b/inception/inception-pdf-editor/src/test/java/de/tudarmstadt/ukp/inception/pdfeditor/pdfanno/model/PdfAnnoRendererTest.java
@@ -239,7 +239,7 @@ public class PdfAnnoRendererTest
         offsets.add(new Offset(28, 28));
         offsets.add(new Offset(28, 30));
         offsets.add(new Offset(35, 38));
-        // convert to offests for document in INCEpTION
+        // convert to offsets for document in INCEpTION
         List<Offset> docOffsets = PdfAnnoSerializer.convertToDocumentOffsets(offsets, documentModel,
                 pdfExtractFile);
         List<Offset> expectedOffsets = new ArrayList<>();

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/UI/span.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/UI/span.ts
@@ -16,7 +16,7 @@ export function mergeRects (glyphs: VGlyph[]) {
     return []
   }
 
-  // a virtical margin of error.
+  // a vertical margin of error.
   const error = 5 * scale()
 
   let tmp = new Rectangle(glyphs[0].bbox)

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/render/renderKnob.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/render/renderKnob.ts
@@ -29,7 +29,7 @@ export function renderKnob ({ a, x, y, readOnly, text }): HTMLElement {
 }
 
 /**
- * Adjust the circle position not overlay anothers.
+ * Adjust the circle position not overlay another.
  */
 function adjustPoint (x, y, radius) {
   // Get all knobs.

--- a/inception/inception-project-initializers-doclabeling/src/main/java/de/tudarmstadt/ukp/inception/project/initializers/doclabeling/BasicDocumentLabelingProjectInitializer.java
+++ b/inception/inception-project-initializers-doclabeling/src/main/java/de/tudarmstadt/ukp/inception/project/initializers/doclabeling/BasicDocumentLabelingProjectInitializer.java
@@ -91,7 +91,7 @@ public class BasicDocumentLabelingProjectInitializer
                 "", //
                 "This project has been pre-configured for document labeling tasks.", //
                 "", //
-                "When you open a document, the document-level annotation sidebar is direclty", //
+                "When you open a document, the document-level annotation sidebar is directly", //
                 "visible and offers a single-choice list to choose between some example labels.", //
                 "You can change the labels **Tag sets** pane of the project settings.", //
                 "Depending on how many tags you add or whether you allow annotators to add tags, ", //

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
@@ -1700,7 +1700,7 @@ public class RecommendationServiceImpl
                 }
                 default:
                     throw new IllegalStateException(
-                            "Unsupport layer type [" + layer.getType() + "]");
+                            "Unsupported layer type [" + layer.getType() + "]");
                 }
 
                 result.add(suggestion);

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/util/OverlapIterator.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/util/OverlapIterator.java
@@ -68,7 +68,7 @@ public class OverlapIterator
     {
         done = !((aList.size() > 0) && (bList.size() > 0));
 
-        // Intialize A
+        // Initialize A
         la = aList;
         maxa = la.size() - 1; // Up until here and no further
         ia = la.listIterator(); // Where we are now

--- a/inception/inception-recommendation/src/main/resources/META-INF/asciidoc/user-guide/annotation_recommendation.adoc
+++ b/inception/inception-recommendation/src/main/resources/META-INF/asciidoc/user-guide/annotation_recommendation.adoc
@@ -38,18 +38,18 @@ appear left and right of the suggestion marker as the mouse hovers over the mark
 
 == Recommender Sidebar
 
-Clicking the chart icon in the left sidebar tray opens the recommendation sidebar which provides access to serveral functionalities:
+Clicking the chart icon in the left sidebar tray opens the recommendation sidebar which provides access to several functionalities:
 
 image::recommender_sidebar.png[align="center"]
 
 View the state of the configured recommenders ::
   The icon in the top-right corner of the info box indicates the state of the recommender, e.g. if it is active, inactive, or if information on the recommender state is not yet available due to no self-evaluation or train/predict run having been completed yet.
 View the self-evaluation results of the recommenders ::
-  When evalation results are available, the info box shows sizes of the training and evaluation data it uses for self-evaluation (for generating actual suggestions, the recommender is trained on all data), and the results of the self-evaluation in terms of F1 score, accuracy, precision and recall.
+  When evaluation results are available, the info box shows sizes of the training and evaluation data it uses for self-evaluation (for generating actual suggestions, the recommender is trained on all data), and the results of the self-evaluation in terms of F1 score, accuracy, precision and recall.
 View the confusion matrix for a recommender ::
-  When evalation results are available, there is also the option to view the confusion matrix of the results. This is a square matrix showing all of the possible labels on each axis and indicating for each pair of labels how often during the self-evaluation run, one was mistaken for the other by the recommender.
+  When evaluation results are available, there is also the option to view the confusion matrix of the results. This is a square matrix showing all of the possible labels on each axis and indicating for each pair of labels how often during the self-evaluation run, one was mistaken for the other by the recommender.
 View the training log of the recommenders ::
-  The recommender log provides detailed informations which recommenders did run or did not run on which layers. This can be useful if you believe that a recommender should be active but it is not. The log usually contains two sections. The first section contains the log messages for the currently visible suggestions. If a background training and prediction run has completed, there is also a second part contains the log messages for the suggestions that will become visible on the next user interaction.
+  The recommender log provides detailed information which recommenders did run or did not run on which layers. This can be useful if you believe that a recommender should be active but it is not. The log usually contains two sections. The first section contains the log messages for the currently visible suggestions. If a background training and prediction run has completed, there is also a second part contains the log messages for the suggestions that will become visible on the next user interaction.
 Manually trigger a re-training of all recommenders ::
   You can manually clear and re-train all recommenders. This causes all suggestions to disappear immediately and a self-evaluation run followed by a training and prediction run is triggered. Once they have completed, the logs become available via the log button and the suggestions become available once the main editor is refreshed either via a user action (e.g. making an annotation) or e.g. by reloading the browser page.
 Bulk-accept the best recommendations of a given recommender ::
@@ -59,12 +59,12 @@ Export the model of the recommender ::
   from this recommender can be uploaded a gazetteer to a String Matching Span Recommender in the project settings. 
 
 === Evaluation scores and recommender activation
-The circles at the top of the sidebar indicate the progress towards the next recommender evalation. Every change to the annotations triggers a new training and prediction run. If a run is already in progress, at most one additional run is queued. When a run starts, it always use the latest annotation data available at the time. Every 5th run, an additional evaluation step is triggered. This updates the recall, precision, accuracy and F1 scores in the sidebar. Also, if a recommender has been configured to activate only at a particular score threshold, then the recommender may get activated or deactivated depending on the evaluation results.
+The circles at the top of the sidebar indicate the progress towards the next recommender evaluation. Every change to the annotations triggers a new training and prediction run. If a run is already in progress, at most one additional run is queued. When a run starts, it always use the latest annotation data available at the time. Every 5th run, an additional evaluation step is triggered. This updates the recall, precision, accuracy and F1 scores in the sidebar. Also, if a recommender has been configured to activate only at a particular score threshold, then the recommender may get activated or deactivated depending on the evaluation results.
 
 === Additional settings
 Additionally, there are several configuration options available from the settings dropdown accessible via the cogwheel icon:
 
-Configure the minium score threshold for a suggestion to be visible ::
+Configure the minimum score threshold for a suggestion to be visible ::
   Sets a minimum score for an individual suggestion to become visible. Any suggestions with a lower score are not shown. 
 Configure how many suggestions are shown for a given position ::
   If there is more than one suggestion generated for a given position by all recommenders, then of all these suggestions only the n suggestions with the highest scores will be shown. Note though, that scores are not necessarily comparable between recommenders.

--- a/inception/inception-recommendation/src/main/resources/META-INF/asciidoc/user-guide/evaluation.adoc
+++ b/inception/inception-recommendation/src/main/resources/META-INF/asciidoc/user-guide/evaluation.adoc
@@ -22,7 +22,7 @@ The evaluation simulation panel provides a visualization of the performance of t
 The training data use for the evaluation can be selected using the *Annotator* dropdown. Here,
 you can select to train on the annotations of a specific user. Selecting *INITIAL_CAS* trains on
 annotations present in the imported original documents. Selecting *CURATION_USER* trains on curated
-documents. The data is split into *80% training data* and *20% test data*. The system tries to split the training data in 10 blocks of roughly the same size. For each training run, an additonal block
+documents. The data is split into *80% training data* and *20% test data*. The system tries to split the training data in 10 blocks of roughly the same size. For each training run, an additional block
 is added to the training data for that run until in the last run, all training data is used.
 
 image::evaluation.png[align="center"]

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/LegacyRemoteApiController.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/LegacyRemoteApiController.java
@@ -274,7 +274,7 @@ public class LegacyRemoteApiController
      * To test when running in Eclipse, use the Linux "curl" command.
      * 
      * curl -v -X DELETE
-     * 'http://USERNAME:PASSOWRD@localhost:8080/webanno-webapp/api/projects/{aProjectId}'
+     * 'http://USERNAME:PASSWORD@localhost:8080/webanno-webapp/api/projects/{aProjectId}'
      * 
      * @param aProjectId
      *            The id of the project.
@@ -727,7 +727,7 @@ public class LegacyRemoteApiController
             FileCopyUtils.copy(inputStream, response.getOutputStream());
         }
         catch (Exception e) {
-            LOG.info("Exception occured" + e.getMessage());
+            LOG.info("Exception occurred" + e.getMessage());
         }
         finally {
             if (downloadableFile.exists()) {
@@ -849,7 +849,7 @@ public class LegacyRemoteApiController
             FileCopyUtils.copy(inputStream, response.getOutputStream());
         }
         catch (Exception e) {
-            LOG.info("Exception occured" + e.getMessage());
+            LOG.info("Exception occurred" + e.getMessage());
         }
         finally {
             if (downloadableFile.exists()) {

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/config/RemoteApiAutoConfiguration.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/config/RemoteApiAutoConfiguration.java
@@ -64,7 +64,7 @@ public class RemoteApiAutoConfiguration
                 .pathsToExclude("/**") //
                 .addOpenApiCustomiser(openApi -> { //
                     openApi.info(new Info() //
-                            .title("Remote API disbled") //
+                            .title("Remote API disabled") //
                             .description("The remote API is not enabled."));
                 })//
                 .build();

--- a/inception/inception-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/webhooks/WebhookServiceTest.java
+++ b/inception/inception-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/webhooks/WebhookServiceTest.java
@@ -247,7 +247,7 @@ public class WebhookServiceTest
                 @RequestBody ProjectStateChangeMessage aMsg)
             throws Exception
         {
-            LOG.info("Recieved: {}", aMsg);
+            LOG.info("Received: {}", aMsg);
             projectStateChangeMsgs.add(Pair.of(aMsg, aHeaders));
             return ResponseEntity.ok().build();
         }
@@ -261,7 +261,7 @@ public class WebhookServiceTest
                 @RequestBody DocumentStateChangeMessage aMsg)
             throws Exception
         {
-            LOG.info("Recieved: {}", aMsg);
+            LOG.info("Received: {}", aMsg);
             docStateChangeMsgs.add(Pair.of(aMsg, aHeaders));
             return ResponseEntity.ok().build();
         }
@@ -275,7 +275,7 @@ public class WebhookServiceTest
                 @RequestBody AnnotationStateChangeMessage aMsg)
             throws Exception
         {
-            LOG.info("Recieved: {}", aMsg);
+            LOG.info("Received: {}", aMsg);
             annStateChangeMsgs.add(Pair.of(aMsg, aHeaders));
             return ResponseEntity.ok().build();
         }

--- a/inception/inception-search-mtas/src/main/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndex.java
+++ b/inception/inception-search-mtas/src/main/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndex.java
@@ -272,7 +272,7 @@ public class MtasDocumentIndex
                 indexWriter.close();
             }
             catch (IOException e1) {
-                log.error("Error while trying to close index which could not be initalized"
+                log.error("Error while trying to close index which could not be initialized"
                         + " - actual exception follows", e);
             }
             throw e;
@@ -832,7 +832,7 @@ public class MtasDocumentIndex
                                     && !aRequest.getUser().getUsername().equals(user)) {
                                 // Exclude result if the retrieved document is an annotation
                                 // document (that is, annotationDocument != -1 and its username
-                                // is different from the quering user
+                                // is different from the querying user
                                 log.trace(
                                         "Skipping results from annotation document for user {} "
                                                 + "which does not match the requested user {}",
@@ -1018,7 +1018,7 @@ public class MtasDocumentIndex
                                     && !aRequest.getUser().getUsername().equals(user)) {
                                 // Exclude result if the retrieved document is an annotation
                                 // document (that is, annotationDocument != -1 and its username
-                                // is different from the quering user
+                                // is different from the querying user
                                 log.trace(
                                         "Skipping results from annotation document for user {} "
                                                 + "which does not match the requested user {}",
@@ -1103,7 +1103,7 @@ public class MtasDocumentIndex
                                     else {
                                         // Only add the whitespace to the match if we already have
                                         // added any text to the match - otherwise consider the
-                                        // whitespace to be part of the left contex
+                                        // whitespace to be part of the left context
                                         if (resultText.length() > 0) {
                                             fill(resultText, prevToken, token);
                                         }

--- a/inception/inception-telemetry/src/main/java/de/tudarmstadt/ukp/clarin/webanno/telemetry/matomo/MatomoTelemetrySupportImpl.java
+++ b/inception/inception-telemetry/src/main/java/de/tudarmstadt/ukp/clarin/webanno/telemetry/matomo/MatomoTelemetrySupportImpl.java
@@ -369,7 +369,7 @@ public class MatomoTelemetrySupportImpl
                         + "number of installations and report it e.g. when applying for funding."),
                 new TelemetryDetail("Visitor ID", Long.toHexString(uuid.getMostSignificantBits()),
                         "This is a short version of the instance ID required for technical "
-                                + "resons by the Matomo telemetry server we are using."),
+                                + "reasons by the Matomo telemetry server we are using."),
                 new TelemetryDetail("Application", applicationName,
                         "The name of the application. There are different applications using this "
                                 + "telemetry service. By this value, we can identify the popularity of "

--- a/inception/inception-telemetry/src/main/java/de/tudarmstadt/ukp/clarin/webanno/telemetry/matomo/MatomoTelemetryTraitsEditor.html
+++ b/inception/inception-telemetry/src/main/java/de/tudarmstadt/ukp/clarin/webanno/telemetry/matomo/MatomoTelemetryTraitsEditor.html
@@ -46,7 +46,7 @@
               <wicket:message key="product.name" />.
             </p>
             <p>
-              Use the <b>Toogle details...</b> button above to see in full detail which data we
+              Use the <b>Toggle details...</b> button above to see in full detail which data we
               collect and why.
             </p>
           </div>

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
@@ -222,7 +222,7 @@ public class AnnotationPage
      * might have triggered a change in some feature that might be shown on screen.
      * <p>
      * NOTE: Considering that this is a backend event, we check here if it even applies to the
-     * current view. It might be more efficient to have another event that more closely mimicks
+     * current view. It might be more efficient to have another event that more closely mimics
      * {@code AnnotationDetailEditorPanel.onChange()}.
      */
     @SuppressWarnings("javadoc")
@@ -245,7 +245,7 @@ public class AnnotationPage
      * triggered a change in some feature that might be shown on screen.
      * <p>
      * NOTE: Considering that this is a backend event, we check here if it even applies to the
-     * current view. It might be more efficient to have another event that more closely mimicks
+     * current view. It might be more efficient to have another event that more closely mimics
      * {@code AnnotationDetailEditorPanel.onChange()}.
      */
     @SuppressWarnings("javadoc")

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
@@ -1557,7 +1557,7 @@ public abstract class AnnotationDetailEditorPanel
     @Deprecated
     protected void onAutoForward(AjaxRequestTarget aTarget)
     {
-        // Overriden in CurationPanel
+        // Overridden in CurationPanel
     }
 
     @SuppressWarnings("unchecked")

--- a/inception/inception-ui-annotation/src/main/resources/META-INF/asciidoc/user-guide/annotation_navigation.adoc
+++ b/inception/inception-ui-annotation/src/main/resources/META-INF/asciidoc/user-guide/annotation_navigation.adoc
@@ -27,7 +27,7 @@ The arrow buttons *first page*, *next page*, *previous page*, *last page*, and *
 The *Prev.* and *Next* buttons in the *Document* frame allow you to go to the previous or next document on your project list. 
 
 When an annotation is selected, there are additional arrow buttons in the right sidebar
-which can be used to navigate between annotations on the selected layer withing the current document.
+which can be used to navigate between annotations on the selected layer within the current document.
 
 You can also use the following keyboard assignments in order to navigate only using your keyboard.
 

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.java
@@ -199,7 +199,7 @@ public abstract class WicketApplicationBase
         File customBootstrap = new File(getApplicationHome(), "bootstrap.css");
 
         if (customBootstrap.exists()) {
-            log.info("Using custom boostrap at [{}]", customBootstrap);
+            log.info("Using custom bootstrap at [{}]", customBootstrap);
             settings.setCssResourceReference(new FileSystemResourceReference(
                     "inception-bootstrap.css", customBootstrap.toPath()));
         }

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/users/package-info.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/users/package-info.java
@@ -16,6 +16,6 @@
  * limitations under the License.
  */
 /**
- * Conatin classes for user management related pages
+ * Contain classes for user management related pages
  */
 package de.tudarmstadt.ukp.clarin.webanno.ui.core.users;

--- a/inception/inception-ui-curation/src/main/resources/META-INF/asciidoc/user-guide/curation.adoc
+++ b/inception/inception-ui-curation/src/main/resources/META-INF/asciidoc/user-guide/curation.adoc
@@ -123,5 +123,5 @@ see an anonymous label like *Anonymized annotator 1* instead of the annotator na
 project managers can still see the annotator names.
 
 NOTE: The order of the annotators is not randomized - only the names are removed from the UI. Only 
-      annotators who have marked their documents as *finished* are shown. Thus, which annotator recieves 
+      annotators who have marked their documents as *finished* are shown. Thus, which annotator receives
       which number may changed depending on documents being marked as finished or put back into progress.

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/DashboardMenu.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/DashboardMenu.java
@@ -161,7 +161,7 @@ public class DashboardMenu
 
             if (currentPage == null) {
                 throw new IllegalStateException(
-                        "Menu item targetting a specific project must be on a project page");
+                        "Menu item targeting a specific project must be on a project page");
             }
 
             Project project = currentPage.getProject();

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/KnowledgeBaseIriPanel.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/KnowledgeBaseIriPanel.java
@@ -122,7 +122,7 @@ public class KnowledgeBaseIriPanel
         iriSchemaChoice.add(new LambdaAjaxFormComponentUpdatingBehavior("change", _target -> {
             SchemaProfile profile = iriSchemaChoice.getModelObject();
             // If the user switches to the custom profile, we retain the values from the
-            // previously selected profile and just make the IRI mapping ediable. If the user
+            // previously selected profile and just make the IRI mapping editable. If the user
             // switches to a pre-defined profile, we reset the values.
             if (SchemaProfile.CUSTOMSCHEMA != profile) {
                 classField.setModelObject(profile.getClassIri());

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/QualifierEditor.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/QualifierEditor.java
@@ -92,7 +92,7 @@ public class QualifierEditor
         private Component initialFocusComponent;
 
         /**
-         * Creates a new fragement for editing a qualifier.<br>
+         * Creates a new fragment for editing a qualifier.<br>
          * The editor has two slightly different behaviors, depending on the value of
          * {@code isNewQualifier}:
          * <ul>

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/StatementEditor.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/StatementEditor.java
@@ -308,7 +308,7 @@ public class StatementEditor
         private Component initialFocusComponent;
 
         /**
-         * Creates a new fragement for editing a statement.<br>
+         * Creates a new fragment for editing a statement.<br>
          * The editor has two slightly different behaviors, depending on the value of
          * {@code isNewStatement}:
          * <ul>

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/editor/StatementEditor.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/stmt/editor/StatementEditor.java
@@ -321,7 +321,7 @@ public class StatementEditor
         private DropDownChoice<ValueType> valueType;
 
         /**
-         * Creates a new fragement for editing a statement.<br>
+         * Creates a new fragment for editing a statement.<br>
          * The editor has two slightly different behaviors, depending on the value of
          * {@code isNewStatement}:
          * <ul>

--- a/inception/inception-ui-kb/src/main/resources/META-INF/asciidoc/user-guide/projects_knowledge-base.adoc
+++ b/inception/inception-ui-kb/src/main/resources/META-INF/asciidoc/user-guide/projects_knowledge-base.adoc
@@ -281,7 +281,7 @@ are supported.
 * HTTP basic authentication
 * OAuth (client credentials)
 
-To enable authentication, select one of the options from the **Authenication** dropdown menu.
+To enable authentication, select one of the options from the **Authentication** dropdown menu.
 
 NOTE: To protect you credentials while sending them to the remote side, it is strongly recommended
       to use a HTTPS connection to the SPARQL endpoint and keep SSL certificate checking enabled.

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/constraints/ProjectConstraintsPanel.java
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/constraints/ProjectConstraintsPanel.java
@@ -261,7 +261,7 @@ public class ProjectConstraintsPanel
             catch (IOException e) {
                 // Cannot call "Component.error()" here - it causes a
                 // org.apache.wicket.WicketRuntimeException: Cannot modify component
-                // hierarchy after render phase has started (page version cant change then
+                // hierarchy after render phase has started (page version can't change then
                 // anymore)
                 LOG.error("Unable to load script", e);
                 return "Unable to load script: " + ExceptionUtils.getRootCauseMessage(e);

--- a/inception/inception-ui-project/src/main/resources/META-INF/asciidoc/user-guide/projects_layers.adoc
+++ b/inception/inception-ui-project/src/main/resources/META-INF/asciidoc/user-guide/projects_layers.adoc
@@ -161,7 +161,7 @@ The layer type defines the structure of the layer. Three different types are sup
 | Example
 
 | Span
-| Continous segment of text delimited by a start and end character offset. The example shows two spans.
+| Continuous segment of text delimited by a start and end character offset. The example shows two spans.
 | image:project_layer_type_span.png[]
 
 | Relation

--- a/inception/inception-ui-tagsets/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/tagsets/TagSetEditorPanel.java
+++ b/inception/inception-ui-tagsets/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/tagsets/TagSetEditorPanel.java
@@ -216,7 +216,7 @@ public class TagSetEditorPanel
                     JSONUtil.generatePrettyJson(exTagSet, exportFile);
                 }
                 catch (IOException e) {
-                    error("File Path not found or No permision to save the file!");
+                    error("File Path not found or No permission to save the file!");
                 }
 
                 info("TagSets successfully exported to :" + exportFile.getAbsolutePath());

--- a/notebooks/external_recommender.ipynb
+++ b/notebooks/external_recommender.ipynb
@@ -101,9 +101,9 @@
    "source": [
     "### Start the server ⏯\n",
     "\n",
-    "If all classifer which we want to use are added, we can start the server.\n",
+    "If all classifiers which we want to use are added, we can start the server.\n",
     "\n",
-    "**⚠️ Attention**: If you changed the code in this jupyter notebook and want to **restart the server 🔁**, it is neccessary to restart the whole kernel (Kernel -> Restart and run all). ⚠️"
+    "**⚠️ Attention**: If you changed the code in this jupyter notebook and want to **restart the server 🔁**, it is necessary to restart the whole kernel (Kernel -> Restart and run all). ⚠️"
    ]
   },
   {


### PR DESCRIPTION
Most of them were found in documentation, comments and messages.
A few typos were in the names of local functions or variables.

Signed-off-by: Stefan Weil <sw@weilnetz.de>

**Documentation**
* [x] PR updates documentation
