### PR TITLE
#3335 - Hiding rejected suggestions wrongly leaks into other documents

### DIFF
--- a/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.java
+++ b/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.java
@@ -1126,8 +1126,8 @@ public class ActiveLearningSidebar
             SuggestionDocumentGroup<SpanSuggestion> group = SuggestionDocumentGroup.groupsOfType(
                     SpanSuggestion.class,
                     predictions.getPredictionsByDocument(aDocument.getName()));
-            recommendationService.calculateSpanSuggestionVisibility(cas, user.getUsername(), aLayer,
-                    group, 0, cas.getDocumentText().length());
+            recommendationService.calculateSpanSuggestionVisibility(aDocument, cas,
+                    user.getUsername(), aLayer, group, 0, cas.getDocumentText().length());
 
             moveToNextSuggestion(aTarget);
         }

--- a/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/SourceDocument.java
+++ b/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/SourceDocument.java
@@ -92,6 +92,18 @@ public class SourceDocument
         state = SourceDocumentState.NEW;
     }
 
+    private SourceDocument(Builder builder)
+    {
+        this.id = builder.id;
+        this.name = builder.name;
+        this.project = builder.project;
+        this.format = builder.format;
+        this.state = builder.state;
+        this.timestamp = builder.timestamp;
+        this.created = builder.created;
+        this.updated = builder.updated;
+    }
+
     public Long getId()
     {
         return id;
@@ -219,4 +231,79 @@ public class SourceDocument
 
     public static final Comparator<SourceDocument> NAME_COMPARATOR = Comparator
             .comparing(SourceDocument::getName);
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static final class Builder
+    {
+        private Long id;
+        private String name;
+        private Project project;
+        private String format;
+        private SourceDocumentState state = SourceDocumentState.NEW;
+        private Date timestamp;
+        private Date created;
+        private Date updated;
+
+        private Builder()
+        {
+            // No instanccs
+        }
+
+        public Builder withId(Long aId)
+        {
+            id = aId;
+            return this;
+        }
+
+        public Builder withName(String aName)
+        {
+            name = aName;
+            return this;
+        }
+
+        public Builder withProject(Project aProject)
+        {
+            project = aProject;
+            return this;
+        }
+
+        public Builder withFormat(String aFormat)
+        {
+            format = aFormat;
+            return this;
+        }
+
+        public Builder withState(SourceDocumentState aState)
+        {
+            state = aState;
+            return this;
+        }
+
+        public Builder withTimestamp(Date aTimestamp)
+        {
+            timestamp = aTimestamp;
+            return this;
+        }
+
+        public Builder withCreated(Date aCreated)
+        {
+            created = aCreated;
+            return this;
+        }
+
+        public Builder withUpdated(Date aUpdated)
+        {
+            updated = aUpdated;
+            return this;
+        }
+
+        public SourceDocument build()
+        {
+            return new SourceDocument(this);
+        }
+    }
 }

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/LearningRecordService.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/LearningRecordService.java
@@ -33,6 +33,9 @@ public interface LearningRecordService
 {
     List<LearningRecord> listRecords(String user, AnnotationLayer layer);
 
+    List<LearningRecord> listRecords(SourceDocument aDocument, String aUser,
+            AnnotationFeature aFeature);
+
     /**
      * @return the learning records for the given document, user and layer. An optional limit can be
      *         used, e.g. for loading only a reduced part of the history in the active learning

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/RecommendationService.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/RecommendationService.java
@@ -216,9 +216,9 @@ public interface RecommendationService
     Predictions computePredictions(User aUser, Project aProject, SourceDocument aCurrentDocument,
             List<SourceDocument> aInherit, int aPredictionBegin, int aPredictionEnd);
 
-    void calculateSpanSuggestionVisibility(CAS aCas, String aUser, AnnotationLayer aLayer,
-            Collection<SuggestionGroup<SpanSuggestion>> aRecommendations, int aWindowBegin,
-            int aWindowEnd);
+    void calculateSpanSuggestionVisibility(SourceDocument aDocument, CAS aCas, String aUser,
+            AnnotationLayer aLayer, Collection<SuggestionGroup<SpanSuggestion>> aRecommendations,
+            int aWindowBegin, int aWindowEnd);
 
     void calculateRelationSuggestionVisibility(CAS aCas, String aUser, AnnotationLayer aLayer,
             Collection<SuggestionGroup<RelationSuggestion>> aRecommendations, int aWindowBegin,

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/LearningRecord.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/LearningRecord.java
@@ -94,6 +94,34 @@ public class LearningRecord
     @Type(type = "de.tudarmstadt.ukp.inception.recommendation.api.model.SuggestionTypeWrapper")
     private SuggestionType suggestionType;
 
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(nullable = false)
+    private Date actionDate = new Date();
+
+    private LearningRecord(Builder builder)
+    {
+        this.id = builder.id;
+        this.sourceDocument = builder.sourceDocument;
+        this.layer = builder.layer;
+        this.annotationFeature = builder.annotationFeature;
+        this.offsetBegin = builder.offsetBegin;
+        this.offsetEnd = builder.offsetEnd;
+        this.offsetBegin2 = builder.offsetBegin2;
+        this.offsetEnd2 = builder.offsetEnd2;
+        this.tokenText = builder.tokenText;
+        this.annotation = builder.annotation;
+        this.userAction = builder.userAction;
+        this.user = builder.user;
+        this.changeLocation = builder.changeLocation;
+        this.suggestionType = builder.suggestionType;
+        this.actionDate = builder.actionDate;
+    }
+
+    public LearningRecord()
+    {
+        // Required for serialization/JPA
+    }
+
     public Long getId()
     {
         return id;
@@ -291,10 +319,6 @@ public class LearningRecord
         annotationFeature = anAnnotationFeature;
     }
 
-    @Temporal(TemporalType.TIMESTAMP)
-    @Column(nullable = false)
-    private Date actionDate = new Date();
-
     @Override
     public boolean equals(Object o)
     {
@@ -356,5 +380,129 @@ public class LearningRecord
         result = 31 * result + (annotation != null ? annotation.hashCode() : 0);
         result = 31 * result + (user != null ? user.hashCode() : 0);
         return result;
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static final class Builder
+    {
+        private Long id;
+        private SourceDocument sourceDocument;
+        private AnnotationLayer layer;
+        private AnnotationFeature annotationFeature;
+        private int offsetBegin;
+        private int offsetEnd;
+        private int offsetBegin2 = -1;
+        private int offsetEnd2 = -1;
+        private String tokenText;
+        private String annotation;
+        private LearningRecordType userAction;
+        private String user;
+        private LearningRecordChangeLocation changeLocation;
+        private SuggestionType suggestionType;
+        private Date actionDate = new Date();
+
+        private Builder()
+        {
+            // No instances
+        }
+
+        public Builder withId(Long aId)
+        {
+            id = aId;
+            return this;
+        }
+
+        public Builder withSourceDocument(SourceDocument aSourceDocument)
+        {
+            sourceDocument = aSourceDocument;
+            return this;
+        }
+
+        public Builder withLayer(AnnotationLayer aLayer)
+        {
+            layer = aLayer;
+            return this;
+        }
+
+        public Builder withAnnotationFeature(AnnotationFeature aAnnotationFeature)
+        {
+            annotationFeature = aAnnotationFeature;
+            return this;
+        }
+
+        public Builder withOffsetBegin(int aOffsetBegin)
+        {
+            offsetBegin = aOffsetBegin;
+            return this;
+        }
+
+        public Builder withOffsetEnd(int aOffsetEnd)
+        {
+            offsetEnd = aOffsetEnd;
+            return this;
+        }
+
+        public Builder withOffsetBegin2(int aOffsetBegin2)
+        {
+            offsetBegin2 = aOffsetBegin2;
+            return this;
+        }
+
+        public Builder withOffsetEnd2(int aOffsetEnd2)
+        {
+            offsetEnd2 = aOffsetEnd2;
+            return this;
+        }
+
+        public Builder withTokenText(String aTokenText)
+        {
+            tokenText = aTokenText;
+            return this;
+        }
+
+        public Builder withAnnotation(String aAnnotation)
+        {
+            annotation = aAnnotation;
+            return this;
+        }
+
+        public Builder withUserAction(LearningRecordType aUserAction)
+        {
+            userAction = aUserAction;
+            return this;
+        }
+
+        public Builder withUser(String aUser)
+        {
+            user = aUser;
+            return this;
+        }
+
+        public Builder withChangeLocation(LearningRecordChangeLocation aChangeLocation)
+        {
+            changeLocation = aChangeLocation;
+            return this;
+        }
+
+        public Builder withSuggestionType(SuggestionType aSuggestionType)
+        {
+            suggestionType = aSuggestionType;
+            return this;
+        }
+
+        public Builder withActionDate(Date aActionDate)
+        {
+            actionDate = aActionDate;
+            return this;
+        }
+
+        public LearningRecord build()
+        {
+            return new LearningRecord(this);
+        }
     }
 }

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/render/RecommendationSpanRenderer.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/render/RecommendationSpanRenderer.java
@@ -112,7 +112,7 @@ public class RecommendationSpanRenderer
 
         String type = typeAdapter.getEncodedTypeName();
 
-        recommendationService.calculateSpanSuggestionVisibility(cas,
+        recommendationService.calculateSpanSuggestionVisibility(aRequest.getSourceDocument(), cas,
                 aRequest.getAnnotationUser().getUsername(), layer, groups,
                 aRequest.getWindowBeginOffset(), aRequest.getWindowEndOffset());
 

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/LearningRecordServiceImpl.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/LearningRecordServiceImpl.java
@@ -167,6 +167,26 @@ public class LearningRecordServiceImpl
 
     @Transactional
     @Override
+    public List<LearningRecord> listRecords(SourceDocument aDocument, String aUsername,
+            AnnotationFeature aFeature)
+    {
+        String sql = String.join("\n", //
+                "FROM LearningRecord l WHERE", //
+                "l.document = :document AND", //
+                "l.user = :user AND", //
+                "l.layer = :layer AND", //
+                "l.userAction != :action", //
+                "ORDER BY l.id desc");
+        TypedQuery<LearningRecord> query = entityManager.createQuery(sql, LearningRecord.class) //
+                .setParameter("document", aDocument) //
+                .setParameter("user", aUsername) //
+                .setParameter("annotationFeature", aFeature) //
+                .setParameter("action", LearningRecordType.SHOWN); // SHOWN records NOT returned
+        return query.getResultList();
+    }
+
+    @Transactional
+    @Override
     public List<LearningRecord> listRecords(String aUsername, AnnotationLayer aLayer, int aLimit)
     {
         String sql = String.join("\n", //

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/LearningRecordServiceImpl.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/LearningRecordServiceImpl.java
@@ -172,13 +172,13 @@ public class LearningRecordServiceImpl
     {
         String sql = String.join("\n", //
                 "FROM LearningRecord l WHERE", //
-                "l.document = :document AND", //
+                "l.sourceDocument = :sourceDocument AND", //
                 "l.user = :user AND", //
-                "l.layer = :layer AND", //
+                "l.annotationFeature = :annotationFeature AND", //
                 "l.userAction != :action", //
                 "ORDER BY l.id desc");
         TypedQuery<LearningRecord> query = entityManager.createQuery(sql, LearningRecord.class) //
-                .setParameter("document", aDocument) //
+                .setParameter("sourceDocument", aDocument) //
                 .setParameter("user", aUsername) //
                 .setParameter("annotationFeature", aFeature) //
                 .setParameter("action", LearningRecordType.SHOWN); // SHOWN records NOT returned

--- a/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/Fixtures.java
+++ b/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/Fixtures.java
@@ -23,6 +23,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.AnnotationSuggestion;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.RelationSuggestion;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.SpanSuggestion;
@@ -34,7 +36,6 @@ public class Fixtures
     // AnnotationSuggestion
     private final static long RECOMMENDER_ID = 1;
     private final static String RECOMMENDER_NAME = "TestEntityRecommender";
-    private final static String DOC_NAME = "TestDocument";
     private final static String UI_LABEL = "TestUiLabel";
     private final static double CONFIDENCE = 0.2;
     private final static String CONFIDENCE_EXPLANATION = "Predictor A: 0.05 | Predictor B: 0.15";
@@ -58,27 +59,27 @@ public class Fixtures
                 .collect(toList());
     }
 
-    static SuggestionDocumentGroup<SpanSuggestion> makeSpanSuggestionGroup(long layerId,
-            String feature, int[][] vals)
+    static SuggestionDocumentGroup<SpanSuggestion> makeSpanSuggestionGroup(SourceDocument doc,
+            AnnotationFeature aFeat, int[][] vals)
     {
         List<SpanSuggestion> suggestions = new ArrayList<>();
         for (int[] val : vals) {
-            suggestions.add(new SpanSuggestion(val[0], RECOMMENDER_ID, RECOMMENDER_NAME, layerId,
-                    feature, DOC_NAME, val[1], val[2], COVERED_TEXT, null, UI_LABEL, CONFIDENCE,
-                    CONFIDENCE_EXPLANATION));
+            suggestions.add(new SpanSuggestion(val[0], RECOMMENDER_ID, RECOMMENDER_NAME,
+                    aFeat.getLayer().getId(), aFeat.getName(), doc.getName(), val[1], val[2],
+                    COVERED_TEXT, null, UI_LABEL, CONFIDENCE, CONFIDENCE_EXPLANATION));
         }
 
         return new SuggestionDocumentGroup<>(suggestions);
     }
 
-    static SuggestionDocumentGroup<RelationSuggestion> makeRelationSuggestionGroup(long layerId,
-            String feature, int[][] vals)
+    static SuggestionDocumentGroup<RelationSuggestion> makeRelationSuggestionGroup(
+            SourceDocument doc, AnnotationFeature aFeat, int[][] vals)
     {
         List<RelationSuggestion> suggestions = new ArrayList<>();
         for (int[] val : vals) {
             suggestions.add(new RelationSuggestion(val[0], RECOMMENDER_ID, RECOMMENDER_NAME,
-                    layerId, feature, DOC_NAME, val[1], val[2], val[3], val[4], null, UI_LABEL,
-                    CONFIDENCE, CONFIDENCE_EXPLANATION));
+                    aFeat.getLayer().getId(), aFeat.getName(), doc.getName(), val[1], val[2],
+                    val[3], val[4], null, UI_LABEL, CONFIDENCE, CONFIDENCE_EXPLANATION));
         }
 
         return new SuggestionDocumentGroup<>(suggestions);

--- a/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImplIntegrationTest.java
+++ b/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImplIntegrationTest.java
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package de.tudarmstadt.ukp.inception.recommendation.service;
 
 import static de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService.FEATURE_NAME_IS_PREDICTION;

--- a/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImplTest.java
+++ b/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImplTest.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.service;
+
+import static de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordType.REJECTED;
+import static de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordType.SKIPPED;
+import static de.tudarmstadt.ukp.inception.recommendation.service.RecommendationServiceImpl.hideSuggestionsRejectedOrSkipped;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecord;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.SpanSuggestion;
+
+class RecommendationServiceImplTest
+{
+    private SourceDocument doc1;
+    private SourceDocument doc2;
+    private AnnotationLayer layer1;
+    private AnnotationLayer layer2;
+    private AnnotationFeature feature1;
+    private AnnotationFeature feature2;
+
+    @BeforeEach
+    void setup()
+    {
+        doc1 = new SourceDocument("doc1", null, null);
+        doc1.setId(1l);
+        doc2 = new SourceDocument("doc2", null, null);
+        doc2.setId(2l);
+        layer1 = AnnotationLayer.builder().withId(1l).withName("layer1").build();
+        layer2 = AnnotationLayer.builder().withId(2l).withName("layer2").build();
+        feature1 = AnnotationFeature.builder().withName("feat1").build();
+        feature2 = AnnotationFeature.builder().withName("feat2").build();
+    }
+
+    @Test
+    void thatRejectedSuggestionIsHidden()
+    {
+        var records = asList(LearningRecord.builder() //
+                .withSourceDocument(doc1) //
+                .withLayer(layer1) //
+                .withAnnotationFeature(feature1) //
+                .withOffsetBegin(0) //
+                .withOffsetEnd(10) //
+                .withAnnotation("x") //
+                .withUserAction(REJECTED).build());
+
+        var doc1Suggestion = makeSuggestion(0, 10, "x", doc1, layer1, feature1);
+        assertThat(doc1Suggestion.isVisible()).isTrue();
+        hideSuggestionsRejectedOrSkipped(doc1Suggestion, records);
+        assertThat(doc1Suggestion.isVisible()) //
+                .as("Suggestion in same document/layer/feature should be hidden") //
+                .isFalse();
+        assertThat(doc1Suggestion.getReasonForHiding().trim()).isEqualTo("rejected");
+
+        var doc2Suggestion = makeSuggestion(0, 10, "x", doc2, layer1, feature1);
+        assertThat(doc2Suggestion.isVisible()).isTrue();
+        hideSuggestionsRejectedOrSkipped(doc2Suggestion, records);
+        assertThat(doc2Suggestion.isVisible()) //
+                .as("Suggestion in other document should not be hidden") //
+                .isTrue();
+
+        var doc3Suggestion = makeSuggestion(0, 10, "x", doc1, layer2, feature1);
+        assertThat(doc3Suggestion.isVisible()).isTrue();
+        hideSuggestionsRejectedOrSkipped(doc3Suggestion, records);
+        assertThat(doc3Suggestion.isVisible()) //
+                .as("Suggestion in other layer should not be hidden") //
+                .isTrue();
+
+        var doc4Suggestion = makeSuggestion(0, 10, "x", doc1, layer1, feature2);
+        assertThat(doc4Suggestion.isVisible()).isTrue();
+        hideSuggestionsRejectedOrSkipped(doc3Suggestion, records);
+        assertThat(doc4Suggestion.isVisible()) //
+                .as("Suggestion in other feature should not be hidden") //
+                .isTrue();
+    }
+
+    @Test
+    void thatSkippedSuggestionIsHidden()
+    {
+        var records = asList(LearningRecord.builder() //
+                .withSourceDocument(doc1) //
+                .withLayer(layer1) //
+                .withAnnotationFeature(feature1) //
+                .withOffsetBegin(0) //
+                .withOffsetEnd(10) //
+                .withAnnotation("x") //
+                .withUserAction(SKIPPED).build());
+
+        var doc1Suggestion = makeSuggestion(0, 10, "x", doc1, layer1, feature1);
+        assertThat(doc1Suggestion.isVisible()).isTrue();
+        hideSuggestionsRejectedOrSkipped(doc1Suggestion, records);
+        assertThat(doc1Suggestion.isVisible()) //
+                .as("Suggestion in same document/layer/feature should be hidden") //
+                .isFalse();
+        assertThat(doc1Suggestion.getReasonForHiding().trim()).isEqualTo("skipped");
+
+        var doc2Suggestion = makeSuggestion(0, 10, "x", doc2, layer1, feature1);
+        assertThat(doc2Suggestion.isVisible()).isTrue();
+        hideSuggestionsRejectedOrSkipped(doc2Suggestion, records);
+        assertThat(doc2Suggestion.isVisible()) //
+                .as("Suggestion in other document should not be hidden") //
+                .isTrue();
+
+        var doc3Suggestion = makeSuggestion(0, 10, "x", doc1, layer2, feature1);
+        assertThat(doc3Suggestion.isVisible()).isTrue();
+        hideSuggestionsRejectedOrSkipped(doc3Suggestion, records);
+        assertThat(doc3Suggestion.isVisible()) //
+                .as("Suggestion in other layer should not be hidden") //
+                .isTrue();
+
+        var doc4Suggestion = makeSuggestion(0, 10, "x", doc1, layer1, feature2);
+        assertThat(doc4Suggestion.isVisible()).isTrue();
+        hideSuggestionsRejectedOrSkipped(doc3Suggestion, records);
+        assertThat(doc4Suggestion.isVisible()) //
+                .as("Suggestion in other feature should not be hidden") //
+                .isTrue();
+    }
+
+    private SpanSuggestion makeSuggestion(int aBegin, int aEnd, String aLabel, SourceDocument aDoc,
+            AnnotationLayer aLayer, AnnotationFeature aFeature)
+    {
+        return new SpanSuggestion(0, // aId,
+                0, // aRecommenderId,
+                "", // aRecommenderName
+                aLayer.getId(), // aLayerId,
+                aFeature.getName(), // aFeature,
+                aDoc.getName(), // aDocumentName
+                aBegin, // aBegin
+                aEnd, // aEnd
+                "", // aCoveredText,
+                aLabel, // aLabel
+                aLabel, // aUiLabel
+                0.0, // aScore
+                "" // aScoreExplanation
+        );
+    }
+}

--- a/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RelationSuggestionVisibilityCalculationTest.java
+++ b/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RelationSuggestionVisibilityCalculationTest.java
@@ -42,6 +42,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
 import de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.Dependency;
 import de.tudarmstadt.ukp.inception.recommendation.api.LearningRecordService;
@@ -57,9 +58,10 @@ public class RelationSuggestionVisibilityCalculationTest
     private @Mock AnnotationSchemaService annoService;
 
     private Project project;
+    private SourceDocument doc;
     private AnnotationLayer layer;
+    private AnnotationFeature feature;
     private String user;
-    private long layerId;
 
     private RecommendationServiceImpl sut;
 
@@ -71,10 +73,14 @@ public class RelationSuggestionVisibilityCalculationTest
         layer = new AnnotationLayer();
         layer.setName(Dependency._TypeName);
         layer.setId(42l);
-        layerId = layer.getId();
+
+        feature = AnnotationFeature.builder().withId(2l).withLayer(layer)
+                .withName(Dependency._FeatName_DependencyType).build();
 
         project = new Project();
         project.setName("Test Project");
+
+        doc = SourceDocument.builder().withId(12l).withName("doc").withProject(project).build();
 
         List<AnnotationFeature> featureList = new ArrayList<AnnotationFeature>();
         featureList
@@ -91,8 +97,8 @@ public class RelationSuggestionVisibilityCalculationTest
         when(recordService.listRecords(user, layer)).thenReturn(new ArrayList<>());
 
         CAS cas = getTestCas();
-        SuggestionDocumentGroup<RelationSuggestion> suggestions = makeRelationSuggestionGroup(
-                layerId, Dependency._FeatName_DependencyType, new int[][] { { 1, 0, 3, 13, 20 } });
+        SuggestionDocumentGroup<RelationSuggestion> suggestions = makeRelationSuggestionGroup(doc,
+                feature, new int[][] { { 1, 0, 3, 13, 20 } });
         sut.calculateRelationSuggestionVisibility(cas, user, layer, suggestions, 0, 25);
 
         assertThat(getVisibleSuggestions(suggestions)) //
@@ -112,8 +118,8 @@ public class RelationSuggestionVisibilityCalculationTest
         when(recordService.listRecords(user, layer)).thenReturn(new ArrayList<>());
 
         CAS cas = getTestCas();
-        SuggestionDocumentGroup<RelationSuggestion> suggestions = makeRelationSuggestionGroup(
-                layerId, Dependency._FeatName_DependencyType, new int[][] { { 1, 0, 3, 13, 20 } });
+        SuggestionDocumentGroup<RelationSuggestion> suggestions = makeRelationSuggestionGroup(doc,
+                feature, new int[][] { { 1, 0, 3, 13, 20 } });
         sut.calculateRelationSuggestionVisibility(cas, user, layer, suggestions, 0, 25);
 
         assertThat(getVisibleSuggestions(suggestions)) //


### PR DESCRIPTION
**What's in the PR**
- Add new query to get only learning records for current document to better hide rejections/skips
- Better checking that a learning record actually belongs to the right doc/layer/feature when hiding rejections/skips
- Added unit tests
- Added a few new builders

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
