### PR TITLE
#3365 - Creating a zero-width annotation breaks PDF rendering

### DIFF
--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/UI/relation.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/UI/relation.ts
@@ -3,14 +3,18 @@ import RelationAnnotation from '../annotation/relation.js'
 import SpanAnnotation from '../annotation/span.js'
 import { scaleDown } from './utils'
 
-let relationAnnotation : RelationAnnotation = null
-let hoveredAnnotation : SpanAnnotation = null
+let relationAnnotation : RelationAnnotation | null = null
+let hoveredAnnotation : SpanAnnotation | null = null
 let mousedownFired = false
 let onAnnotation = false
 let drawing = false
 
 export function installRelationSelection () {
   const viewer = document.getElementById('viewer')
+  if (!viewer) {
+    console.error('Viewer element not found')
+    return
+  }
 
   window.addEventListener('annotationHoverIn', (e) => {
     hoveredAnnotation = e.detail

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/UI/span.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/UI/span.ts
@@ -1,6 +1,6 @@
 import { scaleDown } from './utils'
 import SpanAnnotation from '../annotation/span'
-import { findCharacterOffset, getGlyphsInRange, findGlyphAtPoint } from '../../../page/textLayer'
+import { getGlyphsInRange, findGlyphAtPoint } from '../../../page/textLayer'
 import { Rectangle } from '../../../../vmodel/Rectangle'
 import { VGlyph } from '../../../../vmodel/VGlyph'
 
@@ -181,7 +181,9 @@ function handleMouseUp (e: MouseEvent) {
         bubbles: true,
         detail: { begin: selectionBegin, end: selectionEnd }
       })
+
       document.getElementById('viewer')?.dispatchEvent(event)
+
       // wait a second before destroying selection for better user experience
       setTimeout(function () {
         if (currentSelectionHighlight) {
@@ -219,16 +221,15 @@ function handleClick (e: MouseEvent) {
     const x = e.clientX - left
     const y = e.clientY - top
 
-    const position = findCharacterOffset(page, scaleDown({ x, y }))
-
-    if (!position) {
-      console.log(`Position is ${position}, cannot create zero-width span annotaton`)
+    const glyph = findGlyphAtPoint(page, scaleDown({ x, y }))
+    if (!glyph) {
+      console.log(`No glyph at point ${[x, y]} - cannot create zero-width annotation`)
       return
     }
 
     const event = new CustomEvent('createSpanAnnotation', {
       bubbles: true,
-      detail: { begin: position, end: position }
+      detail: { begin: glyph.begin, end: glyph.begin }
     })
     document.getElementById('viewer')?.dispatchEvent(event)
 

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/UI/span.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/UI/span.ts
@@ -1,11 +1,11 @@
 import { scaleDown } from './utils'
 import SpanAnnotation from '../annotation/span'
-import { findCharacterOffset, getGlyphsInRange, findGlyphAtPoint, Rect } from '../../../page/textLayer'
+import { findCharacterOffset, getGlyphsInRange, findGlyphAtPoint } from '../../../page/textLayer'
 import { Rectangle } from '../../../../vmodel/Rectangle'
 import { VGlyph } from '../../../../vmodel/VGlyph'
 
 function scale () {
-  return window.PDFViewerApplication.pdfViewer.getPageView(0).viewport.scale
+  return globalThis.PDFViewerApplication.pdfViewer.getPageView(0).viewport.scale
 }
 
 /**
@@ -24,9 +24,9 @@ export function mergeRects (glyphs: VGlyph[]) {
   for (let i = 1; i < glyphs.length; i++) {
     const rect = glyphs[i].bbox
 
-    if (tmp.p !== rect.p) {
-      console.log('Page switch')
-    }
+    // if (tmp.p !== rect.p) {
+    //   console.log('Page switch')
+    // }
 
     if (tmp.p === rect.p && withinMargin(rect.top, tmp.top, error)) {
       // Same line/same page -> Merge rects.
@@ -66,23 +66,37 @@ export function getRectangles () {
 
 export function installSpanSelection () {
   const viewer = document.getElementById('viewer')
-  viewer.addEventListener('mousedown', handleMouseDown)
-  viewer.addEventListener('mousemove', handleMouseMove)
-  viewer.addEventListener('mouseup', handleMouseUp)
-  viewer.addEventListener('click', handleClick)
-  window.addEventListener('annotationHoverIn', () => otherAnnotationTreating = true)
-  window.addEventListener('annotationHoverOut', () => otherAnnotationTreating = false)
-  window.addEventListener('annotationDeleted', () => otherAnnotationTreating = false)
+  if (viewer) {
+    viewer.addEventListener('mousedown', handleMouseDown)
+    viewer.addEventListener('mousemove', handleMouseMove)
+    viewer.addEventListener('mouseup', handleMouseUp)
+    viewer.addEventListener('click', handleClick)
+  }
+  window.addEventListener('annotationHoverIn', () => { otherAnnotationTreating = true })
+  window.addEventListener('annotationHoverOut', () => { otherAnnotationTreating = false })
+  window.addEventListener('annotationDeleted', () => { otherAnnotationTreating = false })
 }
 
 function setPositions (e: MouseEvent) {
   const canvasElement = (e.target as HTMLElement).closest('.canvasWrapper')
   if (!canvasElement) {
+    console.error('No canvas element found.')
     return
   }
 
   const pageElement = canvasElement.parentElement
-  const page = parseInt(pageElement.getAttribute('data-page-number'))
+  if (!pageElement) {
+    console.error('No page element found.')
+    return
+  }
+
+  const pageNumberAttribute = pageElement.getAttribute('data-page-number')
+  if (!pageNumberAttribute) {
+    console.error('No page number attribute found.')
+    return
+  }
+
+  const page = parseInt(pageNumberAttribute)
   currentPage = page
 
   const { top, left } = canvasElement.getBoundingClientRect()
@@ -91,7 +105,7 @@ function setPositions (e: MouseEvent) {
 
   const glyph = findGlyphAtPoint(page, scaleDown({ x, y }))
   if (glyph) {
-    if (!selectionBegin || !selectionEnd) {
+    if (selectionBegin === null || selectionEnd === null || initPosition === null) {
       initPosition = glyph.begin
       selectionBegin = glyph.begin
       selectionEnd = glyph.end
@@ -115,7 +129,9 @@ function makeSelections (e: MouseEvent) {
     currentSelectionHighlight = null
   }
 
-  currentSelectionHighlight = selectionHighlight([selectionBegin, selectionEnd], currentPage)
+  if (selectionBegin !== null && selectionEnd !== null && currentPage !== null) {
+    currentSelectionHighlight = selectionHighlight([selectionBegin, selectionEnd], currentPage)
+  }
 }
 
 function handleMouseDown (e: MouseEvent) {
@@ -165,7 +181,7 @@ function handleMouseUp (e: MouseEvent) {
         bubbles: true,
         detail: { begin: selectionBegin, end: selectionEnd }
       })
-      document.getElementById('viewer').dispatchEvent(event)
+      document.getElementById('viewer')?.dispatchEvent(event)
       // wait a second before destroying selection for better user experience
       setTimeout(function () {
         if (currentSelectionHighlight) {
@@ -186,7 +202,18 @@ function handleClick (e: MouseEvent) {
 
   if (e.shiftKey) {
     const pageElement = canvasElement.parentElement
-    const page = parseInt(pageElement.getAttribute('data-page-number'))
+    if (!pageElement) {
+      console.error('No page element found.')
+      return
+    }
+
+    const pageNumberAttribute = pageElement.getAttribute('data-page-number')
+    if (!pageNumberAttribute) {
+      console.error('No page number attribute found.')
+      return
+    }
+
+    const page = parseInt(pageNumberAttribute)
     currentPage = page
     const { top, left } = canvasElement.getBoundingClientRect()
     const x = e.clientX - left
@@ -194,8 +221,8 @@ function handleClick (e: MouseEvent) {
 
     const position = findCharacterOffset(page, scaleDown({ x, y }))
 
-    if (position == null) {
-      console.log('Position is null, cannot create zero-width span annotaton')
+    if (!position) {
+      console.log(`Position is ${position}, cannot create zero-width span annotaton`)
       return
     }
 
@@ -203,7 +230,7 @@ function handleClick (e: MouseEvent) {
       bubbles: true,
       detail: { begin: position, end: position }
     })
-    document.getElementById('viewer').dispatchEvent(event)
+    document.getElementById('viewer')?.dispatchEvent(event)
 
     // wait a second before destroying selection for better user experience
     setTimeout(function () {
@@ -215,7 +242,7 @@ function handleClick (e: MouseEvent) {
   }
 }
 
-function selectionHighlight (textRange: [number, number], page: number): SpanAnnotation {
+function selectionHighlight (textRange: [number, number], page: number): SpanAnnotation | null {
   const hl = new SpanAnnotation()
   hl.color = '#0f0'
   hl.textRange = textRange
@@ -234,9 +261,9 @@ function selectionHighlight (textRange: [number, number], page: number): SpanAnn
 }
 
 let mouseDown = false
-let initPosition = null
-let selectionBegin: number = null
-let selectionEnd: number = null
-let currentPage: number = null
-let currentSelectionHighlight: SpanAnnotation = null
+let initPosition: number | null = null
+let selectionBegin: number | null = null
+let selectionEnd: number | null = null
+let currentPage: number | null = null
+let currentSelectionHighlight: SpanAnnotation | null = null
 let otherAnnotationTreating = false

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/UI/utils.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/UI/utils.ts
@@ -13,7 +13,7 @@ export function scaleUp (svg, rect) {
   }
 
   const result = {}
-  const viewport = window.PDFViewerApplication.pdfViewer.getPageView(0).viewport
+  const viewport = globalThis.PDFViewerApplication.pdfViewer.getPageView(0).viewport
 
   Object.keys(rect).forEach((key) => {
     result[key] = rect[key] * viewport.scale
@@ -35,7 +35,7 @@ export function scaleDown (rect: Record<string, number>) : Record<string, number
   }
 
   const result : Record<string, number> = {}
-  const viewport = window.PDFViewerApplication.pdfViewer.getPageView(0).viewport
+  const viewport = globalThis.PDFViewerApplication.pdfViewer.getPageView(0).viewport
   Object.keys(rect).forEach((key) => {
     result[key] = rect[key] / viewport.scale
   })

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/UI/view.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/UI/view.ts
@@ -2,11 +2,11 @@
  * Deselect annotations when pages clicked.
  */
 function handlePageClick (e) {
-  window.annotationContainer
+  globalThis.annotationContainer
     .getSelectedAnnotations()
     .forEach(a => a.deselect())
 
-  var event = document.createEvent('CustomEvent')
+  const event = document.createEvent('CustomEvent')
   event.initCustomEvent('annotationDeselected', true, true, this)
   window.dispatchEvent(event)
 }

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/annotation/abstract.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/annotation/abstract.ts
@@ -8,15 +8,15 @@ import { VID } from '@inception-project/inception-js-api'
  * Abstract Annotation Class.
  */
 export default abstract class AbstractAnnotation extends EventEmitter {
-  vid: VID = null
-  color: string = null
+  vid: VID | null = null
+  color?: string
   deleted = false
   disabled = false
   readOnly = false
   hoverEventDisable = false
   selectedTime = null
-  element: HTMLElement = null
-  exportId: any
+  element: HTMLElement | null = null
+  // exportId: any
   type: 'span' | 'relation'
   classList: string[] = []
 
@@ -44,30 +44,39 @@ export default abstract class AbstractAnnotation extends EventEmitter {
   /**
    * Render annotation(s).
    */
-  render (): boolean {
-    this.element.remove()
+  render (): void {
+    if (this.element) {
+      this.element.remove()
+      this.element = null
+    }
 
     if (this.deleted) {
-      return false
+      return
     }
 
     const base = document.getElementById('annoLayer2')
+    if (!base) {
+      console.error('annoLayer2 could not be found')
+      return
+    }
+
     this.element = appendChild(base, this)
+    if (!this.element) {
+      return
+    }
 
     if (!this.hoverEventDisable && this.setHoverEvent) {
       this.setHoverEvent()
     }
 
     this.disabled && this.disable()
-
-    return true
   }
 
   /**
    * Save the annotation data.
    */
   save () {
-    window.annotationContainer.add(this)
+    globalThis.annotationContainer.add(this)
   }
 
   /**
@@ -75,12 +84,15 @@ export default abstract class AbstractAnnotation extends EventEmitter {
    */
   destroy () {
     this.deleted = true
-    this.element.remove()
+    if (this.element) {
+      this.element.remove()
+      this.element = null
+    }
 
     const promise = Promise.resolve()
 
     if (this.vid) {
-      window.annotationContainer.remove(this)
+      globalThis.annotationContainer.remove(this)
     }
 
     return promise
@@ -90,16 +102,18 @@ export default abstract class AbstractAnnotation extends EventEmitter {
    * Handle a click event.
    */
   handleSingleClickEvent (e: Event) {
-    const event = document.createEvent('CustomEvent')
-    event.initCustomEvent('annotationSelected', true, true, this)
-    this.element.dispatchEvent(event)
+    if (this.element) {
+      const event = document.createEvent('CustomEvent')
+      event.initCustomEvent('annotationSelected', true, true, this)
+      this.element.dispatchEvent(event)
+    }
   }
 
   /**
    * Handle a hoverIn event.
    */
-  handleHoverInEvent (e) {
-    console.log('handleHoverInEvent', this.element)
+  handleHoverInEvent (e: Event) {
+    // console.log('handleHoverInEvent', this.element)
     this.highlight()
     this.emit('hoverin')
     dispatchWindowEvent('annotationHoverIn', this)
@@ -108,8 +122,8 @@ export default abstract class AbstractAnnotation extends EventEmitter {
   /**
    * Handle a hoverOut event.
    */
-  handleHoverOutEvent (e) {
-    console.log('handleHoverOutEvent')
+  handleHoverOutEvent (e: Event) {
+    // console.log('handleHoverOutEvent')
     this.dehighlight()
     this.emit('hoverout')
     dispatchWindowEvent('annotationHoverOut', this)
@@ -119,14 +133,14 @@ export default abstract class AbstractAnnotation extends EventEmitter {
    * Highlight the annotation.
    */
   highlight () {
-    this.element.classList.add('--hover')
+    this.element?.classList.add('--hover')
   }
 
   /**
    * Dehighlight the annotation.
    */
   dehighlight () {
-    this.element.classList.remove('--hover')
+    this.element?.classList.remove('--hover')
   }
 
   /**
@@ -135,14 +149,15 @@ export default abstract class AbstractAnnotation extends EventEmitter {
   createDummyElement (): HTMLElement {
     const element = document.createElement('dummy')
     element.classList.add('dummy')
-    return element
+    // return element
+    return null
   }
 
   /**
    * Get the central position of the boundingCircle.
    */
   getBoundingCirclePosition () {
-    const knob = this.element.querySelector('.anno-knob') as HTMLElement
+    const knob = this.element?.querySelector('.anno-knob') as HTMLElement | null
     if (!knob) {
       return null
     }
@@ -177,16 +192,20 @@ export default abstract class AbstractAnnotation extends EventEmitter {
 
   enable () {
     this.disabled = false
-    this.element.style.pointerEvents = 'auto'
+    if (this.element) {
+      this.element.style.pointerEvents = 'auto'
+    }
   }
 
   disable () {
     this.disabled = true
-    this.element.style.pointerEvents = 'none'
+    if (this.element) {
+      this.element.style.pointerEvents = 'none'
+    }
   }
 
   /**
    * Check the another annotation is equal to `this`.
    */
-  abstract equalTo(anotherAnnotation): boolean;
+  abstract equalTo(anotherAnnotation: any): boolean;
 }

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/annotation/container.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/annotation/container.ts
@@ -36,7 +36,7 @@ export default class AnnotationContainer {
    * Get all annotations from the container.
    */
   getAllAnnotations () : AbstractAnnotation[] {
-    const list = []
+    const list : AbstractAnnotation[] = []
     this.set.forEach(a => list.push(a))
     return list
   }
@@ -44,8 +44,8 @@ export default class AnnotationContainer {
   /**
    * Find an annotation by the id which an annotation has.
    */
-  findById (vid: VID) : AbstractAnnotation {
-    let annotation
+  findById (vid: VID) : AbstractAnnotation | null {
+    let annotation : AbstractAnnotation | null = null
     this.set.forEach(a => {
       if (a.vid === vid) {
         annotation = a

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/annotation/relation.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/annotation/relation.ts
@@ -6,14 +6,14 @@ import SpanAnnotation from './span'
  * Relation Annotation (one-way / two-way / link)
  */
 export default class RelationAnnotation extends AbstractAnnotation {
-  text: string
+  text: string | null = null
   x1: number
   y1: number
   x2: number
   y2: number
   zIndex: number
-  _rel1Annotation: SpanAnnotation
-  _rel2Annotation: SpanAnnotation
+  _rel1Annotation: SpanAnnotation | null = null
+  _rel2Annotation: SpanAnnotation | null = null
 
   /**
    * Constructor.
@@ -22,11 +22,6 @@ export default class RelationAnnotation extends AbstractAnnotation {
     super()
 
     this.type = 'relation'
-    this.rel1Annotation = null
-    this.rel2Annotation = null
-    this.text = null
-    this.color = null
-    this.readOnly = false
     this.element = this.createDummyElement()
 
     // for render.
@@ -40,17 +35,19 @@ export default class RelationAnnotation extends AbstractAnnotation {
     this.handleHoverInEvent = this.handleHoverInEvent.bind(this)
     this.handleHoverOutEvent = this.handleHoverOutEvent.bind(this)
 
-    window.globalEvent.on('enableViewMode', this.enableViewMode)
+    globalThis.globalEvent.on('enableViewMode', this.enableViewMode)
   }
 
   /**
    * Set a hover event.
    */
   setHoverEvent () {
-    this.element.querySelectorAll('path').forEach(e => {
-      e.addEventListener('mouseenter', this.handleHoverInEvent)
-      e.addEventListener('mouseleave', this.handleHoverOutEvent)
-    })
+    if (this.element) {
+      this.element.querySelectorAll('path').forEach(e => {
+        e.addEventListener('mouseenter', this.handleHoverInEvent)
+        e.addEventListener('mouseleave', this.handleHoverOutEvent)
+      })
+    }
   }
 
   /**
@@ -95,9 +92,9 @@ export default class RelationAnnotation extends AbstractAnnotation {
   /**
    * Render the annotation.
    */
-  render (): boolean {
+  render (): void {
     this.setStartEndPosition()
-    return super.render()
+    super.render()
   }
 
   /**
@@ -110,17 +107,17 @@ export default class RelationAnnotation extends AbstractAnnotation {
       this._rel1Annotation.removeListener('hoverin', this.handleRelHoverIn)
       this._rel1Annotation.removeListener('hoverout', this.handleRelHoverOut)
       this._rel1Annotation.removeListener('delete', this.handleRelDelete)
-      delete this._rel1Annotation
+      this._rel1Annotation = null
     }
 
     if (this._rel2Annotation) {
       this._rel2Annotation.removeListener('hoverin', this.handleRelHoverIn)
       this._rel2Annotation.removeListener('hoverout', this.handleRelHoverOut)
       this._rel2Annotation.removeListener('delete', this.handleRelDelete)
-      delete this._rel2Annotation
+      this._rel2Annotation = null
     }
 
-    window.globalEvent.removeListener('enableViewMode', this.enableViewMode)
+    globalThis.globalEvent.removeListener('enableViewMode', this.enableViewMode)
 
     return promise
   }
@@ -224,7 +221,7 @@ export default class RelationAnnotation extends AbstractAnnotation {
     super.enableViewMode()
 
     if (!this.readOnly) {
-      this.element.querySelectorAll('path').forEach(e =>
+      this.element?.querySelectorAll('path').forEach(e =>
         e.addEventListener('click', this.handleSingleClickEvent))
     }
   }
@@ -234,7 +231,7 @@ export default class RelationAnnotation extends AbstractAnnotation {
    */
   disableViewMode () {
     super.disableViewMode()
-    this.element.querySelectorAll('path').forEach(e =>
+    this.element?.querySelectorAll('path').forEach(e =>
       e.removeEventListener('click', this.handleSingleClickEvent))
   }
 
@@ -244,13 +241,17 @@ export default class RelationAnnotation extends AbstractAnnotation {
   setStartEndPosition () {
     if (this._rel1Annotation) {
       const p = this._rel1Annotation.getBoundingCirclePosition()
-      this.x1 = p.x
-      this.y1 = p.y
+      if (p !== null) {
+        this.x1 = p.x
+        this.y1 = p.y
+      }
     }
     if (this._rel2Annotation) {
       const p = this._rel2Annotation.getBoundingCirclePosition()
-      this.x2 = p.x
-      this.y2 = p.y
+      if (p !== null) {
+        this.x2 = p.x
+        this.y2 = p.y
+      }
     }
   }
 
@@ -259,8 +260,9 @@ export default class RelationAnnotation extends AbstractAnnotation {
       return false
     }
 
-    const isSame = anyOf(this.rel1Annotation.vid, [anno.rel1Annotation.vid, anno.rel2Annotation.vid]) &&
-      anyOf(this.rel2Annotation.vid, [anno.rel1Annotation.vid, anno.rel2Annotation.vid])
+    const isSame =
+      anyOf(this.rel1Annotation?.vid, [anno.rel1Annotation?.vid, anno.rel2Annotation?.vid]) &&
+      anyOf(this.rel2Annotation?.vid, [anno.rel1Annotation?.vid, anno.rel2Annotation?.vid])
 
     return isSame
   }

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/annotation/span.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/annotation/span.ts
@@ -16,31 +16,24 @@ const CLICK_DELAY = 300
  */
 export default class SpanAnnotation extends AbstractAnnotation {
   rectangles: Rectangle[] = []
-  readOnly = false
   knob = true
   border = true
   text: string
   textRange: [number, number]
-  page: number = -1
+  page: number
   zIndex = 10
-  element: HTMLElement
 
   constructor () {
     super()
 
     this.type = 'span'
-    this.vid = null
-    this.color = null
-    this.textRange = null
-    this.page = null
-    this.element = this.createDummyElement()
 
     // Need to bind these event handler methods
     this.handleClickEvent = this.handleClickEvent.bind(this)
     this.handleHoverInEvent = this.handleHoverInEvent.bind(this)
     this.handleHoverOutEvent = this.handleHoverOutEvent.bind(this)
 
-    window.globalEvent.on('enableViewMode', this.enableViewMode)
+    globalThis.globalEvent.on('enableViewMode', this.enableViewMode)
   }
 
   equalTo (anno: SpanAnnotation) {
@@ -54,23 +47,23 @@ export default class SpanAnnotation extends AbstractAnnotation {
   /**
    * Render annotation(s).
    */
-  render (): boolean {
+  render (): void {
     if (!this.rectangles || this.rectangles.length === 0) {
       if (!this.page || !this.textRange) {
         console.error('ERROR: span missing page or textRange. span=', this)
-        return false
+        return
       }
       this.rectangles = mergeRects(getGlyphsInRange(this.textRange))
     }
 
-    return super.render()
+    super.render()
   }
 
   /**
    * Set a hover event.
    */
   setHoverEvent () {
-    this.element.querySelectorAll('.anno-knob').forEach(e => {
+    this.element?.querySelectorAll('.anno-knob').forEach(e => {
       e.addEventListener('mouseenter', this.handleHoverInEvent)
       e.addEventListener('mouseleave', this.handleHoverOutEvent)
     })
@@ -83,24 +76,8 @@ export default class SpanAnnotation extends AbstractAnnotation {
     const promise = super.destroy()
     this.emit('delete')
 
-    window.globalEvent.removeListener('enableViewMode', this.enableViewMode)
+    globalThis.globalEvent.removeListener('enableViewMode', this.enableViewMode)
     return promise
-  }
-
-  /**
-   * Get the position for text.
-   */
-  getTextPosition () {
-    let p = null
-
-    if (this.rectangles.length > 0) {
-      p = {
-        x: this.rectangles[0].x + 7,
-        y: this.rectangles[0].y - 20
-      }
-    }
-
-    return p
   }
 
   /**
@@ -124,7 +101,7 @@ export default class SpanAnnotation extends AbstractAnnotation {
       bubbles: true,
       detail: this
     })
-    this.element.dispatchEvent(event)
+    this.element?.dispatchEvent(event)
   }
 
   /**
@@ -137,7 +114,7 @@ export default class SpanAnnotation extends AbstractAnnotation {
       return
     }
 
-    this.element.querySelectorAll('.anno-knob').forEach(e => {
+    this.element?.querySelectorAll('.anno-knob').forEach(e => {
       e.addEventListener('mousedown', this.preventFocusChange)
       e.addEventListener('click', this.handleClickEvent)
     })
@@ -159,7 +136,7 @@ export default class SpanAnnotation extends AbstractAnnotation {
     ev.preventDefault()
     clickCount++
     if (clickCount === 1) {
-      timer = setTimeout(() => {
+      timer = window.setTimeout(() => {
         try {
           this.handleSingleClickEvent(ev) // perform single-click action
         } finally {
@@ -183,7 +160,7 @@ export default class SpanAnnotation extends AbstractAnnotation {
    */
   disableViewMode () {
     super.disableViewMode()
-    this.element.querySelectorAll('.anno-knob').forEach(e => {
+    this.element?.querySelectorAll('.anno-knob').forEach(e => {
       e.removeEventListener('click', this.handleClickEvent)
       e.removeEventListener('mousedown', this.preventFocusChange)
     })

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/render/appendChild.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/render/appendChild.ts
@@ -16,8 +16,8 @@ export function transform (base: HTMLElement, node: HTMLElement, viewport: any):
   return node
 }
 
-export function appendChild (base: HTMLElement, annotation: AbstractAnnotation): HTMLElement | undefined {
-  let child: HTMLElement | undefined
+export function appendChild (base: HTMLElement, annotation: AbstractAnnotation): HTMLElement | null {
+  let child: HTMLElement | null
   switch (annotation.type) {
     case 'span':
       child = renderSpan(annotation as SpanAnnotation)
@@ -30,7 +30,7 @@ export function appendChild (base: HTMLElement, annotation: AbstractAnnotation):
   // If no type was provided for an annotation it will result in node being null.
   // Skip appending/transforming if node doesn't exist.
   if (child) {
-    const viewport = window.PDFViewerApplication.pdfViewer.getPageView(0).viewport
+    const viewport = globalThis.PDFViewerApplication.pdfViewer.getPageView(0).viewport
     const elm = transform(base, child, viewport)
     base.append(elm)
   }

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/page/pdf/PDFAnnoPage.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/page/pdf/PDFAnnoPage.ts
@@ -40,9 +40,9 @@ export default class PDFAnnoPage {
     console.log(`Loading PDF from ${pdfUrl}`)
 
     // Load PDF.
-    return window.PDFViewerApplication.open(pdfUrl).then(() => {
+    return globalThis.PDFViewerApplication.open(pdfUrl).then(() => {
       // Set the PDF file name.
-      window.PDFViewerApplication.url = name
+      globalThis.PDFViewerApplication.url = name
     })
   }
 
@@ -50,8 +50,8 @@ export default class PDFAnnoPage {
    * Start the viewer.
    */
   initializeViewer (viewerSelector = '#viewer') {
-    window.pdf = null
-    window.pdfName = null
+    // window.pdf = null
+    // window.pdfName = null
 
     // Reset setting.
     this.resetPDFViewerSettings()
@@ -61,9 +61,9 @@ export default class PDFAnnoPage {
    * Close the viewer.
    */
   closePDFViewer () {
-    if (window.PDFViewerApplication) {
-      window.PDFViewerApplication.close()
-      $('#numPages', window.document).text('')
+    if (globalThis.PDFViewerApplication) {
+      globalThis.PDFViewerApplication.close()
+      // $('#numPages', window.document).text('')
       dispatchWindowEvent('didCloseViewer')
     }
   }
@@ -86,24 +86,33 @@ export default class PDFAnnoPage {
       let pageNumber: number
       let y: number
 
-      if (annotation.type === 'span') {
-        const spanAnnotation = annotation as SpanAnnotation
-        pageNumber = spanAnnotation.page
-        y = spanAnnotation.rectangles[0].y
-      }
-
-      if (annotation.type === 'relation') {
-        const relationAnnotation = annotation as RelationAnnotation
-        const d = convertToExportY(relationAnnotation.y1)
-        pageNumber = d.pageNumber
-        y = d.y
+      switch (annotation.type) {
+        case 'span': {
+          const spanAnnotation = annotation as SpanAnnotation
+          pageNumber = spanAnnotation.page
+          y = spanAnnotation.rectangles[0].y
+          break
+        }
+        case 'relation': {
+          const relationAnnotation = annotation as RelationAnnotation
+          const d = convertToExportY(relationAnnotation.y1)
+          pageNumber = d.pageNumber
+          y = d.y
+          break
+        }
+        default:
+          console.error(`Unknown annotation type: ${annotation.type}`)
+          return
       }
 
       const pageHeight = this.getViewerViewport().height
       const scale = this.getViewerViewport().scale
       let _y = (pageHeight + paddingBetweenPages) * (pageNumber - 1) + y * scale
       _y -= 100
-      document.getElementById('viewer').parentElement.scrollTop = _y
+      const viewer = document.getElementById('viewer')
+      if (viewer && viewer.parentElement) {
+        viewer.parentElement.scrollTop = _y
+      }
 
       // highlight.
       annotation.highlight()
@@ -115,7 +124,7 @@ export default class PDFAnnoPage {
    * Get the viewport of the viewer.
    */
   getViewerViewport () {
-    return window.PDFViewerApplication.pdfViewer.getPageView(0).viewport
+    return globalThis.PDFViewerApplication.pdfViewer.getPageView(0).viewport
   }
 
   /**

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/page/textLayer.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/page/textLayer.ts
@@ -57,33 +57,6 @@ export function findPageForOffset (offset: number): VPage | undefined {
 }
 
 /**
- * Find index between characters in the text.
- * Used for zero-width span annotations.
- * @param pageNum - the page number.
- * @param point - { x, y } coords.
- * @return {*} - The nearest text index to the given point.
- */
-export function findCharacterOffset (pageNum: number, point: { x: number, y: number }): number | undefined {
-  const page = getPage(pageNum)
-
-  if (!page) {
-    return undefined
-  }
-
-  for (const g of page.glyphs) {
-    if (g.bbox.x <= point.y && point.y <= (g.bbox.y + g.bbox.h)) {
-      if (g.bbox.x <= point.x && point.x <= g.bbox.x + g.bbox.w / 2) {
-        return g.begin
-      } else if (g.bbox.x + g.bbox.w / 2 < point.x && point.x <= g.bbox.x + g.bbox.w) {
-        return g.begin + 1
-      }
-    }
-  }
-
-  return undefined
-}
-
-/**
  * Find the glyph at the given position in the PDF document. This operation uses the glyph
  * position data that is provided by the server.
  *
@@ -107,6 +80,20 @@ function overlapping (range1: Offsets, range2: Offsets): boolean {
   const aYBegin = range2[0]
   const aYEnd = range2[1]
   return aYBegin === aXBegin || aYEnd === aXEnd || (aXBegin < aYEnd && aYBegin < aXEnd)
+}
+
+export function getGlyphAt (offset: number): VGlyph | null {
+  const page = findPageForOffset(offset)
+  if (!page) {
+    return null
+  }
+
+  const glyph = page.glyphs.find(g => g.begin <= offset && offset < g.end)
+  if (!glyph) {
+    return null
+  }
+
+  return glyph
 }
 
 export function getGlyphsInRange (range: Offsets): VGlyph[] {

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/page/textLayer.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/page/textLayer.ts
@@ -33,7 +33,7 @@ export function getPageBefore (num: number): VPage | undefined {
   return pageBefore
 }
 
-export function getPageAfter(num: number): VPage | undefined {
+export function getPageAfter (num: number): VPage | undefined {
   let stop = false
   for (const page of pages) {
     if (stop) {
@@ -114,7 +114,7 @@ export function getGlyphsInRange (range: Offsets): VGlyph[] {
     return []
   }
 
-  const glyphs = []
+  const glyphs : VGlyph[] = []
   let currentPage = findPageForOffset(range[0])
   while (currentPage && overlapping(range, currentPage.range)) {
     for (const g of currentPage.glyphs) {
@@ -133,9 +133,9 @@ export function getGlyphsInRange (range: Offsets): VGlyph[] {
  * assumed.
  */
 function scale () {
-  if (window.PDFViewerApplication.pdfViewer.getPageView(0) === undefined) {
+  if (globalThis.PDFViewerApplication.pdfViewer.getPageView(0) === undefined) {
     return 1
   } else {
-    return window.PDFViewerApplication.pdfViewer.getPageView(0).viewport.scale
+    return globalThis.PDFViewerApplication.pdfViewer.getPageView(0).viewport.scale
   }
 }

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/page/util/window.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/page/util/window.ts
@@ -25,5 +25,5 @@ export function resizeHandler () {
   viewer.style.height = `${height}px`
 
   document.querySelectorAll('.loadingInProgress').forEach(
-    e => (e as HTMLElement).style.height = '100%')
+    e => { (e as HTMLElement).style.height = '100%' })
 }

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/pdfanno.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/pdfanno.ts
@@ -9,7 +9,7 @@ import AnnotationContainer from './core/src/annotation/container'
 import AbstractAnnotation from './core/src/annotation/abstract'
 import { installSpanSelection, mergeRects } from './core/src/UI/span'
 import { installRelationSelection } from './core/src/UI/relation'
-import { CompactAnnotatedText, DiamAjax } from '@inception-project/inception-js-api'
+import { CompactAnnotatedText, CompactSpan, DiamAjax, Offsets, VID } from '@inception-project/inception-js-api'
 import { DiamLoadAnnotationsOptions } from '@inception-project/inception-js-api/src/diam/DiamAjax'
 import SpanAnnotation from './core/src/annotation/span'
 import { getGlyphsInRange } from './page/textLayer'
@@ -17,6 +17,9 @@ import RelationAnnotation from './core/src/annotation/relation'
 import { createRect, mapToDocumentCoordinates } from './core/src/render/renderSpan'
 import { transform } from './core/src/render/appendChild'
 import { makeMarkerMap } from '@inception-project/inception-js-api/src/model/compact/CompactAnnotatedText'
+import { CompactTextMarker } from '@inception-project/inception-js-api/src/model/compact/CompactTextMarker'
+import { CompactRelation } from '@inception-project/inception-js-api/src/model/compact/CompactRelation'
+import { CompactAnnotationMarker } from '@inception-project/inception-js-api/src/model/compact/CompactAnnotationMarker'
 
 // TODO make it a global const.
 // const svgLayerId = 'annoLayer'
@@ -29,8 +32,8 @@ let currentFocusPage: number
 let pagechangeEventCounter: number
 
 export async function initPdfAnno (ajax: DiamAjax): Promise<void> {
-  window.globalEvent = new EventEmitter()
-  window.globalEvent.setMaxListeners(0)
+  globalThis.globalEvent = new EventEmitter()
+  globalThis.globalEvent.setMaxListeners(0)
   diamAjax = ajax
 
   // Create an annocation container.
@@ -38,31 +41,31 @@ export async function initPdfAnno (ajax: DiamAjax): Promise<void> {
   annoPage = new PDFAnnoPage(annotationContainer)
 
   // FIXME: These should be removed
-  window.annotationContainer = annotationContainer
+  globalThis.annotationContainer = annotationContainer
 
   // Enable a view mode.
   UI.enableViewMode()
 
   const initPromise = new Promise<void>((resolve) => {
     console.log('Waiting for the document to load...')
-    window.PDFViewerApplication.initializedPromise.then(function () {
+    globalThis.PDFViewerApplication.initializedPromise.then(function () {
       // The event called at page rendered by pdfjs.
-      window.PDFViewerApplication.eventBus.on('pagerendered', ev => onPageRendered(ev))
+      globalThis.PDFViewerApplication.eventBus.on('pagerendered', ev => onPageRendered(ev))
       // Adapt to scale change.
-      window.PDFViewerApplication.eventBus.on('scalechanged', ev => onScaleChange(ev))
-      window.PDFViewerApplication.eventBus.on('zoomin', ev => onScaleChange(ev))
-      window.PDFViewerApplication.eventBus.on('zoomout', ev => onScaleChange(ev))
-      window.PDFViewerApplication.eventBus.on('zoomreset', ev => onScaleChange(ev))
-      window.PDFViewerApplication.eventBus.on('sidebarviewchanged', ev => onScaleChange(ev))
-      window.PDFViewerApplication.eventBus.on('resize', ev => onScaleChange(ev))
+      globalThis.PDFViewerApplication.eventBus.on('scalechanged', ev => onScaleChange(ev))
+      globalThis.PDFViewerApplication.eventBus.on('zoomin', ev => onScaleChange(ev))
+      globalThis.PDFViewerApplication.eventBus.on('zoomout', ev => onScaleChange(ev))
+      globalThis.PDFViewerApplication.eventBus.on('zoomreset', ev => onScaleChange(ev))
+      globalThis.PDFViewerApplication.eventBus.on('sidebarviewchanged', ev => onScaleChange(ev))
+      globalThis.PDFViewerApplication.eventBus.on('resize', ev => onScaleChange(ev))
 
       const loadedCallback = () => {
         console.log('Document loaded...')
-        window.PDFViewerApplication.eventBus.off('pagerendered', loadedCallback)
+        globalThis.PDFViewerApplication.eventBus.off('pagerendered', loadedCallback)
         resolve()
       }
 
-      window.PDFViewerApplication.eventBus.on('pagerendered', loadedCallback)
+      globalThis.PDFViewerApplication.eventBus.on('pagerendered', loadedCallback)
     })
   })
 
@@ -85,7 +88,7 @@ function onPageRendered (ev) {
   console.log('pagerendered:', ev.pageNumber)
 
   // No action, if the viewer is closed.
-  if (!window.PDFViewerApplication.pdfViewer.getPageView(0)) {
+  if (!globalThis.PDFViewerApplication.pdfViewer.getPageView(0)) {
     return
   }
 
@@ -106,7 +109,7 @@ function adjustPageGaps () {
   // Correctly rendering when changing scaling.
   // The margin between pages is fixed(9px), and never be scaled in default,
   // then manually have to change the margin.
-  const scale = window.PDFViewerApplication.pdfViewer.getPageView(0).viewport.scale
+  const scale = globalThis.PDFViewerApplication.pdfViewer.getPageView(0).viewport.scale
   document.querySelectorAll('.page').forEach(e => {
     const page = e as HTMLElement
     const borderWidth = `${9 * scale}px`
@@ -131,7 +134,7 @@ function removeAnnoLayer () {
  */
 function renderAnno () {
   // No action, if the viewer is closed.
-  if (!window.PDFViewerApplication.pdfViewer.getPageView(0)) {
+  if (!globalThis.PDFViewerApplication.pdfViewer.getPageView(0)) {
     return
   }
 
@@ -144,7 +147,17 @@ function renderAnno () {
   }
 
   const viewer = document.getElementById('viewer')
+  if (!viewer) {
+    console.error('Cannot render: no viewer element found.')
+    return
+  }
+
   const pageElement = document.querySelector('.page')
+  if (!pageElement) {
+    console.error('Cannot render: no page element found.')
+    return
+  }
+
   let leftMargin = (viewer.clientWidth - pageElement.clientWidth) / 2
 
   // At window.width < page.width.
@@ -228,10 +241,10 @@ export function scrollTo (offset: number, position: string): void {
   let base: HTMLElement = document.createElement('div')
   base.classList.add('anno-span')
   base.style.zIndex = '10'
-  const child = createRect(undefined, rectangles[0])
+  const child = createRect(rectangles[0])
   base.appendChild(child)
 
-  const viewport = window.PDFViewerApplication.pdfViewer.getPageView(0).viewport
+  const viewport = globalThis.PDFViewerApplication.pdfViewer.getPageView(0).viewport
   base = transform(annoLayer, base, viewport)
   annoLayer.appendChild(base)
   child.scrollIntoView({ behavior: 'auto', block: 'center', inline: 'center' })
@@ -261,50 +274,104 @@ export function getAnnotations () {
 
     const annotationMarkers = makeMarkerMap(doc.annotationMarkers)
 
+    console.log(`Loaded ${doc.spans?.length || '0'} spans and ${doc.relations?.length || '0'} relations in range [${doc.window}]`)
+
     if (doc.spans) {
-      console.log(`Loaded ${doc.spans.length} span annotations`)
       for (const s of doc.spans) {
-        const span = new SpanAnnotation()
-        span.vid = `${s[0]}`
-        span.textRange = [s[1][0][0] + doc.window[0], s[1][0][1] + doc.window[0]]
-        span.page = textLayer.findPageForOffset(span.textRange[0]).index
-        span.color = s[2]?.c || '#FFF'
-        span.text = s[2]?.l || ''
-        span.rectangles = mergeRects(getGlyphsInRange(span.textRange))
-        annotationMarkers.get(s[0])?.forEach(m => span.classList.push(`marker-${m[0]}`))
-        span.save()
+        makeSpan(s, doc, annotationMarkers)
       }
     }
 
     if (doc.relations) {
-      console.log(`Loaded ${doc.relations.length} relations annotations`)
       for (const r of doc.relations) {
-        const rel = new RelationAnnotation()
-        rel.vid = `${r[0]}`
-        rel.rel1Annotation = annotationContainer.findById(r[1][0][0])
-        rel.rel2Annotation = annotationContainer.findById(r[1][1][0])
-        rel.color = r[2].c
-        rel.text = r[2].l
-        annotationMarkers.get(r[0])?.forEach(m => rel.classList.push(`marker-${m[0]}`))
-        rel.save()
+        makeRelation(r, annotationMarkers)
       }
     }
 
     if (doc.textMarkers) {
       for (const m of doc.textMarkers) {
-        const span = new SpanAnnotation()
-        span.textRange = [m[1][0][0] + doc.window[0], m[1][0][1] + doc.window[0]]
-        span.page = textLayer.findPageForOffset(span.textRange[0]).index
-        span.knob = false
-        span.border = false
-        span.rectangles = mergeRects(getGlyphsInRange(span.textRange))
-        span.classList = [`marker-${m[0]}`]
-        span.save()
+        makeTextMarker(m, doc)
       }
     }
 
     renderAnnotations()
   })
+}
+
+function makeSpan (s: CompactSpan, doc: CompactAnnotatedText, annotationMarkers: Map<VID, Array<CompactAnnotationMarker>>) {
+  const offsets = s[1]
+  const begin = offsets[0][0] + doc.window[0]
+  const end = offsets[0][1] + doc.window[0]
+  const range: Offsets = [begin, end]
+
+  const page = textLayer.findPageForOffset(begin)?.index
+  if (page === undefined) {
+    console.warn(`No page found for span range ${range}`)
+    return
+  }
+
+  const rectangles = mergeRects(getGlyphsInRange(range))
+  if (!rectangles?.length) {
+    console.warn(`No glyphs found for span range ${range}`)
+    return
+  }
+
+  const span = new SpanAnnotation()
+  span.vid = `${s[0]}`
+  span.textRange = range
+  span.page = page
+  span.color = s[2]?.c || '#FFF'
+  span.text = s[2]?.l || ''
+  span.rectangles = rectangles
+  annotationMarkers.get(s[0])?.forEach(m => span.classList.push(`marker-${m[0]}`))
+  span.save()
+}
+
+function makeRelation (r: CompactRelation, annotationMarkers: Map<VID, Array<CompactAnnotationMarker>>) {
+  const source = annotationContainer.findById(r[1][0][0])
+  const target = annotationContainer.findById(r[1][1][0])
+
+  if (!source || !target) {
+    console.warn(`Cannot find source or target for relation ${r[0]}`)
+    return
+  }
+
+  const rel = new RelationAnnotation()
+  rel.vid = `${r[0]}`
+  rel.rel1Annotation = source as SpanAnnotation
+  rel.rel2Annotation = target as SpanAnnotation
+  rel.color = r[2]?.c
+  rel.text = r[2]?.l || null
+  annotationMarkers.get(r[0])?.forEach(m => rel.classList.push(`marker-${m[0]}`))
+  rel.save()
+}
+
+function makeTextMarker (m: CompactTextMarker, doc: CompactAnnotatedText) {
+  const offsets = m[1]
+  const begin = offsets[0][0] + doc.window[0]
+  const end = offsets[0][1] + doc.window[0]
+  const range: Offsets = [begin, end]
+
+  const page = textLayer.findPageForOffset(begin)?.index
+  if (page === undefined) {
+    console.warn(`No page found for marker range ${range}`)
+    return
+  }
+
+  const rectangles = mergeRects(getGlyphsInRange(range))
+  if (!rectangles?.length) {
+    console.warn(`No glyphs found for marker range ${range}`)
+    return
+  }
+
+  const marker = new SpanAnnotation()
+  marker.textRange = range
+  marker.page = page
+  marker.knob = false
+  marker.border = false
+  marker.rectangles = rectangles
+  marker.classList = [`marker-${m[0]}`]
+  marker.save()
 }
 
 async function displayViewer (): Promise<void> {
@@ -331,11 +398,11 @@ async function displayViewer (): Promise<void> {
           try {
             getAnnotations()
           } finally {
-            window.PDFViewerApplication.eventBus.off('pagerendered', initAnnotations)
+            globalThis.PDFViewerApplication.eventBus.off('pagerendered', initAnnotations)
           }
         }
-        window.PDFViewerApplication.eventBus.on('pagerendered', initAnnotations)
-        window.PDFViewerApplication.eventBus.on('pagechanging', function (e) {
+        globalThis.PDFViewerApplication.eventBus.on('pagerendered', initAnnotations)
+        globalThis.PDFViewerApplication.eventBus.on('pagechanging', function (e) {
           pagechangeEventCounter++
           if (e.pageNumber !== currentFocusPage) {
             const snapshot = pagechangeEventCounter

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/shared/coords.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/shared/coords.ts
@@ -28,7 +28,7 @@ export const paddingBetweenPages = 9
  * Get a page size of a single PDF page.
  */
 export function getPageSize () : {width: number, height: number} {
-  const pdfView = window.PDFView
+  const pdfView = globalThis.PDFView
 
   const viewBox = pdfView.pdfViewer.getPageView(0).viewport.viewBox
   const size = { width: viewBox[2], height: viewBox[3] }


### PR DESCRIPTION
**What's in the PR**
- Improve robustness of the rendering code and add more helpful logging
- Use `globalThis` instead of `window` to remove errors from the TypeScript compiler
- Address various linter issues
- Fix bug that zero-width annotations are created at wrong position
- Fix rendering of zero-width annotations

**How to test manually**
* Try pressing shift and clicking on text in the PDF editor to create a zero-width annotation

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
