### PR TITLE
#3367 - Suggestion covered text may be wrong

### DIFF
--- a/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/AnnotationLayer.java
+++ b/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/AnnotationLayer.java
@@ -608,6 +608,13 @@ public class AnnotationLayer
             return this;
         }
 
+        public Builder forUimaType(org.apache.uima.cas.Type aType)
+        {
+            withName(aType.getName());
+            withUiName(aType.getShortName());
+            return this;
+        }
+
         public Builder withId(Long id)
         {
             this.id = id;

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/Recommender.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/Recommender.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.inception.recommendation.api.model;
 
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
 
@@ -99,6 +100,23 @@ public class Recommender
     @Lob
     @Column(length = 64000)
     private String traits;
+
+    private Recommender(Builder builder)
+    {
+        this.id = builder.id;
+        this.project = builder.project;
+        this.layer = builder.layer;
+        this.feature = builder.feature;
+        this.name = builder.name;
+        this.tool = builder.tool;
+        this.threshold = builder.threshold;
+        this.alwaysSelected = builder.alwaysSelected;
+        this.skipEvaluation = builder.skipEvaluation;
+        this.enabled = builder.enabled;
+        this.maxRecommendations = builder.maxRecommendations;
+        this.statesIgnoredForTraining = builder.statesIgnoredForTraining;
+        this.traits = builder.traits;
+    }
 
     public Recommender()
     {
@@ -265,5 +283,115 @@ public class Recommender
     public String toString()
     {
         return "[" + name + "](" + id + ")";
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static final class Builder
+    {
+        private Long id;
+        private Project project;
+        private AnnotationLayer layer;
+        private AnnotationFeature feature;
+        private String name;
+        private String tool;
+        private double threshold;
+        private boolean alwaysSelected;
+        private boolean skipEvaluation;
+        private boolean enabled = true;
+        private int maxRecommendations;
+        private Set<AnnotationDocumentState> statesIgnoredForTraining = Collections.emptySet();
+        private String traits;
+
+        private Builder()
+        {
+        }
+
+        public Builder withId(Long aId)
+        {
+            id = aId;
+            return this;
+        }
+
+        public Builder withProject(Project aProject)
+        {
+            project = aProject;
+            return this;
+        }
+
+        public Builder withLayer(AnnotationLayer aLayer)
+        {
+            layer = aLayer;
+            return this;
+        }
+
+        public Builder withFeature(AnnotationFeature aFeature)
+        {
+            feature = aFeature;
+            return this;
+        }
+
+        public Builder withName(String aName)
+        {
+            name = aName;
+            return this;
+        }
+
+        public Builder withTool(String aTool)
+        {
+            tool = aTool;
+            return this;
+        }
+
+        public Builder withThreshold(double aThreshold)
+        {
+            threshold = aThreshold;
+            return this;
+        }
+
+        public Builder withAlwaysSelected(boolean aAlwaysSelected)
+        {
+            alwaysSelected = aAlwaysSelected;
+            return this;
+        }
+
+        public Builder withSkipEvaluation(boolean aSkipEvaluation)
+        {
+            skipEvaluation = aSkipEvaluation;
+            return this;
+        }
+
+        public Builder withEnabled(boolean aEnabled)
+        {
+            enabled = aEnabled;
+            return this;
+        }
+
+        public Builder withMaxRecommendations(int aMaxRecommendations)
+        {
+            maxRecommendations = aMaxRecommendations;
+            return this;
+        }
+
+        public Builder withStatesIgnoredForTraining(
+                Set<AnnotationDocumentState> aStatesIgnoredForTraining)
+        {
+            statesIgnoredForTraining = aStatesIgnoredForTraining;
+            return this;
+        }
+
+        public Builder withTraits(String aTraits)
+        {
+            traits = aTraits;
+            return this;
+        }
+
+        public Recommender build()
+        {
+            return new Recommender(this);
+        }
     }
 }

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
@@ -1659,6 +1659,7 @@ public class RecommendationServiceImpl
         List<AnnotationSuggestion> result = new ArrayList<>();
         int id = 0;
 
+        var documentText = aPredictionCas.getDocumentText();
         for (FeatureStructure predictedFS : aPredictionCas.select(predictedType)) {
             if (!predictedFS.getBooleanValue(predictionFeature)) {
                 continue;
@@ -1680,10 +1681,12 @@ public class RecommendationServiceImpl
                         continue;
                     }
 
+                    var offsets = targetOffsets.get();
+                    var coveredText = documentText.substring(offsets.getBegin(), offsets.getEnd());
+
                     suggestion = new SpanSuggestion(id, aRecommender, layer.getId(), featureName,
-                            aDocument.getName(), targetOffsets.get(),
-                            predictedAnnotation.getCoveredText(), label, label, score,
-                            scoreExplanation);
+                            aDocument.getName(), targetOffsets.get(), coveredText, label, label,
+                            score, scoreExplanation);
                     break;
                 }
                 case RELATION_TYPE: {

--- a/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImplTest.java
+++ b/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImplTest.java
@@ -17,23 +17,53 @@
  */
 package de.tudarmstadt.ukp.inception.recommendation.service;
 
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.CHARACTERS;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.SENTENCES;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.SINGLE_TOKEN;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.TOKENS;
+import static de.tudarmstadt.ukp.clarin.webanno.support.uima.FeatureStructureBuilder.buildFS;
+import static de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService.FEATURE_NAME_IS_PREDICTION;
+import static de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService.FEATURE_NAME_SCORE_EXPLANATION_SUFFIX;
+import static de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService.FEATURE_NAME_SCORE_SUFFIX;
 import static de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordType.REJECTED;
 import static de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordType.SKIPPED;
+import static de.tudarmstadt.ukp.inception.recommendation.service.RecommendationServiceImpl.extractSuggestions;
+import static de.tudarmstadt.ukp.inception.recommendation.service.RecommendationServiceImpl.getOffsets;
 import static de.tudarmstadt.ukp.inception.recommendation.service.RecommendationServiceImpl.hideSuggestionsRejectedOrSkipped;
 import static java.util.Arrays.asList;
+import static org.apache.uima.cas.CAS.TYPE_NAME_ANNOTATION;
+import static org.apache.uima.cas.CAS.TYPE_NAME_BOOLEAN;
+import static org.apache.uima.cas.CAS.TYPE_NAME_DOUBLE;
+import static org.apache.uima.cas.CAS.TYPE_NAME_STRING;
+import static org.apache.uima.fit.factory.CasFactory.createCas;
+import static org.apache.uima.fit.factory.TypeSystemDescriptionFactory.createTypeSystemDescription;
+import static org.apache.uima.util.CasCreationUtils.mergeTypeSystems;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
+import org.apache.uima.UIMAFramework;
+import org.apache.uima.fit.factory.CasFactory;
+import org.apache.uima.fit.factory.JCasFactory;
+import org.apache.uima.fit.testing.factory.TokenBuilder;
+import org.apache.uima.jcas.tcas.Annotation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.clarin.webanno.support.WebAnnoConst;
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.AnnotationSuggestion;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecord;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.Offset;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.SpanSuggestion;
 
 class RecommendationServiceImplTest
 {
+    private TokenBuilder<Token, Sentence> tokenBuilder;
     private SourceDocument doc1;
     private SourceDocument doc2;
     private AnnotationLayer layer1;
@@ -44,6 +74,7 @@ class RecommendationServiceImplTest
     @BeforeEach
     void setup()
     {
+        tokenBuilder = new TokenBuilder<>(Token.class, Sentence.class);
         doc1 = new SourceDocument("doc1", null, null);
         doc1.setId(1l);
         doc2 = new SourceDocument("doc2", null, null);
@@ -64,7 +95,8 @@ class RecommendationServiceImplTest
                 .withOffsetBegin(0) //
                 .withOffsetEnd(10) //
                 .withAnnotation("x") //
-                .withUserAction(REJECTED).build());
+                .withUserAction(REJECTED) //
+                .build());
 
         var doc1Suggestion = makeSuggestion(0, 10, "x", doc1, layer1, feature1);
         assertThat(doc1Suggestion.isVisible()).isTrue();
@@ -106,7 +138,8 @@ class RecommendationServiceImplTest
                 .withOffsetBegin(0) //
                 .withOffsetEnd(10) //
                 .withAnnotation("x") //
-                .withUserAction(SKIPPED).build());
+                .withUserAction(SKIPPED) //
+                .build());
 
         var doc1Suggestion = makeSuggestion(0, 10, "x", doc1, layer1, feature1);
         assertThat(doc1Suggestion.isVisible()).isTrue();
@@ -136,6 +169,170 @@ class RecommendationServiceImplTest
         assertThat(doc4Suggestion.isVisible()) //
                 .as("Suggestion in other feature should not be hidden") //
                 .isTrue();
+    }
+
+    @Test
+    void testOffsetAlignmentWithAnchoringOnCharacters() throws Exception
+    {
+        var mode = CHARACTERS;
+        var targetCas = CasFactory.createCas();
+        tokenBuilder.buildTokens(targetCas.getJCas(), "This is a test .");
+
+        var suggestionCas = JCasFactory.createText(targetCas.getDocumentText());
+
+        assertThat(getOffsets(mode, targetCas, new Annotation(suggestionCas, 0, 1))) //
+                .as("Trivial case: one character") //
+                .get().isEqualTo(new Offset(0, 1));
+        assertThat(getOffsets(mode, targetCas, new Annotation(suggestionCas, 4, 8))) //
+                .as("Leading and trailing space should be removed") //
+                .get().isEqualTo(new Offset(5, 7));
+        assertThat(getOffsets(mode, targetCas, new Annotation(suggestionCas, -10, 100))) //
+                .as("Range should be clipped to document boundaries").get()
+                .isEqualTo(new Offset(0, targetCas.getDocumentText().length()));
+    }
+
+    @Test
+    void testOffsetAlignmentWithAnchoringOnSingleToken() throws Exception
+    {
+        var mode = SINGLE_TOKEN;
+        var targetCas = CasFactory.createCas();
+        tokenBuilder.buildTokens(targetCas.getJCas(), "This is a test .");
+
+        var suggestionCas = JCasFactory.createText(targetCas.getDocumentText());
+
+        assertThat(getOffsets(mode, targetCas, new Annotation(suggestionCas, 0, 1))) //
+                .as("Reduce to empty if no token is fully covered") //
+                .isEmpty();
+        assertThat(getOffsets(mode, targetCas, new Annotation(suggestionCas, 0, 4))) //
+                .as("Trivial case: one token") //
+                .get().isEqualTo(new Offset(0, 4));
+        assertThat(getOffsets(mode, targetCas, new Annotation(suggestionCas, 0, 7))) //
+                .as("Discard suggestion if it covers more than one token") //
+                .isEmpty();
+        assertThat(getOffsets(mode, targetCas, new Annotation(suggestionCas, -10, 100))) //
+                .as("Discard suggestion if it covers more than one token (2)") //
+                .isEmpty();
+    }
+
+    @Test
+    void testOffsetAlignmentWithAnchoringOnTokens() throws Exception
+    {
+        var mode = TOKENS;
+        var targetCas = CasFactory.createCas();
+        tokenBuilder.buildTokens(targetCas.getJCas(), "This is a test .");
+
+        var suggestionCas = JCasFactory.createText(targetCas.getDocumentText());
+
+        assertThat(getOffsets(mode, targetCas, new Annotation(suggestionCas, 0, 1))) //
+                .as("Reduce to empty if no token is fully covered") //
+                .isEmpty();
+        assertThat(getOffsets(mode, targetCas, new Annotation(suggestionCas, 0, 4))) //
+                .as("Trivial case: one token") //
+                .get().isEqualTo(new Offset(0, 4));
+        assertThat(getOffsets(mode, targetCas, new Annotation(suggestionCas, 0, 7))) //
+                .as("Trivial case: two tokens") //
+                .get().isEqualTo(new Offset(0, 7));
+        assertThat(getOffsets(mode, targetCas, new Annotation(suggestionCas, 2, 12))) //
+                .as("Discard incompletely covered tokens") //
+                .get().isEqualTo(new Offset(5, 9));
+        assertThat(getOffsets(mode, targetCas, new Annotation(suggestionCas, -10, 100))) //
+                .as("Range should be clipped to document boundaries").get()
+                .isEqualTo(new Offset(0, targetCas.getDocumentText().length()));
+    }
+
+    @Test
+    void testOffsetAlignmentWithAnchoringOnSentences() throws Exception
+    {
+        var mode = SENTENCES;
+        var targetCas = CasFactory.createCas();
+        tokenBuilder.buildTokens(targetCas.getJCas(), "This is a test .\nAnother sentence here .");
+
+        var suggestionCas = JCasFactory.createText(targetCas.getDocumentText());
+        var sentences = targetCas.select(Sentence.class).asList();
+        var sent1 = sentences.get(0);
+        var sent2 = sentences.get(1);
+
+        assertThat(getOffsets(mode, targetCas, new Annotation(suggestionCas, 0, 1))) //
+                .as("Reduce to empty if no sentence is fully covered") //
+                .isEmpty();
+        assertThat(getOffsets(mode, targetCas,
+                new Annotation(suggestionCas, sent1.getBegin(), sent1.getEnd()))) //
+                        .as("Trivial case: one sentence") //
+                        .get().isEqualTo(new Offset(sent1.getBegin(), sent1.getEnd()));
+        assertThat(getOffsets(mode, targetCas,
+                new Annotation(suggestionCas, sent1.getBegin(), sent2.getEnd()))) //
+                        .as("Trivial case: two sentences") //
+                        .get().isEqualTo(new Offset(sent1.getBegin(), sent2.getEnd()));
+        assertThat(getOffsets(mode, targetCas, new Annotation(suggestionCas, 0, 30))) //
+                .as("Discard incompletely covered sentences") //
+                .get().isEqualTo(new Offset(0, 16));
+        assertThat(getOffsets(mode, targetCas, new Annotation(suggestionCas, -10, 100))) //
+                .as("Range should be clipped to document boundaries").get()
+                .isEqualTo(new Offset(0, targetCas.getDocumentText().length()));
+    }
+
+    @Test
+    void testExtractSuggestionsWithSpanSuggestions() throws Exception
+    {
+        var tsd = UIMAFramework.getResourceSpecifierFactory().createTypeSystemDescription();
+        var predType = tsd.addType("Prediction", null, TYPE_NAME_ANNOTATION);
+        predType.addFeature("value", null, TYPE_NAME_STRING);
+        predType.addFeature("value" + FEATURE_NAME_SCORE_SUFFIX, null, TYPE_NAME_DOUBLE);
+        predType.addFeature("value" + FEATURE_NAME_SCORE_EXPLANATION_SUFFIX, null,
+                TYPE_NAME_STRING);
+        predType.addFeature(FEATURE_NAME_IS_PREDICTION, null, TYPE_NAME_BOOLEAN);
+
+        var targetCas = createCas(mergeTypeSystems(asList(tsd, createTypeSystemDescription())));
+        tokenBuilder.buildTokens(targetCas.getJCas(), "This is a test .\nAnother sentence here .");
+
+        var layer = AnnotationLayer.builder() //
+                .withId(1l) //
+                .forUimaType(targetCas.getTypeSystem().getType(predType.getName())) //
+                .withType(WebAnnoConst.SPAN_TYPE) //
+                .withAnchoringMode(TOKENS) //
+                .build();
+        var feature = AnnotationFeature.builder() //
+                .withId(1l) //
+                .withName("value") //
+                .withLayer(layer1) //
+                .build();
+        var recommender = Recommender.builder() //
+                .withId(1l) //
+                .withEnabled(true) //
+                .withLayer(layer) //
+                .withFeature(feature) //
+                .withMaxRecommendations(3) //
+                .build();
+
+        var suggestionCas = createCas(mergeTypeSystems(asList(tsd, createTypeSystemDescription())));
+        buildFS(suggestionCas, predType.getName()) //
+                .withFeature(Annotation._FeatName_begin, 0) //
+                .withFeature(Annotation._FeatName_end, 4) //
+                .withFeature("value", "foo") //
+                .withFeature("value" + FEATURE_NAME_SCORE_SUFFIX, 1.0d) //
+                .withFeature("value" + FEATURE_NAME_SCORE_EXPLANATION_SUFFIX, "one") //
+                .withFeature(FEATURE_NAME_IS_PREDICTION, true) //
+                .buildAndAddToIndexes();
+        buildFS(suggestionCas, predType.getName()) //
+                .withFeature(Annotation._FeatName_begin, 5) //
+                .withFeature(Annotation._FeatName_end, 12) //
+                .withFeature("value", "bar") //
+                .withFeature("value" + FEATURE_NAME_SCORE_SUFFIX, 0.5d) //
+                .withFeature("value" + FEATURE_NAME_SCORE_EXPLANATION_SUFFIX, "two") //
+                .withFeature(FEATURE_NAME_IS_PREDICTION, true) //
+                .buildAndAddToIndexes();
+
+        var suggestions = extractSuggestions(targetCas, suggestionCas, doc1, recommender);
+
+        assertThat(suggestions) //
+                .extracting( //
+                        AnnotationSuggestion::getLabel, //
+                        AnnotationSuggestion::getScore, //
+                        s -> s.getScoreExplanation().orElse(null), //
+                        AnnotationSuggestion::getPosition)
+                .containsExactly( //
+                        tuple("foo", 1.0d, "one", new Offset(0, 4)), //
+                        tuple("bar", 0.5d, "two", new Offset(5, 9)));
     }
 
     private SpanSuggestion makeSuggestion(int aBegin, int aEnd, String aLabel, SourceDocument aDoc,


### PR DESCRIPTION
**What's in the PR**
- Determine the covered text based on the aligned offsets instead of simply calling getCoveredText() on the suggested annotation

**How to test manually**
* Build an external recommender that provides sub-token suggestions for a token-aligned layer

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
