### PR TITLE
#3384 - Trying to used an HTML/XML-based editor on an old document may fail

### DIFF
--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/xhtml/XHtmlXmlDocumentViewControllerImpl.java
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/xhtml/XHtmlXmlDocumentViewControllerImpl.java
@@ -108,14 +108,20 @@ public class XHtmlXmlDocumentViewControllerImpl
         CAS cas = documentService.createOrReadInitialCas(doc);
 
         try (Writer out = new StringWriter()) {
-            ContentHandler ch = XmlCas2SaxEvents.makeSerializer(out);
-
-            var maybeXmlDocument = cas.select(XmlDocument.class).findFirst();
+            Optional<XmlDocument> maybeXmlDocument;
+            if (cas.getTypeSystem().getType(XmlDocument._TypeName) != null) {
+                maybeXmlDocument = cas.select(XmlDocument.class).findFirst();
+            }
+            else {
+                maybeXmlDocument = Optional.empty();
+            }
 
             var casContainsHtml = maybeXmlDocument.map(XmlDocument::getRoot) //
                     .map(XmlElement::getQName) //
                     .map(qname -> HTML.equals(qname.toLowerCase(Locale.ROOT))) //
                     .orElse(false);
+
+            ContentHandler ch = XmlCas2SaxEvents.makeSerializer(out);
 
             // If the CAS contains an actual HTML structure, then we send that. Mind that we do
             // not inject format-specific CSS then!

--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/xml/XmlDocumentViewControllerImpl.java
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/xml/XmlDocumentViewControllerImpl.java
@@ -132,7 +132,14 @@ public class XmlDocumentViewControllerImpl
                 renderEditorStylesheets(out, aEditor.get());
             }
 
-            var maybeXmlDocument = cas.select(XmlDocument.class).findFirst();
+            Optional<XmlDocument> maybeXmlDocument;
+            if (cas.getTypeSystem().getType(XmlDocument._TypeName) != null) {
+                maybeXmlDocument = cas.select(XmlDocument.class).findFirst();
+            }
+            else {
+                maybeXmlDocument = Optional.empty();
+            }
+
             if (maybeXmlDocument.isEmpty()) {
                 // Gracefully handle the case that the CAS does not contain any XML structure at all
                 // and show only the document text in this case.


### PR DESCRIPTION
**What's in the PR**
- First check if XmlDocument exists in the CASes type system before trying to use it

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
