### PR TITLE
#3412 - Backup embedded database before upgrade

### DIFF
--- a/inception/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/INCEpTION.java
+++ b/inception/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/INCEpTION.java
@@ -25,6 +25,7 @@ import static org.apache.uima.cas.impl.CASImpl.ALWAYS_HOLD_ONTO_FSS;
 import static org.springframework.boot.WebApplicationType.NONE;
 import static org.springframework.boot.WebApplicationType.SERVLET;
 
+import java.io.IOException;
 import java.util.Optional;
 
 import org.dkpro.core.api.resources.ResourceObjectProviderBase;
@@ -40,6 +41,7 @@ import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 
 import de.tudarmstadt.ukp.clarin.webanno.support.SettingsUtil;
+import de.tudarmstadt.ukp.clarin.webanno.support.db.EmbeddedDatabaseBackupHandler;
 import de.tudarmstadt.ukp.clarin.webanno.support.standalone.LoadingSplashScreen;
 import de.tudarmstadt.ukp.clarin.webanno.support.standalone.LoadingSplashScreen.SplashWindow;
 import de.tudarmstadt.ukp.inception.app.config.InceptionApplicationContextInitializer;
@@ -82,11 +84,19 @@ public class INCEpTION
         // We do not want DKPro Core to try and auto-download anything
         System.setProperty(ResourceObjectProviderBase.PROP_REPO_OFFLINE, "true");
 
+        SettingsUtil.customizeApplication("inception.home", ".inception");
+
+        try {
+            new EmbeddedDatabaseBackupHandler().maybeBackupEmbeddedDatabase();
+        }
+        catch (IOException e) {
+            throw new RuntimeException("Error trying to perform a backup of the embedded database",
+                    e);
+        }
+
         aBuilder.banner(new InceptionBanner());
         aBuilder.initializers(new InceptionApplicationContextInitializer());
         aBuilder.headless(false);
-
-        SettingsUtil.customizeApplication("inception.home", ".inception");
 
         // Traditionally, the INCEpTION configuration file is called settings.properties and is
         // either located in inception.home or under the user's home directory. Make sure we pick

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/db/EmbeddedDatabaseBackupHandler.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/db/EmbeddedDatabaseBackupHandler.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.support.db;
+
+import static de.tudarmstadt.ukp.clarin.webanno.support.SettingsUtil.PROP_VERSION;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.commons.io.FileUtils.readFileToString;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+
+import de.tudarmstadt.ukp.clarin.webanno.support.SettingsUtil;
+import de.tudarmstadt.ukp.clarin.webanno.support.ZipUtils;
+
+public class EmbeddedDatabaseBackupHandler
+{
+    private static final String UNKNOWN_VERSION = "unknown-version";
+    private static final Logger LOG = getLogger(MethodHandles.lookup().lookupClass());
+
+    public void maybeBackupEmbeddedDatabase() throws IOException
+    {
+        var appHome = SettingsUtil.getApplicationHome();
+
+        var embeddedDbFolder = new File(appHome, "db");
+
+        if (embeddedDbFolder.exists()) {
+            var lastKnownVersion = getPreviouslyStartedVersion();
+            var currentVersion = getCurrentVersion();
+
+            if (!Objects.equals(lastKnownVersion, currentVersion)) {
+                LOG.info("Current version [{}] is different from the version last started " //
+                        + "[{}] - triggering database backup", currentVersion, lastKnownVersion);
+                backupDatabase(embeddedDbFolder, lastKnownVersion);
+            }
+            else {
+                LOG.debug("Current version [{}] is the same as the version last started " //
+                        + "[{}] - no database backup triggered", currentVersion, lastKnownVersion);
+            }
+        }
+        else {
+            // If there is no DB, it might not be there yet (because it is the first time we start)
+            // or the instance is using an external database. In both cases, we have nothing to do.
+            LOG.debug("Instance has no embedded database - so not triggering a backup");
+        }
+
+        writeCurrentVersion();
+    }
+
+    private String getCurrentVersion()
+    {
+        var props = SettingsUtil.getVersionProperties();
+
+        String version = props.getProperty(PROP_VERSION);
+        if ("unknown".equals(version)) {
+            return UNKNOWN_VERSION;
+        }
+
+        return props.getProperty(PROP_VERSION);
+    }
+
+    private void writeCurrentVersion() throws IOException
+    {
+        var appHome = SettingsUtil.getApplicationHome();
+        var currentVersion = getCurrentVersion();
+        File versionFile = new File(appHome, "version");
+        FileUtils.write(versionFile, currentVersion, UTF_8);
+    }
+
+    private void backupDatabase(File embeddedDbFolder, String lastKnownVersion) throws IOException
+    {
+        var appHome = SettingsUtil.getApplicationHome();
+
+        File dbBackupFolder = new File(appHome, "db-backup");
+        if (!dbBackupFolder.exists()) {
+            dbBackupFolder.mkdirs();
+            var notice = String.join("\n", //
+                    "DATABASE BACKUP FOLDER", //
+                    "======================", //
+                    "", //
+                    "This folder contains backups of the embedded database folder ('db'). These",
+                    "backups are created when the application detect that is was upgraded from a",
+                    "previous version.", //
+                    "", //
+                    "Mind that these are backups *only* of the embedded database which *does not*",
+                    "contain the annotations themselves, only the project metadata. Thus, if you",
+                    "replace a broken 'db' folder with the contents of one of these backups, note",
+                    "that e.g. any documents that were added/removed since the backup may appear",
+                    "to be lost/restored, but the actual data and annotations of these documents",
+                    "may actually (not) be present in the 'repository' folder.", //
+                    "", //
+                    "Be sure to backup the 'db' folder once more yourself before trying to recover",
+                    "your system by overwriting it with the contents of one of these backups.", "", //
+                    "These backups are not used by the system itself. If you do not want to keep",
+                    "them, you can simply delete them.", "", //
+                    "THESE BACKUPS DO NOT REPLACE A PROPER BACKUP THAT YOU SHOULD REGULARLY MAKE",
+                    "OF ANY IMPORTANT DATA! It is recommended to regularly export backup archives",
+                    "of important annotation projects and/or to regularly fully backup the",
+                    "application database and data folders.");
+            FileUtils.write(new File(dbBackupFolder, "README.txt"), notice, UTF_8);
+        }
+
+        File dbBackupFile = new File(dbBackupFolder, "db-backup-" + lastKnownVersion + ".zip");
+
+        LOG.info("Embedded database backup starting. This might take a moment...");
+        LOG.info("Writing database backup to: {}", dbBackupFile);
+
+        ZipUtils.zipFolder(embeddedDbFolder, dbBackupFile);
+
+        LOG.info("Embedded database backup completed");
+    }
+
+    /**
+     * @return which was the last version of INCEpTION that was started. If no version file exists,
+     *         it will be "unknown".
+     * @throws IOException
+     *             if there was a problem reading the previous version tag file.
+     */
+    private String getPreviouslyStartedVersion() throws IOException
+    {
+        var appHome = SettingsUtil.getApplicationHome();
+        File versionFile = new File(appHome, "version");
+        if (!versionFile.exists()) {
+            return UNKNOWN_VERSION;
+        }
+
+        var version = readFileToString(versionFile, UTF_8);
+
+        if (!Pattern.matches("[-.0-9a-zA-Z]+", version)) {
+            LOG.warn(
+                    "Illegal last-started version. Considering last started version to be unknown.");
+            return UNKNOWN_VERSION;
+        }
+
+        return version;
+    }
+}


### PR DESCRIPTION
**What's in the PR**
- Store current version in application home folder so we can detect version changes during startup without having to access the database
- If a version change on an instance with an embedded database is detected, perform a backup of the embedded database

**How to test manually**
* Start INCEpTION
* Then start another version of INCEpTION

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
