### PR TITLE
#3403 - Fix name of ZIP file used for exported XMIs

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/actionbar/export/ExportDocumentDialogContent.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/actionbar/export/ExportDocumentDialogContent.java
@@ -19,10 +19,14 @@ package de.tudarmstadt.ukp.clarin.webanno.api.annotation.actionbar.export;
 
 import static java.util.stream.Collectors.toList;
 
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.Serializable;
 import java.util.List;
 
+import org.apache.commons.compress.utils.FileNameUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.wicket.Application;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.extensions.ajax.markup.html.modal.ModalDialog;
 import org.apache.wicket.markup.html.form.DropDownChoice;
@@ -33,15 +37,17 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.LoadableDetachableModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.spring.injection.annot.SpringBean;
-import org.apache.wicket.util.resource.FileResourceStream;
+import org.apache.wicket.util.resource.IResourceStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentImportExportService;
+import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
 import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxFormComponentUpdatingBehavior;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxLink;
 import de.tudarmstadt.ukp.clarin.webanno.support.wicket.AjaxDownloadLink;
+import de.tudarmstadt.ukp.clarin.webanno.support.wicket.InputStreamResourceStream;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
 
 /**
@@ -55,6 +61,7 @@ public class ExportDocumentDialogContent
     private static final Logger LOG = LoggerFactory.getLogger(ExportDocumentDialogContent.class);
 
     private @SpringBean DocumentImportExportService importExportService;
+    private @SpringBean DocumentService documentService;
 
     private IModel<AnnotatorState> state;
     private IModel<Preferences> preferences;
@@ -82,24 +89,48 @@ public class ExportDocumentDialogContent
         format.add(new LambdaAjaxFormComponentUpdatingBehavior("change"));
         queue(format);
 
-        queue(new AjaxDownloadLink("confirm", LoadableDetachableModel.of(this::export)));
+        queue(new AjaxDownloadLink("confirm", //
+                LoadableDetachableModel.of(this::export)));
+
         cancelButton = new LambdaAjaxLink("cancel", this::actionCloseDialog);
         cancelButton.setOutputMarkupId(true);
         queue(cancelButton);
+
         queue(new LambdaAjaxLink("closeDialog", this::actionCloseDialog));
     }
 
-    private FileResourceStream export()
+    private IResourceStream export()
     {
+        File exportedFile = null;
         try {
-            return new FileResourceStream(importExportService.exportAnnotationDocument(
-                    state.getObject().getDocument(), state.getObject().getUser().getUsername(),
-                    importExportService.getFormatByName(preferences.getObject().format).get(),
-                    state.getObject().getDocument().getName(), state.getObject().getMode()));
+            AnnotatorState s = state.getObject();
+            FormatSupport format = importExportService
+                    .getFormatByName(preferences.getObject().format).get();
+            exportedFile = importExportService.exportAnnotationDocument(s.getDocument(),
+                    s.getUser().getUsername(), format, s.getMode());
+
+            var name = exportedFile.getName();
+
+            // Safe-guard for legacy instances where document name validity has not been checked
+            // during import.
+            if (documentService.isValidDocumentName(s.getDocument().getName())) {
+                name = FileNameUtils.getBaseName(s.getDocument().getName()) + "."
+                        + FileNameUtils.getExtension(exportedFile.getName());
+            }
+
+            var resource = new InputStreamResourceStream(new FileInputStream(exportedFile), name);
+
+            var cleaner = Application.get().getResourceSettings().getFileCleaner();
+            cleaner.track(exportedFile, resource);
+
+            return resource;
         }
         catch (Exception e) {
             LOG.error("Export failed", e);
             getSession().error("Export failed: " + ExceptionUtils.getRootCauseMessage(e));
+            if (exportedFile != null) {
+                exportedFile.delete();
+            }
             return null;
         }
     }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/actionbar/export/ExportDocumentDialogContent.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/actionbar/export/ExportDocumentDialogContent.java
@@ -24,7 +24,7 @@ import java.io.FileInputStream;
 import java.io.Serializable;
 import java.util.List;
 
-import org.apache.commons.compress.utils.FileNameUtils;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.wicket.Application;
 import org.apache.wicket.ajax.AjaxRequestTarget;
@@ -114,8 +114,8 @@ public class ExportDocumentDialogContent
             // Safe-guard for legacy instances where document name validity has not been checked
             // during import.
             if (documentService.isValidDocumentName(s.getDocument().getName())) {
-                name = FileNameUtils.getBaseName(s.getDocument().getName()) + "."
-                        + FileNameUtils.getExtension(exportedFile.getName());
+                name = FilenameUtils.getBaseName(s.getDocument().getName()) + "."
+                        + FilenameUtils.getExtension(exportedFile.getName());
             }
 
             var resource = new InputStreamResourceStream(new FileInputStream(exportedFile), name);

--- a/inception/inception-api-formats/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/format/FormatSupport.java
+++ b/inception/inception-api-formats/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/format/FormatSupport.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.clarin.webanno.api.format;
 
 import static de.tudarmstadt.ukp.clarin.webanno.support.ZipUtils.zipFolder;
+import static java.io.File.createTempFile;
 import static org.apache.commons.io.FileUtils.copyFile;
 import static org.apache.uima.fit.factory.AnalysisEngineFactory.createEngine;
 import static org.apache.uima.fit.factory.CollectionReaderFactory.createReader;
@@ -31,6 +32,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.commons.compress.utils.FileNameUtils;
 import org.apache.uima.analysis_engine.AnalysisEngine;
 import org.apache.uima.analysis_engine.AnalysisEngineDescription;
 import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
@@ -168,17 +170,20 @@ public interface FormatSupport
         }
 
         // If the writer produced more than one file, we package it up as a ZIP file
-        File exportFile;
         if (aTargetFolder.listFiles().length > 1) {
-            exportFile = new File(aTargetFolder.getAbsolutePath() + ".zip");
+            File exportFile = createTempFile("inception-document", ".zip");
+            // File exportFile = new File(aTargetFolder.getAbsolutePath() + ".zip");
             zipFolder(aTargetFolder, exportFile);
-        }
-        else {
-            exportFile = new File(aTargetFolder.getParent(),
-                    aTargetFolder.listFiles()[0].getName());
-            copyFile(aTargetFolder.listFiles()[0], exportFile);
+            return exportFile;
         }
 
+        // If the writer produced only a single file, then that is the result
+        File exportFile = createTempFile(
+                FileNameUtils.getBaseName(aTargetFolder.listFiles()[0].getName()),
+                "." + FileNameUtils.getExtension(aTargetFolder.listFiles()[0].getName()));
+        // File exportFile = new File(aTargetFolder.getParent(),
+        // aTargetFolder.listFiles()[0].getName());
+        copyFile(aTargetFolder.listFiles()[0], exportFile);
         return exportFile;
     }
 }

--- a/inception/inception-api-formats/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/format/FormatSupport.java
+++ b/inception/inception-api-formats/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/format/FormatSupport.java
@@ -32,7 +32,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.commons.compress.utils.FileNameUtils;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.uima.analysis_engine.AnalysisEngine;
 import org.apache.uima.analysis_engine.AnalysisEngineDescription;
 import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
@@ -179,8 +179,8 @@ public interface FormatSupport
 
         // If the writer produced only a single file, then that is the result
         File exportFile = createTempFile(
-                FileNameUtils.getBaseName(aTargetFolder.listFiles()[0].getName()),
-                "." + FileNameUtils.getExtension(aTargetFolder.listFiles()[0].getName()));
+                FilenameUtils.getBaseName(aTargetFolder.listFiles()[0].getName()),
+                "." + FilenameUtils.getExtension(aTargetFolder.listFiles()[0].getName()));
         // File exportFile = new File(aTargetFolder.getParent(),
         // aTargetFolder.listFiles()[0].getName());
         copyFile(aTargetFolder.listFiles()[0], exportFile);

--- a/inception/inception-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/DocumentImportExportService.java
+++ b/inception/inception-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/DocumentImportExportService.java
@@ -224,8 +224,37 @@ public interface DocumentImportExportService
             String fileName, Mode mode)
         throws UIMAException, IOException, ClassNotFoundException;
 
+    /**
+     * Exports an {@link AnnotationDocument } CAS Object as TCF/TXT/XMI... file formats.
+     *
+     * @param document
+     *            The {@link SourceDocument} where we get the id which hosts both the source
+     *            Document and the annotated document
+     * @param user
+     *            the {@link User} who annotates the document.
+     * @param aFormat
+     *            the format.
+     * @param mode
+     *            the mode.
+     * @return a temporary file.
+     * @throws UIMAException
+     *             if there was a conversion error.
+     * @throws IOException
+     *             if there was an I/O error.
+     * @throws ClassNotFoundException
+     *             if the DKPro Core writer could not be found.
+     */
+    File exportAnnotationDocument(SourceDocument document, String user, FormatSupport aFormat,
+            Mode mode)
+        throws UIMAException, IOException, ClassNotFoundException;
+
     File exportAnnotationDocument(SourceDocument document, String user, FormatSupport aFormat,
             String fileName, Mode mode, boolean stripExtension,
+            Map<Pair<Project, String>, Object> aBulkOperationContext)
+        throws UIMAException, IOException, ClassNotFoundException;
+
+    File exportAnnotationDocument(SourceDocument aDocument, String aUser, FormatSupport aFormat,
+            Mode aMode, boolean aStripExtension,
             Map<Pair<Project, String>, Object> aBulkOperationContext)
         throws UIMAException, IOException, ClassNotFoundException;
 

--- a/inception/inception-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/DocumentService.java
+++ b/inception/inception-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/DocumentService.java
@@ -31,6 +31,7 @@ import javax.persistence.NoResultException;
 import org.apache.uima.UIMAException;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
+import org.apache.wicket.validation.ValidationError;
 import org.springframework.security.access.prepost.PreAuthorize;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode;
@@ -164,8 +165,8 @@ public interface DocumentService
         throws IOException, UIMAException;
 
     /**
-     * Upload a SourceDocument, obtained as Inputstream, such as from remote API Zip folder to a
-     * repository directory. This way we don't need to create the file to a temporary folder
+     * Upload a SourceDocument, obtained as {@link InputStream}, such as from remote API ZIP folder
+     * to a repository directory. This way we don't need to create the file to a temporary folder
      *
      * @param file
      *            the file.
@@ -778,4 +779,8 @@ public interface DocumentService
 
     void exportSourceDocuments(OutputStream aOs, List<SourceDocument> aSelectedDocuments)
         throws IOException;
+
+    boolean isValidDocumentName(String aDocumentName);
+
+    List<ValidationError> validateDocumentName(String aName);
 }

--- a/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/export/CuratedDocumentsExporter.java
+++ b/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/export/CuratedDocumentsExporter.java
@@ -24,11 +24,12 @@ import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.CURATI
 import static de.tudarmstadt.ukp.clarin.webanno.support.WebAnnoConst.CURATION_USER;
 import static java.lang.Math.ceil;
 import static java.util.Arrays.asList;
-import static org.apache.commons.io.FileUtils.copyFileToDirectory;
+import static org.apache.commons.compress.utils.FileNameUtils.getExtension;
 import static org.apache.commons.io.FileUtils.forceDelete;
 import static org.apache.commons.io.FileUtils.forceMkdir;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -40,8 +41,10 @@ import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.uima.UIMAException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -127,54 +130,64 @@ public class CuratedDocumentsExporter
 
                 // If depending on aInProgress, include only the the curation documents that are
                 // finished or also the ones that are in progress
-                if ((aRequest.isIncludeInProgress()
-                        && CURATION_IN_PROGRESS.equals(sourceDocument.getState()))
+                if (documentService.existsCas(sourceDocument, CURATION_USER)
+                        && (aRequest.isIncludeInProgress()
+                                && CURATION_IN_PROGRESS.equals(sourceDocument.getState()))
                         || CURATION_FINISHED.equals(sourceDocument.getState())) {
-                    if (documentService.existsCas(sourceDocument, CURATION_USER)) {
-                        // Copy CAS - this is used when importing the project again
-                        try (OutputStream os = new FileOutputStream(
-                                new File(curationCasDir, CURATION_USER + ".ser"))) {
-                            documentService.exportCas(sourceDocument, CURATION_USER, os);
-                        }
+                    // Copy CAS - this is used when importing the project again
+                    exportSerializedCas(sourceDocument, curationCasDir);
 
-                        // Determine which format to use for export
-                        if (aRequest.getFormat() != null) {
-                            String formatId = FORMAT_AUTO.equals(aRequest.getFormat())
-                                    ? sourceDocument.getFormat()
-                                    : aRequest.getFormat();
+                    // Determine which format to use for export
+                    if (aRequest.getFormat() != null) {
+                        String formatId = FORMAT_AUTO.equals(aRequest.getFormat())
+                                ? sourceDocument.getFormat()
+                                : aRequest.getFormat();
 
-                            FormatSupport format = importExportService
-                                    .getWritableFormatById(formatId).orElseGet(() -> {
-                                        FormatSupport fallbackFormat = importExportService
-                                                .getFallbackFormat();
-                                        aMonitor.addMessage(LogMessage.warn(this,
-                                                "Curation: %s No writer found for original format [%s] "
-                                                        + "- exporting as [%s] instead.",
-                                                sourceDocument, formatId,
-                                                fallbackFormat.getName()));
-                                        return fallbackFormat;
-                                    });
+                        FormatSupport format = importExportService.getWritableFormatById(formatId)
+                                .orElseGet(() -> {
+                                    var fallbackFormat = importExportService.getFallbackFormat();
+                                    aMonitor.addMessage(LogMessage.warn(this,
+                                            "Curation: %s No writer found for original format [%s] "
+                                                    + "- exporting as [%s] instead.",
+                                            sourceDocument, formatId, fallbackFormat.getName()));
+                                    return fallbackFormat;
+                                });
 
-                            // Copy secondary export format for convenience - not used during import
-                            try {
-                                File curationFile = importExportService.exportAnnotationDocument(
-                                        sourceDocument, CURATION_USER, format, CURATION_USER,
-                                        CURATION, true, bulkOperationContext);
-                                copyFileToDirectory(curationFile, curationDir);
-                                forceDelete(curationFile);
-                            }
-                            catch (Exception e) {
-                                // error("Unexpected error while exporting project: " +
-                                // ExceptionUtils.getRootCauseMessage(e) );
-                                throw new ProjectExportException(
-                                        "Aborting due to unrecoverable error while exporting!");
-                            }
-                        }
+                        // Copy secondary export format for convenience - not used during import
+                        exportAdditionalFormat(bulkOperationContext, sourceDocument, curationDir,
+                                format);
                     }
                 }
             }
             aMonitor.setProgress(initProgress + (int) ceil(((double) i) / documents.size() * 10.0));
             i++;
+        }
+    }
+
+    private void exportAdditionalFormat(Map<Pair<Project, String>, Object> bulkOperationContext,
+            SourceDocument srcDoc, File curationDir, FormatSupport format)
+        throws ProjectExportException, IOException, ClassNotFoundException, UIMAException
+    {
+        File curationFile = null;
+        try {
+            curationFile = importExportService.exportAnnotationDocument(srcDoc, CURATION_USER,
+                    format, CURATION_USER, CURATION, true, bulkOperationContext);
+            var filename = CURATION_USER + "." + getExtension(curationFile.getName());
+            FileUtils.copyFile(curationFile, new File(curationDir, filename));
+        }
+        finally {
+            if (curationFile != null) {
+                forceDelete(curationFile);
+            }
+        }
+    }
+
+    private void exportSerializedCas(SourceDocument sourceDocument, File curationCasDir)
+        throws IOException, FileNotFoundException
+    {
+        try (OutputStream os = new FileOutputStream(
+                new File(curationCasDir, CURATION_USER + ".ser"))) {
+            documentService.exportCas(sourceDocument, CURATION_USER, os);
         }
     }
 

--- a/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/export/CuratedDocumentsExporter.java
+++ b/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/export/CuratedDocumentsExporter.java
@@ -24,9 +24,9 @@ import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.CURATI
 import static de.tudarmstadt.ukp.clarin.webanno.support.WebAnnoConst.CURATION_USER;
 import static java.lang.Math.ceil;
 import static java.util.Arrays.asList;
-import static org.apache.commons.compress.utils.FileNameUtils.getExtension;
 import static org.apache.commons.io.FileUtils.forceDelete;
 import static org.apache.commons.io.FileUtils.forceMkdir;
+import static org.apache.commons.io.FilenameUtils.getExtension;
 
 import java.io.File;
 import java.io.FileNotFoundException;

--- a/inception/inception-documents/pom.xml
+++ b/inception/inception-documents/pom.xml
@@ -67,6 +67,12 @@
       <artifactId>inception-security</artifactId>
     </dependency>
 
+    <!-- Wicket dependencies -->
+    <dependency>
+      <groupId>org.apache.wicket</groupId>
+      <artifactId>wicket-core</artifactId>
+    </dependency>
+
     <!-- Spring dependencies -->
 
     <dependency>

--- a/inception/inception-documents/pom.xml
+++ b/inception/inception-documents/pom.xml
@@ -68,6 +68,7 @@
     </dependency>
 
     <!-- Wicket dependencies -->
+    
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-core</artifactId>

--- a/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/DocumentServiceImpl.java
+++ b/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/DocumentServiceImpl.java
@@ -46,6 +46,7 @@ import static java.util.Objects.isNull;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.io.IOUtils.copyLarge;
 import static org.apache.commons.lang3.ArrayUtils.isEmpty;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -81,10 +82,12 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.apache.uima.UIMAException;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
+import org.apache.wicket.validation.ValidationError;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -129,6 +132,14 @@ public class DocumentServiceImpl
     implements DocumentService
 {
     private final Logger log = LoggerFactory.getLogger(getClass());
+
+    private static final String MSG_DOCUMENT_NAME_TOO_LONG = "document.name.error.too-long";
+    private static final String MSG_DOCUMENT_NAME_EMPTY = "document.name.error.empty";
+    private static final String MSG_DOCUMENT_NAME_ILLEGAL = "document.name.error.illegal";
+    private static final String MVAR_LIMIT = "limit";
+    private static final String MVAR_DETAIL = "detail";
+
+    private static final String BAD_FOR_FILENAMES = "#%&{}\\<>*?/ $!'\":@+`|=";
 
     private final EntityManager entityManager;
     private final CasStorageService casStorageService;
@@ -724,6 +735,11 @@ public class DocumentServiceImpl
             TypeSystemDescription aFullProjectTypeSystem)
         throws IOException
     {
+        var nameValidationResult = validateDocumentName(aDocument.getName());
+        if (!nameValidationResult.isEmpty()) {
+            throw new IllegalArgumentException(nameValidationResult.get(0).getMessage());
+        }
+
         // Create the metadata record - this also assigns the ID to the document
         createSourceDocument(aDocument);
 
@@ -1518,5 +1534,40 @@ public class DocumentServiceImpl
                 // If there is no CAS file, we do not have to upgrade it. Ignoring.
             }
         }
+    }
+
+    @Override
+    public boolean isValidDocumentName(String aDocumentName)
+    {
+        return validateDocumentName(aDocumentName).isEmpty();
+    }
+
+    @Override
+    public List<ValidationError> validateDocumentName(String aName)
+    {
+        var errors = new ArrayList<ValidationError>();
+
+        if (isBlank(aName)) {
+            errors.add(new ValidationError("Document name cannot be empty.") //
+                    .addKey(MSG_DOCUMENT_NAME_EMPTY));
+        }
+
+        if (StringUtils.containsAny(aName, BAD_FOR_FILENAMES)) {
+            errors.add(new ValidationError("Document name contains illegal characters. It must not"
+                    + "contain any of the following characters [" + BAD_FOR_FILENAMES + "]") //
+                            .addKey(MSG_DOCUMENT_NAME_ILLEGAL)
+                            .setVariable(MVAR_DETAIL, BAD_FOR_FILENAMES));
+        }
+
+        var len = aName.length();
+        int maximumUiNameLength = 200;
+        if (len > maximumUiNameLength) {
+            errors.add(new ValidationError("Document name is too long. It can at most consist of "
+                    + maximumUiNameLength + " characters.") //
+                            .addKey(MSG_DOCUMENT_NAME_TOO_LONG)
+                            .setVariable(MVAR_LIMIT, maximumUiNameLength));
+        }
+
+        return errors;
     }
 }

--- a/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/DocumentImportExportServiceImpl.java
+++ b/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/DocumentImportExportServiceImpl.java
@@ -198,10 +198,31 @@ public class DocumentImportExportServiceImpl
     @Override
     @Transactional
     public File exportAnnotationDocument(SourceDocument aDocument, String aUser,
+            FormatSupport aFormat, Mode aMode)
+        throws UIMAException, IOException, ClassNotFoundException
+    {
+        return exportAnnotationDocument(aDocument, aUser, aFormat, aDocument.getName(), aMode, true,
+                null);
+    }
+
+    @Override
+    @Transactional
+    public File exportAnnotationDocument(SourceDocument aDocument, String aUser,
             FormatSupport aFormat, String aFileName, Mode aMode)
         throws UIMAException, IOException, ClassNotFoundException
     {
         return exportAnnotationDocument(aDocument, aUser, aFormat, aFileName, aMode, true, null);
+    }
+
+    @Override
+    @Transactional
+    public File exportAnnotationDocument(SourceDocument aDocument, String aUser,
+            FormatSupport aFormat, Mode aMode, boolean aStripExtension,
+            Map<Pair<Project, String>, Object> aBulkOperationContext)
+        throws UIMAException, IOException, ClassNotFoundException
+    {
+        return exportAnnotationDocument(aDocument, aUser, aFormat, aDocument.getName(), aMode,
+                aStripExtension, aBulkOperationContext);
     }
 
     @Override

--- a/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/DocumentImportExportServiceImpl.java
+++ b/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/DocumentImportExportServiceImpl.java
@@ -29,7 +29,6 @@ import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUt
 import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode.EXCLUSIVE_WRITE_ACCESS;
 import static de.tudarmstadt.ukp.clarin.webanno.support.WebAnnoConst.CHAIN_TYPE;
 import static de.tudarmstadt.ukp.clarin.webanno.support.WebAnnoConst.CURATION_USER;
-import static java.io.File.createTempFile;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.Comparator.comparing;
@@ -45,6 +44,7 @@ import static org.apache.uima.util.CasCreationUtils.mergeTypeSystems;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.nio.file.Files;
 import java.text.BreakIterator;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -503,11 +503,8 @@ public class DocumentImportExportServiceImpl
 
                 addTagsetDefinitionAnnotations(exportCas, project, bulkOperationContext);
 
-                File exportTempDir = createTempFile("inception", "export");
+                File exportTempDir = Files.createTempDirectory("inception-export").toFile();
                 try {
-                    exportTempDir.delete();
-                    exportTempDir.mkdirs();
-
                     return aFormat.write(aDocument, getRealCas(exportCas), exportTempDir,
                             aStripExtension);
                 }

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
@@ -453,7 +453,11 @@ public class KnowledgeBaseServiceImpl
         throws RepositoryConfigException, RepositoryException
     {
         assertRegistration(kb);
-        return repoManager.getRepositoryConfig(kb.getRepositoryId()).getRepositoryImplConfig();
+        var repositoryConfig = repoManager.getRepositoryConfig(kb.getRepositoryId());
+        if (repositoryConfig == null) {
+            return null;
+        }
+        return repositoryConfig.getRepositoryImplConfig();
     }
 
     @Override

--- a/inception/inception-project-export/src/main/java/de/tudarmstadt/ukp/inception/project/export/ProjectExportServiceImpl.java
+++ b/inception/inception-project-export/src/main/java/de/tudarmstadt/ukp/inception/project/export/ProjectExportServiceImpl.java
@@ -201,15 +201,13 @@ public class ProjectExportServiceImpl
             ExportedProject exProjekt = exportProjectToPath(aRequest, aMonitor, exportTempDir);
 
             // all metadata and project settings data from the database as JSON file
-            File projectSettings = File.createTempFile(EXPORTED_PROJECT, ".json");
+            File projectSettings = new File(exportTempDir, EXPORTED_PROJECT + ".json");
             JSONUtil.generatePrettyJson(exProjekt, projectSettings);
-            FileUtils.copyFileToDirectory(projectSettings, exportTempDir);
 
             try {
                 ZipUtils.zipFolder(exportTempDir, projectZipFile);
             }
             finally {
-                FileUtils.forceDelete(projectSettings);
                 System.gc();
                 FileUtils.forceDelete(exportTempDir);
             }

--- a/inception/inception-project-export/src/test/java/de/tudarmstadt/ukp/inception/project/export/controller/ExportServiceControllerImplTest.java
+++ b/inception/inception-project-export/src/test/java/de/tudarmstadt/ukp/inception/project/export/controller/ExportServiceControllerImplTest.java
@@ -53,7 +53,6 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
-import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.messaging.converter.GenericMessageConverter;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompFrameHandler;
@@ -188,7 +187,7 @@ class ExportServiceControllerImplTest
         try {
             session.disconnect();
         }
-        catch (MessageDeliveryException e) {
+        catch (Exception e) {
             // Ignore exceptions during disconnect
         }
 

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/LegacyRemoteApiController.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/LegacyRemoteApiController.java
@@ -706,7 +706,7 @@ public class LegacyRemoteApiController
 
         // Temporary file of annotation document
         File downloadableFile = importExportService.exportAnnotationDocument(srcDoc, annotatorName,
-                format, annDoc.getName(), Mode.ANNOTATION);
+                format, Mode.ANNOTATION);
 
         try {
             // Set mime type
@@ -828,7 +828,7 @@ public class LegacyRemoteApiController
 
         // Temporary file of annotation document
         File downloadableFile = importExportService.exportAnnotationDocument(srcDocument,
-                WebAnnoConst.CURATION_USER, format, srcDocument.getName(), Mode.CURATION);
+                WebAnnoConst.CURATION_USER, format, Mode.CURATION);
 
         try {
             // Set mime type

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
@@ -622,6 +622,8 @@ public class AeroRemoteApiController
             exportedFile = importExportService.exportCasToFile(cas, doc, doc.getName(), format);
             byte[] resource = FileUtils.readFileToByteArray(exportedFile);
 
+            var fileExtension = FilenameUtils.getExtension(exportedFile.getName());
+
             // Send it back to the client
             HttpHeaders httpHeaders = new HttpHeaders();
             httpHeaders.setContentLength(resource.length);
@@ -945,7 +947,7 @@ public class AeroRemoteApiController
         byte[] resource;
         try {
             exportedAnnoFile = importExportService.exportAnnotationDocument(doc, aAnnotatorId,
-                    format, doc.getName(), Mode.ANNOTATION);
+                    format, Mode.ANNOTATION);
             resource = FileUtils.readFileToByteArray(exportedAnnoFile);
         }
         finally {

--- a/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/exporters/AnnotationDocumentExporter.java
+++ b/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/exporters/AnnotationDocumentExporter.java
@@ -35,6 +35,7 @@ import static java.util.stream.Collectors.toMap;
 import static org.apache.commons.io.FileUtils.copyFileToDirectory;
 import static org.apache.commons.io.FileUtils.forceDelete;
 import static org.apache.commons.io.FileUtils.forceMkdir;
+import static org.apache.commons.io.FilenameUtils.getExtension;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -53,7 +54,6 @@ import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
-import org.apache.commons.compress.utils.FileNameUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.time.DurationFormatUtils;
@@ -298,8 +298,7 @@ public class AnnotationDocumentExporter
 
             if (userRepository.isValidUsername(annDoc.getUser())) {
                 // Safe-guard for legacy instances where user name validity has not been checked.
-                var filename = annDoc.getUser() + "."
-                        + FileNameUtils.getExtension(annFile.getName());
+                var filename = annDoc.getUser() + "." + getExtension(annFile.getName());
                 FileUtils.copyFile(annFile, new File(annDocDir, filename));
             }
             else {

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/UserDaoImpl.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/UserDaoImpl.java
@@ -87,12 +87,10 @@ public class UserDaoImpl
     private static final String MSG_EMAIL_INVALID = "email.error.invalid";
     private static final String MSG_EMAIL_ERROR_TOO_LONG = "email.error.too-long";
 
-    private static final String USERNAME_ILLEGAL_CHARACTERS = "^/\\&*?+$![] ";
+    private static final String USERNAME_ILLEGAL_CHARACTERS = "^/\\&*?+$![] .";
 
     private static final Set<String> RESERVED_USERNAMES = Set.of(INITIAL_CAS_PSEUDO_USER,
             CURATION_USER);
-
-    private static final String BAD_FOR_FILENAMES = "#%&{}\\<>*?/ $!'\":@+`|=";
 
     private final Logger log = LoggerFactory.getLogger(getClass());
 

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/wicket/AjaxDownloadBehavior.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/wicket/AjaxDownloadBehavior.java
@@ -91,6 +91,9 @@ public class AjaxDownloadBehavior
             else if (is instanceof FileSystemResourceStream) {
                 name = ((FileSystemResourceStream) is).getPath().getFileName().toString();
             }
+            else if (is instanceof InputStreamResourceStream) {
+                name = ((InputStreamResourceStream) is).getName();
+            }
         }
 
         ResourceStreamRequestHandler handler = new ResourceStreamRequestHandler(is, name);

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/wicket/AjaxDownloadLink.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/wicket/AjaxDownloadLink.java
@@ -96,6 +96,9 @@ public class AjaxDownloadLink
                             name = ((FileSystemResourceStream) is).getPath().getFileName()
                                     .toString();
                         }
+                        else if (is instanceof InputStreamResourceStream) {
+                            name = ((InputStreamResourceStream) is).getName();
+                        }
                     }
 
                     ResourceStreamRequestHandler handler = new ResourceStreamRequestHandler(

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/wicket/InputStreamResourceStream.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/wicket/InputStreamResourceStream.java
@@ -28,17 +28,30 @@ public class InputStreamResourceStream
 {
     private static final long serialVersionUID = 1L;
 
-    private InputStream inputStream;
+    private final InputStream inputStream;
+    private final String name;
 
     public InputStreamResourceStream(InputStream aInputStream)
     {
         inputStream = aInputStream;
+        name = null;
+    }
+
+    public InputStreamResourceStream(InputStream aInputStream, String aName)
+    {
+        inputStream = aInputStream;
+        name = aName;
     }
 
     @Override
     public InputStream getInputStream() throws ResourceStreamNotFoundException
     {
         return inputStream;
+    }
+
+    public String getName()
+    {
+        return name;
     }
 
     @Override

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.properties
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.properties
@@ -130,11 +130,12 @@ username.error.too-short=Username is too short(min. ${limit} characters)
 username.error.too-long=Username is too long (max. ${limit} characters)
 username.error.pattern-mismatch=Username invalid. It must match the pattern ${pattern}
 
-ui-name.error.too-long=Display name is too long (max. ${limit} characters)
+ui-name.error.too-long=Display name is too long (max. ${limit} characters).
 
 email.error.invalid=Not a valid email address.
-email.error.too-long=Email address is too long (max. ${limit} characters)
+email.error.too-long=Email address is too long (max. ${limit} characters).
 
-document.name.error.too-long=Document name is too long (max. ${limit} characters)
+document.name.error.too-long=Document name is too long (max. ${limit} characters).
 document.name.error.empty=Document name cannot be empty.
-document.name.error.illegal=Document name contains illegal characters. It must not contain any of the following characters [${detail}]
+document.name.error.illegal=Document name contains illegal characters. It must not contain any of the following characters [${detail}].
+document.name.error.illegal-leading=Document name cannot start with a dot [.] or dash [-].

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.properties
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.properties
@@ -117,7 +117,7 @@ AnchoringMode.SENTENCES=Sentence-level
 
 password.error.blank=Password cannot be empty or blank
 password.error.too-short=Password is too short (min. ${limit} characters)
-password.error.too-long=Password is too long  (max. ${limit} characters)
+password.error.too-long=Password is too long (max. ${limit} characters)
 password.error.pattern-mismatch=Password invalid. It must match the pattern ${pattern}
 password.error.control-characters=Password cannot contain any control characters
 
@@ -126,11 +126,15 @@ username.error.illegal-space=Username cannot contain a space character
 username.error.illegal-characters=Username cannot contain any of these characters: ${chars}
 username.error.control-characters=Username cannot contain any control characters
 username.error.reserved=Username is reserved
-username.error.too-short=Username is too short (min. ${limit} characters)
-username.error.too-long=Username is too long  (max. ${limit} characters)
+username.error.too-short=Username is too short(min. ${limit} characters)
+username.error.too-long=Username is too long (max. ${limit} characters)
 username.error.pattern-mismatch=Username invalid. It must match the pattern ${pattern}
 
-ui-name.error.too-long=Display name is too long  (max. ${limit} characters)
+ui-name.error.too-long=Display name is too long (max. ${limit} characters)
 
 email.error.invalid=Not a valid email address.
-email.error.too-long=Email address is too long  (max. ${limit} characters)
+email.error.too-long=Email address is too long (max. ${limit} characters)
+
+document.name.error.too-long=Document name is too long (max. ${limit} characters)
+document.name.error.empty=Document name cannot be empty.
+document.name.error.illegal=Document name contains illegal characters. It must not contain any of the following characters [${detail}]

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/KnowledgeBaseDetailsPanel.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/KnowledgeBaseDetailsPanel.java
@@ -92,8 +92,13 @@ public class KnowledgeBaseDetailsPanel
         // set the URL of the KBW to the current SPARQL URL, if dealing with a remote repository
         if (kbw.getKb().getType() == REMOTE) {
             RepositoryImplConfig cfg = kbService.getKnowledgeBaseConfig(kbw.getKb());
-            String url = ((SPARQLRepositoryConfig) cfg).getQueryEndpointUrl();
-            kbw.setUrl(url);
+            if (cfg != null) {
+                String url = ((SPARQLRepositoryConfig) cfg).getQueryEndpointUrl();
+                kbw.setUrl(url);
+            }
+            else {
+                kbw.setUrl(null);
+            }
         }
 
         // wrap the given knowledge base model, then set it as the default model

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/documents/ImportDocumentsPanel.java
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/documents/ImportDocumentsPanel.java
@@ -152,8 +152,15 @@ public class ImportDocumentsPanel
         for (FileUpload documentToUpload : uploadedFiles) {
             String fileName = documentToUpload.getClientFileName();
 
+            var nameValidationResult = documentService.validateDocumentName(fileName);
+            if (!nameValidationResult.isEmpty()) {
+                nameValidationResult
+                        .forEach(msg -> error("[" + fileName + "]:" + msg.getMessage()));
+                continue;
+            }
+
             if (existingDocuments.contains(fileName)) {
-                error("Document [" + fileName + "] already uploaded! Delete "
+                error("[" + fileName + "]: already uploaded! Delete "
                         + "the document if you want to upload again");
                 continue;
             }
@@ -177,7 +184,8 @@ public class ImportDocumentsPanel
                 existingDocuments.add(fileName);
             }
             catch (Throwable e) {
-                error("Error while uploading document " + fileName + ": " + getRootCauseMessage(e));
+                error("Error while uploading document [" + fileName + "]: "
+                        + getRootCauseMessage(e));
                 LOG.error(fileName + ": " + e.getMessage(), e);
                 aTarget.addChildren(getPage(), IFeedback.class);
             }


### PR DESCRIPTION
**What's in the PR**
- Improve naming of files in exports via the export document dialog on the annotation page
- Improve naming of files in exports via the project export
- Try improving cleaning up of temporary files generated when exporting from the annotation page
- Make "." an illegal character in usernames (because it is the extension separator and we use usernames in filenames....)

**How to test manually**
* Export document through the annotation page
* Export via the project export feature and inspect ZIP contents

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
