### PR TITLE
#3452 - Enable Spring MVC CSRF protection on UI API and view endpoints

### DIFF
--- a/inception/inception-app-webapp/src/main/resources/META-INF/spring.factories
+++ b/inception/inception-app-webapp/src/main/resources/META-INF/spring.factories
@@ -1,5 +1,4 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 de.tudarmstadt.ukp.inception.app.config.LiquibaseLockCheckAutoConfiguration,\
-de.tudarmstadt.ukp.inception.app.config.InceptionSecurityActuatorAutoConfiguration,\
 de.tudarmstadt.ukp.inception.app.config.InceptionSecurityWebUIBuiltInAutoConfiguration,\
 de.tudarmstadt.ukp.inception.app.config.InceptionSecurityWebUIPreAuthenticatedAutoConfiguration

--- a/inception/inception-diam/pom.xml
+++ b/inception/inception-diam/pom.xml
@@ -237,6 +237,16 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-config</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-web</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
       <scope>test</scope>

--- a/inception/inception-external-editor/pom.xml
+++ b/inception/inception-external-editor/pom.xml
@@ -55,6 +55,10 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-io-xml</artifactId>
     </dependency>
     <dependency>

--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/xhtml/XHtmlXmlDocumentViewController.java
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/xhtml/XHtmlXmlDocumentViewController.java
@@ -17,6 +17,8 @@
  */
 package de.tudarmstadt.ukp.inception.externaleditor.xhtml;
 
+import static de.tudarmstadt.ukp.inception.security.config.InceptionSecurityWebUIApiAutoConfiguration.BASE_VIEW_URL;
+
 import java.security.Principal;
 import java.util.Optional;
 
@@ -26,7 +28,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 
 public interface XHtmlXmlDocumentViewController
 {
-    String BASE_URL = "/de.tudarmstadt.ukp.inception.externaleditor.xhtml.XHtmlXmlDocumentViewController";
+    String BASE_URL = BASE_VIEW_URL + "/xhtml-xml";
 
     String getDocumentUrl(SourceDocument aDoc);
 

--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/xml/XmlDocumentViewController.java
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/xml/XmlDocumentViewController.java
@@ -17,6 +17,8 @@
  */
 package de.tudarmstadt.ukp.inception.externaleditor.xml;
 
+import static de.tudarmstadt.ukp.inception.security.config.InceptionSecurityWebUIApiAutoConfiguration.BASE_VIEW_URL;
+
 import java.security.Principal;
 import java.util.Optional;
 
@@ -26,7 +28,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 
 public interface XmlDocumentViewController
 {
-    String BASE_URL = "/de.tudarmstadt.ukp.inception.htmleditor.docview.XmlDocumentViewController";
+    String BASE_URL = BASE_VIEW_URL + "/xml";
 
     String getDocumentUrl(SourceDocument aDoc);
 

--- a/inception/inception-html-editor/pom.xml
+++ b/inception/inception-html-editor/pom.xml
@@ -64,6 +64,10 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-io-html</artifactId>
     </dependency>
     <dependency>

--- a/inception/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/htmleditor/docview/HtmlDocumentViewController.java
+++ b/inception/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/htmleditor/docview/HtmlDocumentViewController.java
@@ -17,6 +17,8 @@
  */
 package de.tudarmstadt.ukp.inception.htmleditor.docview;
 
+import static de.tudarmstadt.ukp.inception.security.config.InceptionSecurityWebUIApiAutoConfiguration.BASE_VIEW_URL;
+
 import java.security.Principal;
 
 import org.springframework.http.ResponseEntity;
@@ -25,7 +27,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 
 public interface HtmlDocumentViewController
 {
-    String BASE_URL = "/de.tudarmstadt.ukp.inception.htmleditor.docview.HtmlDocumentViewController";
+    String BASE_URL = BASE_VIEW_URL + "/html";
 
     String getDocumentUrl(SourceDocument aDoc);
 

--- a/inception/inception-project-export/pom.xml
+++ b/inception/inception-project-export/pom.xml
@@ -223,6 +223,16 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-config</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-web</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
       <scope>test</scope>

--- a/inception/inception-project-export/src/main/java/de/tudarmstadt/ukp/inception/project/export/controller/ExportServiceController.java
+++ b/inception/inception-project-export/src/main/java/de/tudarmstadt/ukp/inception/project/export/controller/ExportServiceController.java
@@ -17,7 +17,9 @@
  */
 package de.tudarmstadt.ukp.inception.project.export.controller;
 
+import static de.tudarmstadt.ukp.inception.security.config.InceptionSecurityWebUIApiAutoConfiguration.BASE_API_URL;
+
 public interface ExportServiceController
 {
-    static final String API_BASE = "/ui";
+    String BASE_URL = BASE_API_URL + "/export";
 }

--- a/inception/inception-project-export/src/main/java/de/tudarmstadt/ukp/inception/project/export/controller/ExportServiceControllerImpl.java
+++ b/inception/inception-project-export/src/main/java/de/tudarmstadt/ukp/inception/project/export/controller/ExportServiceControllerImpl.java
@@ -59,7 +59,7 @@ import de.tudarmstadt.ukp.inception.project.export.model.RExportLogMessage;
 import io.swagger.v3.oas.annotations.Operation;
 
 @Controller
-@RequestMapping(ExportServiceController.API_BASE)
+@RequestMapping(ExportServiceController.BASE_URL)
 @ConditionalOnProperty(prefix = "websocket", name = "enabled", havingValue = "true", matchIfMissing = true)
 public class ExportServiceControllerImpl
     implements ExportServiceController
@@ -116,7 +116,7 @@ public class ExportServiceControllerImpl
     }
 
     @Operation(summary = "Fetch export log messages")
-    @GetMapping(value = ("/export/{runId}/log"), produces = { "application/json" })
+    @GetMapping(value = ("/{runId}/log"), produces = { "application/json" })
     public ResponseEntity<List<RExportLogMessage>> projectExportLog(
             @PathVariable("runId") String aRunId)
         throws Exception
@@ -135,7 +135,7 @@ public class ExportServiceControllerImpl
     }
 
     @Operation(summary = "Download a finished export")
-    @GetMapping(value = ("/export/{runId}/data"), produces = { "application/zip" })
+    @GetMapping(value = ("/{runId}/data"), produces = { "application/zip" })
     public ResponseEntity<InputStreamResource> projectExportData(
             @PathVariable("runId") String aRunId)
         throws Exception

--- a/inception/inception-project-export/src/main/java/de/tudarmstadt/ukp/inception/project/export/task/ProjectExportTask_ImplBase.java
+++ b/inception/inception-project-export/src/main/java/de/tudarmstadt/ukp/inception/project/export/task/ProjectExportTask_ImplBase.java
@@ -24,6 +24,7 @@ import static de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExportTaskStat
 import static de.tudarmstadt.ukp.clarin.webanno.support.logging.Logging.KEY_PROJECT_ID;
 import static de.tudarmstadt.ukp.clarin.webanno.support.logging.Logging.KEY_REPOSITORY_PATH;
 import static de.tudarmstadt.ukp.clarin.webanno.support.logging.Logging.KEY_USERNAME;
+import static de.tudarmstadt.ukp.inception.project.export.controller.ExportServiceController.BASE_URL;
 import static java.lang.String.format;
 import static org.apache.commons.lang3.exception.ExceptionUtils.getRootCauseMessage;
 
@@ -96,7 +97,7 @@ public abstract class ProjectExportTask_ImplBase<R extends ProjectExportRequest_
             MDC.put(KEY_REPOSITORY_PATH, repositoryProperties.getPath().toString());
 
             monitor.setState(RUNNING);
-            monitor.setUrl(format("%s/ui/export/%s", servletContext.getContextPath(),
+            monitor.setUrl(format("%s%s/%s", servletContext.getContextPath(), BASE_URL,
                     monitor.getHandle().getRunId()));
 
             File exportedFile = export(request, monitor);

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/config/InceptionSecurityRemoteApiAutoConfiguration.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/config/InceptionSecurityRemoteApiAutoConfiguration.java
@@ -17,11 +17,12 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.config;
 
+import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.provisioning.UserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
@@ -55,7 +56,7 @@ public class InceptionSecurityRemoteApiAutoConfiguration
         aHttp.httpBasic();
 
         aHttp.sessionManagement() //
-                .sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+                .sessionCreationPolicy(STATELESS);
 
         return aHttp.build();
     }

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/config/InceptionSecurityActuatorAutoConfiguration.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/config/InceptionSecurityActuatorAutoConfiguration.java
@@ -15,31 +15,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package de.tudarmstadt.ukp.inception.app.config;
+package de.tudarmstadt.ukp.inception.security.config;
+
+import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 
 public class InceptionSecurityActuatorAutoConfiguration
 {
+    public static final String BASE_URL = "/actuator";
+
     @Order(2)
     @Bean
     public SecurityFilterChain actuatorFilterChain(HttpSecurity aHttp) throws Exception
     {
-        // @formatter:off
-        aHttp
-            .antMatcher("/actuator/**")
-            .csrf().disable()
-            .authorizeRequests()
-                .antMatchers("/actuator/health").permitAll()
-                .anyRequest().denyAll()
-            .and()
-            .sessionManagement()
-                .sessionCreationPolicy(SessionCreationPolicy.STATELESS);
-        // @formatter:on
+        aHttp.antMatcher(BASE_URL + "/**");
+        aHttp.csrf().disable();
+        aHttp.authorizeRequests() //
+                .antMatchers(BASE_URL + "/health").permitAll() //
+                .anyRequest().denyAll();
+        aHttp.sessionManagement() //
+                .sessionCreationPolicy(STATELESS);
         return aHttp.build();
     }
 }

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/config/InceptionSecurityWebUIApiAutoConfiguration.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/config/InceptionSecurityWebUIApiAutoConfiguration.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.security.config;
+
+import static org.springframework.security.config.http.SessionCreationPolicy.NEVER;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.Http403ForbiddenEntryPoint;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+
+public class InceptionSecurityWebUIApiAutoConfiguration
+{
+    public static final String BASE_URL = "/ui";
+    public static final String BASE_VIEW_URL = BASE_URL + "/view";
+    public static final String BASE_API_URL = BASE_URL + "/api";
+
+    @Order(1000)
+    @Bean
+    public SecurityFilterChain uiApiFilterChain(HttpSecurity aHttp) throws Exception
+    {
+        aHttp.antMatcher(BASE_API_URL + "/**");
+        commonConfiguration(aHttp);
+        return aHttp.build();
+    }
+
+    @Order(1001)
+    @Bean
+    public SecurityFilterChain uiViewFilterChain(HttpSecurity aHttp) throws Exception
+    {
+        aHttp.antMatcher(BASE_VIEW_URL + "/**");
+        // Views render data that we generally want to display in an IFrame on the editor page
+        aHttp.headers().frameOptions().sameOrigin();
+        commonConfiguration(aHttp);
+        return aHttp.build();
+    }
+
+    private void commonConfiguration(HttpSecurity aHttp) throws Exception
+    {
+        aHttp.authorizeRequests() //
+                .antMatchers("/**").access("hasAnyRole('ROLE_USER')") //
+                .anyRequest().denyAll();
+        aHttp.sessionManagement().sessionCreationPolicy(NEVER);
+        aHttp.exceptionHandling() //
+                .defaultAuthenticationEntryPointFor( //
+                        new Http403ForbiddenEntryPoint(), //
+                        new AntPathRequestMatcher("/**"));
+
+    }
+}

--- a/inception/inception-security/src/main/resources/META-INF/spring.factories
+++ b/inception/inception-security/src/main/resources/META-INF/spring.factories
@@ -1,3 +1,5 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 de.tudarmstadt.ukp.clarin.webanno.security.config.SecurityAutoConfiguration,\
+de.tudarmstadt.ukp.inception.security.config.InceptionSecurityActuatorAutoConfiguration,\
+de.tudarmstadt.ukp.inception.security.config.InceptionSecurityWebUIApiAutoConfiguration,\
 de.tudarmstadt.ukp.clarin.webanno.security.config.InceptionSecurityAutoConfiguration

--- a/inception/inception-ui-dashboard-activity/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/activity/ActivitiesDashletController.java
+++ b/inception/inception-ui-dashboard-activity/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/activity/ActivitiesDashletController.java
@@ -17,11 +17,13 @@
  */
 package de.tudarmstadt.ukp.inception.ui.core.dashboard.activity;
 
+import static de.tudarmstadt.ukp.inception.security.config.InceptionSecurityWebUIApiAutoConfiguration.BASE_API_URL;
+
 import java.util.List;
 
 public interface ActivitiesDashletController
 {
-    String BASE_URL = "/de.tudarmstadt.ukp.inception.ui.core.dashboard.dashlet.VueActivitiesDashletController";
+    String BASE_URL = BASE_API_URL + "/activity";
     String LIST_PATH = "/project/{projectId}/list";
 
     String listActivitiesUrl(long aProjectId);

--- a/inception/inception-websocket/pom.xml
+++ b/inception/inception-websocket/pom.xml
@@ -192,6 +192,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-web</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
       <scope>test</scope>

--- a/inception/inception-websocket/src/test/java/de/tudarmstadt/ukp/inception/websocket/WebSocketIntegrationTest.java
+++ b/inception/inception-websocket/src/test/java/de/tudarmstadt/ukp/inception/websocket/WebSocketIntegrationTest.java
@@ -24,6 +24,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.tomcat.websocket.Constants.WS_AUTHENTICATION_PASSWORD;
 import static org.apache.tomcat.websocket.Constants.WS_AUTHENTICATION_USER_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
 
 import java.io.File;
 import java.io.IOException;
@@ -55,6 +56,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.core.annotation.Order;
 import org.springframework.messaging.converter.MappingJackson2MessageConverter;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompFrameHandler;
@@ -62,8 +64,10 @@ import org.springframework.messaging.simp.stomp.StompHeaders;
 import org.springframework.messaging.simp.stomp.StompSession;
 import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.provisioning.UserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.socket.client.standard.StandardWebSocketClient;
 import org.springframework.web.socket.messaging.WebSocketStompClient;
 
@@ -89,6 +93,7 @@ import de.tudarmstadt.ukp.inception.log.adapter.DocumentStateChangedEventAdapter
 import de.tudarmstadt.ukp.inception.schema.config.AnnotationSchemaServiceAutoConfiguration;
 import de.tudarmstadt.ukp.inception.support.findbugs.SuppressFBWarnings;
 import de.tudarmstadt.ukp.inception.websocket.config.WebsocketAutoConfiguration;
+import de.tudarmstadt.ukp.inception.websocket.config.WebsocketConfig;
 import de.tudarmstadt.ukp.inception.websocket.config.WebsocketSecurityConfig;
 import de.tudarmstadt.ukp.inception.websocket.model.LoggedEventMessage;
 
@@ -279,6 +284,20 @@ public class WebSocketIntegrationTest
             authProvider.setUserDetailsService(aUserDetailsManager);
             authProvider.setPasswordEncoder(aEncoder);
             return authProvider;
+        }
+
+        @Order(100)
+        @Bean
+        public SecurityFilterChain wsFilterChain(HttpSecurity aHttp) throws Exception
+        {
+            aHttp.antMatcher(WebsocketConfig.WS_ENDPOINT);
+            aHttp.authorizeRequests() //
+                    .antMatchers("/**").authenticated() //
+                    .anyRequest().denyAll();
+            aHttp.sessionManagement() //
+                    .sessionCreationPolicy(STATELESS);
+            aHttp.httpBasic();
+            return aHttp.build();
         }
     }
 }


### PR DESCRIPTION
**What's in the PR**
- Enable Spring MVC CSRF protection on UI API and view endpoints
- Move UI API security configuration and actuator security configuration to security module
- Adjust URL space for views and UI-related APIs to be more manageable and shorter

**How to test manually**
* Check if different views and Spring-MVC based UI elements still work (e.g. project export, activities dashlet)

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
