### PR TITLE
#3495 - Configurable editor content policies

### DIFF
--- a/inception/inception-api-formats/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/format/FormatSupport.java
+++ b/inception/inception-api-formats/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/format/FormatSupport.java
@@ -31,6 +31,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.uima.analysis_engine.AnalysisEngine;
@@ -49,6 +50,7 @@ import org.dkpro.core.api.io.ResourceCollectionReaderBase;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.inception.support.xml.sanitizer.PolicyCollection;
 
 public interface FormatSupport
 {
@@ -87,6 +89,11 @@ public interface FormatSupport
     default List<CssResourceReference> getCssStylesheets()
     {
         return Collections.emptyList();
+    }
+
+    default Optional<PolicyCollection> getPolicy()
+    {
+        return Optional.empty();
     }
 
     /**

--- a/inception/inception-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/DocumentImportExportService.java
+++ b/inception/inception-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/DocumentImportExportService.java
@@ -38,6 +38,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.Mode;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
+import de.tudarmstadt.ukp.inception.support.xml.sanitizer.PolicyCollection;
 
 public interface DocumentImportExportService
 {
@@ -97,6 +98,18 @@ public interface DocumentImportExportService
         FormatSupport formatSupport = maybeFormatSupport.get();
 
         return formatSupport.getCssStylesheets();
+    }
+
+    default Optional<PolicyCollection> getFormatPolicy(SourceDocument aDoc)
+    {
+        Optional<FormatSupport> maybeFormatSupport = getFormatById(aDoc.getFormat());
+        if (!maybeFormatSupport.isPresent()) {
+            return Optional.empty();
+        }
+
+        FormatSupport formatSupport = maybeFormatSupport.get();
+
+        return formatSupport.getPolicy();
     }
 
     // --------------------------------------------------------------------------------------------

--- a/inception/inception-external-editor/pom.xml
+++ b/inception/inception-external-editor/pom.xml
@@ -110,7 +110,16 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
     </dependency>
 
     <dependency>
@@ -143,6 +152,12 @@
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
       <scope>provided</scope>
+    </dependency>
+    
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>

--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/ExternalAnnotationEditorFactory.java
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/ExternalAnnotationEditorFactory.java
@@ -17,6 +17,15 @@
  */
 package de.tudarmstadt.ukp.inception.externaleditor;
 
+import static de.tudarmstadt.ukp.inception.support.xml.sanitizer.PolicyCollectionIOUtils.loadPolicies;
+import static java.nio.file.Files.exists;
+import static java.nio.file.Files.getLastModifiedTime;
+import static java.nio.file.Files.newInputStream;
+
+import java.io.IOException;
+import java.nio.file.attribute.FileTime;
+import java.util.Optional;
+
 import org.apache.wicket.model.IModel;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.CasProvider;
@@ -26,11 +35,15 @@ import de.tudarmstadt.ukp.inception.editor.AnnotationEditorFactoryImplBase;
 import de.tudarmstadt.ukp.inception.editor.action.AnnotationActionHandler;
 import de.tudarmstadt.ukp.inception.externaleditor.config.ExternalEditorPluginDescripion;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
+import de.tudarmstadt.ukp.inception.support.xml.sanitizer.PolicyCollection;
 
 public class ExternalAnnotationEditorFactory
     extends AnnotationEditorFactoryImplBase
 {
     private final ExternalEditorPluginDescripion description;
+
+    private PolicyCollection policy;
+    private FileTime policyMTime;
 
     public ExternalAnnotationEditorFactory(ExternalEditorPluginDescripion aDescription)
     {
@@ -60,5 +73,22 @@ public class ExternalAnnotationEditorFactory
     {
         return new ExternalAnnotationEditor(aId, aModel, aActionHandler, aCasProvider,
                 getBeanName());
+    }
+
+    public Optional<PolicyCollection> getPolicy() throws IOException
+    {
+        var policyFile = getDescription().getBasePath().resolve("policy.yaml");
+        if (exists(policyFile)) {
+            synchronized (this) {
+                FileTime lastModifiedTime = getLastModifiedTime(policyFile);
+                if (policyMTime == null || lastModifiedTime.compareTo(policyMTime) > 0) {
+                    try (var is = newInputStream(policyFile)) {
+                        policy = loadPolicies(is);
+                        policyMTime = lastModifiedTime;
+                    }
+                }
+            }
+        }
+        return Optional.ofNullable(policy);
     }
 }

--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/XmlDocumentViewControllerImplBase.java
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/XmlDocumentViewControllerImplBase.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.externaleditor;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import org.xml.sax.ContentHandler;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.DocumentImportExportService;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.inception.editor.AnnotationEditorRegistry;
+import de.tudarmstadt.ukp.inception.externaleditor.policy.DefaultHtmlDocumentPolicy;
+import de.tudarmstadt.ukp.inception.externaleditor.policy.SafetyNetDocumentPolicy;
+import de.tudarmstadt.ukp.inception.support.xml.sanitizer.PolicyCollection;
+import de.tudarmstadt.ukp.inception.support.xml.sanitizer.SanitizingContentHandler;
+
+public abstract class XmlDocumentViewControllerImplBase
+{
+    private final DefaultHtmlDocumentPolicy defaultPolicy;
+    private final SafetyNetDocumentPolicy safetyNetPolicy;
+    private final DocumentImportExportService formatRegistry;
+    private final AnnotationEditorRegistry annotationEditorRegistry;
+
+    public XmlDocumentViewControllerImplBase(DefaultHtmlDocumentPolicy aDefaultPolicy,
+            SafetyNetDocumentPolicy aSafetyNetPolicy, DocumentImportExportService aFormatRegistry,
+            AnnotationEditorRegistry aAnnotationEditorRegistry)
+    {
+        defaultPolicy = aDefaultPolicy;
+        safetyNetPolicy = aSafetyNetPolicy;
+        formatRegistry = aFormatRegistry;
+        annotationEditorRegistry = aAnnotationEditorRegistry;
+    }
+
+    protected ContentHandler applySanitizers(Optional<String> aEditor, SourceDocument doc,
+            ContentHandler aCh)
+        throws IOException
+    {
+        // Apply safety net
+        var ch = new SanitizingContentHandler(aCh, safetyNetPolicy.getPolicy());
+
+        // Apply editor policy if it exists
+        var editorPolicy = getEditorPolicy(aEditor);
+        if (editorPolicy.isPresent()) {
+            ch = new SanitizingContentHandler(ch, editorPolicy.get());
+        }
+
+        // Apply format policy if it exists
+        var formatPolicy = formatRegistry.getFormatPolicy(doc);
+        if (formatPolicy.isPresent()) {
+            ch = new SanitizingContentHandler(ch, formatPolicy.get());
+        }
+
+        // If neither a format nor an editor policy exists, apply the default policy
+        if (editorPolicy.isEmpty() && formatPolicy.isEmpty()) {
+            ch = new SanitizingContentHandler(ch, defaultPolicy.getPolicy());
+        }
+        return ch;
+    }
+
+    private Optional<PolicyCollection> getEditorPolicy(Optional<String> aEditor) throws IOException
+    {
+        if (!aEditor.isPresent()) {
+            return Optional.empty();
+        }
+
+        var factory = (ExternalAnnotationEditorFactory) annotationEditorRegistry
+                .getEditorFactory(aEditor.get());
+        if (factory == null) {
+            return Optional.empty();
+        }
+
+        return factory.getPolicy();
+    }
+}

--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/config/ExternalEditorAutoConfiguration.java
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/config/ExternalEditorAutoConfiguration.java
@@ -17,13 +17,19 @@
  */
 package de.tudarmstadt.ukp.inception.externaleditor.config;
 
+import java.io.IOException;
+
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 
+import de.tudarmstadt.ukp.inception.externaleditor.policy.DefaultHtmlDocumentPolicy;
+import de.tudarmstadt.ukp.inception.externaleditor.policy.SafetyNetDocumentPolicy;
 import de.tudarmstadt.ukp.inception.externaleditor.xhtml.XHtmlXmlDocumentIFrameViewFactory;
 import de.tudarmstadt.ukp.inception.externaleditor.xml.XmlDocumentIFrameViewFactory;
 
 @ConditionalOnWebApplication
+@EnableConfigurationProperties(ExternalEditorPropertiesImpl.class)
 public class ExternalEditorAutoConfiguration
 {
     @Bean
@@ -36,5 +42,18 @@ public class ExternalEditorAutoConfiguration
     public XmlDocumentIFrameViewFactory xmlDocumentIFrameViewFactory()
     {
         return new XmlDocumentIFrameViewFactory();
+    }
+
+    @Bean
+    public DefaultHtmlDocumentPolicy defaultHtmlDocumentPolicy() throws IOException
+    {
+        return new DefaultHtmlDocumentPolicy();
+    }
+
+    @Bean
+    public SafetyNetDocumentPolicy safetyNetDocumentPolicy(ExternalEditorProperties aProperties)
+        throws IOException
+    {
+        return new SafetyNetDocumentPolicy(aProperties);
     }
 }

--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/config/ExternalEditorLoader.java
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/config/ExternalEditorLoader.java
@@ -78,6 +78,7 @@ public class ExternalEditorLoader
                         ExternalEditorPluginDescripion.class, is);
                 desc.setId(pluginJsonFile.getParent().getFileName().toString());
                 desc.setBasePath(pluginJsonFile.getParent());
+
                 registerEditorPlugin(aRegistry, desc);
                 descriptions.add(desc);
             }

--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/config/ExternalEditorPluginDescripion.java
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/config/ExternalEditorPluginDescripion.java
@@ -22,19 +22,23 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 public class ExternalEditorPluginDescripion
     implements Serializable
 {
     private static final long serialVersionUID = 4400329006838299692L;
 
     private String id;
-    private Path basePath;
     private String factory;
     private String name;
     private String annotationFormat;
     private String view;
+
     private List<String> scripts = Collections.emptyList();
     private List<String> stylesheets = Collections.emptyList();
+
+    private @JsonIgnore Path basePath;
 
     public void setId(String aId)
     {

--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/config/ExternalEditorProperties.java
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/config/ExternalEditorProperties.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.externaleditor.config;
+
+public interface ExternalEditorProperties
+{
+    boolean isBlockStyle();
+
+    boolean isBlockImg();
+
+    boolean isBlockEmbed();
+
+    boolean isBlockAudio();
+
+    boolean isBlockObject();
+
+    boolean isBlockVideo();
+}

--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/config/ExternalEditorPropertiesImpl.java
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/config/ExternalEditorPropertiesImpl.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.externaleditor.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("ui.external")
+public class ExternalEditorPropertiesImpl
+    implements ExternalEditorProperties
+{
+    private boolean blockStyle = true;
+
+    private boolean blockImg = true;
+    private boolean blockEmbed = true;
+    private boolean blockAudio = true;
+    private boolean blockObject = true;
+    private boolean blockVideo = true;
+
+    @Override
+    public boolean isBlockStyle()
+    {
+        return blockStyle;
+    }
+
+    @Override
+    public boolean isBlockImg()
+    {
+        return blockImg;
+    }
+
+    @Override
+    public boolean isBlockEmbed()
+    {
+        return blockEmbed;
+    }
+
+    @Override
+    public boolean isBlockAudio()
+    {
+        return blockAudio;
+    }
+
+    @Override
+    public boolean isBlockObject()
+    {
+        return blockObject;
+    }
+
+    @Override
+    public boolean isBlockVideo()
+    {
+        return blockVideo;
+    }
+}

--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/policy/DefaultHtmlDocumentPolicy.java
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/policy/DefaultHtmlDocumentPolicy.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.externaleditor.policy;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.regex.Pattern;
+
+import de.tudarmstadt.ukp.clarin.webanno.support.SettingsUtil;
+import de.tudarmstadt.ukp.clarin.webanno.support.WatchedResourceFile;
+import de.tudarmstadt.ukp.inception.support.xml.sanitizer.PolicyCollection;
+import de.tudarmstadt.ukp.inception.support.xml.sanitizer.PolicyCollectionBuilder;
+import de.tudarmstadt.ukp.inception.support.xml.sanitizer.PolicyCollectionIOUtils;
+
+public class DefaultHtmlDocumentPolicy
+{
+    static final String DEFAULT_POLICY_YAML = "default-policy.yaml";
+
+    private static final Pattern HTML_TITLE = Pattern
+            .compile("[\\p{L}\\p{N}\\s\\-_',:\\[\\]!\\./\\\\\\(\\)&]*");
+    private static final Pattern HTML_CLASS = Pattern.compile("[a-zA-Z0-9\\s,\\-_]+");
+
+    private final PolicyCollection defaultPolicy;
+
+    private final WatchedResourceFile<PolicyCollection> policyOverrideFile;
+
+    public DefaultHtmlDocumentPolicy()
+    {
+        defaultPolicy = makeDefaultPolicy();
+
+        var appHome = SettingsUtil.getApplicationHome();
+        policyOverrideFile = new WatchedResourceFile<>(
+                new File(appHome, DEFAULT_POLICY_YAML).toPath(),
+                PolicyCollectionIOUtils::loadPolicies);
+    }
+
+    private PolicyCollection makeDefaultPolicy()
+    {
+        return PolicyCollectionBuilder.caseInsensitive() //
+                .allowElements("html", "head", "body", "title") //
+                // Content sectioning
+                .allowElements("address", "article", "aside", "footer", "header", "h1", "h2", "h3",
+                        "h4", "h5", "h6", "main", "section") //
+                // Text content
+                .allowElements("blockquote", "dd", "div", "dl", "dt", "figcaption", "figure", "hr",
+                        "li", "menu", "ol", "p", "pre", "ul") //
+                // Inline text semantics
+                .allowElements("a", "abbr", "b", "bdi", "bdo", "br", "cite", "code", "data", "dfn",
+                        "em", "i", "kbd", "mark", "q", "rp", "rt", "ruby", "s", "samp", "small",
+                        "span", "strong", "sub", "sup", "time", "u", "var", "wbr")
+                // Demarcating edits
+                .allowElements("del", "ins")
+                // Table content
+                .allowElements("caption", "col", "colgroup", "table", "tbody", "td", "tfoot", "th",
+                        "thead", "tr")
+                // Common attributes
+                .allowAttributes("title").matching(HTML_TITLE).globally() //
+                .allowAttributes("class").matching(HTML_CLASS).globally() //
+                .build();
+    }
+
+    public PolicyCollection getPolicy() throws IOException
+    {
+        return policyOverrideFile.get().orElse(defaultPolicy);
+    }
+}

--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/policy/SafetyNetDocumentPolicy.java
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/policy/SafetyNetDocumentPolicy.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.externaleditor.policy;
+
+import static java.util.regex.Pattern.compile;
+
+import java.io.File;
+import java.io.IOException;
+
+import de.tudarmstadt.ukp.clarin.webanno.support.SettingsUtil;
+import de.tudarmstadt.ukp.clarin.webanno.support.WatchedResourceFile;
+import de.tudarmstadt.ukp.inception.externaleditor.config.ExternalEditorProperties;
+import de.tudarmstadt.ukp.inception.support.xml.sanitizer.AttributeAction;
+import de.tudarmstadt.ukp.inception.support.xml.sanitizer.ElementAction;
+import de.tudarmstadt.ukp.inception.support.xml.sanitizer.PolicyCollection;
+import de.tudarmstadt.ukp.inception.support.xml.sanitizer.PolicyCollectionBuilder;
+import de.tudarmstadt.ukp.inception.support.xml.sanitizer.PolicyCollectionIOUtils;
+
+public class SafetyNetDocumentPolicy
+{
+    static final String DEFAULT_POLICY_YAML = "safety-net.yaml";
+
+    private static final String[] JAVASCRIPT_EVENT_ATTRIBUTES = { "onafterprint", "onbeforeprint",
+            "onbeforeunload", "onerror", "onhashchange", "onload", "onmessage", "onoffline",
+            "ononline", "onpagehide", "onpageshow", "onpopstate", "onresize", "onstorage",
+            "onunload", "onblur", "onchange", "oncontextmenu", "onfocus", "oninput", "oninvalid",
+            "onreset", "onsearch", "onselect", "onsubmit", "onkeydown", "onkeypress", "onkeyup",
+            "onclick", "ondblclick", "onmousedown", "onmousemove", "onmouseout", "onmouseover",
+            "onmouseup", "onmousewheel", "onwheel", "ondrag", "ondragend", "ondragenter",
+            "ondragleave", "ondragover", "ondragstart", "ondrop", "onscroll", "oncopy", "oncut",
+            "onpaste", "onabort", "oncanplay", "oncanplaythrough", "oncuechange",
+            "ondurationchange", "onemptied", "onended", "onerror", "onloadeddata",
+            "onloadedmetadata", "onloadstart", "onpause", "onplay", "onplaying", "onprogress",
+            "onratechange", "onseeked", "onseeking", "onstalled", "onsuspend", "ontimeupdate",
+            "onvolumechange", "onwaiting", "ontoggle" };
+
+    private final ExternalEditorProperties properties;
+
+    private final PolicyCollection defaultPolicy;
+
+    private final WatchedResourceFile<PolicyCollection> policyOverrideFile;
+
+    public SafetyNetDocumentPolicy(ExternalEditorProperties aProperties) throws IOException
+    {
+        properties = aProperties;
+
+        defaultPolicy = makeDefaultPolicy();
+
+        var appHome = SettingsUtil.getApplicationHome();
+        policyOverrideFile = new WatchedResourceFile<>(
+                new File(appHome, DEFAULT_POLICY_YAML).toPath(),
+                PolicyCollectionIOUtils::loadPolicies);
+    }
+
+    private PolicyCollection makeDefaultPolicy()
+    {
+        var builder = PolicyCollectionBuilder //
+                .caseInsensitive() //
+                .defaultAttributeAction(AttributeAction.PASS) //
+                .defaultElementAction(ElementAction.PASS);
+
+        builder.disallowElements("script", "meta", "applet", "link", "iframe", "a");
+
+        if (properties.isBlockStyle()) {
+            builder.disallowElements("style");
+        }
+        if (properties.isBlockAudio()) {
+            builder.disallowElements("audio");
+        }
+        if (properties.isBlockEmbed()) {
+            builder.disallowElements("embed");
+        }
+        if (properties.isBlockImg()) {
+            builder.disallowElements("img");
+        }
+        if (properties.isBlockObject()) {
+            builder.disallowElements("object");
+        }
+        if (properties.isBlockVideo()) {
+            builder.disallowElements("video");
+        }
+
+        builder.disallowAttributes("href", "src", "codebase", "cite", "background", "action",
+                "longdesc", "profile", "classid", "data", "usemap", "formaction", "icon",
+                "manifest", "poster", "srcset", "archive").matching(compile("\\s*javascript:.*"))
+                .globally();
+
+        builder.disallowAttributes(JAVASCRIPT_EVENT_ATTRIBUTES).globally();
+        return builder.build();
+    }
+
+    public PolicyCollection getPolicy() throws IOException
+    {
+        return policyOverrideFile.get().orElse(defaultPolicy);
+    }
+}

--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/xhtml/XHtmlXmlDocumentViewControllerImpl.java
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/xhtml/XHtmlXmlDocumentViewControllerImpl.java
@@ -46,6 +46,10 @@ import de.tudarmstadt.ukp.clarin.webanno.api.DocumentImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.support.wicket.ServletContextUtils;
+import de.tudarmstadt.ukp.inception.editor.AnnotationEditorRegistry;
+import de.tudarmstadt.ukp.inception.externaleditor.XmlDocumentViewControllerImplBase;
+import de.tudarmstadt.ukp.inception.externaleditor.policy.DefaultHtmlDocumentPolicy;
+import de.tudarmstadt.ukp.inception.externaleditor.policy.SafetyNetDocumentPolicy;
 import de.tudarmstadt.ukp.inception.externaleditor.xml.XmlCas2SaxEvents;
 import de.tudarmstadt.ukp.inception.io.xml.dkprocore.Cas2SaxEvents;
 
@@ -53,6 +57,7 @@ import de.tudarmstadt.ukp.inception.io.xml.dkprocore.Cas2SaxEvents;
 @RestController
 @RequestMapping(XHtmlXmlDocumentViewController.BASE_URL)
 public class XHtmlXmlDocumentViewControllerImpl
+    extends XmlDocumentViewControllerImplBase
     implements XHtmlXmlDocumentViewController
 {
     private static final String GET_DOCUMENT_PATH = "/p/{projectId}/xml/{documentId}";
@@ -68,8 +73,12 @@ public class XHtmlXmlDocumentViewControllerImpl
 
     @Autowired
     public XHtmlXmlDocumentViewControllerImpl(DocumentService aDocumentService,
-            ServletContext aServletContext, DocumentImportExportService aFormatRegistry)
+            AnnotationEditorRegistry aAnnotationEditorRegistry, ServletContext aServletContext,
+            DocumentImportExportService aFormatRegistry, DefaultHtmlDocumentPolicy aDefaultPolicy,
+            SafetyNetDocumentPolicy aSafetyNetPolicy)
     {
+        super(aDefaultPolicy, aSafetyNetPolicy, aFormatRegistry, aAnnotationEditorRegistry);
+
         documentService = aDocumentService;
         servletContext = aServletContext;
         formatRegistry = aFormatRegistry;
@@ -156,7 +165,8 @@ public class XHtmlXmlDocumentViewControllerImpl
             }
             else {
                 XmlDocument xml = maybeXmlDocument.get();
-                Cas2SaxEvents serializer = new XmlCas2SaxEvents(xml, ch);
+                var sh = applySanitizers(aEditor, doc, ch);
+                Cas2SaxEvents serializer = new XmlCas2SaxEvents(xml, sh);
                 serializer.process(xml.getRoot());
             }
 

--- a/inception/inception-external-editor/src/main/resources/META-INF/asciidoc/developer-guide/external-editor.adoc
+++ b/inception/inception-external-editor/src/main/resources/META-INF/asciidoc/developer-guide/external-editor.adoc
@@ -95,10 +95,89 @@ and CSS stylesheet files required are then injected into this IFrame as well.
 Currently supported views are:
 
 * `cas+html` (deprecated): Renders HTML contained in the CAS directly into the editor area.
-* `iframe:cas+html`: Renders HTML contained in the CAS into a HTML IFrame in the editor area.
+* `iframe:cas+html` (deprecated): Renders HTML contained in the CAS into a HTML IFrame in the editor area.
 * `iframe:cas+xml`: Renders XML contained in the CAS into a generic XML IFrame in the editor area.
 * `iframe:cas+xhtml+xml`: Renders XML contained in the CAS into an XHTML+XML IFrame in the editor area.
 HTML head and body elements are added automatically. The XML is rendered into the body.
+
+== Policies
+
+Every editor should provide a `policy.yaml` right next to the `plugin.json`. The `policy.yaml` declares
+all elements and attributes that are supported by the editor. This policy file should be written as
+a **safelist**, i.e. it should say exactly what is permitted instead of saying what is not allowed.
+Allowing the wrong elements and attributes may cause security problems, e.g. if they can contain
+executable JavaScript or load data from remote locations.
+
+There are several elements like `script`, `meta`, `applet`, `link`, `iframe` as well as `a` which are
+and JavaScript event attributes always filtered out.
+
+If an editor does not provide a `policy.yaml` file, a default built-in policy is used which allows
+most HTML formatting elements.
+
+.Example `policy.yaml` file
+[source,yaml]
+----
+name: Example policy
+version: 1.0
+case_sensitive: false
+default_attribute_action: DROP
+default_element_action: DROP
+debug: false
+policies:
+  - { elements: ["html"], action: "PASS" }
+  - { elements: ["p", "div"], action: "PASS" }
+  - { elements: ["tr", "th"], action: "PASS" }
+  - { attributes: ["class"], action: "PASS" }
+  - { attributes: ["style"], action: "DROP" }
+  - {
+      attributes: ["title"],
+      matching: "[a-zA-Z0-9]*",
+      on_elements: ["div"],
+      action: "PASS",
+    }
+----
+
+There are two types of policies: **element policies**, and **attribute policies**.
+
+=== Element policies
+An element policy must contain the key `elements` which takes a list of element names and the key
+`action` which can be either `PASS` or `DROP`. If an element is dropped, all child elements are
+also dropped. Text within the child elements is replaced by an equivalent amount of space such that
+offsets are not affected.
+
+Note that the root element of your documents should always be allowed to `PASS`, otherwise the
+document may fail to render.
+
+It is possible to preserve elements within dropped elements by explicitly allowing the nested
+elements to `PASS`.
+
+[source,yaml]
+----
+policies:
+  - { elements: ["root", "child2"], action: "PASS" }
+  - { elements: ["child1"], action: "DROP" }
+----
+
+Using this policy, a document `<root><child1><child2>text</child2></child1/></root>` will be transformed
+to `<root><child2>text</child2></root>`.
+
+=== Attribute policies
+An attribute policy must contain the key `attributes` which takes a list of attribute names, 
+and the key `action` which can be either `PASS` or `DROP`. Optionally it may contain the the key 
+`onElements` which takes a list of element names. If this key is present, the policy only affects
+the attributes on the given elements, otherwise the policy affects all elements globally. Also, the
+key `matching` can be optionally included to affect only attributes whose value matches the regular
+expression provided as the value to `matching`.
+
+When declaring attribute policies, the order matters. E.g. you should declare more specific policies
+(e.g. such having a `onElements` or `matching` key) before less specific or global policies.
+
+=== Debugging
+To debug the rules, you can set the key `debug` to `true` and reload your editor in the browser.
+Restarting the whole application is not required. When inspecting the content of the editor IFrame
+in the browser's developer tools, you will see that elements and attributes matched by a `DROP`
+policy have been prefixed with `MASKED-` instead of being fully dropped. Do not forget to set
+debug back to `false` or to remove the key for actual use.
 
 == Editor implementation
 

--- a/inception/inception-external-editor/src/test/java/de/tudarmstadt/ukp/inception/externaleditor/policy/DefaultHtmlDocumentPolicyTest.java
+++ b/inception/inception-external-editor/src/test/java/de/tudarmstadt/ukp/inception/externaleditor/policy/DefaultHtmlDocumentPolicyTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.externaleditor.policy;
+
+import static de.tudarmstadt.ukp.clarin.webanno.support.SettingsUtil.getPropApplicationHome;
+import static de.tudarmstadt.ukp.inception.externaleditor.policy.DefaultHtmlDocumentPolicy.DEFAULT_POLICY_YAML;
+import static java.lang.System.setProperty;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.commons.io.FileUtils.write;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class DefaultHtmlDocumentPolicyTest
+{
+    @Test
+    void thatOverrideFileIsPickedUp(@TempDir Path aTemp) throws IOException
+    {
+        Path policyFile = aTemp.resolve(DEFAULT_POLICY_YAML);
+        setProperty(getPropApplicationHome(), aTemp.toString());
+
+        var sut = new DefaultHtmlDocumentPolicy();
+
+        var p1 = sut.getPolicy();
+        assertThat(p1.getElementPolicies()).hasSize(72);
+
+        write(policyFile.toFile(), "policies: []", UTF_8);
+
+        var p2 = sut.getPolicy();
+        assertThat(p2.getElementPolicies()).isEmpty();
+
+        write(policyFile.toFile(), "policies: [ {elements: [a], action: PASS}]", UTF_8);
+
+        var p3 = sut.getPolicy();
+        assertThat(p3.getElementPolicies()).hasSize(1);
+
+        Files.delete(policyFile);
+
+        var p4 = sut.getPolicy();
+        assertThat(p4.getElementPolicies()).hasSize(72);
+    }
+}

--- a/inception/inception-external-editor/src/test/java/de/tudarmstadt/ukp/inception/externaleditor/policy/SafetyNetDocumentPolicyTest.java
+++ b/inception/inception-external-editor/src/test/java/de/tudarmstadt/ukp/inception/externaleditor/policy/SafetyNetDocumentPolicyTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.externaleditor.policy;
+
+import static de.tudarmstadt.ukp.clarin.webanno.support.SettingsUtil.getPropApplicationHome;
+import static de.tudarmstadt.ukp.inception.externaleditor.policy.SafetyNetDocumentPolicy.DEFAULT_POLICY_YAML;
+import static de.tudarmstadt.ukp.inception.support.xml.XmlParserUtils.makeXmlSerializer;
+import static java.lang.System.setProperty;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.commons.io.FileUtils.write;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import de.tudarmstadt.ukp.inception.externaleditor.config.ExternalEditorPropertiesImpl;
+import de.tudarmstadt.ukp.inception.support.xml.sanitizer.SanitizingContentHandler;
+
+class SafetyNetDocumentPolicyTest
+{
+    @Test
+    void thatScriptBlockIsDropped() throws Exception
+    {
+        var properties = new ExternalEditorPropertiesImpl();
+        var sut = new SafetyNetDocumentPolicy(properties);
+
+        var buffer = new StringWriter();
+        var ch = new SanitizingContentHandler(makeXmlSerializer(buffer), sut.getPolicy());
+
+        ch.startDocument();
+        ch.startElement("html");
+        ch.startElement("head");
+        ch.startElement("script");
+        ch.characters("script in header");
+        ch.endElement("script");
+        ch.endElement("head");
+        ch.startElement("body");
+        ch.characters("content");
+        ch.startElement("script");
+        ch.characters("script in body");
+        ch.endElement("script");
+        ch.endElement("body");
+        ch.endElement("html");
+        ch.endDocument();
+
+        assertThat(buffer.toString()).isEqualTo(
+                "<html><head>                </head><body>content              </body></html>");
+    }
+
+    @Test
+    void thatEventAttributesAreDropped() throws Exception
+    {
+        var properties = new ExternalEditorPropertiesImpl();
+        var sut = new SafetyNetDocumentPolicy(properties);
+
+        var buffer = new StringWriter();
+        var ch = new SanitizingContentHandler(makeXmlSerializer(buffer), sut.getPolicy());
+
+        ch.startDocument();
+        ch.startElement("html");
+        ch.startElement("body", Map.of("onload", "alert('hello!')"));
+        ch.characters("content");
+        ch.endElement("body");
+        ch.endElement("html");
+        ch.endDocument();
+
+        assertThat(buffer.toString()).isEqualTo("<html><body>content</body></html>");
+    }
+
+    @Test
+    void thatAttributeWithJavaScriptIsDropped() throws Exception
+    {
+        var properties = new ExternalEditorPropertiesImpl();
+        var sut = new SafetyNetDocumentPolicy(properties);
+
+        var buffer = new StringWriter();
+        var ch = new SanitizingContentHandler(makeXmlSerializer(buffer), sut.getPolicy());
+
+        ch.startDocument();
+        ch.startElement("html");
+        ch.startElement("body");
+        ch.characters("content");
+        ch.startElement("q", Map.of("cite", "\tjavascript: alert('boooh!')"));
+        ch.endElement("q");
+        ch.startElement("q", Map.of("cite", "http://dum.my"));
+        ch.endElement("q");
+        ch.endElement("body");
+        ch.endElement("html");
+        ch.endDocument();
+
+        assertThat(buffer.toString())
+                .isEqualTo("<html><body>content<q/><q cite=\"http://dum.my\"/></body></html>");
+    }
+
+    @Test
+    void thatOverrideFileIsPickedUp(@TempDir Path aTemp) throws IOException
+    {
+        Path policyFile = aTemp.resolve(DEFAULT_POLICY_YAML);
+        setProperty(getPropApplicationHome(), aTemp.toString());
+
+        var properties = new ExternalEditorPropertiesImpl();
+        var sut = new SafetyNetDocumentPolicy(properties);
+
+        var p1 = sut.getPolicy();
+        assertThat(p1.getElementPolicies()).hasSize(12);
+
+        write(policyFile.toFile(), "policies: []", UTF_8);
+
+        var p2 = sut.getPolicy();
+        assertThat(p2.getElementPolicies()).isEmpty();
+
+        write(policyFile.toFile(), "policies: [ {elements: [a], action: PASS}]", UTF_8);
+
+        var p3 = sut.getPolicy();
+        assertThat(p3.getElementPolicies()).hasSize(1);
+
+        Files.delete(policyFile);
+
+        var p4 = sut.getPolicy();
+        assertThat(p4.getElementPolicies()).hasSize(12);
+    }
+}

--- a/inception/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/htmleditor/config/HtmlAnnotationEditorSupportAutoConfiguration.java
+++ b/inception/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/htmleditor/config/HtmlAnnotationEditorSupportAutoConfiguration.java
@@ -31,22 +31,29 @@ import de.tudarmstadt.ukp.inception.htmleditor.docview.HtmlDocumentViewFactory;
  */
 @ConditionalOnWebApplication
 @Configuration
-@ConditionalOnProperty(prefix = "ui.html", name = "enabled", havingValue = "true", matchIfMissing = false)
 public class HtmlAnnotationEditorSupportAutoConfiguration
 {
+    @ConditionalOnProperty(prefix = "ui.html", name = "enabled", //
+            havingValue = "true", matchIfMissing = false)
     @Bean
     public AnnotatorJsHtmlAnnotationEditorFactory htmlAnnotationEditorFactory()
     {
         return new AnnotatorJsHtmlAnnotationEditorFactory();
     }
 
+    @ConditionalOnProperty(prefix = "ui.html.legacy-html-view", name = "enabled", //
+            havingValue = "true", matchIfMissing = false)
     @Bean
+    @Deprecated
     public HtmlDocumentViewFactory htmlDocumentViewFactory()
     {
         return new HtmlDocumentViewFactory();
     }
 
+    @ConditionalOnProperty(prefix = "ui.html.legacy-iframe-view", name = "enabled", //
+            havingValue = "true", matchIfMissing = false)
     @Bean
+    @Deprecated
     public HtmlDocumentIFrameViewFactory htmlDocumentIFrameViewFactory()
     {
         return new HtmlDocumentIFrameViewFactory();

--- a/inception/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/htmleditor/docview/HtmlDocumentIFrameView.java
+++ b/inception/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/htmleditor/docview/HtmlDocumentIFrameView.java
@@ -24,7 +24,12 @@ import org.apache.wicket.spring.injection.annot.SpringBean;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
+import de.tudarmstadt.ukp.inception.externaleditor.xhtml.XHtmlXmlDocumentIFrameView;
 
+/**
+ * @deprecated Use {@link XHtmlXmlDocumentIFrameView} instead
+ */
+@Deprecated
 public class HtmlDocumentIFrameView
     extends WebMarkupContainer
 {

--- a/inception/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/htmleditor/docview/HtmlDocumentIFrameViewFactory.java
+++ b/inception/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/htmleditor/docview/HtmlDocumentIFrameViewFactory.java
@@ -22,6 +22,7 @@ import org.apache.wicket.model.IModel;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.inception.editor.view.DocumentViewFactory;
+import de.tudarmstadt.ukp.inception.externaleditor.xhtml.XHtmlXmlDocumentIFrameViewFactory;
 import de.tudarmstadt.ukp.inception.htmleditor.config.HtmlAnnotationEditorSupportAutoConfiguration;
 import de.tudarmstadt.ukp.inception.io.html.HtmlFormatSupport;
 
@@ -30,7 +31,10 @@ import de.tudarmstadt.ukp.inception.io.html.HtmlFormatSupport;
  * This class is exposed as a Spring Component via
  * {@link HtmlAnnotationEditorSupportAutoConfiguration#htmlDocumentIFrameViewFactory}.
  * </p>
+ * 
+ * @deprecated Use {@link XHtmlXmlDocumentIFrameViewFactory} instead
  */
+@Deprecated
 public class HtmlDocumentIFrameViewFactory
     implements DocumentViewFactory
 {

--- a/inception/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/htmleditor/docview/HtmlDocumentRenderer.java
+++ b/inception/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/htmleditor/docview/HtmlDocumentRenderer.java
@@ -41,9 +41,16 @@ import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 
 import de.tudarmstadt.ukp.clarin.webanno.support.xml.TextSanitizingContentHandler;
+import de.tudarmstadt.ukp.inception.externaleditor.policy.DefaultHtmlDocumentPolicy;
+import de.tudarmstadt.ukp.inception.externaleditor.xhtml.XHtmlXmlDocumentIFrameView;
 import de.tudarmstadt.ukp.inception.io.xml.dkprocore.Cas2SaxEvents;
 import de.tudarmstadt.ukp.inception.support.xml.XmlParserUtils;
+import de.tudarmstadt.ukp.inception.support.xml.sanitizer.SanitizingContentHandler;
 
+/**
+ * @deprecated Use {@link XHtmlXmlDocumentIFrameView} instead
+ */
+@Deprecated
 public class HtmlDocumentRenderer
 {
     private boolean renderOnlyBody = true;
@@ -64,14 +71,15 @@ public class HtmlDocumentRenderer
             th.getTransformer().setOutputProperty(INDENT, "no");
             th.setResult(new StreamResult(out));
 
-            ContentHandler sh = new TextSanitizingContentHandler(th);
+            ContentHandler ch = new TextSanitizingContentHandler(th);
+            ch = new SanitizingContentHandler(ch, new DefaultHtmlDocumentPolicy().getPolicy());
 
             if (!JCasUtil.exists(aCas.getJCas(), XmlDocument.class)) {
                 String text = aCas.getDocumentText();
 
-                sh.startDocument();
-                sh.characters(text.toCharArray(), 0, text.length());
-                sh.endDocument();
+                ch.startDocument();
+                ch.characters(text.toCharArray(), 0, text.length());
+                ch.endDocument();
                 return out.toString();
             }
 
@@ -80,7 +88,7 @@ public class HtmlDocumentRenderer
             // we wouldn't want to render anything outside the body anyway.
             var rootElement = selectSingle(aCas.getJCas(), XmlDocument.class).getRoot();
 
-            Cas2SaxEvents serializer = new Cas2SaxEvents(sh);
+            Cas2SaxEvents serializer = new Cas2SaxEvents(ch);
             if (renderOnlyBody) {
                 XmlElement body = rootElement.getChildren().stream() //
                         .filter(e -> e instanceof XmlElement) //

--- a/inception/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/htmleditor/docview/HtmlDocumentView.java
+++ b/inception/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/htmleditor/docview/HtmlDocumentView.java
@@ -33,7 +33,12 @@ import org.slf4j.LoggerFactory;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
+import de.tudarmstadt.ukp.inception.externaleditor.xhtml.XHtmlXmlDocumentIFrameView;
 
+/**
+ * @deprecated Use {@link XHtmlXmlDocumentIFrameView} instead
+ */
+@Deprecated
 public class HtmlDocumentView
     extends Label
 {

--- a/inception/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/htmleditor/docview/HtmlDocumentViewController.java
+++ b/inception/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/htmleditor/docview/HtmlDocumentViewController.java
@@ -24,7 +24,12 @@ import java.security.Principal;
 import org.springframework.http.ResponseEntity;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.inception.externaleditor.xhtml.XHtmlXmlDocumentIFrameViewFactory;
 
+/**
+ * @deprecated Use {@link XHtmlXmlDocumentIFrameViewFactory} instead
+ */
+@Deprecated
 public interface HtmlDocumentViewController
 {
     String BASE_URL = BASE_VIEW_URL + "/html";

--- a/inception/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/htmleditor/docview/HtmlDocumentViewControllerImpl.java
+++ b/inception/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/htmleditor/docview/HtmlDocumentViewControllerImpl.java
@@ -35,7 +35,12 @@ import org.springframework.web.bind.annotation.RestController;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.inception.externaleditor.xhtml.XHtmlXmlDocumentIFrameViewFactory;
 
+/**
+ * @deprecated Use {@link XHtmlXmlDocumentIFrameViewFactory} instead
+ */
+@Deprecated
 @ConditionalOnWebApplication
 @RestController
 @RequestMapping(HtmlDocumentViewController.BASE_URL)

--- a/inception/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/htmleditor/docview/HtmlDocumentViewFactory.java
+++ b/inception/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/htmleditor/docview/HtmlDocumentViewFactory.java
@@ -22,6 +22,7 @@ import org.apache.wicket.model.IModel;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.inception.editor.view.DocumentViewFactory;
+import de.tudarmstadt.ukp.inception.externaleditor.xhtml.XHtmlXmlDocumentIFrameViewFactory;
 import de.tudarmstadt.ukp.inception.htmleditor.config.HtmlAnnotationEditorSupportAutoConfiguration;
 import de.tudarmstadt.ukp.inception.io.html.HtmlFormatSupport;
 
@@ -30,7 +31,10 @@ import de.tudarmstadt.ukp.inception.io.html.HtmlFormatSupport;
  * This class is exposed as a Spring Component via
  * {@link HtmlAnnotationEditorSupportAutoConfiguration#htmlDocumentViewFactory}.
  * </p>
+ * 
+ * @deprecated Use {@link XHtmlXmlDocumentIFrameViewFactory} instead
  */
+@Deprecated
 public class HtmlDocumentViewFactory
     implements DocumentViewFactory
 {

--- a/inception/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/htmleditor/docview/LegacyHtmlDocumentRenderer.java
+++ b/inception/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/htmleditor/docview/LegacyHtmlDocumentRenderer.java
@@ -35,7 +35,12 @@ import org.xml.sax.SAXException;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Div;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Heading;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Paragraph;
+import de.tudarmstadt.ukp.inception.externaleditor.xhtml.XHtmlXmlDocumentIFrameViewFactory;
 
+/**
+ * @deprecated Use {@link XHtmlXmlDocumentIFrameViewFactory} instead
+ */
+@Deprecated
 public class LegacyHtmlDocumentRenderer
 {
     public String renderHtmlDocumentStructure(CAS aCas)

--- a/inception/inception-io-xml/src/main/java/de/tudarmstadt/ukp/inception/io/xml/config/XmlSupportAutoConfiguration.java
+++ b/inception/inception-io-xml/src/main/java/de/tudarmstadt/ukp/inception/io/xml/config/XmlSupportAutoConfiguration.java
@@ -24,7 +24,7 @@ import org.springframework.context.annotation.Configuration;
 import de.tudarmstadt.ukp.inception.io.xml.XmlFormatSupport;
 
 @Configuration
-@ConditionalOnProperty(prefix = "format.xml", name = "enabled", havingValue = "true", matchIfMissing = false)
+@ConditionalOnProperty(prefix = "format.generic-xml", name = "enabled", havingValue = "true", matchIfMissing = false)
 public class XmlSupportAutoConfiguration
 {
     @Bean

--- a/inception/inception-support/pom.xml
+++ b/inception/inception-support/pom.xml
@@ -15,7 +15,9 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>de.tudarmstadt.ukp.inception.app</groupId>
@@ -46,7 +48,7 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-collections4</artifactId>
     </dependency>
-    
+
     <dependency>
       <groupId>com.github.rjeschke</groupId>
       <artifactId>txtmark</artifactId>
@@ -184,6 +186,10 @@
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+    </dependency>
     
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -204,7 +210,7 @@
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
     </dependency>
-    
+
     <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/SettingsUtil.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/SettingsUtil.java
@@ -159,14 +159,13 @@ public class SettingsUtil
     public static File getApplicationHome()
     {
         String appHome = System.getProperty(propApplicationHome);
-        String userHome = System.getProperty(PROP_USER_HOME);
 
         if (appHome != null) {
             return new File(appHome);
         }
-        else {
-            return new File(userHome + "/" + applicationUserHomeSubdir);
-        }
+
+        String userHome = System.getProperty(PROP_USER_HOME);
+        return new File(userHome + "/" + applicationUserHomeSubdir);
     }
 
     /**

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/WatchedResourceFile.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/WatchedResourceFile.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.support;
+
+import static java.nio.file.Files.getLastModifiedTime;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Optional;
+
+import org.apache.commons.lang3.function.FailableFunction;
+
+public class WatchedResourceFile<T>
+{
+    private final FailableFunction<InputStream, T, IOException> loader;
+    private final Path resourcePath;
+    private T resource;
+    private Instant resourceMTime;
+
+    public WatchedResourceFile(Path aResourcePath,
+            FailableFunction<InputStream, T, IOException> aLoader)
+    {
+        loader = aLoader;
+        resourcePath = aResourcePath;
+    }
+
+    public Optional<T> get() throws IOException
+    {
+        if (Files.exists(resourcePath)) {
+            if (resourceMTime == null
+                    || getLastModifiedTime(resourcePath).toInstant().isAfter(resourceMTime)) {
+                try (var is = Files.newInputStream(resourcePath)) {
+                    resource = loader.apply(is);
+                }
+            }
+
+            return Optional.of(resource);
+        }
+
+        resourceMTime = null;
+        return Optional.empty();
+    }
+}

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/YamlUtil.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/YamlUtil.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.support;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringWriter;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+
+public class YamlUtil
+{
+    private static final ObjectMapper OBJECT_MAPPER;
+
+    static {
+        OBJECT_MAPPER = new ObjectMapper(new YAMLFactory());
+    }
+
+    public static ObjectMapper getObjectMapper()
+    {
+        return OBJECT_MAPPER;
+    }
+
+    public static <T> T fromYamlStream(Class<T> aClass, InputStream aSrc) throws IOException
+    {
+        return getObjectMapper().readValue(aSrc, aClass);
+    }
+
+    public static String toYamlString(Object aObject) throws IOException
+    {
+        return toYamlString(getObjectMapper(), false, aObject);
+    }
+
+    public static String toYamlString(ObjectMapper aMapper, boolean aPretty, Object aObject)
+        throws IOException
+    {
+        StringWriter out = new StringWriter();
+
+        JsonGenerator yamlGenerator = aMapper.getFactory().createGenerator(out);
+        // if (aPretty) {
+        // yamlGenerator.setPrettyPrinter(new DefaultPrettyPrinter()
+        // .withObjectIndenter(new DefaultIndenter().withLinefeed("\n")));
+        // }
+
+        yamlGenerator.writeObject(aObject);
+        return out.toString();
+    }
+}

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/XmlParserUtils.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/XmlParserUtils.java
@@ -17,18 +17,30 @@
  */
 package de.tudarmstadt.ukp.inception.support.xml;
 
+import static java.lang.String.CASE_INSENSITIVE_ORDER;
+import static java.util.Comparator.comparing;
+import static javax.xml.transform.OutputKeys.INDENT;
+import static javax.xml.transform.OutputKeys.METHOD;
+import static javax.xml.transform.OutputKeys.OMIT_XML_DECLARATION;
+
+import java.io.Writer;
 import java.lang.invoke.MethodHandles;
+import java.util.Comparator;
 
 import javax.xml.XMLConstants;
+import javax.xml.namespace.QName;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.sax.SAXTransformerFactory;
+import javax.xml.transform.sax.TransformerHandler;
+import javax.xml.transform.stream.StreamResult;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXNotRecognizedException;
 import org.xml.sax.SAXNotSupportedException;
@@ -45,6 +57,32 @@ public class XmlParserUtils
     private XmlParserUtils()
     {
         // No instances
+    }
+
+    public static Comparator<QName> caseInsensitiveQNameComparator()
+    {
+        return comparing(QName::getLocalPart, CASE_INSENSITIVE_ORDER);
+    }
+
+    public static String getQName(QName aElement)
+    {
+        var qName = aElement.getLocalPart();
+        if (!aElement.getPrefix().isEmpty()) {
+            qName = aElement.getPrefix() + ':' + qName;
+        }
+        return qName;
+    }
+
+    public static ContentHandler makeXmlSerializer(Writer aOut)
+        throws TransformerConfigurationException
+    {
+        SAXTransformerFactory tf = newTransformerFactory();
+        TransformerHandler th = tf.newTransformerHandler();
+        th.getTransformer().setOutputProperty(OMIT_XML_DECLARATION, "yes");
+        th.getTransformer().setOutputProperty(METHOD, "xml");
+        th.getTransformer().setOutputProperty(INDENT, "no");
+        th.setResult(new StreamResult(aOut));
+        return th;
     }
 
     public static SAXTransformerFactory newTransformerFactory()

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/AttributeAction.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/AttributeAction.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.support.xml.sanitizer;
+
+public enum AttributeAction
+{
+    PASS, //
+    DROP;
+}

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/AttributePolicy.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/AttributePolicy.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.support.xml.sanitizer;
+
+import java.util.Optional;
+
+import javax.xml.namespace.QName;
+
+public class AttributePolicy
+{
+    public static final AttributePolicy UNDEFINED = new AttributePolicy(null, null);
+
+    private final AttributeAction action;
+    private final QName qName;
+
+    public AttributePolicy(QName aQName, AttributeAction aAction)
+    {
+        action = aAction;
+        qName = aQName;
+    }
+
+    public QName getQName()
+    {
+        return qName;
+    }
+
+    public AttributeAction getAction()
+    {
+        return action;
+    }
+
+    public Optional<AttributeAction> apply(String aValue)
+    {
+        return Optional.ofNullable(action);
+    }
+
+    @Override
+    public String toString()
+    {
+        if (action == null) {
+            return "UNDEFINED";
+        }
+
+        return action.toString();
+    }
+
+    public static boolean isUndefined(AttributePolicy aPolicy)
+    {
+        if (aPolicy == null) {
+            return true;
+        }
+
+        if (aPolicy.action == null) {
+            return true;
+        }
+
+        return false;
+    }
+
+    // public static AttributePolicy forAction(AttributeAction aAction)
+    // {
+    // if (aAction == null) {
+    // return UNDEFINED;
+    // }
+    //
+    // if (aAction == AttributeAction.PASS) {
+    // return PASS;
+    // }
+    //
+    // if (aAction == AttributeAction.DROP) {
+    // return DROP;
+    // }
+    //
+    // throw new IllegalArgumentException("Unsupported attribute action [" + aAction + "]");
+    // }
+}

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/AttributePolicyBuilder.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/AttributePolicyBuilder.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.support.xml.sanitizer;
+
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import javax.xml.namespace.QName;
+
+public class AttributePolicyBuilder
+{
+    private final PolicyCollectionBuilder parent;
+    private final QName[] attributeNames;
+    private final AttributeAction action;
+
+    private Pattern pattern;
+
+    public AttributePolicyBuilder(PolicyCollectionBuilder aParent, AttributeAction aAction,
+            QName... aAttributeNames)
+    {
+        parent = aParent;
+        attributeNames = aAttributeNames;
+        action = aAction;
+    }
+
+    public AttributePolicyBuilder matching(Pattern aPattern)
+    {
+        if (aPattern == null) {
+            throw new IllegalArgumentException("matching requires a pattern");
+        }
+
+        this.pattern = aPattern;
+        return this;
+    }
+
+    public PolicyCollectionBuilder globally()
+    {
+        for (var attributeName : attributeNames) {
+            AttributePolicy policy = makePolicy(attributeName);
+            parent.globalAttributePolicy(policy);
+        }
+
+        return parent;
+    }
+
+    public PolicyCollectionBuilder onElements(String... aElementNames)
+    {
+        var elementNames = Stream.of(aElementNames).map(QName::new).toArray(QName[]::new);
+        return onElements(elementNames);
+    }
+
+    public PolicyCollectionBuilder onElements(QName... aElementNames)
+    {
+        if (aElementNames.length == 0) {
+            throw new IllegalArgumentException("onElements does not accept an empty list");
+        }
+
+        for (var elementName : aElementNames) {
+            for (var attributeName : attributeNames) {
+                AttributePolicy policy = makePolicy(attributeName);
+                parent.attributePolicy(elementName, attributeName, policy);
+            }
+        }
+
+        return parent;
+    }
+
+    private AttributePolicy makePolicy(QName attributeName)
+    {
+        AttributePolicy policy;
+        if (pattern != null) {
+            policy = new PatternAttributePolicy(attributeName, action, pattern);
+        }
+        else {
+            policy = new AttributePolicy(attributeName, action);
+        }
+        return policy;
+    }
+}

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/DelegatingAttributePolicy.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/DelegatingAttributePolicy.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.support.xml.sanitizer;
+
+import java.util.Optional;
+
+import javax.xml.namespace.QName;
+
+public abstract class DelegatingAttributePolicy
+    extends AttributePolicy
+{
+    private AttributePolicy delegate;
+
+    public DelegatingAttributePolicy(QName aQName, AttributeAction aAction)
+    {
+        super(aQName, aAction);
+    }
+
+    // FIXME Would be way better if this class would be immutable!!!
+    public void setDelegate(AttributePolicy aDelegate)
+    {
+        delegate = aDelegate;
+    }
+
+    protected Optional<AttributeAction> chain(String aValue)
+    {
+        if (delegate != null) {
+            return delegate.apply(aValue);
+        }
+
+        return Optional.empty();
+    }
+
+    protected AttributePolicy getDelegate()
+    {
+        return delegate;
+    }
+}

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/ElementAction.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/ElementAction.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.support.xml.sanitizer;
+
+public enum ElementAction
+{
+    PASS, //
+    DROP;
+}

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/ElementPolicy.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/ElementPolicy.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.support.xml.sanitizer;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.xml.namespace.QName;
+
+public class ElementPolicy
+{
+    private final QName qName;
+    private final ElementAction action;
+    private final Map<QName, AttributePolicy> attributePolicies;
+
+    public ElementPolicy(ElementAction aAction)
+    {
+        qName = null;
+        action = aAction;
+        attributePolicies = Collections.emptyMap();
+    }
+
+    public ElementPolicy(QName aQName, ElementAction aAction,
+            Map<QName, AttributePolicy> aAttributePolicies)
+    {
+        qName = aQName;
+        action = aAction;
+        attributePolicies = aAttributePolicies;
+    }
+
+    public QName getQName()
+    {
+        return qName;
+    }
+
+    public ElementAction getAction()
+    {
+        return action;
+    }
+
+    public Optional<AttributePolicy> forAttribute(QName aElement, QName aAttributeUri,
+            String aAttributeType, String aAttributeValue)
+    {
+        return Optional.ofNullable(attributePolicies.get(aAttributeUri));
+    }
+
+    public static ElementPolicy drop()
+    {
+        return new ElementPolicy(ElementAction.DROP);
+    }
+
+    public static ElementPolicy pass()
+    {
+        return new ElementPolicy(ElementAction.PASS);
+    }
+}

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/ElementPolicyBuilder.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/ElementPolicyBuilder.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.support.xml.sanitizer;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+import javax.xml.namespace.QName;
+
+public class ElementPolicyBuilder
+{
+    private final QName qName;
+    private final ElementAction action;
+
+    private final Map<QName, AttributePolicy> attributePolicies;
+
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    public ElementPolicyBuilder(QName aQname, ElementAction aAction,
+            Supplier<? extends Map> aMapSupplier)
+    {
+        qName = aQname;
+        action = aAction;
+        attributePolicies = aMapSupplier.get();
+    }
+
+    public ElementPolicy build()
+    {
+        return new ElementPolicy(qName, action, attributePolicies);
+    }
+
+    public void attributePolicies(Map<QName, AttributePolicy> aMap)
+    {
+        if (aMap != null) {
+            attributePolicies.putAll(aMap);
+        }
+    }
+}

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/ExternalPolicy.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/ExternalPolicy.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.support.xml.sanitizer;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class ExternalPolicy
+{
+    private @JsonProperty("elements") List<String> elements;
+    private @JsonProperty("attributes") List<String> attributes;
+    private @JsonProperty("on_elements") List<String> onElements;
+    private @JsonProperty("action") String action;
+    private @JsonProperty("matching") String pattern;
+
+    @JsonCreator
+    public ExternalPolicy( //
+            @JsonProperty("elements") List<String> aElements,
+            @JsonProperty("attributes") List<String> aAttributes,
+            @JsonProperty("on_elements") List<String> aOnElements,
+            @JsonProperty(value = "action", required = true) String aAction,
+            @JsonProperty("matching") String aPattern)
+    {
+        elements = aElements;
+        attributes = aAttributes;
+        onElements = aOnElements;
+        action = aAction;
+        pattern = aPattern;
+    }
+
+    public List<String> getElements()
+    {
+        return elements;
+    }
+
+    public void setElements(List<String> aElements)
+    {
+        elements = aElements;
+    }
+
+    public List<String> getAttributes()
+    {
+        return attributes;
+    }
+
+    public void setAttributes(List<String> aAttributes)
+    {
+        attributes = aAttributes;
+    }
+
+    public List<String> getOnElements()
+    {
+        return onElements;
+    }
+
+    public void setOnElements(List<String> aOnElements)
+    {
+        onElements = aOnElements;
+    }
+
+    public String getAction()
+    {
+        return action;
+    }
+
+    public void setAction(String aAction)
+    {
+        action = aAction;
+    }
+
+    public String getPattern()
+    {
+        return pattern;
+    }
+
+    public void setPattern(String aMatching)
+    {
+        pattern = aMatching;
+    }
+}

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/ExternalPolicyCollection.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/ExternalPolicyCollection.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.support.xml.sanitizer;
+
+import java.util.List;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class ExternalPolicyCollection
+{
+    private String name;
+    private String version;
+    private boolean caseSensitive;
+    private List<ExternalPolicy> policies;
+    private boolean debug;
+    private ElementAction defaultElementAction;
+    private AttributeAction defaultAttributeAction;
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public void setName(String aName)
+    {
+        name = aName;
+    }
+
+    public String getVersion()
+    {
+        return version;
+    }
+
+    public void setVersion(String aVersion)
+    {
+        version = aVersion;
+    }
+
+    public boolean isCaseSensitive()
+    {
+        return caseSensitive;
+    }
+
+    public void setCaseSensitive(boolean aCaseSensitive)
+    {
+        caseSensitive = aCaseSensitive;
+    }
+
+    public List<ExternalPolicy> getPolicies()
+    {
+        return policies;
+    }
+
+    public void setPolicies(List<ExternalPolicy> aPolicies)
+    {
+        policies = aPolicies;
+    }
+
+    public void setDebug(boolean aDebug)
+    {
+        debug = aDebug;
+    }
+
+    public boolean isDebug()
+    {
+        return debug;
+    }
+
+    public void setDefaultElementAction(ElementAction aDefaultElementAction)
+    {
+        defaultElementAction = aDefaultElementAction;
+    }
+
+    public ElementAction getDefaultElementAction()
+    {
+        return defaultElementAction;
+    }
+
+    public void setDefaultAttributeAction(AttributeAction aDefaultAttributeAction)
+    {
+        defaultAttributeAction = aDefaultAttributeAction;
+    }
+
+    public AttributeAction getDefaultAttributeAction()
+    {
+        return defaultAttributeAction;
+    }
+}

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/PatternAttributePolicy.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/PatternAttributePolicy.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.support.xml.sanitizer;
+
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import javax.xml.namespace.QName;
+
+public class PatternAttributePolicy
+    extends DelegatingAttributePolicy
+{
+    private final Pattern pattern;
+
+    public PatternAttributePolicy(QName aQName, AttributeAction aAction, Pattern aPattern)
+    {
+        super(aQName, aAction);
+        pattern = aPattern;
+    }
+
+    @Override
+    public Optional<AttributeAction> apply(String aValue)
+    {
+        if (pattern.matcher(aValue).matches()) {
+            return super.apply(aValue);
+        }
+
+        return chain(aValue);
+    }
+
+    @Override
+    public String toString()
+    {
+        var sb = new StringBuilder();
+        sb.append("[");
+        sb.append(pattern);
+        sb.append("] -> ");
+        sb.append(getAction());
+        if (getDelegate() != null) {
+            sb.append(" :: ");
+            sb.append(getDelegate().toString());
+        }
+        return sb.toString();
+    }
+}

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/PolicyCollection.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/PolicyCollection.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.support.xml.sanitizer;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.xml.namespace.QName;
+
+public class PolicyCollection
+{
+    private final Map<QName, ElementPolicy> elementPolicies;
+    private final Map<QName, AttributePolicy> globalAttributePolicies;
+    private final ElementAction defaultElementAction;
+    private final AttributeAction defaultAttributeAction;
+
+    private boolean debug = false;
+
+    public PolicyCollection(Map<QName, ElementPolicy> aElementPolicies,
+            Map<QName, AttributePolicy> aGlobalAttributePolicies,
+            ElementAction aDefaultElementAction, AttributeAction aDefaultAttributeAction)
+    {
+        elementPolicies = aElementPolicies;
+        globalAttributePolicies = aGlobalAttributePolicies;
+        defaultElementAction = aDefaultElementAction;
+        defaultAttributeAction = aDefaultAttributeAction;
+    }
+
+    public Optional<ElementPolicy> forElement(QName aElement)
+    {
+        return Optional.ofNullable(elementPolicies.get(aElement));
+    }
+
+    public Optional<AttributeAction> forAttribute(QName aElement, QName aAttribute,
+            String aAttributeType, String aAttributeValue)
+    {
+        var elementPolicy = elementPolicies.get(aElement);
+
+        if (elementPolicy != null) {
+            var attributePolicy = elementPolicy.forAttribute(aElement, aAttribute, aAttributeType,
+                    aAttributeValue);
+
+            var attributeAction = attributePolicy.flatMap(p -> p.apply(aAttributeValue));
+
+            if (attributeAction.isPresent()) {
+                return attributeAction;
+            }
+        }
+
+        return Optional.ofNullable(globalAttributePolicies.get(aAttribute))
+                .flatMap(p -> p.apply(aAttributeValue));
+    }
+
+    public Collection<ElementPolicy> getElementPolicies()
+    {
+        return Collections.unmodifiableCollection(elementPolicies.values());
+    }
+
+    public Collection<AttributePolicy> getGlobalAttributeElementPolicies()
+    {
+        return Collections.unmodifiableCollection(globalAttributePolicies.values());
+    }
+
+    public AttributeAction getDefaultAttributeAction()
+    {
+        return defaultAttributeAction;
+    }
+
+    public ElementAction getDefaultElementAction()
+    {
+        return defaultElementAction;
+    }
+
+    public boolean isDebug()
+    {
+        return debug;
+    }
+
+    public void setDebug(boolean aDebug)
+    {
+        debug = aDebug;
+    }
+}

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/PolicyCollectionBuilder.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/PolicyCollectionBuilder.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.support.xml.sanitizer;
+
+import static de.tudarmstadt.ukp.inception.support.xml.XmlParserUtils.caseInsensitiveQNameComparator;
+import static de.tudarmstadt.ukp.inception.support.xml.sanitizer.ElementAction.PASS;
+
+import java.lang.invoke.MethodHandles;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import javax.xml.namespace.QName;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class PolicyCollectionBuilder
+{
+    private final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    @SuppressWarnings("rawtypes")
+    private final Supplier<? extends Map> mapSupplier;
+    private final Map<QName, ElementPolicyBuilder> elementPolicyBuilders;
+    private final Map<QName, Map<QName, AttributePolicy>> elementAttributePolicies;
+    private final Map<QName, AttributePolicy> globalAttributePolicies;
+
+    private ElementAction defaultElementAction = ElementAction.DROP;
+    private AttributeAction defaultAttributeAction = AttributeAction.DROP;
+
+    public static PolicyCollectionBuilder caseSensitive()
+    {
+        return new PolicyCollectionBuilder(LinkedHashMap::new);
+    }
+
+    public static PolicyCollectionBuilder caseInsensitive()
+    {
+        return new PolicyCollectionBuilder(
+                () -> new TreeMap<QName, String>(caseInsensitiveQNameComparator()));
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    public PolicyCollectionBuilder(Supplier<? extends Map> aMapSupplier)
+    {
+        mapSupplier = aMapSupplier;
+        elementPolicyBuilders = mapSupplier.get();
+        elementAttributePolicies = mapSupplier.get();
+        globalAttributePolicies = mapSupplier.get();
+    }
+
+    public PolicyCollectionBuilder defaultAttributeAction(AttributeAction aDefaultAttributeAction)
+    {
+        defaultAttributeAction = aDefaultAttributeAction;
+        return this;
+    }
+
+    public PolicyCollectionBuilder defaultElementAction(ElementAction aDefaultElementAction)
+    {
+        defaultElementAction = aDefaultElementAction;
+        return this;
+    }
+
+    public PolicyCollectionBuilder allowElements(String... aElementNames)
+    {
+        for (var elementName : aElementNames) {
+            elementPolicy(new QName(elementName), PASS);
+        }
+
+        return this;
+    }
+
+    public PolicyCollectionBuilder allowElements(QName... aElementNames)
+    {
+        for (var elementName : aElementNames) {
+            elementPolicy(elementName, PASS);
+        }
+
+        return this;
+    }
+
+    public PolicyCollectionBuilder disallowElements(String... aElementNames)
+    {
+        for (var elementName : aElementNames) {
+            elementPolicy(new QName(elementName), ElementAction.DROP);
+        }
+
+        return this;
+    }
+
+    public PolicyCollectionBuilder disallowElements(QName... aElementNames)
+    {
+        for (var elementName : aElementNames) {
+            elementPolicy(elementName, ElementAction.DROP);
+        }
+
+        return this;
+    }
+
+    PolicyCollectionBuilder elementPolicy(QName aElement, ElementAction aAction)
+    {
+        elementPolicyBuilders.put(aElement,
+                new ElementPolicyBuilder(aElement, aAction, mapSupplier));
+
+        return this;
+    }
+
+    public AttributePolicyBuilder allowAttributes(String... aAttributeNames)
+    {
+        var attributeNames = Stream.of(aAttributeNames).map(QName::new).toArray(QName[]::new);
+
+        return new AttributePolicyBuilder(this, AttributeAction.PASS, attributeNames);
+    }
+
+    public AttributePolicyBuilder allowAttributes(QName... aAttributeNames)
+    {
+        return new AttributePolicyBuilder(this, AttributeAction.PASS, aAttributeNames);
+    }
+
+    public AttributePolicyBuilder disallowAttributes(String... aAttributeNames)
+    {
+        var attributeNames = Stream.of(aAttributeNames).map(QName::new).toArray(QName[]::new);
+        return new AttributePolicyBuilder(this, AttributeAction.DROP, attributeNames);
+    }
+
+    public AttributePolicyBuilder disallowAttributes(QName... aAttributeNames)
+    {
+        return new AttributePolicyBuilder(this, AttributeAction.DROP, aAttributeNames);
+    }
+
+    public PolicyCollection build()
+    {
+        @SuppressWarnings("unchecked")
+        Map<QName, ElementPolicy> elementPolicies = mapSupplier.get();
+
+        for (var entry : elementAttributePolicies.entrySet()) {
+            var elementPolicyBuilder = elementPolicyBuilders.computeIfAbsent(entry.getKey(),
+                    k -> new ElementPolicyBuilder(k, defaultElementAction, mapSupplier));
+            elementPolicyBuilder.attributePolicies(elementAttributePolicies.get(entry.getKey()));
+        }
+
+        for (var entry : elementPolicyBuilders.entrySet()) {
+            elementPolicies.put(entry.getKey(), entry.getValue().build());
+        }
+
+        return new PolicyCollection(elementPolicies, globalAttributePolicies, defaultElementAction,
+                defaultAttributeAction);
+    }
+
+    void attributePolicy(QName aElementName, QName aAttributeName, AttributePolicy aPolicy)
+    {
+        @SuppressWarnings("unchecked")
+        Map<QName, AttributePolicy> attributePolicies = elementAttributePolicies
+                .computeIfAbsent(aElementName, k -> mapSupplier.get());
+        AttributePolicy attributePolicy = attributePolicies.computeIfAbsent(aAttributeName,
+                k -> AttributePolicy.UNDEFINED);
+
+        if (aPolicy instanceof DelegatingAttributePolicy) {
+            ((DelegatingAttributePolicy) aPolicy).setDelegate(attributePolicy);
+            attributePolicies.put(aAttributeName, aPolicy);
+        }
+        else {
+            AttributePolicy oldPolicy = attributePolicies.put(aAttributeName, aPolicy);
+            if (!AttributePolicy.isUndefined(oldPolicy)) {
+                log.warn("On element [{}] overriding policy for attribute [{}]: [{}] -> [{}]",
+                        aElementName, aAttributeName, oldPolicy, aPolicy);
+            }
+        }
+    }
+
+    public void allowAttribute(QName aAttribute, Pattern aPattern)
+    {
+        globalAttributePolicy(new AttributePolicy(aAttribute, AttributeAction.PASS));
+    }
+
+    public void disallowAttribute(QName aAttribute, Pattern aPattern)
+    {
+        globalAttributePolicy(new AttributePolicy(aAttribute, AttributeAction.PASS));
+    }
+
+    public void globalAttributePolicy(AttributePolicy aPolicy)
+    {
+        var newPolicy = aPolicy;
+        var oldPolicy = globalAttributePolicies.put(aPolicy.getQName(), newPolicy);
+        if (!AttributePolicy.isUndefined(oldPolicy)) {
+            log.warn("Globally overriding policy for attribute [{}]: [{}] -> [{}]",
+                    aPolicy.getQName(), oldPolicy, newPolicy);
+        }
+    }
+
+    // XmlPolicyBuilder allowWithoutAttributes(String... aElementNames);
+    // XmlPolicyBuilder disallowWithoutAttributes(String... aElementNames);
+    // XmlPolicyBuilder allowTextIn(String... aElementNames);
+    // XmlPolicyBuilder disallowTextIn(String... aElementNames);
+    // XmlPolicyBuilder allowAttributesGlobally(String... aAttributeNames);
+    // XmlPolicyBuilder allwoAttributesOnElements(String... aElementNames);
+}

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/PolicyCollectionIOUtils.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/PolicyCollectionIOUtils.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.support.xml.sanitizer;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.regex.Pattern;
+
+import javax.xml.namespace.QName;
+
+import org.apache.commons.lang3.StringUtils;
+
+import de.tudarmstadt.ukp.clarin.webanno.support.YamlUtil;
+
+public class PolicyCollectionIOUtils
+{
+    public static PolicyCollection loadPolicies(URL aUrl) throws IOException
+    {
+        try (var is = aUrl.openStream()) {
+            return loadPolicies(is);
+        }
+    }
+
+    public static PolicyCollection loadPolicies(InputStream aIs) throws IOException
+    {
+        var externalCollection = YamlUtil.fromYamlStream(ExternalPolicyCollection.class, aIs);
+
+        var policyCollectionBuilder = externalCollection.isCaseSensitive()
+                ? PolicyCollectionBuilder.caseSensitive()
+                : PolicyCollectionBuilder.caseInsensitive();
+
+        if (externalCollection.getDefaultElementAction() != null) {
+            policyCollectionBuilder
+                    .defaultElementAction(externalCollection.getDefaultElementAction());
+        }
+        if (externalCollection.getDefaultAttributeAction() != null) {
+            policyCollectionBuilder
+                    .defaultAttributeAction(externalCollection.getDefaultAttributeAction());
+        }
+
+        for (ExternalPolicy policy : externalCollection.getPolicies()) {
+            var isElementPolicy = policy.getElements() != null;
+            var isAttributesPolicy = policy.getAttributes() != null;
+
+            if (isElementPolicy && isAttributesPolicy) {
+                throw new IOException(
+                        "Policy must contain either [elements] or [attributes] but not both");
+            }
+
+            if (isElementPolicy) {
+                elementsPolicy(policyCollectionBuilder, policy);
+            }
+
+            if (isAttributesPolicy) {
+                attributesPolicy(policyCollectionBuilder, policy);
+            }
+        }
+
+        var policies = policyCollectionBuilder.build();
+        policies.setDebug(externalCollection.isDebug());
+
+        return policies;
+
+    }
+
+    private static void attributesPolicy(PolicyCollectionBuilder policyCollectionBuilder,
+            ExternalPolicy policy)
+    {
+        var attributes = policy.getAttributes().stream() //
+                .map(s -> new QName(s)) //
+                .toArray(QName[]::new);
+        var action = AttributeAction.valueOf(policy.getAction());
+        var attrBuilder = new AttributePolicyBuilder(policyCollectionBuilder, action, attributes);
+
+        if (StringUtils.isNotBlank(policy.getPattern())) {
+            attrBuilder.matching(Pattern.compile(policy.getPattern()));
+        }
+
+        if (policy.getOnElements() != null) {
+            var elements = policy.getOnElements().stream() //
+                    .map(s -> new QName(s)) //
+                    .toArray(QName[]::new);
+            attrBuilder.onElements(elements);
+        }
+        else {
+            attrBuilder.globally();
+        }
+    }
+
+    private static void elementsPolicy(PolicyCollectionBuilder policyCollectionBuilder,
+            ExternalPolicy policy)
+    {
+        var elements = policy.getElements().stream() //
+                .map(s -> new QName(s)) //
+                .toArray(QName[]::new);
+        var action = ElementAction.valueOf(policy.getAction());
+        for (var element : elements) {
+            policyCollectionBuilder.elementPolicy(element, action);
+        }
+    }
+}

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/SanitizingContentHandler.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/SanitizingContentHandler.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.support.xml.sanitizer;
+
+import static de.tudarmstadt.ukp.inception.support.xml.XmlParserUtils.getQName;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.Stack;
+
+import javax.xml.XMLConstants;
+import javax.xml.namespace.QName;
+
+import org.apache.commons.lang3.StringUtils;
+import org.xml.sax.Attributes;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.AttributesImpl;
+
+import de.tudarmstadt.ukp.clarin.webanno.support.xml.ContentHandlerAdapter;
+
+public class SanitizingContentHandler
+    extends ContentHandlerAdapter
+{
+    private static final String MASKED = "MASKED-";
+
+    private final PolicyCollection policies;
+
+    private final Stack<Frame> stack;
+
+    private char filteredCharacter = ' ';
+
+    public SanitizingContentHandler(ContentHandler aDelegate, PolicyCollection aPolicies)
+    {
+        super(aDelegate);
+        stack = new Stack<>();
+        policies = aPolicies;
+    }
+
+    @Override
+    public void startElement(String aUri, String aLocalName, String aQName, Attributes aAtts)
+        throws SAXException
+    {
+        var element = toQName(aUri, aLocalName, aQName);
+
+        var policy = policies.forElement(element);
+        var action = policy.map(ElementPolicy::getAction)
+                .orElse(policies.getDefaultElementAction());
+        switch (action) {
+        case PASS:
+            var attributes = sanitizeAttributes(element, aAtts);
+            startElement(element, attributes, policy, action);
+            break;
+        case DROP:
+            startElement(element, null, policy, action);
+            break;
+        default:
+            throw new SAXException("Unsupported element action: [" + action + "]");
+        }
+    }
+
+    private void startElement(QName aElement, Attributes aAtts, Optional<ElementPolicy> aPolicy,
+            ElementAction aAction)
+        throws SAXException
+    {
+        QName element = aElement;
+
+        if (aAction == ElementAction.DROP && policies.isDebug()) {
+            element = mask(element);
+        }
+
+        stack.push(new Frame(element, aPolicy, aAction));
+
+        if (aAction == ElementAction.PASS || policies.isDebug()) {
+            super.startElement(element.getNamespaceURI(), element.getLocalPart(), getQName(element),
+                    aAtts);
+        }
+    }
+
+    @Override
+    public void endElement(String aUri, String aLocalName, String aQName) throws SAXException
+    {
+        var frame = stack.pop();
+        if (frame.action == ElementAction.PASS || policies.isDebug()) {
+            var qName = getQName(frame.element);
+            super.endElement(frame.element.getNamespaceURI(), frame.element.getLocalPart(), qName);
+        }
+    }
+
+    @Override
+    public void characters(char[] aCh, int aStart, int aLength) throws SAXException
+    {
+        var action = stack.isEmpty() ? policies.getDefaultElementAction() : stack.peek().action;
+        switch (action) {
+        case DROP:
+            var placeholder = new char[aLength];
+            Arrays.fill(placeholder, filteredCharacter);
+            super.characters(placeholder, 0, aLength);
+            break;
+        case PASS:
+            super.characters(aCh, aStart, aLength);
+            break;
+        default:
+            throw new SAXException("Unsupported element action: [" + action + "]");
+        }
+    }
+
+    @Override
+    public void ignorableWhitespace(char[] aCh, int aStart, int aLength) throws SAXException
+    {
+        var action = stack.peek().action;
+        switch (action) {
+        case DROP:
+            var placeholder = new char[aLength];
+            Arrays.fill(placeholder, filteredCharacter);
+            super.ignorableWhitespace(placeholder, 0, aLength);
+            break;
+        case PASS:
+            super.ignorableWhitespace(aCh, aStart, aLength);
+            break;
+        default:
+            throw new SAXException("Unsupported element action: [" + action + "]");
+        }
+    }
+
+    private Attributes sanitizeAttributes(QName aElement, Attributes aAtts) throws SAXException
+    {
+        if (aAtts == null) {
+            return null;
+        }
+
+        AttributesImpl sanitizedAttributes = new AttributesImpl();
+        for (int i = 0; i < aAtts.getLength(); i++) {
+            sanitizeAttribute(sanitizedAttributes, aElement, aAtts, i);
+        }
+        return sanitizedAttributes;
+    }
+
+    private void sanitizeAttribute(AttributesImpl aSanitizedAttributes, QName aElement,
+            Attributes aAtts, int i)
+        throws SAXException
+    {
+        var uri = aAtts.getURI(i);
+        var localName = aAtts.getLocalName(i);
+        var qName = aAtts.getQName(i);
+        var type = aAtts.getType(i);
+        var value = aAtts.getValue(i);
+
+        var attribute = toQName(uri, localName, qName);
+
+        var action = policies.forAttribute(aElement, attribute, type, value)
+                .orElse(policies.getDefaultAttributeAction());
+
+        switch (action) {
+        case PASS:
+            aSanitizedAttributes.addAttribute(uri, localName, qName, type, value);
+            break;
+        case DROP:
+            if (policies.isDebug()) {
+                attribute = mask(attribute);
+                aSanitizedAttributes.addAttribute(attribute.getNamespaceURI(),
+                        attribute.getLocalPart(), getQName(attribute), type, value);
+            }
+            break;
+        default:
+            throw new SAXException("Unsupported attribute action: [" + action + "]");
+        }
+    }
+
+    private static final class Frame
+    {
+        final QName element;
+        final Optional<ElementPolicy> policy;
+        final ElementAction action;
+
+        public Frame(QName aElement, Optional<ElementPolicy> aPolicy, ElementAction aAction)
+        {
+            element = aElement;
+            policy = aPolicy;
+            action = aAction;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "[" + element.getLocalPart() + " -> " + action + "]";
+        }
+    }
+
+    private QName mask(QName element)
+    {
+        return new QName(element.getNamespaceURI(), MASKED + element.getLocalPart(),
+                element.getPrefix());
+    }
+
+    private QName toQName(String aUri, String aLocalName, String aQName)
+    {
+        String prefix = XMLConstants.DEFAULT_NS_PREFIX;
+        String localName = aLocalName;
+
+        // Workaround bug: localname may contain prefix
+        var li = localName.indexOf(':');
+        if (li >= 0) {
+            localName = localName.substring(li + 1);
+        }
+
+        var qi = aQName.indexOf(':');
+        if (qi >= 0) {
+            prefix = aQName.substring(0, qi);
+        }
+
+        if (StringUtils.isEmpty(localName)) {
+            if (qi >= 0) {
+                localName = aQName.substring(qi + 1, aQName.length());
+            }
+            else {
+                localName = aQName;
+            }
+        }
+
+        return new QName(aUri, localName, prefix);
+    }
+}

--- a/inception/inception-support/src/test/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/PolicyCollectionIOUtilsTest.java
+++ b/inception/inception-support/src/test/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/PolicyCollectionIOUtilsTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.support.xml.sanitizer;
+
+import static de.tudarmstadt.ukp.inception.support.xml.sanitizer.PolicyCollectionIOUtils.loadPolicies;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import javax.xml.namespace.QName;
+
+import org.junit.jupiter.api.Test;
+
+import de.tudarmstadt.ukp.inception.support.xml.sanitizer.AttributeAction;
+import de.tudarmstadt.ukp.inception.support.xml.sanitizer.ElementAction;
+
+class PolicyCollectionIOUtilsTest
+{
+    @Test
+    void thatEmptyPolicyFileCanBeParsed() throws Exception
+    {
+        var sut = loadPolicies(
+                getClass().getResource("/SanitizingContentHandler/EmptyPolicy.yaml"));
+
+        assertThat(sut.isDebug()).isFalse();
+
+        assertThat(sut.getDefaultAttributeAction()).isEqualTo(AttributeAction.DROP);
+        assertThat(sut.getDefaultElementAction()).isEqualTo(ElementAction.DROP);
+
+        assertThat(sut.getElementPolicies()).isEmpty();
+
+        assertThat(sut.getGlobalAttributeElementPolicies()).isEmpty();
+    }
+
+    @Test
+    void thatSimplePolicyFileCanBeParsed() throws Exception
+    {
+        var sut = loadPolicies(getClass().getResource("/SanitizingContentHandler/Policy.yaml"));
+
+        assertThat(sut.isDebug()).isTrue();
+
+        assertThat(sut.getDefaultAttributeAction()).isEqualTo(AttributeAction.PASS);
+        assertThat(sut.getDefaultElementAction()).isEqualTo(ElementAction.PASS);
+
+        assertThat(sut.getElementPolicies()) //
+                .extracting(p -> p.getQName().getLocalPart(), p -> p.getAction()) //
+                .containsExactly( //
+                        tuple("div", ElementAction.PASS), //
+                        tuple("p", ElementAction.PASS), //
+                        tuple("th", ElementAction.PASS), //
+                        tuple("tr", ElementAction.PASS));
+
+        assertThat(sut.getGlobalAttributeElementPolicies())
+                .extracting(p -> p.getQName().getLocalPart(), p -> p.getAction()) //
+                .containsExactly( //
+                        tuple("style", AttributeAction.PASS));
+
+        assertThat(sut.forAttribute(new QName("div"), new QName("title"), null, "blah")).get() //
+                .isEqualTo(AttributeAction.PASS);
+    }
+}

--- a/inception/inception-support/src/test/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/PolicyCollectionTest.java
+++ b/inception/inception-support/src/test/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/PolicyCollectionTest.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.support.xml.sanitizer;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import javax.xml.namespace.QName;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import de.tudarmstadt.ukp.inception.support.xml.sanitizer.AttributeAction;
+import de.tudarmstadt.ukp.inception.support.xml.sanitizer.ElementAction;
+import de.tudarmstadt.ukp.inception.support.xml.sanitizer.ElementPolicy;
+import de.tudarmstadt.ukp.inception.support.xml.sanitizer.PolicyCollectionBuilder;
+
+public class PolicyCollectionTest
+{
+    static List<Arguments> builderVariants()
+    {
+        return asList( //
+                Arguments.of("CASE-SENSITIVE", PolicyCollectionBuilder.caseSensitive()), //
+                Arguments.of("CASE-INSENSITIVE", PolicyCollectionBuilder.caseInsensitive()));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("builderVariants")
+    void thatDefaultElementPolicyIsToDrop(String aName, PolicyCollectionBuilder aBuilder)
+    {
+        var sut = aBuilder.build();
+
+        assertThat(sut.forElement(new QName("body"))).isEmpty();
+        assertThat(sut.getDefaultElementAction()).isEqualTo(ElementAction.DROP);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("builderVariants")
+    void thatPassPolicyForElementIsAccepted(String aName, PolicyCollectionBuilder aBuilder)
+    {
+        QName goodElement = new QName("good");
+
+        var policies = aBuilder //
+                .allowElements(goodElement) //
+                .build();
+
+        assertThat(policies.forElement(goodElement)).get() //
+                .extracting(ElementPolicy::getAction) //
+                .isEqualTo(ElementAction.PASS);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("builderVariants")
+    void thatDropPolicyForElementIsAccepted(String aName, PolicyCollectionBuilder aBuilder)
+    {
+        QName goodElement = new QName("good");
+
+        var policies = aBuilder //
+                .disallowElements(goodElement) //
+                .build();
+
+        assertThat(policies.forElement(goodElement)).get() //
+                .extracting(ElementPolicy::getAction) //
+                .isEqualTo(ElementAction.DROP);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("builderVariants")
+    void thatDropPolicyForAttributeOnElementIsAccepted(String aName,
+            PolicyCollectionBuilder aBuilder)
+    {
+        QName element = new QName("element");
+        QName attr = new QName("attr");
+
+        var policies = aBuilder //
+                .disallowAttributes(attr).onElements(element) //
+                .build();
+
+        assertThat(policies.forAttribute(element, attr, null, null)).get() //
+                .isEqualTo(AttributeAction.DROP);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("builderVariants")
+    void thatDropPolicyForAttributeGloballyIsAccepted(String aName,
+            PolicyCollectionBuilder aBuilder)
+    {
+        QName element = new QName("element");
+        QName attr = new QName("attr");
+
+        var policies = aBuilder //
+                .disallowAttributes(attr).globally() //
+                .build();
+
+        assertThat(policies.forAttribute(element, attr, null, null)).get() //
+                .isEqualTo(AttributeAction.DROP);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("builderVariants")
+    void thatDefaultElementAttributePolicyIsToDrop(String aName, PolicyCollectionBuilder aBuilder)
+    {
+        var sut = aBuilder.build();
+
+        assertThat(sut.forAttribute(new QName("body"), new QName("style"), null, null)) //
+                .isEmpty();
+        assertThat(sut.getDefaultAttributeAction()) //
+                .isEqualTo(AttributeAction.DROP);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("builderVariants")
+    void thatPassPolicyForElementAttributeIsAccepted(String aName, PolicyCollectionBuilder aBuilder)
+    {
+        QName goodElement = new QName("good");
+        QName goodAttribute = new QName("gattr");
+        QName badAttribute = new QName("battr");
+
+        var policies = aBuilder //
+                .allowElements(goodElement) //
+                .allowAttributes(goodAttribute).onElements(goodElement) //
+                .build();
+
+        assertThat(policies.forAttribute(goodElement, goodAttribute, null, null)).get() //
+                .isEqualTo(AttributeAction.PASS);
+
+        assertThat(policies.forAttribute(goodElement, badAttribute, null, null)).isEmpty();
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("builderVariants")
+    void thatLocalAttributePolicyTakesPrecedenceOverGlobalAttributePolicy(String aName,
+            PolicyCollectionBuilder aBuilder)
+    {
+        QName element = new QName("element");
+        QName otherElement = new QName("otherElement");
+        QName attribute = new QName("attr");
+
+        var policies = aBuilder //
+                .allowElements(element) //
+                .allowAttributes(attribute).globally() //
+                .disallowAttributes(attribute).onElements(element) //
+                .build();
+
+        assertThat(policies.forAttribute(element, attribute, null, null)).get() //
+                .isEqualTo(AttributeAction.DROP);
+
+        assertThat(policies.forAttribute(otherElement, attribute, null, null)).get() //
+                .isEqualTo(AttributeAction.PASS);
+    }
+}

--- a/inception/inception-support/src/test/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/SanitizingContentHandlerTest.java
+++ b/inception/inception-support/src/test/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/SanitizingContentHandlerTest.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.support.xml.sanitizer;
+
+import static de.tudarmstadt.ukp.inception.support.xml.XmlParserUtils.makeXmlSerializer;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.StringWriter;
+import java.util.List;
+import java.util.Map;
+
+import javax.xml.namespace.QName;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class SanitizingContentHandlerTest
+{
+    static List<Arguments> builderVariants()
+    {
+        return asList( //
+                Arguments.of("CASE-SENSITIVE", PolicyCollectionBuilder.caseSensitive()), //
+                Arguments.of("CASE-INSENSITIVE", PolicyCollectionBuilder.caseInsensitive()));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("builderVariants")
+    void thatDefaultIsDroppingEverything(String aName, PolicyCollectionBuilder aBuilder)
+        throws Exception
+    {
+        var buffer = new StringWriter();
+        var policy = aBuilder.build();
+
+        var sut = new SanitizingContentHandler(makeXmlSerializer(buffer), policy);
+
+        sut.startDocument();
+        sut.startElement("root");
+        sut.startElement("child");
+        sut.characters("text");
+        sut.endElement("child");
+        sut.endElement("root");
+        sut.endDocument();
+
+        assertThat(buffer.toString()).isEqualTo("    ");
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("builderVariants")
+    void thatElementsCanBeDroppedSelectively(String aName, PolicyCollectionBuilder aBuilder)
+        throws Exception
+    {
+        var buffer = new StringWriter();
+        var policy = aBuilder //
+                .defaultElementAction(ElementAction.PASS) //
+                .defaultAttributeAction(AttributeAction.PASS) //
+                .disallowElements("child") //
+                .build();
+
+        var sut = new SanitizingContentHandler(makeXmlSerializer(buffer), policy);
+
+        sut.startDocument();
+        sut.startElement("root");
+        sut.startElement("child");
+        sut.characters("text");
+        sut.endElement("child");
+        sut.endElement("root");
+        sut.endDocument();
+
+        assertThat(buffer.toString()).isEqualTo("<root>    </root>");
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("builderVariants")
+    void thatChildElementsCanBePreservedSelectively(String aName, PolicyCollectionBuilder aBuilder)
+        throws Exception
+    {
+        var buffer = new StringWriter();
+        var policy = aBuilder //
+                .allowElements("root", "child2") //
+                .build();
+
+        var sut = new SanitizingContentHandler(makeXmlSerializer(buffer), policy);
+
+        sut.startDocument();
+        sut.startElement("root");
+        sut.startElement("child");
+        sut.startElement("child2");
+        sut.characters("text");
+        sut.endElement("child2");
+        sut.endElement("child");
+        sut.endElement("root");
+        sut.endDocument();
+
+        assertThat(buffer.toString()).isEqualTo("<root><child2>text</child2></root>");
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("builderVariants")
+    void thatChildElementsCanBePreservedSelectively2(String aName, PolicyCollectionBuilder aBuilder)
+        throws Exception
+    {
+        var buffer = new StringWriter();
+        var policy = aBuilder //
+                .allowElements("root", "child2") //
+                .disallowElements("child") //
+                .build();
+
+        var sut = new SanitizingContentHandler(makeXmlSerializer(buffer), policy);
+
+        sut.startDocument();
+        sut.startElement("root");
+        sut.startElement("child");
+        sut.startElement("child2");
+        sut.characters("text");
+        sut.endElement("child2");
+        sut.endElement("child");
+        sut.endElement("root");
+        sut.endDocument();
+
+        assertThat(buffer.toString()).isEqualTo("<root><child2>text</child2></root>");
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("builderVariants")
+    void thatAttributesCanBeDroppedSelectively(String aName, PolicyCollectionBuilder aBuilder)
+        throws Exception
+    {
+        var buffer = new StringWriter();
+        var policy = aBuilder //
+                .defaultElementAction(ElementAction.PASS) //
+                .defaultAttributeAction(AttributeAction.PASS) //
+                .disallowAttributes("attr1").onElements("child") //
+                .disallowAttributes("attr1").globally() //
+                .build();
+
+        var sut = new SanitizingContentHandler(makeXmlSerializer(buffer), policy);
+
+        sut.startDocument();
+        sut.startElement("root", Map.of("attr1", "x"));
+        sut.startElement("child", Map.of("attr1", "x"));
+        sut.startElement("child", Map.of("attr2", "y"));
+        sut.characters("text");
+        sut.endElement("child");
+        sut.endElement("child");
+        sut.endElement("root");
+        sut.endDocument();
+
+        assertThat(buffer.toString())
+                .isEqualTo("<root><child><child attr2=\"y\">text</child></child></root>");
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("builderVariants")
+    void thatDisallowedAttributesAreDroppped(String aName, PolicyCollectionBuilder aBuilder)
+        throws Exception
+    {
+        QName root = new QName("root");
+        QName child = new QName("child");
+        QName attr1 = new QName("attr1");
+        QName attr2 = new QName("attr2");
+
+        var buffer = new StringWriter();
+        var policy = aBuilder //
+                .allowElements(root) //
+                .allowElements(child) //
+                .allowAttributes(attr1).onElements(child) //
+                .build();
+
+        var sut = new SanitizingContentHandler(makeXmlSerializer(buffer), policy);
+
+        sut.startDocument();
+        sut.startElement(root);
+        sut.startElement(child, Map.of(attr1, "x", attr2, "y"));
+        sut.characters("text");
+        sut.endElement(child);
+        sut.endElement(root);
+        sut.endDocument();
+
+        assertThat(buffer.toString()).isEqualTo("<root><child attr1=\"x\">text</child></root>");
+    }
+
+    @Test
+    void thatCaseInsensitiveModeWorks() throws Exception
+    {
+        QName root = new QName("root");
+        QName child = new QName("child");
+        QName attr1 = new QName("attr1");
+
+        var buffer = new StringWriter();
+        var policy = PolicyCollectionBuilder.caseInsensitive() //
+                .allowElements(root) //
+                .allowElements(child) //
+                .allowAttributes(attr1).onElements(child) //
+                .build();
+
+        var sut = new SanitizingContentHandler(makeXmlSerializer(buffer), policy);
+
+        sut.startDocument();
+        sut.startElement("ROOT");
+        sut.startElement("child", Map.of("Attr1", "x", "aTTR2", "y"));
+        sut.characters("text");
+        sut.endElement("CHILD");
+        sut.endElement("root");
+        sut.endDocument();
+
+        assertThat(buffer.toString()).isEqualTo("<ROOT><child Attr1=\"x\">text</child></ROOT>");
+    }
+
+    @Test
+    void thatCaseSensitiveModeWorks() throws Exception
+    {
+        QName root = new QName("ROOT");
+        QName child = new QName("child");
+        QName attr1 = new QName("attr1");
+
+        var buffer = new StringWriter();
+        var policy = PolicyCollectionBuilder.caseSensitive() //
+                .allowElements(root) //
+                .allowElements(child) //
+                .allowAttributes(attr1).onElements(child) //
+                .build();
+
+        var sut = new SanitizingContentHandler(makeXmlSerializer(buffer), policy);
+
+        sut.startDocument();
+        sut.startElement("ROOT");
+        sut.startElement("child", Map.of("attr1", "x", "aTTR1", "y"));
+        sut.startElement("CHILD", Map.of("Attr1", "x", "aTTR2", "y"));
+        sut.characters("text");
+        sut.endElement("CHILD");
+        sut.endElement("child");
+        sut.endElement("root");
+        sut.endDocument();
+
+        assertThat(buffer.toString()).isEqualTo("<ROOT><child attr1=\"x\">    </child></ROOT>");
+    }
+}

--- a/inception/inception-support/src/test/resources/SanitizingContentHandler/EmptyPolicy.yaml
+++ b/inception/inception-support/src/test/resources/SanitizingContentHandler/EmptyPolicy.yaml
@@ -1,0 +1,2 @@
+name: Empty policy
+policies: []

--- a/inception/inception-support/src/test/resources/SanitizingContentHandler/Policy.yaml
+++ b/inception/inception-support/src/test/resources/SanitizingContentHandler/Policy.yaml
@@ -1,0 +1,19 @@
+name: Example policy
+version: 1.0
+case_sensitive: false
+default_attribute_action: PASS
+default_element_action: PASS
+debug: true
+policies:
+  - { elements: ["p", "div"], action: "PASS" }
+  - { elements: ["tr", "th"], action: "PASS" }
+  - {
+      attributes: ["title"],
+      matching: "[a-zA-Z0-9]*",
+      on_elements: ["div"],
+      action: "PASS",
+    }
+  - {
+      attributes: ["style"],
+      action: "PASS",
+    }

--- a/inception/inception-support/src/test/resources/log4j2-test.xml
+++ b/inception/inception-support/src/test/resources/log4j2-test.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+  <Appenders>
+    <Console name="ConsoleAppender" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} [%thread] %level{length=5} %logger{1} - %msg%n" />
+    </Console>
+  </Appenders>
+
+  <Loggers>
+    <Root level="WARN">
+      <AppenderRef ref="ConsoleAppender" />
+    </Root>
+  </Loggers>
+</Configuration>


### PR DESCRIPTION
**What's in the PR**
- Add configurable content policies at the level of editors and format supports
- Add default and mandatory policies
- Add documentation and some testing
- Deprecate old views that we probably won't need anymore

**How to test manually**
* Install a custom editor and define a `policy.yaml` file

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [x] PR updates documentation
