### PR TITLE
#3462 - "Required" greyed out but NOT checked for integer features

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/bool/BooleanFeatureSupport.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/bool/BooleanFeatureSupport.java
@@ -84,8 +84,11 @@ public class BooleanFeatureSupport
     @Override
     public void configureFeature(AnnotationFeature aFeature)
     {
-        // If the feature is not a string feature, force the tagset to null.
+        // Boolean features cannot have a tagset
         aFeature.setTagset(null);
+
+        // Boolean features cannot be null
+        aFeature.setRequired(true);
     }
 
     @Override

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/number/NumberFeatureSupport.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/number/NumberFeatureSupport.java
@@ -105,7 +105,7 @@ public class NumberFeatureSupport
 
         switch (feature.getType()) {
         case CAS.TYPE_NAME_INTEGER: {
-            if (traits.getEditorType().equals(NumberFeatureTraits.EDITOR_TYPE.RADIO_BUTTONS)) {
+            if (traits.getEditorType().equals(NumberFeatureTraits.EditorType.RADIO_BUTTONS)) {
                 int min = (int) traits.getMinimum();
                 int max = (int) traits.getMaximum();
                 List<Integer> range = IntStream.range(min, max + 1).boxed()
@@ -127,8 +127,11 @@ public class NumberFeatureSupport
     @Override
     public void configureFeature(AnnotationFeature aFeature)
     {
-        // If the feature is not a string feature, force the tagset to null.
+        // Numeric features cannot have a tagset
         aFeature.setTagset(null);
+
+        // Numeric features cannot be null
+        aFeature.setRequired(true);
     }
 
     // TODO: trait reading/writing needs to be handled in another way to avoid duplicate code

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/number/NumberFeatureTraits.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/number/NumberFeatureTraits.java
@@ -19,6 +19,7 @@ package de.tudarmstadt.ukp.inception.annotation.feature.number;
 
 import java.io.Serializable;
 
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 /**
@@ -30,14 +31,15 @@ public class NumberFeatureTraits
 {
     private static final long serialVersionUID = -2395185084802071593L;
 
-    public enum EDITOR_TYPE
+    public enum EditorType
     {
+        @JsonEnumDefaultValue
         SPINNER("Spinner"), //
         RADIO_BUTTONS("Radio Buttons");
 
         private final String name;
 
-        EDITOR_TYPE(String name)
+        EditorType(String name)
         {
             this.name = name;
         }
@@ -52,7 +54,7 @@ public class NumberFeatureTraits
     private boolean limited = false;
     private Number minimum = 0;
     private Number maximum = 0;
-    private EDITOR_TYPE editorType = EDITOR_TYPE.SPINNER;
+    private EditorType editorType = EditorType.SPINNER;
 
     public NumberFeatureTraits()
     {
@@ -89,12 +91,12 @@ public class NumberFeatureTraits
         this.maximum = maximum;
     }
 
-    public EDITOR_TYPE getEditorType()
+    public EditorType getEditorType()
     {
         return editorType;
     }
 
-    public void setEditorType(EDITOR_TYPE editorType)
+    public void setEditorType(EditorType editorType)
     {
         this.editorType = editorType;
     }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/number/NumberFeatureTraitsEditor.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/number/NumberFeatureTraitsEditor.java
@@ -102,10 +102,10 @@ public class NumberFeatureTraitsEditor
         }
         }
 
-        DropDownChoice<NumberFeatureTraits.EDITOR_TYPE> editorType = new DropDownChoice<>(
+        DropDownChoice<NumberFeatureTraits.EditorType> editorType = new DropDownChoice<>(
                 CID_EDITOR_TYPE);
         editorType.setModel(PropertyModel.of(traits, "editorType"));
-        editorType.setChoices(Arrays.asList(NumberFeatureTraits.EDITOR_TYPE.values()));
+        editorType.setChoices(Arrays.asList(NumberFeatureTraits.EditorType.values()));
         editorType.add(new LambdaAjaxFormComponentUpdatingBehavior("change"));
         editorType.add(visibleWhen(() -> isEditorTypeSelectionPossible()));
         form.add(editorType);
@@ -193,7 +193,7 @@ public class NumberFeatureTraitsEditor
         t.setMinimum(traits.getObject().getMinimum());
         t.setMaximum(traits.getObject().getMaximum());
         t.setEditorType(isEditorTypeSelectionPossible() ? traits.getObject().getEditorType()
-                : NumberFeatureTraits.EDITOR_TYPE.SPINNER);
+                : NumberFeatureTraits.EditorType.SPINNER);
 
         getFeatureSupport().writeTraits(feature.getObject(), t);
     }
@@ -210,7 +210,7 @@ public class NumberFeatureTraitsEditor
         private boolean limited;
         private Number minimum;
         private Number maximum;
-        private NumberFeatureTraits.EDITOR_TYPE editorType;
+        private NumberFeatureTraits.EditorType editorType;
 
         public boolean isLimited()
         {
@@ -242,12 +242,12 @@ public class NumberFeatureTraitsEditor
             this.maximum = maximum;
         }
 
-        public NumberFeatureTraits.EDITOR_TYPE getEditorType()
+        public NumberFeatureTraits.EditorType getEditorType()
         {
             return editorType;
         }
 
-        public void setEditorType(NumberFeatureTraits.EDITOR_TYPE editorType)
+        public void setEditorType(NumberFeatureTraits.EditorType editorType)
         {
             this.editorType = editorType;
         }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/StringFeatureTraits.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/StringFeatureTraits.java
@@ -21,6 +21,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.keybindings.KeyBinding;
@@ -37,6 +38,7 @@ public class StringFeatureTraits
 
     public enum EditorType
     {
+        @JsonEnumDefaultValue
         AUTO("Auto (depending on tagset size)"), //
         RADIOGROUP("Radio group (small tagsets)"), //
         COMBOBOX("Combo box (mid-size tagsets)"), //

--- a/inception/inception-api-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/feature/FeatureSupport.java
+++ b/inception/inception-api-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/feature/FeatureSupport.java
@@ -113,7 +113,7 @@ public interface FeatureSupport<T>
             AnnotationFeature aFeature);
 
     /**
-     * Called when the user selects a feature in the feature detail form. It allows the feature
+     * Called when the user saves a feature in the feature detail form. It allows the feature
      * support to fill in settings which are not configurable through the UI, e.g. link feature
      * details.
      * 

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/JSONUtil.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/JSONUtil.java
@@ -17,6 +17,8 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.support;
 
+import static com.fasterxml.jackson.databind.DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -41,6 +43,10 @@ public class JSONUtil
     static {
         OBJECT_MAPPER = new ObjectMapper();
         OBJECT_MAPPER.registerModule(new JavaTimeModule());
+        // Used mainly by traits e.g. when switching from a string to a number trait or back where
+        // the editortype property has different ranges
+        OBJECT_MAPPER.configure(READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE, true);
+
     }
 
     /**

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/layers/FeatureDetailForm.java
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/layers/FeatureDetailForm.java
@@ -26,6 +26,7 @@ import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.en
 import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
 import static de.tudarmstadt.ukp.clarin.webanno.ui.project.layers.ProjectLayersPanel.MID_FEATURE_DETAIL_FORM;
 import static de.tudarmstadt.ukp.clarin.webanno.ui.project.layers.ProjectLayersPanel.MID_FEATURE_SELECTION_FORM;
+import static java.util.Arrays.asList;
 import static java.util.Objects.isNull;
 import static org.apache.commons.lang3.StringUtils.isAlphanumeric;
 import static org.apache.commons.lang3.StringUtils.isBlank;
@@ -50,6 +51,7 @@ import org.apache.wicket.markup.html.panel.EmptyPanel;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
+import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.model.StringResourceModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 
@@ -122,11 +124,15 @@ public class FeatureDetailForm
         required = new CheckBox("required");
         required.setOutputMarkupPlaceholderTag(true);
         required.add(LambdaBehavior.onConfigure(_this -> {
-            boolean relevant = CAS.TYPE_NAME_STRING
-                    .equals(FeatureDetailForm.this.getModelObject().getType());
-            _this.setEnabled(relevant);
-            if (!relevant) {
-                FeatureDetailForm.this.getModelObject().setRequired(false);
+            boolean mandatory = asList(CAS.TYPE_NAME_INTEGER, CAS.TYPE_NAME_FLOAT,
+                    CAS.TYPE_NAME_DOUBLE, CAS.TYPE_NAME_BOOLEAN)
+                            .contains(FeatureDetailForm.this.getModelObject().getType());
+            _this.setEnabled(!mandatory);
+            if (mandatory) {
+                required.setModel(Model.of(true));
+            }
+            else {
+                required.setModel(PropertyModel.of(FeatureDetailForm.this.getModel(), "required"));
             }
         }));
         add(required);


### PR DESCRIPTION
**What's in the PR**
- Change handling of the required checkbox to kick in when primitive values are used
- Set required to "true" as a save action on the number and boolean features

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
