### PR TITLE
#3502 - Combo-box and auto-complete field dropdown layout is broken

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiSelectTextFeatureEditor.html
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiSelectTextFeatureEditor.html
@@ -26,7 +26,7 @@
       </span>
     </label>
     <div class="feature-editor-value">
-      <select wicket:id="value" class="form-control col-sm-12"></select>
+      <select wicket:id="value" class="col-sm-12"></select>
     </div>
   </div>
 </wicket:panel>

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/KendoAutoCompleteTextFeatureEditor.html
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/KendoAutoCompleteTextFeatureEditor.html
@@ -26,7 +26,7 @@
       </span>
     </label>
     <div class="feature-editor-value">
-      <input wicket:id="value" class="form-control"></input>
+      <input wicket:id="value"></input>
       <div wicket:id="keyBindings" class="col-sm-12"/>
     </div>
   </div>

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/KendoChoiceDescriptionScriptReference.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/KendoChoiceDescriptionScriptReference.java
@@ -104,18 +104,18 @@ public class KendoChoiceDescriptionScriptReference
                 // http://docs.telerik.com/kendo-ui/framework/templates/overview
                 // @formatter:off
                 StringBuilder sb = new StringBuilder();
-                sb.append("<div title='#: data.description #' onmouseover='javascript:applyTooltip(this)'>");
+                sb.append("<span title='#: data.description #' onmouseover='javascript:applyTooltip(this)'>");
                 sb.append("# if (data.reordered == 'true') { #");
-                sb.append("  <b>#: data.name #</b>");
+                sb.append("<b>${data.name}</b>");
                 sb.append("# } else { #");
-                sb.append("  #: data.name #");
+                sb.append("${data.name}");
                 sb.append("# } #");
                 sb.append("# if (data.score) { #");
-                sb.append("  <div class='item-description'>");
-                sb.append("    Score: ${ data.score }");
-                sb.append("  </div>");
-                sb.append("# } #");
+                sb.append("<div class='item-description'>");
+                sb.append("Score: ${ data.score }");
                 sb.append("</div>");
+                sb.append("# } #");
+                sb.append("</span>");
                 // @formatter:on
 
                 return sb.toString();

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/KendoComboboxTextFeatureEditor.html
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/KendoComboboxTextFeatureEditor.html
@@ -27,7 +27,7 @@
     </label>
     <div class="feature-editor-value">
       <span style="padding: 0px;"> 
-        <input wicket:id="value" class="form-control"></input>
+        <input wicket:id="value"></input>
       </span>
       <div wicket:id="keyBindings" class="col-sm-12"/>
     </div>

--- a/inception/inception-bootstrap/src/main/ts/bootstrap/shim-kendo.scss
+++ b/inception/inception-bootstrap/src/main/ts/bootstrap/shim-kendo.scss
@@ -61,10 +61,10 @@
 }
 
 // Avoid comboboxes getting two borders
-.k-combobox.form-control {
-	border: none;
-	width: 100% !important;
-}
+//.k-combobox.form-control {
+//	border: none;
+//	width: 100% !important;
+//}
 
 // Avoid Kendo split panel assumptions messing with Bootstrap layout assumptions
 .k-splitter .k-pane {
@@ -75,4 +75,18 @@
   }
 }
 
+// Expand the items in Kendo auto-complete fields and combo boxes such that the description tooltip
+// appears when hovering anywhere over the item and not only when hovering over the label text
+.k-list-item-text {
+  width: 100%;
+  > span {
+    display: inline-block;
+    width: 100%;
+  }
+}
 
+.k-list-footer {
+  padding: 0px 5px 0px 5px;
+  border-top: 1px solid var(--bs-border-color);
+  background-color: var(--bs-light);
+}


### PR DESCRIPTION
**What's in the PR**
- Adjust style to fix extra space
- Expand item text to cover full width such that tooltips appear when hovering anywhere over the item and not only when the mouse is directly over the label

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
