### PR TITLE
#3506 - No sessions should be created when remote API is accessed

### DIFF
--- a/inception/inception-app-webapp/src/main/resources/application.yml
+++ b/inception/inception-app-webapp/src/main/resources/application.yml
@@ -111,6 +111,8 @@ wicket:
   web:
     servlet:
       dispatcher-types: request, error, async, forward
+      init-parameters:
+        ignorePaths: /api
   verifier:
     dependencies:
       throw-exception-on-dependency-version-mismatch: false


### PR DESCRIPTION
**What's in the PR**
- Exclude /api from the Wicket filter

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
