### PR TITLE
#3527 - Disabled combo boxes and auto-completes have no styling

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/link/LinkFeatureEditor.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/link/LinkFeatureEditor.java
@@ -349,44 +349,30 @@ public class LinkFeatureEditor
         add(constraintsInUseIndicator);
 
         // Add a new empty slot with the specified role
-        content.add(new LambdaAjaxLink("add", this::actionAdd)
-        {
-            private static final long serialVersionUID = 1L;
+        var addButton = new LambdaAjaxLink("add", this::actionAdd);
+        addButton.add(visibleWhen(() -> {
+            AnnotatorState state = stateModel.getObject();
+            return !(state.isSlotArmed()
+                    && getModelObject().feature.equals(state.getArmedFeature().feature));
 
-            @Override
-            protected void onConfigure()
-            {
-                super.onConfigure();
-
-                AnnotatorState state = LinkFeatureEditor.this.stateModel.getObject();
-                setVisible(!(state.isSlotArmed() && LinkFeatureEditor.this.getModelObject().feature
-                        .equals(state.getArmedFeature().feature)));
-            }
-        });
+        }));
+        content.add(addButton);
 
         // Allows user to update slot
-        LambdaAjaxLink setBtn = new LambdaAjaxLink("set", this::actionSet);
-        setBtn.add(visibleWhen(
-                () -> traits.isEnableRoleLabels() && stateModel.getObject().isSlotArmed()
-                        && LinkFeatureEditor.this.getModelObject().feature
-                                .equals(stateModel.getObject().getArmedFeature().feature)));
-        content.add(setBtn);
+        var setButton = new LambdaAjaxLink("set", this::actionSet);
+        setButton.add(visibleWhen(() -> traits.isEnableRoleLabels()
+                && stateModel.getObject().isSlotArmed() && getModelObject().feature
+                        .equals(stateModel.getObject().getArmedFeature().feature)));
+        content.add(setButton);
 
         // Add a new empty slot with the specified role
-        content.add(new LambdaAjaxLink("del", this::actionDel)
-        {
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            protected void onConfigure()
-            {
-                super.onConfigure();
-
-                AnnotatorState state = LinkFeatureEditor.this.stateModel.getObject();
-                setVisible(state.isSlotArmed() && LinkFeatureEditor.this.getModelObject().feature
-                        .equals(state.getArmedFeature().feature));
-            }
-        });
+        var delButton = new LambdaAjaxLink("del", this::actionDel);
+        delButton.add(visibleWhen(() -> {
+            AnnotatorState state = stateModel.getObject();
+            return state.isSlotArmed()
+                    && getModelObject().feature.equals(state.getArmedFeature().feature);
+        }));
+        content.add(delButton);
     }
 
     private AbstractTextComponent makeAutoComplete(String aId)
@@ -397,7 +383,7 @@ public class LinkFeatureEditor
 
     private AbstractTextComponent makeComboBox(String aId)
     {
-        return new StyledComboBox<Tag>(aId, PropertyModel.of(this, "newRole"),
+        var combobox = new StyledComboBox<Tag>(aId, PropertyModel.of(this, "newRole"),
                 PropertyModel.of(getModel(), "tagset"))
         {
             private static final long serialVersionUID = 1L;
@@ -448,6 +434,7 @@ public class LinkFeatureEditor
                 }
             }
         };
+        return combobox;
     }
 
     private void removeAutomaticallyAddedUnusedEntries()

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/ClassicKendoComboboxTextFeatureEditor.html
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/ClassicKendoComboboxTextFeatureEditor.html
@@ -18,7 +18,7 @@
 -->
 <html xmlns:wicket="http://wicket.apache.org">
 <wicket:panel>
-  <div class="row form-row" wicket:enclosure="value">
+  <div class="row form-row fe-classic" wicket:enclosure="value">
     <label wicket:for="value" class="col-sm-3 col-form-label">
       <span wicket:id="feature"/><wicket:enclosure child="textIndicator">&nbsp;<span wicket:id="textIndicator"></span></wicket:enclosure>
     </label>

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/DynamicTextAreaFeatureEditor.html
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/DynamicTextAreaFeatureEditor.html
@@ -18,7 +18,7 @@
 -->
 <html xmlns:wicket="http://wicket.apache.org">
 <wicket:panel>
-  <div class="row form-row" wicket:enclosure="value">
+  <div class="row form-row fe-dynamic-input" wicket:enclosure="value">
     <label wicket:for="value" wicket:enclosure="feature" class="feature-editor-label col-form-label">
       <span wicket:id="feature"/>
       <span class="float-end">

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/InputFieldTextFeatureEditor.html
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/InputFieldTextFeatureEditor.html
@@ -18,7 +18,7 @@
 -->
 <html xmlns:wicket="http://wicket.apache.org">
 <wicket:panel>
-  <div class="row form-row" wicket:enclosure="value">
+  <div class="row form-row fe-input" wicket:enclosure="value">
     <label wicket:for="value" wicket:enclosure="feature" class="feature-editor-label col-form-label">
       <span wicket:id="feature"/>
       <span class="float-end">

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/KendoAutoCompleteTextFeatureEditor.html
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/KendoAutoCompleteTextFeatureEditor.html
@@ -18,7 +18,7 @@
 -->
 <html xmlns:wicket="http://wicket.apache.org">
 <wicket:panel>
-  <div class="row form-row" wicket:enclosure="value">
+  <div class="row form-row fe-autocomplete" wicket:enclosure="value">
     <label wicket:for="value" wicket:enclosure="feature" class="feature-editor-label col-form-label">
       <span wicket:id="feature"/>
       <span class="float-end">

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/KendoComboboxTextFeatureEditor.html
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/KendoComboboxTextFeatureEditor.html
@@ -18,7 +18,7 @@
 -->
 <html xmlns:wicket="http://wicket.apache.org">
 <wicket:panel>
-  <div class="row form-row" wicket:enclosure="value">
+  <div class="row form-row fe-combo-box" wicket:enclosure="value">
     <label wicket:for="value" wicket:enclosure="feature" class="feature-editor-label col-form-label">
       <span wicket:id="feature"/>
       <span class="float-end">

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/RadioGroupStringFeatureEditor.html
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/RadioGroupStringFeatureEditor.html
@@ -18,7 +18,7 @@
 -->
 <html xmlns:wicket="http://wicket.apache.org">
 <wicket:panel>
-  <div class="row form-row" wicket:enclosure="value">
+  <div class="row form-row fe-radio-group" wicket:enclosure="value">
     <label wicket:for="value" wicket:enclosure="feature" class="feature-editor-label col-form-label">
       <span wicket:id="feature"/>
       <span class="float-end">

--- a/inception/inception-bootstrap/src/main/ts/bootstrap/shim-kendo.scss
+++ b/inception/inception-bootstrap/src/main/ts/bootstrap/shim-kendo.scss
@@ -90,3 +90,8 @@
   border-top: 1px solid var(--bs-border-color);
   background-color: var(--bs-light);
 }
+
+.k-input:disabled {
+  background-color: #e9ecef;
+  opacity: 1;
+}

--- a/inception/inception-bootstrap/src/main/ts/bootstrap/shim-kendo.scss
+++ b/inception/inception-bootstrap/src/main/ts/bootstrap/shim-kendo.scss
@@ -94,4 +94,10 @@
 .k-input:disabled {
   background-color: #e9ecef;
   opacity: 1;
+  padding: 6px 12px;
+}
+
+// Remove double focus shadow in composite components like combo boxes
+.k-input-inner.k-input:focus {
+  box-shadow: none;  
 }

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/wicket/kendo/KendoFixDisabledInputComponentStylingBehavior.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/wicket/kendo/KendoFixDisabledInputComponentStylingBehavior.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.support.wicket.kendo;
+
+import static java.util.Arrays.asList;
+
+import java.util.Set;
+
+import org.apache.wicket.ClassAttributeModifier;
+import org.apache.wicket.Component;
+
+public class KendoFixDisabledInputComponentStylingBehavior
+    extends ClassAttributeModifier
+{
+    private static final long serialVersionUID = 1L;
+
+    private Component owner;
+
+    @Override
+    public void bind(Component aComponent)
+    {
+        owner = aComponent;
+    }
+
+    @Override
+    protected Set<String> update(Set<String> aClasses)
+    {
+        aClasses.addAll(asList("k-input", "k-input-solid", "k-input-md", "k-rounded-md"));
+        if (owner.isEnabledInHierarchy()) {
+            aClasses.remove("k-disabled");
+        }
+        else {
+            aClasses.add("k-disabled");
+        }
+
+        return aClasses;
+    }
+}

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.java
@@ -53,6 +53,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.giffing.wicket.spring.boot.starter.app.WicketBootSecuredWebApplication;
+import com.googlecode.wicket.kendo.ui.form.autocomplete.AutoCompleteTextField;
+import com.googlecode.wicket.kendo.ui.form.combobox.ComboBox;
 
 import de.agilecoders.wicket.core.Bootstrap;
 import de.agilecoders.wicket.core.settings.IBootstrapSettings;
@@ -60,6 +62,7 @@ import de.agilecoders.wicket.webjars.WicketWebjars;
 import de.tudarmstadt.ukp.clarin.webanno.security.SpringAuthenticatedWebSession;
 import de.tudarmstadt.ukp.clarin.webanno.support.SettingsUtil;
 import de.tudarmstadt.ukp.clarin.webanno.support.wicket.PatternMatchingCrossOriginEmbedderPolicyRequestCycleListener;
+import de.tudarmstadt.ukp.clarin.webanno.support.wicket.kendo.KendoFixDisabledInputComponentStylingBehavior;
 import de.tudarmstadt.ukp.clarin.webanno.ui.config.FontAwesomeResourceBehavior;
 import de.tudarmstadt.ukp.clarin.webanno.ui.config.JQueryJavascriptBehavior;
 import de.tudarmstadt.ukp.clarin.webanno.ui.config.JQueryUIResourceBehavior;
@@ -199,6 +202,8 @@ public abstract class WicketApplicationBase
 
         addKendoResourcesToAllPages();
 
+        addKendoComponentsDisabledLookFix();
+
         addJQueryUIResourcesToAllPages();
 
         addFontAwesomeToAllPages();
@@ -250,6 +255,15 @@ public abstract class WicketApplicationBase
             if (component instanceof Page) {
                 component.add(new KendoResourceBehavior());
                 component.add(new WicketJQueryFocusPatchBehavior());
+            }
+        });
+    }
+
+    protected void addKendoComponentsDisabledLookFix()
+    {
+        getComponentInstantiationListeners().add(component -> {
+            if (component instanceof ComboBox || component instanceof AutoCompleteTextField) {
+                component.add(new KendoFixDisabledInputComponentStylingBehavior());
             }
         });
     }

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.java
@@ -53,8 +53,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.giffing.wicket.spring.boot.starter.app.WicketBootSecuredWebApplication;
+import com.googlecode.wicket.kendo.ui.form.TextField;
 import com.googlecode.wicket.kendo.ui.form.autocomplete.AutoCompleteTextField;
 import com.googlecode.wicket.kendo.ui.form.combobox.ComboBox;
+import com.googlecode.wicket.kendo.ui.form.multiselect.MultiSelect;
 
 import de.agilecoders.wicket.core.Bootstrap;
 import de.agilecoders.wicket.core.settings.IBootstrapSettings;
@@ -262,7 +264,9 @@ public abstract class WicketApplicationBase
     protected void addKendoComponentsDisabledLookFix()
     {
         getComponentInstantiationListeners().add(component -> {
-            if (component instanceof ComboBox || component instanceof AutoCompleteTextField) {
+            if (component instanceof ComboBox || component instanceof AutoCompleteTextField
+                    || component instanceof TextField || component instanceof MultiSelect
+                    || component instanceof com.googlecode.wicket.kendo.ui.form.multiselect.lazy.MultiSelect) {
                 component.add(new KendoFixDisabledInputComponentStylingBehavior());
             }
         });


### PR DESCRIPTION
**What's in the PR**
- Add marker classes to the different editor types so we can see which of them is used even if no other styling has been set up
- Globally fix disabled Kendo components styling

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
