### PR TITLE
#3519 - Read-only layer's links are removable

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/link/LinkFeatureEditor.html
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/link/LinkFeatureEditor.html
@@ -40,26 +40,24 @@
             </div>
           </div>
         </div>
-        <div class="card-footer small">
-          <div style="display: table;">
-            <div style="display: table-cell; width: 100%;">
-              <input wicket:id="newRole" style="width: 100%;" placeholder="Enter role name..."></input>
-            </div>
-            <div class="text-nowrap" style="display: table-cell; padding-left: 15px;">
-              <button wicket:id="add" class="btn btn-sm btn-primary">
-                <i class="fas fa-plus"></i>&nbsp;
-                Add
+        <div class="card-footer small flex-h-container">
+          <div class="flex-content">
+            <input wicket:id="newRole" style="width: 100%;" placeholder="Enter role name..."></input>
+          </div>
+          <div class="text-nowrap">
+            <button wicket:id="add" class="btn btn-sm btn-primary ms-3">
+              <i class="fas fa-plus"></i>&nbsp;
+              Add
+            </button>
+            <div class="btn-group ms-3" role="group" wicket:enclosure="del">
+              <button wicket:id="del" class="btn btn-sm btn-danger">
+                <i class="fas fa-trash"></i>&nbsp;
+                Del
               </button>
-              <div class="btn-group" role="group">
-                <button wicket:id="del" class="btn btn-sm btn-danger">
-                  <i class="fas fa-trash"></i>&nbsp;
-                  Del
-                </button>
-                <button wicket:id="set" class="btn btn-sm btn-secondary">
-                  <i class="fas fa-check"></i>&nbsp;
-                  Set
-                </button>
-              </div>
+              <button wicket:id="set" class="btn btn-sm btn-secondary">
+                <i class="fas fa-check"></i>&nbsp;
+                Set
+              </button>
             </div>
           </div>
         </div>

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiValueStringFeatureSupport.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiValueStringFeatureSupport.java
@@ -254,12 +254,12 @@ public class MultiValueStringFeatureSupport
         Feature labelFeature = aFs.getType().getFeatureByBaseName(aFeature.getName());
 
         if (labelFeature == null) {
-            return null;
+            return emptyList();
         }
 
         List<String> values = getFeatureValue(aFeature, aFs);
         if (values == null || values.isEmpty()) {
-            return null;
+            return emptyList();
         }
 
         var details = new ArrayList<VLazyDetailQuery>();

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationSelectionPanel.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationSelectionPanel.java
@@ -126,9 +126,9 @@ public class DocumentMetadataAnnotationSelectionPanel
         username = aUsername;
         jcasProvider = aCasProvider;
         project = aProject;
-        selectedLayer = Model.of(selectableMetadataLayers().stream().findFirst().orElse(null));
+        selectedLayer = Model.of(listCreatableMetadataLayers().stream().findFirst().orElse(null));
         IModel<List<AnnotationLayer>> availableLayers = LoadableDetachableModel
-                .of(this::selectableMetadataLayers);
+                .of(this::listCreatableMetadataLayers);
         actionHandler = aActionHandler;
         state = aState;
         annotations = LoadableDetachableModel.of(this::listAnnotations);
@@ -325,7 +325,8 @@ public class DocumentMetadataAnnotationSelectionPanel
                 aItem.add(new LambdaAjaxLink(CID_DELETE,
                         _target -> actionDelete(_target, detailPanel))
                                 .add(visibleWhen(() -> !aItem.getModelObject().singleton))
-                                .add(enabledWhen(annotationPage::isEditable))
+                                .add(enabledWhen(() -> annotationPage.isEditable()
+                                        && !aItem.getModelObject().layer.isReadonly()))
                                 .add(AttributeAppender.append("class",
                                         () -> annotationPage.isEditable() ? "" : "disabled")));
 
@@ -342,9 +343,10 @@ public class DocumentMetadataAnnotationSelectionPanel
                 .collect(Collectors.toList());
     }
 
-    private List<AnnotationLayer> selectableMetadataLayers()
+    private List<AnnotationLayer> listCreatableMetadataLayers()
     {
-        return listMetadataLayers().stream()
+        return listMetadataLayers().stream() //
+                .filter(layer -> !layer.isReadonly()) //
                 .filter(layer -> !getLayerSupport(layer).readTraits(layer).isSingleton())
                 .collect(toList());
     }

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
@@ -346,7 +346,7 @@ public class AnnotationPage
                         getModelObject().getPreferences().getSidebarSizeRight()))));
         detailEditor = createDetailEditor();
         rightSidebar.add(detailEditor);
-        rightSidebar.add(visibleWhen(getModel().map(AnnotatorState::getSelectableLayers)
+        rightSidebar.add(visibleWhen(getModel().map(AnnotatorState::getAnnotationLayers)
                 .map(List::isEmpty).map(b -> !b)));
         return rightSidebar;
     }

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
@@ -23,7 +23,6 @@ import static de.tudarmstadt.ukp.clarin.webanno.support.WebAnnoConst.CHAIN_TYPE;
 import static de.tudarmstadt.ukp.clarin.webanno.support.WebAnnoConst.COREFERENCE_RELATION_FEATURE;
 import static de.tudarmstadt.ukp.clarin.webanno.support.WebAnnoConst.COREFERENCE_TYPE_FEATURE;
 import static de.tudarmstadt.ukp.clarin.webanno.support.WebAnnoConst.RELATION_TYPE;
-import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.enabledWhen;
 import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
 import static de.tudarmstadt.ukp.clarin.webanno.support.uima.ICasUtil.getAddr;
 import static de.tudarmstadt.ukp.clarin.webanno.support.uima.ICasUtil.selectAnnotationByAddr;
@@ -1173,7 +1172,9 @@ public abstract class AnnotationDetailEditorPanel
         setVisible(getModelObject() != null && getModelObject().getDocument() != null);
 
         // Set read only if annotation is finished or the user is viewing other's work
-        setEnabled(editorPage.isEditable());
+        var selectedLayerIsReadOnly = getModel().map(AnnotatorState::getSelectedAnnotationLayer)
+                .map(AnnotationLayer::isReadonly).orElse(true).getObject();
+        setEnabled(editorPage.isEditable() && !selectedLayerIsReadOnly);
     }
 
     /**
@@ -1445,10 +1446,6 @@ public abstract class AnnotationDetailEditorPanel
                     state.getSelection().getAnnotation().isSet() && state.getSelection().isArc()
                             && RELATION_TYPE.equals(state.getSelectedAnnotationLayer().getType())
                             && editorPage.isEditable());
-
-            // Avoid reversing in read-only layers
-            _this.setEnabled(state.getSelectedAnnotationLayer() != null
-                    && !state.getSelectedAnnotationLayer().isReadonly());
         }));
         return link;
     }
@@ -1459,9 +1456,6 @@ public abstract class AnnotationDetailEditorPanel
         link.setOutputMarkupPlaceholderTag(true);
         link.add(visibleWhen(() -> getModelObject().getSelection().getAnnotation().isSet()
                 && editorPage.isEditable()));
-        // Avoid deleting in read-only layers
-        link.add(enabledWhen(() -> getModelObject().getSelectedAnnotationLayer() != null
-                && !getModelObject().getSelectedAnnotationLayer().isReadonly()));
         link.add(new InputBehavior(new KeyType[] { Shift, Delete }, click));
         return link;
     }
@@ -1481,10 +1475,17 @@ public abstract class AnnotationDetailEditorPanel
 
     public void refresh(AjaxRequestTarget aTarget)
     {
+        // Old code that caused a bug not setting the enabled state properly when switching from
+        // one (editable) annotation to another (non-editable) annotation
         // featureEditorListPanel is in a wicket:container, so we cannot refresh it directly. It
         // is in a wicket:container for the no-data-notice to lay out properly
-        featureEditorListPanel.stream().forEach(aTarget::add);
-        aTarget.add(buttonContainer, navContainer, selectedAnnotationInfoPanel, relationListPanel);
+        // featureEditorListPanel.stream().forEach(aTarget::add);
+        // aTarget.add(buttonContainer, navContainer, selectedAnnotationInfoPanel,
+        // relationListPanel);
+
+        // We need to add the entire ADEP because we set the enabled state of the whole ADEP
+        // hierarchy in its configure method for read-only layers or documents
+        aTarget.add(this);
     }
 
     @OnEvent(stop = true)


### PR DESCRIPTION
**What's in the PR**
- Make ADEP and document-metadata sidebar properly disable feature editors on non-editable layers
- Prevent creation and deletion of non-editable annotations in the document metadata sidebar
- Improve layout of the LinkFeatureEditor
- Fix bug that the ADEP would not show if there are only read-only layers in the document meaning one could not inspect them
- Fix NPE in the lazy details when using a multi-value string feature

**How to test manually**
* See issue description
* Try having only read-only layers in a document and viewing its annotations
* Try using the link feature editor
* Try playing around with finishing documents and/or marking layers read-only 
* Switch between annotations on editable and non-editable layers

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
