### PR TITLE
#3545 - Error reading a gazeteer is not visible to the user

### DIFF
--- a/inception/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/span/StringMatchingRecommender.java
+++ b/inception/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/span/StringMatchingRecommender.java
@@ -137,6 +137,7 @@ public class StringMatchingRecommender
             for (GazeteerEntry entry : aData) {
                 learn(dict, entry.text, entry.label);
             }
+            aContext.info("Loaded [%d] entries from gazeteer", aData.size());
         }
 
         aContext.put(KEY_MODEL, dict);
@@ -157,7 +158,9 @@ public class StringMatchingRecommender
                     pretrain(gazeteerService.readGazeteerFile(gaz), aContext);
                 }
                 catch (IOException e) {
-                    log.info(
+                    aContext.error("Unable to load gazeteer [%s]: %s", gaz.getName(),
+                            e.getMessage());
+                    log.error(
                             "Unable to load gazeteer [{}] for recommender [{}]({}) in project [{}]({})",
                             gaz.getName(), gaz.getRecommender().getName(),
                             gaz.getRecommender().getId(),


### PR DESCRIPTION
**What's in the PR**
- Display gazeteer reading errors in the recommender log
- If a gazeteer could be loaded successfully, display how many entries were read from it

**How to test manually**
* Create an invalid gazeteer, e.g. one containing a line without a tab
* Go to the annotation page, trigger a recommendation, look at the recommender log in the recommender sidebar to see the error

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
