### PR TITLE
#3555 - Update dependencies (25.5)

### DIFF
--- a/inception/pom.xml
+++ b/inception/pom.xml
@@ -61,7 +61,8 @@
     <dkpro.core.testCachePath>${session.executionRootDirectory}/cache/dkpro-core-datasets</dkpro.core.testCachePath>
     <excludedTestCategories>slow</excludedTestCategories>
 
-    <junit-jupiter.version>5.9.0</junit-jupiter.version>
+    <junit-jupiter.version>5.9.1</junit-jupiter.version>
+    <junit-platform.version>1.9.1</junit-platform.version>
     <mockito.version>4.6.1</mockito.version>
     <assertj.version>3.23.1</assertj.version>
     <awaitility.version>4.2.0</awaitility.version>
@@ -78,7 +79,7 @@
     <spring.boot.version>2.7.5</spring.boot.version>
     <spring.security.version>5.7.5</spring.security.version>
     <springdoc.version>1.6.12</springdoc.version>
-    <swagger.version>2.2.4</swagger.version>
+    <swagger.version>2.2.6</swagger.version>
 
     <slf4j.version>1.7.36</slf4j.version>
     <log4j2.version>2.18.0</log4j2.version>
@@ -89,9 +90,9 @@
     <tomcat.version>9.0.68</tomcat.version>
     <servlet-api.version>4.0.1</servlet-api.version>
 
-    <mariadb.driver.version>2.7.5</mariadb.driver.version>
-    <hibernate.version>5.6.10.Final</hibernate.version>
-    <hibernate.validator.version>6.2.3.Final</hibernate.validator.version>
+    <mariadb.driver.version>2.7.7</mariadb.driver.version>
+    <hibernate.version>5.6.14.Final</hibernate.version>
+    <hibernate.validator.version>6.2.5.Final</hibernate.validator.version>
 
     <wicket.version>9.11.0</wicket.version>
     <wicketstuff.version>9.11.0</wicketstuff.version>
@@ -109,22 +110,22 @@
     <mtas.version>8.11.1.0</mtas.version> 
     <!-- * 8.11.1.0 depends on Lucene 8.11.1 -->
 
-    <elasticsearch.version>7.17.6</elasticsearch.version> 
+    <elasticsearch.version>7.17.7</elasticsearch.version> 
     <!--   7.10.2   depends on Lucene 8.7.0 - last ASL 2.0 version! -->
     <!-- * 7.17.1   depends on Lucene 8.11.1 -->
     <!--   8.1.1    depends on Lucene 9.0.0 -->
 
-    <opensearch.version>1.3.5</opensearch.version>
+    <opensearch.version>1.3.6</opensearch.version>
     <!-- * 1.3.5    depends on Lucene 8.10.1 -->
 
-    <rdf4j.version>4.1.2</rdf4j.version> 
-    <!-- * 4.1.1 depends on Lucene 8.5.1 -->
+    <rdf4j.version>4.1.3</rdf4j.version> 
+    <!-- * 4.1.x depends on Lucene 8.5.1 -->
 
     <jena.version>4.6.1</jena.version>
     <!-- * 4.6.1    depends on Lucene 8.11.1 -->
 
     <asciidoctor.plugin.version>2.2.1</asciidoctor.plugin.version>
-    <asciidoctor.version>2.5.5</asciidoctor.version>
+    <asciidoctor.version>2.5.7</asciidoctor.version>
     <asciidoctor-diagram.version>2.2.3</asciidoctor-diagram.version>
 
     <json.version>20180813</json.version>
@@ -1029,12 +1030,12 @@
       <dependency>
         <groupId>org.junit.platform</groupId>
         <artifactId>junit-platform-suite-engine</artifactId>
-        <version>1.9.0</version>
+        <version>${junit-platform.version}</version>
       </dependency>
       <dependency>
         <groupId>org.junit.platform</groupId>
         <artifactId>junit-platform-suite-api</artifactId>
-        <version>1.9.0</version>
+        <version>${junit-platform.version}</version>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
@@ -1267,7 +1268,7 @@
       <dependency>
         <groupId>org.webjars</groupId>
         <artifactId>font-awesome</artifactId>
-        <version>5.15.3</version>
+        <version>5.15.4</version>
       </dependency>
       <dependency>
         <groupId>org.webjars.npm</groupId>
@@ -1482,7 +1483,7 @@
       <dependency>
         <groupId>it.unimi.dsi</groupId>
         <artifactId>fastutil</artifactId>
-        <version>8.5.8</version>
+        <version>8.5.9</version>
       </dependency>
 
       <dependency>
@@ -1534,7 +1535,7 @@
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy</artifactId>
-        <version>1.12.10</version>
+        <version>1.12.18</version>
       </dependency>
       <dependency>
         <groupId>org.wicketstuff</groupId>
@@ -1617,18 +1618,10 @@
       <!-- SPRING SECURITY -->
       <dependency>
         <groupId>org.springframework.security</groupId>
-        <artifactId>spring-security-core</artifactId>
+        <artifactId>spring-security-bom</artifactId>
         <version>${spring.security.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework.security</groupId>
-        <artifactId>spring-security-config</artifactId>
-        <version>${spring.security.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.springframework.security</groupId>
-        <artifactId>spring-security-web</artifactId>
-        <version>${spring.security.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.nimbusds</groupId>
@@ -1897,7 +1890,7 @@
       <dependency>
         <groupId>javax.xml.bind</groupId>
         <artifactId>jaxb-api</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1</version>
       </dependency>
       <dependency>
         <groupId>com.sun.xml.bind</groupId>
@@ -1907,7 +1900,7 @@
       <dependency>
         <groupId>com.sun.xml.bind</groupId>
         <artifactId>jaxb-impl</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.7</version>
       </dependency>
       <dependency>
         <groupId>javax.activation</groupId>
@@ -2261,6 +2254,11 @@
           </exclusion>
           -->
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ivy</groupId>
+        <artifactId>ivy</artifactId>
+        <version>2.5.1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
**What's in the PR**
- JUnit 5.9.0 -> 5.9.1
- JUnit Platform 1.9.0 -> 1.9.1
- Swagger 2.2.4 -> 2.2.6
- MariaDB driver 2.7.5 -> 2.7.7
- Hibernate 5.6.10 -> 5.6.14
- Hibernate validator 6.2.3 -> 6.2.5
- ElasitcSearch 7.17.6 -> 7.17.7
- OpenSearch 1.3.5 -> 1.3.6
- RDF4J 4.1.2 -> 4.1.3
- Asciidoctor 2.5.5 -> 2.5.7
- FontAweseom 5.15.3 -> 5.15.4
- Fastutil 8.5.8 -> 8.5.9
- byte-buddy 1.12.10 -> 1.12.18
- jaxb-api 2.3.0 -> 2.3.1
- jaxb-impl 2.3.0 -< 2.3.7
- ivy -> 2.5.1

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
