### PR TITLE
#2068 - Validate documents during import

### DIFF
--- a/inception/inception-api-formats/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/format/FormatSupport.java
+++ b/inception/inception-api-formats/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/format/FormatSupport.java
@@ -84,6 +84,17 @@ public interface FormatSupport
     }
 
     /**
+     * @return whether the format is prone to inconsistencies. Formats that offer a much flexibility
+     *         to the user (e.g. CAS XMI) are also prone to letting the user import inconsistent
+     *         data. When importing documents from such formats, the CAS Doctor should be applied to
+     *         check for inconsistencies.
+     */
+    default boolean isProneToInconsistencies()
+    {
+        return true;
+    }
+
+    /**
      * @return format-specific CSS style-sheets that styleable editors should load.
      */
     default List<CssResourceReference> getCssStylesheets()

--- a/inception/inception-curation/pom.xml
+++ b/inception/inception-curation/pom.xml
@@ -208,6 +208,11 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-diag</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-io-webanno-tsv</artifactId>
       <scope>test</scope>
     </dependency>

--- a/inception/inception-curation/src/test/java/de/tudarmstadt/ukp/inception/curation/export/CuratedDocumentsExporterTest.java
+++ b/inception/inception-curation/src/test/java/de/tudarmstadt/ukp/inception/curation/export/CuratedDocumentsExporterTest.java
@@ -45,6 +45,8 @@ import de.tudarmstadt.ukp.clarin.webanno.api.DocumentImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
 import de.tudarmstadt.ukp.clarin.webanno.api.config.RepositoryProperties;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectImportRequest;
+import de.tudarmstadt.ukp.clarin.webanno.diag.ChecksRegistry;
+import de.tudarmstadt.ukp.clarin.webanno.diag.RepairsRegistry;
 import de.tudarmstadt.ukp.clarin.webanno.export.model.ExportedProject;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
@@ -72,6 +74,8 @@ public class CuratedDocumentsExporterTest
 
     private @Mock DocumentService documentService;
     private @Mock AnnotationSchemaService schemaService;
+    private @Mock ChecksRegistry checksRegistry;
+    private @Mock RepairsRegistry repairsRegistry;
 
     private Project project;
     private File workFolder;
@@ -100,7 +104,8 @@ public class CuratedDocumentsExporterTest
                 new CasStorageCachePropertiesImpl(), null, schemaService));
 
         importExportSerivce = new DocumentImportExportServiceImpl(repositoryProperties,
-                asList(new XmiFormatSupport()), casStorageService, schemaService, properties);
+                asList(new XmiFormatSupport()), casStorageService, schemaService, properties,
+                checksRegistry, repairsRegistry);
 
         // Dynamically generate a SourceDocument with an incrementing ID when asked for one
         when(documentService.getSourceDocument(any(), any())).then(invocation -> {

--- a/inception/inception-export/pom.xml
+++ b/inception/inception-export/pom.xml
@@ -35,6 +35,10 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-diag</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-annotation-storage</artifactId>
     </dependency>
     <dependency>

--- a/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/DocumentImportExportServiceImpl.java
+++ b/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/DocumentImportExportServiceImpl.java
@@ -132,7 +132,6 @@ public class DocumentImportExportServiceImpl
 
     private final TypeSystemDescription schemaTypeSystem;
 
-    @Autowired
     public DocumentImportExportServiceImpl(RepositoryProperties aRepositoryProperties,
             @Lazy @Autowired(required = false) List<FormatSupport> aFormats,
             CasStorageService aCasStorageService, AnnotationSchemaService aAnnotationService,

--- a/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/DocumentImportExportServiceImpl.java
+++ b/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/DocumentImportExportServiceImpl.java
@@ -79,6 +79,9 @@ import de.tudarmstadt.ukp.clarin.webanno.api.DocumentImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil;
 import de.tudarmstadt.ukp.clarin.webanno.api.config.RepositoryProperties;
 import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.diag.CasDoctor;
+import de.tudarmstadt.ukp.clarin.webanno.diag.ChecksRegistry;
+import de.tudarmstadt.ukp.clarin.webanno.diag.RepairsRegistry;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.Mode;
@@ -86,6 +89,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.TagSet;
 import de.tudarmstadt.ukp.clarin.webanno.support.logging.BaseLoggers;
+import de.tudarmstadt.ukp.clarin.webanno.support.logging.LogMessage;
 import de.tudarmstadt.ukp.clarin.webanno.xmi.XmiFormatSupport;
 import de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData;
 import de.tudarmstadt.ukp.dkpro.core.api.metadata.type.TagsetDescription;
@@ -94,6 +98,7 @@ import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
 import de.tudarmstadt.ukp.inception.annotation.storage.CasStorageSession;
 import de.tudarmstadt.ukp.inception.export.config.DocumentImportExportServiceAutoConfiguration;
 import de.tudarmstadt.ukp.inception.export.config.DocumentImportExportServiceProperties;
+import de.tudarmstadt.ukp.inception.export.config.DocumentImportExportServiceProperties.CasDoctorOnImportPolicy;
 import de.tudarmstadt.ukp.inception.schema.AnnotationSchemaService;
 
 /**
@@ -119,6 +124,8 @@ public class DocumentImportExportServiceImpl
     private final CasStorageService casStorageService;
     private final AnnotationSchemaService annotationService;
     private final DocumentImportExportServiceProperties properties;
+    private final ChecksRegistry checksRegistry;
+    private final RepairsRegistry repairsRegistry;
 
     private final List<FormatSupport> formatsProxy;
     private Map<String, FormatSupport> formats;
@@ -129,13 +136,16 @@ public class DocumentImportExportServiceImpl
     public DocumentImportExportServiceImpl(RepositoryProperties aRepositoryProperties,
             @Lazy @Autowired(required = false) List<FormatSupport> aFormats,
             CasStorageService aCasStorageService, AnnotationSchemaService aAnnotationService,
-            DocumentImportExportServiceProperties aServiceProperties)
+            DocumentImportExportServiceProperties aServiceProperties,
+            ChecksRegistry aChecksRegistry, RepairsRegistry aRepairsRegistry)
     {
         repositoryProperties = aRepositoryProperties;
         casStorageService = aCasStorageService;
         annotationService = aAnnotationService;
         formatsProxy = aFormats;
         properties = aServiceProperties;
+        checksRegistry = aChecksRegistry;
+        repairsRegistry = aRepairsRegistry;
 
         schemaTypeSystem = createTypeSystemDescription(
                 "de/tudarmstadt/ukp/clarin/webanno/api/type/schema-types");
@@ -301,6 +311,8 @@ public class DocumentImportExportServiceImpl
         CAS cas = WebAnnoCasUtil.createCas(tsd);
         format.read(WebAnnoCasUtil.getRealCas(cas), aFile);
 
+        runCasDoctorOnImport(aDocument, format, cas);
+
         // Create sentence / token annotations if they are missing - sentences first because
         // tokens are then generated inside the sentences
         splitSenencesIfNecssaryAndCheckQuota(cas, format);
@@ -311,6 +323,24 @@ public class DocumentImportExportServiceImpl
                 cas.getAnnotationIndex(getType(cas, Sentence.class)).size(), aFile, aFile.length());
 
         return cas;
+    }
+
+    private void runCasDoctorOnImport(SourceDocument aDocument, FormatSupport aFormat, CAS aCas)
+    {
+        if (properties.getRunCasDoctorOnImport() == CasDoctorOnImportPolicy.OFF) {
+            return;
+        }
+
+        if (properties.getRunCasDoctorOnImport() == CasDoctorOnImportPolicy.AUTO
+                && !aFormat.isProneToInconsistencies()) {
+            return;
+        }
+
+        var messages = new ArrayList<LogMessage>();
+        CasDoctor casDoctor = new CasDoctor(checksRegistry, repairsRegistry);
+        casDoctor.setActiveChecks(
+                checksRegistry.getExtensions().stream().map(c -> c.getId()).toArray(String[]::new));
+        casDoctor.analyze(aDocument.getProject(), aCas, messages, true);
     }
 
     private void splitTokensIfNecssaryAndCheckQuota(CAS cas, FormatSupport aFormat)

--- a/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/config/DocumentImportExportServiceAutoConfiguration.java
+++ b/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/config/DocumentImportExportServiceAutoConfiguration.java
@@ -29,6 +29,8 @@ import de.tudarmstadt.ukp.clarin.webanno.api.DocumentImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
 import de.tudarmstadt.ukp.clarin.webanno.api.config.RepositoryProperties;
 import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.diag.ChecksRegistry;
+import de.tudarmstadt.ukp.clarin.webanno.diag.RepairsRegistry;
 import de.tudarmstadt.ukp.inception.export.DocumentImportExportServiceImpl;
 import de.tudarmstadt.ukp.inception.export.exporters.ProjectLogExporter;
 import de.tudarmstadt.ukp.inception.export.exporters.ProjectMetaInfExporter;
@@ -44,10 +46,12 @@ public class DocumentImportExportServiceAutoConfiguration
             RepositoryProperties aRepositoryProperties,
             @Lazy @Autowired(required = false) List<FormatSupport> aFormats,
             CasStorageService aCasStorageService, AnnotationSchemaService aAnnotationService,
-            DocumentImportExportServiceProperties aServiceProperties)
+            DocumentImportExportServiceProperties aServiceProperties,
+            ChecksRegistry aChecksRegistry, RepairsRegistry aRepairsRegistry)
     {
         return new DocumentImportExportServiceImpl(aRepositoryProperties, aFormats,
-                aCasStorageService, aAnnotationService, aServiceProperties);
+                aCasStorageService, aAnnotationService, aServiceProperties, aChecksRegistry,
+                aRepairsRegistry);
     }
 
     @Bean

--- a/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/config/DocumentImportExportServiceProperties.java
+++ b/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/config/DocumentImportExportServiceProperties.java
@@ -19,7 +19,14 @@ package de.tudarmstadt.ukp.inception.export.config;
 
 public interface DocumentImportExportServiceProperties
 {
+    CasDoctorOnImportPolicy getRunCasDoctorOnImport();
+
     int getMaxTokens();
 
     int getMaxSentences();
+
+    public static enum CasDoctorOnImportPolicy
+    {
+        AUTO, OFF, ON
+    }
 }

--- a/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/config/DocumentImportExportServicePropertiesImpl.java
+++ b/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/config/DocumentImportExportServicePropertiesImpl.java
@@ -23,8 +23,20 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class DocumentImportExportServicePropertiesImpl
     implements DocumentImportExportServiceProperties
 {
+    private CasDoctorOnImportPolicy runCasDoctorOnImport = CasDoctorOnImportPolicy.AUTO;
     private int maxTokens = 2_000_000;
     private int maxSentences = 20_000;
+
+    @Override
+    public CasDoctorOnImportPolicy getRunCasDoctorOnImport()
+    {
+        return runCasDoctorOnImport;
+    }
+
+    public void setRunCasDoctorOnImport(CasDoctorOnImportPolicy aRunCasDoctorOnImport)
+    {
+        runCasDoctorOnImport = aRunCasDoctorOnImport;
+    }
 
     @Override
     public int getMaxTokens()

--- a/inception/inception-export/src/main/resources/META-INF/asciidoc/admin-guide/settings_document-import-export.adoc
+++ b/inception/inception-export/src/main/resources/META-INF/asciidoc/admin-guide/settings_document-import-export.adoc
@@ -1,0 +1,49 @@
+// Licensed to the Technische Universität Darmstadt under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The Technische Universität Darmstadt 
+// licenses this file to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.
+//  
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+= Document Im-/Export
+
+Control the importing and exporting of documents.
+
+The `run-cas-doctor-on-import` is by default set to `AUTO` which enables running the CAS Doctor on 
+certain file formats which give the user a lot of flexibility but also have great protential for
+importing inconsistent data. It can be set to `OFF` to disable all checks on import or to `ON` to
+check all formats, even the more rigid ones which give little opportunity for inconsistent data.
+
+.Document import/export settings in the `settings.properties` file
+[cols="4*", options="header"]
+|===
+| Setting
+| Description
+| Default
+| Example
+
+| `document-import.max-tokens`
+| Token-count limit for imported documents
+| `2000000`
+| `0` _(no limit)_
+
+| `document-import.max-sentences`
+| Sentence-count limit for imported documents
+| `20000`
+| `0` _(no limit)_
+
+| `document-import.run-cas-doctor-on-import` 
+| Whether to run the CAS Doctor on every imported document
+| `AUTO`
+| `OFF` (faster), `ON` (check all formats) 
+|===
+

--- a/inception/inception-export/src/test/java/de/tudarmstadt/ukp/inception/export/DocumentImportExportServiceImplTest.java
+++ b/inception/inception-export/src/test/java/de/tudarmstadt/ukp/inception/export/DocumentImportExportServiceImplTest.java
@@ -61,6 +61,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -68,6 +69,8 @@ import org.slf4j.MDC;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.config.RepositoryProperties;
 import de.tudarmstadt.ukp.clarin.webanno.api.type.CASMetadata;
+import de.tudarmstadt.ukp.clarin.webanno.diag.ChecksRegistry;
+import de.tudarmstadt.ukp.clarin.webanno.diag.RepairsRegistry;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
@@ -91,6 +94,8 @@ public class DocumentImportExportServiceImplTest
 {
     private CasStorageSession casStorageSession;
     private @Spy AnnotationSchemaService schemaService;
+    private @Mock ChecksRegistry checksRegistry;
+    private @Mock RepairsRegistry repairsRegistry;
 
     public @TempDir File testFolder;
 
@@ -120,7 +125,8 @@ public class DocumentImportExportServiceImplTest
                 null, null);
 
         sut = new DocumentImportExportServiceImpl(repositoryProperties,
-                List.of(new XmiFormatSupport()), storageService, schemaService, properties);
+                List.of(new XmiFormatSupport()), storageService, schemaService, properties,
+                checksRegistry, repairsRegistry);
         sut.onContextRefreshedEvent();
 
         doReturn(emptyList()).when(schemaService).listAnnotationLayer(any());

--- a/inception/inception-io-json/src/main/java/de/tudarmstadt/ukp/inception/io/jsoncas/UimaJsonCasFormatSupport.java
+++ b/inception/inception-io-json/src/main/java/de/tudarmstadt/ukp/inception/io/jsoncas/UimaJsonCasFormatSupport.java
@@ -78,6 +78,12 @@ public class UimaJsonCasFormatSupport
     }
 
     @Override
+    public boolean isProneToInconsistencies()
+    {
+        return true;
+    }
+
+    @Override
     public AnalysisEngineDescription getWriterDescription(Project aProject,
             TypeSystemDescription aTSD, CAS aCAS)
         throws ResourceInitializationException

--- a/inception/inception-io-webanno-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebAnnoTsv1FormatSupport.java
+++ b/inception/inception-io-webanno-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebAnnoTsv1FormatSupport.java
@@ -57,6 +57,12 @@ public class WebAnnoTsv1FormatSupport
     }
 
     @Override
+    public boolean isProneToInconsistencies()
+    {
+        return true;
+    }
+
+    @Override
     public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
         throws ResourceInitializationException
     {

--- a/inception/inception-io-webanno-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebAnnoTsv2FormatSupport.java
+++ b/inception/inception-io-webanno-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebAnnoTsv2FormatSupport.java
@@ -57,6 +57,12 @@ public class WebAnnoTsv2FormatSupport
     }
 
     @Override
+    public boolean isProneToInconsistencies()
+    {
+        return true;
+    }
+
+    @Override
     public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
         throws ResourceInitializationException
     {

--- a/inception/inception-io-webanno-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebAnnoTsv3FormatSupport.java
+++ b/inception/inception-io-webanno-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebAnnoTsv3FormatSupport.java
@@ -67,6 +67,12 @@ public class WebAnnoTsv3FormatSupport
     }
 
     @Override
+    public boolean isProneToInconsistencies()
+    {
+        return true;
+    }
+
+    @Override
     public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
         throws ResourceInitializationException
     {

--- a/inception/inception-io-xmi/src/main/java/de/tudarmstadt/ukp/clarin/webanno/xmi/BinaryCasFormatSupport.java
+++ b/inception/inception-io-xmi/src/main/java/de/tudarmstadt/ukp/clarin/webanno/xmi/BinaryCasFormatSupport.java
@@ -69,6 +69,12 @@ public class BinaryCasFormatSupport
     }
 
     @Override
+    public boolean isProneToInconsistencies()
+    {
+        return true;
+    }
+
+    @Override
     public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
         throws ResourceInitializationException
     {

--- a/inception/inception-io-xmi/src/main/java/de/tudarmstadt/ukp/clarin/webanno/xmi/XmiFormatSupport.java
+++ b/inception/inception-io-xmi/src/main/java/de/tudarmstadt/ukp/clarin/webanno/xmi/XmiFormatSupport.java
@@ -69,6 +69,12 @@ public class XmiFormatSupport
     }
 
     @Override
+    public boolean isProneToInconsistencies()
+    {
+        return true;
+    }
+
+    @Override
     public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
         throws ResourceInitializationException
     {

--- a/inception/inception-io-xmi/src/main/java/de/tudarmstadt/ukp/clarin/webanno/xmi/XmiXml11FormatSupport.java
+++ b/inception/inception-io-xmi/src/main/java/de/tudarmstadt/ukp/clarin/webanno/xmi/XmiXml11FormatSupport.java
@@ -69,6 +69,12 @@ public class XmiXml11FormatSupport
     }
 
     @Override
+    public boolean isProneToInconsistencies()
+    {
+        return true;
+    }
+
+    @Override
     public CollectionReaderDescription getReaderDescription(TypeSystemDescription aTSD)
         throws ResourceInitializationException
     {

--- a/inception/inception-project-export/pom.xml
+++ b/inception/inception-project-export/pom.xml
@@ -249,6 +249,11 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-diag</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-export</artifactId>
       <scope>test</scope>
     </dependency>

--- a/inception/inception-project-export/src/test/java/de/tudarmstadt/ukp/inception/project/export/AnnotationDocumentsExporterTest.java
+++ b/inception/inception-project-export/src/test/java/de/tudarmstadt/ukp/inception/project/export/AnnotationDocumentsExporterTest.java
@@ -41,6 +41,8 @@ import de.tudarmstadt.ukp.clarin.webanno.api.DocumentImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
 import de.tudarmstadt.ukp.clarin.webanno.api.config.RepositoryProperties;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectImportRequest;
+import de.tudarmstadt.ukp.clarin.webanno.diag.ChecksRegistry;
+import de.tudarmstadt.ukp.clarin.webanno.diag.RepairsRegistry;
 import de.tudarmstadt.ukp.clarin.webanno.export.model.ExportedProject;
 import de.tudarmstadt.ukp.clarin.webanno.export.model.ExportedSourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
@@ -69,6 +71,8 @@ public class AnnotationDocumentsExporterTest
 
     private @Mock DocumentService documentService;
     private @Mock AnnotationSchemaService schemaService;
+    private @Mock ChecksRegistry checksRegistry;
+    private @Mock RepairsRegistry repairsRegistry;
 
     private Project project;
     private File workFolder;
@@ -96,7 +100,8 @@ public class AnnotationDocumentsExporterTest
                 null, schemaService);
 
         importExportSerivce = new DocumentImportExportServiceImpl(repositoryProperties,
-                asList(new XmiFormatSupport()), casStorageService, schemaService, properties);
+                asList(new XmiFormatSupport()), casStorageService, schemaService, properties,
+                checksRegistry, repairsRegistry);
 
         sut = new AnnotationDocumentExporter(documentService, null, importExportSerivce,
                 repositoryProperties);

--- a/inception/inception-search-mtas/pom.xml
+++ b/inception/inception-search-mtas/pom.xml
@@ -161,6 +161,11 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-diag</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-documents</artifactId>
       <scope>test</scope>
     </dependency>

--- a/inception/inception-search-mtas/src/test/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndexTest.java
+++ b/inception/inception-search-mtas/src/test/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndexTest.java
@@ -61,6 +61,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
 import de.tudarmstadt.ukp.clarin.webanno.api.config.RepositoryAutoConfiguration;
 import de.tudarmstadt.ukp.clarin.webanno.conll.config.ConllFormatsAutoConfiguration;
+import de.tudarmstadt.ukp.clarin.webanno.diag.config.CasDoctorAutoConfiguration;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
@@ -105,7 +106,9 @@ import de.tudarmstadt.ukp.inception.search.index.mtas.config.MtasDocumentIndexAu
         showSql = false, //
         properties = { //
                 "spring.main.banner-mode=off", //
-                "repository.path=" + MtasDocumentIndexTest.TEST_OUTPUT_FOLDER })
+                "repository.path=" + MtasDocumentIndexTest.TEST_OUTPUT_FOLDER, //
+                "debug.cas-doctor.force-release-behavior=true", //
+                "document-import.run-cas-doctor-on-import=OFF" })
 // REC: Not particularly clear why Propagation.NEVER is required, but if it is not there, the test
 // waits forever for the indexing to complete...
 @Transactional(propagation = Propagation.NEVER)
@@ -114,6 +117,7 @@ import de.tudarmstadt.ukp.inception.search.index.mtas.config.MtasDocumentIndexAu
         TextFormatsAutoConfiguration.class, //
         ConllFormatsAutoConfiguration.class, //
         DocumentImportExportServiceAutoConfiguration.class, //
+        CasDoctorAutoConfiguration.class, //
         DocumentServiceAutoConfiguration.class, //
         ProjectServiceAutoConfiguration.class, //
         ProjectInitializersAutoConfiguration.class, //

--- a/inception/inception-search-mtas/src/test/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasUpgradeTest.java
+++ b/inception/inception-search-mtas/src/test/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasUpgradeTest.java
@@ -43,6 +43,7 @@ import org.springframework.transaction.annotation.Transactional;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
 import de.tudarmstadt.ukp.clarin.webanno.api.config.RepositoryProperties;
+import de.tudarmstadt.ukp.clarin.webanno.diag.config.CasDoctorAutoConfiguration;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
@@ -62,7 +63,11 @@ import de.tudarmstadt.ukp.inception.search.config.SearchServiceAutoConfiguration
 import de.tudarmstadt.ukp.inception.search.index.IndexRebuildRequiredException;
 
 @Transactional
-@DataJpaTest(showSql = false)
+@DataJpaTest( //
+        showSql = false, //
+        properties = { //
+                "debug.cas-doctor.force-release-behavior=true", //
+                "document-import.run-cas-doctor-on-import=OFF" })
 @DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
 @EnableAutoConfiguration
 @ImportAutoConfiguration( //
@@ -70,6 +75,7 @@ import de.tudarmstadt.ukp.inception.search.index.IndexRebuildRequiredException;
                 PreferencesServiceAutoConfig.class, //
                 ProjectServiceAutoConfiguration.class, //
                 AnnotationSchemaServiceAutoConfiguration.class, //
+                CasDoctorAutoConfiguration.class, //
                 DocumentServiceAutoConfiguration.class, //
                 CasStorageServiceAutoConfiguration.class, //
                 DocumentImportExportServiceAutoConfiguration.class, //

--- a/inception/inception-versioning/pom.xml
+++ b/inception/inception-versioning/pom.xml
@@ -150,6 +150,11 @@
     <!-- DEPENDENCIES FOR TESTING -->
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-diag</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-io-text</artifactId>
       <scope>test</scope>
     </dependency>

--- a/inception/inception-versioning/src/test/java/de/tudarmstadt/ukp/inception/versioning/VersioningServiceImplTest.java
+++ b/inception/inception-versioning/src/test/java/de/tudarmstadt/ukp/inception/versioning/VersioningServiceImplTest.java
@@ -53,6 +53,7 @@ import org.springframework.util.FileSystemUtils;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
 import de.tudarmstadt.ukp.clarin.webanno.api.config.RepositoryAutoConfiguration;
+import de.tudarmstadt.ukp.clarin.webanno.diag.config.CasDoctorAutoConfiguration;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.project.config.ProjectServiceAutoConfiguration;
@@ -74,7 +75,9 @@ import de.tudarmstadt.ukp.inception.versioning.config.VersioningServiceAutoConfi
         properties = { //
                 "spring.main.banner-mode=off", //
                 "repository.path=" + VersioningServiceImplTest.TEST_OUTPUT_FOLDER, //
-                "versioning.enabled=true" })
+                "versioning.enabled=true", //
+                "debug.cas-doctor.force-release-behavior=true", //
+                "document-import.run-cas-doctor-on-import=OFF" })
 @EnableAutoConfiguration
 @EntityScan({ //
         "de.tudarmstadt.ukp.clarin.webanno.model",
@@ -86,6 +89,7 @@ import de.tudarmstadt.ukp.inception.versioning.config.VersioningServiceAutoConfi
         CurationDocumentServiceAutoConfiguration.class, //
         TextFormatsAutoConfiguration.class, //
         UimaFormatsAutoConfiguration.class, //
+        CasDoctorAutoConfiguration.class, //
         RepositoryAutoConfiguration.class, //
         DocumentServiceAutoConfiguration.class, //
         DocumentImportExportServiceAutoConfiguration.class, //


### PR DESCRIPTION
**What's in the PR**
- Add option to configure CAS doctor during import - default is "AUTO"
- Add ability to ask format if it should be validated during import
- Turned this option on for flexible formats like CAS formats and TSV
- Add optional CAS Doctor checking to document import
- Display CAS Doctor results to the user in the document import panel

**How to test manually**
* Import an XMI with inconsistent data that CAS Doctor would be able to detect

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
