### PR TITLE
#2285 - Enable Wicket CSP

### DIFF
--- a/inception/inception-image/src/main/resources/META-INF/asciidoc/user-guide/annotation_images.adoc
+++ b/inception/inception-image/src/main/resources/META-INF/asciidoc/user-guide/annotation_images.adoc
@@ -36,3 +36,10 @@ NOTE: The sidebar attempts to add a border of an appropriate color to each image
       server to support CORS. If CORS is not supported by the image server, rendering performance will 
       degrade as there is an attempt to re-load the image without CORS and without trying to determine the
       border color - but the application should still work and the images should still show.
+
+NOTE: If the images are not hosted on the same server as {product-name}, you may have to specify
+      the remote server in the `security.csp.allowed-image-sources` property to enable users to access these
+      images from their browsers within {product-name}. This is a multi-valued property, so you have to 
+      set its values as `security.csp.allowed-image-sources[0]=https://my-first-image.host`,
+      `security.csp.allowed-image-sources[1]=https://my-second-image.host` in the `settings.properties`
+      file.

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/config/CoreUiAutoConfiguration.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/config/CoreUiAutoConfiguration.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.core.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(CspPropertiesImpl.class)
+public class CoreUiAutoConfiguration
+{
+    // No beans yet
+}

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/config/CspProperties.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/config/CspProperties.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.core.config;
+
+import java.util.List;
+
+public interface CspProperties
+{
+    List<String> getAllowedImageSources();
+}

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/config/CspPropertiesImpl.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/config/CspPropertiesImpl.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.core.config;
+
+import static java.util.Collections.emptyList;
+
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("security.csp")
+public class CspPropertiesImpl
+    implements CspProperties
+{
+    private List<String> allowedImageSources;
+
+    @Override
+    public List<String> getAllowedImageSources()
+    {
+        if (allowedImageSources == null) {
+            return emptyList();
+        }
+
+        return allowedImageSources;
+    }
+
+    public void setAllowedImageSources(List<String> aAllowedImageSources)
+    {
+        allowedImageSources = aAllowedImageSources;
+    }
+}

--- a/inception/inception-ui-core/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/inception/inception-ui-core/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+de.tudarmstadt.ukp.inception.ui.core.config.CoreUiAutoConfiguration


### PR DESCRIPTION
**What's in the PR**
- Allow adding image servers to CSP through configuration
- Unrelated: display namespace prefix on logged sanitized elements in the SanitizingContentHandler

**How to test manually**
* Try linking to an image on an external server
* ... without the external server in the CSP setting
* ... then with the external server in the setting

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
