### PR TITLE
#3589 - Import CAS Doctor check runs too early

### DIFF
--- a/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/DocumentImportExportServiceImpl.java
+++ b/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/DocumentImportExportServiceImpl.java
@@ -310,8 +310,6 @@ public class DocumentImportExportServiceImpl
         CAS cas = WebAnnoCasUtil.createCas(tsd);
         format.read(WebAnnoCasUtil.getRealCas(cas), aFile);
 
-        runCasDoctorOnImport(aDocument, format, cas);
-
         // Create sentence / token annotations if they are missing - sentences first because
         // tokens are then generated inside the sentences
         splitSenencesIfNecssaryAndCheckQuota(cas, format);
@@ -320,6 +318,8 @@ public class DocumentImportExportServiceImpl
         log.info("Imported CAS with [{}] tokens and [{}] sentences from file [{}] (size: {} bytes)",
                 cas.getAnnotationIndex(getType(cas, Token.class)).size(),
                 cas.getAnnotationIndex(getType(cas, Sentence.class)).size(), aFile, aFile.length());
+
+        runCasDoctorOnImport(aDocument, format, cas);
 
         return cas;
     }


### PR DESCRIPTION
**What's in the PR**
- Run CAS doctor checks only after tokenization and sentence splitting, just before returning the final initial CAS

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
