### PR TITLE
#2356 - Reduce exceptions thrown to reduce log pollution

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiValueStringFeatureSupport.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiValueStringFeatureSupport.java
@@ -41,7 +41,6 @@ import org.apache.wicket.model.IModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.IllegalFeatureValueException;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.MultiValueMode;
@@ -57,6 +56,7 @@ import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VLazyDetailQuery;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VLazyDetailResult;
 import de.tudarmstadt.ukp.inception.schema.AnnotationSchemaService;
+import de.tudarmstadt.ukp.inception.schema.adapter.IllegalFeatureValueException;
 import de.tudarmstadt.ukp.inception.schema.feature.FeatureEditor;
 import de.tudarmstadt.ukp.inception.schema.feature.FeatureType;
 
@@ -147,20 +147,8 @@ public class MultiValueStringFeatureSupport
             return;
         }
 
-        if (values != null && aFeature.getTagset() != null) {
-            for (String value : values) {
-                if (!schemaService.existsTag(value, aFeature.getTagset())) {
-                    if (!aFeature.getTagset().isCreateTag()) {
-                        throw new IllegalFeatureValueException("[" + value
-                                + "] is not in the tag list. Please choose from the existing tags");
-                    }
-
-                    Tag selectedTag = new Tag();
-                    selectedTag.setName(value);
-                    selectedTag.setTagSet(aFeature.getTagset());
-                    schemaService.createTag(selectedTag);
-                }
-            }
+        for (String value : values) {
+            schemaService.createMissingTag(aFeature, value);
         }
 
         // Create a new array if size differs otherwise re-use existing one

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/StringFeatureSupport.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/StringFeatureSupport.java
@@ -109,19 +109,8 @@ public class StringFeatureSupport
     public void setFeatureValue(CAS aCas, AnnotationFeature aFeature, int aAddress, Object aValue)
         throws AnnotationException
     {
-        if (aValue != null && schemaService != null && aFeature.getTagset() != null
-                && CAS.TYPE_NAME_STRING.equals(aFeature.getType())
-                && !schemaService.existsTag((String) aValue, aFeature.getTagset())) {
-            if (!aFeature.getTagset().isCreateTag()) {
-                throw new IllegalArgumentException("[" + aValue
-                        + "] is not in the tag list. Please choose from the existing tags");
-            }
-            else {
-                Tag selectedTag = new Tag();
-                selectedTag.setName((String) aValue);
-                selectedTag.setTagSet(aFeature.getTagset());
-                schemaService.createTag(selectedTag);
-            }
+        if (schemaService != null) {
+            schemaService.createMissingTag(aFeature, getId());
         }
 
         super.setFeatureValue(aCas, aFeature, aAddress, aValue);

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/StringFeatureSupport.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/StringFeatureSupport.java
@@ -110,7 +110,7 @@ public class StringFeatureSupport
         throws AnnotationException
     {
         if (schemaService != null) {
-            schemaService.createMissingTag(aFeature, getId());
+            schemaService.createMissingTag(aFeature, (String) aValue);
         }
 
         super.setFeatureValue(aCas, aFeature, aAddress, aValue);

--- a/inception/inception-api-annotation/src/test/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiValueStringFeatureSupportTest.java
+++ b/inception/inception-api-annotation/src/test/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiValueStringFeatureSupportTest.java
@@ -87,6 +87,7 @@ public class MultiValueStringFeatureSupportTest
         verify(schemaService).createMissingTag(valueFeature, tag2);
     }
 
+    @SuppressWarnings("unchecked")
     @Test
     public void thatFeatureValueIsSet() throws Exception
     {

--- a/inception/inception-api-annotation/src/test/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiValueStringFeatureSupportTest.java
+++ b/inception/inception-api-annotation/src/test/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiValueStringFeatureSupportTest.java
@@ -35,7 +35,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.IllegalFeatureValueException;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.MultiValueMode;
 import de.tudarmstadt.ukp.clarin.webanno.model.Tag;
@@ -43,6 +42,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.TagSet;
 import de.tudarmstadt.ukp.clarin.webanno.support.uima.ICasUtil;
 import de.tudarmstadt.ukp.inception.annotation.feature.string.StringFeatureSupportPropertiesImpl;
 import de.tudarmstadt.ukp.inception.schema.AnnotationSchemaService;
+import de.tudarmstadt.ukp.inception.schema.adapter.IllegalFeatureValueException;
 
 @ExtendWith(MockitoExtension.class)
 public class MultiValueStringFeatureSupportTest

--- a/inception/inception-api-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/AnnotationSchemaService.java
+++ b/inception/inception-api-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/AnnotationSchemaService.java
@@ -41,6 +41,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.Tag;
 import de.tudarmstadt.ukp.clarin.webanno.model.TagSet;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
+import de.tudarmstadt.ukp.inception.schema.adapter.IllegalFeatureValueException;
 import de.tudarmstadt.ukp.inception.schema.adapter.TypeAdapter;
 import de.tudarmstadt.ukp.inception.schema.feature.FeatureSupport;
 import de.tudarmstadt.ukp.inception.schema.feature.FeatureSupportRegistry;
@@ -655,4 +656,7 @@ public interface AnnotationSchemaService
     boolean isSentenceLayerEditable(Project aProject);
 
     boolean isTokenLayerEditable(Project aProject);
+
+    void createMissingTag(AnnotationFeature aFeature, String aValue)
+        throws IllegalFeatureValueException;
 }

--- a/inception/inception-api-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/adapter/IllegalFeatureValueException.java
+++ b/inception/inception-api-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/adapter/IllegalFeatureValueException.java
@@ -15,9 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception;
-
-import de.tudarmstadt.ukp.inception.schema.adapter.AnnotationException;
+package de.tudarmstadt.ukp.inception.schema.adapter;
 
 public class IllegalFeatureValueException
     extends AnnotationException

--- a/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/merge/CasMerge.java
+++ b/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/merge/CasMerge.java
@@ -63,7 +63,6 @@ import org.springframework.context.ApplicationEventPublisher;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.IllegalFeatureValueException;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.Configuration;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.ConfigurationSet;
@@ -93,6 +92,7 @@ import de.tudarmstadt.ukp.inception.schema.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.adapter.AnnotationComparisonUtils;
 import de.tudarmstadt.ukp.inception.schema.adapter.AnnotationException;
 import de.tudarmstadt.ukp.inception.schema.adapter.FeatureFilter;
+import de.tudarmstadt.ukp.inception.schema.adapter.IllegalFeatureValueException;
 import de.tudarmstadt.ukp.inception.schema.adapter.TypeAdapter;
 import de.tudarmstadt.ukp.inception.schema.feature.LinkWithRoleModel;
 

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationDetailPanel.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationDetailPanel.java
@@ -26,8 +26,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.apache.uima.UIMAException;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.FeatureStructure;
 import org.apache.uima.cas.text.AnnotationFS;
@@ -35,7 +33,6 @@ import org.apache.wicket.Component;
 import org.apache.wicket.MetaDataKey;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.behavior.AttributeAppender;
-import org.apache.wicket.feedback.IFeedback;
 import org.apache.wicket.markup.html.list.ListItem;
 import org.apache.wicket.markup.html.list.ListView;
 import org.apache.wicket.markup.html.panel.Panel;
@@ -55,6 +52,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.Tag;
 import de.tudarmstadt.ukp.clarin.webanno.support.DescriptionTooltipBehavior;
 import de.tudarmstadt.ukp.clarin.webanno.support.uima.ICasUtil;
+import de.tudarmstadt.ukp.clarin.webanno.support.wicket.WicketExceptionUtil;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.AnnotationPage;
 import de.tudarmstadt.ukp.inception.annotation.feature.link.LinkFeatureDeletedEvent;
 import de.tudarmstadt.ukp.inception.annotation.feature.link.LinkFeatureEditor;
@@ -295,7 +293,8 @@ public class DocumentMetadataAnnotationDetailPanel
             findParent(AnnotationPageBase.class).actionRefreshDocument(aTarget);
         }
         catch (Exception e) {
-            handleException(DocumentMetadataAnnotationDetailPanel.this, aTarget, e);
+            WicketExceptionUtil.handleException(LOG, DocumentMetadataAnnotationDetailPanel.this,
+                    aTarget, e);
         }
     }
 
@@ -330,30 +329,6 @@ public class DocumentMetadataAnnotationDetailPanel
         }
     }
 
-    protected static void handleException(Component aComponent, AjaxRequestTarget aTarget,
-            Exception aException)
-    {
-        if (aTarget != null) {
-            aTarget.addChildren(aComponent.getPage(), IFeedback.class);
-        }
-
-        try {
-            throw aException;
-        }
-        catch (AnnotationException e) {
-            aComponent.error("Error: " + e.getMessage());
-            LOG.error("Error: " + ExceptionUtils.getRootCauseMessage(e), e);
-        }
-        catch (UIMAException e) {
-            aComponent.error("Error: " + ExceptionUtils.getRootCauseMessage(e));
-            LOG.error("Error: " + ExceptionUtils.getRootCauseMessage(e), e);
-        }
-        catch (Exception e) {
-            aComponent.error("Error: " + e.getMessage());
-            LOG.error("Error: " + e.getMessage(), e);
-        }
-    }
-
     private static final class IsSidebarAction
         extends MetaDataKey<Boolean>
     {
@@ -384,7 +359,8 @@ public class DocumentMetadataAnnotationDetailPanel
             }
         }
         catch (IOException | AnnotationException e) {
-            handleException(this, target, e);
+            WicketExceptionUtil.handleException(LOG, DocumentMetadataAnnotationDetailPanel.this,
+                    target, e);
         }
     }
 

--- a/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/service/AnnotationSchemaServiceImpl.java
+++ b/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/service/AnnotationSchemaServiceImpl.java
@@ -109,6 +109,7 @@ import de.tudarmstadt.ukp.inception.annotation.storage.CasStorageSession;
 import de.tudarmstadt.ukp.inception.rendering.config.AnnotationEditorProperties;
 import de.tudarmstadt.ukp.inception.schema.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.AttachedAnnotation;
+import de.tudarmstadt.ukp.inception.schema.adapter.IllegalFeatureValueException;
 import de.tudarmstadt.ukp.inception.schema.adapter.TypeAdapter;
 import de.tudarmstadt.ukp.inception.schema.config.AnnotationSchemaServiceAutoConfiguration;
 import de.tudarmstadt.ukp.inception.schema.feature.FeatureSupportRegistry;
@@ -1573,5 +1574,29 @@ public class AnnotationSchemaServiceImpl
         catch (NoResultException e) {
             return false;
         }
+    }
+
+    @Override
+    @Transactional
+    public void createMissingTag(AnnotationFeature aFeature, String aValue)
+        throws IllegalFeatureValueException
+    {
+        if (aValue == null || aFeature.getTagset() == null) {
+            return;
+        }
+
+        if (existsTag(aValue, aFeature.getTagset())) {
+            return;
+        }
+
+        if (!aFeature.getTagset().isCreateTag()) {
+            throw new IllegalFeatureValueException("[" + aValue
+                    + "] is not in the tag list. Please choose from the existing tags");
+        }
+
+        Tag selectedTag = new Tag();
+        selectedTag.setName(aValue);
+        selectedTag.setTagSet(aFeature.getTagset());
+        createTag(selectedTag);
     }
 }

--- a/inception/inception-schema/src/test/java/de/tudarmstadt/ukp/inception/schema/service/AnnotationSchemaServiceImplTest.java
+++ b/inception/inception-schema/src/test/java/de/tudarmstadt/ukp/inception/schema/service/AnnotationSchemaServiceImplTest.java
@@ -17,8 +17,11 @@
  */
 package de.tudarmstadt.ukp.inception.schema.service;
 
+import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.ANNOTATOR;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
+import java.io.File;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -28,10 +31,113 @@ import org.apache.uima.cas.impl.CASImpl;
 import org.apache.uima.jcas.tcas.Annotation;
 import org.apache.uima.util.AutoCloseableNoException;
 import org.apache.uima.util.CasCreationUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.boot.autoconfigure.liquibase.LiquibaseAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.util.FileSystemUtils;
 
+import de.tudarmstadt.ukp.clarin.webanno.api.DocumentImportExportService;
+import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
+import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
+import de.tudarmstadt.ukp.clarin.webanno.api.config.RepositoryAutoConfiguration;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.model.TagSet;
+import de.tudarmstadt.ukp.clarin.webanno.project.config.ProjectServiceAutoConfiguration;
+import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
+import de.tudarmstadt.ukp.clarin.webanno.security.config.SecurityAutoConfiguration;
+import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
+import de.tudarmstadt.ukp.inception.schema.AnnotationSchemaService;
+import de.tudarmstadt.ukp.inception.schema.adapter.IllegalFeatureValueException;
+import de.tudarmstadt.ukp.inception.schema.config.AnnotationSchemaServiceAutoConfiguration;
+
+@EnableAutoConfiguration
+@DataJpaTest( //
+        excludeAutoConfiguration = LiquibaseAutoConfiguration.class, //
+        showSql = false, //
+        properties = { //
+                "spring.main.banner-mode=off", //
+                "repository.path=" + AnnotationSchemaServiceImplTest.TEST_OUTPUT_FOLDER })
+@EntityScan({ //
+        "de.tudarmstadt.ukp.clarin.webanno.model", //
+        "de.tudarmstadt.ukp.clarin.webanno.security.model" })
+@Import({ //
+        ProjectServiceAutoConfiguration.class, //
+        RepositoryAutoConfiguration.class, //
+        AnnotationSchemaServiceAutoConfiguration.class, //
+        SecurityAutoConfiguration.class })
 class AnnotationSchemaServiceImplTest
 {
+    private static final String TAG_NOT_IN_LIST = "TAG-NOT-IN-LIST";
+
+    static final String TEST_OUTPUT_FOLDER = "target/test-output/AnnotationSchemaServiceImplTest";
+
+    private @MockBean DocumentService documentService;
+    private @MockBean DocumentImportExportService documentImportExportService;
+
+    private @Autowired ProjectService projectService;
+    private @Autowired UserDao userRepository;
+    private @Autowired AnnotationSchemaService sut;
+
+    private User annotator1;
+    private Project project;
+
+    @BeforeAll
+    public static void setupClass()
+    {
+        FileSystemUtils.deleteRecursively(new File(TEST_OUTPUT_FOLDER));
+    }
+
+    @BeforeEach
+    public void setup() throws Exception
+    {
+        annotator1 = userRepository.create(new User("anno1"));
+
+        project = projectService.createProject(new Project("project"));
+        projectService.assignRole(project, annotator1, ANNOTATOR);
+    }
+
+    @Test
+    void thatAddingOutOfTagsetTagOnClosedTagsetTriggersException()
+    {
+        var tagset = new TagSet(project, "tagset");
+        tagset.setCreateTag(false);
+        sut.createTagSet(tagset);
+
+        var feature = AnnotationFeature.builder() //
+                .withId(1l) //
+                .withTagset(tagset) //
+                .build();
+
+        assertThatExceptionOfType(IllegalFeatureValueException.class) //
+                .isThrownBy(() -> sut.createMissingTag(feature, TAG_NOT_IN_LIST));
+    }
+
+    @Test
+    void thatAddingOutOfTagsetTagOnOpenTagsetCreatesTag() throws Exception
+    {
+        var tagset = new TagSet(project, "tagset");
+        tagset.setCreateTag(true);
+        sut.createTagSet(tagset);
+
+        var feature = AnnotationFeature.builder() //
+                .withId(1l) //
+                .withTagset(tagset) //
+                .build();
+
+        sut.createMissingTag(feature, TAG_NOT_IN_LIST);
+
+        assertThat(sut.existsTag(TAG_NOT_IN_LIST, tagset)).isTrue();
+    }
+
     @Test
     void testCasUpgradePerformsGarbageCollection() throws Exception
     {
@@ -58,5 +164,11 @@ class AnnotationSchemaServiceImplTest
                     .as("The annotation that was added and then removed before serialization should not be found") //
                     .containsExactly(cas.getSofa());
         }
+    }
+
+    @SpringBootConfiguration
+    public static class TestContext
+    {
+        // No beans
     }
 }

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/wicket/WicketExceptionUtil.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/wicket/WicketExceptionUtil.java
@@ -29,6 +29,12 @@ import org.slf4j.Logger;
 public final class WicketExceptionUtil
 {
     public static void handleException(Logger aLog, IFeedbackContributor aFeedbackTarget,
+            Exception aException)
+    {
+        handleException(aLog, aFeedbackTarget, null, aException);
+    }
+
+    public static void handleException(Logger aLog, IFeedbackContributor aFeedbackTarget,
             AjaxRequestTarget aTarget, Exception aException)
     {
         if (aException instanceof ReplaceHandlerException) {

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/MultiValueConceptFeatureSupport.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/MultiValueConceptFeatureSupport.java
@@ -44,7 +44,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.IllegalFeatureValueException;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.MultiValueMode;
@@ -57,6 +56,7 @@ import de.tudarmstadt.ukp.inception.rendering.editorstate.FeatureState;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VLazyDetailQuery;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VLazyDetailResult;
+import de.tudarmstadt.ukp.inception.schema.adapter.IllegalFeatureValueException;
 import de.tudarmstadt.ukp.inception.schema.feature.FeatureEditor;
 import de.tudarmstadt.ukp.inception.schema.feature.FeatureSupport;
 import de.tudarmstadt.ukp.inception.schema.feature.FeatureType;


### PR DESCRIPTION
**What's in the PR**
- IllegalArgumentException when trying to use an out-of-tagset tag in a string feature using a closed tagset changed to IllegalFeatureValueException
- Pull duplicate code for creating missing tags out of StringFeatureSupport and MultiValueStringFeature into the schema service
- Moved IllegalFeatureValueException to schema api module so we can use it in the schema service

**How to test manually**
* Try using a tag value that is not in the tag set in a string feature editor

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
