### PR TITLE
#3474 - Tagset export dropdown disappears when selecting format

### DIFF
--- a/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/JsonImportUtil.java
+++ b/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/JsonImportUtil.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package de.tudarmstadt.ukp.clarin.webanno.project.initializers;
+package de.tudarmstadt.ukp.inception.export;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/TagsetImportExportUtils.java
+++ b/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/TagsetImportExportUtils.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.export;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.io.IOUtils;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.model.Tag;
+import de.tudarmstadt.ukp.clarin.webanno.model.TagSet;
+import de.tudarmstadt.ukp.inception.schema.AnnotationSchemaService;
+
+public class TagsetImportExportUtils
+{
+    public static TagSet importTagsetFromTabSeparated(AnnotationSchemaService annotationService,
+            Project project, InputStream aInputStream, boolean aOverwrite)
+        throws IOException
+    {
+        String text = IOUtils.toString(aInputStream, UTF_8);
+        Map<String, String> tabbedTagsetFromFile = LayerImportExportUtils.getTagSetFromFile(text);
+
+        Set<String> listOfTagsFromFile = tabbedTagsetFromFile.keySet();
+        int i = 0;
+        String tagSetName = "";
+        String tagSetDescription = "";
+        String tagsetLanguage = "";
+        de.tudarmstadt.ukp.clarin.webanno.model.TagSet tagSet = null;
+        for (String key : listOfTagsFromFile) {
+            // the first key is the tagset name and its
+            // description
+            if (i == 0) {
+                tagSetName = key;
+                tagSetDescription = tabbedTagsetFromFile.get(key);
+            }
+            // the second key is the tagset language
+            else if (i == 1) {
+                tagsetLanguage = key;
+                // remove and replace the tagset if it
+                // exist
+                if (annotationService.existsTagSet(tagSetName, project)) {
+                    // If overwrite is enabled
+                    if (aOverwrite) {
+                        tagSet = annotationService.getTagSet(tagSetName, project);
+                        annotationService.removeAllTags(tagSet);
+                    }
+                    else {
+                        tagSet = new TagSet();
+                        tagSet.setName(JsonImportUtil.copyTagSetName(annotationService, tagSetName,
+                                project));
+                    }
+                }
+                else {
+                    tagSet = new TagSet();
+                    tagSet.setName(tagSetName);
+                }
+                tagSet.setDescription(tagSetDescription.replace("\\n", "\n"));
+                tagSet.setLanguage(tagsetLanguage);
+                tagSet.setProject(project);
+                annotationService.createTagSet(tagSet);
+            }
+            // otherwise it is a tag entry, add the tag to the tagset
+            else {
+                Tag tag = new Tag();
+                tag.setName(key);
+                tag.setDescription(tabbedTagsetFromFile.get(key).replace("\\n", "\n"));
+                tag.setRank(i);
+                tag.setTagSet(tagSet);
+                annotationService.createTag(tag);
+            }
+            i++;
+        }
+
+        return tagSet;
+    }
+
+    public static TagSet importTagsetFromJson(AnnotationSchemaService annotationService,
+            Project project, InputStream aInputStream, boolean aOverwrite)
+        throws IOException
+    {
+        if (aOverwrite) {
+            return JsonImportUtil.importTagSetFromJsonWithOverwrite(project, aInputStream,
+                    annotationService);
+        }
+        else {
+            return JsonImportUtil.importTagSetFromJson(project, aInputStream, annotationService);
+        }
+    }
+}

--- a/inception/inception-model-export/src/main/java/de/tudarmstadt/ukp/clarin/webanno/export/model/ExportedTagSetConstant.java
+++ b/inception/inception-model-export/src/main/java/de/tudarmstadt/ukp/clarin/webanno/export/model/ExportedTagSetConstant.java
@@ -23,26 +23,6 @@ package de.tudarmstadt.ukp.clarin.webanno.export.model;
 public class ExportedTagSetConstant
 {
     /**
-     * Export/import tagsets in JSON format
-     */
-    public static final String JSON_FORMAT = "JSON";
-
-    /**
-     * Export/Import TagSets in TAB separated format where the first five lines are information
-     * about the tagsets such as tagsetname, tagsetdescrition and the remaining lines are tag with
-     * optional tag descriptions. The format looks like:<br>
-     * 
-     * <pre>
-     * tagSetName   TAGSETNAME
-     * tagSetDescription    DESCRIPTION
-     * ...
-     * TAG1 &lt;optional&gt;TAG1Description
-     * ....
-     * </pre>
-     */
-    public static final String TAB_FORMAT = "TAB-sep";
-
-    /**
      * The key for the tagsetNAme
      */
     public static final String TAGSETNAME = "tagset name";

--- a/inception/inception-project-initializers/pom.xml
+++ b/inception/inception-project-initializers/pom.xml
@@ -26,17 +26,12 @@
   <name>INCEpTION - Core - Project initializers</name>
   <dependencies>
     <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-model</artifactId>
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
-      <artifactId>inception-model-export</artifactId>
+      <artifactId>inception-export</artifactId>
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
@@ -65,11 +60,6 @@
       <artifactId>spring-beans</artifactId>
     </dependency>
     
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-    </dependency>
-
     <!-- DKPro Core dependencies -->
     <dependency>
       <groupId>org.apache.uima</groupId>

--- a/inception/inception-project-initializers/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/initializers/CoreferenceRelationTagSetInitializer.java
+++ b/inception/inception-project-initializers/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/initializers/CoreferenceRelationTagSetInitializer.java
@@ -17,7 +17,7 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.project.initializers;
 
-import static de.tudarmstadt.ukp.clarin.webanno.project.initializers.JsonImportUtil.importTagSetFromJson;
+import static de.tudarmstadt.ukp.inception.export.JsonImportUtil.importTagSetFromJson;
 
 import java.io.IOException;
 import java.util.Collections;

--- a/inception/inception-project-initializers/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/initializers/CoreferenceTypeTagSetInitializer.java
+++ b/inception/inception-project-initializers/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/initializers/CoreferenceTypeTagSetInitializer.java
@@ -17,7 +17,7 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.project.initializers;
 
-import static de.tudarmstadt.ukp.clarin.webanno.project.initializers.JsonImportUtil.importTagSetFromJson;
+import static de.tudarmstadt.ukp.inception.export.JsonImportUtil.importTagSetFromJson;
 
 import java.io.IOException;
 import java.util.Collections;

--- a/inception/inception-project-initializers/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/initializers/DependencyTypeTagSetInitializer.java
+++ b/inception/inception-project-initializers/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/initializers/DependencyTypeTagSetInitializer.java
@@ -17,7 +17,7 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.project.initializers;
 
-import static de.tudarmstadt.ukp.clarin.webanno.project.initializers.JsonImportUtil.importTagSetFromJson;
+import static de.tudarmstadt.ukp.inception.export.JsonImportUtil.importTagSetFromJson;
 
 import java.io.IOException;
 import java.util.Collections;

--- a/inception/inception-project-initializers/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/initializers/NamedEntityTagSetInitializer.java
+++ b/inception/inception-project-initializers/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/initializers/NamedEntityTagSetInitializer.java
@@ -17,7 +17,7 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.project.initializers;
 
-import static de.tudarmstadt.ukp.clarin.webanno.project.initializers.JsonImportUtil.importTagSetFromJson;
+import static de.tudarmstadt.ukp.inception.export.JsonImportUtil.importTagSetFromJson;
 
 import java.io.IOException;
 import java.util.Collections;

--- a/inception/inception-project-initializers/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/initializers/PartOfSpeechTagSetInitializer.java
+++ b/inception/inception-project-initializers/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/initializers/PartOfSpeechTagSetInitializer.java
@@ -17,7 +17,7 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.project.initializers;
 
-import static de.tudarmstadt.ukp.clarin.webanno.project.initializers.JsonImportUtil.importTagSetFromJson;
+import static de.tudarmstadt.ukp.inception.export.JsonImportUtil.importTagSetFromJson;
 
 import java.io.IOException;
 import java.util.Collections;

--- a/inception/inception-ui-tagsets/pom.xml
+++ b/inception/inception-ui-tagsets/pom.xml
@@ -32,10 +32,6 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
-      <artifactId>inception-project-initializers</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-ui-core</artifactId>
     </dependency>
     <dependency>

--- a/inception/inception-ui-tagsets/pom.xml
+++ b/inception/inception-ui-tagsets/pom.xml
@@ -100,6 +100,10 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-csv</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework</groupId>

--- a/inception/inception-ui-tagsets/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/tagsets/TagSetEditorPanel.html
+++ b/inception/inception-ui-tagsets/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/tagsets/TagSetEditorPanel.html
@@ -25,42 +25,41 @@
         <wicket:message key="tagset.details"/>
         <div class="actions">
           <span class="dropdown" aria-haspopup="true" aria-expanded="false">
-            <button class="btn btn-secondary btn-action dropdown-toggle flex-content" type="button" data-bs-toggle="dropdown">
-              <i class="fas fa-download"></i>&nbsp;
+            <button class="btn btn-secondary btn-action dropdown-toggle text-nowrap" type="button" data-bs-toggle="dropdown">
+              <i class="fas fa-download pe-1"/>
               <wicket:message key="export"/>
             </button>
-            <div class="dropdown-menu shadow-lg pt-0 pb-0" role="menu" style="min-width: 220px;">
-              <div class="container">
-                <div class="row form-row">
-                  <div wicket:id="format" class="small"></div>
-                </div>
-                <div class="row form-row">
-                  <button wicket:id="export" class="btn btn-sm btn-primary col-sm-12">
-                    <i class="fas fa-download"></i>&nbsp;
-                    <wicket:message key="export"/>
-                  </button>
-                </div>
-              </div>
-            </div>
+            <ul class="dropdown-menu shadow-lg pt-0 pb-0" role="menu" style="min-width: 220px;">
+              <li>
+                <a wicket:id="exportTagsetAsJson" class="dropdown-item">
+                  <wicket:message key="exportTagsetAsJson"/>
+                </a>
+              </li>
+              <li>
+                <a wicket:id="exportTagsetAsTabSeparated" class="dropdown-item">
+                  <wicket:message key="exportTagsetAsTabSeparated"/>
+                </a>
+              </li>
+            </ul>
           </span>
-          <button wicket:id="save" class="btn btn-primary">
-            <i class="fas fa-save"></i>&nbsp;
+          <button wicket:id="save" class="btn btn-primary text-nowrap">
+            <i class="fas fa-save pe-1"/>
             <wicket:message key="save"/>
           </button>
-          <button wicket:id="cancel" class="btn btn-secondary">
-            <i class="fas fa-times"></i>&nbsp;
+          <button wicket:id="cancel" class="btn btn-secondary text-nowrap">
+            <i class="fas fa-times pe-1"/>
             <wicket:message key="cancel"/>
           </button>
           <span class="dropdown" aria-haspopup="true" aria-expanded="false">
             <button class="btn btn-action dropdown-toggle flex-content" type="button" data-bs-toggle="dropdown">
-              <i class="fas fa-ellipsis-v"></i>
+              <i class="fas fa-ellipsis-v"/>
             </button>
             <ul class="dropdown-menu shadow-lg" role="menu" style="min-width: 220px;">
               <li>
                 <button wicket:id="delete" class="dropdown-item" type="button">
                   <wicket:message key="delete"/>
                   <span class="float-end badge badge-pill bg-danger">
-                    <i class="fas fa-trash"></i>
+                    <i class="fas fa-trash"/>
                   </span>
                 </button>
               </li>
@@ -98,7 +97,7 @@
             <div class="form-check">
               <input class="form-check-input" type="checkbox" wicket:id="createTag">
               <label class="form-check-label" wicket:for="createTag">
-                Annotators may add new tags
+                <wicket:message key="allowTagCreation"/>
               </label>
             </div>
           </div>

--- a/inception/inception-ui-tagsets/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/tagsets/TagSetEditorPanel.java
+++ b/inception/inception-ui-tagsets/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/tagsets/TagSetEditorPanel.java
@@ -17,26 +17,19 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.ui.tagsets;
 
-import static de.tudarmstadt.ukp.clarin.webanno.export.model.ExportedTagSetConstant.JSON_FORMAT;
-import static de.tudarmstadt.ukp.clarin.webanno.export.model.ExportedTagSetConstant.TAB_FORMAT;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Arrays.asList;
 import static java.util.Objects.isNull;
+import static org.apache.commons.csv.CSVFormat.EXCEL;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import static org.apache.wicket.ajax.form.AjaxFormChoiceComponentUpdatingBehavior.onUpdateChoice;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
-import java.io.UnsupportedEncodingException;
+import java.io.StringWriter;
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.markup.html.form.CheckBox;
 import org.apache.wicket.markup.html.form.Form;
@@ -44,16 +37,15 @@ import org.apache.wicket.markup.html.form.TextArea;
 import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
-import org.apache.wicket.model.LoadableDetachableModel;
-import org.apache.wicket.model.Model;
 import org.apache.wicket.model.StringResourceModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
-import org.apache.wicket.util.resource.FileResourceStream;
+import org.apache.wicket.util.resource.IResourceStream;
 import org.apache.wicket.validation.IValidatable;
 import org.apache.wicket.validation.IValidator;
 import org.apache.wicket.validation.ValidationError;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import de.agilecoders.wicket.core.markup.html.bootstrap.form.BootstrapRadioChoice;
 import de.tudarmstadt.ukp.clarin.webanno.export.model.ExportedTag;
 import de.tudarmstadt.ukp.clarin.webanno.export.model.ExportedTagSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
@@ -66,12 +58,16 @@ import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxButton;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxLink;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaPanel;
 import de.tudarmstadt.ukp.clarin.webanno.support.wicket.AjaxDownloadLink;
+import de.tudarmstadt.ukp.clarin.webanno.support.wicket.InputStreamResourceStream;
+import de.tudarmstadt.ukp.clarin.webanno.support.wicket.WicketExceptionUtil;
 import de.tudarmstadt.ukp.inception.schema.AnnotationSchemaService;
 
 public class TagSetEditorPanel
     extends LambdaPanel
 {
     private static final long serialVersionUID = 3084260865116114184L;
+
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private @SpringBean AnnotationSchemaService annotationSchemaService;
 
@@ -80,7 +76,6 @@ public class TagSetEditorPanel
     private IModel<Project> selectedProject;
     private IModel<TagSet> selectedTagSet;
     private IModel<Tag> selectedTag;
-    private IModel<String> exportFormat;
 
     public TagSetEditorPanel(String aId, IModel<Project> aProject, IModel<TagSet> aTagSet,
             IModel<Tag> aSelectedTag)
@@ -93,42 +88,27 @@ public class TagSetEditorPanel
         selectedProject = aProject;
         selectedTagSet = aTagSet;
         selectedTag = aSelectedTag;
-        exportFormat = Model.of(supportedFormats().get(0));
 
-        Form<TagSet> form = new Form<>("form", CompoundPropertyModel.of(aTagSet));
-        add(form);
+        queue(new Form<>("form", CompoundPropertyModel.of(aTagSet)));
 
-        form.add(new TextField<String>("name") //
+        queue(new TextField<String>("name") //
                 .add(new TagSetExistsValidator()) //
                 .setRequired(true));
-        form.add(new TextField<String>("language"));
-        form.add(new TextArea<String>("description"));
-        form.add(new CheckBox("createTag").setOutputMarkupId(true));
+        queue(new TextField<String>("language"));
+        queue(new TextArea<String>("description"));
+        queue(new CheckBox("createTag").setOutputMarkupId(true));
 
-        form.add(new LambdaAjaxButton<>("save", this::actionSave));
-        form.add(new LambdaAjaxLink("delete", this::actionDelete)
-                .onConfigure(_this -> _this.setVisible(form.getModelObject().getId() != null)));
-        form.add(new LambdaAjaxLink("cancel", this::actionCancel));
+        queue(new LambdaAjaxButton<>("save", this::actionSave));
+        queue(new LambdaAjaxLink("delete", this::actionDelete)
+                .onConfigure(_this -> _this.setVisible(aTagSet.getObject().getId() != null)));
+        queue(new LambdaAjaxLink("cancel", this::actionCancel));
 
-        BootstrapRadioChoice<String> format = new BootstrapRadioChoice<>("format", exportFormat,
-                LoadableDetachableModel.of(this::supportedFormats));
-        // The AjaxDownloadLink does not submit the form, so the format radio-buttons need to
-        // submit themselves so their value is available when the export button is pressed
-        format.add(onUpdateChoice(_target -> {
-            // NO-OP
-        }));
-        form.add(format);
-
-        form.add(new AjaxDownloadLink("export", LoadableDetachableModel.of(this::export)));
+        queue(new AjaxDownloadLink("exportTagsetAsJson", this::exportTagsetAsJson));
+        queue(new AjaxDownloadLink("exportTagsetAsTabSeparated", this::exportTagsetAsTabSeparated));
 
         confirmationDialog = new ConfirmationDialog("confirmationDialog");
         confirmationDialog.setTitleModel(new StringResourceModel("DeleteDialog.title", this));
         add(confirmationDialog);
-    }
-
-    private List<String> supportedFormats()
-    {
-        return asList(JSON_FORMAT, TAB_FORMAT);
     }
 
     private void actionSave(AjaxRequestTarget aTarget, Form<Tag> aForm)
@@ -181,80 +161,65 @@ public class TagSetEditorPanel
         aTarget.add(getPage());
     }
 
-    private FileResourceStream export()
+    private IResourceStream exportTagsetAsJson()
     {
-        File exportFile = null;
-        if (exportFormat.getObject().equals(JSON_FORMAT)) {
-            try {
-                exportFile = File.createTempFile("exportedtagsets", ".json");
-            }
-            catch (IOException e1) {
-                error("Unable to create temporary File!!");
-                return null;
+        try {
+            String json = exportTagsetToJson(annotationSchemaService, selectedTagSet.getObject());
+            return new InputStreamResourceStream(new ByteArrayInputStream(json.getBytes("UTF-8")),
+                    "tagset.json");
+        }
+        catch (Exception e) {
+            WicketExceptionUtil.handleException(LOG, this, e);
+            return null;
+        }
+    }
 
-            }
-            if (isNull(selectedTagSet.getObject().getId())) {
-                error("Project not yet created. Please save project details first!");
-            }
-            else {
-                TagSet tagSet = selectedTagSet.getObject();
-                ExportedTagSet exTagSet = new ExportedTagSet();
-                exTagSet.setDescription(tagSet.getDescription());
-                exTagSet.setLanguage(tagSet.getLanguage());
-                exTagSet.setName(tagSet.getName());
+    private IResourceStream exportTagsetAsTabSeparated()
+    {
+        try {
+            String json = exportTagsetToTsv(annotationSchemaService, selectedTagSet.getObject());
+            return new InputStreamResourceStream(new ByteArrayInputStream(json.getBytes("UTF-8")),
+                    "tagset.tsv");
+        }
+        catch (Exception e) {
+            WicketExceptionUtil.handleException(LOG, this, e);
+            return null;
+        }
+    }
 
-                List<ExportedTag> exportedTags = new ArrayList<>();
-                for (Tag tag : annotationSchemaService.listTags(tagSet)) {
-                    ExportedTag exportedTag = new ExportedTag();
-                    exportedTag.setDescription(tag.getDescription());
-                    exportedTag.setName(tag.getName());
-                    exportedTags.add(exportedTag);
-                }
-                exTagSet.setTags(exportedTags);
-
-                try {
-                    JSONUtil.generatePrettyJson(exTagSet, exportFile);
-                }
-                catch (IOException e) {
-                    error("File Path not found or No permission to save the file!");
-                }
-
-                info("TagSets successfully exported to :" + exportFile.getAbsolutePath());
+    private String exportTagsetToTsv(AnnotationSchemaService aSchemaService, TagSet tagSet)
+        throws IOException
+    {
+        StringWriter buf = new StringWriter();
+        try (CSVPrinter printer = new CSVPrinter(buf, EXCEL)) {
+            String tagSetDescription = tagSet.getDescription() == null ? ""
+                    : tagSet.getDescription();
+            printer.printRecord(tagSet.getName(), tagSetDescription.replace("\n", "\\n"));
+            for (Tag tag : annotationSchemaService.listTags(tagSet)) {
+                String tagDescription = tag.getDescription() == null ? "" : tag.getDescription();
+                printer.printRecord(tag.getName(), tagDescription.replace("\n", "\\n"));
             }
         }
-        else if (exportFormat.getObject().equals(TAB_FORMAT)) {
-            TagSet tagSet = selectedTagSet.getObject();
-            try {
-                exportFile = File.createTempFile("exportedtagsets", ".txt");
-            }
-            catch (IOException e1) {
-                error("Unable to create temporary File!!");
-            }
+        return buf.toString();
+    }
 
-            try (var bw = new BufferedWriter(
-                    new OutputStreamWriter(new FileOutputStream(exportFile), UTF_8))) {
-                String tagSetDescription = tagSet.getDescription() == null ? ""
-                        : tagSet.getDescription();
-                bw.write(tagSet.getName() + "\t" + tagSetDescription.replace("\n", "\\n") + "\n");
-                bw.write(tagSet.getLanguage() + "\t" + " \n");
-                for (Tag tag : annotationSchemaService.listTags(tagSet)) {
-                    String tagDescription = tag.getDescription() == null ? ""
-                            : tag.getDescription();
-                    bw.write(tag.getName() + "\t" + tagDescription.replace("\n", "\\n") + "\n");
-                }
-            }
-            catch (FileNotFoundException e) {
-                error("The file for export not found " + ExceptionUtils.getRootCauseMessage(e));
-            }
-            catch (UnsupportedEncodingException e) {
-                error("Unsupported encoding " + ExceptionUtils.getRootCauseMessage(e));
-            }
-            catch (IOException e) {
-                error(ExceptionUtils.getRootCause(e));
-            }
+    private String exportTagsetToJson(AnnotationSchemaService aSchemaService, TagSet tagSet)
+        throws IOException
+    {
+        ExportedTagSet exTagSet = new ExportedTagSet();
+        exTagSet.setDescription(tagSet.getDescription());
+        exTagSet.setLanguage(tagSet.getLanguage());
+        exTagSet.setName(tagSet.getName());
 
+        List<ExportedTag> exportedTags = new ArrayList<>();
+        for (Tag tag : aSchemaService.listTags(tagSet)) {
+            ExportedTag exportedTag = new ExportedTag();
+            exportedTag.setDescription(tag.getDescription());
+            exportedTag.setName(tag.getName());
+            exportedTags.add(exportedTag);
         }
-        return new FileResourceStream(exportFile);
+        exTagSet.setTags(exportedTags);
+        return JSONUtil.toPrettyJsonString(exTagSet);
     }
 
     private class TagSetExistsValidator

--- a/inception/inception-ui-tagsets/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/tagsets/TagSetEditorPanel.properties
+++ b/inception/inception-ui-tagsets/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/tagsets/TagSetEditorPanel.properties
@@ -15,3 +15,7 @@
 # limitations under the License.
 DeleteDialog.title=Confirmation
 DeleteDialog.text=Are you sure you want to <b>delete the tagset "{0}"</b>?
+
+exportTagsetAsJson=JSON (recommended)
+exportTagsetAsTabSeparated=Tab-separated
+allowTagCreation=Annotators may add new tags

--- a/inception/inception-ui-tagsets/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/tagsets/TagSetImportPanel.html
+++ b/inception/inception-ui-tagsets/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/tagsets/TagSetImportPanel.html
@@ -25,14 +25,6 @@
       </div>
       <div class="card-body">
         <div class="row form-row">
-          <label wicket:for="format" class="col-sm-4 col-form-label">
-            <wicket:label key="format"/>
-          </label>
-          <div class="col-sm-8">
-            <select wicket:id="format" class="form-select" data-container="body"/>
-          </div>
-        </div>
-        <div class="row form-row">
           <label class="col-sm-4 col-form-label">
             <wicket:message key="filesToImport"/>
           </label>
@@ -52,8 +44,8 @@
         </div>
       </div>
       <div class="card-footer text-end">
-        <button wicket:id="import" class="btn btn-primary">
-          <i class="fas fa-file-upload"></i>&nbsp;
+        <button wicket:id="import" class="btn btn-primary text-nowrap">
+          <i class="fas fa-file-upload pe-1"/>
           <wicket:message key="import"/>
         </button>
       </div>

--- a/inception/inception-ui-tagsets/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/tagsets/TagSetImportPanel.java
+++ b/inception/inception-ui-tagsets/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/tagsets/TagSetImportPanel.java
@@ -17,24 +17,15 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.ui.tagsets;
 
-import static de.tudarmstadt.ukp.clarin.webanno.export.model.ExportedTagSetConstant.JSON_FORMAT;
-import static de.tudarmstadt.ukp.clarin.webanno.export.model.ExportedTagSetConstant.TAB_FORMAT;
-import static java.util.Arrays.asList;
-import static java.util.Objects.isNull;
 import static org.apache.commons.collections.CollectionUtils.isEmpty;
+import static org.apache.commons.io.IOUtils.buffer;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.io.Serializable;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.feedback.IFeedback;
 import org.apache.wicket.markup.html.form.CheckBox;
-import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.form.upload.FileUpload;
 import org.apache.wicket.markup.html.panel.Panel;
@@ -43,17 +34,17 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.model.util.ListModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
+import org.apache.wicket.util.io.BOMInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
-import de.tudarmstadt.ukp.clarin.webanno.model.Tag;
 import de.tudarmstadt.ukp.clarin.webanno.model.TagSet;
-import de.tudarmstadt.ukp.clarin.webanno.project.initializers.JsonImportUtil;
 import de.tudarmstadt.ukp.clarin.webanno.support.bootstrap.BootstrapFileInputField;
-import de.tudarmstadt.ukp.clarin.webanno.support.lambda.AjaxCallback;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxButton;
-import de.tudarmstadt.ukp.inception.export.LayerImportExportUtils;
+import de.tudarmstadt.ukp.clarin.webanno.support.wicket.WicketExceptionUtil;
+import de.tudarmstadt.ukp.clarin.webanno.ui.core.settings.ProjectSettingsPanelBase;
+import de.tudarmstadt.ukp.inception.export.TagsetImportExportUtils;
 import de.tudarmstadt.ukp.inception.schema.AnnotationSchemaService;
 
 public class TagSetImportPanel
@@ -69,8 +60,6 @@ public class TagSetImportPanel
     private IModel<Preferences> preferences;
     private BootstrapFileInputField fileUpload;
 
-    private AjaxCallback importCompleteAction;
-
     public TagSetImportPanel(String aId, IModel<Project> aModel)
     {
         super(aId);
@@ -83,11 +72,6 @@ public class TagSetImportPanel
 
         Form<Preferences> form = new Form<>("form", CompoundPropertyModel.of(preferences));
 
-        DropDownChoice<String> format = new DropDownChoice<>("format",
-                asList(JSON_FORMAT, TAB_FORMAT));
-        form.add(format);
-        format.setModelObject(JSON_FORMAT); // Set after adding to form to have access to for model
-        format.setRequired(true);
         form.add(new CheckBox("overwrite").setOutputMarkupId(true));
 
         form.add(fileUpload = new BootstrapFileInputField("content", new ListModel<>()));
@@ -104,122 +88,36 @@ public class TagSetImportPanel
     private void actionImport(AjaxRequestTarget aTarget, Form<Preferences> aForm)
     {
         List<FileUpload> uploadedFiles = fileUpload.getFileUploads();
-        Project project = selectedProject.getObject();
-
         if (isEmpty(uploadedFiles)) {
             error("Please choose file with tagset before uploading");
+            aTarget.addChildren(getPage(), IFeedback.class);
             return;
         }
-        else if (isNull(project.getId())) {
-            error("Project not yet created, please save project details!");
-            return;
-        }
-        if (JSON_FORMAT.equals(aForm.getModelObject().format)) {
-            for (FileUpload tagFile : uploadedFiles) {
-                InputStream tagInputStream;
-                try {
-                    tagInputStream = tagFile.getInputStream();
-                    if (aForm.getModelObject().overwrite) {
-                        JsonImportUtil.importTagSetFromJsonWithOverwrite(project, tagInputStream,
-                                annotationService);
-                    }
-                    else {
-                        JsonImportUtil.importTagSetFromJson(project, tagInputStream,
-                                annotationService);
-                    }
-                }
-                catch (IOException e) {
-                    error("Error Importing TagSet " + ExceptionUtils.getRootCauseMessage(e));
-                }
-            }
-        }
-        else if (TAB_FORMAT.equals(aForm.getModelObject().format)) {
-            for (FileUpload tagFile : uploadedFiles) {
-                InputStream tagInputStream;
-                try {
-                    tagInputStream = tagFile.getInputStream();
-                    String text = IOUtils.toString(tagInputStream, "UTF-8");
-                    Map<String, String> tabbedTagsetFromFile = LayerImportExportUtils.getTagSetFromFile(text);
 
-                    Set<String> listOfTagsFromFile = tabbedTagsetFromFile.keySet();
-                    int i = 0;
-                    String tagSetName = "";
-                    String tagSetDescription = "";
-                    String tagsetLanguage = "";
-                    de.tudarmstadt.ukp.clarin.webanno.model.TagSet tagSet = null;
-                    for (String key : listOfTagsFromFile) {
-                        // the first key is the tagset name and its
-                        // description
-                        if (i == 0) {
-                            tagSetName = key;
-                            tagSetDescription = tabbedTagsetFromFile.get(key);
-                        }
-                        // the second key is the tagset language
-                        else if (i == 1) {
-                            tagsetLanguage = key;
-                            // remove and replace the tagset if it
-                            // exist
-                            if (annotationService.existsTagSet(tagSetName, project)) {
-                                // If overwrite is enabled
-                                if (aForm.getModelObject().overwrite) {
-                                    tagSet = annotationService.getTagSet(tagSetName, project);
-                                    annotationService.removeAllTags(tagSet);
-                                }
-                                else {
-                                    tagSet = new TagSet();
-                                    tagSet.setName(JsonImportUtil.copyTagSetName(annotationService,
-                                            tagSetName, project));
-                                }
-                            }
-                            else {
-                                tagSet = new TagSet();
-                                tagSet.setName(tagSetName);
-                            }
-                            tagSet.setDescription(tagSetDescription.replace("\\n", "\n"));
-                            tagSet.setLanguage(tagsetLanguage);
-                            tagSet.setProject(project);
-                            annotationService.createTagSet(tagSet);
-                        }
-                        // otherwise it is a tag entry, add the tag
-                        // to the tagset
-                        else {
-                            Tag tag = new Tag();
-                            tag.setName(key);
-                            tag.setDescription(tabbedTagsetFromFile.get(key).replace("\\n", "\n"));
-                            tag.setRank(i);
-                            tag.setTagSet(tagSet);
-                            annotationService.createTag(tag);
-                        }
-                        i++;
-                    }
+        for (FileUpload tagFile : uploadedFiles) {
+            try (var is = buffer(new BOMInputStream(tagFile.getInputStream()), 8 * 1024)) {
+                is.mark(32);
+                int firstChar = is.read();
+                is.reset();
+                TagSet tagset;
+                if (firstChar == '{') {
+                    tagset = TagsetImportExportUtils.importTagsetFromJson(annotationService,
+                            selectedProject.getObject(), is, aForm.getModelObject().overwrite);
                 }
-                catch (Exception e) {
-                    error("Error importing tag set: " + ExceptionUtils.getRootCauseMessage(e));
-                    LOG.error("Error importing tag set", e);
+                else {
+                    tagset = TagsetImportExportUtils.importTagsetFromTabSeparated(annotationService,
+                            selectedProject.getObject(), is, aForm.getModelObject().overwrite);
                 }
+
+                success("Imported tagset: [" + tagset.getName() + "]");
+                aTarget.addChildren(getPage(), IFeedback.class);
+            }
+            catch (Exception e) {
+                WicketExceptionUtil.handleException(LOG, this, aTarget, e);
             }
         }
 
-        try {
-            onImportComplete(aTarget);
-        }
-        catch (Exception e) {
-            error("Error importing tag set: " + ExceptionUtils.getRootCauseMessage(e));
-            LOG.error("Error importing tag set", e);
-        }
-    }
-
-    protected void onImportComplete(AjaxRequestTarget aTarget) throws Exception
-    {
-        if (importCompleteAction != null) {
-            importCompleteAction.accept(aTarget);
-        }
-    }
-
-    public TagSetImportPanel setImportCompleteAction(AjaxCallback aAction)
-    {
-        importCompleteAction = aAction;
-        return this;
+        aTarget.add(findParent(ProjectSettingsPanelBase.class));
     }
 
     static class Preferences

--- a/inception/inception-ui-tagsets/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/tagsets/TagSetSelectionPanel.html
+++ b/inception/inception-ui-tagsets/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/tagsets/TagSetSelectionPanel.html
@@ -23,17 +23,17 @@
       <div class="card-header">
         <wicket:message key="tagsets" />
         <div class="actions">
-          <span class="dropdown" aria-haspopup="true" aria-expanded="false">
-            <button class="btn btn-action btn-secondary dropdown-toggle flex-content" type="button" data-bs-toggle="dropdown">
-              <i class="fas fa-file-upload"></i>&nbsp;
+          <span class="dropdown sticky-dropdown" aria-haspopup="true" aria-expanded="false">
+            <button class="btn btn-action btn-secondary dropdown-toggle text-nowrap" type="button" data-bs-toggle="dropdown">
+              <i class="fas fa-file-upload pe-1"/>
               <wicket:message key="import"/>
             </button>
             <div class="dropdown-menu shadow-lg pt-0 pb-0" role="menu">
               <wicket:container wicket:id="importPanel" />
             </div>
           </span>
-          <button wicket:id="create" class="btn btn-primary">
-            <i class="fas fa-plus-square"></i>&nbsp;
+          <button wicket:id="create" class="btn btn-primary text-nowrap">
+            <i class="fas fa-plus-square pe-1"/>
             <wicket:message key="create"/>
           </button>
         </div>

--- a/inception/inception-ui-tagsets/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/tagsets/TagSetSelectionPanel.java
+++ b/inception/inception-ui-tagsets/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/tagsets/TagSetSelectionPanel.java
@@ -64,9 +64,6 @@ public class TagSetSelectionPanel
         add(new LambdaAjaxLink("create", this::actionCreate));
 
         tagSetImportPanel = new TagSetImportPanel("importPanel", selectedProject);
-        tagSetImportPanel.setImportCompleteAction(target -> {
-            target.add(findParent(ProjectTagSetsPanel.class));
-        });
         add(tagSetImportPanel);
     }
 


### PR DESCRIPTION
**What's in the PR**
- Clicking on a format directly downloads the tagset - selection via a radio-group is no longer necessary
- Importing a tagset auto-detects the format - choosing a format is no longer necessary
- Improve layout of various buttons
- Extract more code from UI layer to service / utils

**How to test manually**
* Try exporting and importing tagsets in different formats

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
