### PR TITLE
#3630 - Export of single document fails when username is too short

### DIFF
--- a/inception/inception-api-formats/pom.xml
+++ b/inception/inception-api-formats/pom.xml
@@ -57,5 +57,9 @@
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/inception/inception-api-formats/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/format/FormatSupport.java
+++ b/inception/inception-api-formats/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/format/FormatSupport.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.uima.analysis_engine.AnalysisEngine;
 import org.apache.uima.analysis_engine.AnalysisEngineDescription;
 import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
@@ -196,8 +197,10 @@ public interface FormatSupport
         }
 
         // If the writer produced only a single file, then that is the result
-        File exportFile = createTempFile(
-                FilenameUtils.getBaseName(aTargetFolder.listFiles()[0].getName()),
+        String filename = FilenameUtils.getBaseName(aTargetFolder.listFiles()[0].getName());
+        // temp-file prefix must be at least 3 chars
+        filename = StringUtils.rightPad(filename, 3, "_");
+        File exportFile = createTempFile(filename,
                 "." + FilenameUtils.getExtension(aTargetFolder.listFiles()[0].getName()));
         // File exportFile = new File(aTargetFolder.getParent(),
         // aTargetFolder.listFiles()[0].getName());

--- a/inception/inception-project-export/src/main/java/de/tudarmstadt/ukp/inception/project/export/ProjectExportServiceImpl.java
+++ b/inception/inception-project-export/src/main/java/de/tudarmstadt/ukp/inception/project/export/ProjectExportServiceImpl.java
@@ -52,6 +52,7 @@ import org.apache.commons.collections4.SetUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.ClassUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.DisposableBean;
@@ -171,7 +172,10 @@ public class ProjectExportServiceImpl
     public File exportProject(FullProjectExportRequest aRequest, ProjectExportTaskMonitor aMonitor)
         throws ProjectExportException, IOException, InterruptedException
     {
-        File projectZipFile = File.createTempFile(aRequest.getProject().getSlug(), ".zip");
+        String filename = aRequest.getProject().getSlug();
+        // temp-file prefix must be at least 3 chars
+        filename = StringUtils.rightPad(filename, 3, "_");
+        File projectZipFile = File.createTempFile(filename, ".zip");
         boolean success = false;
         try {
             exportProject(aRequest, aMonitor, projectZipFile);

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/LegacyRemoteApiController.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/LegacyRemoteApiController.java
@@ -182,7 +182,10 @@ public class LegacyRemoteApiController
 
         // If the current filename does not start with "." and is in the root folder of the ZIP,
         // import it as a source document
-        File zipFile = File.createTempFile(aFile.getOriginalFilename(), ".zip");
+        String filename = aFile.getOriginalFilename();
+        // temp-file prefix must be at least 3 chars
+        filename = StringUtils.rightPad(filename, 3, "_");
+        File zipFile = File.createTempFile(filename, ".zip");
         aFile.transferTo(zipFile);
         ZipFile zip = new ZipFile(zipFile);
 
@@ -191,8 +194,7 @@ public class LegacyRemoteApiController
             ZipEntry entry = (ZipEntry) zipEnumerate.nextElement();
 
             // If it is the zip name, ignore it
-            if ((FilenameUtils.removeExtension(aFile.getOriginalFilename()) + "/")
-                    .equals(entry.toString())) {
+            if ((FilenameUtils.removeExtension(filename) + "/").equals(entry.toString())) {
                 continue;
             }
             // IF the current filename is META-INF/webanno/source-meta-data.properties store it as

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
@@ -400,7 +400,7 @@ public class AeroRemoteApiController
                 userRepository.isAdministrator(user));
 
         Project importedProject;
-        File tempFile = File.createTempFile("webanno-training", null);
+        File tempFile = File.createTempFile("inception-project-import", null);
         try (InputStream is = new BufferedInputStream(aFile.getInputStream());
                 OutputStream os = new FileOutputStream(tempFile);) {
             if (!ZipUtils.isZipStream(is)) {

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/io/FileUploadDownloadHelper.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/io/FileUploadDownloadHelper.java
@@ -36,12 +36,11 @@ import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 
 public class FileUploadDownloadHelper
 {
+    private static final String INCEPTION_TMP_FILE_PREFIX = "inception_file";
 
     private final Logger log = LoggerFactory.getLogger(getClass());
 
     private final IFileCleaner fileTracker;
-
-    private final String INCEPTION_TMP_FILE_PREFIX = "inception_file";
 
     public FileUploadDownloadHelper(Application application)
     {


### PR DESCRIPTION
**What's in the PR**
- Pad temp file names to three char prefix if necessary

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
