### PR TITLE
#3609 - Feature editors do not show annotations in locked documents for multilabel String features

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiSelectTextFeatureEditor.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiSelectTextFeatureEditor.java
@@ -78,10 +78,6 @@ public class MultiSelectTextFeatureEditor
         add(new ConstraintsInUseIndicator(CID_TEXT_INDICATOR, getModel()));
     }
 
-    /**
-     * Hides feature if "Hide un-constraint feature" is enabled and constraint rules are applied and
-     * feature doesn't match any constraint rule
-     */
     @SuppressWarnings("unchecked")
     @Override
     public void onConfigure()
@@ -94,6 +90,8 @@ public class MultiSelectTextFeatureEditor
             field = (FormComponent<ReorderableTag>) field.replaceWith(createInput());
         }
 
+        // Hides feature if "Hide un-constraint feature" is enabled and constraint rules are applied
+        // and feature doesn't match any constraint rule
         // if enabled and constraints rule execution returns anything other than green
         var featState = getModelObject();
         setVisible(!featState.feature.isHideUnconstraintFeature() || //

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureEditor.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureEditor.java
@@ -80,7 +80,7 @@ public class ConceptFeatureEditor
     public ConceptFeatureEditor(String aId, MarkupContainer aItem, IModel<FeatureState> aModel,
             IModel<AnnotatorState> aStateModel, AnnotationActionHandler aHandler)
     {
-        super(aId, aItem, aModel, aStateModel, aHandler);
+        super(aId, aItem, aModel);
 
         AnnotationFeature feat = getModelObject().feature;
         ConceptFeatureTraits traits = readFeatureTraits(feat);

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureEditor_ImplBase.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureEditor_ImplBase.java
@@ -75,8 +75,7 @@ public abstract class ConceptFeatureEditor_ImplBase
     private @SpringBean EntityLinkingProperties entityLinkingProperties;
 
     public ConceptFeatureEditor_ImplBase(String aId, MarkupContainer aItem,
-            IModel<FeatureState> aModel, IModel<AnnotatorState> aStateModel,
-            AnnotationActionHandler aHandler)
+            IModel<FeatureState> aModel)
     {
         super(aId, aItem, new CompoundPropertyModel<>(aModel));
 

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/MultiValueConceptFeatureEditor.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/MultiValueConceptFeatureEditor.java
@@ -46,18 +46,84 @@ public class MultiValueConceptFeatureEditor
 {
     private static final long serialVersionUID = -8326017157405023711L;
 
+    private static final String CID_VALUE = "value";
+
     private @SpringBean FeatureSupportRegistry featureSupportRegistry;
 
-    private MultiSelect<KBHandle> focusComponent;
+    private final AnnotationActionHandler handler;
+    private final IModel<AnnotatorState> stateModel;
+
+    private FormComponent<Collection<KBHandle>> focusComponent;
 
     public MultiValueConceptFeatureEditor(String aId, MarkupContainer aItem,
             IModel<FeatureState> aModel, IModel<AnnotatorState> aStateModel,
             AnnotationActionHandler aHandler)
     {
-        super(aId, aItem, aModel, aStateModel, aHandler);
+        super(aId, aItem, aModel);
 
-        focusComponent = new KBHandleMultiSelect("value", aHandler, aStateModel);
+        handler = aHandler;
+        stateModel = aStateModel;
+
+        focusComponent = createInput();
         add(focusComponent);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void onConfigure()
+    {
+        super.onConfigure();
+
+        // Workaround for https://github.com/sebfz1/wicket-jquery-ui/issues/352
+        if ((isEnabledInHierarchy() && !(focusComponent instanceof MultiSelect))
+                || !isEnabledInHierarchy() && (focusComponent instanceof MultiSelect)) {
+            focusComponent = (FormComponent<Collection<KBHandle>>) focusComponent
+                    .replaceWith(createInput());
+        }
+    }
+
+    private FormComponent<Collection<KBHandle>> createInput()
+    {
+        if (isEnabledInHierarchy()) {
+            return createEditableInput();
+        }
+        else {
+            return createReadOnlyInput();
+        }
+    }
+
+    private FormComponent<Collection<KBHandle>> createEditableInput()
+    {
+        return new KBHandleMultiSelect(CID_VALUE, handler, stateModel);
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    private FormComponent<Collection<KBHandle>> createReadOnlyInput()
+    {
+        var input = new com.googlecode.wicket.kendo.ui.form.multiselect. //
+                MultiSelect<KBHandle>(CID_VALUE)
+        {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public void onConfigure(JQueryBehavior aBehavior)
+            {
+                super.onConfigure(aBehavior);
+                styleMultiSelect(aBehavior);
+            }
+        };
+        input.setChoiceRenderer(
+                new org.apache.wicket.markup.html.form.ChoiceRenderer<>("uiLabel", "identifier"));
+        input.setChoices(() -> input.getModel().map(ArrayList::new).getObject());
+        return (FormComponent) input;
+    }
+
+    private void styleMultiSelect(JQueryBehavior aBehavior)
+    {
+        aBehavior.setOption("autoWidth", true);
+        aBehavior.setOption("animation", false);
+        aBehavior.setOption("delay", 250);
+        aBehavior.setOption("height", 300);
     }
 
     @Override
@@ -113,10 +179,8 @@ public class MultiValueConceptFeatureEditor
         {
             super.onConfigure(aBehavior);
 
-            aBehavior.setOption("autoWidth", true);
-            aBehavior.setOption("animation", false);
-            aBehavior.setOption("delay", 250);
-            aBehavior.setOption("height", 300);
+            styleMultiSelect(aBehavior);
+
             // These three settings should avoid a query when simply clicking into the multiselect
             // field, but they seem to have no effect
             // aBehavior.setOption("autoBind", false);


### PR DESCRIPTION
**What's in the PR**
- Use a non-lazy multi-select when the input is disabled because the lazy multi-select has this bug not showing values when disabled

**How to test manually**
* See issue description - but use a multi-value concept feature

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
