### PR TITLE
#3522 - No color distinction of merged vs unmerged links in curation page

### DIFF
--- a/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/vmodel/VDocument.java
+++ b/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/vmodel/VDocument.java
@@ -173,18 +173,19 @@ public class VDocument
         return emptyList();
     }
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
     public Collection<VObject> objects(long aLayerId)
     {
+        var allObjects = new ArrayList<VObject>();
+
         if (spansByLayer.containsKey(aLayerId)) {
-            return unmodifiableList((List) spansByLayer.get(aLayerId));
+            allObjects.addAll(spansByLayer.get(aLayerId));
         }
 
         if (arcsByLayer.containsKey(aLayerId)) {
-            return unmodifiableList((List) arcsByLayer.get(aLayerId));
+            allObjects.addAll(arcsByLayer.get(aLayerId));
         }
 
-        return emptyList();
+        return unmodifiableList(allObjects);
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })


### PR DESCRIPTION
**What's in the PR**
- Fixed bug in VDocument that if a layer has both arcs and spans, only the spans would be returned by `objects()` but not the arcs

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
