### PR TITLE
#283 - Resize span

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/MoveSpanAnnotationRequest.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/MoveSpanAnnotationRequest.java
@@ -18,28 +18,37 @@
 package de.tudarmstadt.ukp.inception.annotation.layer.span;
 
 import org.apache.uima.cas.CAS;
+import org.apache.uima.cas.text.AnnotationFS;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 
-public class CreateSpanAnnotationRequest
-    extends SpanAnnotationRequest_ImplBase<CreateSpanAnnotationRequest>
+public class MoveSpanAnnotationRequest
+    extends SpanAnnotationRequest_ImplBase<MoveSpanAnnotationRequest>
 {
-    public CreateSpanAnnotationRequest(SourceDocument aDocument, String aUsername, CAS aCas,
-            int aBegin, int aEnd)
+    private final AnnotationFS annotation;
+
+    public MoveSpanAnnotationRequest(SourceDocument aDocument, String aUsername, CAS aCas,
+            AnnotationFS aAnnotation, int aBegin, int aEnd)
     {
-        this(null, aDocument, aUsername, aCas, aBegin, aEnd);
+        this(null, aDocument, aUsername, aCas, aAnnotation, aBegin, aEnd);
     }
 
-    private CreateSpanAnnotationRequest(CreateSpanAnnotationRequest aOriginal,
-            SourceDocument aDocument, String aUsername, CAS aCas, int aBegin, int aEnd)
+    private MoveSpanAnnotationRequest(MoveSpanAnnotationRequest aOriginal, SourceDocument aDocument,
+            String aUsername, CAS aCas, AnnotationFS aAnnotation, int aBegin, int aEnd)
     {
         super(null, aDocument, aUsername, aCas, aBegin, aEnd);
+        annotation = aAnnotation;
+    }
+
+    public AnnotationFS getAnnotation()
+    {
+        return annotation;
     }
 
     @Override
-    public CreateSpanAnnotationRequest changeSpan(int aBegin, int aEnd)
+    public MoveSpanAnnotationRequest changeSpan(int aBegin, int aEnd)
     {
-        return new CreateSpanAnnotationRequest(this, getDocument(), getUsername(), getCas(), aBegin,
-                aEnd);
+        return new MoveSpanAnnotationRequest(this, getDocument(), getUsername(), getCas(),
+                getAnnotation(), aBegin, aEnd);
     }
 }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanAnchoringModeBehavior.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanAnchoringModeBehavior.java
@@ -58,6 +58,20 @@ public class SpanAnchoringModeBehavior
             CreateSpanAnnotationRequest aRequest)
         throws AnnotationException
     {
+        return onRequest(aAdapter, aRequest);
+    }
+
+    public MoveSpanAnnotationRequest onMove(TypeAdapter aAdapter,
+            MoveSpanAnnotationRequest aRequest)
+        throws AnnotationException
+    {
+        return onRequest(aAdapter, aRequest);
+    }
+
+    private <T extends SpanAnnotationRequest_ImplBase<T>> T onRequest(TypeAdapter aAdapter,
+            T aRequest)
+        throws AnnotationException
+    {
         if (aRequest.getBegin() == aRequest.getEnd()) {
             if (!aAdapter.getLayer().getAnchoringMode().isZeroSpanAllowed()) {
                 throw new IllegalPlacementException(
@@ -77,6 +91,7 @@ public class SpanAnchoringModeBehavior
         else {
             return aRequest.changeSpan(adjustedRange[0], adjustedRange[1]);
         }
+
     }
 
     public static int[] adjust(CAS aCas, AnchoringMode aMode, int[] aRange)

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanAnnotationRequest_ImplBase.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanAnnotationRequest_ImplBase.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.annotation.layer.span;
+
+import java.util.Optional;
+
+import org.apache.commons.lang3.Validate;
+import org.apache.uima.cas.CAS;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+
+public abstract class SpanAnnotationRequest_ImplBase<T extends SpanAnnotationRequest_ImplBase<T>>
+{
+    private final SourceDocument document;
+    private final String username;
+    private final CAS cas;
+    private final int begin;
+    private final int end;
+    private final T originalRequest;
+
+    public SpanAnnotationRequest_ImplBase(SourceDocument aDocument, String aUsername, CAS aCas,
+            int aBegin, int aEnd)
+    {
+        this(null, aDocument, aUsername, aCas, aBegin, aEnd);
+    }
+
+    protected SpanAnnotationRequest_ImplBase(T aOriginal, SourceDocument aDocument,
+            String aUsername, CAS aCas, int aBegin, int aEnd)
+    {
+        Validate.isTrue(aBegin <= aEnd, "Annotation begin [%d] must smaller or equal to end [%d]",
+                aBegin, aEnd);
+
+        originalRequest = aOriginal;
+        document = aDocument;
+        username = aUsername;
+        cas = aCas;
+        begin = aBegin;
+        end = aEnd;
+    }
+
+    public SourceDocument getDocument()
+    {
+        return document;
+    }
+
+    public String getUsername()
+    {
+        return username;
+    }
+
+    public CAS getCas()
+    {
+        return cas;
+    }
+
+    public int getBegin()
+    {
+        return begin;
+    }
+
+    public int getEnd()
+    {
+        return end;
+    }
+
+    public Optional<T> getOriginalRequest()
+    {
+        return Optional.ofNullable(originalRequest);
+    }
+
+    public abstract T changeSpan(int aBegin, int aEnd);
+}

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanCrossSentenceBehavior.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanCrossSentenceBehavior.java
@@ -72,6 +72,21 @@ public class SpanCrossSentenceBehavior
             CreateSpanAnnotationRequest aRequest)
         throws AnnotationException
     {
+        return onRequest(aAdapter, aRequest);
+    }
+
+    @Override
+    public MoveSpanAnnotationRequest onMove(TypeAdapter aAdapter,
+            MoveSpanAnnotationRequest aRequest)
+        throws AnnotationException
+    {
+        return onRequest(aAdapter, aRequest);
+    }
+
+    private <T extends SpanAnnotationRequest_ImplBase<T>> T onRequest(TypeAdapter aAdapter,
+            T aRequest)
+        throws AnnotationException
+    {
         if (aAdapter.getLayer().isCrossSentence()) {
             return aRequest;
         }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanLayerBehavior.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanLayerBehavior.java
@@ -41,6 +41,10 @@ public abstract class SpanLayerBehavior
             CreateSpanAnnotationRequest aRequest)
         throws AnnotationException;
 
+    public abstract MoveSpanAnnotationRequest onMove(TypeAdapter aAdapter,
+            MoveSpanAnnotationRequest aRequest)
+        throws AnnotationException;
+
     public void onRender(TypeAdapter aAdapter, VDocument aResponse,
             Map<AnnotationFS, VSpan> annoToSpanIdx, int aPageBegin, int aPageEnd)
     {

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanMovedEvent.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanMovedEvent.java
@@ -17,29 +17,36 @@
  */
 package de.tudarmstadt.ukp.inception.annotation.layer.span;
 
-import org.apache.uima.cas.CAS;
+import org.apache.uima.cas.text.AnnotationFS;
 
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.inception.annotation.events.AnnotationCreatedEvent;
 
-public class CreateSpanAnnotationRequest
-    extends SpanAnnotationRequest_ImplBase<CreateSpanAnnotationRequest>
+public class SpanMovedEvent
+    extends SpanEvent
+    implements AnnotationCreatedEvent
 {
-    public CreateSpanAnnotationRequest(SourceDocument aDocument, String aUsername, CAS aCas,
-            int aBegin, int aEnd)
+    private static final long serialVersionUID = 4144074959212391974L;
+
+    private int oldBegin;
+    private int oldEnd;
+
+    public SpanMovedEvent(Object aSource, SourceDocument aDocument, String aUser,
+            AnnotationLayer aLayer, AnnotationFS aAnnotation, int aOldBegin, int aOldEnd)
     {
-        this(null, aDocument, aUsername, aCas, aBegin, aEnd);
+        super(aSource, aDocument, aUser, aLayer, aAnnotation);
+        oldBegin = aOldBegin;
+        oldEnd = aOldEnd;
     }
 
-    private CreateSpanAnnotationRequest(CreateSpanAnnotationRequest aOriginal,
-            SourceDocument aDocument, String aUsername, CAS aCas, int aBegin, int aEnd)
+    public int getOldBegin()
     {
-        super(null, aDocument, aUsername, aCas, aBegin, aEnd);
+        return oldBegin;
     }
 
-    @Override
-    public CreateSpanAnnotationRequest changeSpan(int aBegin, int aEnd)
+    public int getOldEnd()
     {
-        return new CreateSpanAnnotationRequest(this, getDocument(), getUsername(), getCas(), aBegin,
-                aEnd);
+        return oldEnd;
     }
 }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanOverlapBehavior.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanOverlapBehavior.java
@@ -72,6 +72,27 @@ public class SpanOverlapBehavior
             CreateSpanAnnotationRequest aRequest)
         throws AnnotationException
     {
+        return onRequest(aAdapter, aRequest);
+    }
+
+    @Override
+    public MoveSpanAnnotationRequest onMove(TypeAdapter aAdapter,
+            MoveSpanAnnotationRequest aRequest)
+        throws AnnotationException
+    {
+        try {
+            aRequest.getCas().removeFsFromIndexes(aRequest.getAnnotation());
+            return onRequest(aAdapter, aRequest);
+        }
+        finally {
+            aRequest.getCas().addFsToIndexes(aRequest.getAnnotation());
+        }
+    }
+
+    private <T extends SpanAnnotationRequest_ImplBase<T>> T onRequest(TypeAdapter aAdapter,
+            T aRequest)
+        throws AnnotationException
+    {
         final CAS aCas = aRequest.getCas();
         final int aBegin = aRequest.getBegin();
         final int aEnd = aRequest.getEnd();
@@ -284,7 +305,7 @@ public class SpanOverlapBehavior
                 || (aFS1.getBegin() < aFS2.getEnd() && aFS2.getEnd() <= aFS1.getEnd());
     }
 
-    private static boolean stacking(CreateSpanAnnotationRequest aRequest, AnnotationFS aSpan)
+    private static boolean stacking(SpanAnnotationRequest_ImplBase<?> aRequest, AnnotationFS aSpan)
     {
         return stacking(aRequest.getBegin(), aRequest.getEnd(), aSpan.getBegin(), aSpan.getEnd());
     }

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/CreateSpanAnnotationHandler.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/CreateSpanAnnotationHandler.java
@@ -100,11 +100,9 @@ public class CreateSpanAnnotationHandler
      * selected annotations or offsets contained in the request for the creation of a new
      * annotation.
      */
-    Range getOffsetsFromRequest(AnnotatorState aState, IRequestParameters request, CAS aCas)
+    static Range getOffsetsFromRequest(AnnotatorState aState, IRequestParameters request, CAS aCas)
         throws IOException
     {
-        // Create new span annotation - in this case we get the offset information from the
-        // request
         String offsets = request.getParameterValue(PARAM_OFFSETS).toString();
 
         CompactRangeList offsetLists = JSONUtil.getObjectMapper().readValue(offsets,

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/MoveSpanAnnotationHandler.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/MoveSpanAnnotationHandler.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.diam.editor.actions;
+
+import static de.tudarmstadt.ukp.inception.diam.editor.actions.CreateSpanAnnotationHandler.getOffsetsFromRequest;
+
+import java.io.IOException;
+
+import org.apache.uima.cas.CAS;
+import org.apache.uima.cas.text.AnnotationFS;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.request.Request;
+import org.springframework.core.annotation.Order;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
+import de.tudarmstadt.ukp.clarin.webanno.support.uima.ICasUtil;
+import de.tudarmstadt.ukp.inception.annotation.layer.span.SpanAdapter;
+import de.tudarmstadt.ukp.inception.diam.editor.config.DiamAutoConfig;
+import de.tudarmstadt.ukp.inception.diam.model.ajax.DefaultAjaxResponse;
+import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
+import de.tudarmstadt.ukp.inception.rendering.model.Range;
+import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
+import de.tudarmstadt.ukp.inception.schema.AnnotationSchemaService;
+import de.tudarmstadt.ukp.inception.schema.adapter.AnnotationException;
+
+/**
+ * <p>
+ * This class is exposed as a Spring Component via {@link DiamAutoConfig#moveSpanAnnotationHandler}.
+ * </p>
+ */
+@Order(EditorAjaxRequestHandler.PRIO_ANNOTATION_HANDLER)
+public class MoveSpanAnnotationHandler
+    extends EditorAjaxRequestHandlerBase
+{
+    public static final String COMMAND = "moveSpan";
+
+    private final AnnotationSchemaService annotationService;
+
+    public MoveSpanAnnotationHandler(AnnotationSchemaService aAnnotationService)
+    {
+        annotationService = aAnnotationService;
+    }
+
+    @Override
+    public String getCommand()
+    {
+        return COMMAND;
+    }
+
+    @Override
+    public DefaultAjaxResponse handle(AjaxRequestTarget aTarget, Request aRequest)
+    {
+        try {
+            AnnotationPageBase page = getPage();
+            CAS cas = page.getEditorCas();
+            var vid = getVid(aRequest);
+            AnnotatorState state = getAnnotatorState();
+            var range = getOffsetsFromRequest(state, aRequest.getRequestParameters(), cas);
+            moveSpan(aTarget, cas, vid, range);
+            return new DefaultAjaxResponse(getAction(aRequest));
+        }
+        catch (Exception e) {
+            return handleError("Unable to move span annotation", e);
+        }
+    }
+
+    private void moveSpan(AjaxRequestTarget aTarget, CAS aCas, VID aVid, Range aRange)
+        throws IOException, AnnotationException
+    {
+        AnnotatorState state = getAnnotatorState();
+
+        SpanAdapter adapter = (SpanAdapter) annotationService
+                .getAdapter(state.getSelectedAnnotationLayer());
+
+        AnnotationFS annoFs = ICasUtil.selectAnnotationByAddr(aCas, aVid.getId());
+
+        adapter.move(state.getDocument(), state.getUser().getUsername(), aCas, annoFs,
+                aRange.getBegin(), aRange.getEnd());
+
+        // state.getSelection().selectSpan(annoFs);
+    }
+}

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/config/DiamAutoConfig.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/config/DiamAutoConfig.java
@@ -36,6 +36,7 @@ import de.tudarmstadt.ukp.inception.diam.editor.actions.FillSlotWithNewAnnotatio
 import de.tudarmstadt.ukp.inception.diam.editor.actions.ImplicitUnarmSlotHandler;
 import de.tudarmstadt.ukp.inception.diam.editor.actions.LazyDetailsHandler;
 import de.tudarmstadt.ukp.inception.diam.editor.actions.LoadAnnotationsHandler;
+import de.tudarmstadt.ukp.inception.diam.editor.actions.MoveSpanAnnotationHandler;
 import de.tudarmstadt.ukp.inception.diam.editor.actions.SelectAnnotationHandler;
 import de.tudarmstadt.ukp.inception.diam.editor.lazydetails.LazyDetailsLookupService;
 import de.tudarmstadt.ukp.inception.diam.editor.lazydetails.LazyDetailsLookupServiceImpl;
@@ -78,6 +79,13 @@ public class DiamAutoConfig
     public CreateSpanAnnotationHandler createSpanAnnotationHandler()
     {
         return new CreateSpanAnnotationHandler();
+    }
+
+    @Bean
+    public MoveSpanAnnotationHandler moveSpanAnnotationHandler(
+            AnnotationSchemaService aAnnotationService)
+    {
+        return new MoveSpanAnnotationHandler(aAnnotationService);
     }
 
     @Bean

--- a/inception/inception-diam/src/main/ts/src/diam/DiamAjaxImpl.ts
+++ b/inception/inception-diam/src/main/ts/src/diam/DiamAjaxImpl.ts
@@ -90,6 +90,20 @@ export class DiamAjaxImpl implements DiamAjax {
     })
   }
 
+  moveSpanAnnotation (id: VID, offsets: Array<Offsets>): void {
+    DiamAjaxImpl.performAjaxCall(() => {
+      Wicket.Ajax.ajax({
+        m: 'POST',
+        u: this.ajaxEndpoint,
+        ep: {
+          action: 'moveSpan',
+          id,
+          offsets: JSON.stringify(offsets)
+        }
+      })
+    })
+  }
+
   createRelationAnnotation (originSpanId: VID, targetSpanId: VID): void {
     DiamAjaxImpl.performAjaxCall(() => {
       Wicket.Ajax.ajax({

--- a/inception/inception-js-api/src/main/ts/src/diam/DiamAjax.ts
+++ b/inception/inception-js-api/src/main/ts/src/diam/DiamAjax.ts
@@ -37,6 +37,8 @@ export interface DiamAjax {
 
   createSpanAnnotation(offsets: Array<Offsets>, spanText?: string): void;
 
+  moveSpanAnnotation(id: VID, offsets: Array<Offsets>): void;
+
   createRelationAnnotation(originSpanId: VID, targetSpanId: VID): void;
 
   loadAnnotations(options?: DiamLoadAnnotationsOptions): Promise<any>;

--- a/inception/inception-js-api/src/main/ts/src/util/OffsetUtils.ts
+++ b/inception/inception-js-api/src/main/ts/src/util/OffsetUtils.ts
@@ -16,6 +16,40 @@
  * limitations under the License.
  */
 
+export function caretRangeFromPoint (clientX: number, clientY: number) : Range | null {
+  const range = document.createRange()
+
+  // @ts-expect-error
+  if (document.caretPositionFromPoint) {
+    // Use CSSOM-proprietary caretPositionFromPoint method
+    // @ts-expect-error
+    const caretPosition = document.caretPositionFromPoint(clientX, clientY)
+    if (!caretPosition) {
+      console.error(`Unable to determine caret position from point: ${clientX},${clientY}`)
+      return null
+    }
+    range.setEnd(caretPosition.offsetNode, caretPosition.offset)
+  } else if (document.caretRangeFromPoint) {
+    // Use WebKit-proprietary fallback method
+    const caretRange = document.caretRangeFromPoint(clientX, clientY)
+    if (!caretRange) return null
+    range.setEnd(caretRange.startContainer, caretRange.startOffset)
+  } else {
+    // Neither method is supported, do nothing
+    return null
+  }
+
+  range.collapse()
+  return range
+}
+
+export function positionToOffset (root: Node, clientX: number, clientY: number): number {
+  const range = caretRangeFromPoint(clientX, clientY)
+  if (!range) return -1
+  range.setStart(root, 0)
+  return range.toString().length
+}
+
 export function calculateStartOffset (root: Node, element : Node) : number {
   try {
     const range = document.createRange()


### PR DESCRIPTION
**What's in the PR**
- Introduce a new MoveSpanAnnotation action that allows changing the boundaries of a span without deleting/recreating it

**How to test manually**
* The is no (built-in) editor supporting this yet, so no way of testing

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
