### PR TITLE
#3571 - Update dependencies (27.0)

### DIFF
--- a/inception/inception-app-webapp/pom.xml
+++ b/inception/inception-app-webapp/pom.xml
@@ -656,20 +656,6 @@
       -->
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
-        <!-- 
-          - Downgrade version to avoid exception during Eclipse builds:
-          - 
-          - Execution assemble-documentation of goal 
-          - org.apache.maven.plugins:maven-assembly-plugin:3.2.0:single failed: 
-          - An API incompatibility was encountered while executing 
-          - org.apache.maven.plugins:maven-assembly-plugin:3.2.0:single: 
-          - java.lang.NoSuchMethodError: 'void org.codehaus.plexus.util.DirectoryScanner
-          -  .setFilenameComparator(java.util.Comparator)'
-          -
-          - Update 2021-05-18: Tried with assembly 3.3.0 and even tried adding plexus-utils 3.3.0
-          -                    as a direct dependency, but both didn't fix the problem.
-         -->
-        <version>3.1.1</version>
         <executions>
           <execution>
             <id>assemble-documentation</id>

--- a/inception/inception-constraints/pom.xml
+++ b/inception/inception-constraints/pom.xml
@@ -121,7 +121,6 @@
       <plugin>
         <groupId>com.helger.maven</groupId>
         <artifactId>ph-javacc-maven-plugin</artifactId>
-        <version>4.1.4</version>
         <executions>
           <execution>
             <id>default</id>

--- a/inception/inception-docker/pom.xml
+++ b/inception/inception-docker/pom.xml
@@ -49,7 +49,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-dependency-plugin</artifactId>
-            <version>3.2.0</version>
             <executions>
               <execution>
                 <id>stage-jar</id>
@@ -94,7 +93,6 @@
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>
-            <version>3.0.0</version>
             <executions>
               <execution>
                 <id>build-docker-image</id>

--- a/inception/inception-imls-external/pom.xml
+++ b/inception/inception-imls-external/pom.xml
@@ -167,7 +167,6 @@
       <plugin>
         <groupId>io.github.swagger2markup</groupId>
         <artifactId>swagger2markup-maven-plugin</artifactId>
-        <version>1.3.3</version>
         <configuration>
           <swaggerInput>${project.basedir}/src/main/resources/swagger/external_recommender.yaml</swaggerInput>
           <outputFile>${project.build.directory}/asciidoc/external_recommender_api</outputFile>

--- a/inception/inception-io-lif/pom.xml
+++ b/inception/inception-io-lif/pom.xml
@@ -23,7 +23,12 @@
     <version>27.0-SNAPSHOT</version>
   </parent>
   <artifactId>inception-io-lif</artifactId>
-  <name>INCEpTION - IO - LIF</name>
+  <name>INCEpTION - IO - LIF (deprecated)</name>
+
+  <properties>
+    <groovy.version>4.0.7</groovy.version>
+  </properties>  
+
   <dependencies>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
@@ -72,6 +77,18 @@
       <artifactId>groovy-xml</artifactId>
     </dependency>
   </dependencies>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.groovy</groupId>
+        <artifactId>groovy-bom</artifactId>
+        <version>${groovy.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <build>
     <pluginManagement>

--- a/inception/pom.xml
+++ b/inception/pom.xml
@@ -86,8 +86,6 @@
     <log4j2.version>2.18.0</log4j2.version>
     <jboss.logging.version>3.5.0.Final</jboss.logging.version>
 
-    <groovy.version>4.0.7</groovy.version>
-
     <tomcat.version>9.0.70</tomcat.version>
     <servlet-api.version>4.0.1</servlet-api.version>
 
@@ -126,7 +124,7 @@
     <jena.version>4.6.1</jena.version>
     <!-- * 4.6.1    depends on Lucene 8.11.1 -->
 
-    <asciidoctor.plugin.version>2.2.1</asciidoctor.plugin.version>
+    <asciidoctor.plugin.version>2.2.2</asciidoctor.plugin.version>
     <asciidoctor.version>2.5.7</asciidoctor.version>
     <asciidoctor-diagram.version>2.2.3</asciidoctor-diagram.version>
 
@@ -1735,16 +1733,6 @@
         <version>2.2.1</version>
       </dependency>
 
-
-      <!-- GROOVY -->
-      <dependency>
-        <groupId>org.apache.groovy</groupId>
-        <artifactId>groovy-bom</artifactId>
-        <version>${groovy.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-        
       <!-- Snakeyaml -->
       <dependency>
         <groupId>org.yaml</groupId>
@@ -2615,9 +2603,24 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>com.helger.maven</groupId>
+          <artifactId>ph-javacc-maven-plugin</artifactId>
+          <version>4.1.5</version>
+        </plugin>
+        <plugin>
+          <groupId>io.github.swagger2markup</groupId>
+          <artifactId>swagger2markup-maven-plugin</artifactId>
+          <version>1.3.7</version>
+        </plugin>
+        <plugin>
           <groupId>org.apache.rat</groupId>
           <artifactId>apache-rat-plugin</artifactId>
           <version>0.15</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>3.1.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -2645,14 +2648,6 @@
           <groupId>org.codehaus.gmaven</groupId>
           <artifactId>groovy-maven-plugin</artifactId>
           <version>2.1.1</version>
-          <dependencies>
-            <dependency>
-              <groupId>org.apache.groovy</groupId>
-              <artifactId>groovy-all</artifactId>
-              <version>${groovy.version}</version>
-              <type>pom</type>
-            </dependency>
-          </dependencies>
         </plugin>
         <plugin>
           <groupId>com.github.eirslett</groupId>
@@ -2682,17 +2677,17 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-war-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>3.3.2</version>
         </plugin>
         <plugin>
           <groupId>io.fabric8</groupId>
           <artifactId>docker-maven-plugin</artifactId>
-          <version>0.39.1</version>
+          <version>0.40.3</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>versions-maven-plugin</artifactId>
-          <version>2.10.0</version>
+          <version>2.14.2</version>
           <configuration>
             <rulesUri>file:${maven.multiModuleProjectDirectory}/inception/inception-build/src/main/resources/inception/rules.xml</rulesUri>
             <!--
@@ -2899,7 +2894,7 @@
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>build-helper-maven-plugin</artifactId>
-            <version>3.2.0</version>
+            <version>3.3.0</version>
             <executions>
               <execution>
                 <id>addToSourceFolder</id>
@@ -2939,7 +2934,7 @@
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-checkstyle-plugin</artifactId>
-              <version>3.1.2</version>
+              <version>3.2.0</version>
               <inherited>true</inherited>
               <dependencies>
                 <dependency>


### PR DESCRIPTION
**What's in the PR**
- groovy -> removed (actually scoped to lif module which is no longer part of the final JAR)
- asciidoctor 2.2.1 -> 2.2.2
- ph-javacc-maven-plugin 4.1.4 -> 4.1.5
- swagger2markup-maven-plugin 1.3.3 -> 1.3.7
- exec-maven-plugin 3.0.0 -> 3.1.0
- maven-war-plugin 3.1.0 -> 3.3.2
- docker-maven-plugin 0.39.1 -> 0.40.4
- versions-maven-plugin 2.10.0 -> 2.14.2
- build-helper-maven-plugin 3.2.0 -> 3.3.0
- maven-checkstyle-plugin 3.1.2 -> 3.2.0

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
