### PR TITLE
#3725 - Importing broken TSV file may give unhelpful error message

### DIFF
--- a/inception/inception-io-webanno-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/internal/tsv3x/Tsv3XDeserializer.java
+++ b/inception/inception-io-webanno-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/internal/tsv3x/Tsv3XDeserializer.java
@@ -381,7 +381,7 @@ public class Tsv3XDeserializer
                 else {
                     fields = splitPreserveAllTokens(line, FIELD_SEPARATOR);
                     int expectedFieldCount = headerColumns.size() + 3;
-                    if (fields.length != expectedFieldCount) {
+                    if (fields.length < expectedFieldCount) {
                         throw new IOException("Unable to parse line [" + lineNo + "] as [" + state
                                 + "]: [" + line + "] - expected [" + expectedFieldCount
                                 + "] fields but only found [" + fields.length + "]");

--- a/inception/inception-io-webanno-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/internal/tsv3x/Tsv3XDeserializer.java
+++ b/inception/inception-io-webanno-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/internal/tsv3x/Tsv3XDeserializer.java
@@ -356,6 +356,7 @@ public class Tsv3XDeserializer
         List<TsvColumn> headerColumns = aDoc.getSchema()
                 .getHeaderColumns(aDoc.getSchema().getColumns());
 
+        int lineNo = 1;
         String line = aIn.readLine();
         try {
             while (!Tsv3XParserState.END.equals(state)) {
@@ -379,6 +380,12 @@ public class Tsv3XDeserializer
                 }
                 else {
                     fields = splitPreserveAllTokens(line, FIELD_SEPARATOR);
+                    int expectedFieldCount = headerColumns.size() + 3;
+                    if (fields.length != expectedFieldCount) {
+                        throw new IOException("Unable to parse line [" + lineNo + "] as [" + state
+                                + "]: [" + line + "] - expected [" + expectedFieldCount
+                                + "] fields but only found [" + fields.length + "]");
+                    }
 
                     // Get token metadata
                     id = fields[0];
@@ -495,6 +502,7 @@ public class Tsv3XDeserializer
 
                 prevState = state;
                 line = aIn.readLine();
+                lineNo++;
             }
 
             aDoc.getJCas().setDocumentText(text.toString());
@@ -519,8 +527,12 @@ public class Tsv3XDeserializer
             }
             fses.forEach(cas::addFsToIndexes);
         }
+        catch (IOException e) {
+            throw e;
+        }
         catch (Exception e) {
-            throw new IOException("Unable to parse line as [" + state + "]: [" + line + "]", e);
+            throw new IOException(
+                    "Unable to parse line [" + lineNo + "] as [" + state + "]: [" + line + "]", e);
         }
     }
 


### PR DESCRIPTION
**What's in the PR**
- Add better error message if number of fields in a line is wrong
- If the error is not an IOException, do not chain the cause and instead give a message saying at which point the error occurs and include the error message of the cause

**How to test manually**
* Try importing a broken TSV file

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
