### PR TITLE
#3703 - Concept feature editor tooltips no longer work

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/misc/ReorderableTagAutoCompleteField.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/misc/ReorderableTagAutoCompleteField.java
@@ -80,6 +80,9 @@ public class ReorderableTagAutoCompleteField
         aBehavior.setOption("animation", false);
         aBehavior.setOption("footerTemplate",
                 Options.asString("#: instance.dataSource.total() # items found"));
+        aBehavior.setOption("open", KendoChoiceDescriptionScriptReference.applyTooltipScript());
+        aBehavior.setOption("dataBound",
+                KendoChoiceDescriptionScriptReference.applyTooltipScript());
 
         KendoStyleUtils.keepDropdownVisibleWhenScrolling(aBehavior);
         KendoStyleUtils.autoDropdownHeight(aBehavior);

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiSelectTextFeatureEditor.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiSelectTextFeatureEditor.java
@@ -20,12 +20,14 @@ package de.tudarmstadt.ukp.inception.annotation.feature.multistring;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.startsWithIgnoreCase;
+import static org.apache.wicket.markup.head.JavaScriptHeaderItem.forReference;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
 import org.apache.wicket.MarkupContainer;
+import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.html.form.FormComponent;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
@@ -137,6 +139,14 @@ public class MultiSelectTextFeatureEditor
             private static final long serialVersionUID = 7769511105678209462L;
 
             @Override
+            public void renderHead(IHeaderResponse aResponse)
+            {
+                super.renderHead(aResponse);
+
+                aResponse.render(forReference(KendoChoiceDescriptionScriptReference.get()));
+            }
+
+            @Override
             protected List<ReorderableTag> getChoices(String aInput)
             {
                 return MultiSelectTextFeatureEditor.this
@@ -182,6 +192,9 @@ public class MultiSelectTextFeatureEditor
         aBehavior.setOption("animation", false);
         aBehavior.setOption("delay", 250);
         aBehavior.setOption("height", 300);
+        aBehavior.setOption("open", KendoChoiceDescriptionScriptReference.applyTooltipScript());
+        aBehavior.setOption("dataBound",
+                KendoChoiceDescriptionScriptReference.applyTooltipScript());
     }
 
     @SuppressWarnings("rawtypes")

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/KendoChoiceDescriptionScriptReference.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/KendoChoiceDescriptionScriptReference.java
@@ -66,6 +66,11 @@ public class KendoChoiceDescriptionScriptReference
         return dependencies;
     }
 
+    public static String applyTooltipScript()
+    {
+        return "(evt) => { applyTooltip(evt.sender.list) }";
+    }
+
     public static IJQueryTemplate template()
     {
         return new IJQueryTemplate()
@@ -75,12 +80,11 @@ public class KendoChoiceDescriptionScriptReference
             @Override
             public String getText()
             {
-                // Some docs on how the templates work in Kendo, in case we need
-                // more fancy dropdowns
-                // http://docs.telerik.com/kendo-ui/framework/templates/overview
-                return "<div title=\"#: data.description #\" "
-                        + "onmouseover=\"javascript:applyTooltip(this)\">"
-                        + "#: data.name #</div>\n";
+                StringBuilder sb = new StringBuilder();
+                sb.append("<span class='item-title' title='#: data.description #'>");
+                sb.append("${ data.name }");
+                sb.append("</span>");
+                return sb.toString();
             }
 
             @Override
@@ -104,7 +108,7 @@ public class KendoChoiceDescriptionScriptReference
                 // http://docs.telerik.com/kendo-ui/framework/templates/overview
                 // @formatter:off
                 StringBuilder sb = new StringBuilder();
-                sb.append("<span title='#: data.description #' onmouseover='javascript:applyTooltip(this)'>");
+                sb.append("<span class='item-title' title='#: data.description #'>");
                 sb.append("# if (data.reordered == 'true') { #");
                 sb.append("<b>${data.name}</b>");
                 sb.append("# } else { #");

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/KendoChoiceDescriptionScriptReference.js
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/KendoChoiceDescriptionScriptReference.js
@@ -39,7 +39,7 @@ function applyTooltip(aElement) {
           return html;
         }
       });
-      setTimeout(function() { $(aElement).tooltip().mouseover();; }, 0);
+      setTimeout(function() { $(aElement).tooltip().mouseover(); }, 0);
     }
   }
   catch (e) {

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/KendoComboboxTextFeatureEditor.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/KendoComboboxTextFeatureEditor.java
@@ -136,6 +136,8 @@ public class KendoComboboxTextFeatureEditor
                 super.onConfigure(aBehavior);
                 aBehavior.setOption("animation", false);
                 aBehavior.setOption("delay", 0);
+                aBehavior.setOption("open",
+                        KendoChoiceDescriptionScriptReference.applyTooltipScript());
             }
 
             @Override

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/MultiValueConceptFeatureEditor.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/MultiValueConceptFeatureEditor.java
@@ -27,7 +27,6 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 
 import com.googlecode.wicket.jquery.core.JQueryBehavior;
-import com.googlecode.wicket.jquery.core.Options;
 import com.googlecode.wicket.jquery.core.template.IJQueryTemplate;
 import com.googlecode.wicket.kendo.ui.form.multiselect.lazy.MultiSelect;
 import com.googlecode.wicket.kendo.ui.renderer.ChoiceRenderer;
@@ -189,12 +188,6 @@ public class MultiValueConceptFeatureEditor
             // aBehavior.setOption("autoBind", false);
             // aBehavior.setOption("minLength", 1);
             // aBehavior.setOption("enforceMinLength", true);
-
-            aBehavior.setOption("tagTemplate",
-                    Options.asString(
-                            "<span title=\"#: data.description + '\\n\\n' + data.identifier #\" "
-                                    + "onmouseover=\"javascript:applyTooltip(this)\">"
-                                    + "#: data.uiLabel #</span>\n"));
         }
 
         @Override


### PR DESCRIPTION
**What's in the PR**
* Switch to a way of initializing the tooltips that does not require inline script

**How to test manually**
* Try various feature editors which come with tooltips (single-/multi-value string, single-/multi-value concept)

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
