### PR TITLE
#3729 - Project permissions for project-bound users of foreign project might be created

### DIFF
--- a/inception/inception-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/export/ProjectImportRequest.java
+++ b/inception/inception-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/export/ProjectImportRequest.java
@@ -39,6 +39,13 @@ public class ProjectImportRequest
     private final boolean importPermissions;
     private final User manager;
 
+    private ProjectImportRequest(Builder builder)
+    {
+        this.createMissingUsers = builder.createMissingUsers;
+        this.importPermissions = builder.importPermissions;
+        this.manager = builder.manager;
+    }
+
     /**
      * Request the import of a project, optionally creating any users referenced in the project but
      * missing in the current instance.
@@ -95,5 +102,44 @@ public class ProjectImportRequest
     public Optional<User> getManager()
     {
         return Optional.ofNullable(manager);
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static final class Builder
+    {
+        private boolean createMissingUsers;
+        private boolean importPermissions;
+        private User manager;
+
+        private Builder()
+        {
+        }
+
+        public Builder withCreateMissingUsers(boolean aCreateMissingUsers)
+        {
+            this.createMissingUsers = aCreateMissingUsers;
+            return this;
+        }
+
+        public Builder withImportPermissions(boolean aImportPermissions)
+        {
+            this.importPermissions = aImportPermissions;
+            return this;
+        }
+
+        public Builder withManager(User aManager)
+        {
+            this.manager = aManager;
+            return this;
+        }
+
+        public ProjectImportRequest build()
+        {
+            return new ProjectImportRequest(this);
+        }
     }
 }

--- a/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/Project.java
+++ b/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/Project.java
@@ -69,6 +69,9 @@ public class Project
     @Column(length = 64000)
     private String description;
 
+    /**
+     * @deprecated WebAnno supported project modes - INCEpTION does not.
+     */
     @Deprecated
     @Column(nullable = false)
     private String mode = "annotation";
@@ -96,6 +99,21 @@ public class Project
 
     @Column(nullable = false)
     private boolean anonymousCuration;
+
+    private Project(Builder builder)
+    {
+        this.id = builder.id;
+        this.name = builder.name;
+        this.slug = builder.slug;
+        this.description = builder.description;
+        this.version = builder.version;
+        this.disableExport = builder.disableExport;
+        this.scriptDirection = builder.scriptDirection;
+        this.created = builder.created;
+        this.updated = builder.updated;
+        this.state = builder.state;
+        this.anonymousCuration = builder.anonymousCuration;
+    }
 
     public Project()
     {
@@ -196,12 +214,18 @@ public class Project
         this.scriptDirection = scriptDirection;
     }
 
+    /**
+     * @deprecated WebAnno supported project modes - INCEpTION does not.
+     */
     @Deprecated
     public String getMode()
     {
         return mode;
     }
 
+    /**
+     * @deprecated WebAnno supported project modes - INCEpTION does not.
+     */
     @Deprecated
     public void setMode(String aMode)
     {
@@ -351,5 +375,100 @@ public class Project
     {
         return ('0' <= aChar && aChar <= '9') || ('a' <= aChar && aChar <= 'z') || aChar == '-'
                 || aChar == '_';
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static final class Builder
+    {
+        private Long id;
+        private String name;
+        private String slug;
+        private String description;
+        private int version = 1;
+        private boolean disableExport = false;
+        private ScriptDirection scriptDirection;
+        private Date created;
+        private Date updated;
+        private ProjectState state;
+        private boolean anonymousCuration;
+
+        private Builder()
+        {
+        }
+
+        public Builder withId(Long aId)
+        {
+            id = aId;
+            return this;
+        }
+
+        public Builder withName(String aName)
+        {
+            name = aName;
+            return this;
+        }
+
+        public Builder withSlug(String aSlug)
+        {
+            slug = aSlug;
+            return this;
+        }
+
+        public Builder withDescription(String aDescription)
+        {
+            description = aDescription;
+            return this;
+        }
+
+        public Builder withVersion(int aVersion)
+        {
+            version = aVersion;
+            return this;
+        }
+
+        public Builder withDisableExport(boolean aDisableExport)
+        {
+            disableExport = aDisableExport;
+            return this;
+        }
+
+        public Builder withScriptDirection(ScriptDirection aScriptDirection)
+        {
+            scriptDirection = aScriptDirection;
+            return this;
+        }
+
+        public Builder withCreated(Date aCreated)
+        {
+            created = aCreated;
+            return this;
+        }
+
+        public Builder withUpdated(Date aUpdated)
+        {
+            updated = aUpdated;
+            return this;
+        }
+
+        public Builder withState(ProjectState aState)
+        {
+            state = aState;
+            return this;
+        }
+
+        public Builder withAnonymousCuration(boolean aAnonymousCuration)
+        {
+            anonymousCuration = aAnonymousCuration;
+            return this;
+        }
+
+        public Project build()
+        {
+            return new Project(this);
+        }
     }
 }


### PR DESCRIPTION
**What's in the PR**
- Added more unit tests to user and permission import
- Added builders to some data classes
- Make sure that no permissions are created for project-bound users that could not be created during import

**How to test manually**
* See issue description

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
