### PR TITLE
#3742 - Feature editors do show multi value lists in locked documents for multilabel String features which looks bad

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiSelectTextFeatureEditor.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiSelectTextFeatureEditor.java
@@ -120,6 +120,14 @@ public class MultiSelectTextFeatureEditor
             private static final long serialVersionUID = 1L;
 
             @Override
+            public void renderHead(IHeaderResponse aResponse)
+            {
+                super.renderHead(aResponse);
+
+                aResponse.render(forReference(KendoChoiceDescriptionScriptReference.get()));
+            }
+
+            @Override
             public void onConfigure(JQueryBehavior aBehavior)
             {
                 super.onConfigure(aBehavior);


### PR DESCRIPTION
**What's in the PR**
- Add missing JS reference

**How to test manually**
* See issue

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
