### PR TITLE
#3747 - Tooltip with longer text on annotations truncated in sidebar

### DIFF
--- a/inception/inception-diam-editor/src/main/ts/src/SpanText.svelte
+++ b/inception/inception-diam-editor/src/main/ts/src/SpanText.svelte
@@ -24,13 +24,15 @@
 
     $: begin = span.offsets[0][0]
     $: end = span.offsets[0][1]
-    $: text = data.text.substring(begin, end).trim()
+    $: text = data.text.substring(begin, end).trim().replace(/\s+/g, ' ')
 </script>
 
 {#if text.length === 0}
 <span class="text-muted">(empty span)</span>
+{:else if text.length > 50}
+<span title="{text.substring(0,1000)}">{text.substring(0, 50)}</span><span class="text-muted">…</span>
 {:else}
-<span>{text.substring(0, 50)+(text.length > 50 ? '…' : '')}</span>
+<span>{text}</span>
 {/if}
 
 <style>


### PR DESCRIPTION
**What's in the PR**
- Display a tooltip for long annotations when hovering with the mouse over the covered text in the annotation sidebar

**How to test manually**
* Create a long annotation > 50 characters
* Open the annotation sidebar
* Hover with the mouse over the covered text
* See tooltip

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation

**Demo**

https://user-images.githubusercontent.com/1410238/214902328-86dca391-c862-4ea2-b4d3-f38b127bb2a1.mp4


