### PR TITLE
#3752 - Section headers in annotation sidebar are above modal backdrop

### DIFF
--- a/inception/inception-bootstrap/src/main/ts/bootstrap/shim-wicket.scss
+++ b/inception/inception-bootstrap/src/main/ts/bootstrap/shim-wicket.scss
@@ -23,3 +23,8 @@ a.tree-junction {
 .modal-dialog .modal-dialog-content {
   font-size: initial;
 }
+
+.dialog-theme-default .modal-dialog-overlay {
+  // z-index 1020 is in Bootstrap's .sticky-top and we need to be above that
+  z-index: 1030;
+}


### PR DESCRIPTION
**What's in the PR**
- Slightly increase the z-index of the modal backdrop

**How to test manually**
* See issue

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
