### PR TITLE
#3749 - Delete annotation from annotation sidebar

### DIFF
--- a/inception/inception-diam-editor/src/main/ts/src/AnnotationsByLabelList.svelte
+++ b/inception/inception-diam-editor/src/main/ts/src/AnnotationsByLabelList.svelte
@@ -44,8 +44,21 @@
     function scrollToRelation (relation: Relation) {
         ajaxClient.scrollTo({ id: relation.vid });
     }
+
+    function handleDelete (ev: MouseEvent) {
+      ajaxClient.deleteAnnotation(annotation.vid)
+    }
 </script>
 
+{#if !data}
+<div class="mt-5 d-flex flex-column justify-content-center">
+    <div class="d-flex flex-row justify-content-center">
+        <div class="spinner-border text-muted" role="status">
+            <span class="sr-only">Loading...</span>
+        </div>
+    </div>
+</div>
+{:else}
 <div class="flex-content fit-child-snug">
     {#if sortedLabels || sortedLabels?.length}
         <ul class="scrolling flex-content list-group list-group-flush">
@@ -66,6 +79,9 @@
                                 <div class="flex-grow-1 py-1 px-2" on:click={() => scrollToSpan(span)}>
                                     <div class="float-end">
                                         <LabelBadge annotation={span} {ajaxClient} showText={false} />
+                                        <button class="btn btn-outline-danger border border-0 btn-sm ms-1 fw-normal" on:click={handleDelete} title="Delete">
+                                            <i class="fas fa-times"></i>
+                                        </button>
                                     </div>
                 
                                     <SpanText {data} span={span} />
@@ -81,6 +97,9 @@
                                 <div class="flex-grow-1 py-1 px-2" on:click={() => scrollToRelation(relation)}>
                                     <div class="float-end">
                                         <LabelBadge annotation={relation} {ajaxClient} showText={false} />
+                                        <button class="btn btn-outline-danger border border-0 btn-sm ms-1 fw-normal" on:click={handleDelete} title="Delete">
+                                            <i class="fas fa-times"></i>
+                                        </button>
                                     </div>
 
                                     <SpanText {data} span={relation.arguments[0].target} />
@@ -93,6 +112,7 @@
         </ul>
     {/if}
 </div>
+{/if}
 
 <style lang="scss">
     .annotation-type-marker {

--- a/inception/inception-diam-editor/src/main/ts/src/AnnotationsByPositionList.svelte
+++ b/inception/inception-diam-editor/src/main/ts/src/AnnotationsByPositionList.svelte
@@ -45,8 +45,21 @@
     function scrollToRelation (relation: Relation) {
         ajaxClient.scrollTo({ id: relation.vid });
     }
+
+    function handleDelete (ev: MouseEvent) {
+      ajaxClient.deleteAnnotation(annotation.vid)
+    }
 </script>
 
+{#if !data}
+<div class="mt-5 d-flex flex-column justify-content-center">
+    <div class="d-flex flex-row justify-content-center">
+        <div class="spinner-border text-muted" role="status">
+            <span class="sr-only">Loading...</span>
+        </div>
+    </div>
+</div>
+{:else}
 <div class="flex-content fit-child-snug">
     {#if sortedSpanOffsets || sortedSpanOffsets?.length}
         <ul class="scrolling flex-content list-group list-group-flush">
@@ -60,6 +73,9 @@
                             {#each spans as span}
                                 <LabelBadge annotation={span} {ajaxClient} />
                             {/each}
+                            <button class="btn btn-outline-danger border border-0 btn-sm ms-1 fw-normal" on:click={handleDelete} title="Delete">
+                                <i class="fas fa-times"></i>
+                            </button>
                         </div>
                         <SpanText {data} span={firstSpan} />
                     </div>
@@ -77,6 +93,9 @@
                             <div class="flex-grow-1 py-1 px-2" on:click={() => scrollToRelation(relation)}>
                                 <div class="float-end">
                                     <LabelBadge annotation={relation} {ajaxClient} />
+                                    <button class="btn btn-outline-danger border border-0 btn-sm ms-1 fw-normal" on:click={handleDelete} title="Delete">
+                                        <i class="fas fa-times"></i>
+                                    </button>
                                 </div>
 
                                 <SpanText {data} span={target} />
@@ -88,6 +107,7 @@
         </ul>
     {/if}
 </div>
+{/if}
 
 <style lang="scss">
 </style>


### PR DESCRIPTION
**What's in the PR**
- Added ability to delete annotation from sidebar
- Added animated placeholder while annotations in the sidebar are still loading

**How to test manually**
* Try deleting an annotation from the left sidebar, in particular try one that has relations attached to see if the confirmation dialog also pops up

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation

**Demo**

![Annotation_sidebar](https://user-images.githubusercontent.com/1410238/215137387-df991313-e437-449d-b019-90ba715e3365.png)
