### PR TITLE
#3728 - Allow opening URL feature values in new browser window

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/InputFieldStringFeatureEditor.html
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/InputFieldStringFeatureEditor.html
@@ -22,11 +22,14 @@
     <label wicket:for="value" wicket:enclosure="feature" class="feature-editor-label col-form-label">
       <span wicket:id="feature"/>
       <span class="float-end">
-        <span wicket:id="textIndicator"></span>
+        <span wicket:id="textIndicator"/>
       </span>
+      <a wicket:id="openIri" class="float-end" target="_blank">
+        <i class="fas fa-external-link-alt"/>
+      </a>
     </label>
     <div class="feature-editor-value">
-      <input wicket:id="value" class="form-control col-sm-12"></input>
+      <input class="flex-content" wicket:id="value" type="text"/>
       <div wicket:id="keyBindings" class="col-sm-12"/>
     </div>
   </div>

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/InputFieldStringFeatureEditor.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/InputFieldStringFeatureEditor.java
@@ -21,21 +21,27 @@ import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.vi
 
 import org.apache.wicket.MarkupContainer;
 import org.apache.wicket.markup.html.form.AbstractTextComponent;
+import org.apache.wicket.markup.html.link.ExternalLink;
 import org.apache.wicket.model.IModel;
+import org.apache.wicket.validation.validator.UrlValidator;
 
 import com.googlecode.wicket.kendo.ui.form.TextField;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.keybindings.KeyBindingsPanel;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxFormComponentUpdatingBehavior;
 import de.tudarmstadt.ukp.inception.editor.action.AnnotationActionHandler;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.FeatureState;
 
-public class InputFieldTextFeatureEditor
+public class InputFieldStringFeatureEditor
     extends TextFeatureEditorBase
 {
     private static final long serialVersionUID = 8686646370500180943L;
 
-    public InputFieldTextFeatureEditor(String aId, MarkupContainer aItem,
+    private ExternalLink openIri;
+    private UrlValidator urlValidator = new UrlValidator(new String[] { "http", "https" });
+
+    public InputFieldStringFeatureEditor(String aId, MarkupContainer aItem,
             IModel<FeatureState> aModel, AnnotationActionHandler aHandler)
     {
         super(aId, aItem, aModel);
@@ -43,9 +49,16 @@ public class InputFieldTextFeatureEditor
         AnnotationFeature feat = getModelObject().feature;
         StringFeatureTraits traits = readFeatureTraits(feat);
 
+        var featureValueAsString = aModel.map(FeatureState::getValue).map(Object::toString);
+
+        openIri = new ExternalLink("openIri", featureValueAsString);
+        openIri.add(visibleWhen(featureValueAsString.map(urlValidator::isValid)));
+        openIri.setOutputMarkupPlaceholderTag(true);
+        queue(openIri);
+
         add(new KeyBindingsPanel("keyBindings", () -> traits.getKeyBindings(), aModel, aHandler)
                 // The key bindings are only visible when the label is also enabled, i.e. when the
-                // editor is used in a "normal" context and not e.g. in the keybindings
+                // editor is used in a "normal" context and not e.g. in the key bindings
                 // configuration panel
                 .add(visibleWhen(() -> getLabelComponent().isVisible())));
     }
@@ -54,6 +67,11 @@ public class InputFieldTextFeatureEditor
     @Override
     protected AbstractTextComponent createInputField()
     {
-        return new TextField<>("value");
+
+        var textField = new TextField<>("value");
+        textField.add(new LambdaAjaxFormComponentUpdatingBehavior("change", t -> {
+            t.add(openIri);
+        }));
+        return textField;
     }
 }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/StringFeatureSupport.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/StringFeatureSupport.java
@@ -152,7 +152,7 @@ public class StringFeatureSupport
             }
             else {
                 // Otherwise use a simple input field
-                return new InputFieldTextFeatureEditor(aId, aOwner, aFeatureStateModel, aHandler);
+                return new InputFieldStringFeatureEditor(aId, aOwner, aFeatureStateModel, aHandler);
             }
         }
 

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/IriInfoBadge.html
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/IriInfoBadge.html
@@ -19,7 +19,7 @@
 <html xmlns:wicket="http://wicket.apache.org">
 <body>
   <wicket:panel>
-    <span wicket:id="iri" class="fas fa-info-circle"></span>
+    <button wicket:id="iri" class="btn btn-link p-0 text-reset"><i class="fas fa-info-circle"/></button>
   </wicket:panel>
 </body>
 </html>

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/IriInfoBadge.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/IriInfoBadge.java
@@ -57,4 +57,9 @@ public class IriInfoBadge
     {
         return (String) getDefaultModelObject();
     }
+
+    public IModel<String> getModel()
+    {
+        return (IModel<String>) getDefaultModel();
+    }
 }

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureEditor.html
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureEditor.html
@@ -24,14 +24,14 @@
       <span class="float-end">
         <span wicket:id="disabledKBWarning"/>
       </span>
+      <a wicket:id="openIri" class="float-end" target="_blank">
+        <i class="fas fa-external-link-alt"/>
+      </a>
     </label>
     <div class="feature-editor-value">
       <div class="input-group">
         <div class="input-group-text">
-          <span wicket:id="iriInfoBadge" class="me-2"/>
-          <a wicket:id="openIri" target="_blank">
-            <i class="fas fa-external-link-alt"></i>
-          </a>
+          <span wicket:id="iriInfoBadge"/>
         </div>
         <input class="flex-content" wicket:id="value" type="text"/>
       </div>

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureEditor.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureEditor.java
@@ -43,6 +43,7 @@ import org.apache.wicket.request.http.WebRequest;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.apache.wicket.util.convert.IConverter;
 import org.apache.wicket.util.string.StringValue;
+import org.apache.wicket.validation.validator.UrlValidator;
 import org.danekja.java.util.function.serializable.SerializableFunction;
 import org.wicketstuff.event.annotation.OnEvent;
 
@@ -76,6 +77,7 @@ public class ConceptFeatureEditor
     private Label description;
     private IriInfoBadge iriBadge;
     private ExternalLink openIriLink;
+    private UrlValidator urlValidator = new UrlValidator(new String[] { "http", "https" });
 
     public ConceptFeatureEditor(String aId, MarkupContainer aItem, IModel<FeatureState> aModel,
             IModel<AnnotatorState> aStateModel, AnnotationActionHandler aHandler)
@@ -89,7 +91,7 @@ public class ConceptFeatureEditor
 
         iriBadge = new IriInfoBadge("iriInfoBadge", iriModel);
         iriBadge.setOutputMarkupPlaceholderTag(true);
-        iriBadge.add(visibleWhen(() -> isNotBlank(iriBadge.getModelObject())));
+        iriBadge.add(visibleWhen(iriBadge.getModel().map(urlValidator::isValid)));
         add(iriBadge);
 
         openIriLink = new ExternalLink("openIri", iriModel);


### PR DESCRIPTION
**What's in the PR**
- If a string feature value in a single-value string feature editor without a tagset is a valid URL (http or https), a button appears to open that URL in a new window
- Also apply this design to the concept feature editor

**How to test manually**
* Create a string feature without a tagset
* Create annotation with that feature and enter an URL into it
* Try linking a concept feature to a concept that has a valid URL as its IRI

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation

**Demo**

<img width="526" alt="string-no-url" src="https://user-images.githubusercontent.com/1410238/215320979-9fb9f976-1f87-4522-a474-bdab8f86a5bd.png">
<img width="524" alt="string-url" src="https://user-images.githubusercontent.com/1410238/215320980-4c713a34-061f-4fba-bf99-2b566fd5c3dc.png">
<img width="341" alt="concept-feature-url" src="https://user-images.githubusercontent.com/1410238/215320982-fbcc8a1a-de4d-4c13-a18d-6359ab9bae4e.png">
