### PR TITLE
#3765 - Support for namespaces in SanitizingContentHandler

### DIFF
--- a/inception/inception-io-xml/pom.xml
+++ b/inception/inception-io-xml/pom.xml
@@ -73,5 +73,11 @@
       <groupId>org.dkpro.core</groupId>
       <artifactId>dkpro-core-api-resources-asl</artifactId>
     </dependency>
+    
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/inception/inception-io-xml/src/test/java/de/tudarmstadt/ukp/inception/io/xml/dkprocore/Cas2SaxEventsTest.java
+++ b/inception/inception-io-xml/src/test/java/de/tudarmstadt/ukp/inception/io/xml/dkprocore/Cas2SaxEventsTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.io.xml.dkprocore;
+
+import static org.apache.uima.fit.util.FSCollectionFactory.createFSArray;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.StringWriter;
+
+import org.apache.uima.fit.factory.JCasFactory;
+import org.apache.uima.jcas.JCas;
+import org.dkpro.core.api.xml.type.XmlAttribute;
+import org.dkpro.core.api.xml.type.XmlDocument;
+import org.dkpro.core.api.xml.type.XmlElement;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import de.tudarmstadt.ukp.inception.support.xml.XmlEventLoggingFilter;
+import de.tudarmstadt.ukp.inception.support.xml.XmlParserUtils;
+
+class Cas2SaxEventsTest
+{
+    private JCas jcas;
+    private StringWriter out;
+    private Cas2SaxEvents sut;
+    private XmlEventLoggingFilter loggingFilter;
+
+    @BeforeEach
+    void setup() throws Exception
+    {
+        jcas = JCasFactory.createJCas();
+        out = new StringWriter();
+        loggingFilter = new XmlEventLoggingFilter(XmlParserUtils.makeXmlSerializer(out));
+        sut = new Cas2SaxEvents(loggingFilter);
+    }
+
+    @Test
+    void testWithDefaultNamespace() throws Exception
+    {
+        jcas.setDocumentText("");
+
+        var root = new XmlElement(jcas, 0, 0);
+        var rootAttrXmlns = new XmlAttribute(jcas);
+        rootAttrXmlns.setLocalName("xmlns");
+        rootAttrXmlns.setQName("xmlns");
+        rootAttrXmlns.setValue("http://namespace.org");
+        root.setAttributes(createFSArray(jcas, rootAttrXmlns));
+        root.setQName("root");
+        jcas.addFsToIndexes(root);
+
+        var doc = new XmlDocument(jcas, 0, 0);
+        doc.setRoot(root);
+        jcas.addFsToIndexes(doc);
+
+        sut.setNamespaces(false);
+        sut.process(jcas);
+
+        assertThat(out.toString()).isEqualTo("<root xmlns=\"http://namespace.org\"/>");
+        assertThat(loggingFilter.getEvents()).containsExactly( //
+                "[START-DOCUMENT]", //
+                "[START-ELEMENT [root] {}[]] [[xmlns]{}[xmlns]]=[http://namespace.org]", //
+                "[END-ELEMENT [root] {}[]]", //
+                "[END-DOCUMENT]");
+    }
+
+    @Test
+    void testWithPrefixedNamespace() throws Exception
+    {
+        var root = new XmlElement(jcas, 0, 0);
+        var rootAttrXmlns = new XmlAttribute(jcas);
+        rootAttrXmlns.setLocalName("xmlns:ns");
+        rootAttrXmlns.setQName("xmlns:ns");
+        rootAttrXmlns.setValue("http://namespace.org");
+        root.setAttributes(createFSArray(jcas, rootAttrXmlns));
+        root.setQName("ns:root");
+        jcas.addFsToIndexes(root);
+
+        var doc = new XmlDocument(jcas, 0, 0);
+        doc.setRoot(root);
+        jcas.addFsToIndexes(doc);
+
+        sut.setNamespaces(false);
+        sut.process(jcas);
+
+        assertThat(out.toString()).isEqualTo("<ns:root xmlns:ns=\"http://namespace.org\"/>");
+        assertThat(loggingFilter.getEvents()).containsExactly( //
+                "[START-DOCUMENT]", //
+                "[START-ELEMENT [ns:root] {}[]] [[xmlns:ns]{}[xmlns:ns]]=[http://namespace.org]", //
+                "[END-ELEMENT [ns:root] {}[]]", //
+                "[END-DOCUMENT]");
+    }
+
+    @Test
+    void testWithPrefixedNamespace_NS_enabled() throws Exception
+    {
+        var root = new XmlElement(jcas, 0, 0);
+        var rootAttrXmlns = new XmlAttribute(jcas);
+        rootAttrXmlns.setLocalName("ns");
+        rootAttrXmlns.setQName("xmlns:ns");
+        rootAttrXmlns.setValue("http://namespace.org");
+        root.setAttributes(createFSArray(jcas, rootAttrXmlns));
+        root.setUri("http://namespace.org");
+        root.setLocalName("root");
+        root.setQName("ns:root");
+        jcas.addFsToIndexes(root);
+
+        var doc = new XmlDocument(jcas, 0, 0);
+        doc.setRoot(root);
+        jcas.addFsToIndexes(doc);
+
+        sut.setNamespaces(true);
+        sut.process(jcas);
+
+        assertThat(out.toString()).isEqualTo("<ns:root xmlns:ns=\"http://namespace.org\"/>");
+        assertThat(loggingFilter.getEvents()).containsExactly( //
+                "[START-DOCUMENT]", //
+                "[START-PREFIX-MAPPING [ns] -> http://namespace.org]", //
+                "[START-ELEMENT [ns:root] {http://namespace.org}[root]] [[xmlns:ns]{}[ns]]=[http://namespace.org]", //
+                "[END-ELEMENT [ns:root] {http://namespace.org}[root]]", //
+                "[END-PREFIX-MAPPING [ns]]", //
+                "[END-DOCUMENT]");
+    }
+}

--- a/inception/inception-io-xml/src/test/java/de/tudarmstadt/ukp/inception/io/xml/dkprocore/CasXmlHandlerTest.java
+++ b/inception/inception-io-xml/src/test/java/de/tudarmstadt/ukp/inception/io/xml/dkprocore/CasXmlHandlerTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.io.xml.dkprocore;
+
+import static de.tudarmstadt.ukp.inception.support.xml.XmlParserUtils.enableNamespaceSupport;
+import static de.tudarmstadt.ukp.inception.support.xml.XmlParserUtils.newSaxParser;
+import static de.tudarmstadt.ukp.inception.support.xml.XmlParserUtils.newSaxParserFactory;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.commons.io.IOUtils.toInputStream;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import javax.xml.parsers.SAXParser;
+
+import org.apache.uima.fit.factory.JCasFactory;
+import org.apache.uima.jcas.JCas;
+import org.dkpro.core.api.xml.type.XmlAttribute;
+import org.dkpro.core.api.xml.type.XmlDocument;
+import org.dkpro.core.api.xml.type.XmlElement;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import de.tudarmstadt.ukp.inception.support.xml.XmlParserUtils;
+
+public class CasXmlHandlerTest
+{
+    private JCas jcas;
+    private CasXmlHandler sut;
+
+    @BeforeEach
+    void setup() throws Exception
+    {
+        jcas = JCasFactory.createJCas();
+        sut = new CasXmlHandler(jcas);
+    }
+
+    @Test
+    void testWithDefaultNamespace() throws Exception
+    {
+        String xml = "<root xmlns='http://namespace.org'/>";
+
+        SAXParser parser = XmlParserUtils.newSaxParser();
+        parser.parse(toInputStream(xml, UTF_8), sut);
+
+        assertThat(jcas.select(XmlElement.class).asList()) //
+                .extracting(XmlElement::getUri, XmlElement::getLocalName, XmlElement::getQName) //
+                .containsExactly(tuple(null, null, "root"));
+        assertThat(jcas.select(XmlDocument.class).get().getRoot().getAttributes()) //
+                .extracting(XmlAttribute::getUri, XmlAttribute::getLocalName,
+                        XmlAttribute::getQName, XmlAttribute::getValue) //
+                .containsExactly(tuple(null, "xmlns", "xmlns", "http://namespace.org"));
+    }
+
+    @Test
+    void testWithPrefixedNamespace() throws Exception
+    {
+        String xml = "<ns:root xmlns:ns='http://namespace.org'/>";
+
+        SAXParser parser = XmlParserUtils.newSaxParser();
+        parser.parse(toInputStream(xml, UTF_8), sut);
+
+        assertThat(jcas.select(XmlElement.class).asList()) //
+                .extracting(XmlElement::getUri, XmlElement::getLocalName, XmlElement::getQName) //
+                .containsExactly(tuple(null, null, "ns:root"));
+        assertThat(jcas.select(XmlDocument.class).get().getRoot().getAttributes()) //
+                .extracting(XmlAttribute::getUri, XmlAttribute::getLocalName,
+                        XmlAttribute::getQName, XmlAttribute::getValue) //
+                // Yes, the XML parser does set both localname and qname to the same value!
+                .containsExactly(tuple(null, "xmlns:ns", "xmlns:ns", "http://namespace.org"));
+    }
+
+    @Test
+    void testWithPrefixedNamespace_NS_enabled() throws Exception
+    {
+        String xml = "<ns:root xmlns:ns='http://namespace.org' x='true'/>";
+
+        SAXParser parser = newSaxParser(enableNamespaceSupport(newSaxParserFactory()));
+        parser.parse(toInputStream(xml, UTF_8), sut);
+
+        assertThat(jcas.select(XmlElement.class).asList()) //
+                .extracting(XmlElement::getUri, XmlElement::getLocalName, XmlElement::getQName) //
+                .containsExactly(tuple("http://namespace.org", "root", "ns:root"));
+        assertThat(jcas.select(XmlDocument.class).get().getRoot().getAttributes()) //
+                .extracting(XmlAttribute::getUri, XmlAttribute::getLocalName,
+                        XmlAttribute::getQName, XmlAttribute::getValue) //
+                // Namespace-aware parsers filter out the xmlns attributes!
+                .containsExactly(tuple(null, "x", "x", "true"));
+    }
+}

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/DefaultHandlerToContentHandlerAdapter.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/DefaultHandlerToContentHandlerAdapter.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.support.xml;
+
+import java.io.IOException;
+
+import org.xml.sax.Attributes;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.InputSource;
+import org.xml.sax.Locator;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+import org.xml.sax.helpers.DefaultHandler;
+
+public class DefaultHandlerToContentHandlerAdapter<T extends ContentHandler>
+    extends DefaultHandler
+{
+    protected final T delegate;
+
+    public DefaultHandlerToContentHandlerAdapter(T aDelegate)
+    {
+        delegate = aDelegate;
+    }
+
+    @Override
+    public void setDocumentLocator(Locator aLocator)
+    {
+        // NO-OP
+    }
+
+    @Override
+    public void startDocument() throws SAXException
+    {
+        delegate.startDocument();
+    }
+
+    @Override
+    public void endDocument() throws SAXException
+    {
+        delegate.endDocument();
+    }
+
+    @Override
+    public void startPrefixMapping(String aPrefix, String aUri) throws SAXException
+    {
+        delegate.startPrefixMapping(aPrefix, aUri);
+    }
+
+    @Override
+    public void endPrefixMapping(String aPrefix) throws SAXException
+    {
+        delegate.endPrefixMapping(aPrefix);
+    }
+
+    @Override
+    public void startElement(String aUri, String aLocalName, String aQName, Attributes aAtts)
+        throws SAXException
+    {
+        delegate.startElement(aUri, aLocalName, aQName, aAtts);
+    }
+
+    @Override
+    public void endElement(String aUri, String aLocalName, String aQName) throws SAXException
+    {
+        delegate.endElement(aUri, aLocalName, aQName);
+    }
+
+    @Override
+    public void characters(char[] aCh, int aStart, int aLength) throws SAXException
+    {
+        delegate.characters(aCh, aStart, aLength);
+    }
+
+    @Override
+    public void ignorableWhitespace(char[] aCh, int aStart, int aLength) throws SAXException
+    {
+        delegate.ignorableWhitespace(aCh, aStart, aLength);
+    }
+
+    @Override
+    public void processingInstruction(String aTarget, String aData) throws SAXException
+    {
+        delegate.processingInstruction(aTarget, aData);
+    }
+
+    @Override
+    public void skippedEntity(String aName) throws SAXException
+    {
+        delegate.skippedEntity(aName);
+    }
+
+    @Override
+    public void warning(SAXParseException aE) throws SAXException
+    {
+        // NO-OP
+    }
+
+    @Override
+    public void error(SAXParseException aE) throws SAXException
+    {
+        // NO-OP
+    }
+
+    @Override
+    public void fatalError(SAXParseException aE) throws SAXException
+    {
+        // NO-OP
+    }
+
+    @Override
+    public void notationDecl(String aName, String aPublicId, String aSystemId) throws SAXException
+    {
+        // NO-OP
+    }
+
+    @Override
+    public InputSource resolveEntity(String aPublicId, String aSystemId)
+        throws IOException, SAXException
+    {
+        // NO-OP
+        return null;
+    }
+
+    @Override
+    public void unparsedEntityDecl(String aName, String aPublicId, String aSystemId,
+            String aNotationName)
+        throws SAXException
+    {
+        // NO-OP
+    }
+}

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/XmlEventLoggingFilter.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/XmlEventLoggingFilter.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.support.xml;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.xml.sax.Attributes;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.SAXException;
+
+import de.tudarmstadt.ukp.clarin.webanno.support.xml.ContentHandlerAdapter;
+
+/**
+ * This class is for testing - do not use in production.
+ */
+public class XmlEventLoggingFilter
+    extends ContentHandlerAdapter
+{
+    List<String> events = new ArrayList<>();
+
+    public XmlEventLoggingFilter(ContentHandler aDelegate)
+    {
+        super(aDelegate);
+    }
+
+    public List<String> getEvents()
+    {
+        return Collections.unmodifiableList(events);
+    }
+
+    @Override
+    public void startDocument() throws SAXException
+    {
+        events.add("[START-DOCUMENT]");
+        super.startDocument();
+    }
+
+    @Override
+    public void endDocument() throws SAXException
+    {
+        events.add("[END-DOCUMENT]");
+        super.endDocument();
+    }
+
+    @Override
+    public void startElement(String aUri, String aLocalName, String aQName, Attributes aAtts)
+        throws SAXException
+    {
+        StringBuilder attributes = new StringBuilder();
+        for (int i = 0; i < aAtts.getLength(); i++) {
+            if (i > 0) {
+                attributes.append(" ");
+            }
+            attributes.append("[");
+            attributes.append("[");
+            attributes.append(aAtts.getQName(i));
+            attributes.append("]");
+            attributes.append("{");
+            attributes.append(aAtts.getURI(i));
+            attributes.append("}[");
+            attributes.append(aAtts.getLocalName(i));
+            attributes.append("]]=");
+            attributes.append("[");
+            attributes.append(aAtts.getValue(i));
+            attributes.append("]");
+        }
+        events.add("[START-ELEMENT [" + aQName + "] {" + aUri + "}[" + aLocalName + "]] "
+                + attributes);
+        delegate.startElement(aUri, aLocalName, aQName, aAtts);
+    }
+
+    @Override
+    public void endElement(String aUri, String aLocalName, String aQName) throws SAXException
+    {
+        events.add("[END-ELEMENT [" + aQName + "] {" + aUri + "}[" + aLocalName + "]]");
+        delegate.endElement(aUri, aLocalName, aQName);
+    }
+
+    @Override
+    public void startPrefixMapping(String aPrefix, String aUri) throws SAXException
+    {
+        events.add("[START-PREFIX-MAPPING [" + aPrefix + "] -> " + aUri + "]");
+        super.startPrefixMapping(aPrefix, aUri);
+    }
+
+    @Override
+    public void endPrefixMapping(String aPrefix) throws SAXException
+    {
+        events.add("[END-PREFIX-MAPPING [" + aPrefix + "]]");
+        super.endPrefixMapping(aPrefix);
+    }
+}

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/XmlParserUtils.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/XmlParserUtils.java
@@ -61,7 +61,8 @@ public class XmlParserUtils
 
     public static Comparator<QName> caseInsensitiveQNameComparator()
     {
-        return comparing(QName::getLocalPart, CASE_INSENSITIVE_ORDER);
+        return comparing(QName::getNamespaceURI).thenComparing(QName::getLocalPart,
+                CASE_INSENSITIVE_ORDER);
     }
 
     public static String getQName(QName aElement)
@@ -108,7 +109,14 @@ public class XmlParserUtils
         return factory;
     }
 
-    private static void setFeature(SAXParserFactory aFactory, String aFeature, boolean aValue)
+    public static SAXParserFactory enableNamespaceSupport(SAXParserFactory aFactory)
+        throws ParserConfigurationException
+    {
+        XmlParserUtils.setFeature(aFactory, "http://xml.org/sax/features/namespaces", true);
+        return aFactory;
+    }
+
+    public static void setFeature(SAXParserFactory aFactory, String aFeature, boolean aValue)
         throws ParserConfigurationException
     {
         try {
@@ -124,13 +132,20 @@ public class XmlParserUtils
         }
     }
 
+    public static SAXParser newSaxParser(SAXParserFactory aFactory)
+        throws SAXNotRecognizedException, SAXNotSupportedException, ParserConfigurationException,
+        SAXException
+    {
+        SAXParser saxParser = aFactory.newSAXParser();
+        saxParser.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        saxParser.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        return saxParser;
+    }
+
     public static SAXParser newSaxParser()
         throws SAXNotRecognizedException, SAXNotSupportedException, ParserConfigurationException,
         SAXException
     {
-        SAXParser saxParser = newSaxParserFactory().newSAXParser();
-        saxParser.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-        saxParser.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
-        return saxParser;
+        return newSaxParser(newSaxParserFactory());
     }
 }

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/ElementPolicy.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/ElementPolicy.java
@@ -69,4 +69,10 @@ public class ElementPolicy
     {
         return new ElementPolicy(ElementAction.PASS);
     }
+
+    @Override
+    public String toString()
+    {
+        return "[" + qName + " -> " + action + "]";
+    }
 }

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/PolicyCollectionIOUtils.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/PolicyCollectionIOUtils.java
@@ -86,7 +86,7 @@ public class PolicyCollectionIOUtils
             ExternalPolicy policy)
     {
         var attributes = policy.getAttributes().stream() //
-                .map(s -> new QName(s)) //
+                .map(s -> QName.valueOf(s)) //
                 .toArray(QName[]::new);
         var action = AttributeAction.valueOf(policy.getAction());
         var attrBuilder = new AttributePolicyBuilder(policyCollectionBuilder, action, attributes);
@@ -97,7 +97,7 @@ public class PolicyCollectionIOUtils
 
         if (policy.getOnElements() != null) {
             var elements = policy.getOnElements().stream() //
-                    .map(s -> new QName(s)) //
+                    .map(s -> QName.valueOf(s)) //
                     .toArray(QName[]::new);
             attrBuilder.onElements(elements);
         }
@@ -110,7 +110,7 @@ public class PolicyCollectionIOUtils
             ExternalPolicy policy)
     {
         var elements = policy.getElements().stream() //
-                .map(s -> new QName(s)) //
+                .map(s -> QName.valueOf(s)) //
                 .toArray(QName[]::new);
         var action = ElementAction.valueOf(policy.getAction());
         for (var element : elements) {

--- a/inception/inception-support/src/test/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/PolicyCollectionIOUtilsTest.java
+++ b/inception/inception-support/src/test/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/PolicyCollectionIOUtilsTest.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.inception.support.xml.sanitizer;
 
 import static de.tudarmstadt.ukp.inception.support.xml.sanitizer.PolicyCollectionIOUtils.loadPolicies;
+import static javax.xml.XMLConstants.NULL_NS_URI;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
@@ -54,19 +55,22 @@ class PolicyCollectionIOUtilsTest
         assertThat(sut.getDefaultElementAction()).isEqualTo(ElementAction.PASS);
 
         assertThat(sut.getElementPolicies()) //
-                .extracting(p -> p.getQName().getLocalPart(), p -> p.getAction()) //
-                .containsExactly( //
-                        tuple("div", ElementAction.PASS), //
-                        tuple("p", ElementAction.PASS), //
-                        tuple("th", ElementAction.PASS), //
-                        tuple("tr", ElementAction.PASS));
+                .extracting(p -> p.getQName().getNamespaceURI(), p -> p.getQName().getLocalPart(),
+                        p -> p.getAction()) //
+                .containsExactlyInAnyOrder( //
+                        tuple(NULL_NS_URI, "div", ElementAction.PASS), //
+                        tuple(NULL_NS_URI, "p", ElementAction.PASS), //
+                        tuple(NULL_NS_URI, "th", ElementAction.PASS), //
+                        tuple(NULL_NS_URI, "tr", ElementAction.PASS), //
+                        tuple("http://namespace.org", "custom", ElementAction.PASS));
 
         assertThat(sut.getGlobalAttributeElementPolicies())
-                .extracting(p -> p.getQName().getLocalPart(), p -> p.getAction()) //
+                .extracting(p -> p.getQName().getNamespaceURI(), p -> p.getQName().getLocalPart(),
+                        p -> p.getAction()) //
                 .containsExactly( //
-                        tuple("style", AttributeAction.PASS));
+                        tuple(NULL_NS_URI, "style", AttributeAction.PASS));
 
         assertThat(sut.forAttribute(new QName("div"), new QName("title"), null, "blah")).get() //
-                .isEqualTo(AttributeAction.PASS);
+                .isEqualTo(AttributeAction.DROP);
     }
 }

--- a/inception/inception-support/src/test/resources/SanitizingContentHandler/Policy.yaml
+++ b/inception/inception-support/src/test/resources/SanitizingContentHandler/Policy.yaml
@@ -7,11 +7,12 @@ debug: true
 policies:
   - { elements: ["p", "div"], action: "PASS" }
   - { elements: ["tr", "th"], action: "PASS" }
+  - { elements: ["{http://namespace.org}custom"], action: "PASS" }
   - {
       attributes: ["title"],
       matching: "[a-zA-Z0-9]*",
       on_elements: ["div"],
-      action: "PASS",
+      action: "DROP",
     }
   - {
       attributes: ["style"],


### PR DESCRIPTION
**What's in the PR**
- Support recovering namespace information as SAX events in the Cas2SaxEvents class
- Support recovering and handling namespace information in the SanitizingContentHandler
- Support for namespaces in the PolicyCollectionIOUtils when reading policy files
- Added several tests

**How to test manually**
* No specific test procedure

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
