### PR TITLE
#3767 - Trying to set invalid project name produces error page

### DIFF
--- a/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/Project.java
+++ b/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/Project.java
@@ -305,7 +305,7 @@ public class Project
     }
 
     /**
-     * Check if the name is valid, SPecial characters are not allowed as a project/user name as it
+     * Check if the name is valid. Special characters are not allowed as a project/user name as it
      * will conflict with file naming system
      * 
      * @param aName


### PR DESCRIPTION
**What's in the PR**
- Decouple input field from project
- If the project name is invalid, give an error message and do not leave edit mode

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
