### PR TITLE
#3773 - Support loading resources from documents that are actually archives

### DIFF
--- a/inception/inception-api-formats/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/format/FormatSupport.java
+++ b/inception/inception-api-formats/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/format/FormatSupport.java
@@ -19,7 +19,11 @@ package de.tudarmstadt.ukp.clarin.webanno.api.format;
 
 import static de.tudarmstadt.ukp.clarin.webanno.support.ZipUtils.zipFolder;
 import static java.io.File.createTempFile;
+import static java.util.Collections.unmodifiableSet;
 import static org.apache.commons.io.FileUtils.copyFile;
+import static org.apache.commons.io.FilenameUtils.getExtension;
+import static org.apache.commons.io.FilenameUtils.normalize;
+import static org.apache.commons.lang3.StringUtils.prependIfMissing;
 import static org.apache.uima.fit.factory.AnalysisEngineFactory.createEngine;
 import static org.apache.uima.fit.factory.CollectionReaderFactory.createReader;
 import static org.apache.uima.fit.factory.ConfigurationParameterFactory.addConfigurationParameters;
@@ -29,9 +33,12 @@ import static org.apache.uima.fit.util.LifeCycleUtil.destroy;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -55,6 +62,10 @@ import de.tudarmstadt.ukp.inception.support.xml.sanitizer.PolicyCollection;
 
 public interface FormatSupport
 {
+    Set<String> DEFAULT_PERMITTED_RESOURCE_EXTENSIONS = unmodifiableSet(
+            Set.of("apng", "avif", "gif", "jpg", "jpeg", "jfif", "pjpeg", "pjp", "png", "svg",
+                    "webp", "bmp", "tif", "tiff"));
+
     /**
      * Returns the format identifier which is stored in in {@link SourceDocument#setFormat(String)}.
      * 
@@ -93,6 +104,26 @@ public interface FormatSupport
     default boolean isProneToInconsistencies()
     {
         return true;
+    }
+
+    default boolean hasResources()
+    {
+        return false;
+    }
+
+    default boolean isAccessibelResource(File aDocFile, String aResourcePath)
+    {
+        return DEFAULT_PERMITTED_RESOURCE_EXTENSIONS.contains(getExtension(aResourcePath));
+    }
+
+    default InputStream openResourceStream(File aDocFile, String aResourcePath) throws IOException
+    {
+        if (!hasResources() || !isAccessibelResource(aDocFile, aResourcePath)) {
+            throw new FileNotFoundException("Resource not found [" + aResourcePath + "]");
+        }
+
+        var path = prependIfMissing(normalize(aResourcePath, isProneToInconsistencies()), "/");
+        return new URL("jar:" + aDocFile.toURI().toURL() + "!" + path).openStream();
     }
 
     /**

--- a/inception/inception-external-editor/pom.xml
+++ b/inception/inception-external-editor/pom.xml
@@ -47,6 +47,10 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-api-formats</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-model</artifactId>
     </dependency>
     <dependency>

--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/xhtml/XHtmlXmlDocumentViewController.java
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/xhtml/XHtmlXmlDocumentViewController.java
@@ -22,6 +22,9 @@ import static de.tudarmstadt.ukp.inception.security.config.InceptionSecurityWebU
 import java.security.Principal;
 import java.util.Optional;
 
+import javax.servlet.http.HttpServletRequest;
+
+import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.ResponseEntity;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
@@ -34,5 +37,9 @@ public interface XHtmlXmlDocumentViewController
 
     ResponseEntity<String> getDocument(long aProjectId, long aDocumentId, Optional<String> aEditor,
             Principal aPrincipal)
+        throws Exception;
+
+    ResponseEntity<InputStreamResource> getResource(long aProjectId, long aDocumentId,
+            HttpServletRequest aRequest, Principal aPrincipal)
         throws Exception;
 }


### PR DESCRIPTION
**What's in the PR**
- Allow format supports to offer resources
- Allow to access such resources via the XHtmlXmlDocumentViewController

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
