### PR TITLE
#3809 - Unable to curate documents marked as broken by annotators

### DIFF
--- a/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/service/CurationDocumentService.java
+++ b/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/service/CurationDocumentService.java
@@ -26,6 +26,7 @@ import org.apache.uima.cas.CAS;
 import org.springframework.security.access.prepost.PreAuthorize;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.ConcurentCasModificationException;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 
@@ -70,6 +71,8 @@ public interface CurationDocumentService
 
     List<SourceDocument> listCuratableSourceDocuments(Project aProject);
 
+    List<AnnotationDocument> listCuratableAnnotationDocuments(SourceDocument aDocument);
+
     Optional<Long> getCurationCasTimestamp(SourceDocument aDocument) throws IOException;
 
     Optional<Long> verifyCurationCasTimestamp(SourceDocument aDocument, long aTimeStamp,
@@ -96,4 +99,5 @@ public interface CurationDocumentService
      *             if there was an I/O-level error
      */
     boolean existsCurationCas(SourceDocument aDocument) throws IOException;
+
 }

--- a/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/service/CurationDocumentServiceImpl.java
+++ b/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/service/CurationDocumentServiceImpl.java
@@ -40,6 +40,7 @@ import org.springframework.transaction.annotation.Transactional;
 import de.tudarmstadt.ukp.clarin.webanno.api.CasStorageService;
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.ConcurentCasModificationException;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
@@ -107,6 +108,37 @@ public class CurationDocumentServiceImpl
 
     @Override
     @Transactional
+    public List<AnnotationDocument> listCuratableAnnotationDocuments(SourceDocument aDocument)
+    {
+        Validate.notNull(aDocument, "Document must be specified");
+
+        // Get all annotators in the project
+        List<User> users = projectService.listProjectUsersWithPermissions(aDocument.getProject(),
+                ANNOTATOR);
+        // Bail out already. HQL doesn't seem to like queries with an empty parameter right of "in"
+        if (users.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        String query = String.join("\n", //
+                "SELECT DISTINCT adoc", //
+                "FROM AnnotationDocument AS adoc", //
+                "WHERE adoc.document = :document", //
+                "AND adoc.user in (:users)", //
+                "AND (adoc.state = :state or adoc.annotatorState = :ignore)");
+
+        List<AnnotationDocument> docs = entityManager.createQuery(query, AnnotationDocument.class) //
+                .setParameter("document", aDocument) //
+                .setParameter("users", users.stream().map(User::getUsername).collect(toList())) //
+                .setParameter("state", AnnotationDocumentState.FINISHED) //
+                .setParameter("ignore", AnnotationDocumentState.IGNORE) //
+                .getResultList();
+
+        return docs;
+    }
+
+    @Override
+    @Transactional
     public List<SourceDocument> listCuratableSourceDocuments(Project aProject)
     {
         Validate.notNull(aProject, "Project must be specified");
@@ -123,14 +155,15 @@ public class CurationDocumentServiceImpl
                 "FROM AnnotationDocument AS adoc", //
                 "WHERE adoc.project = :project", //
                 "AND adoc.user in (:users)", //
-                "AND adoc.state = :state");
+                "AND (adoc.state = :state or adoc.annotatorState = :ignore)", //
+                "ORDER BY adoc.document.name");
 
         List<SourceDocument> docs = entityManager.createQuery(query, SourceDocument.class) //
                 .setParameter("project", aProject) //
                 .setParameter("users", users.stream().map(User::getUsername).collect(toList())) //
                 .setParameter("state", AnnotationDocumentState.FINISHED) //
+                .setParameter("ignore", AnnotationDocumentState.IGNORE) //
                 .getResultList();
-        docs.sort(SourceDocument.NAME_COMPARATOR);
 
         return docs;
     }

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/AnnotatorsPanel.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/AnnotatorsPanel.java
@@ -446,7 +446,7 @@ public class AnnotatorsPanel
         casses.put(CURATION_USER, curationDocumentService.readCurationCas(aDocument));
 
         // The source CASes from the annotators are all ready read-only / shared
-        for (var annDoc : documentService.listFinishedAnnotationDocuments(aDocument)) {
+        for (var annDoc : curationDocumentService.listCuratableAnnotationDocuments(aDocument)) {
             casses.put(annDoc.getUser(),
                     documentService.readAnnotationCas(annDoc.getDocument(), annDoc.getUser()));
         }

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/CurationPage.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/CurationPage.java
@@ -582,12 +582,12 @@ public class CurationPage
     {
         AnnotatorState state = getModelObject();
 
-        List<AnnotationDocument> finishedAnnotationDocuments = documentService
-                .listFinishedAnnotationDocuments(state.getDocument());
+        List<AnnotationDocument> curatableAnnotationDocuments = curationDocumentService
+                .listCuratableAnnotationDocuments(state.getDocument());
 
-        if (finishedAnnotationDocuments.isEmpty()) {
+        if (curatableAnnotationDocuments.isEmpty()) {
             getSession().error("This document has the state " + state.getDocument().getState()
-                    + " but " + "there are no finished annotation documents! This "
+                    + " but there are no finished annotation documents! This "
                     + "can for example happen when curation on a document has already started "
                     + "and afterwards all annotators have been removed from the project, have been "
                     + "disabled or if all were put back into " + AnnotationDocumentState.IN_PROGRESS
@@ -603,9 +603,9 @@ public class CurationPage
         }
 
         Map<String, CAS> casses = documentService
-                .readAllCasesSharedNoUpgrade(finishedAnnotationDocuments);
+                .readAllCasesSharedNoUpgrade(curatableAnnotationDocuments);
 
-        AnnotationDocument randomAnnotationDocument = finishedAnnotationDocuments.get(0);
+        AnnotationDocument randomAnnotationDocument = curatableAnnotationDocuments.get(0);
         CAS curationCas = readCurationCas(state, state.getDocument(), casses,
                 randomAnnotationDocument, true, aMergeStrategy, aForceRecreateCas);
 
@@ -722,7 +722,7 @@ public class CurationPage
     {
         // get annotation documents
         Map<String, CAS> casses = documentService.readAllCasesSharedNoUpgrade(
-                documentService.listFinishedAnnotationDocuments(aState.getDocument()));
+                curationDocumentService.listCuratableAnnotationDocuments(aState.getDocument()));
 
         CAS editorCas = readCurationCas(aState, aState.getDocument(), casses, null, false,
                 curationService.getDefaultMergeStrategy(getProject()), false);

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebar.html
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebar.html
@@ -55,7 +55,7 @@
           </div>
         </div>
         
-        <form wicket:id="usersForm" class="card">
+        <form wicket:id="usersForm" class="card flex-content">
           <div class="card-header">
             <wicket:message key="usersLabel"/>
             <div class="actions">
@@ -64,18 +64,17 @@
               </button>
             </div>
           </div>
-                    
-          <div class="card-body">
-            <div wicket:id="selectedUsers">
-              <div class="col-sm-12" wicket:id="users">
+          <div class="scrolling card-body p-0">
+            <ul class="list-group list-group-flush" wicket:id="selectedUsers">
+              <li wicket:id="users" class="list-group-item">
                 <div class="form-check">
                   <input class="form-check-input" type="checkbox" wicket:id="user">
                   <label class="form-check-label" wicket:for="user">
                     <span wicket:id="name"/>
                   </label>
                 </div>
-              </div>
-            </div>
+              </li>
+            </ul>
           </div>
         </form>
         

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebar.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebar.java
@@ -444,7 +444,7 @@ public class CurationSidebar
         User currentUser = userRepository.getCurrentUser();
         String curationTarget = getModelObject().getUser().getUsername();
         return curationSidebarService
-                .listFinishedUsers(getModelObject().getProject(), getModelObject().getDocument())
+                .listCuratableUsers(getModelObject().getDocument())
                 .stream()
                 .filter(user -> !user.equals(currentUser) || curationTarget.equals(CURATION_USER))
                 .collect(Collectors.toList());

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebarService.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebarService.java
@@ -109,7 +109,7 @@ public interface CurationSidebarService
      * @return list of users that have finished the given document
      */
     @SuppressWarnings("javadoc")
-    List<User> listFinishedUsers(Project aProject, SourceDocument aSourceDocument);
+    List<User> listCuratableUsers(SourceDocument aSourceDocument);
 
     /**
      * @return if user in given annotator state is curating and has finished it

--- a/inception/inception-ui-curation/src/test/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationServiceTest.java
+++ b/inception/inception-ui-curation/src/test/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationServiceTest.java
@@ -130,7 +130,7 @@ public class CurationServiceTest
         testEntityManager.persist(annoDoc1);
         testEntityManager.persist(annoDoc2);
 
-        List<User> finishedUsers = sut.listFinishedUsers(testProject, testDocument);
+        List<User> finishedUsers = sut.listCuratableUsers(testDocument);
 
         assertThat(finishedUsers).containsExactly(beate, kevin);
     }


### PR DESCRIPTION
**What's in the PR**
- Change method in curation service(s) to return list of curatable documents (which includes closed broken documents and not only finished documents)

**How to test manually**
* Close a document and mark it as problematic in the close dialog
* Try curating it

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
