### PR TITLE
#3807 - Button to add document level annotations not looking disabled when document is finished

### DIFF
--- a/inception/inception-bootstrap/src/main/ts/bootstrap/inception-custom.scss
+++ b/inception/inception-bootstrap/src/main/ts/bootstrap/inception-custom.scss
@@ -422,8 +422,10 @@ div.left-tabpanel div.tab-row a:hover {
 
   label {
     @extend .btn;
-    border: $border-width solid $primary;
     text-align: left;
+    --bs-btn-border-color: var(--bs-primary);
+    --bs-btn-hover-border-color: var(--bs-primary);
+    --bs-btn-hover-bg: var(--bs-list-group-action-hover-bg);
   }
 
   input[type="radio"]:checked ~ * {

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationSelectionPanel.html
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationSelectionPanel.html
@@ -26,9 +26,9 @@
       <div class=" mb-0">
         <div class="input-group">
           <select class="form-select flex-content" wicket:id="layer" data-size="10"/>
-          <a wicket:id="create" class="btn btn-primary">
+          <button wicket:id="create" class="btn btn-primary">
             <i class="fas fa-plus"></i>
-          </a>
+          </button>
         </div>
       </div>
     </div>

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationSelectionPanel.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationSelectionPanel.java
@@ -36,7 +36,6 @@ import org.apache.uima.cas.FeatureStructure;
 import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxEventBehavior;
 import org.apache.wicket.ajax.AjaxRequestTarget;
-import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.feedback.IFeedback;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
@@ -323,9 +322,7 @@ public class DocumentMetadataAnnotationSelectionPanel
                         _target -> actionDelete(_target, detailPanel))
                                 .add(visibleWhen(() -> !aItem.getModelObject().singleton))
                                 .add(enabledWhen(() -> annotationPage.isEditable()
-                                        && !aItem.getModelObject().layer.isReadonly()))
-                                .add(AttributeAppender.append("class",
-                                        () -> annotationPage.isEditable() ? "" : "disabled")));
+                                        && !aItem.getModelObject().layer.isReadonly())));
 
                 aItem.setOutputMarkupId(true);
             }

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/lambda/LambdaAjaxButton.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/lambda/LambdaAjaxButton.java
@@ -19,6 +19,7 @@ package de.tudarmstadt.ukp.clarin.webanno.support.lambda;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.markup.html.form.AjaxButton;
+import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.feedback.IFeedback;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.request.RequestHandlerExecutor.ReplaceHandlerException;
@@ -49,6 +50,7 @@ public class LambdaAjaxButton<T>
         super(aId);
         action = aAction;
         exceptionHandler = aExceptionHandler;
+        add(AttributeAppender.append("class", () -> isEnabledInHierarchy() ? "" : "disabled"));
     }
 
     public LambdaAjaxButton<T> triggerAfterSubmit()

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/lambda/LambdaAjaxLink.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/lambda/LambdaAjaxLink.java
@@ -19,6 +19,7 @@ package de.tudarmstadt.ukp.clarin.webanno.support.lambda;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.markup.html.AjaxLink;
+import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.feedback.IFeedback;
 import org.apache.wicket.request.RequestHandlerExecutor.ReplaceHandlerException;
 import org.slf4j.LoggerFactory;
@@ -43,6 +44,7 @@ public class LambdaAjaxLink
         super(aId);
         action = aAction;
         exceptionHandler = aExceptionHandler;
+        add(AttributeAppender.append("class", () -> isEnabledInHierarchy() ? "" : "disabled"));
     }
 
     public LambdaAjaxLink onConfigure(SerializableMethodDelegate<LambdaAjaxLink> aAction)


### PR DESCRIPTION
**What's in the PR**
- Changed LambdaAjaxLink and LambdaAjaxButton to always add the disabled class if they are not enabled in the hierarchy
- Fix border of radio button group items disappearing on hover

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
