### PR TITLE
#3822 - Order of matches found in knowledge base search is not correct

### DIFF
--- a/inception/inception-bootstrap/src/main/ts/bootstrap/inception-feature-editors.scss
+++ b/inception/inception-bootstrap/src/main/ts/bootstrap/inception-feature-editors.scss
@@ -72,6 +72,12 @@
   .item-title {
     font-weight: bolder;
   }
+
+  .item-alt-title {
+    font-size: 85%;
+    line-height: normal; 
+    padding-left: 10px;
+  }
   
   .item-title .badge {
     font-size: 8px;

--- a/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/model/CandidateEntity.java
+++ b/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/model/CandidateEntity.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.conceptlinking.model;
 
+import static java.lang.Integer.MAX_VALUE;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.unmodifiableMap;
 
@@ -44,6 +45,13 @@ public class CandidateEntity
     public static final Key<String> KEY_QUERY_NC = new Key<>("queryNC");
 
     /**
+     * The term which had the best match with query or mention. This should be displayed to the user
+     * in addition to the handles pref-label if it does differ from the pref-label.
+     */
+    public static final Key<String> KEY_QUERY_BEST_MATCH_TERM_NC = new Key<>(
+            "queryBestMatchTermNC");
+
+    /**
      * Whether the query entered by the user is completely in lower case.
      */
     public static final Key<Boolean> KEY_QUERY_IS_LOWER_CASE = new Key<>("queryIsLowerCase");
@@ -68,11 +76,10 @@ public class CandidateEntity
      * the default value to ensure that candidates are ranked last on this feature if it could not
      * be calculated.
      */
-    public static final Key<Integer> KEY_LEVENSHTEIN_MENTION = new Key<>("levMention",
-            Integer.MAX_VALUE);
+    public static final Key<Integer> KEY_LEVENSHTEIN_MENTION = new Key<>("levMention", MAX_VALUE);
 
     public static final Key<Integer> KEY_LEVENSHTEIN_MENTION_NC = new Key<>("levMentionNC",
-            Integer.MAX_VALUE);
+            MAX_VALUE);
 
     /**
      * Edit distance between mention + context and candidate entity label
@@ -82,7 +89,7 @@ public class CandidateEntity
      * be calculated.
      */
     public static final Key<Integer> KEY_LEVENSHTEIN_MENTION_CONTEXT = new Key<>("levContext",
-            Integer.MAX_VALUE);
+            MAX_VALUE);
 
     /**
      * Edit distance between typed string and candidate entity label
@@ -91,11 +98,9 @@ public class CandidateEntity
      * the default value to ensure that candidates are ranked last on this feature if it could not
      * be calculated.
      */
-    public static final Key<Integer> KEY_LEVENSHTEIN_QUERY = new Key<>("levQuery",
-            Integer.MAX_VALUE);
+    public static final Key<Integer> KEY_LEVENSHTEIN_QUERY = new Key<>("levQuery", MAX_VALUE);
 
-    public static final Key<Integer> KEY_LEVENSHTEIN_QUERY_NC = new Key<>("levQueryNC",
-            Integer.MAX_VALUE);
+    public static final Key<Integer> KEY_LEVENSHTEIN_QUERY_NC = new Key<>("levQueryNC", MAX_VALUE);
 
     /**
      * set of directly related entities as IRI Strings
@@ -220,10 +225,11 @@ public class CandidateEntity
         }
     }
 
-    public int mergeMin(Key<Integer> aKey, int aValue)
+    public boolean mergeMin(Key<Integer> aKey, int aValue)
     {
-        return (int) features.merge(aKey.name, aValue,
+        var newValue = (int) features.merge(aKey.name, aValue,
                 (o, n) -> o == null ? n : Math.min((int) o, (int) n));
+        return newValue == aValue;
     }
 
     public Map<String, Object> getFeatures()

--- a/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/model/CandidateEntity.java
+++ b/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/model/CandidateEntity.java
@@ -220,6 +220,12 @@ public class CandidateEntity
         }
     }
 
+    public int mergeMin(Key<Integer> aKey, int aValue)
+    {
+        return (int) features.merge(aKey.name, aValue,
+                (o, n) -> o == null ? n : Math.min((int) o, (int) n));
+    }
+
     public Map<String, Object> getFeatures()
     {
         return unmodifiableMap(features);

--- a/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/service/ConceptLinkingServiceImpl.java
+++ b/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/service/ConceptLinkingServiceImpl.java
@@ -294,7 +294,7 @@ public class ConceptLinkingServiceImpl
         }
 
         var duration = currentTimeMillis() - startTime;
-        log.debug("Found [{}] candidates starting with [{}]] in {}ms", startingWithMatches.size(),
+        log.debug("Found [{}] candidates starting with [{}] in {}ms", startingWithMatches.size(),
                 aQuery, duration);
         WicketUtil.serverTiming("findStartingWithMatches", duration);
 
@@ -399,7 +399,7 @@ public class ConceptLinkingServiceImpl
 
         candidate.put(KEY_LABEL_NC, candidate.getLabel().toLowerCase(candidate.getLocale()));
 
-        if (aCas != null) {
+        if (aCas != null && aMention != null) {
             AnnotationFS sentence = selectSentenceCovering(aCas, aBegin);
             if (sentence != null) {
                 List<String> mentionContext = new ArrayList<>();
@@ -423,6 +423,7 @@ public class ConceptLinkingServiceImpl
                 log.warn("Mention sentence could not be determined. Skipping.");
             }
         }
+
         return candidate;
     }
 

--- a/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/service/ConceptLinkingServiceImpl.java
+++ b/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/service/ConceptLinkingServiceImpl.java
@@ -24,6 +24,7 @@ import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.
 import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_MENTION_CONTEXT;
 import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_MENTION_NC;
 import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_QUERY;
+import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_QUERY_BEST_MATCH_TERM_NC;
 import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_QUERY_NC;
 import static java.lang.System.currentTimeMillis;
 import static java.util.Arrays.asList;
@@ -453,6 +454,9 @@ public class ConceptLinkingServiceImpl
                 .map(candidate -> {
                     KBHandle handle = candidate.getHandle();
                     handle.setDebugInfo(String.valueOf(candidate.getFeatures()));
+                    candidate.get(KEY_QUERY_BEST_MATCH_TERM_NC)
+                            .filter(t -> !t.equalsIgnoreCase(handle.getUiLabel()))
+                            .ifPresent(handle::setQueryBestMatchTerm);
                     return handle;
                 }) //
                 .collect(Collectors.toList());

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/KBHandle.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/KBHandle.java
@@ -39,6 +39,7 @@ public class KBHandle
     private static final long serialVersionUID = -4284462837460396185L;
     private String identifier;
     private String name;
+    private String queryBestMatchTerm;
     private Set<Pair<String, String>> matchTerms;
     private String description;
     private KnowledgeBase kb;
@@ -207,6 +208,16 @@ public class KBHandle
     public String getDebugInfo()
     {
         return debugInfo;
+    }
+
+    public void setQueryBestMatchTerm(String aTerm)
+    {
+        queryBestMatchTerm = aTerm;
+    }
+
+    public String getQueryBestMatchTerm()
+    {
+        return queryBestMatchTerm;
     }
 
     public int getRank()

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/KBHandle.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/KBHandle.java
@@ -17,13 +17,16 @@
  */
 package de.tudarmstadt.ukp.inception.kb.graph;
 
+import static java.util.Collections.emptySet;
 import static org.apache.commons.lang3.builder.ToStringStyle.SHORT_PREFIX_STYLE;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.tuple.Pair;
@@ -36,7 +39,7 @@ public class KBHandle
     private static final long serialVersionUID = -4284462837460396185L;
     private String identifier;
     private String name;
-    private List<Pair<String, String>> matchTerms;
+    private Set<Pair<String, String>> matchTerms;
     private String description;
     private KnowledgeBase kb;
     private String language;
@@ -157,14 +160,18 @@ public class KBHandle
     public void addMatchTerm(String aLabel, String aLanguage)
     {
         if (matchTerms == null) {
-            matchTerms = new ArrayList<>();
+            matchTerms = new LinkedHashSet<>();
         }
 
         matchTerms.add(Pair.of(aLabel, aLanguage));
     }
 
-    public List<Pair<String, String>> getMatchTerms()
+    public Set<Pair<String, String>> getMatchTerms()
     {
+        if (matchTerms == null) {
+            return emptySet();
+        }
+
         return matchTerms;
     }
 

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
@@ -2123,16 +2123,27 @@ public class SPARQLQueryBuilder
             // Not recorded yet -> add it
             if (current == null) {
                 cMap.put(handle.getIdentifier(), handle);
+                continue;
             }
+
+            boolean replace = false;
             // Found one with a label while current one doesn't have one
-            else if (current.getName() == null && handle.getName() != null) {
-                cMap.put(handle.getIdentifier(), handle);
+            if (current.getName() == null && handle.getName() != null) {
+                replace = true;
             }
             // Found an exact language match -> use that one instead
             // Note that having a language implies that there is a label!
             else if (kb.getDefaultLanguage() != null
                     && kb.getDefaultLanguage().equals(handle.getLanguage())) {
+                replace = true;
+            }
+
+            if (replace) {
                 cMap.put(handle.getIdentifier(), handle);
+                current.getMatchTerms().forEach(e -> handle.addMatchTerm(e.getKey(), e.getValue()));
+            }
+            else {
+                handle.getMatchTerms().forEach(e -> current.addMatchTerm(e.getKey(), e.getValue()));
             }
         }
 

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FusekiRepositoryTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FusekiRepositoryTest.java
@@ -101,11 +101,13 @@ public class FusekiRepositoryTest
 
     private static List<Arguments> tests() throws Exception
     {
-        // These require additional configuration in Fuseki FTS
         var exclusions = asList( //
+                // These require additional configuration in Fuseki FTS
                 "thatMatchingAgainstAdditionalSearchPropertiesWorks", //
                 "testWithLabelMatchingExactlyAnyOf_subproperty", //
-                "testWithLabelStartingWith_OLIA");
+                "testWithLabelStartingWith_OLIA",
+                // This test returns one match term less than in the RDF4J case - not clear why
+                "thatMatchingAgainstAdditionalSearchPropertiesWorks2");
 
         return SPARQLQueryBuilderTest.tests().stream() //
                 .filter(scenario -> !exclusions.contains(scenario.name))

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/Rdf4JRepositoryTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/Rdf4JRepositoryTest.java
@@ -20,12 +20,20 @@ package de.tudarmstadt.ukp.inception.kb.querybuilder;
 import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_LUCENE;
 import static de.tudarmstadt.ukp.inception.kb.http.PerThreadSslCheckingHttpClientUtils.restoreSslVerification;
 import static de.tudarmstadt.ukp.inception.kb.http.PerThreadSslCheckingHttpClientUtils.suspendSslVerification;
+import static de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilderTest.DATA_ADDITIONAL_SEARCH_PROPERTIES_2;
+import static de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilderTest.TURTLE_PREFIX;
+import static de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilderTest.importDataFromString;
 import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.contentOf;
+import static org.eclipse.rdf4j.rio.RDFFormat.TURTLE;
 
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.apache.wicket.util.file.File;
+import org.eclipse.rdf4j.query.BindingSet;
+import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
@@ -33,6 +41,8 @@ import org.eclipse.rdf4j.sail.lucene.LuceneSail;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -101,5 +111,24 @@ public class Rdf4JRepositoryTest
     public void runTests(String aScenarioName, Scenario aScenario) throws Exception
     {
         aScenario.implementation.accept(repository, kb);
+    }
+
+    @Disabled("Not actually a test but rather a playground for SPARQL queries")
+    @Test
+    void runSparqlQuery() throws Exception
+    {
+        try (RepositoryConnection conn = repository.getConnection()) {
+            importDataFromString(repository, kb, TURTLE, TURTLE_PREFIX,
+                    DATA_ADDITIONAL_SEARCH_PROPERTIES_2);
+
+            var tupleQuery = conn.prepareTupleQuery(contentOf(new File(
+                    "src/test/resources/queries/additional_search_properties_2/rdf4j.sparql")));
+            try (TupleQueryResult result = tupleQuery.evaluate()) {
+                while (result.hasNext()) {
+                    BindingSet bindings = result.next();
+                    System.out.println(bindings);
+                }
+            }
+        }
     }
 }

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/Rdf4JRepositoryTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/Rdf4JRepositoryTest.java
@@ -27,11 +27,11 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.contentOf;
 import static org.eclipse.rdf4j.rio.RDFFormat.TURTLE;
 
+import java.io.File;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.apache.wicket.util.file.File;
 import org.eclipse.rdf4j.query.BindingSet;
 import org.eclipse.rdf4j.query.TupleQueryResult;
 import org.eclipse.rdf4j.repository.Repository;

--- a/inception/inception-kb/src/test/resources/queries/additional_search_properties_2/rdf4j.sparql
+++ b/inception/inception-kb/src/test/resources/queries/additional_search_properties_2/rdf4j.sparql
@@ -1,0 +1,13 @@
+PREFIX search: <http://www.openrdf.org/contrib/lucenesail#>
+          SELECT DISTINCT ?m ?l ?subj
+          WHERE { { { { ?pMatch <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> * <http://www.w3.org/2000/01/rdf-schema#prefLabel> . } UNION { ?pMatch <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> * <http://www.w3.org/2000/01/rdf-schema#label> . }
+          { ?subj search:matches [ search:query "hand" ;
+              search:property ?pMatch ;
+              search:snippet ?snippet ] .
+          BIND( REPLACE( REPLACE( ?snippet, "</B>", "" ), "<B>", "" ) AS ?label )
+          ?subj ?pMatch ?m .
+          FILTER ( ( STR( ?label ) = STR( ?m ) && ( LANGMATCHES( LANG( ?m ), "en" ) || LANG( ?m ) = "" ) ) ) } } }
+          OPTIONAL { ?pPrefLabel <http://www.w3.org/2000/01/rdf-schema#subPropertyOf> * <http://www.w3.org/2000/01/rdf-schema#prefLabel> . }
+          OPTIONAL { { ?subj ?pPrefLabel ?l .
+          FILTER ( ( LANGMATCHES( LANG( ?l ), "en" ) || LANG( ?l ) = "" ) ) } } }
+          LIMIT 200

--- a/inception/inception-kb/src/test/resources/turtle/data_additional_search_properties.ttl
+++ b/inception/inception-kb/src/test/resources/turtle/data_additional_search_properties.ttl
@@ -2,4 +2,4 @@
     rdfs:prefLabel 'specimen' ;
     rdfs:label 'sample' ;
     rdfs:label 'instance' ;
-    rdfs:label 'case'  .
+    rdfs:label 'case' .

--- a/inception/inception-kb/src/test/resources/turtle/data_additional_search_properties_2.ttl
+++ b/inception/inception-kb/src/test/resources/turtle/data_additional_search_properties_2.ttl
@@ -1,0 +1,4 @@
+<#example>
+    rdfs:prefLabel 'Hand structure (body structure)' ;
+    rdfs:label 'Hand' ;
+    rdfs:label 'Hand structure' .

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/KBHandleTemplate.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/KBHandleTemplate.java
@@ -41,7 +41,12 @@ final class KBHandleTemplate
         sb.append("  # if (data.rank) { if (data.rank != '0') { #");
         sb.append("    <span class=\"item-rank\">[${ data.rank }]</span>");
         sb.append("  # } } #");
-        sb.append("  ${ data.uiLabel }");
+        sb.append("  # if (data.queryBestMatchTerm) { #");
+        sb.append("    ${ data.queryBestMatchTerm }");
+        sb.append("    <div class='item-alt-title'>${ data.uiLabel }</div>");
+        sb.append("  # } else { #");
+        sb.append("    ${ data.uiLabel }");
+        sb.append("  # } #");
         sb.append("</span>");
         sb.append("<div class=\"item-identifier\">");
         sb.append("  ${ data.identifier }");
@@ -64,6 +69,7 @@ final class KBHandleTemplate
         properties.add("identifier");
         properties.add("description");
         properties.add("rank");
+        properties.add("queryBestMatchTerm");
         if (DEVELOPMENT.equals(Application.get().getConfigurationType())) {
             properties.add("debugInfo");
         }


### PR DESCRIPTION
**What's in the PR**
- Properly additional match labels in the SPARQLQueryBuilder
- Use the additional match labels when ranking using the LevenshteinFeatureGenerator
- If the best match term differs from the KBHandle primary UI label, display it also in the dropdown

**How to test manually**
* See issue description

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
