### PR TITLE
#3831 - Better support a direct-access workflow

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/page/AnnotationPageBase.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/page/AnnotationPageBase.java
@@ -179,11 +179,22 @@ public abstract class AnnotationPageBase
             return documentService.getSourceDocument(aProject, aDocumentParameter.toString());
         }
         catch (NoResultException e) {
-            error("Document [" + aDocumentParameter + "] does not exist in project ["
-                    + aProject.getName() + "]");
+            failWithDocumentNotFound("Document [" + aDocumentParameter
+                    + "] does not exist in project [" + aProject.getName() + "]");
         }
-
         return null;
+    }
+
+    protected void failWithDocumentNotFound(String aDetails)
+    {
+        if (userRepository.isCurrentUserAdmin()) {
+            getSession().error(aDetails);
+        }
+        else {
+            getSession().error(
+                    "Requested document does not exist or you have no permissions to access it.");
+        }
+        backToProjectPage();
     }
 
     protected UrlParametersReceivingBehavior createUrlFragmentBehavior()

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide.adoc
@@ -97,6 +97,8 @@ include::{include-dir}settings_document-import-export.adoc[leveloffset=+1]
 
 include::{include-dir}settings_custom-header-icons.adoc[leveloffset=+1]
 
+include::{include-dir}settings_dashboard.adoc[leveloffset=+1]
+
 include::{include-dir}settings_theming.adoc[leveloffset=+1]
 
 include::{include-dir}settings_annotation-editor.adoc[leveloffset=+1]

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
@@ -582,18 +582,18 @@ public class AnnotationPage
             // else {
             User requestedUser = userRepository.get(aUserParameter.toString());
             if (requestedUser == null) {
-                error("User not found [" + aUserParameter + "]");
-                backToProjectPage();
+                failWithDocumentNotFound("User not found [" + aUserParameter + "]");
             }
-            state.setUser(requestedUser);
+            else {
+                state.setUser(requestedUser);
+            }
             // }
         }
 
         if (doc != null && !documentAccess.canViewAnnotationDocument(user.getUsername(),
                 String.valueOf(project.getId()), doc.getId(), state.getUser().getUsername())) {
-            getSession().error(
-                    "Requested document does not exist or you have no permissions to access it.");
-            backToProjectPage();
+            failWithDocumentNotFound("Access to document [" + aDocumentParameter + "] in project ["
+                    + project.getName() + "] as denied");
         }
 
         // If we arrive here and the document is not null, then we have a change of document

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/component/DocumentNamePanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/component/DocumentNamePanel.java
@@ -18,17 +18,20 @@
 package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.component;
 
 import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
+import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhenNot;
 import static org.apache.wicket.RuntimeConfigurationType.DEVELOPMENT;
 
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
+import org.apache.wicket.spring.injection.annot.SpringBean;
 
 import de.tudarmstadt.ukp.clarin.webanno.export.model.ExportedProject;
 import de.tudarmstadt.ukp.clarin.webanno.export.model.ExportedSourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.AnnotationPage;
@@ -43,6 +46,8 @@ public class DocumentNamePanel
 {
     private static final long serialVersionUID = 3584950105138069924L;
 
+    private @SpringBean UserDao userService;
+
     public DocumentNamePanel(String id, final IModel<AnnotatorState> aModel)
     {
         super(id, aModel);
@@ -51,7 +56,9 @@ public class DocumentNamePanel
             var page = findParent(AnnotationPage.class);
             return page != null ? !page.isEditable() : false;
         })));
-        queue(new Label("user", aModel.map(AnnotatorState::getUser).map(User::getUiName)));
+        queue(new Label("user", aModel.map(AnnotatorState::getUser).map(User::getUiName))
+                .add(visibleWhenNot(aModel.map(AnnotatorState::getUser)
+                        .map(u -> u.getUsername().equals(userService.getCurrentUsername())))));
         queue(new Label("project", aModel.map(AnnotatorState::getProject).map(Project::getName)));
         queue(new Label("projectId", aModel.map(AnnotatorState::getProject).map(Project::getId))
                 .add(visibleWhen(() -> DEVELOPMENT == getApplication().getConfigurationType())));

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/config/DashboardProperties.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/config/DashboardProperties.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.core.config;
+
+import java.util.Set;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel;
+
+public interface DashboardProperties
+{
+    void setAccessibleByRoles(Set<PermissionLevel> aAccessibleByRoles);
+
+    Set<PermissionLevel> getAccessibleByRoles();
+}

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/config/DashboardPropertiesImpl.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/config/DashboardPropertiesImpl.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.core.config;
+
+import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.ANNOTATOR;
+import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.CURATOR;
+import static java.util.Arrays.asList;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel;
+
+@ConfigurationProperties("ui.dashboard")
+public class DashboardPropertiesImpl
+    implements DashboardProperties
+{
+    private Set<PermissionLevel> accessibleByRoles = new HashSet<>(asList(ANNOTATOR, CURATOR));
+
+    @Override
+    public void setAccessibleByRoles(Set<PermissionLevel> aAccessibleByRoles)
+    {
+        accessibleByRoles = aAccessibleByRoles;
+    }
+
+    @Override
+    public Set<PermissionLevel> getAccessibleByRoles()
+    {
+        return accessibleByRoles;
+    }
+}

--- a/inception/inception-ui-dashboard/pom.xml
+++ b/inception/inception-ui-dashboard/pom.xml
@@ -110,6 +110,10 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
     </dependency>
 

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/config/DashboardAutoConfiguration.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/config/DashboardAutoConfiguration.java
@@ -22,10 +22,12 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 
+import de.tudarmstadt.ukp.inception.ui.core.config.DashboardPropertiesImpl;
 import de.tudarmstadt.ukp.inception.ui.core.dashboard.dashlet.ProjectDashboardDashletExtension;
 import de.tudarmstadt.ukp.inception.ui.core.dashboard.dashlet.ProjectDashboardDashletExtensionPoint;
 import de.tudarmstadt.ukp.inception.ui.core.dashboard.dashlet.ProjectDashboardDashletExtensionPointImpl;
@@ -35,6 +37,7 @@ import de.tudarmstadt.ukp.inception.ui.core.dashboard.settings.export.ProjectExp
 
 @ConditionalOnWebApplication
 @Configuration
+@EnableConfigurationProperties(DashboardPropertiesImpl.class)
 public class DashboardAutoConfiguration
 {
     @Bean

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/project/ProjectDashboardPage.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/project/ProjectDashboardPage.java
@@ -35,12 +35,14 @@ import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.wicketstuff.annotation.mount.MountPath;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
+import de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.clarin.webanno.ui.core.menu.MenuItem;
 import de.tudarmstadt.ukp.clarin.webanno.ui.core.menu.MenuItemRegistry;
 import de.tudarmstadt.ukp.clarin.webanno.ui.core.page.ProjectPageBase;
+import de.tudarmstadt.ukp.inception.ui.core.config.DashboardProperties;
 import de.tudarmstadt.ukp.inception.ui.core.dashboard.DashboardMenu;
 import de.tudarmstadt.ukp.inception.ui.core.dashboard.dashlet.CurrentProjectDashlet;
 import de.tudarmstadt.ukp.inception.ui.core.dashboard.dashlet.ProjectDashboardDashletExtension;
@@ -65,6 +67,7 @@ public class ProjectDashboardPage
     private @SpringBean MenuItemRegistry menuItemService;
     private @SpringBean WorkloadManagementService workloadService;
     private @SpringBean ProjectDashboardDashletExtensionPoint dashletRegistry;
+    private @SpringBean DashboardProperties dashboardProperties;
 
     public ProjectDashboardPage(final PageParameters aPageParameters)
     {
@@ -76,7 +79,8 @@ public class ProjectDashboardPage
         User currentUser = userRepository.getCurrentUser();
 
         if (!userRepository.isAdministrator(currentUser)) {
-            requireAnyProjectRole(currentUser);
+            requireProjectRole(currentUser, PermissionLevel.MANAGER,
+                    dashboardProperties.getAccessibleByRoles().toArray(PermissionLevel[]::new));
         }
 
         add(new DashboardMenu(MID_MENU, LoadableDetachableModel.of(this::getMenuItems)));

--- a/inception/inception-ui-dashboard/src/main/resources/META-INF/asciidoc/admin-guide/settings_dashboard.adoc
+++ b/inception/inception-ui-dashboard/src/main/resources/META-INF/asciidoc/admin-guide/settings_dashboard.adoc
@@ -1,0 +1,22 @@
+= Project dashboard
+
+.Project dashboard settings in the `settings.properties` file
+[cols="4*", options="header"]
+|===
+| Setting
+| Description
+| Default
+| Example
+
+| `ui.dashboard.accessible-by-roles`
+| System roles able to access project dashboards
+| `ANNOTATOR`, `CURATOR`, `MANAGER`
+| `MANAGER`
+|===
+
+NOTE: To specify multiple values of the `ui.dashboard.accessible-by-roles` in a `settings.properties`
+      file, multiple lines need to be added like `ui.dashboard.accessible-by-roles[0]=ANNOTATOR`, 
+      `ui.dashboard.accessible-by-roles[1]=CURATOR`, etc.
+
+NOTE: Project managers can always access the project dashboard, even if they are not included in the
+      `ui.dashboard.accessible-by-roles` setting.

--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/DynamicWorkloadExtensionImpl.java
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/DynamicWorkloadExtensionImpl.java
@@ -137,12 +137,24 @@ public class DynamicWorkloadExtensionImpl
 
     @Override
     @Transactional
+    public void writeTraits(WorkloadManager aWorkloadManager, DynamicWorkloadTraits aTraits)
+    {
+        try {
+            aWorkloadManager.setTraits(JSONUtil.toJsonString(aTraits));
+        }
+        catch (Exception e) {
+            this.log.error("Unable to write traits", e);
+        }
+    }
+
+    @Override
+    @Transactional
     public void writeTraits(DynamicWorkloadTraits aTrait, Project aProject)
     {
         try {
             WorkloadManager manager = workloadManagementService
                     .loadOrCreateWorkloadManagerConfiguration(aProject);
-            manager.setTraits(JSONUtil.toJsonString(aTrait));
+            this.writeTraits(manager, aTrait);
             workloadManagementService.saveConfiguration(manager);
         }
         catch (Exception e) {

--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/annotation/DynamicWorkflowDocumentNavigationActionBarExtension.java
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/annotation/DynamicWorkflowDocumentNavigationActionBarExtension.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.inception.workload.dynamic.annotation;
 
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.CURATOR;
+import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.MANAGER;
 import static de.tudarmstadt.ukp.inception.workload.dynamic.DynamicWorkloadExtension.DYNAMIC_WORKLOAD_MANAGER_EXTENSION_ID;
 
 import java.io.Serializable;
@@ -104,7 +105,7 @@ public class DynamicWorkflowDocumentNavigationActionBarExtension
                 .equals(workloadManagementService.loadOrCreateWorkloadManagerConfiguration(
                         aPage.getModelObject().getProject()).getType())
                 && !projectService.hasRole(aPage.getModelObject().getUser(),
-                        aPage.getModelObject().getProject(), CURATOR);
+                        aPage.getModelObject().getProject(), CURATOR, MANAGER);
     }
 
     @Override

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/annotation/MatrixWorkflowDocumentNavigationActionBarExtension.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/annotation/MatrixWorkflowDocumentNavigationActionBarExtension.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.workload.matrix.annotation;
+
+import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.MANAGER;
+import static de.tudarmstadt.ukp.inception.workload.matrix.MatrixWorkloadExtension.MATRIX_WORKLOAD_MANAGER_EXTENSION_ID;
+
+import java.io.Serializable;
+
+import javax.persistence.EntityManager;
+
+import org.apache.wicket.markup.html.panel.EmptyPanel;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.spring.injection.annot.SpringBean;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
+import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.actionbar.ActionBarExtension;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.inception.workload.matrix.MatrixWorkloadExtension;
+import de.tudarmstadt.ukp.inception.workload.matrix.config.MatrixWorkloadManagerAutoConfiguration;
+import de.tudarmstadt.ukp.inception.workload.model.WorkloadManagementService;
+
+/**
+ * <p>
+ * This class is exposed as a Spring Component via
+ * {@link MatrixWorkloadManagerAutoConfiguration#matrixWorkflowDocumentNavigationActionBarExtension}
+ * </p>
+ */
+public class MatrixWorkflowDocumentNavigationActionBarExtension
+    implements ActionBarExtension, Serializable
+{
+    private static final long serialVersionUID = -8123846972605546654L;
+
+    private final WorkloadManagementService workloadManagementService;
+    private final MatrixWorkloadExtension matrixWorkloadExtension;
+    private final ProjectService projectService;
+
+    // SpringBeans
+    private @SpringBean EntityManager entityManager;
+
+    @Autowired
+    public MatrixWorkflowDocumentNavigationActionBarExtension(DocumentService aDocumentService,
+            WorkloadManagementService aWorkloadManagementService,
+            MatrixWorkloadExtension aMatrixWorkloadExtension, ProjectService aProjectService)
+    {
+        workloadManagementService = aWorkloadManagementService;
+        matrixWorkloadExtension = aMatrixWorkloadExtension;
+        projectService = aProjectService;
+    }
+
+    @Override
+    public String getRole()
+    {
+        return ROLE_NAVIGATOR;
+    }
+
+    @Override
+    public int getPriority()
+    {
+        return 1;
+    }
+
+    @Override
+    public boolean accepts(AnnotationPageBase aPage)
+    {
+        Project project = aPage.getModelObject().getProject();
+        if (project == null) {
+            return false;
+        }
+
+        var workloadManager = workloadManagementService
+                .loadOrCreateWorkloadManagerConfiguration(project);
+        if (!MATRIX_WORKLOAD_MANAGER_EXTENSION_ID.equals(workloadManager.getType())) {
+            return false;
+        }
+
+        if (projectService.hasRole(aPage.getModelObject().getUser(), project, MANAGER)) {
+            return false;
+        }
+
+        return !matrixWorkloadExtension.readTraits(workloadManager).isRandomDocumentAccessAllowed();
+    }
+
+    @Override
+    public Panel createActionBarItem(String aId, AnnotationPageBase aPage)
+    {
+        return new EmptyPanel(aId);
+    }
+}

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/config/MatrixWorkloadManagerAutoConfiguration.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/config/MatrixWorkloadManagerAutoConfiguration.java
@@ -23,10 +23,12 @@ import org.springframework.context.annotation.Configuration;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
+import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.inception.scheduling.SchedulingService;
 import de.tudarmstadt.ukp.inception.workload.matrix.MatrixWorkloadExtension;
 import de.tudarmstadt.ukp.inception.workload.matrix.MatrixWorkloadExtensionImpl;
 import de.tudarmstadt.ukp.inception.workload.matrix.annotation.MatrixWorkflowActionBarExtension;
+import de.tudarmstadt.ukp.inception.workload.matrix.annotation.MatrixWorkflowDocumentNavigationActionBarExtension;
 import de.tudarmstadt.ukp.inception.workload.matrix.event.MatrixWorkloadStateWatcher;
 import de.tudarmstadt.ukp.inception.workload.model.WorkloadManagementService;
 
@@ -37,10 +39,10 @@ public class MatrixWorkloadManagerAutoConfiguration
     @Bean
     public MatrixWorkloadExtension matrixWorkloadExtension(
             WorkloadManagementService aWorkloadManagementService, DocumentService aDocumentService,
-            ProjectService aProjectService)
+            ProjectService aProjectService, UserDao aUserRepository)
     {
         return new MatrixWorkloadExtensionImpl(aWorkloadManagementService, aDocumentService,
-                aProjectService);
+                aProjectService, aUserRepository);
     }
 
     @Bean
@@ -54,5 +56,14 @@ public class MatrixWorkloadManagerAutoConfiguration
     public MatrixWorkflowActionBarExtension matrixWorkflowActionBarExtension()
     {
         return new MatrixWorkflowActionBarExtension();
+    }
+
+    @Bean
+    public MatrixWorkflowDocumentNavigationActionBarExtension matrixWorkflowDocumentNavigationActionBarExtension(
+            DocumentService aDocumentService, WorkloadManagementService aWorkloadManagementService,
+            MatrixWorkloadExtension aMatrixWorkloadExtension, ProjectService aProjectService)
+    {
+        return new MatrixWorkflowDocumentNavigationActionBarExtension(aDocumentService,
+                aWorkloadManagementService, aMatrixWorkloadExtension, aProjectService);
     }
 }

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/trait/MatrixWorkloadTraits.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/trait/MatrixWorkloadTraits.java
@@ -30,7 +30,9 @@ public class MatrixWorkloadTraits
 {
     private static final long serialVersionUID = 6984531953353384507L;
 
-    private boolean reopenableByAnnotator;
+    private boolean reopenableByAnnotator = false;
+
+    private boolean randomDocumentAccessAllowed = true;
 
     public boolean isReopenableByAnnotator()
     {
@@ -40,5 +42,15 @@ public class MatrixWorkloadTraits
     public void setReopenableByAnnotator(boolean aReopenableByAnnotator)
     {
         reopenableByAnnotator = aReopenableByAnnotator;
+    }
+
+    public boolean isRandomDocumentAccessAllowed()
+    {
+        return randomDocumentAccessAllowed;
+    }
+
+    public void setRandomDocumentAccessAllowed(boolean aRandomDocumentAccessAllowed)
+    {
+        randomDocumentAccessAllowed = aRandomDocumentAccessAllowed;
     }
 }

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/trait/MatrixWorkloadTraitsEditor.html
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/trait/MatrixWorkloadTraitsEditor.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<!--
+  Licensed to the Technische Universität Darmstadt under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The Technische Universität Darmstadt 
+  licenses this file to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.
+   
+  http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<html xmlns:wicket="http://wicket.apache.org">
+<wicket:panel>
+  <form wicket:id="form">
+    <div class="row form-row" wicket:enclosure="randomDocumentAccessAllowed">
+      <div class="col-sm-8 offset-sm-4">
+        <div class="form-check">
+          <input wicket:id="randomDocumentAccessAllowed" class="form-check-input" type="checkbox">
+          <label wicket:for="randomDocumentAccessAllowed" class="form-check-label">
+            <wicket:label key="randomDocumentAccessAllowed" />
+          </label>
+        </div>
+      </div>
+    </div>
+    <div class="row form-row" wicket:enclosure="reopenableByAnnotator">
+      <div class="col-sm-8 offset-sm-4">
+        <div class="form-check">
+          <input wicket:id="reopenableByAnnotator" class="form-check-input" type="checkbox">
+          <label wicket:for="reopenableByAnnotator" class="form-check-label">
+            <wicket:label key="reopenableByAnnotator" />
+          </label>
+        </div>
+      </div>
+    </div>
+  </form>
+</wicket:panel>
+</html>

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/trait/MatrixWorkloadTraitsEditor.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/trait/MatrixWorkloadTraitsEditor.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.workload.matrix.trait;
+
+import org.apache.wicket.markup.html.form.CheckBox;
+import org.apache.wicket.markup.html.form.Form;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.model.CompoundPropertyModel;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.spring.injection.annot.SpringBean;
+
+import de.tudarmstadt.ukp.inception.workload.extension.WorkloadManagerExtension;
+import de.tudarmstadt.ukp.inception.workload.extension.WorkloadManagerExtensionPoint;
+import de.tudarmstadt.ukp.inception.workload.model.WorkloadManager;
+
+public class MatrixWorkloadTraitsEditor
+    extends Panel
+{
+    private static final long serialVersionUID = 9150032039791522664L;
+
+    private static final String MID_FORM = "form";
+    private static final String MID_REOPENABLE_BY_ANNOTATOR = "reopenableByAnnotator";
+    private static final String MID_RANDOM_DOCUMENT_ACCESS_ALLOWED = "randomDocumentAccessAllowed";
+
+    private @SpringBean WorkloadManagerExtensionPoint workloadManagerExtensionPoint;
+
+    private IModel<WorkloadManager> workloadManager;
+    private CompoundPropertyModel<MatrixWorkloadTraits> model;
+
+    public MatrixWorkloadTraitsEditor(String aId, IModel<WorkloadManager> aWorkloadManager)
+    {
+        super(aId, aWorkloadManager);
+
+        workloadManager = aWorkloadManager;
+
+        model = CompoundPropertyModel
+                .of(getWorkloadManagerExtension().readTraits(workloadManager.getObject()));
+
+        var form = new Form<MatrixWorkloadTraits>(MID_FORM, model)
+        {
+            private static final long serialVersionUID = 2781481443442601171L;
+
+            @Override
+            protected void onInitialize()
+            {
+                super.onInitialize();
+
+                CheckBox randomDocumentAccessAllowed = new CheckBox(
+                        MID_RANDOM_DOCUMENT_ACCESS_ALLOWED);
+                randomDocumentAccessAllowed.setOutputMarkupId(true);
+                queue(randomDocumentAccessAllowed);
+
+                CheckBox reopenableByAnnotator = new CheckBox(MID_REOPENABLE_BY_ANNOTATOR);
+                reopenableByAnnotator.setOutputMarkupId(true);
+                queue(reopenableByAnnotator);
+            }
+
+            @Override
+            protected void onSubmit()
+            {
+                super.onSubmit();
+                getWorkloadManagerExtension().writeTraits(workloadManager.getObject(),
+                        model.getObject());
+            }
+        };
+        form.setOutputMarkupPlaceholderTag(true);
+        add(form);
+    }
+
+    @SuppressWarnings("unchecked")
+    private WorkloadManagerExtension<MatrixWorkloadTraits> getWorkloadManagerExtension()
+    {
+        return (WorkloadManagerExtension<MatrixWorkloadTraits>) workloadManagerExtensionPoint
+                .getExtension(workloadManager.getObject().getType()).orElseThrow();
+    }
+}

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/trait/MatrixWorkloadTraitsEditor.properties
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/trait/MatrixWorkloadTraitsEditor.properties
@@ -1,0 +1,17 @@
+# Licensed to the Technische Universität Darmstadt under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The Technische Universität Darmstadt 
+# licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.
+#  
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+reopenableByAnnotator=Allow annotators to re-open a document
+randomDocumentAccessAllowed=Allow annotators to freely navigate between documents

--- a/inception/inception-workload-matrix/src/main/resources/META-INF/asciidoc/user-guide/workload_matrix.adoc
+++ b/inception/inception-workload-matrix/src/main/resources/META-INF/asciidoc/user-guide/workload_matrix.adoc
@@ -110,7 +110,19 @@ filter text field. For example, with the checkbox enabled, you could search for 
 all documents whose name starts with `chapter01` or for `train|test` to match all documents containing
 `train` or `test` in their name.
 
-== Allow annotators to re-open documents
+== Navigation between documents
+
+By default, annotators and curators can navigate freely between accessible documents in the matrix
+workload mode. However, there can be cases where users should be directed from an external system 
+only to specific documents and they should not be offered the ability to simply navigate to another
+document. In this case, the option **Allow annotators to freely navigate between documents** can be
+turned off in the matrix workload settings panel in the project settings. 
+
+NOTE: This only disables the navigation elements. Direct access to accessible documents through the
+      URL is still possible. An external workload management system would need to explicitly lock documents
+      to prevent users from accessing them.
+
+== Ability to re-open documents
 
 When an annotator marks a document as **Finished**, the document becomes uneditable for them. 
 By default, the only way to re-open a document for further annotation is that a curator or project manager opens the workload management page and changes the state of the document there.
@@ -122,3 +134,4 @@ If this option is enabled, the dialog that asks users to confirm that they wish 
 NOTE: This option only allows annotators to re-open documents that they have closed themselves. 
     If a document has been marked as finished by a project manager or curator, the annotators can not re-open it. 
     On the workload management page, documents that have been explicitly closed by a curator/manager bear a double icon in their state column (e.g. **finished (in progress)**).
+    

--- a/inception/inception-workload-ui/src/main/java/de/tudarmstadt/ukp/inception/workload/project/WorkloadSettingsPanel.html
+++ b/inception/inception-workload-ui/src/main/java/de/tudarmstadt/ukp/inception/workload/project/WorkloadSettingsPanel.html
@@ -31,6 +31,9 @@
               <select wicket:id="workloadStrategy" class="form-select" data-container="body"/>
             </div>
           </div>
+          <div wicket:id="traitsContainer">
+            <div wicket:id="traits"></div>
+          </div>
         </div>
         <div class="card-footer text-end">
           <button class="btn btn-primary" wicket:id="save">

--- a/inception/inception-workload-ui/src/main/java/de/tudarmstadt/ukp/inception/workload/project/WorkloadSettingsPanel.java
+++ b/inception/inception-workload-ui/src/main/java/de/tudarmstadt/ukp/inception/workload/project/WorkloadSettingsPanel.java
@@ -17,23 +17,28 @@
  */
 package de.tudarmstadt.ukp.inception.workload.project;
 
+import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.HtmlElementEvents.CHANGE_EVENT;
+
 import java.io.IOException;
 
+import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.feedback.IFeedback;
-import org.apache.wicket.markup.html.form.Button;
+import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.markup.html.form.Form;
+import org.apache.wicket.markup.html.panel.EmptyPanel;
 import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
-import org.apache.wicket.model.LoadableDetachableModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxButton;
+import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxFormComponentUpdatingBehavior;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaChoiceRenderer;
+import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaModelAdapter;
 import de.tudarmstadt.ukp.inception.support.help.DocLink;
-import de.tudarmstadt.ukp.inception.workload.extension.WorkloadManagerExtension;
 import de.tudarmstadt.ukp.inception.workload.extension.WorkloadManagerExtensionPoint;
 import de.tudarmstadt.ukp.inception.workload.extension.WorkloadManagerType;
 import de.tudarmstadt.ukp.inception.workload.model.WorkloadManagementService;
@@ -49,11 +54,20 @@ public class WorkloadSettingsPanel
 {
     private static final long serialVersionUID = -6220828178550562376L;
 
-    private final DropDownChoice<WorkloadManagerType> workloadStrategy;
-    private final Project project;
+    private static final String MID_SAVE = "save";
+    private static final String MID_FORM = "form";
+    private static final String MID_WORKLOAD_HELP_LINK = "workloadHelpLink";
+    private static final String MID_WORKLOAD_STRATEGY = "workloadStrategy";
+    private static final String MID_TRAITS_CONTAINER = "traitsContainer";
+    private static final String MID_TRAITS = "traits";
 
     private @SpringBean WorkloadManagementService workloadManagementService;
     private @SpringBean WorkloadManagerExtensionPoint workloadManagerExtensionPoint;
+
+    private final DropDownChoice<WorkloadManagerType> workloadStrategy;
+    private final Project project;
+    private final WebMarkupContainer traitsContainer;
+    private final CompoundPropertyModel<WorkloadManager> workloadManager;
 
     public WorkloadSettingsPanel(String aID, IModel<Project> aProject)
     {
@@ -61,53 +75,63 @@ public class WorkloadSettingsPanel
 
         project = aProject.getObject();
 
-        // Basic form
-        Form<Void> form = new Form<>("form");
+        workloadManager = CompoundPropertyModel
+                .of(workloadManagementService.loadOrCreateWorkloadManagerConfiguration(project));
+        Form<WorkloadManager> form = new Form<>(MID_FORM, workloadManager);
 
-        form.add(new DocLink("workloadHelpLink", "sect_workload"));
+        form.add(new DocLink(MID_WORKLOAD_HELP_LINK, "sect_workload"));
 
-        // Dropdown menu
-        workloadStrategy = new DropDownChoice<>("workloadStrategy");
+        form.add(traitsContainer = new WebMarkupContainer(MID_TRAITS_CONTAINER));
+        traitsContainer.setOutputMarkupId(true);
+
+        workloadStrategy = new DropDownChoice<>(MID_WORKLOAD_STRATEGY)
+        {
+            private static final long serialVersionUID = 9069776195986324794L;
+
+            @Override
+            protected void onModelChanged()
+            {
+                // If the feature type has changed, we need to set up a new traits editor
+                Component newTraits;
+                var wlm = workloadManager.getObject();
+                if (wlm != null) {
+                    var wlmExt = workloadManagerExtensionPoint.getExtension(wlm.getType())
+                            .orElseThrow();
+                    newTraits = wlmExt.createTraitsEditor(MID_TRAITS, workloadManager);
+                }
+                else {
+                    newTraits = new EmptyPanel(MID_TRAITS);
+                }
+
+                traitsContainer.addOrReplace(newTraits);
+            }
+        };
         workloadStrategy
                 .setChoiceRenderer(new LambdaChoiceRenderer<>(WorkloadManagerType::getUiName));
-        workloadStrategy.setModel(LoadableDetachableModel.of(this::getWorkloadManager));
+        workloadStrategy.setChoices(workloadManagerExtensionPoint.getTypes());
+        workloadStrategy.setModel(LambdaModelAdapter.of( //
+                () -> workloadManagerExtensionPoint
+                        .getWorkloadManagerType(workloadManager.getObject()),
+                (v) -> workloadManager.getObject().setType(v.getWorkloadManagerExtensionId())));
         workloadStrategy.setRequired(true);
         workloadStrategy.setNullValid(false);
-        workloadStrategy.setChoices(workloadManagerExtensionPoint.getTypes());
+        workloadStrategy.add(new LambdaAjaxFormComponentUpdatingBehavior(CHANGE_EVENT, _target -> {
+            _target.add(traitsContainer);
+        }));
 
         form.add(workloadStrategy);
 
-        // Finally, add the confirm button at the end
-        Button confirm = new LambdaAjaxButton<>("save", this::actionConfirm);
-        form.add(confirm);
+        // Processing the data in onAfterSubmit so the traits panel can use the override onSubmit in
+        // its nested form and store the traits before we clear the currently selected data.
+        form.add(new LambdaAjaxButton<>(MID_SAVE, this::actionSave).triggerAfterSubmit());
 
         add(form);
     }
 
-    /**
-     * @return current {@link WorkloadManager}
-     */
-    private WorkloadManagerType getWorkloadManager()
+    private void actionSave(AjaxRequestTarget aTarget, Form<?> aForm) throws IOException
     {
-        WorkloadManager manager = workloadManagementService
-                .loadOrCreateWorkloadManagerConfiguration(project);
-        WorkloadManagerExtension<?> extension = workloadManagerExtensionPoint
-                .getExtension(manager.getType()).orElseThrow();
-        return new WorkloadManagerType(extension.getId(), extension.getId());
-    }
-
-    /**
-     * Confirmation action of the button
-     */
-    private void actionConfirm(AjaxRequestTarget aTarget, Form<?> aForm) throws IOException
-    {
-        aTarget.addChildren(getPage(), IFeedback.class);
-
-        WorkloadManager manager = workloadManagementService
-                .loadOrCreateWorkloadManagerConfiguration(project);
-        manager.setType(workloadStrategy.getModelObject().getWorkloadManagerExtensionId());
-        workloadManagementService.saveConfiguration(manager);
-
+        workloadManagementService.saveConfiguration(workloadManager.getObject());
         success("Workload settings saved");
+        aTarget.addChildren(getPage(), IFeedback.class);
     }
 }

--- a/inception/inception-workload/pom.xml
+++ b/inception/inception-workload/pom.xml
@@ -51,6 +51,11 @@
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-model-export</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.wicket</groupId>
+      <artifactId>wicket-core</artifactId>
+    </dependency>
     
     <dependency>
       <groupId>org.springframework</groupId>

--- a/inception/inception-workload/src/main/java/de/tudarmstadt/ukp/inception/workload/extension/WorkloadManagerExtension.java
+++ b/inception/inception-workload/src/main/java/de/tudarmstadt/ukp/inception/workload/extension/WorkloadManagerExtension.java
@@ -17,6 +17,10 @@
  */
 package de.tudarmstadt.ukp.inception.workload.extension;
 
+import org.apache.wicket.markup.html.panel.EmptyPanel;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.model.IModel;
+
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.ProjectState;
 import de.tudarmstadt.ukp.clarin.webanno.support.extensionpoint.Extension;
@@ -44,7 +48,29 @@ public interface WorkloadManagerExtension<T>
 
     T readTraits(WorkloadManager aWorkloadManager);
 
+    void writeTraits(WorkloadManager aWorkloadManager, T aTraits);
+
     void writeTraits(T aTrait, Project aProject);
+
+    /**
+     * Returns a Wicket component to configure the specific traits of this workload extension. Note
+     * that every {@link WorkloadManagerExtension} has to return a <b>different class</b> here. So
+     * it is not possible to simple return a Wicket {@link Panel} here, but it must be a subclass of
+     * {@link Panel} used exclusively by the current {@link WorkloadManagerExtension}. If this is
+     * not done, then the traits editor in the UI will not be correctly updated when switching
+     * between feature types!
+     * 
+     * @param aId
+     *            a markup ID.
+     * @param aWorkloadManager
+     *            a model holding the workload manager for which the traits editor should be
+     *            created.
+     * @return the traits editor component.
+     */
+    default Panel createTraitsEditor(String aId, IModel<WorkloadManager> aWorkloadManager)
+    {
+        return new EmptyPanel(aId);
+    }
 
     /**
      * Ask the workload manager to immediately recalculate the state of all documents in the project

--- a/inception/inception-workload/src/main/java/de/tudarmstadt/ukp/inception/workload/extension/WorkloadManagerExtensionPoint.java
+++ b/inception/inception-workload/src/main/java/de/tudarmstadt/ukp/inception/workload/extension/WorkloadManagerExtensionPoint.java
@@ -22,6 +22,7 @@ import java.util.List;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.support.extensionpoint.ExtensionPoint;
 import de.tudarmstadt.ukp.inception.workload.config.WorkloadManagementAutoConfiguration;
+import de.tudarmstadt.ukp.inception.workload.model.WorkloadManager;
 
 /**
  * <p>
@@ -35,4 +36,6 @@ public interface WorkloadManagerExtensionPoint
     WorkloadManagerExtension<?> getDefault();
 
     List<WorkloadManagerType> getTypes();
+
+    WorkloadManagerType getWorkloadManagerType(WorkloadManager aWorkloadManager);
 }

--- a/inception/inception-workload/src/main/java/de/tudarmstadt/ukp/inception/workload/extension/WorkloadManagerExtensionPointImpl.java
+++ b/inception/inception-workload/src/main/java/de/tudarmstadt/ukp/inception/workload/extension/WorkloadManagerExtensionPointImpl.java
@@ -30,6 +30,7 @@ import org.springframework.context.annotation.Lazy;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.support.extensionpoint.ExtensionPoint_ImplBase;
 import de.tudarmstadt.ukp.inception.workload.config.WorkloadManagementAutoConfiguration;
+import de.tudarmstadt.ukp.inception.workload.model.WorkloadManager;
 
 /**
  * <p>
@@ -71,5 +72,17 @@ public class WorkloadManagerExtensionPointImpl
         return getExtensions().stream()
                 .map(manExt -> new WorkloadManagerType(manExt.getId(), manExt.getLabel()))
                 .collect(toList());
+    }
+
+    @Override
+    public WorkloadManagerType getWorkloadManagerType(WorkloadManager aWorkloadManager)
+    {
+        if (aWorkloadManager.getType() == null) {
+            return null;
+        }
+
+        return getTypes().stream()
+                .filter(t -> t.getWorkloadManagerExtensionId().equals(aWorkloadManager.getType()))
+                .findFirst().orElse(null);
     }
 }


### PR DESCRIPTION
**What's in the PR**
- Added global setting to determine which project roles should be able to access the project dashboard
- Hide the menubar if users are not allowed to access the project dashboard
- If project dashboard access is disabled, do not redirect user to dashboard e.g. if a document is not accessibly on the annotation page - instead show a respective message on that page
- Added option in the project settings to configure if random access to documents is supported for the matrix workload
- Added trait editors to workload modes

**How to test manually**
* Disable random access to documents and try accessing directly accessible as well as non-accessible documents, try closing them, etc.
* Disable dashboard access e.g. for annotators and see what happens if you still try to access the dashboard as a user having only the annotator role. Also try to see if you get redirected to the dashboard, e.g. when trying to access inaccessible documents or when closing the last document as problematic (which locks it for the annotator), etc.

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
