### PR TITLE
#2677 - Make it possible to hide the editor preference menu in the editor

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/page/AnnotationEditorState.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/page/AnnotationEditorState.java
@@ -21,13 +21,20 @@ import java.io.Serializable;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
+import de.tudarmstadt.ukp.inception.preferences.Key;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class AnnotationEditorState
     implements Serializable
 {
     private static final long serialVersionUID = -1637731874872789592L;
 
+    public static final Key<AnnotationEditorState> KEY_EDITOR_STATE = new Key<>(
+            AnnotationEditorState.class, "annotation/editor");
+
     private String defaultEditor;
+
+    private boolean preferencesAccessAllowed = true;
 
     public String getDefaultEditor()
     {
@@ -37,5 +44,15 @@ public class AnnotationEditorState
     public void setDefaultEditor(String aEditorId)
     {
         defaultEditor = aEditorId;
+    }
+
+    public boolean isPreferencesAccessAllowed()
+    {
+        return preferencesAccessAllowed;
+    }
+
+    public void setPreferencesAccessAllowed(boolean aPreferencesAccessAllowed)
+    {
+        preferencesAccessAllowed = aPreferencesAccessAllowed;
     }
 }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/page/AnnotationPageBase.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/page/AnnotationPageBase.java
@@ -76,7 +76,6 @@ import de.tudarmstadt.ukp.clarin.webanno.support.uima.ICasUtil;
 import de.tudarmstadt.ukp.clarin.webanno.support.wicket.DecoratedObject;
 import de.tudarmstadt.ukp.clarin.webanno.ui.core.page.ProjectPageBase;
 import de.tudarmstadt.ukp.inception.editor.action.AnnotationActionHandler;
-import de.tudarmstadt.ukp.inception.preferences.Key;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VRange;
@@ -89,9 +88,6 @@ public abstract class AnnotationPageBase
     extends ProjectPageBase
 {
     private static final long serialVersionUID = -1133219266479577443L;
-
-    public static final Key<AnnotationEditorState> KEY_EDITOR_STATE = new Key<>(
-            AnnotationEditorState.class, "annotation/editor");
 
     public static final String PAGE_PARAM_DOCUMENT = "d";
     public static final String PAGE_PARAM_USER = "u";

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/preferences/AnnotationPreferencesDialogContent.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/preferences/AnnotationPreferencesDialogContent.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.api.annotation.preferences;
 
+import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationEditorState.KEY_EDITOR_STATE;
 import static de.tudarmstadt.ukp.clarin.webanno.model.Mode.ANNOTATION;
 import static de.tudarmstadt.ukp.clarin.webanno.model.Mode.CURATION;
 import static de.tudarmstadt.ukp.clarin.webanno.support.WebAnnoConst.CHAIN_TYPE;
@@ -55,7 +56,6 @@ import org.slf4j.Logger;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationEditorState;
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.AjaxCallback;
@@ -130,8 +130,8 @@ public class AnnotationPreferencesDialogContent
         fontZoomField.setMaximum(AnnotationPreference.FONT_ZOOM_MAX);
         form.add(fontZoomField);
 
-        AnnotationEditorState state = preferencesService.loadDefaultTraitsForProject(
-                AnnotationPageBase.KEY_EDITOR_STATE, stateModel.getObject().getProject());
+        AnnotationEditorState state = preferencesService
+                .loadDefaultTraitsForProject(KEY_EDITOR_STATE, stateModel.getObject().getProject());
 
         DropDownChoice<Pair<String, String>> editor = new DropDownChoice<>("editor");
         editor.setChoiceRenderer(new ChoiceRenderer<>("value"));

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/preferences/UserPreferencesActionBarExtension.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/preferences/UserPreferencesActionBarExtension.java
@@ -17,18 +17,41 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.api.annotation.preferences;
 
+import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationEditorState.KEY_EDITOR_STATE;
+import static de.tudarmstadt.ukp.clarin.webanno.model.Mode.CURATION;
+
 import org.apache.wicket.markup.html.panel.Panel;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.actionbar.ActionBarExtension;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationEditorState;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
+import de.tudarmstadt.ukp.inception.preferences.PreferencesService;
 
 @Order(10000)
 @Component
 public class UserPreferencesActionBarExtension
     implements ActionBarExtension
 {
+    private final PreferencesService preferencesService;
+
+    public UserPreferencesActionBarExtension(PreferencesService aPreferencesService)
+    {
+        super();
+        preferencesService = aPreferencesService;
+    }
+
+    @Override
+    public boolean accepts(AnnotationPageBase aPage)
+    {
+        AnnotationEditorState editorState = preferencesService
+                .loadDefaultTraitsForProject(KEY_EDITOR_STATE, aPage.getProject());
+
+        return editorState.isPreferencesAccessAllowed()
+                || aPage.getModelObject().getMode() == CURATION;
+    }
+
     @Override
     public Panel createActionBarItem(String aId, AnnotationPageBase aPage)
     {

--- a/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/preferences/BratAnnotationEditorManagerPrefPanel.properties
+++ b/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/preferences/BratAnnotationEditorManagerPrefPanel.properties
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 title=Brat annotation editor
-changingScriptDirectionAllowed=Allow annotator to change script direction
+changingScriptDirectionAllowed=Allow changing the script direction in the annotation editor
 defaultPageSize=Default page size
 scriptDirection=Script direction
 ScriptDirection.LTR=left-to-right

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.clarin.webanno.ui.annotation;
 
 import static de.tudarmstadt.ukp.clarin.webanno.api.CasUpgradeMode.FORCE_CAS_UPGRADE;
+import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationEditorState.KEY_EDITOR_STATE;
 import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase.PAGE_PARAM_DOCUMENT;
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState.IGNORE;
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentStateChangeFlag.EXPLICIT_ANNOTATOR_USER_ACTION;

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/login/LoginPage.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/login/LoginPage.java
@@ -320,24 +320,24 @@ public class LoginPage
             // Wicket continueToOriginalDestination();
 
             if (aRedirectUrl == null || aRedirectUrl.contains(".IBehaviorListener.")
-                    || aRedirectUrl.contains("-logoutPanel-")) {
+                    || aRedirectUrl.contains("-logoutPanel-") || aRedirectUrl.endsWith("/ws")) {
                 log.debug("Redirecting to welcome page");
                 setResponsePage(getApplication().getHomePage());
+                return;
             }
-            else {
-                log.debug("Redirecting to saved URL: [{}]", aRedirectUrl);
-                if (isNotBlank(localLoginPanel.urlfragment)
-                        && localLoginPanel.urlfragment.startsWith("!")) {
-                    Url url = Url.parse("http://dummy?" + localLoginPanel.urlfragment.substring(1));
-                    UrlRequestParametersAdapter adapter = new UrlRequestParametersAdapter(url);
-                    LinkedHashMap<String, StringValue> params = new LinkedHashMap<>();
-                    for (String name : adapter.getParameterNames()) {
-                        params.put(name, adapter.getParameterValue(name));
-                    }
-                    Session.get().setMetaData(SessionMetaData.LOGIN_URL_FRAGMENT_PARAMS, params);
+
+            log.debug("Redirecting to saved URL: [{}]", aRedirectUrl);
+            if (isNotBlank(localLoginPanel.urlfragment)
+                    && localLoginPanel.urlfragment.startsWith("!")) {
+                Url url = Url.parse("http://dummy?" + localLoginPanel.urlfragment.substring(1));
+                UrlRequestParametersAdapter adapter = new UrlRequestParametersAdapter(url);
+                LinkedHashMap<String, StringValue> params = new LinkedHashMap<>();
+                for (String name : adapter.getParameterNames()) {
+                    params.put(name, adapter.getParameterValue(name));
                 }
-                throw new NonResettingRestartException(aRedirectUrl);
+                Session.get().setMetaData(SessionMetaData.LOGIN_URL_FRAGMENT_PARAMS, params);
             }
+            throw new NonResettingRestartException(aRedirectUrl);
         }
     }
 

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/DefaultAnnotationEditorStatePanel.html
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/DefaultAnnotationEditorStatePanel.html
@@ -32,6 +32,16 @@
             <select wicket:id="defaultEditor" class="form-select"/>
           </div>
         </div>
+        <div class="row form-row">
+          <div class="offset-sm-4 col-sm-8">
+            <div class="form-check">
+              <input wicket:id="preferencesAccessAllowed" class="form-check-input" type="checkbox"> 
+              <label wicket:for="preferencesAccessAllowed" class="form-check-label" >
+                <wicket:label key="preferencesAccessAllowed"/>
+              </label>
+            </div>
+          </div>
+        </div>
       </div>
     </form>
   </wicket:panel>

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/DefaultAnnotationEditorStatePanel.properties
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/DefaultAnnotationEditorStatePanel.properties
@@ -17,3 +17,4 @@
 defaultEditor=Editor
 defaultEditor.nullValid=Leave choice to annotator
 defaultAnnotationEditorState=Annotation editor
+preferencesAccessAllowed=Allow access to user-specific annotation editor preferences


### PR DESCRIPTION
**What's in the PR**
- Added setting in the annotation project settings to disable access to the preferences dialog
- Respect that setting when constructing the preferences extension for the annotation page action bar
- Avoid redirecting to WebSocket endpoint from login page

**How to test manually**
* Enable/disable the option allowing access to the preference dialog in the annotation panel of the project settings
* Visit the annotation page to see if the setting has an effect
* Visit the curation page to see that the setting has no effect there

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
