### PR TITLE
#3762 - Ability to sort annotation sidebar by recommender scores

### DIFF
--- a/inception/inception-diam-editor/src/main/ts/src/AnnotationsByLabelList.svelte
+++ b/inception/inception-diam-editor/src/main/ts/src/AnnotationsByLabelList.svelte
@@ -34,7 +34,7 @@
 
     let groupedAnnotations: Record<string, Annotation[]>;
     let sortedLabels: string[];
-    let sortByScore: boolean = false;
+    let sortByScore: boolean = true;
 
     $: sortedLabels = uniqueLabels(data);
     $: {

--- a/inception/inception-documents/src/test/java/de/tudarmstadt/ukp/inception/documents/DocumentServiceImplConcurrencyTest.java
+++ b/inception/inception-documents/src/test/java/de/tudarmstadt/ukp/inception/documents/DocumentServiceImplConcurrencyTest.java
@@ -262,9 +262,9 @@ public class DocumentServiceImplConcurrencyTest
         List<Thread> primaryTasks = new ArrayList<>();
         List<Thread> secondaryTasks = new ArrayList<>();
 
-        int threadGroupCount = 8;
-        int iterations = 1000;
-        int userCount = 16;
+        int threadGroupCount = 4;
+        int iterations = 100;
+        int userCount = 4;
         for (int u = 0; u < userCount; u++) {
             for (int n = 0; n < threadGroupCount; n++) {
                 Thread rw = new ExclusiveReadWriteTask(n, doc, user + n, iterations);


### PR DESCRIPTION
**What's in the PR**
- Make sort-by-score the default
- Make the DocumentServiceImplConcurrentyTest run faster again (fewer iterations and less concurrency)

**How to test manually**
* Open the sidebar and check if sorting is enabled by default

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
