### PR TITLE
#3836 - Keyboard shortcuts on dashboard should not trigger when editing project title

### DIFF
--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/DashboardMenu.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/DashboardMenu.java
@@ -186,7 +186,16 @@ public class DashboardMenu
         menulink.add(AttributeAppender.append("class",
                 () -> getPage().getClass().equals(pageClass) ? "active" : ""));
         if (item.shortcut() != null && item.shortcut().length > 0) {
-            menulink.add(new InputBehavior(item.shortcut(), EventType.click));
+            menulink.add(new InputBehavior(item.shortcut(), EventType.click)
+            {
+                private static final long serialVersionUID = -3230776977218522942L;
+
+                @Override
+                protected Boolean getDisable_in_input()
+                {
+                    return true;
+                };
+            });
             menulink.add(AttributeModifier.append("title",
                     "[" + Stream.of(item.shortcut()).map(Object::toString).collect(joining(" + "))
                             + "]"));


### PR DESCRIPTION
**What's in the PR**
- Configure InputBehavior to not trigger when the focus is in an input field

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
