### PR TITLE
#3831 - Better support a direct-access workflow

### DIFF
--- a/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/DocumentAccessImpl.java
+++ b/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/DocumentAccessImpl.java
@@ -19,7 +19,6 @@ package de.tudarmstadt.ukp.inception.documents;
 
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.CURATOR;
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.MANAGER;
-import static de.tudarmstadt.ukp.clarin.webanno.support.WebAnnoConst.CURATION_USER;
 import static org.apache.commons.collections4.CollectionUtils.containsAny;
 
 import java.util.List;
@@ -91,15 +90,17 @@ public class DocumentAccessImpl
                 return false;
             }
 
-            // Annotators can see their own annotations and manager/curators can see annotations of
-            // all users
-            if (!aUser.equals(aAnnotator) && !permissionLevels.contains(MANAGER)
-                    && !(CURATION_USER.equals(aUser)
-                            && containsAny(permissionLevels, MANAGER, CURATOR))) {
+            // Managers and curators can see anything
+            if (containsAny(permissionLevels, MANAGER, CURATOR)) {
+                return true;
+            }
+
+            // Annotators can only see their own documents
+            if (!aUser.equals(aAnnotator)) {
                 return false;
             }
 
-            // Blocked documents cannot be viewed
+            // Annotators cannot view blocked documents
             SourceDocument doc = documentService.getSourceDocument(project.getId(), aDocumentId);
             if (documentService.existsAnnotationDocument(doc, aAnnotator)) {
                 AnnotationDocument aDoc = documentService.getAnnotationDocument(doc, aAnnotator);


### PR DESCRIPTION
**What's in the PR**
- Fix access check so that curators can actually view the curation document (and other annotator's documents)

**How to test manually**
* Try opening the annotation sidebar as a user who is only a curator in sidebar curation mode

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
