### PR TITLE
#3854 - Webserver should run on a headless setup

### DIFF
--- a/inception/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/INCEpTION.java
+++ b/inception/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/INCEpTION.java
@@ -164,6 +164,7 @@ public class INCEpTION
         else {
             builder.web(SERVLET);
             splash = LoadingSplashScreen.setupScreen("INCEpTION");
+            builder.headless(splash.isEmpty());
             builder.profiles(DeploymentModeService.PROFILE_APPLICATION_MODE);
         }
 

--- a/inception/inception-support-standalone/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/standalone/LoadingSplashScreen.java
+++ b/inception/inception-support-standalone/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/standalone/LoadingSplashScreen.java
@@ -67,10 +67,16 @@ public class LoadingSplashScreen
             return Optional.empty();
         }
 
-        SplashWindow window = new SplashWindow(aSplashScreenImageUrl, aIconUrl, aApplicationName);
-        window.setVisible(true);
+        try {
+            SplashWindow window = new SplashWindow(aSplashScreenImageUrl, aIconUrl,
+                    aApplicationName);
+            window.setVisible(true);
 
-        return Optional.of(window);
+            return Optional.of(window);
+        }
+        catch (UnsatisfiedLinkError e) {
+            return Optional.empty();
+        }
     }
 
     public static Optional<SplashWindow> setupScreen(String aApplicationName)


### PR DESCRIPTION
**What's in the PR**
- Catch exception caused by AWT being initialized on a headless Java which doesn't know it is headless and handle it

**How to test manually**
* See issue

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
