### PR TITLE
#3865 - Option to hide the reset button on the annotation page

### DIFF
--- a/inception/inception-workload-matrix/pom.xml
+++ b/inception/inception-workload-matrix/pom.xml
@@ -70,6 +70,10 @@
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-curation</artifactId>
     </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-preferences</artifactId>
+    </dependency>
         
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/trait/MatrixWorkloadTraits.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/trait/MatrixWorkloadTraits.java
@@ -34,6 +34,8 @@ public class MatrixWorkloadTraits
 
     private boolean randomDocumentAccessAllowed = true;
 
+    private boolean documentResetAllowed = true;
+
     public boolean isReopenableByAnnotator()
     {
         return reopenableByAnnotator;
@@ -52,5 +54,15 @@ public class MatrixWorkloadTraits
     public void setRandomDocumentAccessAllowed(boolean aRandomDocumentAccessAllowed)
     {
         randomDocumentAccessAllowed = aRandomDocumentAccessAllowed;
+    }
+
+    public boolean isDocumentResetAllowed()
+    {
+        return documentResetAllowed;
+    }
+
+    public void setDocumentResetAllowed(boolean aDocumentResetAllowed)
+    {
+        documentResetAllowed = aDocumentResetAllowed;
     }
 }

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/trait/MatrixWorkloadTraitsEditor.html
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/trait/MatrixWorkloadTraitsEditor.html
@@ -39,6 +39,16 @@
         </div>
       </div>
     </div>
+    <div class="row form-row">
+      <div class="offset-sm-4 col-sm-8">
+        <div class="form-check">
+          <input wicket:id="documentResetAllowed" class="form-check-input" type="checkbox"> 
+          <label wicket:for="documentResetAllowed" class="form-check-label" >
+            <wicket:label key="documentResetAllowed"/>
+          </label>
+        </div>
+      </div>
+    </div>
   </form>
 </wicket:panel>
 </html>

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/trait/MatrixWorkloadTraitsEditor.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/trait/MatrixWorkloadTraitsEditor.java
@@ -65,6 +65,8 @@ public class MatrixWorkloadTraitsEditor
                 randomDocumentAccessAllowed.setOutputMarkupId(true);
                 queue(randomDocumentAccessAllowed);
 
+                queue(new CheckBox("documentResetAllowed").setOutputMarkupId(true));
+
                 CheckBox reopenableByAnnotator = new CheckBox(MID_REOPENABLE_BY_ANNOTATOR);
                 reopenableByAnnotator.setOutputMarkupId(true);
                 queue(reopenableByAnnotator);

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/trait/MatrixWorkloadTraitsEditor.properties
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/trait/MatrixWorkloadTraitsEditor.properties
@@ -15,3 +15,4 @@
 # limitations under the License.
 reopenableByAnnotator=Allow annotators to re-open a document
 randomDocumentAccessAllowed=Allow annotators to freely navigate between documents
+documentResetAllowed=Allow resetting the document to its original state


### PR DESCRIPTION
**What's in the PR**
- Added option in the workload panel of the project settings to hide the reset button (for matrix workload only)

**How to test manually**
* Enable/disable the option
* Visit the annotation page

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
