### PR TITLE
#3874 - Images not shown in hover popup

### DIFF
--- a/inception/inception-brat-editor/src/main/ts/src/visualizer_ui/VisualizerUI.ts
+++ b/inception/inception-brat-editor/src/main/ts/src/visualizer_ui/VisualizerUI.ts
@@ -284,7 +284,7 @@ export class VisualizerUI {
           if (label && value) {
             // special treatment for some label values
             if (label.toLowerCase() === '<img>') {
-              norminfo += `<img class="norm_info_img" src="${value}"/>`
+              norminfo += `<img class="norm_info_img" crossorigin src="${value}"/>`
             } else {
               // normal, as text max length restriction
               if (value.length > 300) {


### PR DESCRIPTION
**What's in the PR**
- Added "crossorigin" attribute to allow the browser to load images across domains

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
