### PR TITLE
#3877 - Show a bit of context in the annotation sidebar

### DIFF
--- a/inception/inception-diam-editor/src/main/ts/src/AnnotationsByLabelList.svelte
+++ b/inception/inception-diam-editor/src/main/ts/src/AnnotationsByLabelList.svelte
@@ -156,7 +156,7 @@
                                     </div>
                                     <!-- svelte-ignore a11y-click-events-have-key-events -->
                                     <div
-                                        class="flex-grow-1 py-1 px-2"
+                                        class="flex-grow-1 my-1 mx-2 position-relative overflow-hidden"
                                         on:click={() => scrollTo(ann)}
                                     >
                                         <div class="float-end">

--- a/inception/inception-diam-editor/src/main/ts/src/AnnotationsByLabelList.svelte
+++ b/inception/inception-diam-editor/src/main/ts/src/AnnotationsByLabelList.svelte
@@ -159,7 +159,7 @@
                                         class="flex-grow-1 my-1 mx-2 position-relative overflow-hidden"
                                         on:click={() => scrollTo(ann)}
                                     >
-                                        <div class="float-end">
+                                        <div class="float-end labels">
                                             <LabelBadge
                                                 annotation={ann}
                                                 {ajaxClient}
@@ -187,6 +187,13 @@
 {/if}
 
 <style lang="scss">
+    .labels {
+        background: linear-gradient(to right, transparent 0px, white 15px);
+        padding-left: 20px;
+        z-index: 10;
+        position: relative;
+    }
+
     .annotation-type-marker {
         width: 1em;
         text-align: center;

--- a/inception/inception-diam-editor/src/main/ts/src/AnnotationsByPositionList.svelte
+++ b/inception/inception-diam-editor/src/main/ts/src/AnnotationsByPositionList.svelte
@@ -64,7 +64,7 @@
                 {@const firstSpan = spans[0]}
                 <li class="list-group-item list-group-item-action p-0">
                     <!-- svelte-ignore a11y-click-events-have-key-events -->
-                    <div class="flex-grow-1 py-1 px-2" on:click={() => scrollToSpan(firstSpan)}>
+                    <div class="flex-grow-1 my-1 mx-2 overflow-hidden" on:click={() => scrollToSpan(firstSpan)}>
                         <div class="float-end">
                             {#each spans as span}
                                 <LabelBadge annotation={span} {ajaxClient} />
@@ -83,7 +83,7 @@
                                 <span>↳</span>
                             </div>
                             <!-- svelte-ignore a11y-click-events-have-key-events -->
-                            <div class="flex-grow-1 py-1 px-2" on:click={() => scrollToRelation(relation)}>
+                            <div class="flex-grow-1 my-1 mx-2 overflow-hidden" on:click={() => scrollToRelation(relation)}>
                                 <div class="float-end">
                                     <LabelBadge annotation={relation} {ajaxClient} />
                                 </div>

--- a/inception/inception-diam-editor/src/main/ts/src/AnnotationsByPositionList.svelte
+++ b/inception/inception-diam-editor/src/main/ts/src/AnnotationsByPositionList.svelte
@@ -65,7 +65,7 @@
                 <li class="list-group-item list-group-item-action p-0">
                     <!-- svelte-ignore a11y-click-events-have-key-events -->
                     <div class="flex-grow-1 my-1 mx-2 overflow-hidden" on:click={() => scrollToSpan(firstSpan)}>
-                        <div class="float-end">
+                        <div class="float-end labels">
                             {#each spans as span}
                                 <LabelBadge annotation={span} {ajaxClient} />
                             {/each}
@@ -84,7 +84,7 @@
                             </div>
                             <!-- svelte-ignore a11y-click-events-have-key-events -->
                             <div class="flex-grow-1 my-1 mx-2 overflow-hidden" on:click={() => scrollToRelation(relation)}>
-                                <div class="float-end">
+                                <div class="float-end labels">
                                     <LabelBadge annotation={relation} {ajaxClient} />
                                 </div>
 
@@ -100,6 +100,13 @@
 {/if}
 
 <style lang="scss">
+    .labels {
+        background: linear-gradient(to right, transparent 0px, white 15px);
+        padding-left: 20px;
+        z-index: 10;
+        position: relative;
+    }
+
     .list-group-flush > .list-group-item:last-child {
         border-bottom-width: 1px;
     }

--- a/inception/inception-diam-editor/src/main/ts/src/LabelBadge.svelte
+++ b/inception/inception-diam-editor/src/main/ts/src/LabelBadge.svelte
@@ -48,7 +48,6 @@
 </script>
 
 <!-- svelte-ignore a11y-click-events-have-key-events -->
-<div class="wrapper">
 {#if annotation.vid.toString().startsWith("rec:")}
     <div class="btn-group mb-0 ms-0 btn-group-recommendation bg-body" role="group">
         <button
@@ -59,7 +58,7 @@
         >
             <i class="far fa-check-circle" />
             {#if showText}
-                {annotation.label || "No label"}
+                <span class="label">{annotation.label || "No label"}</span>
             {/if}
             {#if annotation.score}
                 <span class="small font-monospace score"
@@ -86,7 +85,7 @@
     >
         <i class="fas fa-clipboard-check" />
         {#if showText}
-            {annotation.label || "No label"}
+            <span class="label">{annotation.label || "No label"}</span>
         {/if}
         {#if annotation.score}
             <span class="small font-monospace score"
@@ -95,7 +94,7 @@
         {/if}
     </button>
 {:else}
-    <div class="btn-group mb-0 ms-0 bg-body" role="group">
+    <div class="btn-group mb-0 ms-1 bg-body" role="group">
         <button
             type="button"
             class="btn-select btn btn-colored btn-sm py-0 px-1 border-dark"
@@ -120,14 +119,10 @@
         </button>
     </div>
 {/if}
-</div>
 
 <style lang="scss">
-    .wrapper {
-        background: linear-gradient(to right, transparent 0px, white 15px);
-        padding-left: 20px;
-        z-index: 10;
-        position: relative;
+    .label {
+        word-break: break-all;
     }
 
     .btn-colored:hover {

--- a/inception/inception-diam-editor/src/main/ts/src/LabelBadge.svelte
+++ b/inception/inception-diam-editor/src/main/ts/src/LabelBadge.svelte
@@ -48,8 +48,9 @@
 </script>
 
 <!-- svelte-ignore a11y-click-events-have-key-events -->
+<div class="wrapper">
 {#if annotation.vid.toString().startsWith("rec:")}
-    <div class="btn-group mb-0 ms-1 btn-group-recommendation" role="group">
+    <div class="btn-group mb-0 ms-0 btn-group-recommendation bg-body" role="group">
         <button
             type="button"
             class="btn-accept btn btn-outline-success btn-sm py-0 px-1"
@@ -94,7 +95,7 @@
         {/if}
     </button>
 {:else}
-    <div class="btn-group mb-0 ms-1" role="group">
+    <div class="btn-group mb-0 ms-0 bg-body" role="group">
         <button
             type="button"
             class="btn-select btn btn-colored btn-sm py-0 px-1 border-dark"
@@ -119,8 +120,16 @@
         </button>
     </div>
 {/if}
+</div>
 
 <style lang="scss">
+    .wrapper {
+        background: linear-gradient(to right, transparent 0px, white 15px);
+        padding-left: 20px;
+        z-index: 10;
+        position: relative;
+    }
+
     .btn-colored:hover {
         filter: brightness(0.8);
     }

--- a/inception/inception-diam-editor/src/main/ts/src/SpanText.svelte
+++ b/inception/inception-diam-editor/src/main/ts/src/SpanText.svelte
@@ -22,17 +22,22 @@
     export let data: AnnotatedText
     export let span: Span
 
+    const maxLength = 50
+    const showTextAfter = false // Experimental
+
     $: begin = span.offsets[0][0]
     $: end = span.offsets[0][1]
     $: text = data.text.substring(begin, end).trim().replace(/\s+/g, ' ')
+    $: textAfter = (showTextAfter && text.length < maxLength) ? 
+        data.text.substring(end, end + maxLength - text.length).trim().replace(/\s+/g, ' ') : ''
 </script>
 
 {#if text.length === 0}
-<span class="text-muted">(empty span)</span>
-{:else if text.length > 50}
+<span class="text-muted">(empty)</span>
+{:else if text.length > maxLength}
 <span title="{text.substring(0,1000)}">{text.substring(0, 50)}</span><span class="text-muted">…</span>
 {:else}
-<span>{text}</span>
+<span>{text} {#if textAfter.length > 0}<span class="text-muted">{textAfter}</span>{/if}</span>
 {/if}
 
 <style>

--- a/inception/inception-diam-editor/src/main/ts/src/SpanText.svelte
+++ b/inception/inception-diam-editor/src/main/ts/src/SpanText.svelte
@@ -22,8 +22,8 @@
     export let data: AnnotatedText
     export let span: Span
 
-    const maxLength = 50
-    const showTextAfter = false // Experimental
+    const maxLength = 100
+    const showTextAfter = true // Experimental
 
     $: begin = span.offsets[0][0]
     $: end = span.offsets[0][1]
@@ -33,12 +33,22 @@
 </script>
 
 {#if text.length === 0}
-<span class="text-muted">(empty)</span>
+    <span class="text-muted">(empty)</span>
 {:else if text.length > maxLength}
-<span title="{text.substring(0,1000)}">{text.substring(0, 50)}</span><span class="text-muted">…</span>
+    <span title="{text.substring(0,1000)}">{text.substring(0, 50)}</span>
+    <span class="text-muted trailing-text">…</span>
 {:else}
-<span>{text} {#if textAfter.length > 0}<span class="text-muted">{textAfter}</span>{/if}</span>
+    {text}
+    {#if textAfter.length > 0}
+        <span class="text-muted trailing-text">{textAfter}</span>
+    {/if}
 {/if}
 
-<style>
+<style lang="scss">
+    .trailing-text {
+        font-weight: lighter;
+        width: 0px;
+        display: inline-block;
+        white-space: nowrap;
+    }
 </style>


### PR DESCRIPTION
**What's in the PR**
- Display part of the text after the covered text as muted text
- No smart cut-off
- Trailing text may cause annotation item to wrap and thereby take up more vertical space

**How to test manually**
* Create a few annotations and check what they look like in the annotation sidebar

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation

**Demo**
![by-position](https://user-images.githubusercontent.com/1410238/225423825-7a1a9a38-2b09-4b69-96f5-98b088a4ecd7.png)

![by-label](https://user-images.githubusercontent.com/1410238/225423849-f25c4fc5-2598-40ae-9cdd-948d18c52a5e.png)

