### PR TITLE
#3879 - Update documentation for move of Docker containers to GitHub

### DIFF
--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/installation_docker.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/installation_docker.adoc
@@ -27,10 +27,10 @@ If you have Docker installed, you can run {product-name} using
 
 [source,shell,subs="+attributes"]
 ----
-$ docker run -it --name inception -p8080:8080 inceptionproject/inception:{revnumber}
+$ docker run -it --name inception -p8080:8080 ghcr.io/inception-project/inception:{revnumber}
 ----
 
-The command downloads {product-name} from Dockerhub and starts it on port 8080. If this port is not
+The command downloads {product-name} from GitHub and starts it on port 8080. If this port is not
 available on your machine, you should provide another port to the `-p` parameter. 
 
 The logs will be printed to the console. To stop the container, press `CTRL-C`.
@@ -39,7 +39,7 @@ To run the {product-name} docker in the background use
 
 [source,shell,subs="+attributes"]
 ----
-$ docker run -d --name inception -p8080:8080 inceptionproject/inception:{revnumber}
+$ docker run -d --name inception -p8080:8080 ghcr.io/inception-project/inception:{revnumber}
 ----
 
 Logs are accessible by typing
@@ -86,7 +86,7 @@ When you run {product-name} via Docker, you then mount this folder into the cont
 
 [source,shell,subs="+attributes"]
 ----
-$ docker run -it --name inception -v /srv/inception:/export -p8080:8080 inceptionproject/inception:{revnumber}
+$ docker run -it --name inception -v /srv/inception:/export -p8080:8080 ghcr.io/inception-project/inception:{revnumber}
 ----
 
 == Settings file

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/scripts/docker-compose-mysql8.yml
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/scripts/docker-compose-mysql8.yml
@@ -28,7 +28,7 @@ services:
       inception-net:
 
   app:
-    image: "${INCEPTION_IMAGE:-inceptionproject/inception}:${INCEPTION_VERSION:-{revnumber}"
+    image: "${INCEPTION_IMAGE:-ghcr.io/inception-project/inception}:${INCEPTION_VERSION:-{revnumber}}"
     ports:
       - "${INCEPTION_PORT:-8080}:8080"
     environment:

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/scripts/docker-compose.yml
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/scripts/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       inception-net:
 
   app:
-    image: "${INCEPTION_IMAGE:-inceptionproject/inception}:${INCEPTION_VERSION:-{revnumber}}"
+    image: "${INCEPTION_IMAGE:-ghcr.io/inception-project/inception}:${INCEPTION_VERSION:-{revnumber}}"
     ports:
       - "${INCEPTION_PORT:-8080}:8080"
     environment:

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/developer-guide/release.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/developer-guide/release.adoc
@@ -105,7 +105,7 @@ version folder under `releases/{version}/docs` in the documentation
 repository. Also update the `_data/releases.yml` file. Create a pull
 request for this as well.
 
-== Publish to DockerHub
+== Publish to GitHub Packages
 
 Make sure that you configured your docker user in your Maven settings:
 
@@ -118,7 +118,7 @@ Make sure that you configured your docker user in your Maven settings:
 </server>
 ----
 
-Also, your user needs to have push rights to the `inceptionproject` Dockerhub group.
+Also, your user needs to have push rights to the `ghcr.io/inception-project` GitHub package repository.
 If you have just made a release, change to `target/checkout/inception-docker`. Otherwise check out the release
 tag e.g. via `git checkout tags/inception-app-0.18.0`. 
 Make sure that in the top-level POM, the version is set to a release version (no snapshot suffix).
@@ -126,11 +126,12 @@ Then go to the `inception-docker` module folder and there run the following comm
 
 [source,xml]
 ----
-mvn -Pdocker clean docker:build -Ddocker.image.name="inceptionproject/inception"
-mvn -Pdocker docker:push -Ddocker.image.name="inceptionproject/inception"
+mvn -Pdocker clean docker:build -Ddocker.image.name="ghcr.io/inception-project/inception"
+mvn -Pdocker docker:push -Ddocker.image.name="ghcr.io/inception-project/inception"
 ----
 
-After successfully publishing to DockerHub, the DockerHub repository will show your released version as the latest version.
+After successfully publishing, the GitHub package repository will show your released
+version as the latest version.
 
 == Aborting and re-running a release
 

--- a/inception/inception-docker/README.md
+++ b/inception/inception-docker/README.md
@@ -13,20 +13,20 @@ To create a SNAPSHOT build:
 
 To run the latest SNAPSHOT build, use: 
 
-    docker run -p8080:8080 -v inception-data:/export -it inceptionproject/inception-snapshots
+    docker run -p8080:8080 -v inception-data:/export -it ghcr.io/inception-project/inception-snapshots
 
 To run the latest SNAPSHOT build with Docker Compose, use:
 
-    INCEPTION_IMAGE=inceptionproject/inception-snapshots INCEPTION_VERSION=latest docker-compose -f ../inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/scripts/docker-compose.yml -p inception up
+    INCEPTION_IMAGE=ghcr.io/inception-project/inception-snapshots INCEPTION_VERSION=latest docker-compose -f ../inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/scripts/docker-compose.yml -p inception up
 
 ## Release builds
    
 For a release build:
 
-    mvn -Pdocker clean docker:build -Ddocker.image.name="inceptionproject/inception"
-    mvn -Pdocker docker:push -Ddocker.image.name="inceptionproject/inception"
+    mvn -Pdocker clean docker:build -Ddocker.image.name="ghcr.io/inception-project/inception"
+    mvn -Pdocker docker:push -Ddocker.image.name="ghcr.io/inception-project/inception"
         
-    docker run -p8080:8080 -v inception-data:/export -it inceptionproject/inception
+    docker run -p8080:8080 -v inception-data:/export -it ghcr.io/inception-project/inception
 
 ## Multi-platform build for ARM46 and AMD64
 
@@ -35,7 +35,7 @@ To build a docker images which runs on AMD64 as well as ARM64 machines, use:
     docker buildx create --use          (need to do this only once!)
     mvn -Pdocker-buildx clean package   (will be pushed immediately!)
 
-Mind that you may have to log in to DockerHub before being able to publish. This can be done e.g.
+Mind that you may have to log in to GitHub before being able to publish. This can be done e.g.
 via Docker Desktop or on the command line via `docker login`.
 
 ## Options
@@ -55,7 +55,7 @@ In the folder where the **inception-doc/src/main/resources/META-INF/asciidoc/adm
 
     docker-compose -p inception up -d
     
-This starts an INCEpTION instance together with a MySQL database.   
+This starts an INCEpTION instance together with a MariaDB database.   
     
 To stop, call
 

--- a/inception/inception-docker/pom.xml
+++ b/inception/inception-docker/pom.xml
@@ -27,7 +27,7 @@
   <name>INCEpTION - Docker Image</name>
   <packaging>pom</packaging>
   <properties>
-    <docker.image.name>inceptionproject/inception-snapshots</docker.image.name>
+    <docker.image.name>ghcr.io/inception-project/inception-snapshots</docker.image.name>
   </properties>
   <dependencies>
     <dependency>


### PR DESCRIPTION
**What's in the PR**
- Updated documentation to refer to the GitHub packages repository instead of DockerHub
- Update compose example files accordingly as well

**How to test manually**
* Check if e.g. deploying docker images as part of a release still works
* Check if the docker compose files still work

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
