### PR TITLE
#3884 - Telemetry enable setting toggle logic inverted

### DIFF
--- a/inception/inception-telemetry/src/main/java/de/tudarmstadt/ukp/clarin/webanno/telemetry/matomo/MatomoTelemetrySupportImpl.java
+++ b/inception/inception-telemetry/src/main/java/de/tudarmstadt/ukp/clarin/webanno/telemetry/matomo/MatomoTelemetrySupportImpl.java
@@ -83,6 +83,7 @@ public class MatomoTelemetrySupportImpl
     implements MatomoTelemetrySupport, DisposableBean
 {
     public static final String MATOMO_TELEMETRY_SUPPORT_ID = "MatomoTelemetry";
+    public static final int CURRENT_SETTINGS_VERSION = 3;
 
     public static final String ACTION_BOOT = "boot";
     public static final String ACTION_HELLO = "hello";
@@ -159,7 +160,7 @@ public class MatomoTelemetrySupportImpl
     @Override
     public int getVersion()
     {
-        return 2;
+        return CURRENT_SETTINGS_VERSION;
     }
 
     @Override
@@ -171,7 +172,7 @@ public class MatomoTelemetrySupportImpl
             return false;
         }
 
-        boolean outdated = settings.get().getVersion() < getVersion();
+        boolean outdated = settings.get().getVersion() != getVersion();
         if (outdated) {
             return false;
         }

--- a/inception/inception-telemetry/src/main/java/de/tudarmstadt/ukp/clarin/webanno/telemetry/matomo/ToggleBox.java
+++ b/inception/inception-telemetry/src/main/java/de/tudarmstadt/ukp/clarin/webanno/telemetry/matomo/ToggleBox.java
@@ -19,6 +19,8 @@ package de.tudarmstadt.ukp.clarin.webanno.telemetry.matomo;
 
 import static java.util.Arrays.asList;
 
+import org.apache.wicket.markup.html.form.IChoiceRenderer;
+
 import com.googlecode.wicket.jquery.core.JQueryBehavior;
 import com.googlecode.wicket.jquery.core.Options;
 import com.googlecode.wicket.kendo.ui.form.dropdown.DropDownList;
@@ -36,7 +38,31 @@ public class ToggleBox
 
         setRequired(true);
         setNullValid(false);
-        setChoices(asList(true, false));
+        setChoices(asList(false, true));
+        setChoiceRenderer(new IChoiceRenderer<Boolean>()
+        {
+            private static final long serialVersionUID = -180513167658049798L;
+
+            @Override
+            public String getDisplayValue(Boolean aObject)
+            {
+                if (aObject == null) {
+                    return null;
+                }
+
+                return aObject ? "enabled" : "disabled";
+            }
+
+            @Override
+            public String getIdValue(Boolean aObject, int aIndex)
+            {
+                if (aObject == null) {
+                    return null;
+                }
+
+                return aObject ? "true" : "false";
+            }
+        });
         setEscapeModelStrings(false); // SAFE - ONLY RENDERING A FEW HARD-CODED CHOICES WITH ICONS
     }
 
@@ -46,9 +72,9 @@ public class ToggleBox
         super.onConfigure(aBehavior);
 
         var template = Options.asString(String.join("\n", //
-                "# if (data.value == '0') { #", //
+                "# if (data.value == 'false') { #", //
                 "<i class='fa fa-ban'></i> Disabled", //
-                "# } else if (data.value == '1') { #", //
+                "# } else if (data.value == 'true') { #", //
                 "<i class='fa fa-check'></i> Enabled", //
                 "# } else { #", //
                 "<i class='fa fa-question'></i> Choose...", //

--- a/inception/inception-telemetry/src/test/java/de/tudarmstadt/ukp/clarin/webanno/telemetry/matomo/MatomoTelemetrySupportImplTest.java
+++ b/inception/inception-telemetry/src/test/java/de/tudarmstadt/ukp/clarin/webanno/telemetry/matomo/MatomoTelemetrySupportImplTest.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.clarin.webanno.telemetry.matomo;
 
 import static de.tudarmstadt.ukp.clarin.webanno.support.JSONUtil.fromJsonString;
+import static de.tudarmstadt.ukp.clarin.webanno.telemetry.matomo.MatomoTelemetrySupportImpl.CURRENT_SETTINGS_VERSION;
 import static java.lang.String.format;
 import static java.net.URLDecoder.decode;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -60,6 +61,7 @@ public class MatomoTelemetrySupportImplTest
     private MockWebServer matomoServer;
     private MatomoTelemetryServicePropertiesImpl properties;
     private UUID instanceId;
+    private TelemetrySettings telemetrySettings;
 
     @BeforeEach
     public void setup() throws Exception
@@ -78,8 +80,8 @@ public class MatomoTelemetrySupportImplTest
         when(identityService.getInstanceIdentity())
                 .thenReturn(new InstanceIdentity(instanceId.toString()));
 
-        TelemetrySettings telemetrySettings = new TelemetrySettings();
-        telemetrySettings.setVersion(2);
+        telemetrySettings = new TelemetrySettings();
+        telemetrySettings.setVersion(CURRENT_SETTINGS_VERSION);
         telemetrySettings.setTraits("{\"enabled\": true}");
         TelemetryService telemetryService = mock(TelemetryService.class);
         when(telemetryService.readSettings(any())).thenReturn(Optional.of(telemetrySettings));
@@ -108,6 +110,8 @@ public class MatomoTelemetrySupportImplTest
     @Test
     public void thatAliveIsRecieved() throws Exception
     {
+        assertThat(sut.isEnabled()).isTrue();
+
         matomoServer.enqueue(new MockResponse().setResponseCode(200));
 
         sut.sendAlive();
@@ -135,6 +139,8 @@ public class MatomoTelemetrySupportImplTest
     @Test
     public void thatPingIsRecieved() throws Exception
     {
+        assertThat(sut.isEnabled()).isTrue();
+
         matomoServer.enqueue(new MockResponse().setResponseCode(200));
 
         sut.sendPing();
@@ -157,5 +163,16 @@ public class MatomoTelemetrySupportImplTest
         assertThat(map.get("3")).isEqualTo(asList("activeUsers", "2"));
         assertThat(map.get("4")).isEqualTo(asList("enabledUsers", "2"));
         assertThat(map.get("5")).isEqualTo(asList("deploymentMode", "DESKTOP"));
+    }
+
+    @Test
+    public void thatVersionMismatchDisablesTelemetry() throws Exception
+    {
+        assertThat(telemetrySettings.getVersion()).isEqualTo(CURRENT_SETTINGS_VERSION);
+        assertThat(sut.isEnabled()).isTrue();
+
+        telemetrySettings.setVersion(CURRENT_SETTINGS_VERSION - 1);
+        assertThat(telemetrySettings.getVersion()).isNotEqualTo(CURRENT_SETTINGS_VERSION);
+        assertThat(sut.isEnabled()).isFalse();
     }
 }


### PR DESCRIPTION
**What's in the PR**
- Fix telemetry toggle button
- Bump settings version so users need to confirm telemetry again on the next admin login (implicitly disabled until then)

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
