### PR TITLE
#3868 - Allow a recommender to force-create annotations

### DIFF
--- a/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/ActiveLearningServiceImpl.java
+++ b/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/ActiveLearningServiceImpl.java
@@ -284,7 +284,7 @@ public class ActiveLearningServiceImpl
         // Request clearing selection and when onFeatureValueUpdated is triggered as a callback
         // from the update event created by upsertSpanFeature.
         AnnotationFeature feature = schemaService.getFeature(suggestion.getFeature(), layer);
-        recommendationService.upsertSpanFeature(schemaService, sourceDoc, username, cas, layer,
+        recommendationService.upsertSpanFeature(sourceDoc, username, cas, layer,
                 feature, value, suggestion.getBegin(), suggestion.getEnd());
 
         // Save CAS after annotation has been created

--- a/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.java
+++ b/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.java
@@ -69,7 +69,6 @@ import org.wicketstuff.event.annotation.OnEvent;
 import de.tudarmstadt.ukp.clarin.webanno.api.CasProvider;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.keybindings.KeyBindingsPanel;
-import de.tudarmstadt.ukp.clarin.webanno.api.event.AfterDocumentResetEvent;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
@@ -96,6 +95,7 @@ import de.tudarmstadt.ukp.inception.active.learning.event.ActiveLearningSessionC
 import de.tudarmstadt.ukp.inception.active.learning.event.ActiveLearningSessionStartedEvent;
 import de.tudarmstadt.ukp.inception.active.learning.event.ActiveLearningSuggestionOfferedEvent;
 import de.tudarmstadt.ukp.inception.active.learning.strategy.UncertaintySamplingStrategy;
+import de.tudarmstadt.ukp.inception.annotation.events.DocumentOpenedEvent;
 import de.tudarmstadt.ukp.inception.annotation.events.FeatureValueUpdatedEvent;
 import de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationCreatedEvent;
 import de.tudarmstadt.ukp.inception.annotation.layer.span.SpanCreatedEvent;
@@ -1353,7 +1353,7 @@ public class ActiveLearningSidebar
     }
 
     @OnEvent
-    public void onDocumentReset(AfterDocumentResetEvent aEvent)
+    public void onDocumentOpenedEvent(DocumentOpenedEvent aEvent)
     {
         // If active learning is not active, update the sidebar in case the session auto-terminated
         ActiveLearningUserState alState = alStateModel.getObject();

--- a/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/CasStorageServiceImpl.java
+++ b/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/CasStorageServiceImpl.java
@@ -1062,6 +1062,10 @@ public class CasStorageServiceImpl
     {
         analyze(aDocument.getProject(), aDocument.getName(), aDocument.getId(), aUserName, aCas);
 
+        log.debug("Writing annotation document [{}] ({}) for user [{}] in project [{}] ({})",
+                aDocument.getName(), aDocument.getId(), aUserName, aDocument.getProject().getName(),
+                aDocument.getProject().getId());
+
         driver.writeCas(aDocument, aUserName, aCas);
     }
 }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/events/DocumentOpenedEvent.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/events/DocumentOpenedEvent.java
@@ -20,6 +20,7 @@ package de.tudarmstadt.ukp.inception.annotation.events;
 import org.apache.uima.cas.CAS;
 import org.springframework.context.ApplicationEvent;
 
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.support.wicket.event.HybridApplicationUIEvent;
 
@@ -35,15 +36,17 @@ public class DocumentOpenedEvent
     private final String annotator;
     // user who opened the document
     private final String opener;
+    private final AnnotationDocumentState stateBeforeOpening;
 
     public DocumentOpenedEvent(Object aSource, CAS aCas, SourceDocument aDocument,
-            String aAnnotator, String aOpener)
+            AnnotationDocumentState aStateBeforeOpening, String aAnnotator, String aOpener)
     {
         super(aSource);
         cas = aCas;
         document = aDocument;
         annotator = aAnnotator;
         opener = aOpener;
+        stateBeforeOpening = aStateBeforeOpening;
     }
 
     public CAS getCas()
@@ -64,5 +67,10 @@ public class DocumentOpenedEvent
     public String getAnnotator()
     {
         return annotator;
+    }
+
+    public AnnotationDocumentState getStateBeforeOpening()
+    {
+        return stateBeforeOpening;
     }
 }

--- a/inception/inception-api-editor/src/main/java/de/tudarmstadt/ukp/inception/editor/AnnotationEditorBase.java
+++ b/inception/inception-api-editor/src/main/java/de/tudarmstadt/ukp/inception/editor/AnnotationEditorBase.java
@@ -171,7 +171,7 @@ public abstract class AnnotationEditorBase
 
             if (getModelObject().getDocument() != null) {
                 // Fire render event into UI
-                extensionRegistry.fireRenderRequested(getModelObject());
+                extensionRegistry.fireRenderRequested(aTarget, getModelObject());
                 send(getPage(), Broadcast.BREADTH, new RenderRequestedEvent(aTarget));
             }
         }

--- a/inception/inception-api-editor/src/main/java/de/tudarmstadt/ukp/inception/editor/AnnotationEditorExtension.java
+++ b/inception/inception-api-editor/src/main/java/de/tudarmstadt/ukp/inception/editor/AnnotationEditorExtension.java
@@ -69,7 +69,7 @@ public interface AnnotationEditorExtension
         // Do nothing by default
     }
 
-    default void renderRequested(AnnotatorState aState)
+    default void renderRequested(AjaxRequestTarget aTarget, AnnotatorState aState)
     {
         // Do nothing by default
     }

--- a/inception/inception-api-editor/src/main/java/de/tudarmstadt/ukp/inception/editor/AnnotationEditorExtensionRegistry.java
+++ b/inception/inception-api-editor/src/main/java/de/tudarmstadt/ukp/inception/editor/AnnotationEditorExtensionRegistry.java
@@ -40,7 +40,7 @@ public interface AnnotationEditorExtensionRegistry
             AjaxRequestTarget aTarget, CAS aCas, VID aParamId, String aAction)
         throws IOException, AnnotationException;
 
-    void fireRenderRequested(AnnotatorState aState);
+    void fireRenderRequested(AjaxRequestTarget aTarget, AnnotatorState aState);
 
     void generateContextMenuItems(List<IMenuItem> aItems);
 }

--- a/inception/inception-api-editor/src/main/java/de/tudarmstadt/ukp/inception/editor/AnnotationEditorExtensionRegistryImpl.java
+++ b/inception/inception-api-editor/src/main/java/de/tudarmstadt/ukp/inception/editor/AnnotationEditorExtensionRegistryImpl.java
@@ -122,10 +122,10 @@ public class AnnotationEditorExtensionRegistryImpl
     }
 
     @Override
-    public void fireRenderRequested(AnnotatorState aState)
+    public void fireRenderRequested(AjaxRequestTarget aTarget, AnnotatorState aState)
     {
         for (AnnotationEditorExtension ext : getExtensions()) {
-            ext.renderRequested(aState);
+            ext.renderRequested(aTarget, aState);
         }
     }
 

--- a/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/editorstate/AnnotatorState.java
+++ b/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/editorstate/AnnotatorState.java
@@ -65,6 +65,7 @@ public interface AnnotatorState
 
     // REC: would be very nice if we didn't need the mode - the behaviors specific to annotation,
     // curation, automation, correction, etc. should be local to the respective modules / pages
+    @Deprecated
     Mode getMode();
 
     // ---------------------------------------------------------------------------------------------

--- a/inception/inception-imls-external/src/main/resources/META-INF/asciidoc/developer-guide/external_recommender.adoc
+++ b/inception/inception-imls-external/src/main/resources/META-INF/asciidoc/developer-guide/external_recommender.adoc
@@ -15,35 +15,16 @@ When making changes to the API, just copy the stuff from there over to this docu
 
 [[_external_recommender_api_overview]]
 == Overview
-This section describes the External Recommender API for INCEpTION. An external recommender is a
+This section describes the External Recommender API for {product-name}. An external recommender is a
 classifier whose functionality is exposed via a HTTP web service. It can predict annotations for
 given documents and optionally be trained on new data. This document describes the endpoints a web
-service needs to expose so it can be used with INCEpTION. The documents that are exchanged are in
+service needs to expose so it can be used with {product-name}. The documents that are exchanged are in
 form of a UIMA CAS. For sending, they have to be serialized to CAS XMI. For receiving, it has to be
-deserialized back. There are two main libraries available that manage CAS handling, one is the UIMA
-Java SDK, the other one dkpro-cassis (Python).
-
-=== Version information
-[%hardbreaks]
-__Version__ : 1.0.0
-
-
-=== Contact information
-[%hardbreaks]
-__Contact Email__ : inception-users@googlegroups.com
-
-
-=== License information
-[%hardbreaks]
-__License__ : Apache 2.0
-__License URL__ : http://www.apache.org/licenses/LICENSE-2.0.html
-__Terms of service__ : https://inception-project.github.io
-
-
-
+deserialized back. There are two main libraries available that manage CAS handling, one is the
+link:https://uima.apache.org[Apache UIMA Java SDK], the other one link:https://github.com/dkpro/dkpro-cassis#dkpro-cassis[dkpro-cassis] (Python).
 
 [[_external_recommender_api_paths]]
-== Paths
+== API Endpoints
 
 [[_external_recommender_api_predictcas]]
 === Predict annotations for a single document
@@ -291,5 +272,16 @@ __required__|Type system XML of the CAS +
 **Example** : `"<?xml version=\"1.0\" encoding=\"UTF-8\"?> <typeSystemDescription xmlns=\"http://uima.apache.org/resourceSpecifier\"> <types> <typeDescription> <name>uima.tcas.DocumentAnnotation</name> <description/> <supertypeName>uima.tcas.Annotation</supertypeName> <features> <featureDescription> <name>language</name> <description/> <rangeTypeName>uima.cas.String</rangeTypeName> </featureDescription> </features> </typeDescription> </types> </typeSystemDescription>"`|string
 |===
 
+== Encoding annotation suggestions
 
+This section explains how annotation suggestions can be encoded in the response to a `predict` call.
 
+Note that a recommender can only produce suggestions for one feature on one layer. The name of the layer and feature are contained in the request to the `predict` call and only suggestions generated for that specific layer and feature will be processed by {product-name} when the call returns.
+
+For the purpose of producing annotation suggestions, this specific layer is extended with additional features that can be set. Some of these features start with the name of the feature (we use `<FEATURE_NAME>` as a placeholder for the actual feature name below) to be predicted and then add a suffix:
+
+* `inception_internal_predicted`: this boolean feature indicates that an annotation was added by the external recommender. It allows the system to distinguish between annotations that already existed in the document and annotations that the recommender has created. Only annotations where this flag is set to `true` will be processed by {product-name}.
+* `<FEATURE_NAME>`: this feature takes the label that the external recommender assigns.
+* `<FEATURE_NAME>_score` (optional): this floating-point (double) feature can be used to indicate the score assigned to a predicted label.
+* `<FEATURE_NAME>_score_explanation` (optional): this string feature can be used to provide an explanation for the score. This explanation is shown on the annotation page when the user inspects a particular suggestion (note that not all editors may support displaying explanations).
+* `<FEATURE_NAME>_auto_accept` (optional): this feature can be set to `on-first-access` to force-accept an annotation into a document when an annotator accesses a document for the first time. This should only be used in conjunction with non-trainable recommenders and with the option **Wait for suggestions from non-trainable recommenders when opening document** in the recommender project settings. Thus, when an annotator opens a document for the first time, the system would wait for recommendations by non-trainable (pre-trained) recommenders and then directly accept any of the suggestions that the recommender has marked to uto-accept on-first-access. When the annotator resets a document via the action bar, this procedure is also followed. This provides a convenient way of "pre-annotating" documents with the help of external recommenders. Note though that an annotator has to actually open a document in order for this process to trigger.

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/RecommendationService.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/RecommendationService.java
@@ -41,7 +41,6 @@ import de.tudarmstadt.ukp.inception.recommendation.api.model.SpanSuggestion;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.SuggestionGroup;
 import de.tudarmstadt.ukp.inception.recommendation.api.recommender.RecommendationEngineFactory;
 import de.tudarmstadt.ukp.inception.recommendation.api.recommender.RecommenderContext;
-import de.tudarmstadt.ukp.inception.schema.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.adapter.AnnotationException;
 
 /**
@@ -56,6 +55,7 @@ public interface RecommendationService
     String FEATURE_NAME_IS_PREDICTION = "inception_internal_predicted";
     String FEATURE_NAME_SCORE_SUFFIX = "_score";
     String FEATURE_NAME_SCORE_EXPLANATION_SUFFIX = "_score_explanation";
+    String FEATURE_NAME_AUTO_ACCEPT_MODE_SUFFIX = "_auto_accept";
 
     int MAX_RECOMMENDATIONS_DEFAULT = 3;
     int MAX_RECOMMENDATIONS_CAP = 10;
@@ -150,8 +150,6 @@ public interface RecommendationService
      * Uses the given annotation suggestion to create a new annotation or to update a feature in an
      * existing annotation.
      * 
-     * @param annotationService
-     *            the annotation schema service
      * @param aDocument
      *            the source document to which the annotations belong
      * @param aUsername
@@ -173,14 +171,12 @@ public interface RecommendationService
      * @throws AnnotationException
      *             if there was an annotation-level problem
      */
-    int upsertSpanFeature(AnnotationSchemaService annotationService, SourceDocument aDocument,
-            String aUsername, CAS aCas, AnnotationLayer layer, AnnotationFeature aFeature,
-            String aValue, int aBegin, int aEnd)
+    int upsertSpanFeature(SourceDocument aDocument, String aUsername, CAS aCas,
+            AnnotationLayer layer, AnnotationFeature aFeature, String aValue, int aBegin, int aEnd)
         throws AnnotationException;
 
-    int upsertRelationFeature(AnnotationSchemaService annotationService, SourceDocument aDocument,
-            String aUsername, CAS aCas, AnnotationLayer layer, AnnotationFeature aFeature,
-            RelationSuggestion aSuggestion)
+    int upsertRelationFeature(SourceDocument aDocument, String aUsername, CAS aCas,
+            AnnotationLayer layer, AnnotationFeature aFeature, RelationSuggestion aSuggestion)
         throws AnnotationException;
 
     /**

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/AnnotationSuggestion.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/AnnotationSuggestion.java
@@ -81,11 +81,13 @@ public abstract class AnnotationSuggestion
     protected final String uiLabel;
     protected final double score;
     protected final String scoreExplanation;
+
+    private AutoAcceptMode autoAcceptMode;
     private int hidingFlags = 0;
 
     public AnnotationSuggestion(int aId, long aRecommenderId, String aRecommenderName,
             long aLayerId, String aFeature, String aDocumentName, String aLabel, String aUiLabel,
-            double aScore, String aScoreExplanation)
+            double aScore, String aScoreExplanation, AutoAcceptMode aAutoAcceptMode)
     {
         label = aLabel;
         uiLabel = aUiLabel;
@@ -97,6 +99,7 @@ public abstract class AnnotationSuggestion
         scoreExplanation = aScoreExplanation;
         recommenderId = aRecommenderId;
         documentName = aDocumentName;
+        autoAcceptMode = aAutoAcceptMode;
     }
 
     public AnnotationSuggestion(AnnotationSuggestion aObject)
@@ -111,6 +114,7 @@ public abstract class AnnotationSuggestion
         scoreExplanation = aObject.scoreExplanation;
         recommenderId = aObject.recommenderId;
         documentName = aObject.documentName;
+        autoAcceptMode = aObject.autoAcceptMode;
     }
 
     public int getId()
@@ -207,6 +211,16 @@ public abstract class AnnotationSuggestion
     public boolean isVisible()
     {
         return hidingFlags == 0;
+    }
+
+    public AutoAcceptMode getAutoAcceptMode()
+    {
+        return autoAcceptMode;
+    }
+
+    public void clearAutoAccept()
+    {
+        autoAcceptMode = AutoAcceptMode.NEVER;
     }
 
     public VID getVID()

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/AutoAcceptMode.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/AutoAcceptMode.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.api.model;
+
+public enum AutoAcceptMode
+{
+    NEVER, ON_FIRST_ACCESS
+}

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/RelationSuggestion.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/RelationSuggestion.java
@@ -32,20 +32,21 @@ public class RelationSuggestion
 
     public RelationSuggestion(int aId, Recommender aRecommender, long aLayerId, String aFeature,
             String aDocumentName, AnnotationFS aSource, AnnotationFS aTarget, String aLabel,
-            String aUiLabel, double aScore, String aScoreExplanation)
+            String aUiLabel, double aScore, String aScoreExplanation,
+            AutoAcceptMode aAutoAcceptMode)
     {
         this(aId, aRecommender.getId(), aRecommender.getName(), aLayerId, aFeature, aDocumentName,
                 aSource.getBegin(), aSource.getEnd(), aTarget.getBegin(), aTarget.getEnd(), aLabel,
-                aUiLabel, aScore, aScoreExplanation);
+                aUiLabel, aScore, aScoreExplanation, aAutoAcceptMode);
     }
 
     public RelationSuggestion(int aId, long aRecommenderId, String aRecommenderName, long aLayerId,
             String aFeature, String aDocumentName, int aSourceBegin, int aSourceEnd,
             int aTargetBegin, int aTargetEnd, String aLabel, String aUiLabel, double aScore,
-            String aScoreExplanation)
+            String aScoreExplanation, AutoAcceptMode aAutoAcceptMode)
     {
         super(aId, aRecommenderId, aRecommenderName, aLayerId, aFeature, aDocumentName, aLabel,
-                aUiLabel, aScore, aScoreExplanation);
+                aUiLabel, aScore, aScoreExplanation, aAutoAcceptMode);
 
         position = new RelationPosition(aSourceBegin, aSourceEnd, aTargetBegin, aTargetEnd);
     }

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/SpanSuggestion.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/SpanSuggestion.java
@@ -32,19 +32,21 @@ public class SpanSuggestion
 
     public SpanSuggestion(int aId, Recommender aRecommender, long aLayerId, String aFeature,
             String aDocumentName, Offset aOffset, String aCoveredText, String aLabel,
-            String aUiLabel, double aScore, String aScoreExplanation)
+            String aUiLabel, double aScore, String aScoreExplanation,
+            AutoAcceptMode aAutoAcceptMode)
     {
         this(aId, aRecommender.getId(), aRecommender.getName(), aLayerId, aFeature, aDocumentName,
                 aOffset.getBegin(), aOffset.getEnd(), aCoveredText, aLabel, aUiLabel, aScore,
-                aScoreExplanation);
+                aScoreExplanation, aAutoAcceptMode);
     }
 
     public SpanSuggestion(int aId, long aRecommenderId, String aRecommenderName, long aLayerId,
             String aFeature, String aDocumentName, int aBegin, int aEnd, String aCoveredText,
-            String aLabel, String aUiLabel, double aScore, String aScoreExplanation)
+            String aLabel, String aUiLabel, double aScore, String aScoreExplanation,
+            AutoAcceptMode aAutoAcceptMode)
     {
         super(aId, aRecommenderId, aRecommenderName, aLayerId, aFeature, aDocumentName, aLabel,
-                aUiLabel, aScore, aScoreExplanation);
+                aUiLabel, aScore, aScoreExplanation, aAutoAcceptMode);
 
         position = new Offset(aBegin, aEnd);
         coveredText = aCoveredText;

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/recommender/RecommendationEngine.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/recommender/RecommendationEngine.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.recommendation.api.recommender;
 
+import static de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService.FEATURE_NAME_AUTO_ACCEPT_MODE_SUFFIX;
 import static de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService.FEATURE_NAME_IS_PREDICTION;
 import static de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService.FEATURE_NAME_SCORE_EXPLANATION_SUFFIX;
 import static de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService.FEATURE_NAME_SCORE_SUFFIX;
@@ -209,6 +210,12 @@ public abstract class RecommendationEngine
     protected Feature getScoreExplanationFeature(CAS aCas)
     {
         String scoreExplanationFeature = featureName + FEATURE_NAME_SCORE_EXPLANATION_SUFFIX;
+        return getPredictedType(aCas).getFeatureByBaseName(scoreExplanationFeature);
+    }
+
+    protected Feature getModeFeature(CAS aCas)
+    {
+        String scoreExplanationFeature = featureName + FEATURE_NAME_AUTO_ACCEPT_MODE_SUFFIX;
         return getPredictedType(aCas).getFeatureByBaseName(scoreExplanationFeature);
     }
 

--- a/inception/inception-recommendation-api/src/test/java/de/tudarmstadt/ukp/inception/recommendation/api/model/AnnotationSuggestionTest.java
+++ b/inception/inception-recommendation-api/src/test/java/de/tudarmstadt/ukp/inception/recommendation/api/model/AnnotationSuggestionTest.java
@@ -21,6 +21,7 @@
  */
 package de.tudarmstadt.ukp.inception.recommendation.api.model;
 
+import static de.tudarmstadt.ukp.inception.recommendation.api.model.AutoAcceptMode.NEVER;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -34,13 +35,13 @@ public class AnnotationSuggestionTest
     public void thatEqualsAndHashCodeAndCompareToWorkCorrectly()
     {
         SpanSuggestion rec1Sug1 = new SpanSuggestion(1, 1, "rec1", 1, "value", "doc1", 0, 1, "a",
-                "A", "#A", 0.1, "E1");
+                "A", "#A", 0.1, "E1", NEVER);
         SpanSuggestion rec1Sug2 = new SpanSuggestion(2, 1, "rec1", 1, "value", "doc1", 0, 1, "b",
-                "B", "#B", 0.2, "E2");
+                "B", "#B", 0.2, "E2", NEVER);
         SpanSuggestion rec2Sug1 = new SpanSuggestion(3, 2, "rec2", 1, "value", "doc1", 0, 1, "c",
-                "C", "#C", 0.1, "E1");
+                "C", "#C", 0.1, "E1", NEVER);
         SpanSuggestion rec2Sug2 = new SpanSuggestion(4, 2, "rec2", 1, "value", "doc1", 0, 1, "d",
-                "D", "#D", 0.3, "E3");
+                "D", "#D", 0.3, "E3", NEVER);
 
         List<SpanSuggestion> all = asList(rec1Sug1, rec1Sug2, rec2Sug1, rec2Sug2);
         for (SpanSuggestion x : all) {

--- a/inception/inception-recommendation-api/src/test/java/de/tudarmstadt/ukp/inception/recommendation/api/model/PredictionGroupTest.java
+++ b/inception/inception-recommendation-api/src/test/java/de/tudarmstadt/ukp/inception/recommendation/api/model/PredictionGroupTest.java
@@ -21,6 +21,7 @@
  */
 package de.tudarmstadt.ukp.inception.recommendation.api.model;
 
+import static de.tudarmstadt.ukp.inception.recommendation.api.model.AutoAcceptMode.NEVER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
 
@@ -32,13 +33,13 @@ public class PredictionGroupTest
     public void thatAddingElementsToGroupWorks()
     {
         var rec1Sug1 = new SpanSuggestion(1, 1, "rec1", 1, "value", "doc1", 0, 1, "a", "A", "#A",
-                0.1, "E1");
+                0.1, "E1", NEVER);
         var rec1Sug2 = new SpanSuggestion(2, 1, "rec1", 1, "value", "doc1", 0, 1, "b", "B", "#B",
-                0.2, "E2");
+                0.2, "E2", NEVER);
         var rec2Sug1 = new SpanSuggestion(3, 2, "rec2", 1, "value", "doc1", 0, 1, "c", "C", "#C",
-                0.1, "E1");
+                0.1, "E1", NEVER);
         var rec2Sug2 = new SpanSuggestion(4, 2, "rec2", 1, "value", "doc1", 0, 1, "d", "D", "#D",
-                0.3, "E3");
+                0.3, "E3", NEVER);
 
         // Ensure that group grows and that all elements are added properly
         var sut = new SuggestionGroup<>();
@@ -60,13 +61,13 @@ public class PredictionGroupTest
     public void thatSortingWorks()
     {
         var rec1Sug1 = new SpanSuggestion(1, 1, "rec1", 1, "value", "doc1", 0, 1, "a", "A", "#A",
-                0.1, "E1");
+                0.1, "E1", NEVER);
         var rec1Sug2 = new SpanSuggestion(2, 1, "rec1", 1, "value", "doc1", 0, 1, "b", "B", "#B",
-                0.2, "E2");
+                0.2, "E2", NEVER);
         var rec2Sug1 = new SpanSuggestion(3, 2, "rec2", 1, "value", "doc1", 0, 1, "c", "C", "#C",
-                0.1, "E1");
+                0.1, "E1", NEVER);
         var rec2Sug2 = new SpanSuggestion(4, 2, "rec2", 1, "value", "doc1", 0, 1, "d", "D", "#D",
-                0.3, "E3");
+                0.3, "E3", NEVER);
 
         var sut = new SuggestionGroup<>(rec1Sug1, rec1Sug2, rec2Sug1, rec2Sug2);
 
@@ -87,13 +88,13 @@ public class PredictionGroupTest
     public void thatTopDeltasAreCorrect()
     {
         var rec1Sug1 = new SpanSuggestion(1, 1, "rec1", 1, "value", "doc1", 0, 1, "a", "A", "#A",
-                0.1, "E1");
+                0.1, "E1", NEVER);
         var rec1Sug2 = new SpanSuggestion(2, 1, "rec1", 1, "value", "doc1", 0, 1, "b", "B", "#B",
-                0.2, "E2");
+                0.2, "E2", NEVER);
         var rec2Sug1 = new SpanSuggestion(3, 2, "rec2", 1, "value", "doc1", 0, 1, "c", "C", "#C",
-                0.1, "E1");
+                0.1, "E1", NEVER);
         var rec2Sug2 = new SpanSuggestion(4, 2, "rec2", 1, "value", "doc1", 0, 1, "d", "D", "#D",
-                0.3, "E3");
+                0.3, "E3", NEVER);
 
         var sut = new SuggestionGroup<>(rec1Sug1, rec1Sug2, rec2Sug1, rec2Sug2);
 

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderListPanel.properties
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderListPanel.properties
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 recommenders=Recommenders
-waitForRecommendersOnOpenDocument=Wait for suggestions from pre-trained recommenders when opening document
+waitForRecommendersOnOpenDocument=Wait for suggestions from non-trainable recommenders when opening document

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommenderInfoPanel.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommenderInfoPanel.java
@@ -237,7 +237,7 @@ public class RecommenderInfoPanel
     }
 
     @OnEvent
-    public void onRenderAnnotations(PredictionsSwitchedEvent aEvent)
+    public void onPredictionsSwitched(PredictionsSwitchedEvent aEvent)
     {
         aEvent.getRequestTarget().add(this);
     }
@@ -303,7 +303,7 @@ public class RecommenderInfoPanel
                 AnnotationFeature feature = annotationService.getFeature(suggestion.getFeature(),
                         layer);
                 // int address =
-                recommendationService.upsertSpanFeature(annotationService, state.getDocument(),
+                recommendationService.upsertSpanFeature(state.getDocument(),
                         state.getUser().getUsername(), cas, layer, feature, suggestion.getLabel(),
                         suggestion.getBegin(), suggestion.getEnd());
 

--- a/inception/inception-recommendation/src/main/resources/META-INF/asciidoc/user-guide/projects_recommendation.adoc
+++ b/inception/inception-recommendation/src/main/resources/META-INF/asciidoc/user-guide/projects_recommendation.adoc
@@ -29,6 +29,21 @@ meet the configured threshold, the recommender will not be used.
 Recommenders can be configured in the *Project Settings* under the *Recommenders* tab. To create a new
 recommender, click *Create*. Then, the layer, feature and the classifier type has to be selected.
 
+== Overall recommender settings
+
+The option **wait for suggestions from non-trainable recommenders when opening document** can be
+enabled overall. It is accessible from the settings dropdown on the recommender list panel.
+When this option is enabled, the system will wait for responses from all non-trainable recommenders
+in the project when a user is opening a document before actually displaying the document to the
+user. If this option is not checked, then recommendations may only appear after the user has 
+performed some action such as creating an annotation.
+
+NOTE: Enable this option only if all of your non-trainable recommenders have a fast response time,
+      as otherwise your users may complain about a long delay when opening documents.
+
+
+== Per-recommender settings
+
 By default, the name of new recommenders are auto-generated based on the choice of layer, feature and tool. However, you can deactivate this behavior by unchecking the *auto-generate* option next to the name field.
 
 Recommenders can be enabled and disabled. This behaviour is configured by the *Enabled* checkbox.

--- a/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/Fixtures.java
+++ b/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/Fixtures.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.recommendation.service;
 
+import static de.tudarmstadt.ukp.inception.recommendation.api.model.AutoAcceptMode.NEVER;
 import static java.util.stream.Collectors.toList;
 
 import java.util.ArrayList;
@@ -66,7 +67,7 @@ public class Fixtures
         for (int[] val : vals) {
             suggestions.add(new SpanSuggestion(val[0], RECOMMENDER_ID, RECOMMENDER_NAME,
                     aFeat.getLayer().getId(), aFeat.getName(), doc.getName(), val[1], val[2],
-                    COVERED_TEXT, null, UI_LABEL, CONFIDENCE, CONFIDENCE_EXPLANATION));
+                    COVERED_TEXT, null, UI_LABEL, CONFIDENCE, CONFIDENCE_EXPLANATION, NEVER));
         }
 
         return new SuggestionDocumentGroup<>(suggestions);
@@ -79,7 +80,7 @@ public class Fixtures
         for (int[] val : vals) {
             suggestions.add(new RelationSuggestion(val[0], RECOMMENDER_ID, RECOMMENDER_NAME,
                     aFeat.getLayer().getId(), aFeat.getName(), doc.getName(), val[1], val[2],
-                    val[3], val[4], null, UI_LABEL, CONFIDENCE, CONFIDENCE_EXPLANATION));
+                    val[3], val[4], null, UI_LABEL, CONFIDENCE, CONFIDENCE_EXPLANATION, NEVER));
         }
 
         return new SuggestionDocumentGroup<>(suggestions);

--- a/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/LearningRecordServiceImplIntegrationTest.java
+++ b/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/LearningRecordServiceImplIntegrationTest.java
@@ -18,6 +18,7 @@
 
 package de.tudarmstadt.ukp.inception.recommendation.service;
 
+import static de.tudarmstadt.ukp.inception.recommendation.api.model.AutoAcceptMode.NEVER;
 import static de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordChangeLocation.DETAIL_EDITOR;
 import static de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordChangeLocation.MAIN_EDITOR;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -81,7 +82,7 @@ public class LearningRecordServiceImplIntegrationTest
 
         SpanSuggestion suggestion = new SpanSuggestion(42, 1337, "testRecommender", layer.getId(),
                 feature.getName(), sourceDoc.getName(), 7, 14, "aCoveredText", "testLabel",
-                "testUiLabel", 0.42, "Test confidence");
+                "testUiLabel", 0.42, "Test confidence", NEVER);
 
         sut.logSpanRecord(sourceDoc, USER_NAME, suggestion, layer, feature,
                 LearningRecordType.ACCEPTED, MAIN_EDITOR);
@@ -115,7 +116,7 @@ public class LearningRecordServiceImplIntegrationTest
 
         RelationSuggestion suggestion = new RelationSuggestion(42, 1337, "testRecommender",
                 layer.getId(), feature.getName(), sourceDoc.getName(), 7, 14, 21, 28, "testLabel",
-                "testUiLabel", 0.42, "Test confidence");
+                "testUiLabel", 0.42, "Test confidence", NEVER);
 
         sut.logRelationRecord(sourceDoc, USER_NAME, suggestion, layer, feature,
                 LearningRecordType.REJECTED, DETAIL_EDITOR);
@@ -153,25 +154,25 @@ public class LearningRecordServiceImplIntegrationTest
         sut.logSpanRecord(sourceDoc1, USER_NAME,
                 new SpanSuggestion(42, 1337, "testRecommender", layer1.getId(), feature1.getName(),
                         sourceDoc1.getName(), 7, 14, "aCoveredText", "testLabel", "testUiLabel",
-                        0.42, "Test confidence"),
+                        0.42, "Test confidence", NEVER),
                 layer1, feature1, LearningRecordType.ACCEPTED, MAIN_EDITOR);
 
         sut.logSpanRecord(sourceDoc1, USER_NAME,
                 new SpanSuggestion(42, 1337, "testRecommender2", layer2.getId(), feature2.getName(),
                         sourceDoc1.getName(), 7, 14, "aCoveredText", "testLabel", "testUiLabel",
-                        0.42, "Test confidence"),
+                        0.42, "Test confidence", NEVER),
                 layer2, feature2, LearningRecordType.ACCEPTED, MAIN_EDITOR);
 
         sut.logSpanRecord(sourceDoc2, USER_NAME,
                 new SpanSuggestion(42, 1337, "testRecommender", layer1.getId(), feature1.getName(),
                         sourceDoc2.getName(), 7, 14, "aCoveredText", "testLabel", "testUiLabel",
-                        0.42, "Test confidence"),
+                        0.42, "Test confidence", NEVER),
                 layer1, feature1, LearningRecordType.ACCEPTED, MAIN_EDITOR);
 
         sut.logSpanRecord(sourceDoc2, USER_NAME,
                 new SpanSuggestion(42, 1337, "testRecommender2", layer2.getId(), feature2.getName(),
                         sourceDoc2.getName(), 7, 14, "aCoveredText", "testLabel", "testUiLabel",
-                        0.42, "Test confidence"),
+                        0.42, "Test confidence", NEVER),
                 layer2, feature2, LearningRecordType.ACCEPTED, MAIN_EDITOR);
 
         assertThat(sut.listRecords(sourceDoc1, USER_NAME, feature1)).hasSize(1);

--- a/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImplIntegrationTest.java
+++ b/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImplIntegrationTest.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.recommendation.service;
 
+import static de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService.FEATURE_NAME_AUTO_ACCEPT_MODE_SUFFIX;
 import static de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService.FEATURE_NAME_IS_PREDICTION;
 import static de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService.FEATURE_NAME_SCORE_EXPLANATION_SUFFIX;
 import static de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService.FEATURE_NAME_SCORE_SUFFIX;
@@ -202,12 +203,13 @@ public class RecommendationServiceImplIntegrationTest
             assertThat(type.getFeatures()).extracting(Feature::getShortName)
                     .contains(feature.getName() + FEATURE_NAME_SCORE_SUFFIX)
                     .contains(feature.getName() + FEATURE_NAME_SCORE_EXPLANATION_SUFFIX)
+                    .contains(feature.getName() + FEATURE_NAME_AUTO_ACCEPT_MODE_SUFFIX)
                     .contains(FEATURE_NAME_IS_PREDICTION);
         }
     }
 
     @Test
-    void thatZeroWithAnnotationsAreCorretlyAnchoredOnTokens() throws Exception
+    void thatZeroWithAnnotationsAreCorrectlyAnchoredOnTokens() throws Exception
     {
         JCas jCas = createJCas();
         TokenBuilder.create(Token.class, Sentence.class).buildTokens(jCas, "  This is  a test.  ");

--- a/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImplTest.java
+++ b/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImplTest.java
@@ -22,9 +22,11 @@ import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.SENTENCES;
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.SINGLE_TOKEN;
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.TOKENS;
 import static de.tudarmstadt.ukp.clarin.webanno.support.uima.FeatureStructureBuilder.buildFS;
+import static de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService.FEATURE_NAME_AUTO_ACCEPT_MODE_SUFFIX;
 import static de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService.FEATURE_NAME_IS_PREDICTION;
 import static de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService.FEATURE_NAME_SCORE_EXPLANATION_SUFFIX;
 import static de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService.FEATURE_NAME_SCORE_SUFFIX;
+import static de.tudarmstadt.ukp.inception.recommendation.api.model.AutoAcceptMode.NEVER;
 import static de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordType.REJECTED;
 import static de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordType.SKIPPED;
 import static de.tudarmstadt.ukp.inception.recommendation.service.RecommendationServiceImpl.extractSuggestions;
@@ -280,6 +282,7 @@ class RecommendationServiceImplTest
         predType.addFeature("value" + FEATURE_NAME_SCORE_SUFFIX, null, TYPE_NAME_DOUBLE);
         predType.addFeature("value" + FEATURE_NAME_SCORE_EXPLANATION_SUFFIX, null,
                 TYPE_NAME_STRING);
+        predType.addFeature("value" + FEATURE_NAME_AUTO_ACCEPT_MODE_SUFFIX, null, TYPE_NAME_STRING);
         predType.addFeature(FEATURE_NAME_IS_PREDICTION, null, TYPE_NAME_BOOLEAN);
 
         var targetCas = createCas(mergeTypeSystems(asList(tsd, createTypeSystemDescription())));
@@ -350,7 +353,8 @@ class RecommendationServiceImplTest
                 aLabel, // aLabel
                 aLabel, // aUiLabel
                 0.0, // aScore
-                "" // aScoreExplanation
+                "", // aScoreExplanation,
+                NEVER // autoAccept
         );
     }
 }

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
@@ -430,6 +430,7 @@ public class AnnotationPage
             // create one.
             AnnotationDocument annotationDocument = documentService
                     .createOrGetAnnotationDocument(state.getDocument(), state.getUser());
+            var stateBeforeOpening = annotationDocument.getState();
 
             // Read the CAS
             // Update the annotation document CAS
@@ -519,7 +520,7 @@ public class AnnotationPage
 
             applicationEventPublisherHolder.get().publishEvent(
                     new DocumentOpenedEvent(this, editorCas, getModelObject().getDocument(),
-                            getModelObject().getUser().getUsername(),
+                            stateBeforeOpening, getModelObject().getUser().getUsername(),
                             userRepository.getCurrentUser().getUsername()));
         }
         catch (Exception e) {


### PR DESCRIPTION
**What's in the PR**
- Extended recommender API to allow force-accepting suggestions into a document when the document is opened for the first time
- Documented the extension

**How to test manually**
* Create a non-trainable recommender and hook it up to a project - ensure that the recommender sets `<feature-name>_auto_accept` to `on-first-access` on at least one recommendation
* Enable the option "wait for non-trainable recommenders when opening a project" in configuration panel of the recommender list in the project settings
* Open a document and see that the auto-accept recommendation is auto-accepted

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
