### PR TITLE
#3903 - Enable filtering by canonical term

### DIFF
--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureEditor_ImplBase.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureEditor_ImplBase.java
@@ -105,14 +105,14 @@ public abstract class ConceptFeatureEditor_ImplBase
 
         String input = aInput;
 
-        // Extract filter on the description
-        final String descriptionFilter;
+        // Extract filter on the description and/or canonical term
+        final String secondaryFilter;
         if (input.contains("::")) {
-            descriptionFilter = substringAfter(input, "::").trim();
+            secondaryFilter = substringAfter(input, "::").trim();
             input = substringBefore(input, "::");
         }
         else {
-            descriptionFilter = null;
+            secondaryFilter = null;
         }
 
         // Extract exact match filter on the query
@@ -165,9 +165,8 @@ public abstract class ConceptFeatureEditor_ImplBase
                     .collect(Collectors.toList());
         }
 
-        if (isNotBlank(descriptionFilter)) {
-            choices = choices.stream()
-                    .filter(kb -> containsIgnoreCase(kb.getDescription(), descriptionFilter))
+        if (isNotBlank(secondaryFilter)) {
+            choices = choices.stream().filter(kb -> applySecondaryFilter(kb, secondaryFilter))
                     .collect(Collectors.toList());
         }
 
@@ -178,6 +177,20 @@ public abstract class ConceptFeatureEditor_ImplBase
         WicketUtil.serverTiming("getCandidates", currentTimeMillis() - startTime);
 
         return result;
+    }
+
+    private boolean applySecondaryFilter(KBHandle aObject, String aFilter)
+    {
+        if (containsIgnoreCase(aObject.getDescription(), aFilter)) {
+            return true;
+        }
+
+        if (aObject.getQueryBestMatchTerm() != null
+                && containsIgnoreCase(aObject.getUiLabel(), aFilter)) {
+            return true;
+        }
+
+        return false;
     }
 
     protected abstract ConceptFeatureTraits_ImplBase readFeatureTraits(

--- a/inception/inception-ui-kb/src/main/resources/META-INF/asciidoc/user-guide/annotation_create-annotations_concept-features.adoc
+++ b/inception/inception-ui-kb/src/main/resources/META-INF/asciidoc/user-guide/annotation_create-annotations_concept-features.adoc
@@ -18,11 +18,16 @@ the annotated text.
 TIP: Just press kbd:[SPACEBAR] instead of writing anything into the field to search the knowledge
      base for concepts matching the annotated text.
 
-.Filtering by description
+.Filtering
 The query entered into the field only matches against the label of the knowledge base items, not
 against their description. However, you can filter the candidates by their description. E.g. if you
 wish to find all knowledge base items with `Obama` in the label and `president` in the description,
 then you can write `Obama :: president`. A case-insensitive matching is being used.
+
+If the knowledge base is configured for additional matching properties and the value entered into
+the field matches such an additional property, then the label property will be shown separately
+in the dropdown. In this case, filtering does not only apply to the description but also to the
+canonical label.
 
 .Substring matching
 Depending on the knowledge base and full-text mode being used, there may be fuzzy matching. To


### PR DESCRIPTION
**What's in the PR**
- Consider the canonical term as well when filtering

**How to test manually**
* Create a knowledge base that uses additional matching properties
* Have a concept that e.g. has the label `foo (bar)` and an additional label `boo`
* Locate the concept on the annotation page by entering `boo::bar`

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
