### PR TITLE
#3905 - Allow sentence splitting to consider document structure

### DIFF
--- a/inception/inception-export/pom.xml
+++ b/inception/inception-export/pom.xml
@@ -87,6 +87,10 @@
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>
+    <dependency>
+      <groupId>it.unimi.dsi</groupId>
+      <artifactId>fastutil</artifactId>
+    </dependency>
     
     <dependency>
       <groupId> org.springframework</groupId>

--- a/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/DocumentImportExportServiceImpl.java
+++ b/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/DocumentImportExportServiceImpl.java
@@ -398,7 +398,7 @@ public class DocumentImportExportServiceImpl
         splitSentences(aCas, null);
     }
 
-    public static void splitSentences(CAS aCas, Iterable<AnnotationFS> aZones)
+    public static void splitSentences(CAS aCas, Iterable<? extends AnnotationFS> aZones)
     {
         if (aCas.getDocumentText() == null) {
             return;
@@ -428,10 +428,10 @@ public class DocumentImportExportServiceImpl
             int last = bi.first();
             int cur = bi.next();
             while (cur != BreakIterator.DONE) {
-                int[] span = new int[] { last, cur };
+                int[] span = new int[] { last + begin, cur + begin };
                 trim(aCas.getDocumentText(), span);
                 if (!isEmpty(span[0], span[1])) {
-                    aCas.addFsToIndexes(createSentence(aCas, span[0] + begin, span[1] + end));
+                    aCas.addFsToIndexes(createSentence(aCas, span[0], span[1]));
                 }
                 last = cur;
                 cur = bi.next();

--- a/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/DocumentImportExportServiceImpl.java
+++ b/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/DocumentImportExportServiceImpl.java
@@ -100,6 +100,7 @@ import de.tudarmstadt.ukp.inception.export.config.DocumentImportExportServiceAut
 import de.tudarmstadt.ukp.inception.export.config.DocumentImportExportServiceProperties;
 import de.tudarmstadt.ukp.inception.export.config.DocumentImportExportServiceProperties.CasDoctorOnImportPolicy;
 import de.tudarmstadt.ukp.inception.schema.AnnotationSchemaService;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
 
 /**
  * <p>
@@ -394,23 +395,56 @@ public class DocumentImportExportServiceImpl
 
     public static void splitSentences(CAS aCas)
     {
-        BreakIterator bi = BreakIterator.getSentenceInstance(Locale.US);
-        bi.setText(aCas.getDocumentText());
-        int last = bi.first();
-        int cur = bi.next();
-        while (cur != BreakIterator.DONE) {
-            int[] span = new int[] { last, cur };
-            trim(aCas.getDocumentText(), span);
-            if (!isEmpty(span[0], span[1])) {
-                aCas.addFsToIndexes(createSentence(aCas, span[0], span[1]));
+        splitSentences(aCas, null);
+    }
+
+    public static void splitSentences(CAS aCas, Iterable<AnnotationFS> aZones)
+    {
+        if (aCas.getDocumentText() == null) {
+            return;
+        }
+
+        int[] sortedZoneBoundaries = null;
+
+        if (aZones != null) {
+            var zoneBoundaries = new IntArrayList();
+            for (var zone : aZones) {
+                zoneBoundaries.add(zone.getBegin());
+                zoneBoundaries.add(zone.getEnd());
             }
-            last = cur;
-            cur = bi.next();
+
+            sortedZoneBoundaries = zoneBoundaries.intStream().distinct().sorted().toArray();
+        }
+
+        if (sortedZoneBoundaries == null || sortedZoneBoundaries.length < 2) {
+            sortedZoneBoundaries = new int[] { 0, aCas.getDocumentText().length() };
+        }
+
+        for (int i = 1; i < sortedZoneBoundaries.length; i++) {
+            var begin = sortedZoneBoundaries[i - 1];
+            var end = sortedZoneBoundaries[i];
+            BreakIterator bi = BreakIterator.getSentenceInstance(Locale.US);
+            bi.setText(aCas.getDocumentText().substring(begin, end));
+            int last = bi.first();
+            int cur = bi.next();
+            while (cur != BreakIterator.DONE) {
+                int[] span = new int[] { last, cur };
+                trim(aCas.getDocumentText(), span);
+                if (!isEmpty(span[0], span[1])) {
+                    aCas.addFsToIndexes(createSentence(aCas, span[0] + begin, span[1] + end));
+                }
+                last = cur;
+                cur = bi.next();
+            }
         }
     }
 
     public static void tokenize(CAS aCas)
     {
+        if (aCas.getDocumentText() == null) {
+            return;
+        }
+
         BreakIterator bi = BreakIterator.getWordInstance(Locale.US);
         for (AnnotationFS s : selectSentences(aCas)) {
             bi.setText(s.getCoveredText());

--- a/inception/inception-export/src/test/java/de/tudarmstadt/ukp/inception/export/SegmentationTest.java
+++ b/inception/inception-export/src/test/java/de/tudarmstadt/ukp/inception/export/SegmentationTest.java
@@ -17,15 +17,17 @@
  */
 package de.tudarmstadt.ukp.inception.export;
 
-import static java.util.Arrays.asList;
 import static org.apache.uima.fit.util.CasUtil.toText;
 import static org.apache.uima.fit.util.JCasUtil.select;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.uima.fit.factory.JCasFactory;
 import org.apache.uima.jcas.JCas;
 import org.junit.jupiter.api.Test;
 
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Div;
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Heading;
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Paragraph;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
 
@@ -38,7 +40,21 @@ public class SegmentationTest
 
         DocumentImportExportServiceImpl.splitSentences(jcas.getCas());
 
-        assertEquals(asList("I am one.", "I am two."), toText(select(jcas, Sentence.class)));
+        assertThat(toText(select(jcas, Sentence.class))) //
+                .containsExactly("I am one.", "I am two.");
+    }
+
+    @Test
+    public void testSplitSentencesWithZones() throws Exception
+    {
+        JCas jcas = JCasFactory.createText("Heading I am two.", "en");
+        new Heading(jcas, 0, 7).addToIndexes();
+        new Paragraph(jcas, 8, 17).addToIndexes();
+
+        DocumentImportExportServiceImpl.splitSentences(jcas.getCas(), jcas.select(Div.class));
+
+        assertThat(toText(select(jcas, Sentence.class))) //
+                .containsExactly("Heading", "I am two.");
     }
 
     @Test
@@ -46,13 +62,14 @@ public class SegmentationTest
     {
         JCas jcas = JCasFactory.createText("i am one.i am two.", "en");
         new Sentence(jcas, 0, 9).addToIndexes();
-        ;
         new Sentence(jcas, 9, 18).addToIndexes();
 
         DocumentImportExportServiceImpl.tokenize(jcas.getCas());
 
-        assertEquals(asList("i am one.", "i am two."), toText(select(jcas, Sentence.class)));
-        assertEquals(asList("i", "am", "one", ".", "i", "am", "two", "."),
-                toText(select(jcas, Token.class)));
+        assertThat(toText(select(jcas, Sentence.class))) //
+                .containsExactly("i am one.", "i am two.");
+
+        assertThat(toText(select(jcas, Token.class))) //
+                .containsExactly("i", "am", "one", ".", "i", "am", "two", ".");
     }
 }


### PR DESCRIPTION
**What's in the PR**
- Add an additional parameter to the sentence splitting function that allows specifying zoning annotations.

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
