### PR TITLE
#3914 - Allow pinning label groups to the annotation sidebar

### DIFF
--- a/inception/inception-diam-editor/pom.xml
+++ b/inception/inception-diam-editor/pom.xml
@@ -52,6 +52,18 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-api-editor</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-model</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-preferences</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-security</artifactId>
     </dependency>
     <dependency>
@@ -95,11 +107,6 @@
     <dependency>
       <groupId>org.wicketstuff</groupId>
       <artifactId>wicketstuff-annotationeventdispatcher</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
     </dependency>
 
     <dependency>

--- a/inception/inception-diam-editor/src/main/java/de/tudarmstadt/ukp/inception/diam/sidebar/preferences/DiamSidebarManagerPrefPanel.html
+++ b/inception/inception-diam-editor/src/main/java/de/tudarmstadt/ukp/inception/diam/sidebar/preferences/DiamSidebarManagerPrefPanel.html
@@ -19,21 +19,19 @@
 <html xmlns:wicket="http://wicket.apache.org">
 <body>
   <wicket:panel>
-    <form wicket:id="form" class="card border-0 flex-content flex-v-container">
-      <div class="flex-content scrolling card-body">
-        <div class="flex-v-container flex-content flex-gutter">
-          <div wicket:id="annotationEditor"/>
-          <div wicket:id="bratAnnotationEditorManagerPrefs"/>
-          <div wicket:id="diamAnnotationSidebarManagerPrefs"/>
-          <div wicket:id="annotationSidebar"/>
-          <div wicket:id="annotationSearch"/>
-        </div>
+    <form wicket:id="form" class="card">
+      <div class="card-header">
+        <wicket:message key="title"/>
       </div>
-      <div class="card-footer text-end">
-        <button wicket:id="save" class="btn btn-primary">
-          <i class="fas fa-save"></i>&nbsp;
-          <wicket:message key="save"/>
-        </button>
+      <div class="card-body">
+        <div class="row form-row">
+          <label class="col-sm-4 col-form-label">
+            <wicket:message key="pinnedGroups"/>
+          </label>
+          <div class="col-sm-8">
+            <div wicket:id="pinnedGroups"/>
+          </div>
+        </div>
       </div>
     </form>
   </wicket:panel>

--- a/inception/inception-diam-editor/src/main/java/de/tudarmstadt/ukp/inception/diam/sidebar/preferences/DiamSidebarManagerPrefPanel.java
+++ b/inception/inception-diam-editor/src/main/java/de/tudarmstadt/ukp/inception/diam/sidebar/preferences/DiamSidebarManagerPrefPanel.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.diam.sidebar.preferences;
+
+import static de.tudarmstadt.ukp.inception.diam.sidebar.preferences.DiamSidebarManagerPrefs.KEY_DIAM_SIDEBAR_MANAGER_PREFS;
+
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.markup.html.form.Form;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.model.CompoundPropertyModel;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.spring.injection.annot.SpringBean;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaForm;
+import de.tudarmstadt.ukp.inception.editor.AnnotationEditorRegistry;
+import de.tudarmstadt.ukp.inception.preferences.PreferencesService;
+
+public class DiamSidebarManagerPrefPanel
+    extends Panel
+{
+    private static final long serialVersionUID = 3635729182772294488L;
+
+    private @SpringBean AnnotationEditorRegistry annotationEditorRegistry;
+    private @SpringBean PreferencesService preferencesService;
+    private @SpringBean ProjectService projectService;
+
+    private CompoundPropertyModel<DiamSidebarManagerPrefs> sidebarPreferences;
+
+    public DiamSidebarManagerPrefPanel(String aId, IModel<Project> aProjectModel)
+    {
+        super(aId, aProjectModel);
+        setOutputMarkupPlaceholderTag(true);
+
+        sidebarPreferences = CompoundPropertyModel.of(actionLoad());
+
+        LambdaForm<DiamSidebarManagerPrefs> form = new LambdaForm<>("form", sidebarPreferences);
+
+        form.add(new PinnedGroupsPanel("pinnedGroups", sidebarPreferences.bind("pinnedGroups")));
+
+        form.onSubmit(this::actionSave);
+
+        add(form);
+    }
+
+    @SuppressWarnings("unchecked")
+    public IModel<Project> getModel()
+    {
+        return (IModel<Project>) getDefaultModel();
+    }
+
+    private DiamSidebarManagerPrefs actionLoad()
+    {
+        return preferencesService.loadDefaultTraitsForProject(KEY_DIAM_SIDEBAR_MANAGER_PREFS,
+                getModel().getObject());
+    }
+
+    private void actionSave(AjaxRequestTarget aTarget, Form<DiamSidebarManagerPrefs> aForm)
+    {
+        preferencesService.saveDefaultTraitsForProject(KEY_DIAM_SIDEBAR_MANAGER_PREFS,
+                getModel().getObject(), aForm.getModelObject());
+    }
+}

--- a/inception/inception-diam-editor/src/main/java/de/tudarmstadt/ukp/inception/diam/sidebar/preferences/DiamSidebarManagerPrefPanel.properties
+++ b/inception/inception-diam-editor/src/main/java/de/tudarmstadt/ukp/inception/diam/sidebar/preferences/DiamSidebarManagerPrefPanel.properties
@@ -1,0 +1,18 @@
+# Licensed to the Technische Universität Darmstadt under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The Technische Universität Darmstadt 
+# licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.
+#  
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+title=Annotation sidebar
+pinnedGroups=Pinned groups

--- a/inception/inception-diam-editor/src/main/java/de/tudarmstadt/ukp/inception/diam/sidebar/preferences/DiamSidebarManagerPrefs.java
+++ b/inception/inception-diam-editor/src/main/java/de/tudarmstadt/ukp/inception/diam/sidebar/preferences/DiamSidebarManagerPrefs.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.diam.sidebar.preferences;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import de.tudarmstadt.ukp.inception.preferences.Key;
+
+public class DiamSidebarManagerPrefs
+    implements Serializable
+{
+    private static final long serialVersionUID = 8420554954400084375L;
+
+    public static final Key<DiamSidebarManagerPrefs> KEY_DIAM_SIDEBAR_MANAGER_PREFS = new Key<>(
+            DiamSidebarManagerPrefs.class, "annotation/editor/annotation-sidebar/manager");
+
+    private final List<String> pinnedGroups = new ArrayList<>();
+
+    public List<String> getPinnedGroups()
+    {
+        System.out.println("[" + hashCode() + "] GET " + String.join(",", pinnedGroups));
+        return pinnedGroups;
+    }
+
+    public void setPinnedGroups(List<String> aPinnedGroups)
+    {
+        pinnedGroups.clear();
+        if (aPinnedGroups != null) {
+            pinnedGroups.addAll(aPinnedGroups);
+        }
+        System.out.println("[" + hashCode() + "] SET " + String.join(",", aPinnedGroups));
+    }
+}

--- a/inception/inception-diam-editor/src/main/java/de/tudarmstadt/ukp/inception/diam/sidebar/preferences/PinnedGroupsPanel.html
+++ b/inception/inception-diam-editor/src/main/java/de/tudarmstadt/ukp/inception/diam/sidebar/preferences/PinnedGroupsPanel.html
@@ -33,12 +33,16 @@
     <div wicket:id=items class="list-group-item">
       <form wicket:id="itemForm">
         <div class="input-group">
+          <a wicket:id="moveUp" class="btn btn-outline-secondary">
+            <i class="fas fa-arrow-up" aria-hidden="true"></i>
+          </a>
+          <a wicket:id="moveDown" class="btn btn-outline-secondary">
+            <i class="fas fa-arrow-down" aria-hidden="true"></i>
+          </a>
           <input type="text" wicket:id="textField" class="form-control"/>
-          <span class="input-group-btn">
-            <a wicket:id="removeItem" class="btn btn-danger">
-              <i class="fas fa-trash" aria-hidden="true"></i>
-            </a>
-          </span>
+          <a wicket:id="removeItem" class="btn btn-outline-danger">
+            <i class="fas fa-trash" aria-hidden="true"></i>
+          </a>
         </div>
       </form>
     </div>

--- a/inception/inception-diam-editor/src/main/java/de/tudarmstadt/ukp/inception/diam/sidebar/preferences/PinnedGroupsPanel.html
+++ b/inception/inception-diam-editor/src/main/java/de/tudarmstadt/ukp/inception/diam/sidebar/preferences/PinnedGroupsPanel.html
@@ -16,26 +16,32 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
+
 <html xmlns:wicket="http://wicket.apache.org">
-<body>
-  <wicket:panel>
-    <form wicket:id="form" class="card border-0 flex-content flex-v-container">
-      <div class="flex-content scrolling card-body">
-        <div class="flex-v-container flex-content flex-gutter">
-          <div wicket:id="annotationEditor"/>
-          <div wicket:id="bratAnnotationEditorManagerPrefs"/>
-          <div wicket:id="diamAnnotationSidebarManagerPrefs"/>
-          <div wicket:id="annotationSidebar"/>
-          <div wicket:id="annotationSearch"/>
+<wicket:panel>
+  <div class="list-group">
+    <div class="list-group-item">
+      <div class="input-group">
+        <input type="text" wicket:id="newItemName" class="form-control"/>
+        <span class="input-group-btn">
+          <a wicket:id="addItem" class="btn btn-primary">
+            <i class="fas fa-plus" aria-hidden="true"></i>
+          </a>
+        </span>
+      </div>
+    </div>
+    <div wicket:id=items class="list-group-item">
+      <form wicket:id="itemForm">
+        <div class="input-group">
+          <input type="text" wicket:id="textField" class="form-control"/>
+          <span class="input-group-btn">
+            <a wicket:id="removeItem" class="btn btn-danger">
+              <i class="fas fa-trash" aria-hidden="true"></i>
+            </a>
+          </span>
         </div>
-      </div>
-      <div class="card-footer text-end">
-        <button wicket:id="save" class="btn btn-primary">
-          <i class="fas fa-save"></i>&nbsp;
-          <wicket:message key="save"/>
-        </button>
-      </div>
-    </form>
-  </wicket:panel>
-</body>
+      </form>
+    </div>
+  </div>
+</wicket:panel>
 </html>

--- a/inception/inception-diam-editor/src/main/java/de/tudarmstadt/ukp/inception/diam/sidebar/preferences/PinnedGroupsPanel.java
+++ b/inception/inception-diam-editor/src/main/java/de/tudarmstadt/ukp/inception/diam/sidebar/preferences/PinnedGroupsPanel.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.diam.sidebar.preferences;
+
+import java.util.List;
+
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.markup.html.form.Form;
+import org.apache.wicket.markup.html.form.TextField;
+import org.apache.wicket.markup.html.list.ListItem;
+import org.apache.wicket.markup.html.list.ListView;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
+
+import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxFormComponentUpdatingBehavior;
+import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxLink;
+
+public class PinnedGroupsPanel
+    extends Panel
+{
+    private static final long serialVersionUID = 5606608290992666303L;
+
+    private final IModel<String> newItemName = Model.of();
+
+    public PinnedGroupsPanel(String id, IModel<List<String>> aModel)
+    {
+        super(id, aModel);
+
+        setOutputMarkupId(true);
+
+        ListView<String> additionalMatchingPropertiesListView = new ListView<String>("items",
+                getModel())
+        {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            protected void populateItem(ListItem<String> item)
+            {
+                Form<Void> propertyForm = new Form<Void>("itemForm");
+                propertyForm.add(buildTextField("textField", item.getModel()));
+                propertyForm.add(new LambdaAjaxLink("removeItem", t -> PinnedGroupsPanel.this
+                        .actionRemoveProperty(t, item.getModelObject())));
+                item.add(propertyForm);
+            }
+
+        };
+        additionalMatchingPropertiesListView.setOutputMarkupId(true);
+        add(additionalMatchingPropertiesListView);
+
+        TextField<String> newPropertyField = new TextField<>("newItemName", newItemName);
+        newPropertyField.add(new LambdaAjaxFormComponentUpdatingBehavior("change"));
+        add(newPropertyField);
+
+        LambdaAjaxLink addPropertyButton = new LambdaAjaxLink("addItem",
+                PinnedGroupsPanel.this::actionAddProperty);
+        add(addPropertyButton);
+    }
+
+    public IModel<List<String>> getModel()
+    {
+        return (IModel<List<String>>) getDefaultModel();
+    }
+
+    private TextField<String> buildTextField(String id, IModel<String> model)
+    {
+        TextField<String> iriTextfield = new TextField<>(id, model);
+        iriTextfield.setOutputMarkupId(true);
+        iriTextfield.add(new LambdaAjaxFormComponentUpdatingBehavior("change", t -> {
+            // Do nothing just update the model values
+        }));
+        iriTextfield.setEnabled(false);
+        return iriTextfield;
+    }
+
+    private void actionAddProperty(AjaxRequestTarget aTarget)
+    {
+        String itemName = newItemName.getObject();
+        getModel().getObject().add(itemName);
+        newItemName.setObject(null);
+        aTarget.add(this);
+    }
+
+    private void actionRemoveProperty(AjaxRequestTarget aTarget, String aItem)
+    {
+        getModel().getObject().remove(aItem);
+        aTarget.add(this);
+    }
+}

--- a/inception/inception-diam-editor/src/main/resources/META-INF/asciidoc/user-guide/annotation-sidebar.adoc
+++ b/inception/inception-diam-editor/src/main/resources/META-INF/asciidoc/user-guide/annotation-sidebar.adoc
@@ -1,0 +1,40 @@
+// Licensed to the Technische Universität Darmstadt under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The Technische Universität Darmstadt 
+// licenses this file to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.
+//  
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+[[sect_annotation_sidebar]]
+= Annotation Sidebar
+
+The annotation sidebar provides an overview over all annotations in the current document. It is located in the left sidebar panel.
+
+The sidebar supports two modes of displaying annotations:
+
+* **Grouped by label (default)**: Annotations are grouped by label. Every annotation is represented
+  by its text. If the same text is annotated multiple times, there will be multiple items with the
+  same text. To help disambiguating between the same text occurring in different contexts, each item
+  also shows a bit of trailing context in a lighter font. Additionally, there is a small badge in
+  every annotation item which allows selecting the annotation or deleting it. Clicking on the text
+  itself will scroll to the annotation in the editor window, but it will not select the annotation.
+  If an item represents an annotation suggestion from a recommender, the badge instead has buttons
+  for accepting or rejecting the suggestion. Again, clicking on the text will scroll the editor
+  window to the suggestion without accepting or rejecting it. Within each group, annotations are
+  sorted alphabetically by their text. If the option **sort by score** is enabled, then 
+  suggestions are sorted by score.
+* **Grouped by position**: In this mode, the items are ordered by their position in the text.
+  Relation annotations are grouped under their respective source span annotation. If there are 
+  multiple annotations at the same position, then there are multiple badges in the respective item.
+  Each of these badges shows the label of an annotation present at this position and allows 
+  selecting or deleting it. Clicking on the text will will scroll to the respective position in the 
+  editor window.

--- a/inception/inception-diam-editor/src/main/resources/META-INF/asciidoc/user-guide/projects_annotation_sidebar.adoc
+++ b/inception/inception-diam-editor/src/main/resources/META-INF/asciidoc/user-guide/projects_annotation_sidebar.adoc
@@ -1,0 +1,35 @@
+// Licensed to the Technische Universität Darmstadt under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The Technische Universität Darmstadt 
+// licenses this file to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.
+//  
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+[[sect_projects_annotation_sidebar]]
+= Annotation sidebar
+
+.Pinned Groups
+This setting allows configuring groups which are always visible in the annotation sidebar on the
+annotation page when the sidebar is in **group by label** mode.
+
+Consider a situation where annotators should always locate one or more mentions of a particular 
+concept in every document. Configuring the labels of these concepts as pinned groups will show 
+them in the sidebar, even if the annotator has not yet created an annotation for them. This can
+help the annotator to see which concepts still need to be located and annotated in the text.
+
+This functionality can also be used to enforce a particular order of groups if the automatic alphabetic sorting is not convenient.
+
+Note that groups are formed by the label of an annotation which consists of the concatenated feature 
+values. Thus, for annotations that have multiple features included in their labels, you need to pay
+close attention to exactly match the rendered labels in your pinned groups (wildcards are not 
+supported!). You might consider excluding non-essential features from the label by unchecking the 
+option **Visible** in the settings for the respective feature.

--- a/inception/inception-diam-editor/src/main/ts/src/AnnotationsByLabelList.svelte
+++ b/inception/inception-diam-editor/src/main/ts/src/AnnotationsByLabelList.svelte
@@ -31,13 +31,17 @@
 
     export let ajaxClient: DiamAjax;
     export let data: AnnotatedText;
+    export let pinnedGroups: string[];
 
     let groupedAnnotations: Record<string, Annotation[]>;
     let sortedLabels: string[];
     let sortByScore: boolean = true;
     let recommendationsFirst: boolean = false;
 
-    $: sortedLabels = uniqueLabels(data);
+    $: { 
+        sortedLabels = [...new Set([...pinnedGroups, ...uniqueLabels(data)])];
+        sortedLabels.sort()
+    }
     $: {
         const relations = data?.relations.values() || [];
         const spans = data?.spans.values() || [];
@@ -137,6 +141,7 @@
                             {label || "No label"}
                         </div>
                         <ul class="px-0 list-group list-group-flush">
+                            {#if groupedAnnotations[label]}
                             {#each groupedAnnotations[label] as ann}
                                 <li
                                     class="list-group-item list-group-item-action p-0 d-flex"
@@ -178,6 +183,11 @@
                                     </div>
                                 </li>
                             {/each}
+                            {:else}
+                            <li class="list-group-item list-group-item-action p-2 text-center text-secondary bg-light">
+                                No occurrences
+                            </li>
+                            {/if}
                         </ul>
                     </li>
                 {/each}

--- a/inception/inception-diam-editor/src/main/ts/src/AnnotationsByLabelList.svelte
+++ b/inception/inception-diam-editor/src/main/ts/src/AnnotationsByLabelList.svelte
@@ -38,17 +38,16 @@
     let sortByScore: boolean = true;
     let recommendationsFirst: boolean = false;
 
-    $: { 
-        sortedLabels = [...new Set([...pinnedGroups, ...uniqueLabels(data)])];
-        sortedLabels.sort()
-    }
     $: {
-        const relations = data?.relations.values() || [];
-        const spans = data?.spans.values() || [];
+        sortedLabels = [...pinnedGroups, ...uniqueLabels(data).filter(v => !pinnedGroups.includes(v))]
+
+        const relations = data?.relations.values() || []
+        const spans = data?.spans.values() || []
         groupedAnnotations = groupBy(
             [...spans, ...relations],
             (s) => s.label || ""
-        );
+        )
+
         for (const items of Object.values(groupedAnnotations)) {
             items.sort((a, b) => {
                 if (a instanceof Span && !(b instanceof Span)) {

--- a/inception/inception-diam-editor/src/main/ts/src/DiamAnnotationBrowser.svelte
+++ b/inception/inception-diam-editor/src/main/ts/src/DiamAnnotationBrowser.svelte
@@ -27,6 +27,7 @@
     export let wsEndpointUrl: string
     export let topicChannel: string
     export let ajaxEndpointUrl: string
+    export let pinnedGroups: string[]
     
     let connected = false
     let element = null;
@@ -78,7 +79,7 @@
     {#if mode=='Group by position'}
         <AnnotationsByPositionList {ajaxClient} {data} />
     {:else}
-        <AnnotationsByLabelList {ajaxClient} {data} />
+        <AnnotationsByLabelList {ajaxClient} {data} {pinnedGroups} />
     {/if}
 </div>
 

--- a/inception/inception-diam-editor/src/main/ts/src/Utils.ts
+++ b/inception/inception-diam-editor/src/main/ts/src/Utils.ts
@@ -22,7 +22,7 @@ export function uniqueLabels (data: AnnotatedText): string[] {
   if (!data) return []
 
   const sortedLabelsWithDuplicates = Array.from(data.annotations(), (ann) => ann?.label || '')
-    .sort()
+    .sort((a, b) => a.localeCompare(b, undefined, { usage: 'sort', sensitivity: 'variant' }))
 
   const sortedLabels: string[] = []
   for (let i = 0; i < sortedLabelsWithDuplicates.length; i++) {

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/user-guide.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/user-guide.adoc
@@ -50,8 +50,6 @@ include::{include-dir}annotation_open.adoc[leveloffset=+2]
 
 include::{include-dir}annotation_navigation.adoc[leveloffset=+2]
 
-include::{include-dir}annotation_undo.adoc[leveloffset=+2]
-
 include::{include-dir}annotation_create-annotations.adoc[leveloffset=+2]
 
 include::{include-dir}annotation_create-annotations_span.adoc[leveloffset=+3]
@@ -69,6 +67,10 @@ include::{include-dir}annotation_create-annotations_link-features.adoc[leveloffs
 include::{include-dir}annotation_create-annotations_image-features.adoc[leveloffset=+3]
 
 include::{include-dir}annotation_create-annotations_concept-features.adoc[leveloffset=+3]
+
+include::{include-dir}annotation-sidebar.adoc[leveloffset=+2]
+
+include::{include-dir}annotation_undo.adoc[leveloffset=+2]
 
 include::{include-dir}annotation_settings.adoc[leveloffset=+2]
 
@@ -130,6 +132,8 @@ include::{include-dir}projects_layers.adoc[leveloffset=+2]
 include::{include-dir}projects_layers_feature_lookup.adoc[leveloffset=+4]
 
 include::{include-dir}projects_annotation.adoc[leveloffset=+2]
+
+include::{include-dir}projects_annotation_sidebar.adoc[leveloffset=+3]
 
 include::{include-dir}projects_knowledge-base.adoc[leveloffset=+2]
 

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/user-guide/getting-started.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/user-guide/getting-started.adoc
@@ -575,8 +575,11 @@ You can modify and create tagsets in the project settings.
 See section xref:tagsets_in_getting_started[Tagsets] in _Getting Started_ or check the main documentation for <<Tagsets>>.
 
 You have almost finished the _Getting Started_.
-One word about the left *Annotation Sidebar*.
-It folds out when clicking on the little arrow on top. Then you get detailed information about the currently chosen feature of the sidebar.
+One word can still be said about the *Sidebars* on the left. These offer access to various 
+additional functionalities such as an annotation overview, search, recommenders, etc. Which 
+functionalities are available to you is determined by the project settings. The sidebars can be
+opened by clicking on one of the sidebar icons and they can be closed by clicking on the arrow icon at the top.
+
 
 image::getting_started_Sidebar_closed.png[align="center"]
 

--- a/inception/inception-ui-dashboard/pom.xml
+++ b/inception/inception-ui-dashboard/pom.xml
@@ -84,6 +84,10 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-diam-editor</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-project-initializers</artifactId>
     </dependency>
   

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/AnnotationPreferencesProjectSettingsPanel.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/AnnotationPreferencesProjectSettingsPanel.java
@@ -27,6 +27,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxButton;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaForm;
 import de.tudarmstadt.ukp.clarin.webanno.ui.core.settings.ProjectSettingsPanelBase;
+import de.tudarmstadt.ukp.inception.diam.sidebar.preferences.DiamSidebarManagerPrefPanel;
 
 public class AnnotationPreferencesProjectSettingsPanel
     extends ProjectSettingsPanelBase
@@ -38,6 +39,7 @@ public class AnnotationPreferencesProjectSettingsPanel
     private static final String CID_ANNOTATION_SIDEBAR = "annotationSidebar";
     private static final String CID_ANNOTATION_EDITOR = "annotationEditor";
     private static final String CID_BRAT_ANNOTATION_EDITOR_MANAGER_PREFS = "bratAnnotationEditorManagerPrefs";
+    private static final String CID_DIAM_ANNOTATION_SIDEBAR_MANAGER_PREFS = "diamAnnotationSidebarManagerPrefs";
     private static final String CID_ANNOTATION_SEARCH = "annotationSearch";
 
     public AnnotationPreferencesProjectSettingsPanel(String aId, IModel<Project> aProjectModel)
@@ -49,6 +51,8 @@ public class AnnotationPreferencesProjectSettingsPanel
         queue(new LambdaAjaxButton<>(CID_SAVE, this::actionSave));
 
         queue(new DefaultAnnotationSidebarStatePanel(CID_ANNOTATION_SIDEBAR, aProjectModel));
+        queue(new DiamSidebarManagerPrefPanel(CID_DIAM_ANNOTATION_SIDEBAR_MANAGER_PREFS,
+                aProjectModel));
         queue(new DefaultAnnotationEditorStatePanel(CID_ANNOTATION_EDITOR, aProjectModel));
         queue(new BratAnnotationEditorManagerPrefPanel(CID_BRAT_ANNOTATION_EDITOR_MANAGER_PREFS,
                 aProjectModel));

--- a/inception/inception-ui-dashboard/src/main/resources/META-INF/asciidoc/user-guide/projects_annotation.adoc
+++ b/inception/inception-ui-dashboard/src/main/resources/META-INF/asciidoc/user-guide/projects_annotation.adoc
@@ -1,3 +1,18 @@
+// Licensed to the Technische Universität Darmstadt under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The Technische Universität Darmstadt 
+// licenses this file to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.
+//  
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 [[sect_projects_annotation]]
 = Annotation 
 

--- a/inception/inception-ui-project/src/main/resources/META-INF/asciidoc/user-guide/projects_documents.adoc
+++ b/inception/inception-ui-project/src/main/resources/META-INF/asciidoc/user-guide/projects_documents.adoc
@@ -1,3 +1,18 @@
+// Licensed to the Technische Universität Darmstadt under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The Technische Universität Darmstadt 
+// licenses this file to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.
+//  
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 = Documents
 
 The documents in a project can be managed on the documents panel. 


### PR DESCRIPTION
**What's in the PR**
- Add ability to add pinned categories in project settings
- Use the pinned categories in the annotation sidebar when in group-by-label mode

**How to test manually**
* Add some pinned categories in the project settings on the annotation panel
* Open the annotation page, open the annotation sidebar, put it into "group-by-label" mode and see the pinned categories
* Add an annotation with one of the pinned labels

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
