### PR TITLE
#3909 - Accept best button missing from recommendation sidebar

### DIFF
--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
@@ -1833,8 +1833,8 @@ public class RecommendationServiceImpl
         if (sentences.isEmpty()) {
             // This can happen if a recommender uses different token boundaries (e.g. if a
             // remote service performs its own tokenization). We might be smart here by
-            // looking for overlapping sentences instead of contained sentences.
-            LOG.trace("Discarding suggestion because no covering sentences were found: {}",
+            // looking for overlapping sentences instead of covered sentences.
+            LOG.trace("Discarding suggestion because no covered sentences were found: {}",
                     aPredictedAnnotation);
             return Optional.empty();
         }
@@ -1879,8 +1879,8 @@ public class RecommendationServiceImpl
 
             // This can happen if a recommender uses different token boundaries (e.g. if a
             // remote service performs its own tokenization). We might be smart here by
-            // looking for overlapping tokens instead of contained tokens.
-            LOG.trace("Discarding suggestion because no covering tokens were found: {}",
+            // looking for overlapping tokens instead of covered tokens.
+            LOG.trace("Discarding suggestion because no covered tokens were found: {}",
                     aPredictedAnnotation);
             return Optional.empty();
         }

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommenderInfoPanel.html
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommenderInfoPanel.html
@@ -63,17 +63,17 @@
             </div>
           </div>
         </div>
-        <div class="card-footer actions text-end">
-          <button wicket:id="exportModel" class="btn btn-sm btn-secondary">
-            <i class="fas fa-download"/>
-          </button>
-          <button wicket:id="showDetails" class="btn btn-sm btn-secondary">
-            <i class="fas fa-table"/>
-          </button>
-          <button wicket:id="acceptBest" class="btn btn-sm btn-success text-nowrap">
-            <i class="fas fa-check"/> Accept best
-          </button>
-        </div>
+      </div>
+      <div class="card-footer actions text-end">
+        <button wicket:id="exportModel" class="btn btn-sm btn-secondary">
+          <i class="fas fa-download"/>
+        </button>
+        <button wicket:id="showDetails" class="btn btn-sm btn-secondary">
+          <i class="fas fa-table"/>
+        </button>
+        <button wicket:id="acceptBest" class="btn btn-sm btn-success text-nowrap">
+          <i class="fas fa-check"/> Accept best
+        </button>
       </div>
       <div class="clearfix"></div>
     </div>

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommenderInfoPanel.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommenderInfoPanel.java
@@ -168,13 +168,17 @@ public class RecommenderInfoPanel
                 resultsContainer.add(new Label("testSampleCount",
                         evalResult.map(EvaluationResult::getTestSetSize).orElse(0)));
 
-                resultsContainer.add(new LambdaAjaxLink("acceptBest",
+                item.add(resultsContainer);
+
+                item.add(new LambdaAjaxLink("acceptBest",
                         _tgt -> actionAcceptBest(_tgt, recommender))
                                 .setVisible(evaluatedRecommender.map(EvaluatedRecommender::isActive)
                                         .orElse(false)));
 
-                resultsContainer.add(new LambdaAjaxLink("showDetails",
-                        _tgt -> actionShowDetails(_tgt, recommender)));
+                item.add(new LambdaAjaxLink("showDetails",
+                        _tgt -> actionShowDetails(_tgt, recommender))
+                                .setVisible(evalResult.map(r -> !r.isEvaluationSkipped())
+                                        .orElse(evalResult.isPresent())));
 
                 AjaxDownloadLink exportModel = new AjaxDownloadLink("exportModel",
                         LoadableDetachableModel.of(() -> exportModelName(recommender)),
@@ -183,9 +187,7 @@ public class RecommenderInfoPanel
                         () -> recommendationService.getRecommenderFactory(recommender).isPresent()
                                 && recommendationService.getRecommenderFactory(recommender).get()
                                         .isModelExportSupported()));
-                resultsContainer.add(exportModel);
-
-                item.add(resultsContainer);
+                item.add(exportModel);
 
                 item.add(new Label("noEvaluationMessage",
                         evaluatedRecommender.map(EvaluatedRecommender::getReasonForState)


### PR DESCRIPTION
**What's in the PR**
- Move "accept best" buttons (and other buttons) out of the results group so they are visible even when no evaluation results are available

**How to test manually**
* Configure an external recommender (or another recommender without evaluation)
* Open the recommender sidebar
* Check if the "accept best" button is available

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
