### PR TITLE
#3921 - Unable to merge slot filler when a feature in the project is disabled

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanRenderer.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanRenderer.java
@@ -166,6 +166,7 @@ public class SpanRenderer
         int fi = 0;
         nextFeature: for (AnnotationFeature feat : typeAdapter.listFeatures()) {
             if (!feat.isEnabled()) {
+                fi++;
                 continue nextFeature;
             }
 
@@ -191,6 +192,7 @@ public class SpanRenderer
                     aSpansAndSlots.add(arc);
                 }
             }
+
             fi++;
         }
     }


### PR DESCRIPTION
**What's in the PR**
- Index was not properly increased when a feature is disabled causing VID to be wrong

**How to test manually**
* Create a layer with two features, one is a slot feature and the other is a primitive feature
* Ensure that the slot feature's name comes alphabetically after the primitive feature's name
* Annotate something so that the slot is filled
* Disable the primitive feature
* Try curating this, in particular try merging the slot filler

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
