### PR TITLE
#3926 - Projects may not delete if WebSocket-based event notification is enabled

### DIFF
--- a/inception/inception-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
+++ b/inception/inception-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
@@ -539,7 +539,7 @@ public class ProjectServiceImpl
     }
 
     @Override
-    @Transactional
+    @Transactional(noRollbackFor = NoResultException.class)
     public Project getProjectBySlug(String aSlug)
     {
         String query = "FROM Project WHERE slug = :slug";
@@ -549,7 +549,7 @@ public class ProjectServiceImpl
     }
 
     @Override
-    @Transactional
+    @Transactional(noRollbackFor = NoResultException.class)
     public Project getProject(long aId)
     {
         String query = "FROM Project " + "WHERE id = :id";
@@ -597,7 +597,6 @@ public class ProjectServiceImpl
     }
 
     @Override
-    @Transactional(noRollbackFor = NoResultException.class)
     public List<Project> listProjectsWithFinishedAnnos()
     {
         String query = String.join("\n", //

--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchServiceImpl.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchServiceImpl.java
@@ -285,6 +285,13 @@ public class SearchServiceImpl
     {
         Project project = aEvent.getProject();
 
+        if (isBeingDeleted(project.getId())) {
+            log.trace(
+                    "Ignoring repeated attempt to delete project which is already in progress of being deleted",
+                    project);
+            return;
+        }
+
         log.trace("Removing index for project {} because project is being removed", project);
 
         try (PooledIndex pooledIndex = acquireIndex(project.getId())) {
@@ -314,6 +321,17 @@ public class SearchServiceImpl
     }
 
     private final Map<Long, PooledIndex> indexes = new HashMap<>();
+
+    private boolean isBeingDeleted(long aProjectId)
+    {
+        synchronized (indexes) {
+            PooledIndex pooledIndex = indexes.get(aProjectId);
+            if (pooledIndex != null && pooledIndex.isTombstone()) {
+                return true;
+            }
+            return false;
+        }
+    }
 
     private PooledIndex acquireIndex(long aProjectId)
     {

--- a/inception/inception-websocket/pom.xml
+++ b/inception/inception-websocket/pom.xml
@@ -118,8 +118,8 @@
     <dependency>
       <groupId>javax.persistence</groupId>
       <artifactId>javax.persistence-api</artifactId>
-      <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.apache.tomcat.embed</groupId>
       <artifactId>tomcat-embed-websocket</artifactId>


### PR DESCRIPTION
**What's in the PR**
- Avoid deleting an index again if the index is already being deleted
- Do not roll back a running transaction if a project cannot be found by ID or name
- If a project or document has been deleted, do not generate a WebSocket event notification for it

**How to test manually**
* Set `websocket.logged-events.enabled=true` in the `settings.properties`
* Try deleting a project

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
