### PR TITLE
#3922 - Search results not showing

### DIFF
--- a/inception/inception-search-mtas/src/main/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndex.java
+++ b/inception/inception-search-mtas/src/main/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndex.java
@@ -1071,11 +1071,12 @@ public class MtasDocumentIndex
                                         .filter(t -> t.getPositionStart() >= matchStart
                                                 && t.getPositionEnd() < matchEnd)
                                         .mapToInt(MtasTokenString::getOffsetStart).min()
-                                        .getAsInt());
+                                        .orElse(matchStart));
                                 result.setOffsetEnd(tokens.stream()
                                         .filter(t -> t.getPositionStart() >= matchStart
                                                 && t.getPositionEnd() < matchEnd)
-                                        .mapToInt(MtasTokenString::getOffsetEnd).max().getAsInt());
+                                        .mapToInt(MtasTokenString::getOffsetEnd).max()
+                                        .orElse(matchEnd));
                                 result.setTokenStart(matchStart);
                                 result.setTokenLength(matchEnd - matchStart);
                                 result.setReadOnly(annotationDocument != null


### PR DESCRIPTION
**What's in the PR**
- Fix search in case the user only searches for a start or end of an annotation, e.g. only `<blah>` or `</blah>`

**How to test manually**
* Try search only for the start or end of an annotation

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
