### PR TITLE
#3929 - Spaces in feature names not treated same as in layer names when indexing

### DIFF
--- a/inception/inception-search-mtas/src/main/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasUimaParser.java
+++ b/inception/inception-search-mtas/src/main/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasUimaParser.java
@@ -431,8 +431,8 @@ public class MtasUimaParser
                 MultiValuedMap<String, String> fieldsAndValues = fis.get().indexFeatureValue(aLayer,
                         aAnnotation, aPrefix, feature);
                 for (Entry<String, String> e : fieldsAndValues.entries()) {
-                    indexFeatureValue(e.getKey(), e.getValue(), mtasId++, aAnnotation.getBegin(),
-                            aAnnotation.getEnd(), aRange, aFSAddress);
+                    indexFeatureValue(getIndexedName(e.getKey()), e.getValue(), mtasId++,
+                            aAnnotation.getBegin(), aAnnotation.getEnd(), aRange, aFSAddress);
                 }
 
                 if (LOG.isTraceEnabled()) {


### PR DESCRIPTION
**What's in the PR**
- Sanitize feature names in the same way as layer names when indexing

**How to test manually**
* Create a feature with a space in its name and try searching for it, replacing the space with an underscore in the query

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
