### PR TITLE
#3951 - Lots of errors and warnings from logging system during startup

### DIFF
--- a/inception/inception-app-webapp/src/main/resources/log4j2-spring.xml
+++ b/inception/inception-app-webapp/src/main/resources/log4j2-spring.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Configuration status="WARN" packages="de.tudarmstadt.ukp">
+<Configuration status="WARN">
   <properties>
     <SpringProfile name="!app &amp; !cli"> <!-- While booting before Spring is there-->
       <property name="pattern">%d{yyyy-MM-dd HH:mm:ss} %level{length=5} [%encode{$${ctx:username:-SYSTEM}}{CRLF}] %logger{1} - %encode{%msg}{CRLF}%n</property>

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/logging.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/logging.adoc
@@ -39,7 +39,7 @@ logging.level.de.tudarmstadt.ukp.inception.security=TRACE
 == Custom logging
 
 A custom logging configuration can be specified when starting up {product-name} using the parameter
-`-Dlog4j.configurationFile=/path/to/your/log4.xml`. This should be a standard Log4J configuration file.
+`-Dlogging.config=/path/to/your/log4.xml`. This should be a standard Log4J2 configuration file.
 A good starting point is the default configuration used by {product-name} which can be found in link:https://github.com/inception-project/inception/blob/main/inception/inception-app-webapp/src/main/resources/log4j2.xml[our code repository].
 
 == Logging in JSON format
@@ -47,7 +47,7 @@ A good starting point is the default configuration used by {product-name} which 
 If you would like to integrate the logging output of {product-name} with something like LogStash and
 Kibana, you may want log output to be in a properly interpretable JSON format, instead of the usual
 plain text format. {product-name} comes with several JSON configurations that are compatible with
-popular tools like LogStash and others. You can activate it by adding the following sections to a custom `log4j.xml` file in the `Appenders` sections and in the `Root` logger.
+popular tools like LogStash and others. You can activate it by adding the following sections to a custom `log4j2.xml` file in the `Appenders` sections and in the `Root` logger.
 
 [source,text]
 ----

--- a/inception/pom.xml
+++ b/inception/pom.xml
@@ -2439,6 +2439,11 @@
               <artifactId>hibernate-jpamodelgen</artifactId>
               <version>${hibernate.version}</version>
             </path>
+            <path>
+              <groupId>org.apache.logging.log4j</groupId>
+              <artifactId>log4j-core</artifactId>
+              <version>${log4j2.version}</version>
+            </path>
           </annotationProcessorPaths>
         </configuration>
       </plugin>


### PR DESCRIPTION
**What's in the PR**
- Use log4j2-spring.xml instead of log4j2.xml so Spring gets a chance of initializing before the logging framework is initialized
- Remove package-scanning from the config file and instead properly configure the annotation processor to set up the log4j plugin descriptor during build

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
