### PR TITLE
#3963 - Merging the label into the unlabeled concept issue while stacking is enabled

### DIFF
--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
@@ -900,14 +900,19 @@ public class RecommendationServiceImpl
 
         // Check if there is already an annotation of the target type at the given location
         var type = CasUtil.getType(aCas, adapter.getAnnotationTypeName());
-        var annoFS = selectAt(aCas, type, aBegin, aEnd).stream().findFirst().orElse(null);
+
+        var candidates = aCas.select(type).at(aBegin, aEnd).asList();
+
+        var candidateWithEmptyLabel = candidates.stream() //
+                .filter(c -> adapter.getFeatureValue(aFeature, c) == null) //
+                .findFirst();
 
         int address;
-        if (annoFS != null && adapter.getFeatureValue(aFeature, annoFS) == null) {
+        if (candidateWithEmptyLabel.isPresent()) {
             // If there is an annotation where the predicted feature is unset, use it ...
-            address = ICasUtil.getAddr(annoFS);
+            address = ICasUtil.getAddr(candidateWithEmptyLabel.get());
         }
-        else if (annoFS == null || aLayer.isAllowStacking()) {
+        else if (candidates.isEmpty() || aLayer.isAllowStacking()) {
             // ... if not or if stacking is allowed, then we create a new annotation - this also
             // takes care of attaching to an annotation if necessary
             var newAnnotation = adapter.add(aDocument, aDocumentOwner, aCas, aBegin, aEnd);
@@ -916,7 +921,7 @@ public class RecommendationServiceImpl
         else {
             // ... if yes and stacking is not allowed, then we update the feature on the existing
             // annotation
-            address = ICasUtil.getAddr(annoFS);
+            address = ICasUtil.getAddr(candidates.get(0));
         }
 
         // Update the feature value

--- a/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImplIntegrationTest.java
+++ b/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImplIntegrationTest.java
@@ -328,6 +328,21 @@ public class RecommendationServiceImplIntegrationTest
                         tuple(0, 10, "V1"), //
                         tuple(0, 10, "V2"), //
                         tuple(10, 20, "V3"));
+
+        new NamedEntity(cas, 0, 10).addToIndexes();
+        new NamedEntity(cas, 0, 10).addToIndexes();
+
+        sut.upsertSpanFeature(doc, docOwner, cas.getCas(), layer, feature, "V4", 0, 10);
+
+        assertThat(cas.select(NamedEntity.class).asList()) //
+                .as("Label was merged again into one of the entities without a label") //
+                .extracting(NamedEntity::getBegin, NamedEntity::getEnd, NamedEntity::getValue)
+                .containsExactlyInAnyOrder( //
+                        tuple(0, 10, "V1"), //
+                        tuple(0, 10, "V2"), //
+                        tuple(0, 10, "V4"), //
+                        tuple(0, 10, null), //
+                        tuple(10, 20, "V3"));
     }
 
     // Helper


### PR DESCRIPTION
**What's in the PR**
- When checking if there is a candidate without a label, consider **all** candidates and not just the arbitrary first one

**How to test manually**
* See issue description

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
