### PR TITLE
#3975 - Upgrade dependencies (27.7)

### DIFF
--- a/inception/pom.xml
+++ b/inception/pom.xml
@@ -77,8 +77,8 @@
     <pdfbox.version>2.0.27</pdfbox.version>
 
     <spring.version>5.3.27</spring.version>
-    <spring.boot.version>2.7.10</spring.boot.version>
-    <spring.data.version>2.7.10</spring.data.version>
+    <spring.boot.version>2.7.11</spring.boot.version>
+    <spring.data.version>2.7.11</spring.data.version>
     <spring.security.version>5.8.2</spring.security.version>
     <springdoc.version>1.6.14</springdoc.version>
     <swagger.version>2.2.8</swagger.version>
@@ -88,7 +88,7 @@
     <log4j2.version>2.20.0</log4j2.version>
     <jboss.logging.version>3.5.0.Final</jboss.logging.version>
 
-    <tomcat.version>9.0.71</tomcat.version>
+    <tomcat.version>9.0.74</tomcat.version>
     <servlet-api.version>4.0.1</servlet-api.version>
 
     <mariadb.driver.version>2.7.8</mariadb.driver.version>
@@ -99,7 +99,7 @@
     <wicket.version>9.12.0</wicket.version>
     <wicketstuff.version>9.12.0</wicketstuff.version>
     <wicket-jquery-ui.version>9.12.0</wicket-jquery-ui.version>
-    <wicket-bootstrap.version>6.0.1</wicket-bootstrap.version>
+    <wicket-bootstrap.version>6.0.3</wicket-bootstrap.version>
     <wicket-jquery-selectors.version>3.0.4</wicket-jquery-selectors.version>
     <wicket-webjars.version>3.0.6</wicket-webjars.version>
     <!-- Stuck with 3.1.6: https://github.com/MarcGiffing/wicket-spring-boot/issues/199 -->
@@ -130,13 +130,13 @@
     <!-- * 4.6.1    depends on Lucene 8.11.1 -->
     <!--   4.7.0    depends on Lucene 9.4.2 -->
 
-    <asciidoctor.plugin.version>2.2.2</asciidoctor.plugin.version>
-    <asciidoctor.version>2.5.7</asciidoctor.version>
-    <asciidoctor-diagram.version>2.2.4</asciidoctor-diagram.version>
+    <asciidoctor.plugin.version>2.2.3</asciidoctor.plugin.version>
+    <asciidoctor.version>2.5.8</asciidoctor.version>
+    <asciidoctor-diagram.version>2.2.7</asciidoctor-diagram.version>
 
     <json.version>20230227</json.version>
     <pf4j.version>2.6.0</pf4j.version>
-    <jackson.version>2.14.1</jackson.version>
+    <jackson.version>2.14.2</jackson.version>
     <snakeyaml.version>1.33</snakeyaml.version>
     <okhttp.version>4.10.0</okhttp.version>
     <okio.version>3.3.0</okio.version>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.dkpro</groupId>
     <artifactId>dkpro-parent-pom</artifactId>
-    <version>28</version>
+    <version>30</version>
   </parent>
 
   <groupId>de.tudarmstadt.ukp.inception.app</groupId>


### PR DESCRIPTION
**What's in the PR**
- dkpro-parent-pom 28 -> 30
- spring-boot 2.7.10 -> 2.7.11
- spring-data 2.7.10 -> 2.7.11
- tomcat 9.0.71 -> 9.0.74
- wicket-bootstrap 6.0.1 -> 6.0.3
- asciidoctor-plugin 2.2.2 -> 2.2.3
- asciidoctor 2.5.7 -> 2.5.8
- asciidoctor-diagram 2.2.4 -> 2.2.7
- jackson 2.14.1 -> 2.14.2

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
