### PR TITLE
#3992 - Ability to configure leniency for the CAS access modification check

### DIFF
--- a/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/config/CasStorageProperties.java
+++ b/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/config/CasStorageProperties.java
@@ -17,6 +17,8 @@
  */
 package de.tudarmstadt.ukp.inception.annotation.storage.config;
 
+import java.time.Duration;
+
 public interface CasStorageProperties
 {
     boolean isTraceAccess();
@@ -24,4 +26,6 @@ public interface CasStorageProperties
     boolean isParanoidCasSerialization();
 
     boolean isCompressedCasSerialization();
+
+    Duration getFileSystemTimestampAccuracy();
 }

--- a/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/config/CasStoragePropertiesImpl.java
+++ b/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/config/CasStoragePropertiesImpl.java
@@ -17,6 +17,8 @@
  */
 package de.tudarmstadt.ukp.inception.annotation.storage.config;
 
+import java.time.Duration;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.jmx.export.annotation.ManagedAttribute;
 import org.springframework.jmx.export.annotation.ManagedResource;
@@ -34,6 +36,7 @@ public class CasStoragePropertiesImpl
     private boolean compressedCasSerialization = true;
     private boolean paranoidCasSerialization = false;
     private boolean traceAccess = false;
+    private Duration fileSystemTimestampAccuracy = Duration.ofMillis(0);
 
     @ManagedAttribute
     public void setTraceAccess(boolean aTraceAccess)
@@ -70,5 +73,18 @@ public class CasStoragePropertiesImpl
     public boolean isCompressedCasSerialization()
     {
         return compressedCasSerialization;
+    }
+
+    @ManagedAttribute
+    public void setFileSystemTimestampAccuracy(Duration aFileSystemTimestampAccuracy)
+    {
+        fileSystemTimestampAccuracy = aFileSystemTimestampAccuracy;
+    }
+
+    @Override
+    @ManagedAttribute
+    public Duration getFileSystemTimestampAccuracy()
+    {
+        return fileSystemTimestampAccuracy;
     }
 }

--- a/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/driver/filesystem/FileSystemCasStorageDriver.java
+++ b/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/driver/filesystem/FileSystemCasStorageDriver.java
@@ -463,7 +463,8 @@ public class FileSystemCasStorageDriver
         }
 
         long diskLastModified = casFile.lastModified();
-        if (diskLastModified != aExpectedTimeStamp) {
+        if (Math.abs(diskLastModified - aExpectedTimeStamp) > casStorageProperties
+                .getFileSystemTimestampAccuracy().toMillis()) {
             StringBuilder lastWriteMsg = new StringBuilder();
             if (metadataCache != null) {
                 InternalMetadata meta = metadataCache.get(casFile);
@@ -485,7 +486,8 @@ public class FileSystemCasStorageDriver
                     + " (expected: " + formatTimestamp(aExpectedTimeStamp) + " actual on storage: "
                     + formatTimestamp(diskLastModified) + ", delta: "
                     + formatDurationHMS(Math.abs(diskLastModified - aExpectedTimeStamp)) + ")"
-                    + lastWriteMsg);
+                    + lastWriteMsg + ", accuracy: "
+                    + casStorageProperties.getFileSystemTimestampAccuracy().toMillis() + "ms");
 
         }
 

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/settings_cas-storage.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/settings_cas-storage.adoc
@@ -26,10 +26,16 @@ This section describes settings related to the storage of CAS data objects (i.e.
 | Default
 | Example
 
-| cas-storage.compressed-cas-serialization
+| `cas-storage.compressed-cas-serialization`
 | Whether to compress annotation files
-| true
-| false
+| `true`
+| `false`
+
+| `cas-storage.file-system-timestamp-accuracy`
+| For file systems where timestamps are not exact, this can be used to configure some leniency. This setting should be used with extreme caution. If an editor accesses an annotation file that is out-of-sync with the editor, this can lead to unexpected behavior. However, when deploying {product-name} e.g. on certain cloud storage facilitites, the file system timestamps may not be exact down to the millisecond,
+this it may be helpful to configure a slight leniency here.
+| `0`
+| `500ms`
 |===
 
 The compression setting takes effect whenever a CAS is written to disk. Changing it does not 
@@ -49,19 +55,19 @@ This cache can be tuned using the following properties:
 | Default
 | Example
 
-| cas-storage.cache.shared-cas-cache-size
+| `cas-storage.cache.shared-cas-cache-size`
 | Number of shared read-only CASes to keep in memory
-| 10-5000 _(depending on heap size)_
-| 20000
+| `10`-`5000` _(depending on heap size)_
+| `20000`
 
-| cas-storage.cache.idle-cas-eviction-delay
+| `cas-storage.cache.idle-cas-eviction-delay`
 | Time a CAS is retained in the caches after the last access
-| 5m
-| 1h
+| `5m`
+| `1h`
 
-| cas-storage.cache.cas-borrow-wait-timeout
+| `cas-storage.cache.cas-borrow-wait-timeout`
 | Time for an exclusive action to wait for another exclusive action to finish
-| 3m
-| 5m
+| `3m`
+| `5m`
 |===
 


### PR DESCRIPTION
**What's in the PR**
- Add a timestamp leniency check option
- Document it

**How to test manually**
* Configure a lenience
* Access a document in the editor
* Locate document on the file system and `touch` it
* Make a change in the editor
* If the `touch` happened before the lenience period expires, there should not be an error

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
