### PR TITLE
#1592 - Allow re-ordering of features

### DIFF
--- a/inception/inception-api-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/AnnotationSchemaService.java
+++ b/inception/inception-api-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/AnnotationSchemaService.java
@@ -78,6 +78,8 @@ public interface AnnotationSchemaService
 
     void updateTagRanks(TagSet aTagSet, List<Tag> aTags);
 
+    void updateFeatureRanks(AnnotationLayer aLayer, List<AnnotationFeature> aTags);
+
     /**
      * creates a {@link TagSet} object in the database
      *

--- a/inception/inception-model-export/src/main/java/de/tudarmstadt/ukp/clarin/webanno/export/model/ExportedAnnotationFeature.java
+++ b/inception/inception-model-export/src/main/java/de/tudarmstadt/ukp/clarin/webanno/export/model/ExportedAnnotationFeature.java
@@ -87,6 +87,9 @@ public class ExportedAnnotationFeature
     @JsonProperty("curatable")
     private boolean curatable = true;
 
+    @JsonProperty("rank")
+    private int rank = 0;
+
     public String getName()
     {
         return name;
@@ -275,6 +278,16 @@ public class ExportedAnnotationFeature
     public void setCuratable(boolean aCuratable)
     {
         curatable = aCuratable;
+    }
+
+    public int getRank()
+    {
+        return rank;
+    }
+
+    public void setRank(int aRank)
+    {
+        rank = aRank;
     }
 
     @Override

--- a/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/AnnotationFeature.java
+++ b/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/AnnotationFeature.java
@@ -133,6 +133,9 @@ public class AnnotationFeature
 
     private boolean curatable = true;
 
+    @Column(nullable = false)
+    private int rank;
+
     public AnnotationFeature()
     {
         // Nothing to do
@@ -202,6 +205,7 @@ public class AnnotationFeature
         this.linkTypeTargetFeatureName = builder.linkTypeTargetFeatureName;
         this.traits = builder.traits;
         this.curatable = builder.curatable;
+        this.rank = builder.rank;
     }
 
     public Long getId()
@@ -560,6 +564,16 @@ public class AnnotationFeature
         curatable = aCuratable;
     }
 
+    public int getRank()
+    {
+        return rank;
+    }
+
+    public void setRank(int aRank)
+    {
+        rank = aRank;
+    }
+
     @Override
     public String toString()
     {
@@ -655,6 +669,7 @@ public class AnnotationFeature
         private String linkTypeTargetFeatureName;
         private String traits;
         private boolean curatable = true;
+        private int rank = 0;
 
         private Builder()
         {
@@ -805,6 +820,12 @@ public class AnnotationFeature
         public Builder withCuratable(boolean curatable)
         {
             this.curatable = curatable;
+            return this;
+        }
+
+        public Builder withRank(int aRank)
+        {
+            this.rank = aRank;
             return this;
         }
 

--- a/inception/inception-model/src/main/resources/de/tudarmstadt/ukp/clarin/webanno/model/db-changelog.xml
+++ b/inception/inception-model/src/main/resources/de/tudarmstadt/ukp/clarin/webanno/model/db-changelog.xml
@@ -1425,4 +1425,17 @@
   <changeSet author="INCEpTION Team" id="20220930-1-pg" dbms="postgresql">
     <sql>ALTER TABLE project ALTER "disableExport" TYPE BOOLEAN USING ("disableExport"::int::bool)</sql>
   </changeSet>
+  
+  <changeSet author="INCEpTION Team" id="20230507-1">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="annotation_feature" columnName="rank"/>
+      </not>
+    </preConditions>
+    <addColumn tableName="annotation_feature">
+      <column name="rank" type="INT" defaultValueNumeric="0">
+        <constraints nullable="false"/>
+      </column>
+    </addColumn>
+  </changeSet>
 </databaseChangeLog>

--- a/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/exporters/LayerExporter.java
+++ b/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/exporters/LayerExporter.java
@@ -186,6 +186,7 @@ public class LayerExporter
         exFeature.setLinkTypeTargetFeatureName(feature.getLinkTypeTargetFeatureName());
         exFeature.setTraits(feature.getTraits());
         exFeature.setCuratable(feature.isCuratable());
+        exFeature.setRank(feature.getRank());
 
         if (feature.getTagset() != null) {
             TagSet tagSet = feature.getTagset();
@@ -332,6 +333,7 @@ public class LayerExporter
         aFeature.setLinkTypeTargetFeatureName(aExFeature.getLinkTypeTargetFeatureName());
         aFeature.setTraits(aExFeature.getTraits());
         aFeature.setCuratable(aExFeature.isCuratable());
+        aFeature.setRank(aExFeature.getRank());
 
         if (aExFeature.getTagSet() != null) {
             TagSet tagset = annotationService.getTagSet(aExFeature.getTagSet().getName(), aProject);

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.properties
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.properties
@@ -37,6 +37,8 @@ search=Search
 preferences=Preferences
 undo=Undo
 redo=Redo
+moveUp=Up
+moveDown=Down
 busy=Busy...
 
 enabled=Enabled

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/layers/ProjectLayersPanel.html
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/layers/ProjectLayersPanel.html
@@ -250,6 +250,12 @@
             <wicket:message key="features"/>
             <a wicket:id="featuresHelpLink"/>
             <div class="actions">
+              <button wicket:id="moveUp" class="btn btn-secondary" type="button" wicket:message="title:moveUp">
+                <i class="fas fa-arrow-up"></i>
+              </button>
+              <button wicket:id="moveDown" class="btn btn-secondary" type="button" wicket:message="title:moveDown">
+                <i class="fas fa-arrow-down"></i>
+              </button>
               <button wicket:id="new" class="btn btn-primary">
                 <i class="fas fa-plus-square"></i>&nbsp;
                 <wicket:message key="create"/>

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/layers/ProjectLayersPanel.java
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/layers/ProjectLayersPanel.java
@@ -21,6 +21,7 @@ import static de.tudarmstadt.ukp.clarin.webanno.support.WebAnnoConst.CHAIN_TYPE;
 import static de.tudarmstadt.ukp.clarin.webanno.support.WebAnnoConst.COREFERENCE_RELATION_FEATURE;
 import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.enabledWhen;
 import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
+import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhenModelIsNotNull;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Comparator.comparing;
@@ -432,6 +433,10 @@ public class ProjectLayersPanel
 
         private static final long serialVersionUID = -1L;
 
+        private LambdaAjaxLink btnMoveUp;
+        private LambdaAjaxLink btnMoveDown;
+        private ListChoice<AnnotationFeature> overviewList;
+
         public FeatureSelectionForm(String id, IModel<AnnotationFeature> aModel)
         {
             super(id, aModel);
@@ -440,7 +445,7 @@ public class ProjectLayersPanel
 
             add(new DocLink("featuresHelpLink", "sect_projects_layers_features"));
 
-            add(new ListChoice<AnnotationFeature>("feature")
+            overviewList = new ListChoice<AnnotationFeature>("feature")
             {
                 private static final long serialVersionUID = 1L;
                 {
@@ -458,13 +463,16 @@ public class ProjectLayersPanel
                         }
                     });
                     setNullValid(false);
-                    add(new LambdaAjaxFormComponentUpdatingBehavior("change", _target -> {
-                        // list and detail panel share the same model, but they are not
-                        // automatically notified of updates to the model unless the
-                        // updates go through their respective setModelObject() calls
-                        featureDetailForm.modelChanged();
-                        _target.add(featureDetailForm);
-                    }));
+                    add(new LambdaAjaxFormComponentUpdatingBehavior("change", this::onChange));
+                }
+
+                private void onChange(AjaxRequestTarget _target)
+                {
+                    // list and detail panel share the same model, but they are not
+                    // automatically notified of updates to the model unless the
+                    // updates go through their respective setModelObject() calls
+                    featureDetailForm.modelChanged();
+                    _target.add(featureDetailForm, btnMoveDown, btnMoveUp);
                 }
 
                 @Override
@@ -472,7 +480,18 @@ public class ProjectLayersPanel
                 {
                     return "";
                 }
-            });
+            };
+            add(overviewList);
+
+            btnMoveUp = new LambdaAjaxLink("moveUp", this::moveTagUp);
+            btnMoveUp.setOutputMarkupPlaceholderTag(true);
+            btnMoveUp.add(visibleWhenModelIsNotNull(overviewList));
+            add(btnMoveUp);
+
+            btnMoveDown = new LambdaAjaxLink("moveDown", this::moveTagDown);
+            btnMoveDown.setOutputMarkupPlaceholderTag(true);
+            btnMoveDown.add(visibleWhenModelIsNotNull(overviewList));
+            add(btnMoveDown);
 
             LambdaAjaxLink createButton = new LambdaAjaxLink(CID_CREATE_FEATURE,
                     this::actionCreateFeature);
@@ -482,6 +501,53 @@ public class ProjectLayersPanel
 
             ));
             add(createButton);
+        }
+
+        private void moveTagUp(AjaxRequestTarget aTarget)
+        {
+            @SuppressWarnings("unchecked")
+            var tags = (List<AnnotationFeature>) overviewList.getChoices();
+            int i = tags.indexOf(overviewList.getModelObject());
+
+            if (i < 1) {
+                return;
+            }
+
+            var tag = tags.remove(i);
+            tags.add(i - 1, tag);
+
+            updateFeatureRanks(aTarget, tags);
+        }
+
+        private void moveTagDown(AjaxRequestTarget aTarget)
+        {
+            @SuppressWarnings("unchecked")
+            var tags = (List<AnnotationFeature>) overviewList.getChoices();
+            int i = tags.indexOf(overviewList.getModelObject());
+
+            if (i >= tags.size() - 1) {
+                return;
+            }
+
+            var tag = tags.remove(i);
+            tags.add(i + 1, tag);
+
+            updateFeatureRanks(aTarget, tags);
+        }
+
+        private void updateFeatureRanks(AjaxRequestTarget aTarget,
+                List<AnnotationFeature> aFeatures)
+        {
+            annotationService.updateFeatureRanks(selectedLayer.getObject(), aFeatures);
+
+            var selected = overviewList.getModelObject();
+            for (var t : aFeatures) {
+                if (t.equals(selected)) {
+                    selected.setRank(t.getRank());
+                }
+            }
+
+            aTarget.add(overviewList, btnMoveUp, btnMoveDown);
         }
 
         private void actionCreateFeature(AjaxRequestTarget aTarget)

--- a/inception/inception-ui-tagsets/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/tagsets/ProjectTagSetsPanel.properties
+++ b/inception/inception-ui-tagsets/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/tagsets/ProjectTagSetsPanel.properties
@@ -27,6 +27,3 @@ tagDetailForm.save.label=Save tag
 tagDetailForm.cancel.label=Cancel
 
 tagSelectionForm.new.label=Create tag
-
-moveUp=Up
-moveDown=Down


### PR DESCRIPTION
**What's in the PR**
- Add buttons to change order of features
- Sort features primarily by rank when fetching them from the DB
- Rewrite some DB queries using the criteria API

**How to test manually**
* Create multiple features on a layer
* Change their order using the arrow buttons that appear when selecting a layer
* Check if the order is reflected in the annotation sidebar on the annotation page

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
