### PR TITLE
#4008 - PDF highlighting disables after double-clicking on a recommended annotation

### DIFF
--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/UI/span.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/UI/span.ts
@@ -22,7 +22,8 @@ export function installSpanSelection () {
 
   window.addEventListener('annotationHoverIn', () => { otherAnnotationTreating = true })
   window.addEventListener('annotationHoverOut', () => { otherAnnotationTreating = false })
-  window.addEventListener('annotationDeleted', () => { otherAnnotationTreating = false })
+  // See https://github.com/inception-project/inception/issues/4008
+  window.addEventListener('doubleClickAnnotation', () => { otherAnnotationTreating = false })
 }
 
 function startSelection () {


### PR DESCRIPTION
**What's in the PR**
- Restore ability to select text after doing a double-click

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
