### PR TITLE
#4018 - Display loading indicator in editor view area

### DIFF
--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/model/AnnotationEditorProperties.java
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/model/AnnotationEditorProperties.java
@@ -26,6 +26,7 @@ public class AnnotationEditorProperties
     private String diamWsUrl;
     private List<String> scriptSources;
     private List<String> stylesheetSources;
+    private boolean loadingIndicatorDisabled = false;
 
     public String getEditorFactory()
     {
@@ -75,5 +76,15 @@ public class AnnotationEditorProperties
     public void setStylesheetSources(List<String> aStylesheetSources)
     {
         stylesheetSources = aStylesheetSources;
+    }
+
+    public boolean isLoadingIndicatorDisabled()
+    {
+        return loadingIndicatorDisabled;
+    }
+
+    public void setLoadingIndicatorDisabled(boolean aLoadingIndicatorDisabled)
+    {
+        loadingIndicatorDisabled = aLoadingIndicatorDisabled;
     }
 }

--- a/inception/inception-js-api/src/main/ts/src/editor/AnnotationEditorProperties.ts
+++ b/inception/inception-js-api/src/main/ts/src/editor/AnnotationEditorProperties.ts
@@ -2,13 +2,13 @@
  * Licensed to the Technische Universität Darmstadt under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
- * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * regarding copyright ownership.  The Technische Universität Darmstadt
  * licenses this file to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.
- *  
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,9 +17,10 @@
  */
 
 export interface AnnotationEditorProperties {
-  editorFactory: string;
-  scriptSources: ReadonlyArray<string>;
-  stylesheetSources: ReadonlyArray<string>;
-  diamAjaxCallbackUrl: string;
-  diamWsUrl: string;
+  editorFactory: string
+  scriptSources: ReadonlyArray<string>
+  stylesheetSources: ReadonlyArray<string>
+  diamAjaxCallbackUrl: string
+  diamWsUrl: string
+  loadingIndicatorDisabled: boolean
 }

--- a/inception/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/PdfAnnotationEditor.java
+++ b/inception/inception-pdf-editor/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor/PdfAnnotationEditor.java
@@ -134,6 +134,7 @@ public class PdfAnnotationEditor
                 referenceToUrl(servletContext, PdfAnnotationEditorCssResourceReference.get())));
         props.setScriptSources(asList(referenceToUrl(servletContext,
                 PdfAnnotationEditorJavascriptResourceReference.get())));
+        props.setLoadingIndicatorDisabled(true);
         return props;
     }
 

--- a/inception/inception-pdf-editor2/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor2/PdfAnnotationEditor.java
+++ b/inception/inception-pdf-editor2/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor2/PdfAnnotationEditor.java
@@ -90,6 +90,7 @@ public class PdfAnnotationEditor
                 referenceToUrl(servletContext, PdfAnnotationEditorCssResourceReference.get())));
         props.setScriptSources(asList(referenceToUrl(servletContext,
                 PdfAnnotationEditorJavascriptResourceReference.get())));
+        props.setLoadingIndicatorDisabled(true);
         return props;
     }
 }


### PR DESCRIPTION
**What's in the PR**
- Display loading indicator if the editor takes a bit longer to load
- Allow editors that do not need this to turn it off

**How to test manually**
* Try opening a large document in the PDF editor (editor should come up quickly and loading indicator of pdfjs should be used)
* Try opening a large document e.g. using the Apache Annotator external editor plugin (loading indicator should show)

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
