### PR TITLE
#4022 - Hiding reason not shown if suggestion has no or empty label

### DIFF
--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/lazydetails/LazyDetailsLookupServiceImpl.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/lazydetails/LazyDetailsLookupServiceImpl.java
@@ -140,8 +140,8 @@ public class LazyDetailsLookupServiceImpl
             StringValue keyParam, String topic, AnnotationLayer layer,
             List<VLazyDetailResult> details)
     {
-        // Only applies to synthetic annotations (i.e. from extensions) and the key is mandatory
-        if (!paramId.isSynthetic() || keyParam.isEmpty()) {
+        // Only applies to synthetic annotations (i.e. from extensions)
+        if (!paramId.isSynthetic()) {
             return;
         }
 
@@ -149,7 +149,8 @@ public class LazyDetailsLookupServiceImpl
 
         String extensionId = paramId.getExtensionId();
         extensionRegistry.getExtension(extensionId)
-                .renderLazyDetails(aSourceDocument, aUser, paramId, feature, keyParam.toString()) //
+                .renderLazyDetails(aSourceDocument, aUser, paramId, feature,
+                        keyParam.toOptionalString()) //
                 .forEach(details::add);
     }
 }

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/RecommendationEditorExtension.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/RecommendationEditorExtension.java
@@ -25,6 +25,7 @@ import static de.tudarmstadt.ukp.clarin.webanno.model.Mode.ANNOTATION;
 import static de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordChangeLocation.MAIN_EDITOR;
 import static de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordType.ACCEPTED;
 import static java.util.Collections.emptyList;
+import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
 import static org.apache.wicket.event.Broadcast.BREADTH;
 
 import java.io.IOException;
@@ -356,8 +357,9 @@ public class RecommendationEditorExtension
             return emptyList();
         }
 
+        var label = defaultIfBlank(aQuery, null);
         var sortedByScore = group.get().bestSuggestionsByFeatureAndLabel(pref, aFeature.getName(),
-                aQuery);
+                label);
 
         List<VLazyDetailResult> details = new ArrayList<>();
         for (AnnotationSuggestion ao : sortedByScore) {


### PR DESCRIPTION
**What's in the PR**
- Allow empty queries when rendering extension-level lazy details
- Normalize empty query to null because suggestions with no label have null as a label and not the empty string

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
