### PR TITLE
#4032 - Allow using externalized strings from backend code

### DIFF
--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/wicket/resource/ContextSensitivePackageStringResourceLoader.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/wicket/resource/ContextSensitivePackageStringResourceLoader.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.support.wicket.resource;
+
+import java.lang.StackWalker.Option;
+import java.util.Locale;
+import java.util.Set;
+
+import org.apache.wicket.Localizer;
+import org.apache.wicket.resource.loader.PackageStringResourceLoader;
+
+public class ContextSensitivePackageStringResourceLoader
+    extends PackageStringResourceLoader
+{
+    private static final Set<String> IGNORED_PREFIXES = Set.of(
+            ContextSensitivePackageStringResourceLoader.class.getPackageName() + ".",
+            Localizer.class.getPackageName() + ".");
+
+    @Override
+    public String loadStringResource(Class<?> aClazz, String aKey, Locale aLocale, String aStyle,
+            String aVariation)
+    {
+        var context = StackWalker.getInstance(Option.RETAIN_CLASS_REFERENCE)
+                .walk(s -> s.dropWhile(
+                        f -> IGNORED_PREFIXES.stream().anyMatch(f.getClassName()::startsWith))
+                        .findFirst());
+
+        return context.map(v -> super.loadStringResource(v.getDeclaringClass(), aKey, aLocale,
+                aStyle, aVariation)).orElse(null);
+    }
+}

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/wicket/resource/Strings.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/wicket/resource/Strings.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.support.wicket.resource;
+
+public class Strings
+{
+    public static String getString(String aKey, String aDefaultValue)
+    {
+        return org.apache.wicket.Application.get().getResourceSettings().getLocalizer()
+                .getString(aKey, null, aDefaultValue);
+    }
+}


### PR DESCRIPTION
**What's in the PR**
- Add getStrings() mechanism that could be used from backend code
- Bit of cleaning up
- Remove support for `.vue` files which are no longer used by INCEpTION

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
