### PR TITLE
#4032 - Allow using externalized strings from backend code

### DIFF
--- a/inception/inception-api-editor/src/main/java/de/tudarmstadt/ukp/inception/editor/AnnotationEditorBase.java
+++ b/inception/inception-api-editor/src/main/java/de/tudarmstadt/ukp/inception/editor/AnnotationEditorBase.java
@@ -19,6 +19,7 @@ package de.tudarmstadt.ukp.inception.editor;
 
 import static de.tudarmstadt.ukp.clarin.webanno.model.Mode.CURATION;
 import static de.tudarmstadt.ukp.clarin.webanno.support.WebAnnoConst.CHAIN_TYPE;
+import static org.slf4j.LoggerFactory.getLogger;
 
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
@@ -37,7 +38,6 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.CasProvider;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
@@ -46,7 +46,6 @@ import de.tudarmstadt.ukp.clarin.webanno.support.wicket.AjaxComponentRespondList
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
 import de.tudarmstadt.ukp.inception.editor.action.AnnotationActionHandler;
-import de.tudarmstadt.ukp.inception.rendering.coloring.ColoringService;
 import de.tudarmstadt.ukp.inception.rendering.config.AnnotationEditorProperties;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
 import de.tudarmstadt.ukp.inception.rendering.pipeline.RenderingPipeline;
@@ -54,19 +53,16 @@ import de.tudarmstadt.ukp.inception.rendering.request.RenderRequest;
 import de.tudarmstadt.ukp.inception.rendering.request.RenderRequestedEvent;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VDocument;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.serialization.VDocumentSerializer;
-import de.tudarmstadt.ukp.inception.schema.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.adapter.AnnotationException;
 
 public abstract class AnnotationEditorBase
     extends Panel
 {
     private static final long serialVersionUID = 8637373389151630602L;
-    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+    private static final Logger LOG = getLogger(MethodHandles.lookup().lookupClass());
 
     private @SpringBean AnnotationEditorProperties properties;
     private @SpringBean AnnotationEditorExtensionRegistry extensionRegistry;
-    private @SpringBean AnnotationSchemaService annotationService;
-    private @SpringBean ColoringService coloringService;
     private @SpringBean UserDao userService;
     private @SpringBean RenderingPipeline renderingPipeline;
 

--- a/inception/inception-api-editor/src/main/java/de/tudarmstadt/ukp/inception/editor/AnnotationEditorFactory.java
+++ b/inception/inception-api-editor/src/main/java/de/tudarmstadt/ukp/inception/editor/AnnotationEditorFactory.java
@@ -37,6 +37,9 @@ public interface AnnotationEditorFactory
      */
     String getBeanName();
 
+    /**
+     * @return the name of the editor as shown to the user.
+     */
     String getDisplayName();
 
     default int accepts(Project aProject, String aFormat)

--- a/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/annotation/BratAnnotationEditor.java
+++ b/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/annotation/BratAnnotationEditor.java
@@ -49,10 +49,8 @@ import de.tudarmstadt.ukp.clarin.webanno.brat.resource.BratResourceReference;
 import de.tudarmstadt.ukp.clarin.webanno.brat.schema.BratSchemaGenerator;
 import de.tudarmstadt.ukp.inception.diam.editor.DiamAjaxBehavior;
 import de.tudarmstadt.ukp.inception.diam.editor.actions.EditorAjaxRequestHandlerBase;
-import de.tudarmstadt.ukp.inception.diam.editor.actions.EditorAjaxRequestHandlerExtensionPoint;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.AjaxResponse;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.DefaultAjaxResponse;
-import de.tudarmstadt.ukp.inception.editor.AnnotationEditorExtensionRegistry;
 import de.tudarmstadt.ukp.inception.editor.action.AnnotationActionHandler;
 import de.tudarmstadt.ukp.inception.externaleditor.ExternalAnnotationEditorBase;
 import de.tudarmstadt.ukp.inception.externaleditor.command.EditorCommand;
@@ -60,7 +58,6 @@ import de.tudarmstadt.ukp.inception.externaleditor.command.LoadAnnotationsComman
 import de.tudarmstadt.ukp.inception.externaleditor.command.QueuedEditorCommandsMetaDataKey;
 import de.tudarmstadt.ukp.inception.externaleditor.model.AnnotationEditorProperties;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
-import de.tudarmstadt.ukp.inception.schema.AnnotationSchemaService;
 
 /**
  * Brat annotator component.
@@ -73,11 +70,8 @@ public class BratAnnotationEditor
 
     private static final long serialVersionUID = -1537506294440056609L;
 
-    private @SpringBean AnnotationSchemaService annotationService;
-    private @SpringBean AnnotationEditorExtensionRegistry extensionRegistry;
     private @SpringBean BratMetrics metrics;
     private @SpringBean BratAnnotationEditorProperties bratProperties;
-    private @SpringBean EditorAjaxRequestHandlerExtensionPoint handlers;
     private @SpringBean BratSerializer bratSerializer;
     private @SpringBean BratSchemaGenerator bratSchemaGenerator;
     private @SpringBean ServletContext servletContext;

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/developer-guide/setup_eclipse.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/developer-guide/setup_eclipse.adoc
@@ -26,8 +26,8 @@ We recommend you start from a *Eclipse IDE for Java Developers* package.
 
 == Use a JDK
 
-On Linux or OS X, the following setting is not necessary. Having a full JDK installed on your
-system is generally sufficient. You can skip on to the next section.
+On Linux or OS X, having a full JDK installed on your system is generally sufficient. You can skip
+on to the next section.
 
 On Windows, you need to edit the `eclipse.ini` file and directly before the `-vmargs` line, you
 have to add the following two lines. Mind to replace `C:/Program Files/Java/jdk11` with the actual
@@ -59,8 +59,9 @@ C:/Program Files/Java/jdk11/jre/bin/server/jvm.dll
 
 == Eclipse Workspace Settings
 
-* You should check that Text file encoding is UTF-8  in *Preferences -> General -> Workspace* of 
-  your Eclipse install.
+* You should check that Text file encoding is `UTF-8` in *Preferences -> General -> Workspace*.
+* You need to enable Java annotation preprocessors. Go to *Preferences -> Maven -> Annotation Processing*
+  and set the *Annotation Processing Mode* to *Automatic*.
 
 == Importing {product-name} into the Workspace
 

--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/ExternalAnnotationEditorBase.java
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/ExternalAnnotationEditorBase.java
@@ -58,7 +58,6 @@ import de.tudarmstadt.ukp.inception.diam.model.ajax.AjaxResponse;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.DefaultAjaxResponse;
 import de.tudarmstadt.ukp.inception.editor.AnnotationEditorBase;
 import de.tudarmstadt.ukp.inception.editor.AnnotationEditorExtensionRegistry;
-import de.tudarmstadt.ukp.inception.editor.AnnotationEditorRegistry;
 import de.tudarmstadt.ukp.inception.editor.action.AnnotationActionHandler;
 import de.tudarmstadt.ukp.inception.editor.view.DocumentViewExtensionPoint;
 import de.tudarmstadt.ukp.inception.externaleditor.command.CommandQueue;
@@ -85,7 +84,6 @@ public abstract class ExternalAnnotationEditorBase
 
     private @SpringBean DocumentViewExtensionPoint documentViewExtensionPoint;
     private @SpringBean DocumentService documentService;
-    private @SpringBean AnnotationEditorRegistry annotationEditorRegistry;
     private @SpringBean AnnotationEditorExtensionRegistry extensionRegistry;
     private @SpringBean ServletContext context;
 

--- a/inception/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/annotatorjs/AnnotatorJsHtmlAnnotationEditor.java
+++ b/inception/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/annotatorjs/AnnotatorJsHtmlAnnotationEditor.java
@@ -27,6 +27,8 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 
+import com.github.kklisura.java.processing.annotations.PropertySourceConstants;
+
 import de.tudarmstadt.ukp.clarin.webanno.api.CasProvider;
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentService;
 import de.tudarmstadt.ukp.inception.annotatorjs.resources.AnnotatorJsCssResourceReference;
@@ -38,6 +40,7 @@ import de.tudarmstadt.ukp.inception.externaleditor.ExternalAnnotationEditorBase;
 import de.tudarmstadt.ukp.inception.externaleditor.model.AnnotationEditorProperties;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
 
+@PropertySourceConstants(resourceName = "de/tudarmstadt/ukp/inception/annotatorjs/wicket-package.properties", className = "Messages_")
 public class AnnotatorJsHtmlAnnotationEditor
     extends ExternalAnnotationEditorBase
 {

--- a/inception/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/annotatorjs/AnnotatorJsHtmlAnnotationEditorFactory.java
+++ b/inception/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/annotatorjs/AnnotatorJsHtmlAnnotationEditorFactory.java
@@ -22,6 +22,7 @@ import org.apache.wicket.model.IModel;
 import de.tudarmstadt.ukp.clarin.webanno.api.CasProvider;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.paging.NoPagingStrategy;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.support.wicket.resource.Strings;
 import de.tudarmstadt.ukp.inception.annotatorjs.config.AnnotatorJsAnnotationEditorSupportAutoConfiguration;
 import de.tudarmstadt.ukp.inception.editor.AnnotationEditorBase;
 import de.tudarmstadt.ukp.inception.editor.AnnotationEditorFactoryImplBase;
@@ -43,7 +44,7 @@ public class AnnotatorJsHtmlAnnotationEditorFactory
     @Override
     public String getDisplayName()
     {
-        return "HTML (AnnotatorJS)";
+        return Strings.getString(Messages_.ANNOTATORJS_EDITOR_NAME);
     }
 
     @Override

--- a/inception/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/annotatorjs/wicket-package.properties
+++ b/inception/inception-html-editor/src/main/java/de/tudarmstadt/ukp/inception/annotatorjs/wicket-package.properties
@@ -1,0 +1,16 @@
+# Licensed to the Technische Universität Darmstadt under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The Technische Universität Darmstadt 
+# licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.
+#  
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+annotatorjs-editor.name=HTML (AnnotatorJS)

--- a/inception/inception-html-editor/suppressions.xml
+++ b/inception/inception-html-editor/suppressions.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+"-//Puppy Crawl//DTD Suppressions 1.1//EN"
+"http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+    <suppress files=".*[/\\]target[/\\].*" checks=".*"/>
+</suppressions>

--- a/inception/inception-support/pom.xml
+++ b/inception/inception-support/pom.xml
@@ -26,6 +26,11 @@
   <name>INCEpTION - Support library</name>
   <dependencies>
     <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.uima</groupId>
       <artifactId>uimaj-core</artifactId>
     </dependency>
@@ -213,16 +218,19 @@
                 <excludes combine.children="append">
                   <!-- Trivial template file which a license header would bloat too much-->
                   <exclude>src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/wicket/input/remove-input-behavior.js</exclude>
-                  <!-- Apache License without header -->
-                  <exclude>src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/sass/*.java</exclude>
-                  <!-- MIT License -->
-                  <exclude>src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/wicketstuff/UrlParametersReceivingBehavior.java</exclude>
-                  <exclude>src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/bootstrap/select/css/*</exclude>
-                  <exclude>src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/bootstrap/select/js/*</exclude>
                 </excludes>
               </configuration>
             </execution>
           </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <configuration>
+            <usedDependencies>
+              <usedDependency>jakarta.annotation:jakarta.annotation-api</usedDependency>
+            </usedDependencies>
+          </configuration>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/wicket/resource/Strings.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/wicket/resource/Strings.java
@@ -19,6 +19,11 @@ package de.tudarmstadt.ukp.clarin.webanno.support.wicket.resource;
 
 public class Strings
 {
+    public static String getString(String aKey)
+    {
+        return getString(aKey);
+    }
+
     public static String getString(String aKey, String aDefaultValue)
     {
         return org.apache.wicket.Application.get().getResourceSettings().getLocalizer()

--- a/inception/inception-support/src/main/resources/META-INF/DEPENDENCIES-EMBEDDED.spdx.json
+++ b/inception/inception-support/src/main/resources/META-INF/DEPENDENCIES-EMBEDDED.spdx.json
@@ -12,17 +12,6 @@
       "hasFiles": [
         "de/tudarmstadt/ukp/clarin/webanno/support/wicket/AjaxDownloadBehavior.java"
       ]
-    },
-    {
-      "name": "vue3-sfc-loader",
-      "versionInfo": "0.2.21",
-      "originator": "Franck Freiburger",
-      "homepage": "https://github.com/FranckFreiburger/vue3-sfc-loader",
-      "licenseDeclared": "MIT",
-      "hasFiles": [
-        "de/tudarmstadt/ukp/inception/support/vue/vue3-sfc-loader.min.js",
-        "de/tudarmstadt/ukp/inception/support/vue/vue3-sfc-loader.min.js.map"
-      ]
     }
   ]
 }

--- a/inception/pom.xml
+++ b/inception/pom.xml
@@ -130,6 +130,8 @@
     <!-- * 4.6.1    depends on Lucene 8.11.1 -->
     <!--   4.7.0    depends on Lucene 9.4.2 -->
 
+    <props-to-constants-generator.version>1.0.0</props-to-constants-generator.version>
+  
     <asciidoctor.plugin.version>2.2.3</asciidoctor.plugin.version>
     <asciidoctor.version>2.5.8</asciidoctor.version>
     <asciidoctor-diagram.version>2.2.7</asciidoctor-diagram.version>
@@ -333,6 +335,14 @@
       <artifactId>spring-boot-configuration-processor</artifactId>
       <optional>true</optional>
     </dependency>
+    
+    <!-- Generation of constants for I18N properties files -->
+    <dependency>
+      <groupId>com.github.kklisura.java.processing</groupId>
+      <artifactId>props-to-constants-generator</artifactId>
+      <optional>true</optional>
+    </dependency>
+    
 
     <!-- JAXB is no longer included with Java 9+ by default -->
     <dependency>
@@ -2281,6 +2291,12 @@
         <artifactId>ivy</artifactId>
         <version>2.5.1</version>
       </dependency>
+      
+      <dependency>
+        <groupId>com.github.kklisura.java.processing</groupId>
+        <artifactId>props-to-constants-generator</artifactId>
+        <version>${props-to-constants-generator.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -2447,6 +2463,16 @@
         <configuration>
           <annotationProcessorPaths>
             <path>
+              <groupId>com.github.kklisura.java.processing</groupId>
+              <artifactId>props-to-constants-generator</artifactId>
+              <version>${props-to-constants-generator.version}</version>
+            </path>
+            <path>
+              <groupId>org.hibernate</groupId>
+              <artifactId>hibernate-jpamodelgen</artifactId>
+              <version>${hibernate.version}</version>
+            </path>
+            <path>
               <groupId>org.hibernate</groupId>
               <artifactId>hibernate-jpamodelgen</artifactId>
               <version>${hibernate.version}</version>
@@ -2568,6 +2594,10 @@
               - Generation of Spring Property Metadata files 
               -->
             <dependency>org.springframework.boot:spring-boot-configuration-processor</dependency>
+            <!-- 
+              - Generation of constants for I18N properties files
+              -->
+            <dependency>com.github.kklisura.java.processing:props-to-constants-generator</dependency>
             <!--
               - Common test dependencies
             -->


### PR DESCRIPTION
**What's in the PR**
- Use getStrings to fetch name of AnnotatorJS in backend factory class
- Bit of cleaning up
- Remove more support for `.vue` files which are no longer used by INCEpTION
- Remove unused rat-plugin excludes
- Some minor cleaning up
- Document that annotation processing needs to be turned on in Eclipse

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
