### PR TITLE
#1496 - Some spans are missing begin offset field

### DIFF
--- a/inception/inception-io-json/pom.xml
+++ b/inception/inception-io-json/pom.xml
@@ -52,6 +52,10 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
     </dependency>
 

--- a/inception/inception-io-json/src/main/java/de/tudarmstadt/ukp/inception/io/jsoncas/LegacyUimaJsonFormatSupport.java
+++ b/inception/inception-io-json/src/main/java/de/tudarmstadt/ukp/inception/io/jsoncas/LegacyUimaJsonFormatSupport.java
@@ -27,12 +27,20 @@ import org.dkpro.core.io.json.JsonWriter;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.inception.io.jsoncas.config.LegacyUimaJsonCasFormatProperties;
 
 public class LegacyUimaJsonFormatSupport
     implements FormatSupport
 {
     public static final String ID = "json";
     public static final String NAME = "UIMA CAS JSON (legacy)";
+
+    private final LegacyUimaJsonCasFormatProperties properties;
+
+    public LegacyUimaJsonFormatSupport(LegacyUimaJsonCasFormatProperties aProps)
+    {
+        properties = aProps;
+    }
 
     @Override
     public String getId()
@@ -57,6 +65,7 @@ public class LegacyUimaJsonFormatSupport
             TypeSystemDescription aTSD, CAS aCAS)
         throws ResourceInitializationException
     {
-        return createEngineDescription(JsonWriter.class, aTSD);
+        return createEngineDescription(JsonWriter.class, aTSD, //
+                JsonWriter.PARAM_OMIT_DEFAULT_VALUES, properties.isOmitDefaultValues());
     }
 }

--- a/inception/inception-io-json/src/main/java/de/tudarmstadt/ukp/inception/io/jsoncas/config/LegacyUimaJsonCasFormatProperties.java
+++ b/inception/inception-io-json/src/main/java/de/tudarmstadt/ukp/inception/io/jsoncas/config/LegacyUimaJsonCasFormatProperties.java
@@ -1,0 +1,19 @@
+package de.tudarmstadt.ukp.inception.io.jsoncas.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("format.json-cas-legacy")
+public class LegacyUimaJsonCasFormatProperties
+{
+    private boolean omitDefaultValues = false;
+
+    public void setOmitDefaultValues(boolean aOmitDefaultValues)
+    {
+        omitDefaultValues = aOmitDefaultValues;
+    }
+
+    public boolean isOmitDefaultValues()
+    {
+        return omitDefaultValues;
+    }
+}

--- a/inception/inception-io-json/src/main/java/de/tudarmstadt/ukp/inception/io/jsoncas/config/LegacyUimaJsonCasFormatProperties.java
+++ b/inception/inception-io-json/src/main/java/de/tudarmstadt/ukp/inception/io/jsoncas/config/LegacyUimaJsonCasFormatProperties.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.tudarmstadt.ukp.inception.io.jsoncas.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;

--- a/inception/inception-io-json/src/main/java/de/tudarmstadt/ukp/inception/io/jsoncas/config/UimaJsonCasSupportAutoConfiguration.java
+++ b/inception/inception-io-json/src/main/java/de/tudarmstadt/ukp/inception/io/jsoncas/config/UimaJsonCasSupportAutoConfiguration.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.inception.io.jsoncas.config;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -26,14 +27,16 @@ import de.tudarmstadt.ukp.inception.io.jsoncas.LegacyUimaJsonFormatSupport;
 import de.tudarmstadt.ukp.inception.io.jsoncas.UimaJsonCasFormatSupport;
 
 @Configuration
+@EnableConfigurationProperties(LegacyUimaJsonCasFormatProperties.class)
 public class UimaJsonCasSupportAutoConfiguration
 {
     @ConditionalOnProperty(prefix = "format.json-cas-legacy", name = "enabled", //
             havingValue = "true", matchIfMissing = false)
     @Bean
-    public LegacyUimaJsonFormatSupport legacyUimaJsonFormatSupport()
+    public LegacyUimaJsonFormatSupport legacyUimaJsonFormatSupport(
+            LegacyUimaJsonCasFormatProperties aProps)
     {
-        return new LegacyUimaJsonFormatSupport();
+        return new LegacyUimaJsonFormatSupport(aProps);
     }
 
     @ConditionalOnProperty(prefix = "format.json-cas", name = "enabled", //

--- a/inception/inception-io-json/src/main/resources/META-INF/asciidoc/user-guide/formats-uimajson-legacy.adoc
+++ b/inception/inception-io-json/src/main/resources/META-INF/asciidoc/user-guide/formats-uimajson-legacy.adoc
@@ -23,13 +23,16 @@ CAUTION: Legacy feature. To use this functionality, you need to enable it first 
 Support for this feature will be removed in a future version. The replacement is <<sect_formats_uimajson>>.
 ====
 
-
 This is an old and deprecated UIMA CAS JSON format which can be exported but not imported.
 It should no longer be used. Instead, one should turn to <<sect_formats_uimajson>>.
 
 The format does support custom layers.
 
 For more details on this format, please refer to the link:https://uima.apache.org/d/uimaj-current/references.html#ugr.ref.json[UIMA Reference Guide].
+
+By default, the format writes all values to the JSON output, even if the values are the default values
+in JSON (e.g. `0` for numbers or `false` for booleans). You can configure this behavior by setting
+`format.json-cas-legacy.omit-default-values` to `true` or `false` (default) respectively.
 
 [cols="2,1,1,1,3"]
 |====
@@ -41,4 +44,3 @@ For more details on this format, please refer to the link:https://uima.apache.or
 | yes
 | UIMA CAS JSON (legacy)
 |====
-


### PR DESCRIPTION
**What's in the PR**
- Disable omission of default values for legacy UIMA JSON format
- Add option to switch to previous behavior of omitting default values
- Updated documentation

**How to test manually**
* Export basically any file as legacy JSON and check if the sofa string item has a `begin: 0` property.

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
