### PR TITLE
#4048 - Document navigation options not visible to manager when viewing other users document

### DIFF
--- a/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/DocumentAccess.java
+++ b/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/DocumentAccess.java
@@ -17,7 +17,9 @@
  */
 package de.tudarmstadt.ukp.inception.documents;
 
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.security.AccessCheckingBean;
+import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.inception.documents.config.DocumentServiceAutoConfiguration;
 
 /**
@@ -36,4 +38,6 @@ public interface DocumentAccess
 
     boolean canEditAnnotationDocument(String aUser, String aProjectId, long aDocumentId,
             String aAnnotator);
+
+    boolean canExportAnnotationDocument(User aUser, Project aProject);
 }

--- a/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/DocumentAccessImpl.java
+++ b/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/DocumentAccessImpl.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.documents;
 
+import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.ANNOTATOR;
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.CURATOR;
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.MANAGER;
 import static org.apache.commons.collections4.CollectionUtils.containsAny;
@@ -72,15 +73,16 @@ public class DocumentAccessImpl
     }
 
     @Override
-    public boolean canViewAnnotationDocument(String aUser, String aProjectId, long aDocumentId,
-            String aAnnotator)
+    public boolean canViewAnnotationDocument(String aSessionOwner, String aProjectId,
+            long aDocumentId, String aAnnotator)
     {
         log.trace(
-                "Permission check: canViewAnnotationDocument [user: {}] [project: {}] [document: {}] [annotator: {}]",
-                aUser, aProjectId, aDocumentId, aAnnotator);
+                "Permission check: canViewAnnotationDocument [aSessionOwner: {}] [project: {}] "
+                        + "[document: {}] [annotator: {}]",
+                aSessionOwner, aProjectId, aDocumentId, aAnnotator);
 
         try {
-            User user = getUser(aUser);
+            User user = getUser(aSessionOwner);
             Project project = getProject(aProjectId);
 
             List<PermissionLevel> permissionLevels = projectService.listRoles(project, user);
@@ -96,7 +98,7 @@ public class DocumentAccessImpl
             }
 
             // Annotators can only see their own documents
-            if (!aUser.equals(aAnnotator)) {
+            if (!aSessionOwner.equals(aAnnotator)) {
                 return false;
             }
 
@@ -118,24 +120,25 @@ public class DocumentAccessImpl
     }
 
     @Override
-    public boolean canEditAnnotationDocument(String aUser, String aProjectId, long aDocumentId,
-            String aAnnotator)
+    public boolean canEditAnnotationDocument(String aSessionOwner, String aProjectId,
+            long aDocumentId, String aAnnotator)
     {
         log.trace(
-                "Permission check: canEditAnnotationDocument [user: {}] [project: {}] [document: {}] [annotator: {}]",
-                aUser, aProjectId, aDocumentId, aAnnotator);
+                "Permission check: canEditAnnotationDocument [aSessionOwner: {}] [project: {}] "
+                        + "[document: {}] [annotator: {}]",
+                aSessionOwner, aProjectId, aDocumentId, aAnnotator);
 
         try {
-            User user = getUser(aUser);
+            User user = getUser(aSessionOwner);
             Project project = getProject(aProjectId);
 
             // Does the user have the permission to access the project at all?
-            if (!projectService.hasRole(user, project, PermissionLevel.ANNOTATOR)) {
+            if (!projectService.hasRole(user, project, ANNOTATOR)) {
                 return false;
             }
 
             // Users can edit their own annotations
-            if (!aUser.equals(aAnnotator)) {
+            if (!aSessionOwner.equals(aAnnotator)) {
                 return false;
             }
 
@@ -154,6 +157,20 @@ public class DocumentAccessImpl
             // If any object does not exist, the user cannot edit
             return false;
         }
+    }
+
+    @Override
+    public boolean canExportAnnotationDocument(User aSessionOwner, Project aProject)
+    {
+        if (aProject == null) {
+            return false;
+        }
+
+        if (projectService.hasRole(aSessionOwner, aProject, MANAGER)) {
+            return true;
+        }
+
+        return !aProject.isDisableExport();
     }
 
     private Project getProject(String aProjectId)

--- a/inception/inception-ui-curation/pom.xml
+++ b/inception/inception-ui-curation/pom.xml
@@ -58,6 +58,10 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-documents</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-api</artifactId>
     </dependency>
     <dependency>

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/actionbar/CurationDocumentNavigator.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/actionbar/CurationDocumentNavigator.java
@@ -17,7 +17,6 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.ui.curation.actionbar;
 
-import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.MANAGER;
 import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
 import static wicket.contrib.input.events.EventType.click;
 import static wicket.contrib.input.events.key.KeyType.Page_down;
@@ -32,9 +31,10 @@ import org.apache.wicket.spring.injection.annot.SpringBean;
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.actionbar.export.ExportDocumentDialog;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
+import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxLink;
 import de.tudarmstadt.ukp.clarin.webanno.support.wicket.input.InputBehavior;
-import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
+import de.tudarmstadt.ukp.inception.documents.DocumentAccess;
 import de.tudarmstadt.ukp.inception.ui.curation.actionbar.opendocument.CurationOpenDocumentDialog;
 import wicket.contrib.input.events.key.KeyType;
 
@@ -44,6 +44,8 @@ public class CurationDocumentNavigator
     private static final long serialVersionUID = 7061696472939390003L;
 
     private @SpringBean ProjectService projectService;
+    private @SpringBean DocumentAccess documentAccess;
+    private @SpringBean UserDao userService;
 
     private AnnotationPageBase page;
 
@@ -71,10 +73,8 @@ public class CurationDocumentNavigator
 
     private boolean isExportable()
     {
-        AnnotatorState state = page.getModelObject();
-        return state.getProject() != null
-                && (projectService.hasRole(state.getUser(), state.getProject(), MANAGER)
-                        || !state.getProject().isDisableExport());
+        return documentAccess.canExportAnnotationDocument(userService.getCurrentUser(),
+                page.getModelObject().getProject());
     }
 
     /**

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/annotation/MatrixWorkflowDocumentNavigationActionBarExtension.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/annotation/MatrixWorkflowDocumentNavigationActionBarExtension.java
@@ -34,6 +34,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.actionbar.ActionBarExtension;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.inception.workload.matrix.MatrixWorkloadExtension;
 import de.tudarmstadt.ukp.inception.workload.matrix.config.MatrixWorkloadManagerAutoConfiguration;
 import de.tudarmstadt.ukp.inception.workload.model.WorkloadManagementService;
@@ -52,6 +53,7 @@ public class MatrixWorkflowDocumentNavigationActionBarExtension
     private final WorkloadManagementService workloadManagementService;
     private final MatrixWorkloadExtension matrixWorkloadExtension;
     private final ProjectService projectService;
+    private final UserDao userService;
 
     // SpringBeans
     private @SpringBean EntityManager entityManager;
@@ -59,11 +61,13 @@ public class MatrixWorkflowDocumentNavigationActionBarExtension
     @Autowired
     public MatrixWorkflowDocumentNavigationActionBarExtension(DocumentService aDocumentService,
             WorkloadManagementService aWorkloadManagementService,
-            MatrixWorkloadExtension aMatrixWorkloadExtension, ProjectService aProjectService)
+            MatrixWorkloadExtension aMatrixWorkloadExtension, ProjectService aProjectService,
+            UserDao aUserService)
     {
         workloadManagementService = aWorkloadManagementService;
         matrixWorkloadExtension = aMatrixWorkloadExtension;
         projectService = aProjectService;
+        userService = aUserService;
     }
 
     @Override
@@ -92,7 +96,8 @@ public class MatrixWorkflowDocumentNavigationActionBarExtension
             return false;
         }
 
-        if (projectService.hasRole(aPage.getModelObject().getUser(), project, MANAGER)) {
+        var sessionOwner = userService.getCurrentUser();
+        if (projectService.hasRole(sessionOwner, project, MANAGER)) {
             return false;
         }
 

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/config/MatrixWorkloadManagerAutoConfiguration.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/config/MatrixWorkloadManagerAutoConfiguration.java
@@ -61,9 +61,11 @@ public class MatrixWorkloadManagerAutoConfiguration
     @Bean
     public MatrixWorkflowDocumentNavigationActionBarExtension matrixWorkflowDocumentNavigationActionBarExtension(
             DocumentService aDocumentService, WorkloadManagementService aWorkloadManagementService,
-            MatrixWorkloadExtension aMatrixWorkloadExtension, ProjectService aProjectService)
+            MatrixWorkloadExtension aMatrixWorkloadExtension, ProjectService aProjectService,
+            UserDao aUserService)
     {
         return new MatrixWorkflowDocumentNavigationActionBarExtension(aDocumentService,
-                aWorkloadManagementService, aMatrixWorkloadExtension, aProjectService);
+                aWorkloadManagementService, aMatrixWorkloadExtension, aProjectService,
+                aUserService);
     }
 }


### PR DESCRIPTION
**What's in the PR**
- Centralize permission check for exporting documents into DocumentAccess class
- Permission check for exporting should consider the session owner, not the document owner

**How to test manually**
* Create a new project
* Import a document
* Add another user with the annotator and curator roles to the project
* Enable the "Disable export in annotation views" options in the "Details" tab of the project settings
* Disable the "Allow annotators to freely navigate between documents" in the "Workflow" tab of the project settings
* Visit the annotation page as the user that created the project (which should be a user with the "manager" permission level) and check that the document navigation and export buttons are present
* Use the open document dialog to open the document but this time selecting the other user from the dropdown at the top before selecting the document and check that the document navigation and export buttons are present
* Enable the curation mode from the curation sidebar and check that the document navigation and export buttons are present
* Copy the URL!
* Log out and log in as the other user
* Paste the URL to access the document directly
* Visit the annotation page as the user that created the project (which should be a user with the "manager" permission level) and check that the document navigation and export buttons are **not** present
* Use the open document dialog to open the document but this time selecting the other user from the dropdown at the top before selecting the document and check that the document navigation and export buttons are **not** present
* Enable the curation mode from the curation sidebar and check that the document navigation and export buttons are **not** present
* Log out
* Log back in again as the project manager
* Enable the "Allow annotators to freely navigate between documents" in the "Workflow" tab of the project settings
* Log out
* Log out and log in as the other user
* Visit the annotation page as the user that created the project (which should be a user with the "manager" permission level) and check that the document navigation **are** present and export button are **not** present
* Use the open document dialog to open the document but this time selecting the other user from the dropdown at the top before selecting the document and check that the document navigation **are** present and export button are **not** present
* Enable the curation mode from the curation sidebar and check that the document navigation **are** present and export button are **not** present
* Mark the document as finished
* Now also check if the export button is gone on the curation page
* Log out
* Log out and log in as the project manager user
* Now also check if the export button is present on the curation page

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
