### PR TITLE
#4052 - Admins no longer see all projects in the project overview

### DIFF
--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/projectlist/ProjectsOverviewPage.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/projectlist/ProjectsOverviewPage.java
@@ -586,10 +586,11 @@ public class ProjectsOverviewPage
 
     private List<ProjectEntry> loadProjects()
     {
+        var isAdmin = userRepository.isAdministrator(currentUser.getObject());
         return projectService.listAccessibleProjectsWithPermissions(currentUser.getObject())
                 .entrySet().stream() //
                 .map(e -> new ProjectEntry(e.getKey(), e.getValue())) //
-                .filter(e -> e.getLevels().contains(MANAGER)
+                .filter(e -> isAdmin || e.getLevels().contains(MANAGER)
                         || containsAny(e.getLevels(), dashboardProperties.getAccessibleByRoles()))
                 .sorted(comparing(ProjectEntry::getName)) //
                 .collect(toList());


### PR DESCRIPTION
**What's in the PR**
- Change role filter such that admin users see everything

**How to test manually**
* Log in as `admin`
* Create some user `testuser`
* Create a new project
* Add `testuser` as manager to the project and remove `admin` from the project
* Go to the project overview page
* Check if the project can be found (should be since administrators should be able to see any project even if they have no role in it)

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
