### PR TITLE
#4055 - Editor scrolls up when left sidebar is opened/closed

### DIFF
--- a/inception/inception-brat-editor/src/main/ts/src/BratEditor.ts
+++ b/inception/inception-brat-editor/src/main/ts/src/BratEditor.ts
@@ -41,6 +41,15 @@ export class BratEditor implements AnnotationEditor {
     element.dispatcher = this.dispatcher
     element.visualizer = this.visualizer
 
+    // Ensure that the visualizer is resized when the container element size changes, e.g. when
+    // the sidebars are opened or closed.
+    if (element.parentElement) {
+      new ResizeObserver(() => {
+        console.log(`resize: ${element.id} ${element.clientWidth} ${element.clientHeight}`)
+        this.dispatcher.post('resize')
+      }).observe(element.parentElement)
+    }
+
     this.resizer = new ResizeManager(this.dispatcher, this.visualizer, ajax)
   }
 

--- a/inception/inception-brat-editor/src/main/ts/src/visualizer_ui/VisualizerUI.ts
+++ b/inception/inception-brat-editor/src/main/ts/src/visualizer_ui/VisualizerUI.ts
@@ -447,7 +447,7 @@ export class VisualizerUI {
 
   resizerTimeout: number
   onResize (evt: Event) {
-    if (evt.target === window) {
+    if (!evt || evt.target === window) {
       clearTimeout(this.resizerTimeout)
       this.resizerTimeout = setTimeout(() => this.dispatcher.post('rerender'), 300)
     }

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/sidebar/SidebarTabbedPanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/sidebar/SidebarTabbedPanel.java
@@ -82,7 +82,7 @@ public class SidebarTabbedPanel<T extends SidebarTab>
     {
         expanded = !expanded;
         saveSidebarState();
-        WicketUtil.refreshPage(aTarget, getPage());
+        aTarget.add(findParent(SidebarPanel.class));
     }
 
     public boolean isExpanded()


### PR DESCRIPTION
**What's in the PR**
- Re-render only the sidebar when its size is changed instead of the whole page
- Make brat editor get notified when its container element changes size so it can resize/rerender accordingly

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
