### PR TITLE
#4074 - Text color does not change depending on background color in color rule editor

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/coloring/ColoringRulesConfigurationPanel.html
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/coloring/ColoringRulesConfigurationPanel.html
@@ -32,16 +32,12 @@
           </button>
         </div>
       </div>
-      <div class="flex-v-container flex-gutter">
-        <div wicket:id="coloringRules" class="flex-h-container flex-gutter flex-only-internal-gutter">
-          <div class="flex-content">
-            <span class="badge fw-normal" style="font-size: inherit;" wicket:id="pattern"/>
-          </div>
-          <div class="flex-h-container flex-centered" style="white-space:nowrap;">
-            <a wicket:id="removeColoringRule" class="btn-sm btn-danger pull-right">
-              <i class="fas fa-trash" aria-hidden="true"></i>
-            </a>
-          </div>
+      <div class="flex-v-container flex-gutter overflow-auto">
+        <div wicket:id="coloringRules" class="input-group flex-nowrap">
+          <label class="input-group-text flex-grow-1" wicket:id="pattern"/>
+          <button wicket:id="removeColoringRule" type="button" class="btn btn-outline-danger">
+            <i class="fas fa-trash" aria-hidden="true"/>
+          </button>
         </div>
       </div>
     </div>

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/coloring/ColoringRulesConfigurationPanel.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/coloring/ColoringRulesConfigurationPanel.java
@@ -41,6 +41,7 @@ import org.apache.wicket.validation.validator.PatternValidator;
 
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.form.ColorPickerTextField;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.support.Coloring;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxLink;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxSubmitLink;
 import de.tudarmstadt.ukp.inception.rendering.coloring.ColoringRule;
@@ -108,6 +109,7 @@ public class ColoringRulesConfigurationPanel
                     @Override
                     protected Map<String, String> update(Map<String, String> aStyles)
                     {
+                        aStyles.put("color", Coloring.bgToFgColor(coloringRule.getColor()));
                         aStyles.put("background-color", coloringRule.getColor());
                         return aStyles;
                     }

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/Coloring.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/clarin/webanno/support/Coloring.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.support;
+
+public class Coloring
+{
+    // http://24ways.org/2010/calculating-color-contrast/
+    // http://stackoverflow.com/questions/11867545/change-text-color-based-on-brightness-of-the-covered-background-area
+    public static String bgToFgColor(String hexcolor)
+    {
+        try {
+            int r = Integer.parseInt(hexcolor.substring(1, 3), 16);
+            int g = Integer.parseInt(hexcolor.substring(3, 5), 16);
+            int b = Integer.parseInt(hexcolor.substring(5, 7), 16);
+            double yiq = ((r * 299) + (g * 587) + (b * 114)) / 1000;
+            return (yiq >= 128) ? "#000000" : "#ffffff";
+        }
+        catch (Exception e) {
+            return "#000000";
+        }
+    }
+}


### PR DESCRIPTION
**What's in the PR**
- Port text-color-selection code used in frontend to backend and use it in the coloring rule editor
- Nicer style for coloring rule editor

**How to test manually**
* Create a coloring rule with a light color (e.g. `#eeeeee`)
* Create a coloring rule with a dark color, (e.g. `#111111`)
* Check that the rules are rendered using a dark/light text color such that rule text is always readable

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
