### PR TITLE
#4088 - Cannot save multi-value concept feature after closing another document

### DIFF
--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/MultiValueConceptFeatureEditor.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/MultiValueConceptFeatureEditor.java
@@ -54,6 +54,8 @@ public class MultiValueConceptFeatureEditor
     private final IModel<AnnotatorState> stateModel;
 
     private FormComponent<Collection<KBHandle>> focusComponent;
+    private boolean featureUpdateBehaviorRequested = false;
+    private boolean featureUpdateBehaviorAdded = false;
 
     public MultiValueConceptFeatureEditor(String aId, MarkupContainer aItem,
             IModel<FeatureState> aModel, IModel<AnnotatorState> aStateModel,
@@ -80,16 +82,28 @@ public class MultiValueConceptFeatureEditor
             focusComponent = (FormComponent<Collection<KBHandle>>) focusComponent
                     .replaceWith(createInput());
         }
+
+        if (featureUpdateBehaviorRequested && !featureUpdateBehaviorAdded) {
+            super.addFeatureUpdateBehavior();
+            featureUpdateBehaviorAdded = true;
+        }
     }
 
     private FormComponent<Collection<KBHandle>> createInput()
     {
+        featureUpdateBehaviorAdded = false;
         if (isEnabledInHierarchy()) {
             return createEditableInput();
         }
         else {
             return createReadOnlyInput();
         }
+    }
+
+    @Override
+    public void addFeatureUpdateBehavior()
+    {
+        featureUpdateBehaviorRequested = true;
     }
 
     private FormComponent<Collection<KBHandle>> createEditableInput()


### PR DESCRIPTION
**What's in the PR**
- Make sure that the feature-update behavior is attached when switching between the read-only and the editable feature editor

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
