### PR TITLE
#4090 - Error in brat editor when switching between documents

### DIFF
--- a/inception/inception-brat-editor/src/main/ts/src/visualizer/Visualizer.ts
+++ b/inception/inception-brat-editor/src/main/ts/src/visualizer/Visualizer.ts
@@ -3305,6 +3305,12 @@ export class Visualizer {
    * @param {SourceData} sourceData
    */
   renderDataReal (sourceData?: SourceData) {
+    // Check if the SVG is actually on the page
+    if (!this.svgContainer.ownerDocument.contains(this.svg.node)) {
+      console.trace('Recieved render request for stale SVG that is no longer on the page. Ignoring.')
+      return
+    }
+
     try {
       Util.profileEnd('before render')
       Util.profileStart('render')


### PR DESCRIPTION
**What's in the PR**
- Check if the SVG is still part of a document before starting to render. If it is not, do not render.

**How to test manually**
* Switch between documents when the brat editor is active and monitor the JS console in the browser

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
