### PR TITLE
#4093 - Problem loading document in curation editor

### DIFF
--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
@@ -420,12 +420,13 @@ public class AnnotationPage
     {
         LOG.trace("BEGIN LOAD_DOCUMENT_ACTION at focus " + aFocus);
 
-        AnnotatorState state = getModelObject();
-        if (state.getUser() == null) {
-            state.setUser(userRepository.getCurrentUser());
-        }
-
         try {
+            AnnotatorState state = getModelObject();
+            if (state.getUser() == null) {
+                state.setUser(userRepository.getCurrentUser());
+            }
+            state.reset();
+
             // Check if there is an annotation document entry in the database. If there is none,
             // create one.
             AnnotationDocument annotationDocument = documentService
@@ -436,9 +437,6 @@ public class AnnotationPage
             // Update the annotation document CAS
             CAS editorCas = documentService.readAnnotationCas(annotationDocument,
                     FORCE_CAS_UPGRADE);
-
-            // (Re)initialize brat model after potential creating / upgrading CAS
-            state.reset();
 
             boolean editable = isEditable();
             applicationEventPublisherHolder.get()

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
@@ -1204,10 +1204,10 @@ public abstract class AnnotationDetailEditorPanel
         }
     }
 
-    private boolean isAnnotationEventRelevant(AnnotationEvent aEvent)
+    private boolean annotationEventAffectsSelectedAnnotation(AnnotationEvent aEvent)
     {
-        AnnotatorState state = getModelObject();
-        Selection selection = state.getSelection();
+        var state = getModelObject();
+        var selection = state.getSelection();
         if (selection.getAnnotation().isNotSet()) {
             return false;
         }
@@ -1220,14 +1220,14 @@ public abstract class AnnotationDetailEditorPanel
     }
 
     @OnEvent
-    public void onAnnotationDeletedEvent(BulkAnnotationEvent aEvent)
+    public void onBulkAnnotationEvent(BulkAnnotationEvent aEvent)
     {
-        if (!isAnnotationEventRelevant(aEvent)) {
+        if (!annotationEventAffectsSelectedAnnotation(aEvent)) {
             return;
         }
 
         try {
-            Selection selection = getModelObject().getSelection();
+            var selection = getModelObject().getSelection();
             int id = selection.getAnnotation().getId();
             boolean annotationStillExists = getEditorCas().select(Annotation.class) //
                     .at(selection.getBegin(), selection.getEnd()) //

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/CurationPage.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/CurationPage.java
@@ -513,20 +513,19 @@ public class CurationPage
     }
 
     /**
-     * Open a document or to a different document. This method should be used only the first time
-     * that a document is accessed. It reset the annotator state and upgrades the CAS.
+     * Open a document. This method should be used only the first time that a document is accessed.
+     * It resets the editor state and upgrades the CAS.
      */
     private void actionLoadDocument(AjaxRequestTarget aTarget, int aFocus)
     {
         LOG.trace("BEGIN LOAD_DOCUMENT_ACTION at focus " + aFocus);
 
-        AnnotatorState state = getModelObject();
-
-        state.setUser(userRepository.getCurationUser());
-
         try {
-            // Update source document state to CURRATION_INPROGRESS, if it was not
-            // CURATION_FINISHED
+            AnnotatorState state = getModelObject();
+            state.setUser(userRepository.getCurationUser());
+            state.reset();
+
+            // Update source document state to CURRATION_INPROGRESS, if it was not CURATION_FINISHED
             if (!CURATION_FINISHED.equals(state.getDocument().getState())) {
                 documentService.transitionSourceDocumentState(state.getDocument(),
                         ANNOTATION_IN_PROGRESS_TO_CURATION_IN_PROGRESS);
@@ -546,9 +545,6 @@ public class CurationPage
 
             CAS mergeCas = readOrCreateCurationCas(
                     curationService.getDefaultMergeStrategy(getProject()), false);
-
-            // (Re)initialize brat model after potential creating / upgrading CAS
-            state.reset();
 
             // Initialize timestamp in state
             curationDocumentService.getCurationCasTimestamp(state.getDocument())


### PR DESCRIPTION
**What's in the PR**
- Reset editor state before loading CAS
- In particular on the curation page, that ensures that the selection is cleared before a re-merge is attempted (which was causing a problem because a callback listening for the merge-bulk-action tried to fetch the editor CAS too early to check if the selected annotation is still there)

**How to test manually**
* See issue description
* ... otherwise try opening and switching between documents in general
* ... try changing the annotation schema (i.e. add/remove layers or features) before opening/switching documents

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
