### PR TITLE
#4104 - Editor type choice does not become available after selecting a tagset

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/StringFeatureTraitsEditor.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/StringFeatureTraitsEditor.java
@@ -125,8 +125,10 @@ public class StringFeatureTraitsEditor
         tagset.add(visibleWhen(() -> !traits.getObject().isMultipleRows()));
         // If we change the tagset, the input component for the key bindings may change, so we need
         // to re-generate the key bindings
-        tagset.add(new LambdaAjaxFormComponentUpdatingBehavior("change",
-                _target -> refreshKeyBindings(_target, aFeature)));
+        tagset.add(new LambdaAjaxFormComponentUpdatingBehavior("change", _target -> {
+            _target.add(form);
+            refreshKeyBindings(_target, aFeature);
+        }));
         form.add(tagset);
 
         CheckBox multipleRows = new CheckBox("multipleRows");


### PR DESCRIPTION
**What's in the PR**
- Refresh form when changing the tagset

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
