### PR TITLE
#3691 - No message when merging already existing slot filler

### DIFF
--- a/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/merge/CasMerge.java
+++ b/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/merge/CasMerge.java
@@ -720,9 +720,18 @@ public class CasMerge
                         && Objects.equals(l.role, newLink.role))) {
                     links.add(newLink);
                 }
+                else {
+                    throw new AlreadyMergedException(
+                            "The slot has already been filled with this annotation in the target document.");
+                }
             }
             else {
-                links.remove(existingLinkWithTarget(newLink, links));
+                LinkWithRoleModel existing = existingLinkWithTarget(newLink, links);
+                if (existing != null && existing.equals(newLink)) {
+                    throw new AlreadyMergedException(
+                            "The slot has already been filled with this annotation in the target document.");
+                }
+                links.remove(existing);
                 links.add(newLink);
             }
             break;

--- a/inception/inception-curation/src/test/java/de/tudarmstadt/ukp/inception/curation/merge/CasMergeLinkTest.java
+++ b/inception/inception-curation/src/test/java/de/tudarmstadt/ukp/inception/curation/merge/CasMergeLinkTest.java
@@ -27,6 +27,7 @@ import static java.util.Arrays.asList;
 import static org.apache.uima.fit.factory.JCasFactory.createJCas;
 import static org.apache.uima.fit.util.FSUtil.getFeature;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.util.List;
 
@@ -102,8 +103,9 @@ public class CasMergeLinkTest
                 .buildAndAddToIndexes();
 
         // Perform merge
-        sut.mergeSlotFeature(document, DUMMY_USER, slotLayer, targetCas.getCas(), sourceFs,
-                slotFeature.getName(), 0);
+        assertThatExceptionOfType(AlreadyMergedException.class)
+                .isThrownBy(() -> sut.mergeSlotFeature(document, DUMMY_USER, slotLayer,
+                        targetCas.getCas(), sourceFs, slotFeature.getName(), 0));
 
         var adapter = schemaService.getAdapter(slotLayer);
         List<LinkWithRoleModel> mergedLinks = adapter.getFeatureValue(slotFeature, targetFs);
@@ -162,8 +164,9 @@ public class CasMergeLinkTest
                 .buildAndAddToIndexes();
 
         // Perform merge
-        sut.mergeSlotFeature(document, DUMMY_USER, slotLayer, targetCas.getCas(), sourceFs,
-                slotFeature.getName(), 0);
+        assertThatExceptionOfType(AlreadyMergedException.class)
+                .isThrownBy(() -> sut.mergeSlotFeature(document, DUMMY_USER, slotLayer,
+                        targetCas.getCas(), sourceFs, slotFeature.getName(), 0));
 
         var adapter = schemaService.getAdapter(slotLayer);
         List<LinkWithRoleModel> mergedLinks = adapter.getFeatureValue(slotFeature, targetFs);

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/BratSuggestionVisualizer.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/BratSuggestionVisualizer.java
@@ -410,7 +410,7 @@ public abstract class BratSuggestionVisualizer
                 return new DefaultAjaxResponse(getAction(aRequest));
             }
             catch (Exception e) {
-                return handleError("Unable to scroll to annotation", e);
+                return handleError("Unable to merge", e);
             }
         }
 


### PR DESCRIPTION
**What's in the PR**
- Added the message when merging slots has no effect
- Fix bad copy/pasted error message in BratSuggestionVisualizer while we are at it

**How to test manually**
* See issue description
* Try on a link feature with role labels as well as one without role labels

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
