### PR TITLE
#4128 - Display layer type in annotation detail panel header

### DIFF
--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.html
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.html
@@ -24,21 +24,21 @@
       <div id="annotationFeatureForm" class="annotatation-detail-panel flex-content flex-v-container flex-gutter">
         <div wicket:id="layerContainer" class="card"/>
         <div class="flex-content panel card">
-          <div class="card-header">
+          <div wicket:id="header" class="card-header">
             <div class="clearfix">
-              <wicket:message key="annotation"/>
+              <span wicket:id="layerType"/>
               <div wicket:id="buttonContainer" class="actions">
                 <button wicket:id="delete" class="btn btn-danger" wicket:message="title:delete">
                   <i class="fas fa-trash"></i>
-                  <span class="d-none d-xl-inline">&nbsp;<wicket:message key="delete"/></span>
+                  <span class="d-none d-xl-inline ms-1"><wicket:message key="delete"/></span>
                 </button>
                 <button wicket:id="reverse" class="btn btn-secondary" wicket:message="title:reverse">
                   <i class="fas fa-arrows-alt-h"></i>
-                  <span class="d-none d-xl-inline">&nbsp;<wicket:message key="reverse"/></span>
+                  <span class="d-none d-xl-inline ms-1"><wicket:message key="reverse"/></span>
                 </button>
                 <button wicket:id="clear" class="btn btn-secondary" wicket:message="title:clear">
                   <i class="fas fa-times"></i>
-                  <span class="d-none d-xl-inline">&nbsp;<wicket:message key="clear"/></span>
+                  <span class="d-none d-xl-inline ms-1"><wicket:message key="clear"/></span>
                 </button>
               </div>
             </div>

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
@@ -67,6 +67,7 @@ import org.apache.wicket.feedback.IFeedback;
 import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.head.JavaScriptHeaderItem;
 import org.apache.wicket.markup.html.WebMarkupContainer;
+import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
@@ -149,33 +150,38 @@ public abstract class AnnotationDetailEditorPanel
         setOutputMarkupPlaceholderTag(true);
         setMarkupId("annotationDetailEditorPanel");
 
+        queue(new WebMarkupContainer("header")
+                .add(visibleWhen(() -> getModelObject().getSelection().getAnnotation().isSet())));
+        queue(new Label("layerType", getModel().map(m -> m.getSelectedAnnotationLayer())
+                .map(l -> l.getType()).map(t -> getString(t))).setOutputMarkupId(true));
+
         confirmationDialog = new BootstrapModalDialog("deleteAnnotationDialog");
         confirmationDialog.trapFocus();
-        add(confirmationDialog);
+        queue(confirmationDialog);
 
-        add(layerSelectionPanel = new LayerSelectionPanel("layerContainer", getModel()));
-        add(selectedAnnotationInfoPanel = new AnnotationInfoPanel("infoContainer", getModel(),
+        queue(layerSelectionPanel = new LayerSelectionPanel("layerContainer", getModel()));
+        queue(selectedAnnotationInfoPanel = new AnnotationInfoPanel("infoContainer", getModel(),
                 this));
-        add(featureEditorListPanel = new FeatureEditorListPanel("featureEditorListPanel",
+        queue(featureEditorListPanel = new FeatureEditorListPanel("featureEditorListPanel",
                 getModel(), this));
-        add(relationListPanel = new AttachedAnnotationListPanel("relationListContainer", aPage,
+        queue(relationListPanel = new AttachedAnnotationListPanel("relationListContainer", aPage,
                 this, aModel));
         relationListPanel.setOutputMarkupPlaceholderTag(true);
 
         buttonContainer = new WebMarkupContainer("buttonContainer");
         buttonContainer.setOutputMarkupPlaceholderTag(true);
-        buttonContainer.add(createDeleteButton());
-        buttonContainer.add(createReverseButton());
-        buttonContainer.add(createClearButton());
-        add(buttonContainer);
+        queue(createDeleteButton());
+        queue(createReverseButton());
+        queue(createClearButton());
+        queue(buttonContainer);
 
         navContainer = new WebMarkupContainer("navContainer");
         navContainer
                 .add(visibleWhen(() -> getModelObject().getSelection().getAnnotation().isSet()));
         navContainer.setOutputMarkupPlaceholderTag(true);
-        navContainer.add(createNextAnnotationButton());
-        navContainer.add(createPreviousAnnotationButton());
-        add(navContainer);
+        queue(createNextAnnotationButton());
+        queue(createPreviousAnnotationButton());
+        queue(navContainer);
     }
 
     @Override
@@ -296,7 +302,7 @@ public abstract class AnnotationDetailEditorPanel
         // Creating a relation
         AnnotationFS arc = aAdapter.add(state.getDocument(), state.getUser().getUsername(),
                 originFs, targetFs, aCas);
-        selection.selectArc(new VID(arc), originFs, targetFs);
+        selection.selectArc(VID.of(arc), originFs, targetFs);
     }
 
     private void createNewSpanAnnotation(AjaxRequestTarget aTarget, SpanAdapter aAdapter, CAS aCas)
@@ -1241,15 +1247,6 @@ public abstract class AnnotationDetailEditorPanel
         catch (Exception e) {
             handleException(this, aEvent.getRequestTarget(), e);
         }
-    }
-
-    /**
-     * @deprecated to be removed without replacement
-     */
-    @Deprecated
-    protected void onAutoForward(AjaxRequestTarget aTarget)
-    {
-        // Overridden in CurationPanel
     }
 
     @SuppressWarnings("unchecked")

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.properties
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.properties
@@ -109,6 +109,11 @@ selectedFeatures=Selected features
 useOtherLayersAsTrainingFeatures=Use other layers as training features
 repeatAnnotation=Repeat annotation
 
+span=Span
+relation=Relation
+chain=Chain
+document-metadata=Metadata
+
 PermissionLevel.ANNOTATOR=Annotator
 PermissionLevel.CURATOR=Curator
 PermissionLevel.MANAGER=Manager

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/CurationPage.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/CurationPage.java
@@ -323,16 +323,6 @@ public class CurationPage
         {
             private static final long serialVersionUID = 2857345299480098279L;
 
-            /**
-             * @deprecated to be removed without replacement
-             */
-            @Deprecated
-            @Override
-            protected void onAutoForward(AjaxRequestTarget aTarget)
-            {
-                annotationEditor.requestRender(aTarget);
-            }
-
             @Override
             public CAS getEditorCas() throws IOException
             {


### PR DESCRIPTION
**What's in the PR**
- Implement the change
- Hide the entire card header when no annotation is selected, leaving only the no-data notice
- Remove deprecated code

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
