### PR TITLE
#4155 - Better annotation suggestion IDs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
   }
 
   agent {
-    label agentLabel
+    label params.agentLabel
   }
   
   tools {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 config = [
     agentLabel: '',
     maven: 'Maven 3',
-    jdk: 'Zulu 11',
+    jdk: 'Zulu 17',
     extraMavenArguments: '-U -Ddkpro.core.testCachePath="${WORKSPACE}/cache/dkpro-core-datasets" -Dmaven.artifact.threads=15',
     wipeWorkspaceBeforeBuild: true,
     wipeWorkspaceAfterBuild: true

--- a/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/ActiveLearningService.java
+++ b/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/ActiveLearningService.java
@@ -25,7 +25,6 @@ import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.inception.active.learning.ActiveLearningServiceImpl.ActiveLearningUserState;
-import de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecord;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordType;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.SpanSuggestion;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.SuggestionGroup;
@@ -45,15 +44,6 @@ public interface ActiveLearningService
     List<SuggestionGroup<SpanSuggestion>> getSuggestions(User aDataOwner, AnnotationLayer aLayer);
 
     /**
-     * @param aRecord
-     *            record to check
-     * @return if the suggestions from which the given record was created (or an equivalent one) is
-     *         visible to the user. This is useful to check if the suggestion can be highlighted
-     *         when clicking on a history record.
-     */
-    boolean isSuggestionVisible(LearningRecord aRecord);
-
-    /**
      * @return if the are any records of type {@link LearningRecordType#SKIPPED} in the history of
      *         the given layer for the given user.
      * 
@@ -64,8 +54,8 @@ public interface ActiveLearningService
      */
     boolean hasSkippedSuggestions(String aSessionOwner, User aDataOwner, AnnotationLayer aLayer);
 
-    void hideRejectedOrSkippedAnnotations(String aSessionOwner, User aDataOwner, AnnotationLayer aLayer,
-            boolean aFilterSkippedRecommendation,
+    void hideRejectedOrSkippedAnnotations(String aSessionOwner, User aDataOwner,
+            AnnotationLayer aLayer, boolean aFilterSkippedRecommendation,
             List<SuggestionGroup<SpanSuggestion>> aSuggestionGroups);
 
     Optional<Delta<SpanSuggestion>> generateNextSuggestion(String aSessionOwner, User aDataOwner,

--- a/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/ActiveLearningServiceImpl.java
+++ b/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/ActiveLearningServiceImpl.java
@@ -27,8 +27,8 @@ import static java.util.stream.Collectors.toList;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import org.slf4j.Logger;
@@ -49,10 +49,7 @@ import de.tudarmstadt.ukp.inception.annotation.layer.span.SpanAdapter;
 import de.tudarmstadt.ukp.inception.recommendation.api.LearningRecordService;
 import de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.AnnotationSuggestion;
-import de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecord;
-import de.tudarmstadt.ukp.inception.recommendation.api.model.Predictions;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.SpanSuggestion;
-import de.tudarmstadt.ukp.inception.recommendation.api.model.SuggestionDocumentGroup;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.SuggestionGroup;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.SuggestionGroup.Delta;
 import de.tudarmstadt.ukp.inception.schema.AnnotationSchemaService;
@@ -68,7 +65,7 @@ import de.tudarmstadt.ukp.inception.schema.feature.FeatureSupportRegistry;
 public class ActiveLearningServiceImpl
     implements ActiveLearningService
 {
-    private final Logger log = LoggerFactory.getLogger(getClass());
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private final ApplicationEventPublisher applicationEventPublisher;
     private final DocumentService documentService;
@@ -97,37 +94,18 @@ public class ActiveLearningServiceImpl
     @Override
     public List<SuggestionGroup<SpanSuggestion>> getSuggestions(User aUser, AnnotationLayer aLayer)
     {
-        Predictions predictions = recommendationService.getPredictions(aUser, aLayer.getProject());
+        var predictions = recommendationService.getPredictions(aUser, aLayer.getProject());
 
         if (predictions == null) {
             return emptyList();
         }
 
-        Map<String, SuggestionDocumentGroup<SpanSuggestion>> recommendationsMap = predictions
-                .getPredictionsForWholeProject(SpanSuggestion.class, aLayer, documentService);
+        var recommendationsMap = predictions.getPredictionsForWholeProject(SpanSuggestion.class,
+                aLayer, documentService);
 
         return recommendationsMap.values().stream() //
                 .flatMap(docMap -> docMap.stream()) //
                 .collect(toList());
-    }
-
-    @Override
-    public boolean isSuggestionVisible(LearningRecord aRecord)
-    {
-        var aSessionOwner = userService.get(aRecord.getUser());
-        var suggestionGroups = getSuggestions(aSessionOwner, aRecord.getLayer());
-        for (var suggestionGroup : suggestionGroups) {
-            if (suggestionGroup.stream().anyMatch(suggestion -> suggestion.getDocumentName()
-                    .equals(aRecord.getSourceDocument().getName())
-                    && suggestion.getFeature().equals(aRecord.getAnnotationFeature().getName())
-                    && suggestion.labelEquals(aRecord.getAnnotation())
-                    && suggestion.getBegin() == aRecord.getOffsetBegin()
-                    && suggestion.getEnd() == aRecord.getOffsetEnd() //
-                    && suggestion.isVisible())) {
-                return true;
-            }
-        }
-        return false;
     }
 
     @Override
@@ -174,27 +152,31 @@ public class ActiveLearningServiceImpl
         long startTimer = System.currentTimeMillis();
         var suggestionGroups = alState.getSuggestions();
         long getRecommendationsFromRecommendationService = System.currentTimeMillis();
-        log.trace("Getting recommendations from recommender system took {} ms.",
+        LOG.trace("Getting recommendations from recommender system took {} ms.",
                 (getRecommendationsFromRecommendationService - startTimer));
-
-        // remove duplicate recommendations
-        suggestionGroups = suggestionGroups.stream() //
-                .map(it -> removeDuplicateRecommendations(it)) //
-                .collect(toList());
-        long removeDuplicateRecommendation = System.currentTimeMillis();
-        log.trace("Removing duplicate recommendations took {} ms.",
-                (removeDuplicateRecommendation - getRecommendationsFromRecommendationService));
 
         // hide rejected recommendations
         hideRejectedOrSkippedAnnotations(aSessionOwner, aDataOwner, alState.getLayer(), true,
                 suggestionGroups);
         long removeRejectedSkippedRecommendation = System.currentTimeMillis();
-        log.trace("Removing rejected or skipped ones took {} ms.",
-                (removeRejectedSkippedRecommendation - removeDuplicateRecommendation));
+        LOG.trace("Hiding rejected or skipped ones took {} ms.",
+                (removeRejectedSkippedRecommendation
+                        - getRecommendationsFromRecommendationService));
+
+        // remove duplicate recommendations
+        suggestionGroups = suggestionGroups.stream() //
+                .map(it -> removeDuplicatesAndHiddenSuggestions(it)) //
+                .filter(it -> !it.isEmpty()) //
+                .collect(toList());
+        long removeDuplicateRecommendation = System.currentTimeMillis();
+        LOG.trace("Removing duplicate recommendations took {} ms.",
+                (removeDuplicateRecommendation - removeRejectedSkippedRecommendation));
 
         var pref = recommendationService.getPreferences(aDataOwner,
                 alState.getLayer().getProject());
-        return alState.getStrategy().generateNextSuggestion(pref, suggestionGroups);
+        var nextSuggestion = alState.getStrategy().generateNextSuggestion(pref, suggestionGroups);
+        assert nextSuggestion.get().getFirst().isVisible() : "Generated suggestion must be visible";
+        return nextSuggestion;
     }
 
     @Override
@@ -296,35 +278,40 @@ public class ActiveLearningServiceImpl
                 alternativeSuggestions));
     }
 
-    private static SuggestionGroup<SpanSuggestion> removeDuplicateRecommendations(
-            SuggestionGroup<SpanSuggestion> unmodifiedRecommendationList)
+    private static SuggestionGroup<SpanSuggestion> removeDuplicatesAndHiddenSuggestions(
+            SuggestionGroup<SpanSuggestion> aSuggestionGroup)
     {
-        SuggestionGroup<SpanSuggestion> cleanRecommendationList = new SuggestionGroup<>();
+        var cleanSuggestionGroup = new SuggestionGroup<SpanSuggestion>();
 
-        unmodifiedRecommendationList.forEach(recommendationItem -> {
-            if (!isAlreadyInCleanList(cleanRecommendationList, recommendationItem)) {
-                cleanRecommendationList.add(recommendationItem);
+        aSuggestionGroup.forEach(suggestion -> {
+            if (!suggestion.isVisible()) {
+                return;
+            }
+
+            if (!isAlreadyInCleanList(cleanSuggestionGroup, suggestion)) {
+                cleanSuggestionGroup.add(suggestion);
             }
         });
 
-        return cleanRecommendationList;
+        return cleanSuggestionGroup;
     }
 
     private static boolean isAlreadyInCleanList(
             SuggestionGroup<SpanSuggestion> cleanRecommendationList,
             AnnotationSuggestion recommendationItem)
     {
-        String source = recommendationItem.getRecommenderName();
-        String annotation = recommendationItem.getLabel();
-        String documentName = recommendationItem.getDocumentName();
+        var source = recommendationItem.getRecommenderName();
+        var annotation = recommendationItem.getLabel();
+        var documentName = recommendationItem.getDocumentName();
 
-        for (AnnotationSuggestion existingRecommendation : cleanRecommendationList) {
-            boolean areLabelsEqual = existingRecommendation.labelEquals(annotation);
+        for (var existingRecommendation : cleanRecommendationList) {
+            var areLabelsEqual = existingRecommendation.labelEquals(annotation);
             if (existingRecommendation.getRecommenderName().equals(source) && areLabelsEqual
                     && existingRecommendation.getDocumentName().equals(documentName)) {
                 return true;
             }
         }
+
         return false;
     }
 

--- a/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.java
+++ b/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.java
@@ -75,7 +75,6 @@ import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.ReorderableTag;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
-import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.clarin.webanno.support.bootstrap.BootstrapModalDialog;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxButton;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxLink;
@@ -302,10 +301,10 @@ public class ActiveLearningSidebar
 
     private void actionStartSession(AjaxRequestTarget aTarget, Form<?> form)
     {
-        ActiveLearningUserState alState = alStateModel.getObject();
-        AnnotatorState state = getModelObject();
-        String userName = state.getUser().getUsername();
-        Project project = state.getProject();
+        var alState = alStateModel.getObject();
+        var state = getModelObject();
+        var userName = state.getUser().getUsername();
+        var project = state.getProject();
 
         recommendationService.setPredictForAllDocuments(userName, project, true);
         recommendationService.triggerPrediction(userName, "ActionStartActiveLearningSession",
@@ -333,6 +332,7 @@ public class ActiveLearningSidebar
      */
     private void requestClearningSelectionAndJumpingToSuggestion()
     {
+        LOG.trace("Requesting clearing and jumping");
         RequestCycle.get().setMetaData(ClearSelectionAndJumpToSuggestionKey.INSTANCE, true);
     }
 
@@ -365,7 +365,7 @@ public class ActiveLearningSidebar
 
     private void setActiveLearningHighlight(SpanSuggestion aSuggestion)
     {
-        assert aSuggestion.isVisible();
+        assert aSuggestion.isVisible() : "Cannot highlight hidden suggestions";
 
         if (protectHighlight) {
             LOG.trace("Active learning sidebar not updating protected highlights");
@@ -519,12 +519,18 @@ public class ActiveLearningSidebar
 
     private void actionJumpToSuggestion(AjaxRequestTarget aTarget) throws IOException
     {
-        ActiveLearningUserState alState = alStateModel.getObject();
-        SpanSuggestion suggestion = alState.getSuggestion().get();
+        var alState = alStateModel.getObject();
+        var suggestion = alState.getSuggestion().get();
+
+        if (!suggestion.isVisible()) {
+            error("Cannot jump to hidden suggestion");
+            aTarget.addChildren(getPage(), IFeedback.class);
+            return;
+        }
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("Active suggestion: {}", suggestion);
-            Optional<SpanSuggestion> updatedSuggestion = getMatchingSuggestion(activeLearningService
+            var updatedSuggestion = getMatchingSuggestion(activeLearningService
                     .getSuggestions(getModelObject().getUser(), alState.getLayer()), suggestion)
                             .stream().findFirst();
             updatedSuggestion.ifPresent(s -> LOG.debug("Update suggestion: {}", s));
@@ -732,13 +738,14 @@ public class ActiveLearningSidebar
         var sessionOwner = userService.getCurrentUser();
 
         // Generate the next recommendation but remember the current one
-        Optional<SpanSuggestion> prevSuggestion = alState.getSuggestion();
-        alState.setCurrentDifference(activeLearningService
-                .generateNextSuggestion(sessionOwner.getUsername(), dataOwner, alState));
+        var currentSuggestion = alState.getSuggestion();
+        var nextSuggestion = activeLearningService
+                .generateNextSuggestion(sessionOwner.getUsername(), dataOwner, alState);
+        alState.setCurrentDifference(nextSuggestion);
 
         // If there is no new suggestion, nothing left to do here
         if (!alState.getSuggestion().isPresent()) {
-            if (prevSuggestion.isPresent()) {
+            if (currentSuggestion.isPresent()) {
                 infoOnce(aTarget, "There are no more recommendations right now.");
             }
 
@@ -749,10 +756,11 @@ public class ActiveLearningSidebar
         }
 
         // If the active suggestion has changed, inform the user
-        if (prevSuggestion.isPresent()
-                && !alState.getSuggestion().get().equals(prevSuggestion.get())) {
+        if (currentSuggestion.isPresent()
+                && !alState.getSuggestion().get().equals(currentSuggestion.get())) {
             // infoOnce(aTarget, "Active learning has moved to next best suggestion.");
-            LOG.trace("Moving from {} to {}", prevSuggestion.get(), alState.getSuggestion().get());
+            LOG.trace("Moving from {} to {}", currentSuggestion.get(),
+                    alState.getSuggestion().get());
         }
 
         // If there is a suggestion, open it in the sidebar and take the main editor to its location
@@ -778,7 +786,7 @@ public class ActiveLearningSidebar
 
     private void clearSelectedAnnotationAndJumpToSuggestion(AjaxRequestTarget aTarget)
     {
-        ActiveLearningUserState alState = alStateModel.getObject();
+        var alState = alStateModel.getObject();
         if (!alState.getSuggestion().isPresent()) {
             return;
         }
@@ -787,11 +795,11 @@ public class ActiveLearningSidebar
         // I.e. we must not make the editor/feature details jump to the next suggestion but rather
         // keep the view and selected annotation that the user has chosen to provide the opportunity
         // to the user to continue editing on it
-        SpanSuggestion suggestion = alState.getSuggestion().get();
-        AnnotatorState state = getModelObject();
-        Project project = state.getProject();
-        User user = state.getUser();
-        SourceDocument sourceDocument = documentService.getSourceDocument(project,
+        var suggestion = alState.getSuggestion().get();
+        var state = getModelObject();
+        var project = state.getProject();
+        var user = state.getUser();
+        var sourceDocument = documentService.getSourceDocument(project,
                 suggestion.getDocumentName());
 
         LOG.trace("Jumping to {}", suggestion);
@@ -829,12 +837,12 @@ public class ActiveLearningSidebar
         // Obtain some left and right context of the active suggestion while we have easy
         // access to the document which contains the current suggestion
         try {
-            CAS cas = documentService.readAnnotationCas(sourceDocument,
+            var cas = documentService.readAnnotationCas(sourceDocument,
                     getModelObject().getUser().getUsername(), AUTO_CAS_UPGRADE,
                     SHARED_READ_ONLY_ACCESS);
-            String text = cas.getDocumentText();
+            var text = cas.getDocumentText();
 
-            ActiveLearningUserState alState = alStateModel.getObject();
+            var alState = alStateModel.getObject();
             alState.setLeftContext(
                     text.substring(Math.max(0, suggestion.getBegin() - 20), suggestion.getBegin()));
             alState.setRightContext(text.substring(suggestion.getEnd(),
@@ -872,8 +880,8 @@ public class ActiveLearningSidebar
             @Override
             protected void populateItem(ListItem<LearningRecord> item)
             {
-                LearningRecord rec = item.getModelObject();
-                AnnotationFeature recAnnotationFeature = rec.getAnnotationFeature();
+                var rec = item.getModelObject();
+                var recAnnotationFeature = rec.getAnnotationFeature();
                 String recFeatureValue;
                 if (recAnnotationFeature != null) {
                     FeatureSupport<?> featureSupport = featureSupportRegistry
@@ -885,7 +893,7 @@ public class ActiveLearningSidebar
                     recFeatureValue = rec.getAnnotation();
                 }
 
-                LambdaAjaxLink textLink = new LambdaAjaxLink(CID_JUMP_TO_ANNOTATION,
+                var textLink = new LambdaAjaxLink(CID_JUMP_TO_ANNOTATION,
                         _target -> actionSelectHistoryItem(_target, item.getModelObject()));
                 textLink.setBody(rec::getTokenText);
                 item.add(textLink);
@@ -923,10 +931,10 @@ public class ActiveLearningSidebar
 
         // Since we have switched documents above (if it was necessary), the editor CAS should
         // now point to the correct one
-        CAS cas = getCasProvider().get();
+        var cas = getCasProvider().get();
 
         // ... if a matching annotation exists, highlight the annotaiton
-        Optional<AnnotationFS> annotation = getMatchingAnnotation(cas, aRecord);
+        var annotation = getMatchingAnnotation(cas, aRecord);
 
         if (annotation.isPresent()) {
             setActiveLearningHighlight(aRecord.getSourceDocument(), annotation.get());
@@ -976,7 +984,8 @@ public class ActiveLearningSidebar
                         && (aFeature == null || aFeature.equals(group.getFeature()))
                         && (aBegin == -1 || aBegin == ((Offset) group.getPosition()).getBegin())
                         && (aEnd == -1 || aEnd == ((Offset) group.getPosition()).getEnd()))
-                .flatMap(group -> group.stream())
+                .flatMap(group -> group.stream()) //
+                .filter(suggestion -> suggestion.isVisible()) //
                 .filter(suggestion -> aLabel == null || aLabel.equals(suggestion.getLabel()))
                 .collect(toList());
     }
@@ -1360,10 +1369,10 @@ public class ActiveLearningSidebar
     {
         LOG.trace("refreshAvailableSuggestions()");
 
-        AnnotatorState state = getModelObject();
-        ActiveLearningUserState alState = alStateModel.getObject();
-        alState.setSuggestions(
-                activeLearningService.getSuggestions(state.getUser(), alState.getLayer()));
+        var state = getModelObject();
+        var alState = alStateModel.getObject();
+        var suggestions = activeLearningService.getSuggestions(state.getUser(), alState.getLayer());
+        alState.setSuggestions(suggestions);
     }
 
     @OnEvent
@@ -1420,11 +1429,11 @@ public class ActiveLearningSidebar
         // is still relevant - if yes, we need to replace it with its current counterpart since.
         // if no counterpart exists in the current suggestions, then we need to load a
         // suggestion from the current list.
-        ActiveLearningUserState alState = alStateModel.getObject();
-        SpanSuggestion activeSuggestion = alState.getSuggestion().get();
+        var alState = alStateModel.getObject();
+        var activeSuggestion = alState.getSuggestion().get();
         // Find the groups which matches the active recommendation
-        Optional<SpanSuggestion> updatedSuggestion = getMatchingSuggestion(alState.getSuggestions(),
-                activeSuggestion).stream().findFirst();
+        var updatedSuggestion = getMatchingSuggestion(alState.getSuggestions(), activeSuggestion)
+                .stream().findFirst();
 
         if (updatedSuggestion.isEmpty()) {
             moveToNextSuggestion(aTarget);
@@ -1432,8 +1441,7 @@ public class ActiveLearningSidebar
         }
 
         LOG.debug("Replacing outdated suggestion {} with new suggestion {}",
-                alState.getCurrentDifference().get().getFirst().getId(),
-                updatedSuggestion.get().getId());
+                alState.getCurrentDifference().get().getFirst(), updatedSuggestion.get());
 
         // Update the highlight
         if (alState.getSuggestion().get().getVID().equals(highlightVID)) {

--- a/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/strategy/UncertaintySamplingStrategy.java
+++ b/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/strategy/UncertaintySamplingStrategy.java
@@ -34,9 +34,9 @@ public class UncertaintySamplingStrategy
 
     @Override
     public Optional<Delta<SpanSuggestion>> generateNextSuggestion(Preferences aPreferences,
-            List<SuggestionGroup<SpanSuggestion>> suggestions)
+            List<SuggestionGroup<SpanSuggestion>> aSuggestions)
     {
-        return suggestions.stream()
+        return aSuggestions.stream()
                 // Fetch the top deltas per recommender
                 .flatMap(group -> group.getTopDeltas(aPreferences).values().stream())
                 // ... sort them in ascending order (smallest delta first)

--- a/inception/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/doccat/OpenNlpDoccatRecommender.java
+++ b/inception/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/doccat/OpenNlpDoccatRecommender.java
@@ -19,6 +19,7 @@ package de.tudarmstadt.ukp.inception.recommendation.imls.opennlp.doccat;
 
 import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.selectOverlapping;
 import static de.tudarmstadt.ukp.inception.recommendation.api.evaluation.EvaluationResult.toEvaluationResult;
+import static de.tudarmstadt.ukp.inception.rendering.model.Range.rangeCoveringAnnotations;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.uima.fit.util.CasUtil.getType;
 import static org.apache.uima.fit.util.CasUtil.indexCovered;
@@ -72,6 +73,9 @@ public class OpenNlpDoccatRecommender
     private static final Class<Sentence> SAMPLE_UNIT = Sentence.class;
     private static final Class<Sentence> DATAPOINT_UNIT = Sentence.class;
 
+    private static final int MIN_TRAINING_SET_SIZE = 2;
+    private static final int MIN_TEST_SET_SIZE = 2;
+
     private final OpenNlpDoccatRecommenderTraits traits;
 
     public OpenNlpDoccatRecommender(Recommender aRecommender,
@@ -91,7 +95,7 @@ public class OpenNlpDoccatRecommender
     @Override
     public void train(RecommenderContext aContext, List<CAS> aCasses) throws RecommendationException
     {
-        List<DocumentSample> docSamples = extractSamples(aCasses);
+        var docSamples = extractSamples(aCasses);
 
         if (docSamples.size() < 2) {
             aContext.warn("Not enough training data: [%d] items", docSamples.size());
@@ -109,10 +113,10 @@ public class OpenNlpDoccatRecommender
         // OpenNLP
         int beamSize = Math.max(maxRecommendations, NameFinderME.DEFAULT_BEAM_SIZE);
 
-        TrainingParameters params = traits.getParameters();
+        var params = traits.getParameters();
         params.put(BeamSearch.BEAM_SIZE_PARAMETER, Integer.toString(beamSize));
 
-        DoccatModel model = train(docSamples, params);
+        var model = train(docSamples, params);
 
         aContext.put(KEY_MODEL, model);
     }
@@ -127,43 +131,42 @@ public class OpenNlpDoccatRecommender
     public Range predict(RecommenderContext aContext, CAS aCas, int aBegin, int aEnd)
         throws RecommendationException
     {
-        DoccatModel model = aContext.get(KEY_MODEL).orElseThrow(
+        var model = aContext.get(KEY_MODEL).orElseThrow(
                 () -> new RecommendationException("Key [" + KEY_MODEL + "] not found in context"));
 
-        DocumentCategorizerME finder = new DocumentCategorizerME(model);
+        var finder = new DocumentCategorizerME(model);
 
-        Type sampleUnitType = getType(aCas, SAMPLE_UNIT);
-        Type predictedType = getPredictedType(aCas);
-        Type tokenType = getType(aCas, Token.class);
-        Feature scoreFeature = getScoreFeature(aCas);
-        Feature predictedFeature = getPredictedFeature(aCas);
-        Feature isPredictionFeature = getIsPredictionFeature(aCas);
+        var sampleUnitType = getType(aCas, SAMPLE_UNIT);
+        var predictedType = getPredictedType(aCas);
+        var tokenType = getType(aCas, Token.class);
+        var scoreFeature = getScoreFeature(aCas);
+        var predictedFeature = getPredictedFeature(aCas);
+        var isPredictionFeature = getIsPredictionFeature(aCas);
 
         var units = selectOverlapping(aCas, sampleUnitType, aBegin, aEnd);
-        int predictionCount = 0;
-        for (AnnotationFS sampleUnit : units) {
+        var predictionCount = 0;
+        for (var unit : units) {
             if (predictionCount >= traits.getPredictionLimit()) {
                 break;
             }
             predictionCount++;
 
-            List<AnnotationFS> tokenAnnotations = selectCovered(tokenType, sampleUnit);
-            String[] tokens = tokenAnnotations.stream() //
+            var tokenAnnotations = selectCovered(tokenType, unit);
+            var tokens = tokenAnnotations.stream() //
                     .map(AnnotationFS::getCoveredText) //
                     .toArray(String[]::new);
 
-            double[] outcome = finder.categorize(tokens);
-            String label = finder.getBestCategory(outcome);
+            var outcome = finder.categorize(tokens);
+            var label = finder.getBestCategory(outcome);
 
-            AnnotationFS annotation = aCas.createAnnotation(predictedType, sampleUnit.getBegin(),
-                    sampleUnit.getEnd());
+            var annotation = aCas.createAnnotation(predictedType, unit.getBegin(), unit.getEnd());
             annotation.setStringValue(predictedFeature, label);
             annotation.setDoubleValue(scoreFeature, NumberUtils.max(outcome));
             annotation.setBooleanValue(isPredictionFeature, true);
             aCas.addFsToIndexes(annotation);
         }
 
-        return new Range(units);
+        return rangeCoveringAnnotations(units);
     }
 
     @Override
@@ -176,9 +179,9 @@ public class OpenNlpDoccatRecommender
     public EvaluationResult evaluate(List<CAS> aCasses, DataSplitter aDataSplitter)
         throws RecommendationException
     {
-        List<DocumentSample> data = extractSamples(aCasses);
-        List<DocumentSample> trainingSet = new ArrayList<>();
-        List<DocumentSample> testSet = new ArrayList<>();
+        var data = extractSamples(aCasses);
+        var trainingSet = new ArrayList<DocumentSample>();
+        var testSet = new ArrayList<DocumentSample>();
 
         for (DocumentSample nameSample : data) {
             switch (aDataSplitter.getTargetSet(nameSample)) {
@@ -194,39 +197,33 @@ public class OpenNlpDoccatRecommender
             }
         }
 
-        int testSetSize = testSet.size();
-        int trainingSetSize = trainingSet.size();
-        double overallTrainingSize = data.size() - testSetSize;
-        double trainRatio = (overallTrainingSize > 0) ? trainingSetSize / overallTrainingSize : 0.0;
+        var testSetSize = testSet.size();
+        var trainingSetSize = trainingSet.size();
+        var overallTrainingSize = data.size() - testSetSize;
+        var trainRatio = (overallTrainingSize > 0) ? trainingSetSize / overallTrainingSize : 0.0;
 
-        final int minTrainingSetSize = 2;
-        final int minTestSetSize = 2;
-        if (trainingSetSize < minTrainingSetSize || testSetSize < minTestSetSize) {
-            if ((getRecommender().getThreshold() <= 0.0d)) {
-                return new EvaluationResult(DATAPOINT_UNIT.getSimpleName(),
-                        SAMPLE_UNIT.getSimpleName());
-            }
+        if (trainingSetSize < MIN_TRAINING_SET_SIZE || testSetSize < MIN_TEST_SET_SIZE) {
+            String msg = String.format(
+                    "Not enough evaluation data: training set size [%d] (min. %d), test set size [%d] (min. %d) of total [%d] (min. %d)",
+                    trainingSetSize, MIN_TRAINING_SET_SIZE, testSetSize, MIN_TEST_SET_SIZE,
+                    data.size(), (MIN_TRAINING_SET_SIZE + MIN_TEST_SET_SIZE));
+            LOG.info(msg);
 
-            String info = String.format(
-                    "Not enough evaluation data: training set [%s] items, test set [%s] of total [%s]",
-                    trainingSetSize, testSetSize, data.size());
-            LOG.info(info);
-
-            EvaluationResult result = new EvaluationResult(DATAPOINT_UNIT.getSimpleName(),
+            var result = new EvaluationResult(DATAPOINT_UNIT.getSimpleName(),
                     SAMPLE_UNIT.getSimpleName(), trainingSetSize, testSetSize, trainRatio);
             result.setEvaluationSkipped(true);
-            result.setErrorMsg(info);
+            result.setErrorMsg(msg);
             return result;
         }
 
         if (trainingSet.stream().map(DocumentSample::getCategory).distinct().count() <= 1) {
-            String info = String.format("Training data requires at least two different labels");
-            LOG.info(info);
+            var msg = String.format("Training data requires at least two different labels");
+            LOG.info(msg);
 
-            EvaluationResult result = new EvaluationResult(DATAPOINT_UNIT.getSimpleName(),
+            var result = new EvaluationResult(DATAPOINT_UNIT.getSimpleName(),
                     SAMPLE_UNIT.getSimpleName(), trainingSetSize, testSetSize, trainRatio);
             result.setEvaluationSkipped(true);
-            result.setErrorMsg(info);
+            result.setErrorMsg(msg);
             return result;
         }
 
@@ -234,11 +231,11 @@ public class OpenNlpDoccatRecommender
                 trainingSet.size(), testSet.size());
 
         // Train model
-        DoccatModel model = train(trainingSet, traits.getParameters());
-        DocumentCategorizerME doccat = new DocumentCategorizerME(model);
+        var model = train(trainingSet, traits.getParameters());
+        var doccat = new DocumentCategorizerME(model);
 
         // Evaluate
-        EvaluationResult result = testSet.stream()
+        var result = testSet.stream()
                 .map(sample -> new LabelPair(sample.getCategory(),
                         doccat.getBestCategory(doccat.categorize(sample.getText()))))
                 .collect(toEvaluationResult(DATAPOINT_UNIT.getSimpleName(),
@@ -250,7 +247,7 @@ public class OpenNlpDoccatRecommender
 
     private List<DocumentSample> extractSamples(List<CAS> aCasses)
     {
-        List<DocumentSample> samples = new ArrayList<>();
+        var samples = new ArrayList<DocumentSample>();
         casses: for (CAS cas : aCasses) {
             Type sampleUnitType = getType(cas, SAMPLE_UNIT);
             Type tokenType = getType(cas, Token.class);

--- a/inception/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/pos/OpenNlpPosRecommender.java
+++ b/inception/inception-imls-opennlp/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/pos/OpenNlpPosRecommender.java
@@ -59,7 +59,6 @@ import opennlp.tools.postag.POSModel;
 import opennlp.tools.postag.POSSample;
 import opennlp.tools.postag.POSTaggerFactory;
 import opennlp.tools.postag.POSTaggerME;
-import opennlp.tools.util.Sequence;
 import opennlp.tools.util.TrainingParameters;
 
 public class OpenNlpPosRecommender
@@ -72,6 +71,9 @@ public class OpenNlpPosRecommender
 
     private static final Class<Sentence> SAMPLE_UNIT = Sentence.class;
     private static final Class<Token> DATAPOINT_UNIT = Token.class;
+
+    private static final int MIN_TRAINING_SET_SIZE = 2;
+    private static final int MIN_TEST_SET_SIZE = 2;
 
     private final OpenNlpPosRecommenderTraits traits;
 
@@ -91,7 +93,7 @@ public class OpenNlpPosRecommender
     @Override
     public void train(RecommenderContext aContext, List<CAS> aCasses) throws RecommendationException
     {
-        List<POSSample> posSamples = extractPosSamples(aCasses);
+        var posSamples = extractPosSamples(aCasses);
 
         if (posSamples.size() < 2) {
             aContext.warn("Not enough training data: [%d] items", posSamples.size());
@@ -101,9 +103,9 @@ public class OpenNlpPosRecommender
         // The beam size controls how many results are returned at most. But even if the user
         // requests only few results, we always use at least the default bean size recommended by
         // OpenNLP
-        int beamSize = Math.max(maxRecommendations, POSTaggerME.DEFAULT_BEAM_SIZE);
+        var beamSize = Math.max(maxRecommendations, POSTaggerME.DEFAULT_BEAM_SIZE);
 
-        TrainingParameters params = traits.getParameters();
+        var params = traits.getParameters();
         params.put(BeamSearch.BEAM_SIZE_PARAMETER, Integer.toString(beamSize));
         POSModel model = train(posSamples, params);
 
@@ -120,60 +122,60 @@ public class OpenNlpPosRecommender
     public Range predict(RecommenderContext aContext, CAS aCas, int aBegin, int aEnd)
         throws RecommendationException
     {
-        POSModel model = aContext.get(KEY_MODEL).orElseThrow(
+        var model = aContext.get(KEY_MODEL).orElseThrow(
                 () -> new RecommendationException("Key [" + KEY_MODEL + "] not found in context"));
 
-        POSTaggerME tagger = new POSTaggerME(model);
+        var tagger = new POSTaggerME(model);
 
-        Type sampleUnitType = getType(aCas, SAMPLE_UNIT);
-        Type predictedType = getPredictedType(aCas);
-        Type tokenType = getType(aCas, Token.class);
+        var sampleUnitType = getType(aCas, SAMPLE_UNIT);
+        var predictedType = getPredictedType(aCas);
+        var tokenType = getType(aCas, Token.class);
 
-        Feature scoreFeature = getScoreFeature(aCas);
-        Feature predictedFeature = getPredictedFeature(aCas);
-        Feature isPredictionFeature = getIsPredictionFeature(aCas);
+        var scoreFeature = getScoreFeature(aCas);
+        var predictedFeature = getPredictedFeature(aCas);
+        var isPredictionFeature = getIsPredictionFeature(aCas);
 
         var units = selectOverlapping(aCas, sampleUnitType, aBegin, aEnd);
         int predictionCount = 0;
-        for (AnnotationFS sampleUnit : units) {
+        for (var unit : units) {
             if (predictionCount >= traits.getPredictionLimit()) {
                 break;
             }
             predictionCount++;
 
-            List<AnnotationFS> tokenAnnotations = selectCovered(tokenType, sampleUnit);
-            String[] tokens = tokenAnnotations.stream() //
+            var tokenAnnotations = selectCovered(tokenType, unit);
+            var tokens = tokenAnnotations.stream() //
                     .map(AnnotationFS::getCoveredText) //
                     .toArray(String[]::new);
 
-            Sequence[] bestSequences = tagger.topKSequences(tokens);
+            var bestSequences = tagger.topKSequences(tokens);
 
             // LOG.debug("Total number of sequences predicted: {}", bestSequences.length);
 
             for (int s = 0; s < Math.min(bestSequences.length, maxRecommendations); s++) {
-                Sequence sequence = bestSequences[s];
-                List<String> outcomes = sequence.getOutcomes();
-                double[] probabilities = sequence.getProbs();
+                var sequence = bestSequences[s];
+                var outcomes = sequence.getOutcomes();
+                var probabilities = sequence.getProbs();
 
                 // LOG.debug("Sequence {} score {}", s, sequence.getScore());
                 // LOG.debug("Outcomes: {}", outcomes);
                 // LOG.debug("Probabilities: {}", asList(probabilities));
 
                 for (int i = 0; i < outcomes.size(); i++) {
-                    String label = outcomes.get(i);
+                    var label = outcomes.get(i);
 
                     // Do not return PADded tokens
                     if (PAD.equals(label)) {
                         continue;
                     }
 
-                    AnnotationFS token = tokenAnnotations.get(i);
+                    var token = tokenAnnotations.get(i);
                     int begin = token.getBegin();
                     int end = token.getEnd();
                     double score = probabilities[i];
 
                     // Create the prediction
-                    AnnotationFS annotation = aCas.createAnnotation(predictedType, begin, end);
+                    var annotation = aCas.createAnnotation(predictedType, begin, end);
                     annotation.setStringValue(predictedFeature, label);
                     annotation.setDoubleValue(scoreFeature, score);
                     annotation.setBooleanValue(isPredictionFeature, true);
@@ -182,7 +184,7 @@ public class OpenNlpPosRecommender
             }
         }
 
-        return new Range(units);
+        return Range.rangeCoveringAnnotations(units);
     }
 
     @Override
@@ -195,11 +197,11 @@ public class OpenNlpPosRecommender
     public EvaluationResult evaluate(List<CAS> aCasses, DataSplitter aDataSplitter)
         throws RecommendationException
     {
-        List<POSSample> data = extractPosSamples(aCasses);
-        List<POSSample> trainingSet = new ArrayList<>();
-        List<POSSample> testSet = new ArrayList<>();
+        var data = extractPosSamples(aCasses);
+        var trainingSet = new ArrayList<POSSample>();
+        var testSet = new ArrayList<POSSample>();
 
-        for (POSSample posSample : data) {
+        for (var posSample : data) {
             switch (aDataSplitter.getTargetSet(posSample)) {
             case TRAIN:
                 trainingSet.add(posSample);
@@ -213,29 +215,22 @@ public class OpenNlpPosRecommender
             }
         }
 
-        int testSetSize = testSet.size();
-        int trainingSetSize = trainingSet.size();
-        double overallTrainingSize = data.size() - testSetSize;
-        double trainRatio = (overallTrainingSize > 0) ? trainingSetSize / overallTrainingSize : 0.0;
+        var testSetSize = testSet.size();
+        var trainingSetSize = trainingSet.size();
+        var overallTrainingSize = data.size() - testSetSize;
+        var trainRatio = (overallTrainingSize > 0) ? trainingSetSize / overallTrainingSize : 0.0;
 
-        final int minTrainingSetSize = 2;
-        final int minTestSetSize = 2;
-        if (trainingSetSize < minTrainingSetSize || testSetSize < minTestSetSize) {
-            if ((getRecommender().getThreshold() <= 0.0d)) {
-                return new EvaluationResult(DATAPOINT_UNIT.getSimpleName(),
-                        SAMPLE_UNIT.getSimpleName());
-            }
-
-            String info = String.format(
+        if (trainingSetSize < MIN_TRAINING_SET_SIZE || testSetSize < MIN_TEST_SET_SIZE) {
+            var msg = String.format(
                     "Not enough evaluation data: training set size [%d] (min. %d), test set size [%d] (min. %d) of total [%d] (min. %d)",
-                    trainingSetSize, minTrainingSetSize, testSetSize, minTestSetSize, data.size(),
-                    (minTrainingSetSize + minTestSetSize));
-            LOG.info(info);
+                    trainingSetSize, MIN_TRAINING_SET_SIZE, testSetSize, MIN_TEST_SET_SIZE,
+                    data.size(), (MIN_TRAINING_SET_SIZE + MIN_TEST_SET_SIZE));
+            LOG.info(msg);
 
-            EvaluationResult result = new EvaluationResult(DATAPOINT_UNIT.getSimpleName(),
+            var result = new EvaluationResult(DATAPOINT_UNIT.getSimpleName(),
                     SAMPLE_UNIT.getSimpleName(), trainingSetSize, testSetSize, trainRatio);
             result.setEvaluationSkipped(true);
-            result.setErrorMsg(info);
+            result.setErrorMsg(msg);
             return result;
         }
 
@@ -243,7 +238,7 @@ public class OpenNlpPosRecommender
                 testSet.size(), data.size());
 
         // Train model
-        POSModel model = train(trainingSet, traits.getParameters());
+        var model = train(trainingSet, traits.getParameters());
         if (model == null) {
             throw new RecommendationException("Model is null, cannot evaluate!");
         }
@@ -251,8 +246,8 @@ public class OpenNlpPosRecommender
         POSTaggerME tagger = new POSTaggerME(model);
 
         // Evaluate
-        List<LabelPair> labelPairs = new ArrayList<>();
-        for (POSSample sample : testSet) {
+        var labelPairs = new ArrayList<LabelPair>();
+        for (var sample : testSet) {
             String[] predictedTags = tagger.tag(sample.getSentence());
             String[] goldTags = sample.getTags();
             for (int i = 0; i < predictedTags.length; i++) {
@@ -266,13 +261,13 @@ public class OpenNlpPosRecommender
 
     private List<POSSample> extractPosSamples(List<CAS> aCasses)
     {
-        List<POSSample> posSamples = new ArrayList<>();
+        var posSamples = new ArrayList<POSSample>();
 
         casses: for (CAS cas : aCasses) {
-            Type sampleUnitType = getType(cas, SAMPLE_UNIT);
-            Type tokenType = getType(cas, Token.class);
+            var sampleUnitType = getType(cas, SAMPLE_UNIT);
+            var tokenType = getType(cas, Token.class);
 
-            for (Annotation sampleUnit : cas.<Annotation> select(sampleUnitType)) {
+            for (var sampleUnit : cas.<Annotation> select(sampleUnitType)) {
                 if (posSamples.size() >= traits.getTrainingSetSizeLimit()) {
                     break casses;
                 }
@@ -281,8 +276,7 @@ public class OpenNlpPosRecommender
                     continue;
                 }
 
-                List<Annotation> tokens = cas.<Annotation> select(tokenType).coveredBy(sampleUnit)
-                        .asList();
+                var tokens = cas.<Annotation> select(tokenType).coveredBy(sampleUnit).asList();
 
                 createPosSample(cas, sampleUnit, tokens).map(posSamples::add);
             }
@@ -296,19 +290,19 @@ public class OpenNlpPosRecommender
     private Optional<POSSample> createPosSample(CAS aCas, AnnotationFS aSentence,
             Collection<? extends AnnotationFS> aTokens)
     {
-        Type annotationType = getType(aCas, layerName);
-        Feature feature = annotationType.getFeatureByBaseName(featureName);
+        var annotationType = getType(aCas, layerName);
+        var feature = annotationType.getFeatureByBaseName(featureName);
 
-        int numberOfTokens = aTokens.size();
-        String[] tokens = new String[numberOfTokens];
-        String[] tags = new String[numberOfTokens];
+        var numberOfTokens = aTokens.size();
+        var tokens = new String[numberOfTokens];
+        var tags = new String[numberOfTokens];
 
-        int withTagCount = 0;
+        var withTagCount = 0;
 
-        int i = 0;
-        for (AnnotationFS token : aTokens) {
+        var i = 0;
+        for (var token : aTokens) {
             tokens[i] = token.getCoveredText();
-            String tag = getFeatureValueCovering(aCas, token, annotationType, feature);
+            var tag = getFeatureValueCovering(aCas, token, annotationType, feature);
             tags[i] = tag;
 
             // If the tag is neither PAD nor null, then there is at
@@ -322,7 +316,7 @@ public class OpenNlpPosRecommender
 
         // Require at least X percent of the sentence to have tags to avoid class imbalance on PAD
         // tag.
-        double coverage = ((double) withTagCount * 100) / (double) numberOfTokens;
+        var coverage = ((double) withTagCount * 100) / (double) numberOfTokens;
         if (coverage >= traits.getTaggedTokensThreshold()) {
             return Optional.of(new POSSample(tokens, tags));
         }
@@ -334,13 +328,13 @@ public class OpenNlpPosRecommender
     private String getFeatureValueCovering(CAS aCas, AnnotationFS aToken, Type aType,
             Feature aFeature)
     {
-        List<AnnotationFS> annotations = CasUtil.selectCovered(aType, aToken);
+        var annotations = CasUtil.selectCovered(aType, aToken);
 
         if (annotations.isEmpty()) {
             return PAD;
         }
 
-        String value = annotations.get(0).getFeatureValueAsString(aFeature);
+        var value = annotations.get(0).getFeatureValueAsString(aFeature);
         return isNoneBlank(value) ? value : PAD;
     }
 
@@ -352,8 +346,8 @@ public class OpenNlpPosRecommender
             return null;
         }
 
-        try (POSSampleStream stream = new POSSampleStream(aPosSamples)) {
-            POSTaggerFactory taggerFactory = new POSTaggerFactory();
+        try (var stream = new POSSampleStream(aPosSamples)) {
+            var taggerFactory = new POSTaggerFactory();
             return POSTaggerME.train("unknown", stream, aParameters, taggerFactory);
         }
         catch (IOException e) {

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/AnnotationSuggestion.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/AnnotationSuggestion.java
@@ -33,6 +33,8 @@ public abstract class AnnotationSuggestion
 {
     private static final long serialVersionUID = -7137765759688480950L;
 
+    public static final int NEW_ID = -1;
+
     public static final String EXTENSION_ID = "rec";
 
     /**
@@ -84,6 +86,7 @@ public abstract class AnnotationSuggestion
 
     private AutoAcceptMode autoAcceptMode;
     private int hidingFlags = 0;
+    private int age = 0;
 
     public AnnotationSuggestion(int aId, long aRecommenderId, String aRecommenderName,
             long aLayerId, String aFeature, String aDocumentName, String aLabel, String aUiLabel,
@@ -100,21 +103,6 @@ public abstract class AnnotationSuggestion
         recommenderId = aRecommenderId;
         documentName = aDocumentName;
         autoAcceptMode = aAutoAcceptMode;
-    }
-
-    public AnnotationSuggestion(AnnotationSuggestion aObject)
-    {
-        label = aObject.label;
-        uiLabel = aObject.uiLabel;
-        id = aObject.id;
-        layerId = aObject.layerId;
-        feature = aObject.feature;
-        recommenderName = aObject.recommenderName;
-        score = aObject.score;
-        scoreExplanation = aObject.scoreExplanation;
-        recommenderId = aObject.recommenderId;
-        documentName = aObject.documentName;
-        autoAcceptMode = aObject.autoAcceptMode;
     }
 
     public int getId()
@@ -297,4 +285,24 @@ public abstract class AnnotationSuggestion
             return false;
         }
     }
+
+    public int incrementAge()
+    {
+        age++;
+        return age;
+    }
+
+    public int getAge()
+    {
+        return age;
+    }
+
+    /**
+     * @return a clone of the current suggestion with the new ID. This is used when adding a
+     *         suggestion to {@link Predictions} if the ID of the suggestion is set to
+     *         {@link #NEW_ID}.
+     * @param aId
+     *            the ID of the suggestion.
+     */
+    abstract public AnnotationSuggestion assignId(int aId);
 }

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/AnnotationSuggestion.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/AnnotationSuggestion.java
@@ -73,6 +73,7 @@ public abstract class AnnotationSuggestion
     public static final int FLAG_ALL = FLAG_OVERLAP | FLAG_SKIPPED | FLAG_REJECTED
             | FLAG_TRANSIENT_ACCEPTED | FLAG_TRANSIENT_REJECTED | FLAG_TRANSIENT_CORRECTED;
 
+    protected final int generation;
     protected final int id;
     protected final long recommenderId;
     protected final String recommenderName;
@@ -88,10 +89,13 @@ public abstract class AnnotationSuggestion
     private int hidingFlags = 0;
     private int age = 0;
 
-    public AnnotationSuggestion(int aId, long aRecommenderId, String aRecommenderName,
-            long aLayerId, String aFeature, String aDocumentName, String aLabel, String aUiLabel,
-            double aScore, String aScoreExplanation, AutoAcceptMode aAutoAcceptMode)
+    public AnnotationSuggestion(int aId, int aGeneration, int aAge, long aRecommenderId,
+            String aRecommenderName, long aLayerId, String aFeature, String aDocumentName,
+            String aLabel, String aUiLabel, double aScore, String aScoreExplanation,
+            AutoAcceptMode aAutoAcceptMode, int aHidingFlags)
     {
+        generation = aGeneration;
+        age = aAge;
         label = aLabel;
         uiLabel = aUiLabel;
         id = aId;
@@ -103,6 +107,7 @@ public abstract class AnnotationSuggestion
         recommenderId = aRecommenderId;
         documentName = aDocumentName;
         autoAcceptMode = aAutoAcceptMode;
+        hidingFlags = aHidingFlags;
     }
 
     public int getId()
@@ -170,6 +175,11 @@ public abstract class AnnotationSuggestion
     public void show(int aFlags)
     {
         hidingFlags &= ~aFlags;
+    }
+
+    protected int getHidingFlags()
+    {
+        return hidingFlags;
     }
 
     public String getReasonForHiding()

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/ExtendedId.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/ExtendedId.java
@@ -25,22 +25,21 @@ class ExtendedId
 {
     private static final long serialVersionUID = -5214683455382881005L;
 
-    private final String documentName;
-    private final long layerId;
-    private final Position position;
-    private final int annotationId;
+    private final int suggestionId;
     private final long recommenderId;
+    private final long layerId;
+    private final String documentName;
+    private final Position position;
     private final int hash;
 
-    public ExtendedId(String documentName, long layerId, Position aPosition, long recommenderId,
-            int annotationId)
+    public ExtendedId(AnnotationSuggestion aSuggestion)
     {
-        this.documentName = documentName;
-        this.layerId = layerId;
-        this.annotationId = annotationId;
-        this.recommenderId = recommenderId;
-        this.position = aPosition;
-        hash = Objects.hash(annotationId, documentName, layerId, position, recommenderId);
+        documentName = aSuggestion.getDocumentName();
+        layerId = aSuggestion.getLayerId();
+        suggestionId = aSuggestion.getId();
+        recommenderId = aSuggestion.getRecommenderId();
+        position = aSuggestion.getPosition();
+        hash = Objects.hash(suggestionId, documentName, layerId, position, recommenderId);
     }
 
     public String getDocumentName()
@@ -58,9 +57,9 @@ class ExtendedId
         return position;
     }
 
-    public int getAnnotationId()
+    public int getSuggestionId()
     {
-        return annotationId;
+        return suggestionId;
     }
 
     public long getRecommenderId()
@@ -91,7 +90,7 @@ class ExtendedId
 
         ExtendedId other = (ExtendedId) obj;
         return Objects.equals(position, other.position) //
-                && annotationId == other.annotationId //
+                && suggestionId == other.suggestionId //
                 && Objects.equals(documentName, other.documentName) //
                 && layerId == other.layerId //
                 && recommenderId == other.recommenderId;

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/Predictions.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/Predictions.java
@@ -53,6 +53,7 @@ public class Predictions
 {
     private static final long serialVersionUID = -1598768729246662885L;
 
+    private final int generation;
     private final Project project;
     private final User sessionOwner;
     private final String dataOwner;
@@ -77,6 +78,7 @@ public class Predictions
         sessionOwner = aSessionOwner;
         dataOwner = aDataOwner;
         nextId = 0;
+        generation = 1;
     }
 
     public Predictions(Predictions aPredecessor)
@@ -85,6 +87,7 @@ public class Predictions
         sessionOwner = aPredecessor.sessionOwner;
         dataOwner = aPredecessor.dataOwner;
         nextId = aPredecessor.nextId;
+        generation = aPredecessor.generation + 1;
     }
 
     public User getSessionOwner()
@@ -360,6 +363,11 @@ public class Predictions
         synchronized (log) {
             log.addAll(0, aLogMessages);
         }
+    }
+
+    public int getGeneration()
+    {
+        return generation;
     }
 
     public List<LogMessage> getLog()

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/Recommender.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/Recommender.java
@@ -195,6 +195,11 @@ public class Recommender
         return threshold;
     }
 
+    /**
+     * Activation score threshold.
+     * 
+     * @param aThreshold
+     */
     public void setThreshold(double aThreshold)
     {
         threshold = aThreshold;

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/RelationSuggestion.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/RelationSuggestion.java
@@ -20,7 +20,6 @@ package de.tudarmstadt.ukp.inception.recommendation.api.model;
 import java.io.Serializable;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.uima.cas.text.AnnotationFS;
 
 public class RelationSuggestion
     extends AnnotationSuggestion
@@ -32,30 +31,25 @@ public class RelationSuggestion
 
     private RelationSuggestion(Builder builder)
     {
-        super(builder.id, builder.recommenderId, builder.recommenderName, builder.layerId,
-                builder.feature, builder.documentName, builder.label, builder.uiLabel,
-                builder.score, builder.scoreExplanation, builder.autoAcceptMode);
+        super(builder.id, builder.generation, builder.age, builder.recommenderId,
+                builder.recommenderName, builder.layerId, builder.feature, builder.documentName,
+                builder.label, builder.uiLabel, builder.score, builder.scoreExplanation,
+                builder.autoAcceptMode, builder.hidingFlags);
 
         this.position = builder.position;
     }
 
-    public RelationSuggestion(int aId, Recommender aRecommender, long aLayerId, String aFeature,
-            String aDocumentName, AnnotationFS aSource, AnnotationFS aTarget, String aLabel,
-            String aUiLabel, double aScore, String aScoreExplanation,
-            AutoAcceptMode aAutoAcceptMode)
-    {
-        this(aId, aRecommender.getId(), aRecommender.getName(), aLayerId, aFeature, aDocumentName,
-                aSource.getBegin(), aSource.getEnd(), aTarget.getBegin(), aTarget.getEnd(), aLabel,
-                aUiLabel, aScore, aScoreExplanation, aAutoAcceptMode);
-    }
-
+    /**
+     * @deprecated Use builder instead
+     */
+    @Deprecated
     public RelationSuggestion(int aId, long aRecommenderId, String aRecommenderName, long aLayerId,
             String aFeature, String aDocumentName, int aSourceBegin, int aSourceEnd,
             int aTargetBegin, int aTargetEnd, String aLabel, String aUiLabel, double aScore,
             String aScoreExplanation, AutoAcceptMode aAutoAcceptMode)
     {
-        super(aId, aRecommenderId, aRecommenderName, aLayerId, aFeature, aDocumentName, aLabel,
-                aUiLabel, aScore, aScoreExplanation, aAutoAcceptMode);
+        super(aId, 0, 0, aRecommenderId, aRecommenderName, aLayerId, aFeature, aDocumentName,
+                aLabel, aUiLabel, aScore, aScoreExplanation, aAutoAcceptMode, 0);
 
         position = new RelationPosition(aSourceBegin, aSourceEnd, aTargetBegin, aTargetEnd);
     }
@@ -87,14 +81,25 @@ public class RelationSuggestion
     @Override
     public String toString()
     {
-        return new ToStringBuilder(this).append("id", id).append("recommenderId", recommenderId)
-                .append("recommenderName", recommenderName).append("layerId", layerId)
-                .append("feature", feature).append("documentName", documentName)
+        return new ToStringBuilder(this) //
+                .append("id", id) //
+                .append("generation", generation) //
+                .append("age", getAge()) //
+                .append("recommenderId", recommenderId) //
+                .append("recommenderName", recommenderName) //
+                .append("layerId", layerId) //
+                .append("feature", feature) //
+                .append("documentName", documentName) //
                 .append("position", position) //
-                .append("windowBegin", getWindowBegin()).append("windowEnd", getWindowEnd()) //
-                .append("label", label).append("uiLabel", uiLabel).append("score", score)
-                .append("confindenceExplanation", scoreExplanation).append("visible", isVisible())
-                .append("reasonForHiding", getReasonForHiding()).toString();
+                .append("windowBegin", getWindowBegin()) //
+                .append("windowEnd", getWindowEnd()) //
+                .append("label", label) //
+                .append("uiLabel", uiLabel) //
+                .append("score", score) //
+                .append("confindenceExplanation", scoreExplanation) //
+                .append("visible", isVisible()) //
+                .append("reasonForHiding", getReasonForHiding()) //
+                .toString();
     }
 
     @Override
@@ -112,6 +117,8 @@ public class RelationSuggestion
     {
         return builder() //
                 .withId(id) //
+                .withGeneration(generation) //
+                .withAge(getAge()) //
                 .withRecommenderId(recommenderId) //
                 .withRecommenderName(recommenderName) //
                 .withLayerId(layerId) //
@@ -122,11 +129,14 @@ public class RelationSuggestion
                 .withScore(score) //
                 .withScoreExplanation(scoreExplanation) //
                 .withPosition(position) //
-                .withAutoAcceptMode(getAutoAcceptMode());
+                .withAutoAcceptMode(getAutoAcceptMode()) //
+                .withHidingFlags(getHidingFlags());
     }
 
     public static final class Builder
     {
+        private int generation;
+        private int age;
         private int id;
         private long recommenderId;
         private String recommenderName;
@@ -139,6 +149,7 @@ public class RelationSuggestion
         private String scoreExplanation;
         private RelationPosition position;
         private AutoAcceptMode autoAcceptMode;
+        private int hidingFlags;
 
         private Builder()
         {
@@ -147,6 +158,18 @@ public class RelationSuggestion
         public Builder withId(int aId)
         {
             this.id = aId;
+            return this;
+        }
+
+        public Builder withGeneration(int aGeneration)
+        {
+            this.generation = aGeneration;
+            return this;
+        }
+
+        public Builder withAge(int aAge)
+        {
+            this.age = aAge;
             return this;
         }
 
@@ -222,6 +245,12 @@ public class RelationSuggestion
         public Builder withAutoAcceptMode(AutoAcceptMode aAutoAcceptMode)
         {
             this.autoAcceptMode = aAutoAcceptMode;
+            return this;
+        }
+
+        public Builder withHidingFlags(int aFlags)
+        {
+            this.hidingFlags = aFlags;
             return this;
         }
 

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/RelationSuggestion.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/RelationSuggestion.java
@@ -60,19 +60,6 @@ public class RelationSuggestion
         position = new RelationPosition(aSourceBegin, aSourceEnd, aTargetBegin, aTargetEnd);
     }
 
-    /**
-     * Copy constructor.
-     *
-     * @param aObject
-     *            The annotationObject to copy
-     */
-    public RelationSuggestion(RelationSuggestion aObject)
-    {
-        super(aObject);
-
-        position = new RelationPosition(aObject.position);
-    }
-
     // Getter and setter
 
     @Override
@@ -110,9 +97,32 @@ public class RelationSuggestion
                 .append("reasonForHiding", getReasonForHiding()).toString();
     }
 
+    @Override
+    public AnnotationSuggestion assignId(int aId)
+    {
+        return toBuilder().withId(aId).build();
+    }
+
     public static Builder builder()
     {
         return new Builder();
+    }
+
+    public Builder toBuilder()
+    {
+        return builder() //
+                .withId(id) //
+                .withRecommenderId(recommenderId) //
+                .withRecommenderName(recommenderName) //
+                .withLayerId(layerId) //
+                .withFeature(feature) //
+                .withDocumentName(documentName) //
+                .withLabel(label) //
+                .withUiLabel(uiLabel) //
+                .withScore(score) //
+                .withScoreExplanation(scoreExplanation) //
+                .withPosition(position) //
+                .withAutoAcceptMode(getAutoAcceptMode());
     }
 
     public static final class Builder

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/SpanSuggestion.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/SpanSuggestion.java
@@ -32,31 +32,26 @@ public class SpanSuggestion
 
     private SpanSuggestion(Builder builder)
     {
-        super(builder.id, builder.recommenderId, builder.recommenderName, builder.layerId,
-                builder.feature, builder.documentName, builder.label, builder.uiLabel,
-                builder.score, builder.scoreExplanation, builder.autoAcceptMode);
+        super(builder.id, builder.generation, builder.age, builder.recommenderId,
+                builder.recommenderName, builder.layerId, builder.feature, builder.documentName,
+                builder.label, builder.uiLabel, builder.score, builder.scoreExplanation,
+                builder.autoAcceptMode, builder.hidingFlags);
 
         position = builder.position;
         coveredText = builder.coveredText;
     }
 
-    public SpanSuggestion(int aId, Recommender aRecommender, long aLayerId, String aFeature,
-            String aDocumentName, Offset aOffset, String aCoveredText, String aLabel,
-            String aUiLabel, double aScore, String aScoreExplanation,
-            AutoAcceptMode aAutoAcceptMode)
-    {
-        this(aId, aRecommender.getId(), aRecommender.getName(), aLayerId, aFeature, aDocumentName,
-                aOffset.getBegin(), aOffset.getEnd(), aCoveredText, aLabel, aUiLabel, aScore,
-                aScoreExplanation, aAutoAcceptMode);
-    }
-
+    /**
+     * @deprecated Use builder instead.
+     */
+    @Deprecated
     public SpanSuggestion(int aId, long aRecommenderId, String aRecommenderName, long aLayerId,
             String aFeature, String aDocumentName, int aBegin, int aEnd, String aCoveredText,
             String aLabel, String aUiLabel, double aScore, String aScoreExplanation,
             AutoAcceptMode aAutoAcceptMode)
     {
-        super(aId, aRecommenderId, aRecommenderName, aLayerId, aFeature, aDocumentName, aLabel,
-                aUiLabel, aScore, aScoreExplanation, aAutoAcceptMode);
+        super(aId, 0, 0, aRecommenderId, aRecommenderName, aLayerId, aFeature, aDocumentName,
+                aLabel, aUiLabel, aScore, aScoreExplanation, aAutoAcceptMode, 0);
 
         position = new Offset(aBegin, aEnd);
         coveredText = aCoveredText;
@@ -100,14 +95,25 @@ public class SpanSuggestion
     @Override
     public String toString()
     {
-        return new ToStringBuilder(this).append("id", id).append("recommenderId", recommenderId)
-                .append("recommenderName", recommenderName).append("layerId", layerId)
-                .append("feature", feature).append("documentName", documentName)
-                .append("position", position).append("coveredText", coveredText)
-                .append("label", label).append("uiLabel", uiLabel).append("score", score)
-                .append("confindenceExplanation", scoreExplanation).append("visible", isVisible())
-                .append("reasonForHiding", getReasonForHiding())
-                .append("autoAcceptMode", getAutoAcceptMode()).toString();
+        return new ToStringBuilder(this) //
+                .append("id", id) //
+                .append("generation", generation) //
+                .append("age", getAge()) //
+                .append("recommenderId", recommenderId) //
+                .append("recommenderName", recommenderName) //
+                .append("layerId", layerId) //
+                .append("feature", feature) //
+                .append("documentName", documentName) //
+                .append("position", position) //
+                .append("coveredText", coveredText) //
+                .append("label", label) //
+                .append("uiLabel", uiLabel) //
+                .append("score", score) //
+                .append("confindenceExplanation", scoreExplanation) //
+                .append("visible", isVisible()) //
+                .append("reasonForHiding", getReasonForHiding()) //
+                .append("autoAcceptMode", getAutoAcceptMode()) //
+                .toString();
     }
 
     @Override
@@ -125,6 +131,8 @@ public class SpanSuggestion
     {
         return builder() //
                 .withId(id) //
+                .withGeneration(generation) //
+                .withAge(getAge()) //
                 .withRecommenderId(recommenderId) //
                 .withRecommenderName(recommenderName) //
                 .withLayerId(layerId) //
@@ -136,12 +144,15 @@ public class SpanSuggestion
                 .withScoreExplanation(scoreExplanation) //
                 .withPosition(position) //
                 .withCoveredText(coveredText) //
-                .withAutoAcceptMode(getAutoAcceptMode());
+                .withAutoAcceptMode(getAutoAcceptMode()) //
+                .withHidingFlags(getHidingFlags());
     }
 
     public static final class Builder
     {
         private int id;
+        private int generation;
+        private int age;
         private long recommenderId;
         private String recommenderName;
         private long layerId;
@@ -154,6 +165,7 @@ public class SpanSuggestion
         private Offset position;
         private String coveredText;
         private AutoAcceptMode autoAcceptMode;
+        private int hidingFlags;
 
         private Builder()
         {
@@ -162,6 +174,18 @@ public class SpanSuggestion
         public Builder withId(int aId)
         {
             this.id = aId;
+            return this;
+        }
+
+        public Builder withAge(int aAge)
+        {
+            this.age = aAge;
+            return this;
+        }
+
+        public Builder withGeneration(int aGeneration)
+        {
+            this.generation = aGeneration;
             return this;
         }
 
@@ -243,6 +267,12 @@ public class SpanSuggestion
         public Builder withAutoAcceptMode(AutoAcceptMode aAutoAcceptMode)
         {
             this.autoAcceptMode = aAutoAcceptMode;
+            return this;
+        }
+
+        public Builder withHidingFlags(int aFlags)
+        {
+            this.hidingFlags = aFlags;
             return this;
         }
 

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/SpanSuggestion.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/SpanSuggestion.java
@@ -62,20 +62,6 @@ public class SpanSuggestion
         coveredText = aCoveredText;
     }
 
-    /**
-     * Copy constructor.
-     *
-     * @param aObject
-     *            The annotationObject to copy
-     */
-    public SpanSuggestion(SpanSuggestion aObject)
-    {
-        super(aObject);
-
-        position = new Offset(aObject.position.getBegin(), aObject.position.getEnd());
-        coveredText = aObject.coveredText;
-    }
-
     // Getter and setter
 
     public String getCoveredText()
@@ -124,6 +110,17 @@ public class SpanSuggestion
                 .append("autoAcceptMode", getAutoAcceptMode()).toString();
     }
 
+    @Override
+    public AnnotationSuggestion assignId(int aId)
+    {
+        return toBuilder().withId(aId).build();
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
     public Builder toBuilder()
     {
         return builder() //
@@ -140,11 +137,6 @@ public class SpanSuggestion
                 .withPosition(position) //
                 .withCoveredText(coveredText) //
                 .withAutoAcceptMode(getAutoAcceptMode());
-    }
-
-    public static Builder builder()
-    {
-        return new Builder();
     }
 
     public static final class Builder

--- a/inception/inception-recommendation-api/src/test/java/de/tudarmstadt/ukp/inception/recommendation/api/model/PredictionsTest.java
+++ b/inception/inception-recommendation-api/src/test/java/de/tudarmstadt/ukp/inception/recommendation/api/model/PredictionsTest.java
@@ -109,6 +109,35 @@ class PredictionsTest
         }
     }
 
+    @Test
+    void thatIdsAreAssigned() throws Exception
+    {
+        var doc = "doc";
+        sut = new Predictions(user, user.getUsername(), project);
+        sut.putPredictions(asList( //
+                SpanSuggestion.builder() //
+                        .withId(AnnotationSuggestion.NEW_ID) //
+                        .withDocumentName(doc) //
+                        .build()));
+
+        assertThat(sut.getPredictionsByDocument(doc)) //
+                .extracting(AnnotationSuggestion::getId) //
+                .containsExactly(0);
+
+        var inheritedPredictions = sut.getPredictionsByDocument(doc);
+        sut = new Predictions(sut);
+        sut.putPredictions(asList( //
+                SpanSuggestion.builder() //
+                        .withId(AnnotationSuggestion.NEW_ID) //
+                        .withDocumentName(doc) //
+                        .build()));
+        sut.putPredictions(inheritedPredictions);
+
+        assertThat(sut.getPredictionsByDocument(doc)) //
+                .extracting(AnnotationSuggestion::getId) //
+                .containsExactlyInAnyOrder(0, 1);
+    }
+
     private List<AnnotationSuggestion> generatePredictions(int aDocs, int aRecommenders,
             int aSuggestions)
         throws Exception

--- a/inception/inception-recommendation-api/src/test/java/de/tudarmstadt/ukp/inception/recommendation/api/model/RelationSuggestionTest.java
+++ b/inception/inception-recommendation-api/src/test/java/de/tudarmstadt/ukp/inception/recommendation/api/model/RelationSuggestionTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.api.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class RelationSuggestionTest
+{
+    @Test
+    void thatCloningRetainsAllInformation()
+    {
+        var s = RelationSuggestion.builder() //
+                .withId(1) //
+                .withGeneration(2) //
+                .withAge(3) //
+                .withRecommenderId(4) //
+                .withRecommenderName("rec") //
+                .withLayerId(5) //
+                .withFeature("feature") //
+                .withDocumentName("document") //
+                .withLabel("label") //
+                .withUiLabel("uiLabel") //
+                .withScore(6.0) //
+                .withScoreExplanation("scoreExplanation") //
+                .withPosition(new RelationPosition(1, 2, 3, 4)) //
+                .withAutoAcceptMode(AutoAcceptMode.ON_FIRST_ACCESS) //
+                .withHidingFlags(7) //
+                .build();
+
+        assertThat(s.toBuilder().build()).usingRecursiveComparison().isEqualTo(s);
+    }
+}

--- a/inception/inception-recommendation-api/src/test/java/de/tudarmstadt/ukp/inception/recommendation/api/model/SpanSuggestionTest.java
+++ b/inception/inception-recommendation-api/src/test/java/de/tudarmstadt/ukp/inception/recommendation/api/model/SpanSuggestionTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.api.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class SpanSuggestionTest
+{
+    @Test
+    void thatCloningRetainsAllInformation()
+    {
+        var s = SpanSuggestion.builder() //
+                .withId(1) //
+                .withGeneration(2) //
+                .withAge(3) //
+                .withRecommenderId(4) //
+                .withRecommenderName("rec") //
+                .withLayerId(5) //
+                .withFeature("feature") //
+                .withDocumentName("document") //
+                .withLabel("label") //
+                .withUiLabel("uiLabel") //
+                .withScore(6.0) //
+                .withScoreExplanation("scoreExplanation") //
+                .withPosition(new Offset(1, 2)) //
+                .withCoveredText("coveredText") //
+                .withAutoAcceptMode(AutoAcceptMode.ON_FIRST_ACCESS) //
+                .withHidingFlags(7) //
+                .build();
+
+        assertThat(s.toBuilder().build()).usingRecursiveComparison().isEqualTo(s);
+    }
+}

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/LogDialog.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/LogDialog.java
@@ -66,7 +66,7 @@ public class LogDialog
             model = new ListModel<>(asList(group));
         }
 
-        LogDialogContent content = new LogDialogContent(ModalDialog.CONTENT_ID, model);
+        var content = new LogDialogContent(ModalDialog.CONTENT_ID, model);
         open(content, aTarget);
         aTarget.focusComponent(content.getFocusComponent());
     }

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommenderInfoPanel.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommenderInfoPanel.java
@@ -106,7 +106,7 @@ public class RecommenderInfoPanel
                     + repeat("<i class=\"far fa-circle\"></i>&nbsp;", p.getTodo());
         })).setEscapeModelStrings(false)); // SAFE - RENDERING ONLY SPECIFIC ICONS
 
-        WebMarkupContainer recommenderContainer = new WebMarkupContainer("recommenderContainer");
+        var recommenderContainer = new WebMarkupContainer("recommenderContainer");
         add(recommenderContainer);
 
         ListView<Recommender> searchResultGroups = new ListView<Recommender>("recommender")
@@ -116,12 +116,12 @@ public class RecommenderInfoPanel
             @Override
             protected void populateItem(ListItem<Recommender> item)
             {
-                Recommender recommender = item.getModelObject();
+                var recommender = item.getModelObject();
                 Optional<EvaluatedRecommender> evaluatedRecommender = recommendationService
                         .getEvaluatedRecommender(sessionOwner, recommender);
                 item.add(new Label("name", recommender.getName()));
 
-                WebMarkupContainer state = new WebMarkupContainer("state");
+                var state = new WebMarkupContainer("state");
                 if (evaluatedRecommender.isPresent()) {
                     EvaluatedRecommender evalRec = evaluatedRecommender.get();
                     if (evalRec.isActive()) {
@@ -147,7 +147,7 @@ public class RecommenderInfoPanel
 
                 Optional<EvaluationResult> evalResult = evaluatedRecommender
                         .map(EvaluatedRecommender::getEvaluationResult);
-                WebMarkupContainer resultsContainer = new WebMarkupContainer("resultsContainer");
+                var resultsContainer = new WebMarkupContainer("resultsContainer");
                 // Show results only if the evaluation was not skipped (and of course only if the
                 // result is actually present).
                 resultsContainer.setVisible(evalResult.map(r -> !r.isEvaluationSkipped())
@@ -189,10 +189,11 @@ public class RecommenderInfoPanel
                                         .isModelExportSupported()));
                 item.add(exportModel);
 
-                item.add(new Label("noEvaluationMessage",
-                        evaluatedRecommender.map(EvaluatedRecommender::getReasonForState)
-                                .orElse("Waiting for evalation..."))
-                                        .add(visibleWhen(() -> !resultsContainer.isVisible())));
+                item.add(new Label("noEvaluationMessage", evaluatedRecommender //
+                        .flatMap(r -> r.getEvaluationResult().getErrorMsg())
+                        // .map(EvaluatedRecommender::getReasonForState)
+                        .orElse("Waiting for evalation..."))
+                                .add(visibleWhen(() -> !resultsContainer.isVisible())));
             }
         };
         IModel<List<Recommender>> recommenders = LoadableDetachableModel

--- a/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImplIntegrationTest.java
+++ b/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImplIntegrationTest.java
@@ -39,7 +39,6 @@ import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.apache.uima.cas.CAS;
@@ -146,10 +145,11 @@ public class RecommendationServiceImplIntegrationTest
     {
         sut.createOrUpdateRecommender(rec);
 
-        List<Recommender> enabledRecommenders = sut.listEnabledRecommenders(rec.getLayer());
+        var enabledRecommenders = sut.listEnabledRecommenders(rec.getLayer());
 
-        assertThat(enabledRecommenders).as("Check that the previously created recommender is found")
-                .hasSize(1).contains(rec);
+        assertThat(enabledRecommenders) //
+                .as("Check that the previously created recommender is found") //
+                .containsExactly(rec);
     }
 
     @SuppressWarnings("unchecked")
@@ -174,16 +174,13 @@ public class RecommendationServiceImplIntegrationTest
         rec.setEnabled(false);
         testEntityManager.persist(rec);
 
-        long numOfRecommenders = sut.countEnabledRecommenders();
-        assertThat(numOfRecommenders).isEqualTo(0);
+        assertThat(sut.countEnabledRecommenders()).isEqualTo(0);
     }
 
     @Test
     public void getRecommenders_WithOneEnabledRecommender_ShouldReturnStoredRecommender()
     {
-        Optional<Recommender> enabledRecommenders = sut.getEnabledRecommender(rec.getId());
-
-        assertThat(enabledRecommenders)
+        assertThat(sut.getEnabledRecommender(rec.getId()))
                 .as("Check that only the previously created recommender is found").isPresent()
                 .contains(rec);
     }
@@ -194,15 +191,14 @@ public class RecommendationServiceImplIntegrationTest
         rec.setEnabled(false);
         testEntityManager.persist(rec);
 
-        Optional<Recommender> enabledRecommenders = sut.getEnabledRecommender(rec.getId());
-
-        assertThat(enabledRecommenders).as("Check that no recommender is found").isEmpty();
+        assertThat(sut.getEnabledRecommender(rec.getId())) //
+                .as("Check that no recommender is found") //
+                .isEmpty();
     }
 
     @Test
     public void getRecommenders_WithOtherRecommenderId_ShouldReturnEmptyList()
     {
-
         long otherId = 9999L;
         Optional<Recommender> enabledRecommenders = sut.getEnabledRecommender(otherId);
 

--- a/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImplTest.java
+++ b/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImplTest.java
@@ -385,7 +385,7 @@ class RecommendationServiceImplTest
                 .withFeature(FEATURE_NAME_IS_PREDICTION, true) //
                 .buildAndAddToIndexes();
 
-        var suggestions = extractSuggestions(targetCas, suggestionCas, doc1, recommender);
+        var suggestions = extractSuggestions(0, targetCas, suggestionCas, doc1, recommender);
 
         assertThat(suggestions) //
                 .extracting( //

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
@@ -195,15 +195,14 @@ public abstract class AnnotationDetailEditorPanel
 
     private LambdaAjaxLink createNextAnnotationButton()
     {
-        LambdaAjaxLink link = new LambdaAjaxLink("nextAnnotation", this::actionNextAnnotation);
+        var link = new LambdaAjaxLink("nextAnnotation", this::actionNextAnnotation);
         link.add(new InputBehavior(new KeyType[] { Shift, Right }, click));
         return link;
     }
 
     private LambdaAjaxLink createPreviousAnnotationButton()
     {
-        LambdaAjaxLink link = new LambdaAjaxLink("previousAnnotation",
-                this::actionPreviousAnnotation);
+        var link = new LambdaAjaxLink("previousAnnotation", this::actionPreviousAnnotation);
         link.add(new InputBehavior(new KeyType[] { Shift, Left }, click));
         return link;
     }
@@ -1042,13 +1041,13 @@ public abstract class AnnotationDetailEditorPanel
     {
         LOG.trace("loadFeatureEditorModels()");
 
-        CAS aCas = getEditorCas();
+        var aCas = getEditorCas();
 
-        AnnotatorState state = getModelObject();
-        Selection selection = state.getSelection();
+        var state = getModelObject();
+        var selection = state.getSelection();
 
-        List<FeatureState> featureStates = state.getFeatureStates();
-        for (FeatureState featureState : featureStates) {
+        var featureStates = state.getFeatureStates();
+        for (var featureState : featureStates) {
             if (StringUtils.isNotBlank(featureState.feature.getLinkTypeName())) {
                 featureState.value = new ArrayList<>();
             }

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationInfoPanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationInfoPanel.java
@@ -23,6 +23,7 @@ import static org.apache.wicket.RuntimeConfigurationType.DEVELOPMENT;
 
 import java.lang.invoke.MethodHandles;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.panel.Panel;
@@ -104,14 +105,13 @@ public class AnnotationInfoPanel
     {
         Label label = new Label("selectedAnnotationType", LoadableDetachableModel.of(() -> {
             try {
-                AnnotationDetailEditorPanel editorPanel = findParent(
-                        AnnotationDetailEditorPanel.class);
+                var editorPanel = findParent(AnnotationDetailEditorPanel.class);
                 return String.valueOf(selectFsByAddr(editorPanel.getEditorCas(),
                         getModelObject().getSelection().getAnnotation().getId())).trim();
             }
             catch (Exception e) {
                 LOG.warn("Unable to render selected annotation type", e);
-                return "";
+                return ExceptionUtils.getRootCauseMessage(e);
             }
         }));
         label.setOutputMarkupPlaceholderTag(true);

--- a/inception/pom.xml
+++ b/inception/pom.xml
@@ -28,7 +28,7 @@
 
   <properties>
     <maven.surefire.heap>6g</maven.surefire.heap>
-    <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.release>17</maven.compiler.release>
     <maven.compiler.target>${maven.compiler.release}</maven.compiler.target>
     <maven.compiler.source>${maven.compiler.release}</maven.compiler.source>
     <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>


### PR DESCRIPTION
**What's in the PR**
- Defer setting annotation suggestion IDs until they are added to the predictions object
- If an extracted suggestion matches an existing one, inherit the existing suggestion (and its ID) instead
- Inherit the ID counter across prediction generations
- Upgrade to Java 17 (so we can use records)

**How to test manually**
* Use the recommenders

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
