### PR TITLE
#4173 - Using too much memory when exporting large project

### DIFF
--- a/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/CasHolder.java
+++ b/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/CasHolder.java
@@ -33,8 +33,8 @@ public class CasHolder
 
     private CAS cas;
     private Exception exception;
-    private boolean typeSystemOutdated;
-    private boolean deleted;
+    private boolean typeSystemOutdated = false;
+    private boolean deleted = false;
 
     public CasHolder(CasKey aKey)
     {
@@ -141,7 +141,9 @@ public class CasHolder
     public String toString()
     {
         return new ToStringBuilder(this, SHORT_PREFIX_STYLE).append("key", key)
-                .append("deleted", deleted).append("typeSystemOutdated", typeSystemOutdated)
+                .append("cas", getCasHashCode()) //
+                .append("deleted", deleted) //
+                .append("typeSystemOutdated", typeSystemOutdated) //
                 .toString();
     }
 

--- a/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/PooledCasHolderFactory.java
+++ b/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/PooledCasHolderFactory.java
@@ -41,13 +41,21 @@ public class PooledCasHolderFactory
     @Override
     public boolean validateObject(CasKey aKey, PooledObject<CasHolder> aP)
     {
+        var casHolder = aP.getObject();
         // When the holder is being returned, we do not need to keep the holder if the CAS has not
         // been loaded - no need to cache an empty holder, we can easily recreate it. Keeping it
         // just gives us a wrong impression of the fill state of the cache.
-        return (aP.getState() != RETURNING || aP.getObject().isCasSet()) &&
+        if (aP.getState() == RETURNING && !casHolder.isCasSet()) {
+            return false;
+        }
+
         // If the type system has changed or the CAS being held has been deleted, we can
         // also discard the holder. This forces a re-load from disk next time the CAS is
         // accessed.
-                !aP.getObject().isTypeSystemOutdated() && !aP.getObject().isDeleted();
+        if (casHolder.isTypeSystemOutdated() || casHolder.isDeleted()) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/config/CasStorageCacheProperties.java
+++ b/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/config/CasStorageCacheProperties.java
@@ -28,10 +28,17 @@ public interface CasStorageCacheProperties
     Duration getCasBorrowWaitTimeout();
 
     /**
-     * @return time that exclusive-access CAS instances as well as shared CAS instances are kept in
-     *         memory after the last access to them.
+     * @return time how often the exclusive-access pool is checked for idle CASes that can be
+     *         removed and how long shared-access CASes remain the cache when not being used.
      */
     Duration getIdleCasEvictionDelay();
+
+    /**
+     * @return time that a CAS should remain in the exclusive-access pool before being evicted. This
+     *         is meant to ensure that CASes that are used regularly remain a while in the pool
+     *         before we have to read them from disk again.
+     */
+    Duration getMinIdleCasTime();
 
     /**
      * @return number of CAS instances that should be kept in memory for shared-read-only access.

--- a/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/config/CasStorageCachePropertiesImpl.java
+++ b/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/config/CasStorageCachePropertiesImpl.java
@@ -31,6 +31,7 @@ public class CasStorageCachePropertiesImpl
     implements CasStorageCacheProperties
 {
     private Duration idleCasEvictionDelay = Duration.ofMinutes(5);
+    private Duration minIdleCasTime = Duration.ofMinutes(5);
     private Duration casBorrowWaitTimeout = Duration.ofMinutes(3);
     private long sharedCasCacheSize = getDefaultCasCacheSize();
 
@@ -65,6 +66,17 @@ public class CasStorageCachePropertiesImpl
     public void setSharedCasCacheSize(long aSharedCasCacheSize)
     {
         sharedCasCacheSize = aSharedCasCacheSize;
+    }
+
+    @Override
+    public Duration getMinIdleCasTime()
+    {
+        return minIdleCasTime;
+    }
+
+    public void setMinIdleCasTime(Duration aMinIdleCasTime)
+    {
+        minIdleCasTime = aMinIdleCasTime;
     }
 
     private static final long MB = 1024 * 1024;

--- a/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/driver/filesystem/FileSystemCasStorageDriver.java
+++ b/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/driver/filesystem/FileSystemCasStorageDriver.java
@@ -112,6 +112,8 @@ public class FileSystemCasStorageDriver
     @Override
     public CAS readCas(SourceDocument aDocument, String aUser) throws IOException
     {
+        log.trace("Reading CAS [{}]@{}", aUser, aDocument);
+
         File casFile = getCasFile(aDocument.getProject().getId(), aDocument.getId(), aUser);
         File oldCasFile = new File(casFile.getPath() + OLD_EXTENSION);
 

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/settings_cas-storage.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/settings_cas-storage.adoc
@@ -61,13 +61,17 @@ This cache can be tuned using the following properties:
 | `20000`
 
 | `cas-storage.cache.idle-cas-eviction-delay`
-| Time a CAS is retained in the caches after the last access
+| Periodic interval in which the system should check if CASes can be removed from the memory cache
 | `5m`
-| `1h`
+| `30s`
+
+| `cas-storage.cache.min-idle-cas-time`
+| Time a CAS should at least remain cached in memory to avoid loading from disk
+| `5m`
+| `30s`
 
 | `cas-storage.cache.cas-borrow-wait-timeout`
 | Time for an exclusive action to wait for another exclusive action to finish
 | `3m`
 | `5m`
 |===
-

--- a/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/exporters/SourceDocumentExporter.java
+++ b/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/exporters/SourceDocumentExporter.java
@@ -132,10 +132,9 @@ public class SourceDocumentExporter
                 FileUtils.copyFileToDirectory(documentService.getSourceDocumentFile(sourceDocument),
                         sourceDocumentDir);
                 aMonitor.setProgress((int) Math.ceil(((double) i) / documents.size() * 10.0));
+                log.info("Exported content for source document {}/{}: {} in {}", i,
+                        documents.size(), sourceDocument, project);
                 i++;
-                log.info("Exported content for source document [" + sourceDocument.getId()
-                        + "] in project [" + project.getName() + "] with id [" + project.getId()
-                        + "]");
             }
             catch (FileNotFoundException e) {
                 log.error("Source file [{}] related to project couldn't be located in repository",
@@ -159,8 +158,8 @@ public class SourceDocumentExporter
         importSourceDocuments(aExProject, aProject);
         importSourceDocumentContents(aZip, aProject);
 
-        log.info("Imported [{}] source documents for project [{}] ({})",
-                aExProject.getSourceDocuments().size(), aExProject.getName(),
+        log.info("Imported [{}] source documents into aProject ({})",
+                aExProject.getSourceDocuments().size(), aProject,
                 DurationFormatUtils.formatDurationWords(currentTimeMillis() - start, true, true));
     }
 
@@ -240,9 +239,8 @@ public class SourceDocumentExporter
                 copy(zip.getInputStream(entry), sourceFilePath);
 
                 n++;
-                log.info("Imported content for source document {}/{}: [{}]({}) in project [{}]({})",
-                        n, docs.size(), sourceDocument.getName(), sourceDocument.getId(),
-                        aProject.getName(), aProject.getId());
+                log.info("Imported content for source document {}/{}: {} in {}", n, docs.size(),
+                        sourceDocument, aProject);
             }
         }
     }

--- a/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/DocumentImportExportServiceImpl.java
+++ b/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/DocumentImportExportServiceImpl.java
@@ -27,6 +27,7 @@ import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUt
 import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.getRealCas;
 import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUtil.selectSentences;
 import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode.EXCLUSIVE_WRITE_ACCESS;
+import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode.UNMANAGED_ACCESS;
 import static de.tudarmstadt.ukp.clarin.webanno.support.WebAnnoConst.CHAIN_TYPE;
 import static de.tudarmstadt.ukp.clarin.webanno.support.WebAnnoConst.CURATION_USER;
 import static java.util.Collections.unmodifiableList;
@@ -269,13 +270,15 @@ public class DocumentImportExportServiceImpl
             // Read file
             File exportFile;
             try (CasStorageSession session = CasStorageSession.openNested()) {
-                CAS cas = casStorageService.readCas(aDocument, username);
+                // We do not want to add the CAS to the exclusive access pool here to avoid
+                // potentially running out of memory when exporting a large project
+                CAS cas = casStorageService.readCas(aDocument, username, UNMANAGED_ACCESS);
                 exportFile = exportCasToFile(cas, aDocument, aFileName, aFormat, aStripExtension,
                         bulkOperationContext);
             }
 
-            LOG.info("Exported annotations {} for user [{}] from project {} " + "using format [{}]",
-                    aDocument, aUser, aDocument.getProject(), aFormat.getId());
+            LOG.info("Exported annotations for [{}]@{} in {} using format [{}]", aUser, aDocument,
+                    aDocument.getProject(), aFormat.getId());
 
             return exportFile;
         }

--- a/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/service/AnnotationSchemaServiceImpl.java
+++ b/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/service/AnnotationSchemaServiceImpl.java
@@ -1195,8 +1195,7 @@ public class AnnotationSchemaServiceImpl
             if (!upgraded) {
                 try (var logCtx = withProjectLogger(aSourceDocument.getProject())) {
                     log.debug(
-                            "CAS of user [{}] for document {} in project {} is already "
-                                    + "compatible with project type system - skipping upgrade",
+                            "CAS [{}]@{} in {} is already compatible with project type system - skipping upgrade",
                             aUser, aSourceDocument, aSourceDocument.getProject());
                 }
             }


### PR DESCRIPTION
**What's in the PR**
- Do not use the exclusive-access pool when exporting annotations
- Log eviction of CASes from the shared-access cache and exclusive-access pool at trace level
- Actually enable periodic cleaning up of the shared-access pool using the system scheduler
- Introduce a new setting "min-idle-cas-time"
- Improve readability of the validateObject function in PooledCasHolderFactory
- Improve logging messages

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
