### PR TITLE
#4167 - Keyboard shortcut for the padlock

### DIFF
--- a/inception/inception-bootstrap/src/main/ts/bootstrap/shim-kendo.scss
+++ b/inception/inception-bootstrap/src/main/ts/bootstrap/shim-kendo.scss
@@ -32,7 +32,7 @@
 }
 
 .k-splitbar {
-    background-color: var(--bs-body-color) !important;
+    background-color: var(--bs-secondary-border-subtle) !important;
 }
 
 .k-splitbar .k-resize-handle {

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/component/DocumentNamePanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/component/DocumentNamePanel.java
@@ -27,6 +27,7 @@ import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
 import de.tudarmstadt.ukp.clarin.webanno.export.model.ExportedProject;
 import de.tudarmstadt.ukp.clarin.webanno.export.model.ExportedSourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
@@ -34,7 +35,6 @@ import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior;
-import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.AnnotationPage;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
 
 /**
@@ -53,7 +53,7 @@ public class DocumentNamePanel
         super(id, aModel);
         setOutputMarkupId(true);
         queue(new WebMarkupContainer("read-only").add(LambdaBehavior.visibleWhen(() -> {
-            var page = findParent(AnnotationPage.class);
+            var page = findParent(AnnotationPageBase.class);
             return page != null ? !page.isEditable() : false;
         })));
         queue(new Label("user", aModel.map(AnnotatorState::getUser).map(User::getUiName))

--- a/inception/inception-ui-annotation/src/main/resources/META-INF/asciidoc/user-guide/annotation_navigation.adoc
+++ b/inception/inception-ui-annotation/src/main/resources/META-INF/asciidoc/user-guide/annotation_navigation.adoc
@@ -61,4 +61,7 @@ You can also use the following keyboard assignments in order to navigate only us
 
 | kbd:[Shift + Delete]
 | delete the currently selected annotation
+
+| kbd:[Ctrl + End]
+| toggle document state (finished / in-progress)
 |====

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/actionbar/CuratorWorkflowActionBarItemGroup.html
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/actionbar/CuratorWorkflowActionBarItemGroup.html
@@ -23,10 +23,10 @@
       <div wicket:id="resetDocumentDialog"></div>
       <!-- <div wicket:id="finishDocumentDialog"></div> -->
       <div class="btn-group">
-        <button wicket:id="showResetDocumentDialog" class="btn btn-action-bar" type="button">
+        <button wicket:id="showResetDocumentDialog" class="btn btn-action-bar" type="button" wicket:message="title:reset">
           <i class="fas fa-recycle"></i>
         </button>
-        <button wicket:id="toggleCurationState" class="btn btn-action-bar" type="button">
+        <button wicket:id="toggleCurationState" class="btn btn-action-bar" type="button" wicket:message="title:stateToggle">
           <i wicket:id="state"></i>
         </button>
       </div>

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/actionbar/CuratorWorkflowActionBarItemGroup.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/actionbar/CuratorWorkflowActionBarItemGroup.java
@@ -20,6 +20,9 @@ package de.tudarmstadt.ukp.clarin.webanno.ui.curation.actionbar;
 import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.CURATION_FINISHED;
 import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.CURATION_IN_PROGRESS;
 import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.enabledWhen;
+import static wicket.contrib.input.events.EventType.click;
+import static wicket.contrib.input.events.key.KeyType.Ctrl;
+import static wicket.contrib.input.events.key.KeyType.End;
 
 import java.io.IOException;
 
@@ -43,6 +46,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxLink;
+import de.tudarmstadt.ukp.clarin.webanno.support.wicket.input.InputBehavior;
 import de.tudarmstadt.ukp.clarin.webanno.ui.curation.page.CurationPage;
 import de.tudarmstadt.ukp.clarin.webanno.ui.curation.page.MergeDialog;
 import de.tudarmstadt.ukp.inception.curation.merge.MergeStrategyFactory;
@@ -52,6 +56,7 @@ import de.tudarmstadt.ukp.inception.curation.service.CurationDocumentService;
 import de.tudarmstadt.ukp.inception.curation.service.CurationService;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
 import de.tudarmstadt.ukp.inception.schema.adapter.AnnotationException;
+import wicket.contrib.input.events.key.KeyType;
 
 public class CuratorWorkflowActionBarItemGroup
     extends Panel
@@ -85,6 +90,7 @@ public class CuratorWorkflowActionBarItemGroup
         toggleCurationStateLink.setOutputMarkupId(true);
         toggleCurationStateLink.add(new Label("state")
                 .add(new CssClassNameModifier(LambdaModel.of(this::getStateClass))));
+        toggleCurationStateLink.add(new InputBehavior(new KeyType[] { Ctrl, End }, click));
 
         curationWorkflowModel = Model.of(
                 curationService.readOrCreateCurationWorkflow(page.getModelObject().getProject()));

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/actionbar/CuratorWorkflowActionBarItemGroup.properties
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/actionbar/CuratorWorkflowActionBarItemGroup.properties
@@ -13,10 +13,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-finishDocumentDescription=This action will mark the document as <b>Finished</b>. <br/> You can no longer make changes to the document after this step. <br/> Only a project manager or curator can put the document back into editing mode. <br/> If you indicate that the document had a problem, it will be removed from your list of documents and you can no longer access it.
-
-stateToggle.curationFinished=Curation finished. Click return to curation-in-progress.
-stateToggle.curationInProgress=Curation in progress. Click to finish curation.
-stateToggle.annotationFinished=Annotation finished.
-stateToggle.annotationInProgress=Annotation in progress. Click to finish annotation.
+reset=Reset
 stateToggle=Toggle state (Ctrl+End)

--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/annotation/DynamicAnnotatorWorkflowActionBarItemGroup.html
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/annotation/DynamicAnnotatorWorkflowActionBarItemGroup.html
@@ -23,7 +23,7 @@
     <div wicket:id="finishDocumentDialog"></div>
     <div class="action-bar-group">
       <div class="btn-group">
-        <button wicket:id="showFinishDocumentDialog" class="btn btn-action-bar" type="button">
+        <button wicket:id="showFinishDocumentDialog" class="btn btn-action-bar" type="button"  wicket:message="title:stateToggle">
           <i wicket:id="state"></i>
         </button>
       </div>

--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/annotation/DynamicAnnotatorWorkflowActionBarItemGroup.java
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/annotation/DynamicAnnotatorWorkflowActionBarItemGroup.java
@@ -21,6 +21,9 @@ package de.tudarmstadt.ukp.inception.workload.dynamic.annotation;
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState.FINISHED;
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentStateChangeFlag.EXPLICIT_ANNOTATOR_USER_ACTION;
 import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.enabledWhen;
+import static wicket.contrib.input.events.EventType.click;
+import static wicket.contrib.input.events.key.KeyType.Ctrl;
+import static wicket.contrib.input.events.key.KeyType.End;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -51,6 +54,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.clarin.webanno.support.bootstrap.BootstrapModalDialog;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxLink;
+import de.tudarmstadt.ukp.clarin.webanno.support.wicket.input.InputBehavior;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
 import de.tudarmstadt.ukp.inception.schema.adapter.AnnotationException;
 import de.tudarmstadt.ukp.inception.workload.dynamic.DynamicWorkloadExtension;
@@ -58,6 +62,7 @@ import de.tudarmstadt.ukp.inception.workload.dynamic.trait.DynamicWorkloadTraits
 import de.tudarmstadt.ukp.inception.workload.dynamic.workflow.WorkflowExtensionPoint;
 import de.tudarmstadt.ukp.inception.workload.model.WorkloadManagementService;
 import de.tudarmstadt.ukp.inception.workload.model.WorkloadManager;
+import wicket.contrib.input.events.key.KeyType;
 
 /**
  * This is only enabled for annotators of a project with the dynamic workload enabled. An annotator
@@ -100,6 +105,7 @@ public class DynamicAnnotatorWorkflowActionBarItemGroup
                 this::actionFinishDocument));
         finishDocumentLink.setOutputMarkupId(true);
         finishDocumentLink.add(enabledWhen(page::isEditable));
+        finishDocumentLink.add(new InputBehavior(new KeyType[] { Ctrl, End }, click));
 
         queue(new Label("state")
                 .add(new CssClassNameModifier(LambdaModel.of(this::getStateClass))));

--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/annotation/DynamicAnnotatorWorkflowActionBarItemGroup.properties
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/annotation/DynamicAnnotatorWorkflowActionBarItemGroup.properties
@@ -14,3 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 finishDocumentDescription=This action will mark the document as <b>Finished</b>. <br/> When you confirm this dialog, you are automatically forwarded to the <br/> next available document and will not be able to go back.
+stateToggle=Toggle state (Ctrl+End)

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/annotation/MatrixWorkflowActionBarItemGroup.html
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/annotation/MatrixWorkflowActionBarItemGroup.html
@@ -26,7 +26,7 @@
         <button wicket:id="showResetDocumentDialog" class="btn btn-action-bar" type="button" title="Reset document">
           <i class="fas fa-recycle"></i>
         </button>
-        <button wicket:id="toggleDocumentState" class="btn btn-action-bar" type="button" title="Finish document">
+        <button wicket:id="toggleDocumentState" class="btn btn-action-bar" type="button" wicket:message="title:stateToggle">
           <i wicket:id="state"></i>
         </button>
       </div>

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/annotation/MatrixWorkflowActionBarItemGroup.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/annotation/MatrixWorkflowActionBarItemGroup.java
@@ -26,6 +26,9 @@ import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.CURATI
 import static de.tudarmstadt.ukp.clarin.webanno.support.WebAnnoConst.CURATION_USER;
 import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.enabledWhen;
 import static de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaBehavior.visibleWhen;
+import static wicket.contrib.input.events.EventType.click;
+import static wicket.contrib.input.events.key.KeyType.Ctrl;
+import static wicket.contrib.input.events.key.KeyType.End;
 
 import java.io.IOException;
 
@@ -59,12 +62,14 @@ import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.support.bootstrap.BootstrapModalDialog;
 import de.tudarmstadt.ukp.clarin.webanno.support.dialog.ChallengeResponseDialog;
 import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxLink;
+import de.tudarmstadt.ukp.clarin.webanno.support.wicket.input.InputBehavior;
 import de.tudarmstadt.ukp.inception.preferences.PreferencesService;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
 import de.tudarmstadt.ukp.inception.schema.adapter.AnnotationException;
 import de.tudarmstadt.ukp.inception.workload.matrix.MatrixWorkloadExtension;
 import de.tudarmstadt.ukp.inception.workload.matrix.trait.MatrixWorkloadTraits;
 import de.tudarmstadt.ukp.inception.workload.model.WorkloadManagementService;
+import wicket.contrib.input.events.key.KeyType;
 
 public class MatrixWorkflowActionBarItemGroup
     extends Panel
@@ -128,6 +133,7 @@ public class MatrixWorkflowActionBarItemGroup
         }
         link.setOutputMarkupId(true);
         link.add(enabledWhen(() -> page.isEditable() || isReopenableByUser()));
+        link.add(new InputBehavior(new KeyType[] { Ctrl, End }, click));
         var stateLabel = new Label("state");
         stateLabel.add(new CssClassNameModifier(LoadableDetachableModel.of(this::getStateClass)));
         stateLabel.add(AttributeModifier.replace("title", LoadableDetachableModel.of(() -> {


### PR DESCRIPTION
**What's in the PR**
- Add shortcut for toggling the document state
- Fix display of "read-only" marker in document name panel on curation page

**How to test manually**
* Try it on the curation and annotation pages

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
