### PR TITLE
#4184 - Improve handling of XML and HTML files

### DIFF
--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/policy/DefaultHtmlDocumentPolicy.java
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/policy/DefaultHtmlDocumentPolicy.java
@@ -19,63 +19,44 @@ package de.tudarmstadt.ukp.inception.externaleditor.policy;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.regex.Pattern;
 
 import de.tudarmstadt.ukp.clarin.webanno.support.SettingsUtil;
 import de.tudarmstadt.ukp.clarin.webanno.support.WatchedResourceFile;
 import de.tudarmstadt.ukp.inception.support.xml.sanitizer.PolicyCollection;
-import de.tudarmstadt.ukp.inception.support.xml.sanitizer.PolicyCollectionBuilder;
 import de.tudarmstadt.ukp.inception.support.xml.sanitizer.PolicyCollectionIOUtils;
 
 public class DefaultHtmlDocumentPolicy
 {
-    static final String DEFAULT_POLICY_YAML = "default-policy.yaml";
+    static final String HTML_POLICY_OVERRIDE_YAML = "default-policy.yaml";
 
-    private static final Pattern HTML_TITLE = Pattern
-            .compile("[\\p{L}\\p{N}\\s\\-_',:\\[\\]!\\./\\\\\\(\\)&]*");
-    private static final Pattern HTML_CLASS = Pattern.compile("[a-zA-Z0-9\\s,\\-_]+");
+    static final String DEFAULT_HTML_POLICY_YAML = //
+            "/de/tudarmstadt/ukp/inception/externaleditor/policy/DefaultHtmlDocumentPolicy.yaml";
 
-    private final PolicyCollection defaultPolicy;
+    private final WatchedResourceFile<PolicyCollection> defaultPolicy;
 
     private final WatchedResourceFile<PolicyCollection> policyOverrideFile;
 
     public DefaultHtmlDocumentPolicy() throws IOException
     {
-        defaultPolicy = makeDefaultPolicy();
+        defaultPolicy = new WatchedResourceFile<PolicyCollection>(
+                getClass().getResource(DEFAULT_HTML_POLICY_YAML),
+                PolicyCollectionIOUtils::loadPolicies);
 
         var appHome = SettingsUtil.getApplicationHome();
         policyOverrideFile = new WatchedResourceFile<>(
-                new File(appHome, DEFAULT_POLICY_YAML).toPath(),
+                new File(appHome, HTML_POLICY_OVERRIDE_YAML).toPath(),
                 PolicyCollectionIOUtils::loadPolicies);
-    }
-
-    private PolicyCollection makeDefaultPolicy()
-    {
-        return PolicyCollectionBuilder.caseInsensitive() //
-                .allowElements("html", "head", "body", "title") //
-                // Content sectioning
-                .allowElements("address", "article", "aside", "footer", "header", "h1", "h2", "h3",
-                        "h4", "h5", "h6", "main", "section") //
-                // Text content
-                .allowElements("blockquote", "dd", "div", "dl", "dt", "figcaption", "figure", "hr",
-                        "li", "menu", "ol", "p", "pre", "ul") //
-                // Inline text semantics
-                .allowElements("a", "abbr", "b", "bdi", "bdo", "br", "cite", "code", "data", "dfn",
-                        "em", "i", "kbd", "mark", "q", "rp", "rt", "ruby", "s", "samp", "small",
-                        "span", "strong", "sub", "sup", "time", "u", "var", "wbr")
-                // Demarcating edits
-                .allowElements("del", "ins")
-                // Table content
-                .allowElements("caption", "col", "colgroup", "table", "tbody", "td", "tfoot", "th",
-                        "thead", "tr")
-                // Common attributes
-                .allowAttributes("title").matching(HTML_TITLE).globally() //
-                .allowAttributes("class").matching(HTML_CLASS).globally() //
-                .build();
     }
 
     public PolicyCollection getPolicy() throws IOException
     {
-        return policyOverrideFile.get().orElse(defaultPolicy);
+        var policyOverride = policyOverrideFile.get();
+        if (policyOverride.isPresent()) {
+            return policyOverride.get();
+        }
+
+        return defaultPolicy.get().orElseThrow(
+                () -> new IOException("Default HTML document policy file not found at ["
+                        + DEFAULT_HTML_POLICY_YAML + "]"));
     }
 }

--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/policy/DefaultHtmlDocumentPolicy.yaml
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/policy/DefaultHtmlDocumentPolicy.yaml
@@ -1,0 +1,65 @@
+# Licensed to the Technische Universität Darmstadt under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The Technische Universität Darmstadt 
+# licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.
+#  
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Default HTML policy
+version: 1.0
+case_sensitive: false
+default_attribute_action: DROP
+default_element_action: DROP
+debug: true
+policies:
+  - action: PASS
+    elements: ["html", "head", "body", "title"] 
+  # Content sectioning
+  - action: PASS
+    elements: ["address", "article", "aside", "footer", "header", 
+               "h1", "h2", "h3", "h4", "h5", "h6", "main", "section"]
+  # Text content
+  - action: PASS
+    elements: ["blockquote", "dd", "div", "dl", "dt", "figcaption", "figure", "hr", "li", 
+               "menu", "ol", "p", "pre", "ul"]
+  # Inline text semantics
+  - action: SKIP
+    elements: ["a"]
+  - action: PASS
+    elements: ["abbr", "b", "bdi", "bdo", "br", "cite", "code", "data", "dfn",
+               "em", "i", "kbd", "mark", "q", "rp", "rt", "ruby", "s", "samp", "small",
+               "span", "strong", "sub", "sup", "time", "u", "var", "wbr"]
+  # Demarcating edits
+  - action: PASS
+    elements: ["del", "ins"]
+  # Table content
+  - action: PASS
+    elements: ["caption", "col", "colgroup", "table", "tbody", "td", "tfoot", "th",
+               "thead", "tr"]
+  # Deprecated stuff
+  - action: PASS
+    elements: ["font", "center"]
+  - on_elements: ["font"]
+    action: PASS
+    attributes: ["face", "size"]
+  - action: PASS
+    attributes: ["align", "size", "width"]
+    # We leave out "color", "bgcolor" because they could interfere with the annotation highlights
+  # Common attributes
+  - action: PASS
+    attributes: ["title"]
+    matching: "[\\p{L}\\p{N}\\s\\-_',:\\[\\]!\\./\\\\\\(\\)&]*"
+  - action: PASS
+    attributes: ["class"]
+    matching: "[a-zA-Z0-9\\s,\\-_]+"
+    
+  

--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/policy/SafetyNetDocumentPolicy.java
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/policy/SafetyNetDocumentPolicy.java
@@ -33,7 +33,7 @@ import de.tudarmstadt.ukp.inception.support.xml.sanitizer.PolicyCollectionIOUtil
 
 public class SafetyNetDocumentPolicy
 {
-    static final String DEFAULT_POLICY_YAML = "safety-net.yaml";
+    static final String SAFETY_NET_POLICY_OVERRIDE_YAML = "safety-net.yaml";
 
     private static final String[] JAVASCRIPT_EVENT_ATTRIBUTES = { "onafterprint", "onbeforeprint",
             "onbeforeunload", "onerror", "onhashchange", "onload", "onmessage", "onoffline",
@@ -63,7 +63,7 @@ public class SafetyNetDocumentPolicy
 
         var appHome = SettingsUtil.getApplicationHome();
         policyOverrideFile = new WatchedResourceFile<>(
-                new File(appHome, DEFAULT_POLICY_YAML).toPath(),
+                new File(appHome, SAFETY_NET_POLICY_OVERRIDE_YAML).toPath(),
                 PolicyCollectionIOUtils::loadPolicies);
     }
 
@@ -74,7 +74,7 @@ public class SafetyNetDocumentPolicy
                 .defaultAttributeAction(AttributeAction.PASS) //
                 .defaultElementAction(ElementAction.PASS);
 
-        builder.disallowElements("script", "meta", "applet", "link", "iframe", "a");
+        builder.disallowElements("script", "meta", "applet", "link", "iframe");
 
         if (properties.isBlockStyle()) {
             builder.disallowElements("style");

--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/xhtml/XHtmlXmlDocumentViewControllerImpl.java
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/xhtml/XHtmlXmlDocumentViewControllerImpl.java
@@ -145,7 +145,8 @@ public class XHtmlXmlDocumentViewControllerImpl
             // not inject format-specific CSS then!
             if (casContainsHtml) {
                 XmlDocument xml = maybeXmlDocument.get();
-                Cas2SaxEvents serializer = new XmlCas2SaxEvents(xml, ch);
+                var sh = applySanitizers(aEditor, doc, ch);
+                Cas2SaxEvents serializer = new XmlCas2SaxEvents(xml, sh);
                 ch.startDocument();
                 ch.startPrefixMapping("", XHTML_NS_URI);
                 serializer.process(xml.getRoot());

--- a/inception/inception-external-editor/src/test/java/de/tudarmstadt/ukp/inception/externaleditor/policy/DefaultHtmlDocumentPolicyTest.java
+++ b/inception/inception-external-editor/src/test/java/de/tudarmstadt/ukp/inception/externaleditor/policy/DefaultHtmlDocumentPolicyTest.java
@@ -18,7 +18,7 @@
 package de.tudarmstadt.ukp.inception.externaleditor.policy;
 
 import static de.tudarmstadt.ukp.clarin.webanno.support.SettingsUtil.getPropApplicationHome;
-import static de.tudarmstadt.ukp.inception.externaleditor.policy.DefaultHtmlDocumentPolicy.DEFAULT_POLICY_YAML;
+import static de.tudarmstadt.ukp.inception.externaleditor.policy.DefaultHtmlDocumentPolicy.HTML_POLICY_OVERRIDE_YAML;
 import static de.tudarmstadt.ukp.inception.externaleditor.policy.SafetyNetDocumentPolicyTest.touch;
 import static java.lang.System.setProperty;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -36,7 +36,7 @@ class DefaultHtmlDocumentPolicyTest
     @Test
     void thatOverrideFileIsPickedUp(@TempDir Path aTemp) throws Exception
     {
-        Path policyFile = aTemp.resolve(DEFAULT_POLICY_YAML);
+        Path policyFile = aTemp.resolve(HTML_POLICY_OVERRIDE_YAML);
         setProperty(getPropApplicationHome(), aTemp.toString());
 
         var sut = new DefaultHtmlDocumentPolicy();

--- a/inception/inception-external-editor/src/test/java/de/tudarmstadt/ukp/inception/externaleditor/policy/DefaultHtmlDocumentPolicyTest.java
+++ b/inception/inception-external-editor/src/test/java/de/tudarmstadt/ukp/inception/externaleditor/policy/DefaultHtmlDocumentPolicyTest.java
@@ -41,7 +41,7 @@ class DefaultHtmlDocumentPolicyTest
 
         var sut = new DefaultHtmlDocumentPolicy();
 
-        assertThat(sut.getPolicy().getElementPolicies()).hasSize(72);
+        assertThat(sut.getPolicy().getElementPolicies()).hasSize(74);
 
         write(policyFile.toFile(), "policies: []", UTF_8);
         assertThat(policyFile).exists();
@@ -54,6 +54,6 @@ class DefaultHtmlDocumentPolicyTest
 
         Files.delete(policyFile);
         assertThat(policyFile).doesNotExist();
-        assertThat(sut.getPolicy().getElementPolicies()).hasSize(72);
+        assertThat(sut.getPolicy().getElementPolicies()).hasSize(74);
     }
 }

--- a/inception/inception-external-editor/src/test/java/de/tudarmstadt/ukp/inception/externaleditor/policy/SafetyNetDocumentPolicyTest.java
+++ b/inception/inception-external-editor/src/test/java/de/tudarmstadt/ukp/inception/externaleditor/policy/SafetyNetDocumentPolicyTest.java
@@ -133,7 +133,7 @@ class SafetyNetDocumentPolicyTest
         var sut = new SafetyNetDocumentPolicy(properties);
 
         assertThat(policyFile).doesNotExist();
-        assertThat(sut.getPolicy().getElementPolicies()).hasSize(12);
+        assertThat(sut.getPolicy().getElementPolicies()).hasSize(11);
 
         write(policyFile.toFile(), "policies: []", UTF_8);
         assertThat(policyFile).exists();
@@ -146,7 +146,7 @@ class SafetyNetDocumentPolicyTest
 
         Files.delete(policyFile);
         assertThat(policyFile).doesNotExist();
-        assertThat(sut.getPolicy().getElementPolicies()).hasSize(12);
+        assertThat(sut.getPolicy().getElementPolicies()).hasSize(11);
     }
 
     static void touch(Path policyFile) throws IOException, InterruptedException

--- a/inception/inception-external-editor/src/test/java/de/tudarmstadt/ukp/inception/externaleditor/policy/SafetyNetDocumentPolicyTest.java
+++ b/inception/inception-external-editor/src/test/java/de/tudarmstadt/ukp/inception/externaleditor/policy/SafetyNetDocumentPolicyTest.java
@@ -18,7 +18,7 @@
 package de.tudarmstadt.ukp.inception.externaleditor.policy;
 
 import static de.tudarmstadt.ukp.clarin.webanno.support.SettingsUtil.getPropApplicationHome;
-import static de.tudarmstadt.ukp.inception.externaleditor.policy.SafetyNetDocumentPolicy.DEFAULT_POLICY_YAML;
+import static de.tudarmstadt.ukp.inception.externaleditor.policy.SafetyNetDocumentPolicy.SAFETY_NET_POLICY_OVERRIDE_YAML;
 import static de.tudarmstadt.ukp.inception.support.xml.XmlParserUtils.makeXmlSerializer;
 import static java.lang.System.setProperty;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -126,7 +126,7 @@ class SafetyNetDocumentPolicyTest
     @Test
     void thatOverrideFileIsPickedUp(@TempDir Path aTemp) throws Exception
     {
-        Path policyFile = aTemp.resolve(DEFAULT_POLICY_YAML);
+        Path policyFile = aTemp.resolve(SAFETY_NET_POLICY_OVERRIDE_YAML);
         setProperty(getPropApplicationHome(), aTemp.toString());
 
         var properties = new ExternalEditorPropertiesImpl();

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/ElementAction.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/ElementAction.java
@@ -19,6 +19,18 @@ package de.tudarmstadt.ukp.inception.support.xml.sanitizer;
 
 public enum ElementAction
 {
-    PASS, //
+    /**
+     * Element is passed through.
+     */
+    PASS,
+
+    /**
+     * Element is not passed through filter but any child text nodes are passed.
+     */
+    SKIP,
+
+    /**
+     * Element is not passed through.
+     */
     DROP;
 }

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/PolicyCollectionBuilder.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/PolicyCollectionBuilder.java
@@ -114,6 +114,24 @@ public class PolicyCollectionBuilder
         return this;
     }
 
+    public PolicyCollectionBuilder skipElements(String... aElementNames)
+    {
+        for (var elementName : aElementNames) {
+            elementPolicy(new QName(elementName), ElementAction.SKIP);
+        }
+
+        return this;
+    }
+
+    public PolicyCollectionBuilder skipElements(QName... aElementNames)
+    {
+        for (var elementName : aElementNames) {
+            elementPolicy(elementName, ElementAction.SKIP);
+        }
+
+        return this;
+    }
+
     PolicyCollectionBuilder elementPolicy(QName aElement, ElementAction aAction)
     {
         elementPolicyBuilders.put(aElement,
@@ -210,5 +228,5 @@ public class PolicyCollectionBuilder
     // XmlPolicyBuilder allowTextIn(String... aElementNames);
     // XmlPolicyBuilder disallowTextIn(String... aElementNames);
     // XmlPolicyBuilder allowAttributesGlobally(String... aAttributeNames);
-    // XmlPolicyBuilder allwoAttributesOnElements(String... aElementNames);
+    // XmlPolicyBuilder allowAttributesOnElements(String... aElementNames);
 }

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/SanitizingContentHandler.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/SanitizingContentHandler.java
@@ -105,6 +105,7 @@ public class SanitizingContentHandler
             var attributes = sanitizeAttributes(element, aAtts);
             startElement(element, attributes, policy, action, localNamespace);
             break;
+        case SKIP: // fall-through
         case DROP:
             startElement(element, null, policy, action, localNamespace);
             break;
@@ -119,7 +120,8 @@ public class SanitizingContentHandler
     {
         QName element = aElement;
 
-        if (aAction == ElementAction.DROP && policies.isDebug()) {
+        if ((aAction == ElementAction.DROP || aAction == ElementAction.SKIP)
+                && policies.isDebug()) {
             element = maskElement(element);
         }
 
@@ -186,6 +188,7 @@ public class SanitizingContentHandler
             Arrays.fill(placeholder, filteredCharacter);
             super.characters(placeholder, 0, aLength);
             break;
+        case SKIP: // pass-through
         case PASS:
             super.characters(aCh, aStart, aLength);
             break;
@@ -204,6 +207,7 @@ public class SanitizingContentHandler
             Arrays.fill(placeholder, filteredCharacter);
             super.ignorableWhitespace(placeholder, 0, aLength);
             break;
+        case SKIP: // pass-through
         case PASS:
             super.ignorableWhitespace(aCh, aStart, aLength);
             break;
@@ -263,7 +267,7 @@ public class SanitizingContentHandler
     private static final class Frame
     {
         final QName element;
-        final Optional<ElementPolicy> policy;
+        final @SuppressWarnings("unused") Optional<ElementPolicy> policy;
         final ElementAction action;
         final Map<String, String> namespaces;
 

--- a/inception/inception-support/src/test/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/SanitizingContentHandlerTest.java
+++ b/inception/inception-support/src/test/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/SanitizingContentHandlerTest.java
@@ -94,6 +94,31 @@ public class SanitizingContentHandlerTest
 
     @ParameterizedTest(name = "{0}")
     @MethodSource("builderVariants")
+    void thatElementsCanBeSkippedSelectively(String aName, PolicyCollectionBuilder aBuilder)
+        throws Exception
+    {
+        var buffer = new StringWriter();
+        var policy = aBuilder //
+                .defaultElementAction(ElementAction.PASS) //
+                .defaultAttributeAction(AttributeAction.PASS) //
+                .skipElements("child") //
+                .build();
+
+        var sut = new SanitizingContentHandler(makeXmlSerializer(buffer), policy);
+
+        sut.startDocument();
+        sut.startElement("root");
+        sut.startElement("child");
+        sut.characters("text");
+        sut.endElement("child");
+        sut.endElement("root");
+        sut.endDocument();
+
+        assertThat(buffer.toString()).isEqualTo("<root>text</root>");
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("builderVariants")
     void thatChildElementsCanBePreservedSelectively(String aName, PolicyCollectionBuilder aBuilder)
         throws Exception
     {


### PR DESCRIPTION
**What's in the PR**
- Introduce a SKIP option for elements that skips the element but passes text node children
- Allow certain HTML4 tags like font or center or such to pass
- Read default HTML policy from monitored resource to simplify development

**How to test manually**
* Try out different HTML files

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
