### PR TITLE
#4188 - Option to reduce information on error page

### DIFF
--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/settings_general.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/settings_general.adoc
@@ -53,4 +53,9 @@
 | Whether to enable the ability to install plugins into {product-name} (experimental).
 | `false`
 | `true`
+
+| `ui.error-page.hide-details`
+| Disable display of information about operating system, Java version, etc. on the error page. While this information is useful for local users when reporting bugs, security-conscious administrators running {application-name} as a service may want to enable hiding the details to avoid information about their system being exposed.
+| `false`
+| `true`
 |===

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/ErrorPage.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/ErrorPage.java
@@ -41,6 +41,7 @@ import org.apache.wicket.request.Url;
 import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.request.handler.TextRequestHandler;
 import org.apache.wicket.request.http.WebRequest;
+import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -56,6 +57,7 @@ import com.giffing.wicket.spring.boot.context.scan.WicketInternalErrorPage;
 
 import de.tudarmstadt.ukp.clarin.webanno.support.SettingsUtil;
 import de.tudarmstadt.ukp.clarin.webanno.ui.core.page.ApplicationPageBase;
+import de.tudarmstadt.ukp.inception.ui.core.config.ErrorPageProperties;
 
 @WicketInternalErrorPage
 @WicketExpiredPage
@@ -66,6 +68,8 @@ public class ErrorPage
 {
     private static final long serialVersionUID = 7848496813044538495L;
     private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    private @SpringBean ErrorPageProperties errorPageProperties;
 
     public ErrorPage()
     {
@@ -117,60 +121,66 @@ public class ErrorPage
                 && !(authentication instanceof AnonymousAuthenticationToken);
 
         Label statusCode = new Label("statusCode", LoadableDetachableModel.of(this::getStatusCode));
-        statusCode.add(visibleWhen(() -> statusCode.getDefaultModelObject() != null));
+        statusCode.add(visibleWhen(
+                () -> statusCode.getDefaultModelObject() != null && isShowErrorDetails()));
         add(statusCode);
 
         Label statusReasonPhrase = new Label("statusReasonPhrase",
                 LoadableDetachableModel.of(this::getStatusReasonPhrase));
-        statusReasonPhrase
-                .add(visibleWhen(() -> statusReasonPhrase.getDefaultModelObject() != null));
+        statusReasonPhrase.add(visibleWhen(
+                () -> statusReasonPhrase.getDefaultModelObject() != null && isShowErrorDetails()));
         add(statusReasonPhrase);
 
         Label requestUri = new Label("requestUri", LoadableDetachableModel.of(this::getRequestUri));
-        requestUri.add(visibleWhen(() -> requestUri.getDefaultModelObject() != null));
+        requestUri.add(visibleWhen(
+                () -> requestUri.getDefaultModelObject() != null && isShowErrorDetails()));
         add(requestUri);
 
         Label servletName = new Label("servletName",
                 LoadableDetachableModel.of(this::getServletName));
-        servletName.add(visibleWhen(() -> servletName.getDefaultModelObject() != null));
+        servletName.add(visibleWhen(
+                () -> servletName.getDefaultModelObject() != null && isShowErrorDetails()));
         add(servletName);
 
         Label message = new Label("message", LoadableDetachableModel.of(this::getMessage));
-        message.add(visibleWhen(() -> message.getDefaultModelObject() != null));
+        message.add(
+                visibleWhen(() -> message.getDefaultModelObject() != null && isShowErrorDetails()));
         add(message);
 
         Label exceptionMessage = new Label("exceptionMessage",
                 LoadableDetachableModel.of(this::getExceptionMessage));
-        exceptionMessage.add(visibleWhen(() -> exceptionMessage.getDefaultModelObject() != null));
+        exceptionMessage.add(visibleWhen(
+                () -> exceptionMessage.getDefaultModelObject() != null && isShowErrorDetails()));
         add(exceptionMessage);
 
         Label exceptionStackTrace = new Label("exceptionStackTrace",
                 LoadableDetachableModel.of(this::getExceptionStackTrace));
-        exceptionStackTrace
-                .add(visibleWhen(() -> exceptionStackTrace.getDefaultModelObject() != null));
+        exceptionStackTrace.add(visibleWhen(
+                () -> exceptionStackTrace.getDefaultModelObject() != null && isShowErrorDetails()));
         add(exceptionStackTrace);
 
         Label appVersion = new Label("appVersion", SettingsUtil.getVersionString());
+        appVersion.add(visibleWhen(() -> isShowErrorDetails()));
         add(appVersion);
 
         Label javaVendor = new Label("javaVendor", System.getProperty("java.vendor"));
-        javaVendor.setVisible(authenticated);
+        javaVendor.setVisible(authenticated && isShowErrorDetails());
         add(javaVendor);
 
         Label javaVersion = new Label("javaVersion", System.getProperty("java.version"));
-        javaVersion.setVisible(authenticated);
+        javaVersion.setVisible(authenticated && isShowErrorDetails());
         add(javaVersion);
 
         Label osName = new Label("osName", System.getProperty("os.name"));
-        osName.setVisible(authenticated);
+        osName.setVisible(authenticated && isShowErrorDetails());
         add(osName);
 
         Label osVersion = new Label("osVersion", System.getProperty("os.version"));
-        osVersion.setVisible(authenticated);
+        osVersion.setVisible(authenticated && isShowErrorDetails());
         add(osVersion);
 
         Label osArch = new Label("osArch", System.getProperty("os.arch"));
-        osArch.setVisible(authenticated);
+        osArch.setVisible(authenticated && isShowErrorDetails());
         add(osArch);
     }
 
@@ -211,6 +221,11 @@ public class ErrorPage
     private Integer getStatusCode()
     {
         return getErrorAttributes().map(ErrorAttributes::getStatusCode).orElse(null);
+    }
+
+    private boolean isShowErrorDetails()
+    {
+        return !errorPageProperties.isHideDetails();
     }
 
     private String getStatusReasonPhrase()

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/config/CoreUiAutoConfiguration.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/config/CoreUiAutoConfiguration.java
@@ -31,7 +31,8 @@ import de.tudarmstadt.ukp.inception.ui.core.darkmode.DarkModePropertiesImpl;
 import de.tudarmstadt.ukp.inception.ui.core.menubar.HelpMenuBarItemSupport;
 
 @Configuration
-@EnableConfigurationProperties({ CspPropertiesImpl.class, DarkModePropertiesImpl.class })
+@EnableConfigurationProperties({ CspPropertiesImpl.class, DarkModePropertiesImpl.class,
+        ErrorPagePropertiesImpl.class })
 public class CoreUiAutoConfiguration
 {
     @ConditionalOnMissingBean(value = VersionFooterItem.class)

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/config/ErrorPageProperties.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/config/ErrorPageProperties.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.core.config;
+
+public interface ErrorPageProperties
+{
+    public boolean isHideDetails();
+}

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/config/ErrorPagePropertiesImpl.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/config/ErrorPagePropertiesImpl.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.core.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("ui.error-page")
+public class ErrorPagePropertiesImpl
+    implements ErrorPageProperties
+{
+    private boolean hideDetails;
+
+    @Override
+    public boolean isHideDetails()
+    {
+        return hideDetails;
+    }
+
+    public void setHideDetails(boolean aHideDetails)
+    {
+        hideDetails = aHideDetails;
+    }
+}


### PR DESCRIPTION
**What's in the PR**
- Add new configuration option to disable details on error page

**How to test manually**
* Enable developer mode `-Dinception.dev=true`
* Enable the setting `-Dui.error-page.hide-details=true`
* Visit `.../whoops/test`

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
