### PR TITLE
#4196 - Save memory by not creating empty arrays in CAS

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiValueStringFeatureSupport.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiValueStringFeatureSupport.java
@@ -137,7 +137,7 @@ public class MultiValueStringFeatureSupport
 
         FeatureStructure fs = getFS(aCas, aFeature, aAddress);
         List<String> values = unwrapFeatureValue(aFeature, fs.getCAS(), aValue);
-        if (values == null) {
+        if (values == null || values.isEmpty()) {
             FSUtil.setFeature(fs, aFeature.getName(), (Collection<String>) null);
             return;
         }

--- a/inception/inception-api-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/feature/FeatureUtil.java
+++ b/inception/inception-api-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/feature/FeatureUtil.java
@@ -147,6 +147,11 @@ public class FeatureUtil
     public static void setLinkFeatureValue(FeatureStructure aFS, Feature aFeature,
             List<FeatureStructure> linkFSes)
     {
+        if (linkFSes == null || linkFSes.isEmpty()) {
+            aFS.setFeatureValue(aFeature, null);
+            return;
+        }
+
         // Create a new array if size differs otherwise re-use existing one
         var array = (ArrayFS<FeatureStructure>) ICasUtil.getFeatureFS(aFS, aFeature.getShortName());
         if (array == null || (array.size() != linkFSes.size())) {

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/MultiValueConceptFeatureSupport.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/MultiValueConceptFeatureSupport.java
@@ -282,7 +282,7 @@ public class MultiValueConceptFeatureSupport
 
         FeatureStructure fs = getFS(aCas, aFeature, aAddress);
         List<String> values = unwrapFeatureValue(aFeature, fs.getCAS(), aValue);
-        if (values == null) {
+        if (values == null || values.isEmpty()) {
             FSUtil.setFeature(fs, aFeature.getName(), (Collection<String>) null);
             return;
         }


### PR DESCRIPTION
**What's in the PR**
- Adjust link features and multi-value features to not store empty arrays

**How to test manually**
* Try using link features and multi-value features and look for NullPointerExceptions

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
