### PR TITLE
#4212 - Unable to mark local KB as read-only

### DIFF
--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
@@ -306,26 +306,33 @@ public class KnowledgeBaseServiceImpl
     }
 
     @Override
-    public void defineBaseProperties(KnowledgeBase akb)
+    public void defineBaseProperties(KnowledgeBase aKB)
     {
         // KB will initialize base properties with base IRI schema properties defined by user
-        if (akb.getType() == RepositoryType.LOCAL) {
-            ValueFactory vf = SimpleValueFactory.getInstance();
+        if (aKB.getType() == RepositoryType.LOCAL) {
+            var readOnly = aKB.isReadOnly();
+            aKB.setReadOnly(false);
+            try {
+                ValueFactory vf = SimpleValueFactory.getInstance();
 
-            createBaseProperty(akb, new KBProperty(akb.getSubclassIri(),
-                    vf.createIRI(akb.getSubclassIri()).getLocalName()));
-            createBaseProperty(akb,
-                    new KBProperty(akb.getLabelIri(),
-                            vf.createIRI(akb.getLabelIri()).getLocalName(), null,
-                            XSD.STRING.stringValue()));
-            createBaseProperty(akb,
-                    new KBProperty(akb.getDescriptionIri(),
-                            vf.createIRI(akb.getDescriptionIri()).getLocalName(), null,
-                            XSD.STRING.stringValue()));
-            createBaseProperty(akb, new KBProperty(akb.getTypeIri(),
-                    vf.createIRI(akb.getTypeIri()).getLocalName()));
-            createBaseProperty(akb, new KBProperty(akb.getSubPropertyIri(),
-                    vf.createIRI(akb.getSubPropertyIri()).getLocalName()));
+                createBaseProperty(aKB, new KBProperty(aKB.getSubclassIri(),
+                        vf.createIRI(aKB.getSubclassIri()).getLocalName()));
+                createBaseProperty(aKB,
+                        new KBProperty(aKB.getLabelIri(),
+                                vf.createIRI(aKB.getLabelIri()).getLocalName(), null,
+                                XSD.STRING.stringValue()));
+                createBaseProperty(aKB,
+                        new KBProperty(aKB.getDescriptionIri(),
+                                vf.createIRI(aKB.getDescriptionIri()).getLocalName(), null,
+                                XSD.STRING.stringValue()));
+                createBaseProperty(aKB, new KBProperty(aKB.getTypeIri(),
+                        vf.createIRI(aKB.getTypeIri()).getLocalName()));
+                createBaseProperty(aKB, new KBProperty(aKB.getSubPropertyIri(),
+                        vf.createIRI(aKB.getSubPropertyIri()).getLocalName()));
+            }
+            finally {
+                aKB.setReadOnly(readOnly);
+            }
         }
     }
 

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/AccessSpecificSettingsPanel.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/AccessSpecificSettingsPanel.java
@@ -73,9 +73,6 @@ public class AccessSpecificSettingsPanel
         KnowledgeBase kb = getModel().getObject().getKb();
         switch (kb.getType()) {
         case LOCAL:
-            // local knowledge bases are editable by default
-            kb.setReadOnly(false);
-
             // We need to handle this manually here because the onSubmit method of the upload
             // form is only called *after* the upload component has already been detached and
             // as a consequence all uploaded files have been cleared

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/wizard/KnowledgeBaseCreationWizard.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/wizard/KnowledgeBaseCreationWizard.java
@@ -158,10 +158,14 @@ public class KnowledgeBaseCreationWizard
 
             switch (kbModel.getObject().getKb().getType()) {
             case LOCAL:
+                // Local KBs are writeable by default
+                kbModel.getObject().getKb().setReadOnly(false);
                 // local KBs are always RDF4J + Lucene, so we can set the FTS mode accordingly
                 kbModel.getObject().getKb().setFullTextSearchIri(FTS_LUCENE.stringValue());
                 break;
             case REMOTE:
+                // Local KBs are read-only
+                kbModel.getObject().getKb().setReadOnly(true);
                 // remote KBs are by default not using FTS but if we apply a remote DB profile,
                 // then it will set the FTS according to the setting in the profile
                 kbModel.getObject().getKb().setFullTextSearchIri(FTS_NONE.stringValue());


### PR DESCRIPTION
**What's in the PR**
- Move default setting of read-only flag to a different location
- For local KBs, temporarily make the KB writable while updating the base properties

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
