### PR TITLE
#4215 - Ability to specify GID and UID for the user used inside the Docker image

### DIFF
--- a/inception/inception-docker/src/main/docker/Dockerfile
+++ b/inception/inception-docker/src/main/docker/Dockerfile
@@ -8,28 +8,45 @@ FROM eclipse-temurin:17
 
 MAINTAINER INCEpTION Team
 
+# Define network ports
+EXPOSE 8080
+
 # make sure INCEpTION is running in en_US.UTF-8 locale
 RUN set -ex \
-      && DEBIAN_FRONTEND=noninteractive \
-      && apt-get update \
-      && apt-get install -y --no-install-recommends locales \
-      && apt-get upgrade -y
+    && DEBIAN_FRONTEND=noninteractive \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends locales \
+    && apt-get upgrade -y
+
+# Set up language
 RUN set -ex \
-      && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
-      && dpkg-reconfigure --frontend=noninteractive locales \
-      && update-locale LANG=en_US.UTF-8
+    && sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
+    && dpkg-reconfigure --frontend=noninteractive locales \
+    && update-locale LANG=en_US.UTF-8
 ENV LANG en_US.UTF-8
 
+# Install application JAR
 WORKDIR /opt/inception
-
 COPY @docker.jarfile@ inception-app-standalone.jar
+COPY launch.sh .
 
-# this will be the INCEpTION home folder
+# Set up user, group and home folder permissions
+ENV APP_USER=inception
+ENV APP_UID=2000
+ENV APP_GROUP=inception
+ENV APP_GID=2000
+RUN groupadd -g ${APP_GID} ${APP_GROUP} \ 
+    && useradd -m \
+      -d /opt/inception  \
+      -s /bin/bash  \
+      -g ${APP_GROUP} -u ${APP_UID} ${APP_USER} \
+    && chown -R ${APP_USER}:${APP_GROUP} /opt/inception \
+    && chmod +x launch.sh
+
+# Set up application data folder
 RUN mkdir /export
 VOLUME /export
 
-EXPOSE 8080
-
+# Launch application
 ENV JAVA_OPTS="-Xmx750m"
-
-CMD java ${JAVA_OPTS} -Djava.awt.headless=true -Dinception.home=/export -jar inception-app-standalone.jar
+CMD /opt/inception/launch.sh java ${JAVA_OPTS} -Djava.awt.headless=true -Dinception.home=/export -jar inception-app-standalone.jar

--- a/inception/inception-docker/src/main/docker/launch.sh
+++ b/inception/inception-docker/src/main/docker/launch.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Licensed to the Technische Universität Darmstadt under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The Technische Universität Darmstadt 
+# licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.
+#  
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -x
+
+# Update the user and group IDs for an existing user
+echo "Updating UID [$APP_UID] and GID [$APP_GID] for user [$APP_USER] and group [$APP_GROUP]..."
+usermod -u "$APP_UID" "$APP_USER"
+groupmod -g "$APP_GID" "$APP_GROUP"
+
+# Change the ownership of application files
+echo "Updating file ownership user inception - this may take a moment..."
+chown -R "$APP_USER":"$APP_GROUP" /opt/inception
+chown -R "$APP_USER":"$APP_GROUP" /export
+
+# Run application as the application user
+echo "Launching application..."
+COMMAND="$(which $1)" 
+shift
+ARGUMENTS="$(printf "\"%s\" " "$@")"
+exec su -l -c "${COMMAND} ${ARGUMENTS}" "$APP_USER"


### PR DESCRIPTION
**What's in the PR**
- Added ENV variables to define the APP_UID and APP_GID
- Added a wrapper boot script which ensures that all relevant files belong to these UID/GID

**How to test manually**
* Build INCEpTION (`mvn clean install -DskipTests`)
* Build the Docker image in `inception/inception-docker` using `mvn -Pdocker clean docker:build`
* Run the image using e.g. `docker run -e APP_UID=1234 -e APP_GID=4321 -it ghcr.io/inception-project/inception-snapshots:latest`
* Check that the UID/GID used by the INCEpTION process and files are as specified

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
