### PR TITLE
#4223 - Covered text should show in popover

### DIFF
--- a/inception/inception-brat-editor/src/main/ts/src/util/Util.ts
+++ b/inception/inception-brat-editor/src/main/ts/src/util/Util.ts
@@ -106,12 +106,12 @@ export class Util {
     return str.replace(/"/g, '&quot;')
   }
 
-  getSpanLabels (spanTypes, spanType) {
+  getSpanLabels (spanTypes: Record<string, EntityTypeDto>, spanType: string) : string[] {
     const type = spanTypes[spanType]
     return (type && type.labels) || []
   }
 
-  spanDisplayForm (spanTypes, spanType) {
+  spanDisplayForm (spanTypes: Record<string, EntityTypeDto>, spanType: string) : string {
     const labels = this.getSpanLabels(spanTypes, spanType)
     if (labels[0]) {
       return labels[0]

--- a/inception/inception-brat-editor/src/main/ts/src/visualizer/Visualizer.ts
+++ b/inception/inception-brat-editor/src/main/ts/src/visualizer/Visualizer.ts
@@ -3545,6 +3545,7 @@ export class Visualizer {
     if (evt.target) {
       const fakeSpan = new Span()
       fakeSpan.vid = id
+      fakeSpan.document = { text: this.data.text }
       fakeSpan.layer = { id: span.type, name: Util.spanDisplayForm(this.entityTypes, span.type) }
       evt.target.dispatchEvent(new AnnotationOverEvent(fakeSpan, evt.originalEvent))
     }

--- a/inception/inception-diam-editor/src/main/ts/src/SpanText.svelte
+++ b/inception/inception-diam-editor/src/main/ts/src/SpanText.svelte
@@ -35,7 +35,9 @@
 {#if text.length === 0}
     <span class="text-muted">(empty)</span>
 {:else if text.length > maxLength}
-    <span title="{text.substring(0,1000)}">{text.substring(0, 50)}</span>
+    <!-- The AnnotationDetailPopOver displays the text now provided that the lazy detail provider
+         of the span layer sends it. - title="{text.substring(0,1000)}" -->
+    <span>{text.substring(0, 50)}</span>
     <span class="text-muted trailing-text">…</span>
 {:else}
     {text}

--- a/inception/inception-js-api/src/main/ts/src/model/Annotation.ts
+++ b/inception/inception-js-api/src/main/ts/src/model/Annotation.ts
@@ -15,9 +15,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { VID, Comment, Layer } from '.'
+import { VID, Comment, Layer, AnnotatedText } from '.'
 
 export interface Annotation {
+    document: AnnotatedText
+
     layer: Layer
 
     vid: VID

--- a/inception/inception-js-api/src/main/ts/src/model/Relation.ts
+++ b/inception/inception-js-api/src/main/ts/src/model/Relation.ts
@@ -15,9 +15,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Annotation, VID, Argument, Layer, Comment } from '.'
+import { Annotation, VID, Argument, Layer, Comment, AnnotatedText } from '.'
 
 export class Relation implements Annotation {
+  document: AnnotatedText
   layer: Layer
   vid: VID
   color?: string
@@ -25,4 +26,16 @@ export class Relation implements Annotation {
   score?: number
   comments?: Comment[]
   arguments: Array<Argument>
+
+  constructor (other?: Relation) {
+    if (other) {
+      this.document = other.document
+      this.layer = other.layer
+      this.vid = other.vid
+      this.color = other.color
+      this.label = other.label
+      this.comments = other.comments
+      this.arguments = other.arguments
+    }
+  }
 }

--- a/inception/inception-js-api/src/main/ts/src/model/Span.ts
+++ b/inception/inception-js-api/src/main/ts/src/model/Span.ts
@@ -15,12 +15,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Annotation, Offsets, VID, Comment } from '.'
+import { Annotation, Offsets, VID, Comment, AnnotatedText } from '.'
 import { Layer } from './Layer'
 
 export type ClippingStatus = undefined | 's' | 'e' | 'se'
 
 export class Span implements Annotation {
+  document: AnnotatedText
   layer: Layer
   vid: VID
   offsets: Array<Offsets>
@@ -36,6 +37,7 @@ export class Span implements Annotation {
 
   constructor (other?: Span) {
     if (other) {
+      this.document = other.document
       this.layer = other.layer
       this.vid = other.vid
       this.offsets = other.offsets

--- a/inception/inception-js-api/src/main/ts/src/model/compact_v2/CompactRelation.ts
+++ b/inception/inception-js-api/src/main/ts/src/model/compact_v2/CompactRelation.ts
@@ -29,6 +29,7 @@ export type CompactRelation = [
 
 export function unpackCompactRelation (doc: AnnotatedText, raw: CompactRelation): Relation {
   const cooked = new Relation()
+  cooked.document = doc
   cooked.layer = doc.__getOrCreateLayer(raw[0])
   cooked.vid = raw[1]
   cooked.arguments = raw[2].map(arg => unpackCompactArgument(doc, arg))

--- a/inception/inception-js-api/src/main/ts/src/model/compact_v2/CompactSpan.ts
+++ b/inception/inception-js-api/src/main/ts/src/model/compact_v2/CompactSpan.ts
@@ -28,6 +28,7 @@ export type CompactSpan = [
 
 export function unpackCompactSpan (doc: AnnotatedText, raw: CompactSpan): Span {
   const cooked = new Span()
+  cooked.document = doc
   cooked.layer = doc.__getOrCreateLayer(raw[0])
   cooked.vid = raw[1]
   cooked.offsets = raw[2]

--- a/inception/inception-js-api/src/main/ts/src/widget/AnnotationDetailPopOver.svelte
+++ b/inception/inception-js-api/src/main/ts/src/widget/AnnotationDetailPopOver.svelte
@@ -127,7 +127,7 @@
         const y = e.clientY;
 
         // Flip up if the popover is about to be clipped at the bottom
-        if (y + rect.height > window.innerHeight) {
+        if (y + rect.height + yOffset > window.innerHeight) {
             top = y - rect.height - yOffset;
         } else {
             top = y + yOffset;


### PR DESCRIPTION
**What's in the PR**
- Move the text from the HTML tooltip into the popover
- Show the text in all popovers, not only on the left annotation sidebar
- If the text is shown is controlled by the "show in hover" layer setting
- Extend client-side annotations with a reference to their respective document

**How to test manually**
* Try the right annotation sidebar in both modes and see if the popover replaces the HTML tooltip well

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation

**Screenshots**
<img width="681" alt="Screenshot 2023-10-03 at 11 04 17" src="https://github.com/inception-project/inception/assets/1410238/6003a594-93ca-48c1-a3e5-7d964f71b9bd">

<img width="653" alt="Screenshot 2023-10-03 at 11 03 58" src="https://github.com/inception-project/inception/assets/1410238/50252138-55e1-462e-a248-8e3e41c9cd54">

