### PR TITLE
#4226 - Display logout button on annotation page if dashboard access is disabled

### DIFF
--- a/inception/inception-bootstrap/src/main/ts/bootstrap/inception-actionbar.scss
+++ b/inception/inception-bootstrap/src/main/ts/bootstrap/inception-actionbar.scss
@@ -26,7 +26,7 @@
   align-items: center;
   
   @include media-breakpoint-down(xl) {
-    font-size: 1vw !important;
+    font-size: 1.3vw !important;
   }
 
   @include media-breakpoint-down(xl) {
@@ -34,25 +34,6 @@
       // Bootstrap forces the font size in btns but we want buttons in the action bar to follow
       // the action bar scaling
       font-size: inherit !important;
-    }
-  }
-
-  @include media-breakpoint-down(lg) {
-    .btn {
-      padding-left: calc($input-btn-padding-x / 2);
-      padding-right: calc($input-btn-padding-x / 2);
-    }
-  }
-
-  > * {
-    padding-left: calc($grid-gutter-width / 4);
-    padding-right: calc($grid-gutter-width / 4);
-  }
-
-  @include media-breakpoint-down(xl) {
-    > * {
-      padding-left: calc($grid-gutter-width / 8);
-      padding-right: calc($grid-gutter-width / 8);
     }
   }
   
@@ -65,32 +46,23 @@
   
   .btn-action-bar {
     @extend .btn-outline-secondary;
+    
+    @include media-breakpoint-down(xl) {
+      --bs-btn-padding-x: 1vw !important;
+      --bs-btn-padding-y: 0.55vw !important;
+    }
   }
     
   .action-bar-group {
-    padding: 2px;
+    margin-left: 0.25rem;
+    margin-right: 0.25rem;
+    padding-top: 0.25rem;
+    padding-bottom: 0.25rem;
     background-color: var(--bs-light-border-subtle);
-    border-radius: 5px;
+    border-radius: var(--bs-border-radius);
     display: flex;
     flex-direction: row;
     align-items: center;
     flex: 0;
-
-    > * {
-      padding-left: calc($grid-gutter-width / 8);
-      padding-right: calc($grid-gutter-width / 8);
-    }
-
-    @include media-breakpoint-down(xl) {
-      > * {
-        padding-left: calc($grid-gutter-width / 16);
-        padding-right: calc($grid-gutter-width / 16);
-      }
-    }
-  }
-  
-  .action-bar-group-title {
-    padding-left: calc($grid-gutter-width / 2);
-    padding-right: calc($grid-gutter-width / 2);
   }
 }

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/closesession/CloseSessionActionBarExtension.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/closesession/CloseSessionActionBarExtension.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Technische UniversitÃ¤t Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische UniversitÃ¤t Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.closesession;
+
+import org.apache.wicket.markup.html.panel.Panel;
+import org.springframework.core.annotation.Order;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.actionbar.ActionBarExtension;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
+import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.config.AnnotationUIAutoConfiguration;
+import de.tudarmstadt.ukp.inception.ui.core.menubar.MenuBar;
+
+/**
+ * <p>
+ * This class is exposed as a Spring Component via
+ * {@link AnnotationUIAutoConfiguration#annotationCloseSessionActionBarExtension}.
+ * </p>
+ */
+@Order(10000)
+public class CloseSessionActionBarExtension
+    implements ActionBarExtension
+{
+    @Override
+    public boolean accepts(AnnotationPageBase aPage)
+    {
+        return aPage.visitChildren(MenuBar.class, (c, v) -> {
+            v.stop(!((MenuBar) c).isVisible());
+        });
+    }
+
+    @Override
+    public Panel createActionBarItem(String aId, AnnotationPageBase aPage)
+    {
+        return new CloseSessionPanel(aId, aPage);
+    }
+}

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/closesession/CloseSessionPanel.html
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/closesession/CloseSessionPanel.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
 <!--
-  Licensed to the Technische Universität Darmstadt under one
+  Licensed to the Technische UniversitÃ¤t Darmstadt under one
   or more contributor license agreements.  See the NOTICE file
   distributed with this work for additional information
-  regarding copyright ownership.  The Technische Universität Darmstadt 
+  regarding copyright ownership.  The Technische UniversitÃ¤t Darmstadt 
   licenses this file to you under the Apache License, Version 2.0 (the
   "License"); you may not use this file except in compliance
   with the License.
@@ -17,11 +17,22 @@
   limitations under the License.
 -->
 <html xmlns:wicket="http://wicket.apache.org">
+
 <body>
   <wicket:panel>
-    <wicket:container wicket:id="items">
-      <wicket:container wicket:id="item"/>
-    </wicket:container>
+    <div class="d-flex flex-grow-1">
+      <div class="flex-grow-1" />
+      <div class="action-bar-group">
+        <div class="btn-group">
+          <button wicket:id="logoutButton" class="btn btn-action-bar" type="button" wicket:message="title:logOut">
+            <div class="text-nowrap">
+              <i class="fas fa-sign-out-alt"/>
+            </div>
+          </button>
+        </div>
+      </div>
+    </div>
   </wicket:panel>
 </body>
+
 </html>

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/closesession/CloseSessionPanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/closesession/CloseSessionPanel.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Technische UniversitÃ¤t Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische UniversitÃ¤t Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.closesession;
+
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.spring.injection.annot.SpringBean;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
+import de.tudarmstadt.ukp.clarin.webanno.security.config.LoginProperties;
+import de.tudarmstadt.ukp.clarin.webanno.security.config.PreauthenticationProperties;
+import de.tudarmstadt.ukp.clarin.webanno.support.lambda.LambdaAjaxLink;
+import de.tudarmstadt.ukp.clarin.webanno.ui.core.logout.LogoutPanel;
+
+public class CloseSessionPanel
+    extends Panel
+{
+    private static final long serialVersionUID = -9213541738534665790L;
+
+    private @SpringBean PreauthenticationProperties preauthenticationProperties;
+    private @SpringBean LoginProperties securityProperties;
+
+    public CloseSessionPanel(String aId, AnnotationPageBase aPage)
+    {
+        super(aId);
+        queue(new LambdaAjaxLink("logoutButton", this::actionLogout));
+    }
+
+    private void actionLogout(AjaxRequestTarget aTarget)
+    {
+        LogoutPanel.actionLogout(this, preauthenticationProperties, securityProperties);
+    }
+}

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/config/AnnotationUIAutoConfiguration.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/config/AnnotationUIAutoConfiguration.java
@@ -30,6 +30,7 @@ import org.springframework.context.annotation.Lazy;
 import de.tudarmstadt.ukp.clarin.webanno.api.ProjectService;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.AnnotationPageMenuItem;
+import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.closesession.CloseSessionActionBarExtension;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.AnnotationUndoActionBarExtension;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.actions.ChainAnnotationActionUndoSupport;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.undo.actions.FeatureValueActionUndoSupport;
@@ -84,5 +85,11 @@ public class AnnotationUIAutoConfiguration
     public FeatureValueActionUndoSupport featureValueActionUndoSupport()
     {
         return new FeatureValueActionUndoSupport();
+    }
+    
+    @Bean
+    public CloseSessionActionBarExtension closeSessionActionBarExtension()
+    {
+        return new CloseSessionActionBarExtension();
     }
 }

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.properties
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.properties
@@ -40,6 +40,7 @@ redo=Redo
 moveUp=Up
 moveDown=Down
 busy=Busy...
+logOut=Log out
 
 enabled=Enabled
 

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/login/LoginPage.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/login/LoginPage.java
@@ -82,7 +82,7 @@ import de.tudarmstadt.ukp.inception.support.markdown.MarkdownLabel;
 public class LoginPage
     extends ApplicationPageBase
 {
-    private static final String PARAM_SKIP_AUTP_LOGIN = "skipAutoLogin";
+    public static final String PARAM_SKIP_AUTO_LOGIN = "skipAutoLogin";
     private static final String PARAM_ERROR = "error";
 
     private static final String PROP_RESTORE_DEFAULT_ADMIN_ACCOUNT = "restoreDefaultAdminAccount";
@@ -124,7 +124,7 @@ public class LoginPage
         saml2LoginPanel.add(visibleWhen(this::isLoginAllowed));
         queue(saml2LoginPanel);
 
-        var skipAutoLogin = aParameters.get(PARAM_SKIP_AUTP_LOGIN).toBoolean(false)
+        var skipAutoLogin = aParameters.get(PARAM_SKIP_AUTO_LOGIN).toBoolean(false)
                 || tooManyUsers.getObject();
 
         // Failed OAuth2/SAML call this page with the parameter `?error` so we display a message

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/logout/LogoutPanel.html
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/logout/LogoutPanel.html
@@ -34,7 +34,7 @@
         <a class="nav-link" wicket:id="logout">
           <i class="fas fa-sign-out-alt"></i>
           <span class="nav-link active p-0 d-none d-md-inline">
-            Log out
+            <wicket:message key="logOut"/>
           </span>
         </a>
       </div>


### PR DESCRIPTION
**What's in the PR**
- Added logout button to the annotation action bar if the menu bar is not accessible
- If menubar is accessible, the logout button should always be there
- If logging out while auto-login is enabled, make sure to pass the skip-auto-login parameter to the login page
- Allow items in the annotation action bar to grow which allows the logout button to be positioned at the far right
- Improve scaling of the annotation action bar when window is resized

**How to test manually**
* Try annotation page with menu bar enabled / disabled
* Try logout button on the annotation page

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
