### PR TITLE
#4235 - Direct access-by-URL to sidebar curation mode sometimes does not work

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/events/PreparingToOpenDocumentEvent.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/events/PreparingToOpenDocumentEvent.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.annotation.events;
+
+import org.springframework.context.ApplicationEvent;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.clarin.webanno.support.wicket.event.HybridApplicationUIEvent;
+import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
+
+/**
+ * Fire this event to give listeners a chance to look at or even modify the {@link AnnotatorState}
+ * before actually loading the data.
+ */
+public class PreparingToOpenDocumentEvent
+    extends ApplicationEvent
+    implements HybridApplicationUIEvent
+{
+    private static final long serialVersionUID = -5971290341142438144L;
+
+    private final SourceDocument document;
+    // user who owns/annotates the opened document
+    private final String documentOwner;
+    // user who opened the document
+    private final String sessionOwner;
+
+    public PreparingToOpenDocumentEvent(AnnotationPageBase aSource, SourceDocument aDocument,
+            String aDocumentOwner, String aSessionOwner)
+    {
+        super(aSource);
+        document = aDocument;
+        documentOwner = aDocumentOwner;
+        sessionOwner = aSessionOwner;
+    }
+
+    public SourceDocument getDocument()
+    {
+        return document;
+    }
+
+    public String getSessionOwner()
+    {
+        return sessionOwner;
+    }
+
+    public String getDocumentOwner()
+    {
+        return documentOwner;
+    }
+
+    @Override
+    public AnnotationPageBase getSource()
+    {
+        return (AnnotationPageBase) super.getSource();
+    }
+}

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingPropertiesImpl.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingPropertiesImpl.java
@@ -24,6 +24,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.event.AfterCasWrittenEvent;
 import de.tudarmstadt.ukp.inception.annotation.events.BeforeDocumentOpenedEvent;
+import de.tudarmstadt.ukp.inception.annotation.events.PreparingToOpenDocumentEvent;
 
 @ConfigurationProperties("event-logging")
 public class EventLoggingPropertiesImpl
@@ -37,6 +38,7 @@ public class EventLoggingPropertiesImpl
             AvailabilityChangeEvent.class.getSimpleName(), //
             "RecommenderTaskNotificationEvent", //
             BeforeDocumentOpenedEvent.class.getSimpleName(), //
+            PreparingToOpenDocumentEvent.class.getSimpleName(), //
             "BrokerAvailabilityEvent", //
             "ShutdownDialogAvailableEvent");
 

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
@@ -85,6 +85,7 @@ import de.tudarmstadt.ukp.inception.annotation.events.AnnotationEvent;
 import de.tudarmstadt.ukp.inception.annotation.events.BeforeDocumentOpenedEvent;
 import de.tudarmstadt.ukp.inception.annotation.events.DocumentOpenedEvent;
 import de.tudarmstadt.ukp.inception.annotation.events.FeatureValueUpdatedEvent;
+import de.tudarmstadt.ukp.inception.annotation.events.PreparingToOpenDocumentEvent;
 import de.tudarmstadt.ukp.inception.documents.DocumentAccess;
 import de.tudarmstadt.ukp.inception.editor.AnnotationEditorBase;
 import de.tudarmstadt.ukp.inception.editor.AnnotationEditorExtensionRegistry;
@@ -123,7 +124,7 @@ public class AnnotationPage
     private @SpringBean PreferencesService preferencesService;
     private @SpringBean DocumentAccess documentAccess;
 
-    private long currentprojectId;
+    private long currentProjectId;
 
     private WebMarkupContainer centerArea;
     private WebMarkupContainer actionBar;
@@ -135,15 +136,22 @@ public class AnnotationPage
     {
         super(aPageParameters);
 
-        LOG.debug("Setting up annotation page with parameters: {}", aPageParameters);
-
-        AnnotatorState state = new AnnotatorStateImpl(Mode.ANNOTATION);
+        var state = new AnnotatorStateImpl(Mode.ANNOTATION);
         state.setUser(userRepository.getCurrentUser());
         setModel(Model.of(state));
 
-        StringValue document = aPageParameters.get(PAGE_PARAM_DOCUMENT);
-        StringValue focus = aPageParameters.get(PAGE_PARAM_FOCUS);
-        StringValue user = aPageParameters.get(PAGE_PARAM_USER);
+        // AnnotationPageBase will push the document and user parameters into the URL fragment so
+        // we can afterwards navigate between documents freely. When AnnotationPageBase
+        // does that, it restarts the request. So basically when we get here, PAGE_PARAM_DOCUMENT
+        // will always be `null`... PAGE_PARAM_DATA_OWNER may be non-null if it is set without a
+        // document being specified - but in that case it is pretty useless
+        //
+        // The actual loading of the documents will be handled by onParameterArrival in the
+        // UrlFragmentBehavior which will call handleParameters again, this time with the right
+        // information.
+        var document = aPageParameters.get(PAGE_PARAM_DOCUMENT);
+        var focus = aPageParameters.get(PAGE_PARAM_FOCUS);
+        var user = aPageParameters.get(PAGE_PARAM_DATA_OWNER);
 
         handleParameters(document, focus, user);
 
@@ -420,32 +428,44 @@ public class AnnotationPage
 
     protected void actionLoadDocument(AjaxRequestTarget aTarget, int aFocus)
     {
-        LOG.trace("BEGIN LOAD_DOCUMENT_ACTION at focus " + aFocus);
-
         try {
-            AnnotatorState state = getModelObject();
+            var sessionOwner = userRepository.getCurrentUser().getUsername();
+
+            var state = getModelObject();
             if (state.getUser() == null) {
                 state.setUser(userRepository.getCurrentUser());
             }
+
+            LOG.trace("Preparing to open document {}@{} {}", state.getUser(), state.getDocument(),
+                    aFocus);
             state.reset();
+            applicationEventPublisherHolder.get().publishEvent(
+                    new PreparingToOpenDocumentEvent(this, getModelObject().getDocument(),
+                            getModelObject().getUser().getUsername(), sessionOwner));
+
+            // INFO BOUNDARY ---------------------------------------------------------------
+            // PreparingToOpenDocumentEvent has the option to change the annotator state.
+            // No information from the annotator state read before this point may be
+            // used afterwards. Information has to be re-read from the annotator state to get
+            // the latest values.
 
             // Check if there is an annotation document entry in the database. If there is none,
             // create one.
-            AnnotationDocument annotationDocument = documentService
+            LOG.trace("Opening document {}@{} {}", state.getUser(), state.getDocument(), aFocus);
+            var annotationDocument = documentService
                     .createOrGetAnnotationDocument(state.getDocument(), state.getUser());
             var stateBeforeOpening = annotationDocument.getState();
 
             // Read the CAS
             // Update the annotation document CAS
-            CAS editorCas = documentService.readAnnotationCas(annotationDocument,
+            var editorCas = documentService.readAnnotationCas(annotationDocument,
                     FORCE_CAS_UPGRADE);
 
-            boolean editable = isEditable();
+            var editable = isEditable();
             applicationEventPublisherHolder.get()
                     .publishEvent(new BeforeDocumentOpenedEvent(this, editorCas,
                             getModelObject().getDocument(),
-                            getModelObject().getUser().getUsername(),
-                            userRepository.getCurrentUser().getUsername(), editable));
+                            getModelObject().getUser().getUsername(), sessionOwner, editable));
 
             if (editable) {
                 // After creating an new CAS or upgrading the CAS, we need to save it. If the
@@ -467,9 +487,9 @@ public class AnnotationPage
             loadPreferences();
 
             // if project is changed, reset some project specific settings
-            if (currentprojectId != state.getProject().getId()) {
+            if (currentProjectId != state.getProject().getId()) {
                 state.clearRememberedFeatures();
-                currentprojectId = state.getProject().getId();
+                currentProjectId = state.getProject().getId();
             }
 
             // Set the actual editor component. This has to happen *before* any AJAX refreshes are
@@ -518,16 +538,16 @@ public class AnnotationPage
                 WicketUtil.refreshPage(aTarget, getPage());
             }
 
-            applicationEventPublisherHolder.get().publishEvent(
-                    new DocumentOpenedEvent(this, editorCas, getModelObject().getDocument(),
-                            stateBeforeOpening, getModelObject().getUser().getUsername(),
-                            userRepository.getCurrentUser().getUsername()));
+            LOG.trace("Document opened {}@{} {}", state.getUser(), state.getDocument(), aFocus);
+
+            applicationEventPublisherHolder.get()
+                    .publishEvent(new DocumentOpenedEvent(this, editorCas,
+                            getModelObject().getDocument(), stateBeforeOpening,
+                            getModelObject().getUser().getUsername(), sessionOwner));
         }
         catch (Exception e) {
             handleException(aTarget, e);
         }
-
-        LOG.trace("END LOAD_DOCUMENT_ACTION");
     }
 
     @Override
@@ -555,21 +575,24 @@ public class AnnotationPage
     protected void handleParameters(StringValue aDocumentParameter, StringValue aFocusParameter,
             StringValue aUserParameter)
     {
-        User user = userRepository.getCurrentUser();
-        requireAnyProjectRole(user);
+        var sessionOwner = userRepository.getCurrentUser();
+        requireAnyProjectRole(sessionOwner);
 
-        AnnotatorState state = getModelObject();
-        Project project = getProject();
-        SourceDocument doc = getDocumentFromParameters(project, aDocumentParameter);
+        var state = getModelObject();
+        var project = getProject();
+        var doc = getDocumentFromParameters(project, aDocumentParameter);
 
         // If there is no change in the current document, then there is nothing to do. Mind
         // that document IDs are globally unique and a change in project does not happen unless
         // there is also a document change.
+        String dataOwner = state.getUser().getUsername();
         if (doc != null && //
                 doc.equals(state.getDocument()) && //
                 aFocusParameter.toInt(0) == state.getFocusUnitIndex() && //
-                state.getUser().getUsername().equals(aUserParameter.toString()) //
+                dataOwner.equals(aUserParameter.toString()) //
         ) {
+            LOG.trace("Page parameters match page state ({}@{} {}) - nothing to do", dataOwner,
+                    state.getDocument(), state.getFocusUnitIndex());
             return;
         }
 
@@ -584,46 +607,47 @@ public class AnnotationPage
             // state.setUser(new User(CURATION_USER));
             // }
             // else {
-            User requestedUser = userRepository.get(aUserParameter.toString());
+            var requestedUser = userRepository.get(aUserParameter.toString());
             if (requestedUser == null) {
                 failWithDocumentNotFound("User not found [" + aUserParameter + "]");
             }
             else {
+                LOG.trace("Changing data owner: {}", requestedUser);
                 state.setUser(requestedUser);
             }
             // }
         }
 
-        if (doc != null && !documentAccess.canViewAnnotationDocument(user.getUsername(),
+        if (doc != null && !documentAccess.canViewAnnotationDocument(sessionOwner.getUsername(),
                 String.valueOf(project.getId()), doc.getId(), state.getUser().getUsername())) {
             failWithDocumentNotFound("Access to document [" + aDocumentParameter + "] in project ["
-                    + project.getName() + "] as denied");
+                    + project.getName() + "] is denied");
         }
 
         // If we arrive here and the document is not null, then we have a change of document
         // or a change of focus (or both)
         if (doc != null && !doc.equals(state.getDocument())) {
+            LOG.trace("Changing document: {} (prev: {})", doc, state.getDocument());
             state.setDocument(doc, getListOfDocs());
         }
     }
 
     @Override
     protected void updateDocumentView(AjaxRequestTarget aTarget, SourceDocument aPreviousDocument,
-            User aPreviousUser, StringValue aFocusParameter)
+            User aPreviousDataOwner, StringValue aFocusParameter)
     {
-        // url is from external link, not just paging through documents,
+        // URL is from external link, not just paging through documents,
         // tabs may have changed depending on user rights
         if (aTarget != null && aPreviousDocument == null) {
+            LOG.trace(
+                    "Refreshing left sidebar as this is the first document loaded on this page instance");
             leftSidebar.refreshTabs(aTarget);
         }
 
-        SourceDocument currentDocument = getModelObject().getDocument();
-        if (currentDocument == null) {
-            return;
-        }
-
-        User currentUser = getModelObject().getUser();
-        if (currentUser == null) {
+        var currentDocument = getModelObject().getDocument();
+        var dataOwner = getModelObject().getUser();
+        if (currentDocument == null || dataOwner == null) {
+            LOG.trace("No document open");
             return;
         }
 
@@ -640,15 +664,20 @@ public class AnnotationPage
         // that document IDs are globally unique and a change in project does not happen unless
         // there is also a document change.
         if (aPreviousDocument != null && aPreviousDocument.equals(currentDocument) && //
-                aPreviousUser != null && aPreviousUser.equals(currentUser) && //
+                aPreviousDataOwner != null && aPreviousDataOwner.equals(dataOwner) && //
                 focus == getModelObject().getFocusUnitIndex() //
         ) {
+            LOG.trace("Document and data owner have not changed: {}@{}", dataOwner,
+                    currentDocument);
             return;
         }
 
         // never had set a document or is a new one
         if (aPreviousDocument == null || !aPreviousDocument.equals(currentDocument)
-                || aPreviousUser == null || !aPreviousUser.equals(currentUser)) {
+                || aPreviousDataOwner == null || !aPreviousDataOwner.equals(dataOwner)) {
+            LOG.trace(
+                    "Document or data owner have changed (old: {}@{}, new: {}@{}) - loading document",
+                    aPreviousDataOwner, aPreviousDocument, dataOwner, currentDocument);
             actionLoadDocument(aTarget, focus);
             return;
         }

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/page/ApplicationPageBase.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/page/ApplicationPageBase.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.ui.core.page;
 
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
@@ -60,7 +61,7 @@ import de.tudarmstadt.ukp.inception.ui.core.darkmode.DarkModeWrapper;
 public abstract class ApplicationPageBase
     extends WebPage
 {
-    private final static Logger LOG = LoggerFactory.getLogger(ApplicationPageBase.class);
+    private final static Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private static final long serialVersionUID = -1690130604031181803L;
 
@@ -85,9 +86,13 @@ public abstract class ApplicationPageBase
         commonInit();
     }
 
-    protected ApplicationPageBase(final PageParameters parameters)
+    protected ApplicationPageBase(final PageParameters aPageParameters)
     {
-        super(parameters);
+        super(aPageParameters);
+
+        LOG.debug("Setting up page [{}] with parameters: {}", this.getClass().getName(),
+                aPageParameters);
+
         commonInit();
     }
 

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/CurationPage.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/CurationPage.java
@@ -660,7 +660,7 @@ public class CurationPage
     protected void updateDocumentView(AjaxRequestTarget aTarget, SourceDocument aPreviousDocument,
             User aPreviousUser, StringValue aFocusParameter)
     {
-        SourceDocument currentDocument = getModelObject().getDocument();
+        var currentDocument = getModelObject().getDocument();
         if (currentDocument == null) {
             return;
         }

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebarBehavior.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebarBehavior.java
@@ -27,14 +27,17 @@ import org.apache.wicket.Component;
 import org.apache.wicket.RestartResponseException;
 import org.apache.wicket.behavior.Behavior;
 import org.apache.wicket.event.IEvent;
-import org.apache.wicket.request.cycle.RequestCycle;
+import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.AnnotationPage;
-import de.tudarmstadt.ukp.inception.annotation.events.BeforeDocumentOpenedEvent;
+import de.tudarmstadt.ukp.inception.annotation.events.PreparingToOpenDocumentEvent;
 
 public class CurationSidebarBehavior
     extends Behavior
@@ -54,120 +57,97 @@ public class CurationSidebarBehavior
     private @SpringBean UserDao userService;
 
     @Override
-    public void onConfigure(Component aComponent)
-    {
-        super.onConfigure(aComponent);
-
-        var page = aComponent.getPage();
-        if (!(page instanceof AnnotationPage)) {
-            return;
-        }
-
-        var annotationPage = (AnnotationPage) page;
-
-        if (annotationPage.getModelObject().getDocument() == null) {
-            return;
-        }
-
-        handleCurationSessionPageParameters(annotationPage);
-
-        handleWrongAnnotatorUserInState(annotationPage);
-    }
-
-    @Override
     public void onEvent(Component aComponent, IEvent<?> aEvent)
     {
-        if (aEvent.getPayload() instanceof BeforeDocumentOpenedEvent) {
-            var event = (BeforeDocumentOpenedEvent) aEvent.getPayload();
-            var page = event.getRequestTarget().getPage();
-
-            if (!(page instanceof AnnotationPage)) {
-                return;
-            }
-
-            var annotationPage = (AnnotationPage) page;
-
-            handleCurationSessionPageParameters(annotationPage);
-
-            handleWrongAnnotatorUserInState(annotationPage);
+        if (!(aEvent.getPayload() instanceof PreparingToOpenDocumentEvent)) {
+            return;
         }
-    }
 
-    private void handleWrongAnnotatorUserInState(AnnotationPage aPage)
-    {
-        if (isViewingPotentialCurationTarget(aPage) && isSessionActive(aPage)) {
-            var sessionOwner = userService.getCurrentUsername();
-            var state = aPage.getModelObject();
+        var event = (PreparingToOpenDocumentEvent) aEvent.getPayload();
 
-            // If curation is possible and the curation target user is different from the user set
-            // in the annotation state, then we need to update the state and reload.
-            var curationTarget = curationSidebarService.getCurationTargetUser(sessionOwner,
-                    state.getProject().getId());
-            if (!state.getUser().equals(curationTarget)) {
-                LOG.trace("Wrong user in state, setting and reloading");
-                state.setUser(curationTarget);
-                aPage.actionLoadDocument(null);
-                RequestCycle.get().setResponsePage(aPage);
-            }
+        var page = event.getSource();
+
+        if (!(page instanceof AnnotationPage)) {
+            // Only applies to the AnnotationPage - not to the CurationPage!
+            return;
         }
-    }
 
-    private void handleCurationSessionPageParameters(AnnotationPage aPage)
-    {
-        var params = aPage.getPageParameters();
+        var params = page.getPageParameters();
 
-        var curationSessionParameterValue = params.get(PARAM_CURATION_SESSION);
-        var curationTargetOwnParameterValue = params.get(PARAM_CURATION_TARGET_OWN);
-        var project = aPage.getModelObject().getProject();
         var sessionOwner = userService.getCurrentUsername();
+        var doc = event.getDocument();
+        var project = doc.getProject();
+        var dataOwner = event.getDocumentOwner();
 
-        switch (curationSessionParameterValue.toString(STAY)) {
-        case ON:
-            LOG.trace("Checking if to start curation session");
-            // Start a new session or switch to new curation target
-            if (!isSessionActive(aPage) || !curationTargetOwnParameterValue.isEmpty()) {
-                curationSidebarService.startSession(sessionOwner, project,
-                        curationTargetOwnParameterValue.toBoolean(false));
-            }
-            break;
-        case OFF:
-            LOG.trace("Checking if to stop curation session");
-            if (isSessionActive(aPage)) {
-                curationSidebarService.closeSession(sessionOwner, project.getId());
-            }
-            break;
-        default:
-            // Ignore
-        }
+        handleSessionActivation(page, params, doc, sessionOwner);
 
-        if (!curationSessionParameterValue.isEmpty()) {
-            LOG.trace("Reloading page without session parameters");
-            params.remove(PARAM_CURATION_TARGET_OWN);
-            params.remove(PARAM_CURATION_SESSION);
-            setProjectPageParameter(params, project);
-            params.set(AnnotationPage.PAGE_PARAM_DOCUMENT,
-                    aPage.getModelObject().getDocument().getId());
-            throw new RestartResponseException(aPage.getClass(), params);
+        ensureDataOwnerMatchesCurationTarget(page, project, sessionOwner, dataOwner);
+    }
+
+    private void ensureDataOwnerMatchesCurationTarget(AnnotationPageBase aPage, Project aProject,
+            String aSessionOwner, String aDataOwner)
+    {
+        // Are we curating?
+        if (isViewingPotentialCurationTarget(aDataOwner) && isSessionActive(aProject)) {
+            // If the curation target user is different from the data owner set in the annotation
+            // state, then we need to update the state and reload.
+            var curationTarget = curationSidebarService.getCurationTargetUser(aSessionOwner,
+                    aProject.getId());
+            if (!aDataOwner.equals(curationTarget.getUsername())) {
+                LOG.trace("Data owner [{}] should match curation target {} - changing to {}",
+                        curationTarget, aDataOwner, curationTarget);
+                aPage.getModelObject().setUser(curationTarget);
+            }
         }
     }
 
-    private boolean isViewingPotentialCurationTarget(AnnotationPage aPage)
+    private void handleSessionActivation(AnnotationPageBase aPage, PageParameters aParams,
+            SourceDocument aDoc, String aSessionOwner)
+    {
+        var project = aDoc.getProject();
+        var curationSessionParameterValue = aParams.get(PARAM_CURATION_SESSION);
+        if (!curationSessionParameterValue.isEmpty()) {
+            switch (curationSessionParameterValue.toString(STAY)) {
+            case ON:
+                LOG.trace("Checking if to start curation session");
+                // Start a new session or switch to new curation target
+                var curationTargetOwnParameterValue = aParams.get(PARAM_CURATION_TARGET_OWN);
+                if (!isSessionActive(project) || !curationTargetOwnParameterValue.isEmpty()) {
+                    curationSidebarService.startSession(aSessionOwner, project,
+                            curationTargetOwnParameterValue.toBoolean(false));
+                }
+                break;
+            case OFF:
+                LOG.trace("Checking if to stop curation session");
+                if (isSessionActive(project)) {
+                    curationSidebarService.closeSession(aSessionOwner, project.getId());
+                }
+                break;
+            default:
+                // Ignore
+            }
+
+            LOG.trace("Removing session control parameters and reloading (redirect)");
+            aParams.remove(PARAM_CURATION_TARGET_OWN);
+            aParams.remove(PARAM_CURATION_SESSION);
+            setProjectPageParameter(aParams, project);
+            aParams.set(AnnotationPage.PAGE_PARAM_DOCUMENT, aDoc.getId());
+            // We need to do a redirect here to discard the arguments from the URL.
+            // This also discards the page state.
+            throw new RestartResponseException(aPage.getClass(), aParams);
+        }
+    }
+
+    private boolean isViewingPotentialCurationTarget(String aDataOwner)
     {
         // Curation sidebar is not allowed when viewing another users annotations
         var sessionOwner = userService.getCurrentUsername();
-        var state = aPage.getModelObject();
-        return asList(CURATION_USER, sessionOwner).contains(state.getUser().getUsername());
+        return asList(CURATION_USER, sessionOwner).contains(aDataOwner);
     }
 
-    private boolean isSessionActive(AnnotationPage aPage)
+    private boolean isSessionActive(Project aProject)
     {
         var sessionOwner = userService.getCurrentUsername();
-        var project = aPage.getModelObject().getProject();
-        if (project != null
-                && curationSidebarService.existsSession(sessionOwner, project.getId())) {
-            return true;
-        }
-
-        return false;
+        return curationSidebarService.existsSession(sessionOwner, aProject.getId());
     }
 }


### PR DESCRIPTION
**What's in the PR**
- Introduce a new event "PreparingToOpenDocumentEvent" which gives the curation sidebar the opportunity to set the data owner to the curation target before actually starting to load the document.
- Improve debug/trace logging
- Modernizing some terminologies and use var

**How to test manually**
* Use the annotation page normally
* Access the annotation page with the curation session management parameters (see https://inception-project.github.io/releases/29.5/docs/user-guide.html#_curation_sidebar - end of section)

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
