### PR TITLE
#4263 - Spans starting before the current viewport are not rendered as partial spans

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanRenderer.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanRenderer.java
@@ -105,7 +105,7 @@ public class SpanRenderer
         FSIterator<AnnotationFS> it = aCas.getAnnotationIndex(type).iterator();
 
         // Skip annotations whose start is before the start parameter.
-        while (it.isValid() && (it.get()).getBegin() < aWindowBegin) {
+        while (it.isValid() && (it.get()).getBegin() < 0) {
             it.moveToNext();
         }
 

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorVisualizer.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorVisualizer.ts
@@ -309,8 +309,10 @@ export class ApacheAnnotatorVisualizer {
 
       const coreBegin = Math.max(begin, viewportBegin)
       const coreEnd = Math.min(end, viewportEnd)
-      this.renderHighlight(span, coreBegin, coreEnd, attributes)
-      fragmentCount++
+      if (coreBegin <= coreEnd) {
+        this.renderHighlight(span, coreBegin, coreEnd, attributes)
+        fragmentCount++
+      }
 
       attributes.class += ' iaa-zero-width' // Prevent prefix/suffix fragmens from being cleaned up
       if (!(viewportBegin <= begin && begin <= viewportEnd)) {


### PR DESCRIPTION
**What's in the PR**
- Fix workaround to UIMA leaking temporary annotations using the same begin offset as in the original non-workaround code

**How to test manually**
* Import a document with two sentences
* Create an annotation covering both sentences
* Configure the brat-by-sentence viewer to show only one sentence
* Switch to the second page

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
