### PR TITLE
#4279 - Ability to disable startup notice

### DIFF
--- a/inception/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/app/config/InceptionApplicationContainerConfiguration.java
+++ b/inception/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/app/config/InceptionApplicationContainerConfiguration.java
@@ -55,6 +55,9 @@ public class InceptionApplicationContainerConfiguration
 
     private StartupNoticeValve startupNoticeValve;
 
+    @Value("${server.startup-notice.enabled:true}")
+    private boolean statupNoticeEnabled;
+
     @Bean
     @Primary
     public Validator validator()
@@ -80,7 +83,7 @@ public class InceptionApplicationContainerConfiguration
             protected void postProcessContext(Context context)
             {
                 final int maxCacheSize = 40 * 1024;
-                StandardRoot standardRoot = new StandardRoot(context);
+                var standardRoot = new StandardRoot(context);
                 standardRoot.setCacheMaxSize(maxCacheSize);
                 context.setResources(standardRoot);
             }
@@ -88,7 +91,7 @@ public class InceptionApplicationContainerConfiguration
             @Override
             public WebServer getWebServer(ServletContextInitializer... initializers)
             {
-                final WebServer container = super.getWebServer(initializers);
+                final var container = super.getWebServer(initializers);
 
                 // Start server early so we can display the boot-up notice
                 container.start();
@@ -97,8 +100,10 @@ public class InceptionApplicationContainerConfiguration
             }
         };
 
-        startupNoticeValve = new StartupNoticeValve();
-        factory.addContextValves(startupNoticeValve);
+        if (statupNoticeEnabled) {
+            startupNoticeValve = new StartupNoticeValve();
+            factory.addContextValves(startupNoticeValve);
+        }
 
         if (ajpPort > 0) {
             Connector ajpConnector = new Connector(PROTOCOL);

--- a/inception/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/app/startup/StartupNoticeValve.java
+++ b/inception/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/app/startup/StartupNoticeValve.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.inception.app.startup;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import javax.servlet.ServletException;
 
@@ -34,6 +35,7 @@ public class StartupNoticeValve
     {
         try (var loadingHtml = getClass().getResourceAsStream("startup.html")) {
             response.setContentType(MediaType.TEXT_HTML_VALUE);
+            response.setCharacterEncoding(StandardCharsets.UTF_8.name());
             loadingHtml.transferTo(response.getOutputStream());
         }
     }

--- a/inception/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/app/startup/StartupNoticeValve.java
+++ b/inception/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/app/startup/StartupNoticeValve.java
@@ -18,14 +18,13 @@
 package de.tudarmstadt.ukp.inception.app.startup;
 
 import java.io.IOException;
-import java.io.InputStream;
 
 import javax.servlet.ServletException;
 
 import org.apache.catalina.connector.Request;
 import org.apache.catalina.connector.Response;
 import org.apache.catalina.valves.ValveBase;
-import org.apache.tomcat.util.http.fileupload.IOUtils;
+import org.springframework.http.MediaType;
 
 public class StartupNoticeValve
     extends ValveBase
@@ -33,8 +32,9 @@ public class StartupNoticeValve
     @Override
     public void invoke(Request request, Response response) throws IOException, ServletException
     {
-        try (InputStream loadingHtml = getClass().getResourceAsStream("startup.html")) {
-            IOUtils.copy(loadingHtml, response.getOutputStream());
+        try (var loadingHtml = getClass().getResourceAsStream("startup.html")) {
+            response.setContentType(MediaType.TEXT_HTML_VALUE);
+            loadingHtml.transferTo(response.getOutputStream());
         }
     }
 }

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/settings_server.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/settings_server.adoc
@@ -26,37 +26,42 @@ These settings relate to the embedded web server in the JAR version of {product-
 | Default
 | Example
 
-| server.port
+| `server.port`
 | Port on which the server listens
-| 8080
-| 18080
+| `8080`
+| `18080`
 
-| server.address
+| `server.address`
 | IP address on which the server listens
-| 0.0.0.0
-| 127.0.0.1
+| `0.0.0.0`
+| `127.0.0.1`
 
-| server.ajp.port
+| `server.ajp.port`
 | Port for AJP connector
-| -1 _(disabled)_
-| 8009
+| `-1` _(disabled)_
+| `8009`
 
-| server.ajp.address
+| `server.ajp.address`
 | IP address on which the AJP connector listens
-| 127.0.0.1
-| 0.0.0.0
+| `127.0.0.1`
+| `0.0.0.0`
 
-| server.ajp.secret-required
+| `server.ajp.secret-required`
 | Whether AJP connections require a shared secret
-| true
-| false
+| `true`
+| `false`
 
-| server.ajp.secret
+| `server.ajp.secret`
 | Shared secret for AJP connections
 | _unset_
 | _some secret string of your choice_
+
+| `server.startup-notice.enabled`
+| Whether a self-refreshing startup screen is served while the application is booting before the login screen becomes available
+| `true`
+| `false`
 |===
 
 NOTE: The application is based on Spring Boot and using an embedded Tomcat server. You can configure 
-      additional aspects of the embedded web server using default link:https://docs.spring.io/spring-boot/docs/1.5.22.RELEASE/reference/html/common-application-properties.html[Spring Boot configuration settings].
+      additional aspects of the embedded web server using default link:https://docs.spring.io/spring-boot/docs/2.7.x/reference/html/application-properties.html[Spring Boot configuration settings].
 


### PR DESCRIPTION
**What's in the PR**
- Added option to disable startup notice
- Added content-type to startup-notice page

**How to test manually**
* Disable the startup screen using the respective option
* Check the content type reported to the browser on the startup page

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
