### PR TITLE
#4289 - Ability to skip SSL certificate validation on external recommenders

### DIFF
--- a/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/v1/ExternalRecommenderTraits.java
+++ b/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/v1/ExternalRecommenderTraits.java
@@ -29,6 +29,7 @@ public class ExternalRecommenderTraits
 
     private String remoteUrl;
     private boolean trainable;
+    private boolean verifyCertificates = true;
 
     public String getRemoteUrl()
     {
@@ -48,5 +49,15 @@ public class ExternalRecommenderTraits
     public void setTrainable(boolean aTrainable)
     {
         trainable = aTrainable;
+    }
+    
+    public void setVerifyCertificates(boolean aVerifyCertificates)
+    {
+        verifyCertificates = aVerifyCertificates;
+    }
+    
+    public boolean isVerifyCertificates()
+    {
+        return verifyCertificates;
     }
 }

--- a/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/v1/ExternalRecommenderTraitsEditor.html
+++ b/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/v1/ExternalRecommenderTraitsEditor.html
@@ -27,6 +27,16 @@
         <input wicket:id="remoteUrl" type="text" class="form-control"></input>
       </div>
     </div>
+    <div class="row form-row" wicket:enclosure="verifyCertificates">
+      <div class="offset-sm-3 col-sm-9">
+        <div class="form-check">
+          <input wicket:id="verifyCertificates" class="form-check-input" type="checkbox"/>
+          <label wicket:for="verifyCertificates" class="form-check-label">
+            <wicket:label key="verifyCertificates"/>
+          </label>
+        </div>
+      </div>
+    </div>
     <div class="row form-row" wicket:enclosure="trainable">
       <div class="offset-sm-3 col-sm-9">
         <div class="form-check">

--- a/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/v1/ExternalRecommenderTraitsEditor.java
+++ b/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/v1/ExternalRecommenderTraitsEditor.java
@@ -63,12 +63,16 @@ public class ExternalRecommenderTraitsEditor
             }
         };
 
-        TextField<String> remoteUrl = new TextField<>("remoteUrl");
+        var remoteUrl = new TextField<String>("remoteUrl");
         remoteUrl.setRequired(true);
         remoteUrl.add(new UrlValidator());
         form.add(remoteUrl);
 
-        CheckBox trainable = new CheckBox("trainable");
+        var verifyCertificates = new CheckBox("verifyCertificates");
+        verifyCertificates.setOutputMarkupId(true);
+        form.add(verifyCertificates);
+
+        var trainable = new CheckBox("trainable");
         trainable.setOutputMarkupId(true);
         trainable.add(new LambdaAjaxFormComponentUpdatingBehavior("change",
                 _target -> _target.add(getTrainingStatesChoice())));

--- a/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/v1/ExternalRecommenderTraitsEditor.properties
+++ b/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/v1/ExternalRecommenderTraitsEditor.properties
@@ -16,3 +16,4 @@
 
 remoteUrl=Remote URL
 trainable=Trainable
+verifyCertificates=Verify certificates


### PR DESCRIPTION
**What's in the PR**
- Added checkbox in external recommender settings that can be used to disable certificate checks

**How to test manually**
* Set up an external recommender and point it to `https://expired.badssl.com/`
* With certificate checks enabled, it should fail with a PKIX exception
* Without certificate checks it should fail with a 404

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
