### PR TITLE
#4294 - Infer paragraph boundaries when displaying plain text files in HTML-based editors

### DIFF
--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/xml/XmlDocumentViewControllerImpl.java
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/xml/XmlDocumentViewControllerImpl.java
@@ -41,7 +41,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.xml.sax.ContentHandler;
 import org.xml.sax.helpers.AttributesImpl;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.DocumentImportExportService;
@@ -53,7 +52,6 @@ import de.tudarmstadt.ukp.inception.externaleditor.ExternalAnnotationEditorFacto
 import de.tudarmstadt.ukp.inception.externaleditor.XmlDocumentViewControllerImplBase;
 import de.tudarmstadt.ukp.inception.externaleditor.policy.DefaultHtmlDocumentPolicy;
 import de.tudarmstadt.ukp.inception.externaleditor.policy.SafetyNetDocumentPolicy;
-import de.tudarmstadt.ukp.inception.io.xml.dkprocore.Cas2SaxEvents;
 
 @ConditionalOnWebApplication
 @RestController
@@ -130,7 +128,7 @@ public class XmlDocumentViewControllerImpl
         try (Writer out = new StringWriter()) {
             renderXmlDeclaration(out);
 
-            for (String cssUrl : formatRegistry.getFormatCssStylesheets(doc).stream()
+            for (var cssUrl : formatRegistry.getFormatCssStylesheets(doc).stream()
                     .map(css -> referenceToUrl(servletContext, css)).collect(toList())) {
                 renderXmlStylesheet(out, cssUrl);
             }
@@ -150,25 +148,25 @@ public class XmlDocumentViewControllerImpl
             if (maybeXmlDocument.isEmpty()) {
                 // Gracefully handle the case that the CAS does not contain any XML structure at all
                 // and show only the document text in this case.
-                ContentHandler ch = XmlCas2SaxEvents.makeSerializer(out);
+                var ch = XmlCas2SaxEvents.makeSerializer(out);
                 ch.startDocument();
                 ch.startElement(null, null, DOCUMENT, null);
-                AttributesImpl attrs = new AttributesImpl();
+                var attrs = new AttributesImpl();
                 attrs.addAttribute(null, null, XmlCas2SaxEvents.DATA_CAPTURE_ROOT, null, "");
                 ch.startElement(null, null, BODY, attrs);
-                String text = cas.getDocumentText();
+                var text = cas.getDocumentText();
                 ch.characters(text.toCharArray(), 0, text.length());
                 ch.endElement(null, null, BODY);
                 ch.endElement(null, null, DOCUMENT);
                 ch.endDocument();
             }
             else {
-                XmlDocument xml = selectSingle(cas.getJCas(), XmlDocument.class);
+                var xml = selectSingle(cas.getJCas(), XmlDocument.class);
 
-                ContentHandler ch = XmlCas2SaxEvents.makeSerializer(out);
+                var ch = XmlCas2SaxEvents.makeSerializer(out);
                 var sh = applySanitizers(aEditor, doc, ch);
 
-                Cas2SaxEvents serializer = new XmlCas2SaxEvents(xml, sh);
+                var serializer = new XmlCas2SaxEvents(xml, sh);
                 serializer.process(xml);
             }
 


### PR DESCRIPTION
**What's in the PR**
- Detect multi-line-breaks and inject p-tags accordingly

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
