### PR TITLE
#4302 - Files imported as HTML do not show properly in HTML-based editor

### DIFF
--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/xhtml/XHtmlXmlDocumentViewControllerImpl.java
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/xhtml/XHtmlXmlDocumentViewControllerImpl.java
@@ -163,7 +163,7 @@ public class XHtmlXmlDocumentViewControllerImpl
 
             renderHead(doc, rawHandler);
 
-            sanitizingHandler.startElement(null, null, BODY, null);
+            rawHandler.startElement(null, null, BODY, null);
             if (maybeXmlDocument.isEmpty()) {
                 // Gracefully handle the case that the CAS does not contain any XML structure at all
                 // and show only the document text in this case.
@@ -172,7 +172,7 @@ public class XHtmlXmlDocumentViewControllerImpl
             else {
                 renderXmlContent(doc, sanitizingHandler, aEditor, maybeXmlDocument.get());
             }
-            sanitizingHandler.endElement(null, null, BODY);
+            rawHandler.endElement(null, null, BODY);
 
             rawHandler.endElement(null, null, HTML);
 

--- a/inception/inception-io-html/pom.xml
+++ b/inception/inception-io-html/pom.xml
@@ -37,6 +37,14 @@
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-model</artifactId>
     </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-external-editor</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-support</artifactId>
+    </dependency>
     
     <dependency>
       <groupId>commons-io</groupId>

--- a/inception/inception-io-html/src/main/java/de/tudarmstadt/ukp/inception/io/html/HtmlFormatSupport.java
+++ b/inception/inception-io-html/src/main/java/de/tudarmstadt/ukp/inception/io/html/HtmlFormatSupport.java
@@ -19,20 +19,25 @@ package de.tudarmstadt.ukp.inception.io.html;
 
 import static org.apache.uima.fit.factory.CollectionReaderFactory.createReaderDescription;
 
+import java.io.IOException;
+import java.util.Optional;
+
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.inception.externaleditor.policy.DefaultHtmlDocumentPolicy;
 import de.tudarmstadt.ukp.inception.io.html.config.HtmlSupportAutoConfiguration;
 import de.tudarmstadt.ukp.inception.io.html.dkprocore.HtmlDocumentReader;
+import de.tudarmstadt.ukp.inception.support.xml.sanitizer.PolicyCollection;
 
 /**
  * Support for HTML format.
  * <p>
  * This class is exposed as a Spring Component via
- * {@link HtmlSupportAutoConfiguration#htmlFormatSupport()}.
+ * {@link HtmlSupportAutoConfiguration#htmlFormatSupport}.
  * </p>
  */
 public class HtmlFormatSupport
@@ -40,6 +45,13 @@ public class HtmlFormatSupport
 {
     public static final String ID = "htmldoc";
     public static final String NAME = "HTML";
+
+    private final DefaultHtmlDocumentPolicy defaultPolicy;
+
+    public HtmlFormatSupport(DefaultHtmlDocumentPolicy aDefaultPolicy)
+    {
+        defaultPolicy = aDefaultPolicy;
+    }
 
     @Override
     public String getId()
@@ -65,5 +77,11 @@ public class HtmlFormatSupport
         throws ResourceInitializationException
     {
         return createReaderDescription(HtmlDocumentReader.class, aTSD);
+    }
+
+    @Override
+    public Optional<PolicyCollection> getPolicy() throws IOException
+    {
+        return Optional.of(defaultPolicy.getPolicy());
     }
 }

--- a/inception/inception-io-html/src/main/java/de/tudarmstadt/ukp/inception/io/html/config/HtmlSupportAutoConfiguration.java
+++ b/inception/inception-io-html/src/main/java/de/tudarmstadt/ukp/inception/io/html/config/HtmlSupportAutoConfiguration.java
@@ -21,6 +21,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import de.tudarmstadt.ukp.inception.externaleditor.policy.DefaultHtmlDocumentPolicy;
 import de.tudarmstadt.ukp.inception.io.html.HtmlFormatSupport;
 import de.tudarmstadt.ukp.inception.io.html.LegacyHtmlFormatSupport;
 
@@ -30,9 +31,9 @@ public class HtmlSupportAutoConfiguration
     @Bean
     @ConditionalOnProperty(prefix = "format.html", name = "enabled", //
             havingValue = "true", matchIfMissing = false)
-    public HtmlFormatSupport htmlFormatSupport()
+    public HtmlFormatSupport htmlFormatSupport(DefaultHtmlDocumentPolicy aDefaultPolicy)
     {
-        return new HtmlFormatSupport();
+        return new HtmlFormatSupport(aDefaultPolicy);
     }
 
     @Bean

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/SanitizingContentHandler.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/SanitizingContentHandler.java
@@ -163,13 +163,13 @@ public class SanitizingContentHandler
 
         if (stack.isEmpty()) {
             if (policies.isDebug() && log.isDebugEnabled()) {
-                log.debug("Masked elements: {}", maskedElements.stream() //
+                log.debug("[{}] Masked elements: {}", policies.getName(), maskedElements.stream() //
                         .map(QName::toString) //
                         .sorted() //
                         .collect(toList()));
                 for (var element : maskedAttributes.keySet().stream()
                         .sorted(comparing(QName::getLocalPart)).collect(toList())) {
-                    log.debug("Masked attributes on {}: {}", element,
+                    log.debug("[{}] Masked attributes on {}: {}", policies.getName(), element,
                             maskedAttributes.get(element).stream().map(QName::toString) //
                                     .sorted() //
                                     .collect(toList()));


### PR DESCRIPTION
**What's in the PR**
- The HtmlFormatSupport now returns the default HTML content policy
- When logging masked element, also log the name of the respective policy
- Do not pass the body element through the sanitizer - it should always pass

**How to test manually**
* See issue

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
