### PR TITLE
#4305 - New predictions message is shown even if no new predictions were generated

### DIFF
--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/Predictions.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/Predictions.java
@@ -68,6 +68,8 @@ public class Predictions
     // session, the pool of IDs of positive integer values is never exhausted.
     private int nextId;
 
+    private int newSuggestionCount = 0;
+
     public Predictions(User aSessionOwner, String aDataOwner, Project aProject)
     {
         Validate.notNull(aProject, "Project must be specified");
@@ -227,6 +229,10 @@ public class Predictions
                 var byDocument = idxDocuments.computeIfAbsent(prediction.getDocumentName(),
                         $ -> new HashMap<>());
                 byDocument.put(xid, prediction);
+
+                if (prediction.getAge() == 0) {
+                    newSuggestionCount++;
+                }
             }
         }
     }
@@ -241,6 +247,16 @@ public class Predictions
         synchronized (predictionsLock) {
             return idxDocuments.values().stream().allMatch(Map::isEmpty);
         }
+    }
+
+    public boolean hasNewSuggestions()
+    {
+        return newSuggestionCount > 0;
+    }
+
+    public int getNewSuggestionCount()
+    {
+        return newSuggestionCount;
     }
 
     public int size()

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/recommender/PredictionCapability.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/recommender/PredictionCapability.java
@@ -26,9 +26,8 @@ public enum PredictionCapability
     PREDICTION_USES_TEXT_ONLY,
 
     /**
-     * Predictions make take annotations into account. When there are changes to annotations, new
-     * predictions need to be generated. If the recommender is also trainable, then recommendations
-     * should only be generated once a training phase has completed.
+     * Predictions may take annotations into account. When there are changes to annotations, new
+     * predictions should be generated.
      */
     PREDICTION_USES_ANNOTATIONS;
 }

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/footer/RecommendationEventWebsocketControllerImpl.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/footer/RecommendationEventWebsocketControllerImpl.java
@@ -37,7 +37,9 @@ import org.springframework.messaging.simp.annotation.SendToUser;
 import org.springframework.stereotype.Controller;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.inception.recommendation.actionbar.RecommenderActionBarPanel;
+import de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService;
 import de.tudarmstadt.ukp.inception.recommendation.event.RecommenderTaskNotificationEvent;
 import de.tudarmstadt.ukp.inception.recommendation.tasks.PredictionTask;
 
@@ -50,34 +52,47 @@ public class RecommendationEventWebsocketControllerImpl
     private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private final SimpMessagingTemplate msgTemplate;
+    private final RecommendationService recommendationService;
+    private final UserDao userService;
 
-    public RecommendationEventWebsocketControllerImpl(@Autowired SimpMessagingTemplate aMsgTemplate)
+    public RecommendationEventWebsocketControllerImpl(@Autowired SimpMessagingTemplate aMsgTemplate,
+            RecommendationService aRecommenderService, UserDao aUserService)
     {
         msgTemplate = aMsgTemplate;
+        recommendationService = aRecommenderService;
+        userService = aUserService;
     }
 
     @EventListener
     @Override
     public void onRecommenderTaskEvent(RecommenderTaskNotificationEvent aEvent)
     {
-        Project project = aEvent.getProject();
-        RRecommenderLogMessage eventMsg;
-        if (aEvent.getSource() instanceof PredictionTask) {
-            eventMsg = new RRecommenderLogMessage(aEvent.getMessage().getLevel(),
-                    aEvent.getMessage().getMessage(),
-                    asList(RecommenderActionBarPanel.STATE_PREDICTIONS_AVAILABLE), emptyList());
+        var project = aEvent.getProject();
+        var eventMsg = makeEventMessage(aEvent);
 
-        }
-        else {
-            eventMsg = new RRecommenderLogMessage(aEvent.getMessage().getLevel(),
-                    aEvent.getMessage().getMessage());
-        }
-
-        String channel = getChannel(project, aEvent.getUser());
+        var channel = getChannel(project, aEvent.getUser());
 
         LOG.debug("Sending event to [{}]: {}", channel, eventMsg);
 
         msgTemplate.convertAndSend("/topic" + channel, eventMsg);
+    }
+
+    private RRecommenderLogMessage makeEventMessage(RecommenderTaskNotificationEvent aEvent)
+    {
+        if (aEvent.getSource() instanceof PredictionTask) {
+            var sessionOwner = userService.get(aEvent.getUser());
+            var predictions = recommendationService.getIncomingPredictions(sessionOwner,
+                    aEvent.getProject());
+
+            if (predictions != null && predictions.hasNewSuggestions()) {
+                return new RRecommenderLogMessage(aEvent.getMessage().getLevel(),
+                        aEvent.getMessage().getMessage(),
+                        asList(RecommenderActionBarPanel.STATE_PREDICTIONS_AVAILABLE), emptyList());
+            }
+        }
+
+        return new RRecommenderLogMessage(aEvent.getMessage().getLevel(),
+                aEvent.getMessage().getMessage());
     }
 
     static String getChannel(Project project, String aUsername)

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
@@ -39,6 +39,7 @@ import static de.tudarmstadt.ukp.inception.recommendation.api.model.LearningReco
 import static de.tudarmstadt.ukp.inception.recommendation.api.model.SuggestionDocumentGroup.groupsOfType;
 import static de.tudarmstadt.ukp.inception.recommendation.api.model.SuggestionType.RELATION;
 import static de.tudarmstadt.ukp.inception.recommendation.api.model.SuggestionType.SPAN;
+import static de.tudarmstadt.ukp.inception.recommendation.api.recommender.PredictionCapability.PREDICTION_USES_TEXT_ONLY;
 import static de.tudarmstadt.ukp.inception.recommendation.api.recommender.TrainingCapability.TRAINING_NOT_SUPPORTED;
 import static de.tudarmstadt.ukp.inception.rendering.model.Range.rangeCoveringDocument;
 import static java.lang.Math.max;
@@ -229,7 +230,7 @@ public class RecommendationServiceImpl
     private final ConcurrentMap<RecommendationStateKey, RecommendationState> states;
 
     /*
-     * Marks user/projects to which annotations were added during this request.
+     * Marks users/projects to which annotations were added during this request.
      */
     @SuppressWarnings("serial")
     private static final MetaDataKey<Set<DirtySpot>> DIRTIES = //
@@ -1645,6 +1646,7 @@ public class RecommendationServiceImpl
             // If the recommender is not trainable and not sensitive to annotations,
             // we can actually re-use the predictions.
             if (TRAINING_NOT_SUPPORTED == engine.getTrainingCapability()
+                    && PREDICTION_USES_TEXT_ONLY == engine.getPredictionCapability()
                     && activePredictions != null
                     && activePredictions.hasRunPredictionOnDocument(aDocument)) {
                 inheritSuggestionsAtRecommenderLevel(aPredictions, originalCas,

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/PredictionTask.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/PredictionTask.java
@@ -104,10 +104,20 @@ public class PredictionTask
 
             recommendationService.putIncomingPredictions(sessionOwner, project, predictions);
 
-            appEventPublisher.publishEvent(RecommenderTaskNotificationEvent
-                    .builder(this, project, sessionOwner.getUsername()) //
-                    .withMessage(LogMessage.info(this, "New predictions available")) //
-                    .build());
+            if (predictions.hasNewSuggestions()) {
+                appEventPublisher.publishEvent(RecommenderTaskNotificationEvent
+                        .builder(this, project, sessionOwner.getUsername()) //
+                        .withMessage(LogMessage.info(this,
+                                predictions.getNewSuggestionCount() + " new predictions available")) //
+                        .build());
+            }
+            else {
+                appEventPublisher.publishEvent(RecommenderTaskNotificationEvent
+                        .builder(this, project, sessionOwner.getUsername()) //
+                        .withMessage(
+                                LogMessage.info(this, "Prediction run produced no new suggestions")) //
+                        .build());
+            }
 
             // We reset this in case the state was not properly cleared, e.g. the AL session
             // was started but then the browser closed. Places where it is set include


### PR DESCRIPTION
**What's in the PR**
- Display new predictions only if new predictions were generated
- Also "activate" the refresh button only if new predictions were generated

**How to test manually**
* E.g. trigger a retraining for a dictionary recommender when nothing has been annotated yet

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
