### PR TITLE
#4310 - Viewport tracking does not work well in RecogitoJS editor

### DIFF
--- a/inception/inception-html-recogito-editor/src/main/ts/src/recogito/RecogitoEditor.ts
+++ b/inception/inception-html-recogito-editor/src/main/ts/src/recogito/RecogitoEditor.ts
@@ -159,7 +159,7 @@ export class RecogitoEditor implements AnnotationEditor {
       this.root.ownerDocument.body.addEventListener('mouseover', e => this.addAnnotationHighlight(e as MouseEvent))
       this.root.ownerDocument.body.addEventListener('mouseout', e => this.removeAnnotationHighight(e as MouseEvent))
 
-      this.tracker = new ViewportTracker(this.root, () => this.loadAnnotations())
+      this.tracker = new ViewportTracker(this.root, () => this.loadAnnotations(), { ignoreSelector: '.r6o-relations-layer' })
 
       this.popover = new AnnotationDetailPopOver({
         target: this.root.ownerDocument.body,

--- a/inception/inception-js-api/src/main/ts/src/util/ViewportTracker.ts
+++ b/inception/inception-js-api/src/main/ts/src/util/ViewportTracker.ts
@@ -19,6 +19,13 @@ import { calculateEndOffset, calculateStartOffset } from './OffsetUtils'
 
 export type ViewportTrackerCallback = (range: [number, number]) => void
 
+export type ViewportTrackerOptions = {
+  sectionSelector?: string,
+  ignoreSelector?: string
+}
+
+export const NO_TRACKING_CLASS = 'data-i7n-no-tracking'
+
 export class ViewportTracker {
   private _visibleElements = new Set<Element>()
   private _currentRange: [number, number] = [0, 0]
@@ -31,18 +38,23 @@ export class ViewportTracker {
   private debounceDelay = 250
   private callback: ViewportTrackerCallback
 
-  private sectionSelector?: string
+  private options?: ViewportTrackerOptions
 
   /**
    * @param element the element containing the elemnts to track
    * @param callback the callback to invoke when the visible elements change
-   * @param sectionSelector optional CSS selector indicating which elements are considered sections
-   * and should be tracked as a whole
+   * @param options optional CSS selector indicating which elements are considered sections
+   * and should be tracked as a whole or an options object
    */
-  public constructor (element: Element, callback: ViewportTrackerCallback, sectionSelector?: string) {
+  public constructor (element: Element, callback: ViewportTrackerCallback, options?: string | ViewportTrackerOptions, ignoreClasses?: string[]) {
     this.root = element
     this.callback = callback
-    this.sectionSelector = sectionSelector
+    if (typeof options === 'string') {
+      this.options = { sectionSelector: options }
+    }
+    else {
+      this.options = options;
+    }
 
     this.initializeElementTracking(this.root)
   }
@@ -56,6 +68,10 @@ export class ViewportTracker {
   }
 
   private shouldTrack (element: Element): boolean {
+    if (this.options?.ignoreSelector && element.matches(this.options.ignoreSelector)) {
+      return false
+    }
+
     const style = getComputedStyle(element)
     if (!style.display) {
       return false
@@ -84,11 +100,11 @@ export class ViewportTracker {
 
     if (trackingCandidates.length > 0) {
       trackingCandidates = trackingCandidates.map(e => {
-        if (!this.sectionSelector || e.matches(this.sectionSelector)) {
+        if (!this.options?.sectionSelector || e.matches(this.options.sectionSelector)) {
           return e
         }
 
-        return e.closest(this.sectionSelector) || e
+        return e.closest(this.options.sectionSelector) || e
       })
       leafTrackingCandidates = new Set<Element>([...trackingCandidates])
       trackingCandidates.map(e => e.parentElement && leafTrackingCandidates.delete(e.parentElement))


### PR DESCRIPTION
**What's in the PR**
- Allow providing a CSS selector for elements to be ignored to the viewport tracker
- Ignore the SVG element injected by RecogitoJS

**How to test manually**
* Try opening a large document using the RecogitoJS editor and check that partial loading of the visible annotations works

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
