### PR TITLE
#4150 - Upgrade dependencies

### DIFF
--- a/inception/inception-dependencies/pom.xml
+++ b/inception/inception-dependencies/pom.xml
@@ -175,7 +175,7 @@
       <dependency>
         <groupId>com.nimbusds</groupId>
         <artifactId>nimbus-jose-jwt</artifactId>
-        <version>9.36</version>
+        <version>9.37.1</version>
       </dependency>
       <dependency>
         <groupId>org.awaitility</groupId>
@@ -458,7 +458,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-dbcp2</artifactId>
-        <version>2.10.0</version>
+        <version>2.11.0</version>
       </dependency>
       <dependency>
         <groupId>org.dom4j</groupId>
@@ -676,12 +676,12 @@
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy</artifactId>
-        <version>1.14.9</version>
+        <version>1.14.10</version>
       </dependency>
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy-agent</artifactId>
-        <version>1.14.9</version>
+        <version>1.14.10</version>
       </dependency>
       <dependency>
         <groupId>org.wicketstuff</groupId>
@@ -961,22 +961,22 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.14.0</version>
+        <version>2.15.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-text</artifactId>
-        <version>1.10.0</version>
+        <version>1.11.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.13.0</version>
+        <version>3.14.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-compress</artifactId>
-        <version>1.24.0</version>
+        <version>1.25.0</version>
       </dependency>
       <dependency>
         <groupId>commons-codec</groupId>

--- a/inception/inception-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController_Authentication_Jwt_Test.java
+++ b/inception/inception-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController_Authentication_Jwt_Test.java
@@ -235,10 +235,10 @@ class AeroRemoteApiController_Authentication_Jwt_Test
                 @Override
                 public Jwt decode(String aToken)
                 {
-                    var parser = Jwts.parserBuilder().build();
+                    var parser = Jwts.parser().unsecured().build();
                     var jwt = parser.parse(aToken);
 
-                    return new Jwt(aToken, null, null, jwt.getHeader(), (Claims) jwt.getBody());
+                    return new Jwt(aToken, null, null, jwt.getHeader(), (Claims) jwt.getPayload());
                 }
             };
         }

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
   <properties>
     <junit-jupiter.version>5.10.1</junit-jupiter.version>
     <junit-platform.version>1.10.1</junit-platform.version>
-    <mockito.version>5.5.0</mockito.version>
+    <mockito.version>5.7.0</mockito.version>
     <assertj.version>3.24.2</assertj.version>
     <xmlunit.version>2.9.1</xmlunit.version>
 
@@ -77,25 +77,25 @@
 
     <dkpro.version>2.4.0</dkpro.version>
     <uima.version>3.5.0</uima.version>
-    <uimafit.version>3.4.0</uimafit.version>
+    <uimafit.version>3.5.0</uimafit.version>
     <uima-json.version>0.5.0</uima-json.version>
 
     <pdfbox.version>2.0.30</pdfbox.version>
 
-    <spring.version>5.3.30</spring.version>
-    <spring.boot.version>2.7.17</spring.boot.version>
-    <spring.data.version>2.7.17</spring.data.version>
+    <spring.version>5.3.31</spring.version>
+    <spring.boot.version>2.7.18</spring.boot.version>
+    <spring.data.version>2.7.18</spring.data.version>
     <spring.security.version>5.8.8</spring.security.version>
     <springdoc.version>1.7.0</springdoc.version>
-    <swagger.version>2.2.16</swagger.version>
-    <jjwt.version>0.11.5</jjwt.version>
+    <swagger.version>2.2.19</swagger.version>
+    <jjwt.version>0.12.3</jjwt.version>
 
     <slf4j.version>2.0.9</slf4j.version>
-    <log4j2.version>2.20.0</log4j2.version>
+    <log4j2.version>2.22.0</log4j2.version>
     <jboss.logging.version>3.5.3.Final</jboss.logging.version>
-    <sentry.version>6.30.0</sentry.version>
+    <sentry.version>6.34.0</sentry.version>
 
-    <tomcat.version>9.0.82</tomcat.version>
+    <tomcat.version>9.0.83</tomcat.version>
     <servlet-api.version>4.0.1</servlet-api.version>
 
     <mariadb.driver.version>2.7.10</mariadb.driver.version>
@@ -121,7 +121,7 @@
     <!-- * 8.11.1.0 depends on Lucene 8.11.1 -->
     <!--   no mtas  depends on Lucene 9.x -->
 
-    <elasticsearch.version>7.17.14</elasticsearch.version> 
+    <elasticsearch.version>7.17.15</elasticsearch.version> 
     <!--   7.10.x   depends on Lucene 8.7.0 - last ASL 2.0 version! -->
     <!-- * 7.17.x   depends on Lucene 8.11.1 -->
     <!--   8.1.x    depends on Lucene 9.0.0 -->
@@ -143,10 +143,10 @@
 
     <json.version>20230227</json.version>
     <pf4j.version>2.6.0</pf4j.version>
-    <jackson.version>2.15.3</jackson.version>
+    <jackson.version>2.16.0</jackson.version>
     <snakeyaml.version>1.33</snakeyaml.version>
-    <okhttp.version>4.11.0</okhttp.version>
-    <okio.version>3.5.0</okio.version>
+    <okhttp.version>4.12.0</okhttp.version>
+    <okio.version>3.6.0</okio.version>
 
     <node.version>18.18.0</node.version>
     <apache-annotator.version>0.2.0</apache-annotator.version>


### PR DESCRIPTION
**What's in the PR**
- nimbus-jose-jwt 9.36 -> 9.37.1
- commons-dbcp2 2.10.0 -> 2.11.0
- byte-buddy 1.14.9 -> 1.14.10
- commons-io 2.14.0 -> 2.15.0
- commons-text 1.10.0 -> 1.11.0
- commons-lang3 3.13.0 -> 3.14.0
- commons-compress 1.24.0 -> 1.25.0
- mockito 5.5.0 -> 5.7.0
- uimafit 3.4.0 -> 3.5.0
- spring 5.3.30 -> 5.3.31
- spring-boot 2.7.17 -> 2.7.18
- spring-data 2.7.17 -> 2.7.18
- swagger 2.2.16 -> 2.2.19
- jjwt 0.11.5 -> 0.12.3
- log4j 2.20.0 -> 2.22.0
- sentry 6.30.0 -> 6.34.0
- tomcat 9.0.82 -> 9.0.83
- elasticsearch 7.17.14 -> 7.17.15
- jackson 2.15.3 -> 2.16.0
- okhttp 4.11.0 -> 4.12.0
- okio 3.5.0 -> 3.6.0

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
