### PR TITLE
#4328 - HTML files are not rendered if they use the HTML namespace

### DIFF
--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/policy/DefaultHtmlDocumentPolicy.yaml
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/policy/DefaultHtmlDocumentPolicy.yaml
@@ -19,6 +19,7 @@ version: 1.0
 case_sensitive: false
 default_attribute_action: DROP
 default_element_action: DROP
+default_namespace: http://www.w3.org/1999/xhtml
 debug: true
 policies:
   - action: PASS

--- a/inception/inception-external-editor/src/test/java/de/tudarmstadt/ukp/inception/externaleditor/policy/DefaultHtmlDocumentPolicyTest.java
+++ b/inception/inception-external-editor/src/test/java/de/tudarmstadt/ukp/inception/externaleditor/policy/DefaultHtmlDocumentPolicyTest.java
@@ -41,7 +41,7 @@ class DefaultHtmlDocumentPolicyTest
 
         var sut = new DefaultHtmlDocumentPolicy();
 
-        assertThat(sut.getPolicy().getElementPolicies()).hasSize(74);
+        assertThat(sut.getPolicy().getElementPolicies()).hasSize(148);
 
         write(policyFile.toFile(), "policies: []", UTF_8);
         assertThat(policyFile).exists();
@@ -54,6 +54,6 @@ class DefaultHtmlDocumentPolicyTest
 
         Files.delete(policyFile);
         assertThat(policyFile).doesNotExist();
-        assertThat(sut.getPolicy().getElementPolicies()).hasSize(74);
+        assertThat(sut.getPolicy().getElementPolicies()).hasSize(148);
     }
 }

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/ExternalPolicyCollection.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/ExternalPolicyCollection.java
@@ -32,6 +32,7 @@ public class ExternalPolicyCollection
     private boolean debug;
     private ElementAction defaultElementAction;
     private AttributeAction defaultAttributeAction;
+    private String defaultNamespace;
 
     public String getName()
     {
@@ -101,5 +102,15 @@ public class ExternalPolicyCollection
     public AttributeAction getDefaultAttributeAction()
     {
         return defaultAttributeAction;
+    }
+
+    public String getDefaultNamespace()
+    {
+        return defaultNamespace;
+    }
+
+    public void setDefaultNamespace(String aDefaultNamespace)
+    {
+        defaultNamespace = aDefaultNamespace;
     }
 }

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/PolicyCollectionIOUtils.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/PolicyCollectionIOUtils.java
@@ -53,6 +53,9 @@ public class PolicyCollectionIOUtils
             policyCollectionBuilder
                     .defaultAttributeAction(externalCollection.getDefaultAttributeAction());
         }
+        if (externalCollection.getDefaultNamespace() != null) {
+            policyCollectionBuilder.defaultNamespace(externalCollection.getDefaultNamespace());
+        }
 
         for (ExternalPolicy policy : externalCollection.getPolicies()) {
             var isElementPolicy = policy.getElements() != null;


### PR DESCRIPTION
**What's in the PR**
- Add "defaultNamespace" setting to policy to add a default namespace to all elements defined in the policy (also allowing there non-NS versions)
- Fix cases where an element or attributeconsists only of a prefix and no local part (we filter those out)

**How to test manually**
* No specific test procedure

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
