### PR TITLE
#4340 - Allow pruning elements in XML policy

### DIFF
--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/policy/DefaultHtmlDocumentPolicy.yaml
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/policy/DefaultHtmlDocumentPolicy.yaml
@@ -20,6 +20,7 @@ case_sensitive: false
 default_attribute_action: DROP
 default_element_action: DROP
 default_namespace: http://www.w3.org/1999/xhtml
+match_without_namespace: true
 debug: true
 policies:
   - action: PASS

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/AttributePolicyBuilder.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/AttributePolicyBuilder.java
@@ -70,9 +70,9 @@ public class AttributePolicyBuilder
             throw new IllegalArgumentException("onElements does not accept an empty list");
         }
 
-        for (var elementName : aElementNames) {
-            for (var attributeName : attributeNames) {
-                AttributePolicy policy = makePolicy(attributeName);
+        for (var attributeName : attributeNames) {
+            var policy = makePolicy(attributeName);
+            for (var elementName : aElementNames) {
                 parent.attributePolicy(elementName, attributeName, policy);
             }
         }

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/ElementAction.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/ElementAction.java
@@ -32,5 +32,12 @@ public enum ElementAction
     /**
      * Element is not passed through.
      */
-    DROP;
+    DROP,
+
+    /**
+     * Element is not passed through and neither are any descendants even if they might otherwise be
+     * marked to pass.
+     */
+    PRUNE;
+
 }

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/ElementPolicy.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/ElementPolicy.java
@@ -65,6 +65,16 @@ public class ElementPolicy
         return new ElementPolicy(ElementAction.DROP);
     }
 
+    public static ElementPolicy skip()
+    {
+        return new ElementPolicy(ElementAction.SKIP);
+    }
+
+    public static ElementPolicy prune()
+    {
+        return new ElementPolicy(ElementAction.PRUNE);
+    }
+
     public static ElementPolicy pass()
     {
         return new ElementPolicy(ElementAction.PASS);

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/ExternalPolicyCollection.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/ExternalPolicyCollection.java
@@ -33,6 +33,8 @@ public class ExternalPolicyCollection
     private ElementAction defaultElementAction;
     private AttributeAction defaultAttributeAction;
     private String defaultNamespace;
+    private boolean matchWithoutNamespace = false;
+    private boolean useDefaultNamespaceForAttributes = true;
 
     public String getName()
     {
@@ -112,5 +114,25 @@ public class ExternalPolicyCollection
     public void setDefaultNamespace(String aDefaultNamespace)
     {
         defaultNamespace = aDefaultNamespace;
+    }
+
+    public boolean isMatchWithoutNamespace()
+    {
+        return matchWithoutNamespace;
+    }
+
+    public void setMatchWithoutNamespace(boolean aMatchWithoutNamespace)
+    {
+        matchWithoutNamespace = aMatchWithoutNamespace;
+    }
+
+    public boolean isUseDefaultNamespaceForAttributes()
+    {
+        return useDefaultNamespaceForAttributes;
+    }
+
+    public void setUseDefaultNamespaceForAttributes(boolean aUseDefaultNamespaceForAttribues)
+    {
+        useDefaultNamespaceForAttributes = aUseDefaultNamespaceForAttribues;
     }
 }

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/PolicyCollectionIOUtils.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/PolicyCollectionIOUtils.java
@@ -56,8 +56,14 @@ public class PolicyCollectionIOUtils
         if (externalCollection.getDefaultNamespace() != null) {
             policyCollectionBuilder.defaultNamespace(externalCollection.getDefaultNamespace());
         }
+        if (externalCollection.isMatchWithoutNamespace()) {
+            policyCollectionBuilder.matchWithoutNamespace();
+        }
+        if (externalCollection.isUseDefaultNamespaceForAttributes()) {
+            policyCollectionBuilder.useDefaultNamespaceForAttributes();
+        }
 
-        for (ExternalPolicy policy : externalCollection.getPolicies()) {
+        for (var policy : externalCollection.getPolicies()) {
             var isElementPolicy = policy.getElements() != null;
             var isAttributesPolicy = policy.getAttributes() != null;
 

--- a/inception/inception-support/src/test/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/SanitizingContentHandlerTest.java
+++ b/inception/inception-support/src/test/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/SanitizingContentHandlerTest.java
@@ -227,6 +227,34 @@ public class SanitizingContentHandlerTest
         assertThat(buffer.toString()).isEqualTo("<root><child attr1=\"x\">text</child></root>");
     }
 
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("builderVariants")
+    void thatPrunedBranchesAreDropped(String aName, PolicyCollectionBuilder aBuilder)
+        throws Exception
+    {
+        var buffer = new StringWriter();
+        var policy = aBuilder //
+                .defaultElementAction(ElementAction.DROP) //
+                .defaultAttributeAction(AttributeAction.DROP) //
+                .allowElements("root", "child") //
+                .pruneElements("prune") //
+                .build();
+
+        var sut = new SanitizingContentHandler(makeXmlSerializer(buffer), policy);
+
+        sut.startDocument();
+        sut.startElement("root");
+        sut.startElement("prune");
+        sut.startElement("child");
+        sut.characters("text");
+        sut.endElement("child");
+        sut.endElement("prune");
+        sut.endElement("root");
+        sut.endDocument();
+
+        assertThat(buffer.toString()).isEqualTo("<root>    </root>");
+    }
+
     @Test
     void thatCaseInsensitiveModeWorks() throws Exception
     {


### PR DESCRIPTION
**What's in the PR**
- Allow pruning a subtree
- Allow configuring whether the default namespace also matches elements without namespace
- Allow configuring whether the default namespace is applied to attributes as well

**How to test manually**
* No specific test procedure

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
