### PR TITLE
#4344 - Allow format to inject default namespace if document does not specify one

### DIFF
--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/xhtml/XHtmlXmlDocumentViewControllerImpl.java
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/xhtml/XHtmlXmlDocumentViewControllerImpl.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import javax.servlet.ServletContext;
+import javax.xml.XMLConstants;
 
 import org.apache.uima.cas.CAS;
 import org.dkpro.core.api.xml.type.XmlDocument;
@@ -170,7 +171,19 @@ public class XHtmlXmlDocumentViewControllerImpl
                 renderTextContent(cas, sanitizingHandler);
             }
             else {
+                var formatPolicy = formatRegistry.getFormatPolicy(doc);
+                var defaultNamespace = formatPolicy.flatMap(policy -> policy.getDefaultNamespace());
+
+                if (defaultNamespace.isPresent()) {
+                    sanitizingHandler.startPrefixMapping(XMLConstants.DEFAULT_NS_PREFIX,
+                            defaultNamespace.get());
+                }
+
                 renderXmlContent(doc, sanitizingHandler, aEditor, maybeXmlDocument.get());
+
+                if (defaultNamespace.isPresent()) {
+                    sanitizingHandler.endPrefixMapping(XMLConstants.DEFAULT_NS_PREFIX);
+                }
             }
             rawHandler.endElement(null, null, BODY);
 

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/PolicyCollection.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/PolicyCollection.java
@@ -31,15 +31,17 @@ public class PolicyCollection
     private final ElementAction defaultElementAction;
     private final AttributeAction defaultAttributeAction;
 
-    private boolean debug = false;
-
     private String name;
     private String version;
 
-    public PolicyCollection(Map<QName, ElementPolicy> aElementPolicies,
+    private boolean debug = false;
+    private String defaultNamespace;
+
+    public PolicyCollection(String aDefaultNamespace, Map<QName, ElementPolicy> aElementPolicies,
             Map<QName, AttributePolicy> aGlobalAttributePolicies,
             ElementAction aDefaultElementAction, AttributeAction aDefaultAttributeAction)
     {
+        defaultNamespace = aDefaultNamespace;
         elementPolicies = aElementPolicies;
         globalAttributePolicies = aGlobalAttributePolicies;
         defaultElementAction = aDefaultElementAction;
@@ -104,6 +106,11 @@ public class PolicyCollection
     public String getName()
     {
         return name;
+    }
+
+    public Optional<String> getDefaultNamespace()
+    {
+        return Optional.ofNullable(defaultNamespace);
     }
 
     public void setName(String aName)

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/PolicyCollectionIOUtils.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/PolicyCollectionIOUtils.java
@@ -81,6 +81,8 @@ public class PolicyCollectionIOUtils
             }
         }
 
+        policyCollectionBuilder.allowAttributes("data-capture-root").globally();
+
         var policies = policyCollectionBuilder.build();
         policies.setDebug(externalCollection.isDebug());
 

--- a/inception/inception-support/src/test/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/PolicyCollectionIOUtilsTest.java
+++ b/inception/inception-support/src/test/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/PolicyCollectionIOUtilsTest.java
@@ -41,7 +41,12 @@ class PolicyCollectionIOUtilsTest
 
         assertThat(sut.getElementPolicies()).isEmpty();
 
-        assertThat(sut.getGlobalAttributeElementPolicies()).isEmpty();
+        assertThat(sut.getGlobalAttributeElementPolicies())
+                .extracting(p -> p.getQName().getNamespaceURI(), p -> p.getQName().getLocalPart(),
+                        p -> p.getAction()) //
+                .containsExactly( //
+                        tuple(NULL_NS_URI, "data-capture-root", AttributeAction.PASS));
+
     }
 
     @Test
@@ -68,6 +73,7 @@ class PolicyCollectionIOUtilsTest
                 .extracting(p -> p.getQName().getNamespaceURI(), p -> p.getQName().getLocalPart(),
                         p -> p.getAction()) //
                 .containsExactly( //
+                        tuple(NULL_NS_URI, "data-capture-root", AttributeAction.PASS),
                         tuple(NULL_NS_URI, "style", AttributeAction.PASS));
 
         assertThat(sut.forAttribute(new QName("div"), new QName("title"), null, "blah")).get() //


### PR DESCRIPTION
**What's in the PR**
- If the format defines a default namespace in its policy, then we inject it
- Fix bug that default namespace is not considerd for global attribute rules

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
