### PR TITLE
#4347 - CAS doctor fails to generate a proper report on projects not containing INITIAL_CASes

### DIFF
--- a/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/DocumentServiceImpl.java
+++ b/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/DocumentServiceImpl.java
@@ -867,7 +867,7 @@ public class DocumentServiceImpl
                     // adding this feature, the existing projects do not yet have initial CASes, so
                     // we create them here lazily
                     try {
-                        return importExportService.importCasFromFile(
+                        return importExportService.importCasFromFileNoChecks(
                                 getSourceDocumentFile(aDocument), aDocument,
                                 aFullProjectTypeSystem);
                     }

--- a/inception/inception-documents/src/test/java/de/tudarmstadt/ukp/inception/documents/DocumentServiceImplConcurrencyTest.java
+++ b/inception/inception-documents/src/test/java/de/tudarmstadt/ukp/inception/documents/DocumentServiceImplConcurrencyTest.java
@@ -137,7 +137,7 @@ public class DocumentServiceImplConcurrencyTest
         }).when(sut).getAnnotationDocument(any(), any(String.class));
 
         lenient()
-                .when(importExportService.importCasFromFile(any(File.class),
+                .when(importExportService.importCasFromFileNoChecks(any(File.class),
                         any(SourceDocument.class), any()))
                 .thenReturn(CasFactory.createText("Test"));
     }
@@ -146,9 +146,9 @@ public class DocumentServiceImplConcurrencyTest
     public void thatCreatingOrReadingInitialCasForNewDocumentCreatesNewCas() throws Exception
     {
         try (CasStorageSession session = CasStorageSession.open()) {
-            SourceDocument doc = makeSourceDocument(1l, 1l, "test");
+            var doc = makeSourceDocument(1l, 1l, "test");
 
-            JCas cas = sut.createOrReadInitialCas(doc).getJCas();
+            var cas = sut.createOrReadInitialCas(doc).getJCas();
 
             assertThat(cas).isNotNull();
             assertThat(cas.getDocumentText()).isEqualTo("Test");
@@ -178,8 +178,8 @@ public class DocumentServiceImplConcurrencyTest
         var typeSystem = mergeTypeSystems(
                 asList(createTypeSystemDescription(), getInternalTypeSystem()));
 
-        when(importExportService.importCasFromFile(any(File.class), any(SourceDocument.class),
-                any())).then(_invocation -> {
+        when(importExportService.importCasFromFileNoChecks(any(File.class),
+                any(SourceDocument.class), any())).then(_invocation -> {
                     CAS cas = createCas(typeSystem);
                     cas.setDocumentText(docText);
                     return cas;
@@ -246,8 +246,8 @@ public class DocumentServiceImplConcurrencyTest
         var typeSystem = mergeTypeSystems(
                 asList(createTypeSystemDescription(), getInternalTypeSystem()));
 
-        when(importExportService.importCasFromFile(any(File.class), any(SourceDocument.class),
-                any())).then(_invocation -> {
+        when(importExportService.importCasFromFileNoChecks(any(File.class),
+                any(SourceDocument.class), any())).then(_invocation -> {
                     CAS cas = createCas(typeSystem);
                     cas.setDocumentText(docText);
                     return cas;

--- a/inception/inception-export-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/export/DocumentImportExportService.java
+++ b/inception/inception-export-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/export/DocumentImportExportService.java
@@ -158,6 +158,13 @@ public interface DocumentImportExportService
             TypeSystemDescription aFullProjectTypeSystem)
         throws UIMAException, IOException;
 
+    CAS importCasFromFileNoChecks(File aFile, SourceDocument aDocument)
+        throws UIMAException, IOException;
+
+    CAS importCasFromFileNoChecks(File aFile, SourceDocument aDocument,
+            TypeSystemDescription aFullProjectTypeSystem)
+        throws UIMAException, IOException;
+
     /**
      * Exports the given CAS to a file on disk.
      * 

--- a/inception/inception-schema/src/test/java/de/tudarmstadt/ukp/inception/documents/service/DocumentServiceImplDatabaseTest.java
+++ b/inception/inception-schema/src/test/java/de/tudarmstadt/ukp/inception/documents/service/DocumentServiceImplDatabaseTest.java
@@ -108,9 +108,9 @@ public class DocumentServiceImplDatabaseTest
     @Test
     public void testThatAnnotationDocumentsForNonExistingUserAreNotReturned() throws Exception
     {
-        SourceDocument doc = sut.createSourceDocument(new SourceDocument("doc", project, "text"));
+        var doc = sut.createSourceDocument(new SourceDocument("doc", project, "text"));
 
-        AnnotationDocument ann = sut
+        var ann = sut
                 .createAnnotationDocument(new AnnotationDocument(annotator1.getUsername(), doc));
 
         assertThat(sut.listAnnotationDocuments(doc))
@@ -127,9 +127,9 @@ public class DocumentServiceImplDatabaseTest
     @Test
     public void thatExplicitUserActionsSetAnnotatorState()
     {
-        SourceDocument doc = sut.createSourceDocument(new SourceDocument("doc", project, "text"));
+        var doc = sut.createSourceDocument(new SourceDocument("doc", project, "text"));
 
-        AnnotationDocument ann = sut
+        var ann = sut
                 .createAnnotationDocument(new AnnotationDocument(annotator1.getUsername(), doc));
 
         sut.setAnnotationDocumentState(ann, AnnotationDocumentState.IGNORE);
@@ -191,10 +191,10 @@ public class DocumentServiceImplDatabaseTest
     @Test
     public void thatResettingADocumentSetsAlsoResetsTheStates() throws Exception
     {
-        SourceDocument doc = sut
+        var doc = sut
                 .createSourceDocument(new SourceDocument("doc.txt", project, TextFormatSupport.ID));
 
-        AnnotationDocument ann = sut
+        var ann = sut
                 .createAnnotationDocument(new AnnotationDocument(annotator1.getUsername(), doc));
 
         try (var session = CasStorageSession.open()) {
@@ -226,7 +226,7 @@ public class DocumentServiceImplDatabaseTest
         {
             var tsd = createTypeSystemDescription();
             var importService = mock(DocumentImportExportService.class);
-            when(importService.importCasFromFile(any(), any(), any()))
+            when(importService.importCasFromFileNoChecks(any(), any(), any()))
                     .thenReturn(CasCreationUtils.createCas(tsd, null, null, null));
             return importService;
         }

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/casdoctor/ProjectCasDoctorPanel.java
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/casdoctor/ProjectCasDoctorPanel.java
@@ -159,7 +159,7 @@ public class ProjectCasDoctorPanel
 
                 try {
                     casStorageService.forceActionOnCas(sd, INITIAL_CAS_PSEUDO_USER,
-                            (doc, user) -> createOrReadInitialCasWithoutSaving(doc, messageSet),
+                            (doc, user) -> createOrReadInitialCasWithoutSavingOrChecks(doc, messageSet),
                             (cas) -> casDoctor.repair(project, cas, messageSet.messages), //
                             true);
                 }
@@ -257,7 +257,7 @@ public class ProjectCasDoctorPanel
                 try {
                     objectCount++;
                     casStorageService.forceActionOnCas(sd, INITIAL_CAS_PSEUDO_USER,
-                            (doc, user) -> createOrReadInitialCasWithoutSaving(doc, messageSet),
+                            (doc, user) -> createOrReadInitialCasWithoutSavingOrChecks(doc, messageSet),
                             (cas) -> casDoctor.analyze(project, cas, messageSet.messages), //
                             false);
                 }
@@ -341,7 +341,7 @@ public class ProjectCasDoctorPanel
         aTarget.add(this);
     }
 
-    private CAS createOrReadInitialCasWithoutSaving(SourceDocument aDocument,
+    private CAS createOrReadInitialCasWithoutSavingOrChecks(SourceDocument aDocument,
             LogMessageSet aMessageSet)
         throws IOException, UIMAException
     {
@@ -350,8 +350,8 @@ public class ProjectCasDoctorPanel
                     UNMANAGED_NON_INITIALIZING_ACCESS);
         }
 
-        CAS cas = importExportService
-                .importCasFromFile(documentService.getSourceDocumentFile(aDocument), aDocument);
+        var cas = importExportService.importCasFromFileNoChecks(
+                documentService.getSourceDocumentFile(aDocument), aDocument);
         aMessageSet.messages.add(
                 LogMessage.info(getClass(), "Created initial CAS for [%s]", aDocument.getName()));
         return cas;

--- a/inception/inception-workload-dynamic/src/test/java/de/tudarmstadt/ukp/inception/workload/dynamic/DynamicWorkloadExtensionImpl2Test.java
+++ b/inception/inception-workload-dynamic/src/test/java/de/tudarmstadt/ukp/inception/workload/dynamic/DynamicWorkloadExtensionImpl2Test.java
@@ -227,7 +227,7 @@ public class DynamicWorkloadExtensionImpl2Test
         {
             var tsd = createTypeSystemDescription();
             var importService = mock(DocumentImportExportService.class);
-            when(importService.importCasFromFile(any(), any(), any()))
+            when(importService.importCasFromFileNoChecks(any(), any(), any()))
                     .thenReturn(CasCreationUtils.createCas(tsd, null, null, null));
             return importService;
         }

--- a/inception/inception-workload-dynamic/src/test/java/de/tudarmstadt/ukp/inception/workload/dynamic/DynamicWorkloadExtensionImplTest.java
+++ b/inception/inception-workload-dynamic/src/test/java/de/tudarmstadt/ukp/inception/workload/dynamic/DynamicWorkloadExtensionImplTest.java
@@ -240,7 +240,7 @@ public class DynamicWorkloadExtensionImplTest
         {
             var tsd = createTypeSystemDescription();
             var importService = mock(DocumentImportExportService.class);
-            when(importService.importCasFromFile(any(), any(), any()))
+            when(importService.importCasFromFileNoChecks(any(), any(), any()))
                     .thenReturn(CasCreationUtils.createCas(tsd, null, null, null));
             return importService;
         }

--- a/inception/inception-workload-matrix/src/test/java/de/tudarmstadt/ukp/inception/workload/matrix/MatrixWorkloadExtensionImplTest.java
+++ b/inception/inception-workload-matrix/src/test/java/de/tudarmstadt/ukp/inception/workload/matrix/MatrixWorkloadExtensionImplTest.java
@@ -152,7 +152,7 @@ public class MatrixWorkloadExtensionImplTest
         {
             var tsd = createTypeSystemDescription();
             var importService = mock(DocumentImportExportService.class);
-            when(importService.importCasFromFile(any(), any(), any()))
+            when(importService.importCasFromFileNoChecks(any(), any(), any()))
                     .thenReturn(CasCreationUtils.createCas(tsd, null, null, null));
             return importService;
         }


### PR DESCRIPTION
**What's in the PR**
- Disable implicit CAS doctor check when creating the INITIAL_CAS since either CAS Doctor on the panel is run immediately after or the usual option CAS Doctor check is run on document open

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
