### PR TITLE
#4355 - Limit label length in label rendering utility

### DIFF
--- a/inception/inception-diam-editor/src/main/ts/src/Utils.ts
+++ b/inception/inception-diam-editor/src/main/ts/src/Utils.ts
@@ -20,7 +20,13 @@ import { compareOffsets } from '@inception-project/inception-js-api/src/model/Of
 
 export function renderLabel (ann?: Annotation): string {
   if (!ann) return ''
-  return `${ann.label || `[${ann.layer.name}]`}`
+  const maxLength = 300
+  let label = `${ann.label || `[${ann.layer.name}]`}`
+  label = label.replace(/\s+/g, ' ').trim()
+  if (label.length > maxLength) {
+    label = label.substring(0, maxLength).trim() + '…'
+  }
+  return label
 }
 
 export function uniqueLabels (data: AnnotatedText): string[] {


### PR DESCRIPTION
**What's in the PR**
- Limit label to 300 chars plus ellipsis

**How to test manually**
* Create an annotation with a very long label (e.g. a multi-line string field)

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
