### PR TITLE
#4356 - Very long suggestion spans not rendered

### DIFF
--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/Predictions.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/Predictions.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import org.apache.commons.lang3.Validate;
+import org.apache.uima.cas.text.AnnotationPredicates;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
@@ -169,19 +170,17 @@ public class Predictions
     private <T extends AnnotationSuggestion> List<T> getFlattenedPredictions(Class<T> type,
             String aDocumentName, AnnotationLayer aLayer, int aWindowBegin, int aWindowEnd)
     {
+        var windowBegin = aWindowBegin == -1 ? 0 : aWindowBegin;
+        var windowEnd = aWindowEnd == -1 ? Integer.MAX_VALUE : aWindowEnd;
+
         synchronized (predictionsLock) {
             var byDocument = idxDocuments.getOrDefault(aDocumentName, emptyMap());
             return byDocument.entrySet().stream() //
                     .filter(f -> type.isInstance(f.getValue())) //
                     .map(f -> (Entry<ExtendedId, T>) (Entry) f) //
                     .filter(f -> f.getKey().getLayerId() == aLayer.getId()) //
-                    // .filter(f -> overlapping(f.getValue().getWindowBegin(),
-                    // f.getValue().getWindowEnd(),
-                    // aWindowBegin == -1 ? 0 : aWindowBegin,
-                    // aWindowEnd == -1 ? MAX_VALUE : aWindowEnd))
-                    .filter(f -> aWindowBegin == -1
-                            || (f.getValue().getWindowBegin() >= aWindowBegin))
-                    .filter(f -> aWindowEnd == -1 || (f.getValue().getWindowEnd() <= aWindowEnd))
+                    .filter(f -> AnnotationPredicates.overlapping(f.getValue().getWindowBegin(),
+                            f.getValue().getWindowEnd(), windowBegin, windowEnd))
                     .sorted(comparingInt(e2 -> e2.getValue().getWindowBegin())) //
                     .map(Map.Entry::getValue) //
                     .collect(toList());


### PR DESCRIPTION
**What's in the PR**
- Properly check for overlap of the suggestion span with the viewport

**How to test manually**
* E.g. use an external recommender to generate a suggestion that covers the entire document and then just render a single sentence out of it by setting the number of units to 1 in the annotation editor preferences using the brat editor.

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
