### PR TITLE
Docs/admin apache proxy config

### DIFF
--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/installation_ssl_apache.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/installation_ssl_apache.adoc
@@ -55,6 +55,11 @@ ProxyPreserveHost On
   Allow from all
 </Proxy>
 
+<Location "/inception">
+  RequestHeader set "X-Forwarded-Proto" expr=%{REQUEST_SCHEME}
+  RequestHeader set "X-Forwarded-SSL" expr=%{HTTPS}
+</Location>
+
 ProxyPass /inception/ws ws://localhost:8080/inception/ws
 ProxyPass /inception http://localhost:8080/inception
 ProxyPassReverse /inception https://your.public.domain.name.com/inception

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/installation_ssl_apache.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/installation_ssl_apache.adoc
@@ -64,6 +64,15 @@ ProxyPass /inception/ws ws://localhost:8080/inception/ws
 ProxyPass /inception http://localhost:8080/inception
 ProxyPassReverse /inception https://your.public.domain.name.com/inception
 ----
+If you use Apache 2.4 without `mod_apache_compat` exchange the `<Proxy> … </Proxy>` section from the above example with this:
++
+[source,xml]
+----
+<Proxy http://localhost/inception >
+  require all granted
+</Proxy>
+----
+It is important to not mix both styles in any case throughout your configuration in order to avoid unforseen errors.
 
 * Enable the configuration with
 +

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/installation_ssl_apache.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/installation_ssl_apache.adoc
@@ -64,7 +64,7 @@ ProxyPass /inception/ws ws://localhost:8080/inception/ws
 ProxyPass /inception http://localhost:8080/inception
 ProxyPassReverse /inception https://your.public.domain.name.com/inception
 ----
-If you use Apache 2.4 without `mod_apache_compat` exchange the `<Proxy> … </Proxy>` section from the above example with this:
+If you use Apache 2.4 without `mod_access_compat` exchange the `<Proxy> … </Proxy>` section from the above example with this:
 +
 [source,xml]
 ----


### PR DESCRIPTION
**What's in the PR**
* Added information about forwarding the URL scheme when using Apache HTTPD with mod_proxy and SSL. 
* The existing documentation shows a deprecated approach to setting permissions in the Apache config. Apache 2.4 can be configured to use still support the older approach, and often it is (by use of mod_access_compat). If not, the example might not work at all. Therefore the newer method was added beneath.

**How to test manually**
* -

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation

Please also refer to: https://github.com/inception-project/inception/issues/3923#issuecomment-1840413567