### PR TITLE
#4375 - SanitizingContentHandler blocks namespace mappings

### DIFF
--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/SanitizingContentHandler.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/SanitizingContentHandler.java
@@ -267,10 +267,6 @@ public class SanitizingContentHandler
 
         var sanitizedAttributes = new AttributesImpl();
         for (var i = 0; i < aAtts.getLength(); i++) {
-            if (XMLNS.equals(aAtts.getQName(i)) || aAtts.getQName(i).startsWith(XMLNS_PREFIX)) {
-                continue;
-            }
-
             sanitizeAttribute(sanitizedAttributes, aElement, aAtts, i);
         }
         return sanitizedAttributes;
@@ -291,7 +287,8 @@ public class SanitizingContentHandler
         var action = policies.forAttribute(aElement, attribute, type, value)
                 .orElse(policies.getDefaultAttributeAction());
 
-        if (XMLNS.equals(attribute.getPrefix())) {
+        // Default namespace and namespace prefix declarations always pass
+        if (XMLNS.equals(aAtts.getQName(i)) || XMLNS.equals(attribute.getPrefix())) {
             action = AttributeAction.PASS;
         }
 

--- a/inception/inception-support/src/test/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/SanitizingContentHandlerTest.java
+++ b/inception/inception-support/src/test/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/SanitizingContentHandlerTest.java
@@ -330,4 +330,25 @@ public class SanitizingContentHandlerTest
 
         assertThat(buffer.toString()).isEqualTo("<ns:ROOT xmlns:ns=\"http://namespace.org\"/>");
     }
+
+    @Test
+    void thatNamespaceDeclarationsPass() throws Exception
+    {
+        QName root = new QName("http://namespace.org", "ROOT");
+
+        var buffer = new StringWriter();
+        var policy = PolicyCollectionBuilder.caseSensitive() //
+                .allowElements(root) //
+                .build();
+
+        var sut = new SanitizingContentHandler(makeXmlSerializer(buffer), policy);
+
+        String xml = "<ns:ROOT xmlns:ns='http://namespace.org' xmlns:other='otherNs' xmlns='default'/>";
+
+        var parser = newSaxParser();
+        parser.parse(toInputStream(xml, UTF_8), new DefaultHandlerToContentHandlerAdapter<>(sut));
+
+        assertThat(buffer.toString()).isEqualTo(
+                "<ns:ROOT xmlns:ns=\"http://namespace.org\" xmlns:other=\"otherNs\" xmlns=\"default\"/>");
+    }
 }


### PR DESCRIPTION
**What's in the PR**
- Namespace declarations should always pass

**How to test manually**
* No specific test procedure

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
