### PR TITLE
#4383 - Hide negative scores in annotation sidebar but still sort by it

### DIFF
--- a/inception/inception-diam-compactv2/src/main/java/de/tudarmstadt/ukp/inception/diam/model/compactv2/CompactAnnotationAttributes.java
+++ b/inception/inception-diam-compactv2/src/main/java/de/tudarmstadt/ukp/inception/diam/model/compactv2/CompactAnnotationAttributes.java
@@ -20,6 +20,8 @@ package de.tudarmstadt.ukp.inception.diam.model.compactv2;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Shape;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -32,11 +34,13 @@ public class CompactAnnotationAttributes
     public static final String ATTR_COLOR = "c";
     public static final String ATTR_COMMENTS = "cm";
     public static final String ATTR_SCORE = "s";
+    public static final String ATTR_HIDE_SCORE = "hs";
 
     private @JsonProperty(ATTR_LABEL) String labelText;
     private @JsonProperty(ATTR_COLOR) String color;
     private @JsonProperty(ATTR_COMMENTS) List<CompactComment> comments;
     private @JsonProperty(ATTR_SCORE) double score;
+    private @JsonProperty(ATTR_HIDE_SCORE) boolean hideScore;
 
     @JsonInclude(Include.NON_DEFAULT)
     @JsonSerialize(using = ScoreSerializer.class)
@@ -48,6 +52,18 @@ public class CompactAnnotationAttributes
     public void setScore(double aScore)
     {
         score = aScore;
+    }
+
+    @JsonFormat(shape = Shape.NUMBER)
+    @JsonInclude(Include.NON_DEFAULT)
+    public boolean isHideScore()
+    {
+        return hideScore;
+    }
+    
+    public void setHideScore(boolean aHideScore)
+    {
+        hideScore = aHideScore;
     }
 
     public void setLabelText(String aLabelText)

--- a/inception/inception-diam-compactv2/src/main/java/de/tudarmstadt/ukp/inception/diam/model/compactv2/CompactSerializerV2Impl.java
+++ b/inception/inception-diam-compactv2/src/main/java/de/tudarmstadt/ukp/inception/diam/model/compactv2/CompactSerializerV2Impl.java
@@ -125,6 +125,7 @@ public class CompactSerializerV2Impl
                 getArgument(varc.getSource(), varc.getTarget()), varc.getLabelHint(),
                 varc.getColorHint());
         carc.getAttributes().setScore(varc.getScore());
+        carc.getAttributes().setHideScore(varc.isHideScore());
         return carc;
     }
 
@@ -151,6 +152,7 @@ public class CompactSerializerV2Impl
                     vspan.getColorHint());
         }
         cspan.getAttributes().setScore(vspan.getScore());
+        cspan.getAttributes().setHideScore(vspan.isHideScore());
         return cspan;
     }
 

--- a/inception/inception-diam-editor/src/main/ts/src/LabelBadge.svelte
+++ b/inception/inception-diam-editor/src/main/ts/src/LabelBadge.svelte
@@ -62,7 +62,7 @@
                 <span class="label">{renderLabel(annotation)}</span>
             {/if}
             <!-- Negative scores used only for sorting/ranking but not shown -->
-            {#if annotation.score > 0}
+            {#if annotation.score && !annotation.hideScore}
                 <span class="small font-monospace score"
                     >{annotation.score.toFixed(2)}</span
                 >
@@ -90,7 +90,7 @@
             <span class="label">{renderLabel(annotation)}</span>
         {/if}
         <!-- Negative scores used only for sorting/ranking but not shown -->
-        {#if annotation.score > 0}
+        {#if annotation.score && !annotation.hideScore}
             <span class="small font-monospace score"
                 >{annotation.score.toFixed(2)}</span
             >

--- a/inception/inception-diam-editor/src/main/ts/src/LabelBadge.svelte
+++ b/inception/inception-diam-editor/src/main/ts/src/LabelBadge.svelte
@@ -61,7 +61,8 @@
             {#if showText}
                 <span class="label">{renderLabel(annotation)}</span>
             {/if}
-            {#if annotation.score}
+            <!-- Negative scores used only for sorting/ranking but not shown -->
+            {#if annotation.score > 0}
                 <span class="small font-monospace score"
                     >{annotation.score.toFixed(2)}</span
                 >
@@ -88,7 +89,8 @@
         {#if showText}
             <span class="label">{renderLabel(annotation)}</span>
         {/if}
-        {#if annotation.score}
+        <!-- Negative scores used only for sorting/ranking but not shown -->
+        {#if annotation.score > 0}
             <span class="small font-monospace score"
                 >{annotation.score.toFixed(2)}</span
             >

--- a/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/v1/ExternalRecommenderFactory.java
+++ b/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/v1/ExternalRecommenderFactory.java
@@ -97,4 +97,11 @@ public class ExternalRecommenderFactory
     {
         return false;
     }
+
+    @Override
+    public boolean isRanker(Recommender aRecommender)
+    {
+        var traits = readTraits(aRecommender);
+        return traits.isRanker();
+    }
 }

--- a/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/v1/ExternalRecommenderTraits.java
+++ b/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/v1/ExternalRecommenderTraits.java
@@ -30,6 +30,7 @@ public class ExternalRecommenderTraits
     private String remoteUrl;
     private boolean trainable;
     private boolean verifyCertificates = true;
+    private boolean ranker;
 
     public String getRemoteUrl()
     {
@@ -50,14 +51,24 @@ public class ExternalRecommenderTraits
     {
         trainable = aTrainable;
     }
-    
+
     public void setVerifyCertificates(boolean aVerifyCertificates)
     {
         verifyCertificates = aVerifyCertificates;
     }
-    
+
     public boolean isVerifyCertificates()
     {
         return verifyCertificates;
+    }
+
+    public void setRanker(boolean aRanker)
+    {
+        ranker = aRanker;
+    }
+
+    public boolean isRanker()
+    {
+        return ranker;
     }
 }

--- a/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/v1/ExternalRecommenderTraitsEditor.html
+++ b/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/v1/ExternalRecommenderTraitsEditor.html
@@ -47,6 +47,16 @@
         </div>
       </div>
     </div>
+    <div class="row form-row" wicket:enclosure="ranker">
+      <div class="offset-sm-3 col-sm-9">
+        <div class="form-check">
+          <input wicket:id="ranker" class="form-check-input" type="checkbox"/>
+          <label wicket:for="ranker" class="form-check-label">
+            <wicket:label key="ranker"/>
+          </label>
+        </div>
+      </div>
+    </div>
   </form>
 </wicket:extend>
 </html>

--- a/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/v1/ExternalRecommenderTraitsEditor.java
+++ b/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/v1/ExternalRecommenderTraitsEditor.java
@@ -80,6 +80,10 @@ public class ExternalRecommenderTraitsEditor
 
         getTrainingStatesChoice().add(visibleWhen(() -> trainable.getModelObject() == true));
 
+        var ranker = new CheckBox("ranker");
+        ranker.setOutputMarkupId(true);
+        form.add(ranker);
+
         add(form);
     }
 }

--- a/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/v1/ExternalRecommenderTraitsEditor.properties
+++ b/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/v1/ExternalRecommenderTraitsEditor.properties
@@ -16,4 +16,5 @@
 
 remoteUrl=Remote URL
 trainable=Trainable
+ranker=Ranker
 verifyCertificates=Verify certificates

--- a/inception/inception-js-api/src/main/ts/src/model/Annotation.ts
+++ b/inception/inception-js-api/src/main/ts/src/model/Annotation.ts
@@ -40,6 +40,11 @@ export interface Annotation {
     score?: number
 
     /**
+     * Whether to display the score in the UI or not.
+     */
+    hideScore: boolean
+
+    /**
      * Comments
      */
     comments?: Comment[]

--- a/inception/inception-js-api/src/main/ts/src/model/Relation.ts
+++ b/inception/inception-js-api/src/main/ts/src/model/Relation.ts
@@ -24,6 +24,7 @@ export class Relation implements Annotation {
   color?: string
   label?: string
   score?: number
+  hideScore: boolean
   comments?: Comment[]
   arguments: Array<Argument>
 
@@ -36,6 +37,7 @@ export class Relation implements Annotation {
       this.label = other.label
       this.comments = other.comments
       this.arguments = other.arguments
+      this.hideScore = other.hideScore
     }
   }
 }

--- a/inception/inception-js-api/src/main/ts/src/model/Span.ts
+++ b/inception/inception-js-api/src/main/ts/src/model/Span.ts
@@ -28,6 +28,7 @@ export class Span implements Annotation {
   color?: string
   label?: string
   score?: number
+  hideScore: boolean
   comments?: Comment[]
 
   /**
@@ -45,6 +46,7 @@ export class Span implements Annotation {
       this.label = other.label
       this.comments = other.comments
       this.clippingFlags = other.clippingFlags
+      this.hideScore = other.hideScore
     }
   }
 }

--- a/inception/inception-js-api/src/main/ts/src/model/compact_v2/CompactAnnotationAttributes.ts
+++ b/inception/inception-js-api/src/main/ts/src/model/compact_v2/CompactAnnotationAttributes.ts
@@ -37,4 +37,9 @@ export interface CompactAnnotationAttributes {
    * Score (optional)
    */
   s: number
+
+  /**
+   * Hide score (optional)
+   */
+  hs: number
 }

--- a/inception/inception-js-api/src/main/ts/src/model/compact_v2/CompactRelation.ts
+++ b/inception/inception-js-api/src/main/ts/src/model/compact_v2/CompactRelation.ts
@@ -36,6 +36,7 @@ export function unpackCompactRelation (doc: AnnotatedText, raw: CompactRelation)
   cooked.color = raw[3]?.c
   cooked.label = raw[3]?.l
   cooked.score = raw[3]?.s
+  cooked.hideScore = raw[3]?.hs ? true : false
   cooked.comments = unpackCompactComments(doc, cooked, raw[3]?.cm)
   return cooked
 }

--- a/inception/inception-js-api/src/main/ts/src/model/compact_v2/CompactSpan.ts
+++ b/inception/inception-js-api/src/main/ts/src/model/compact_v2/CompactSpan.ts
@@ -35,6 +35,7 @@ export function unpackCompactSpan (doc: AnnotatedText, raw: CompactSpan): Span {
   cooked.color = raw[3]?.c
   cooked.label = raw[3]?.l
   cooked.score = raw[3]?.s
+  cooked.hideScore = raw[3]?.hs ? true : false
   cooked.clippingFlags = raw[3]?.cl
   cooked.comments = unpackCompactComments(doc, cooked, raw[3]?.cm)
   return cooked

--- a/inception/inception-model-vdoc/src/main/java/de/tudarmstadt/ukp/inception/rendering/vmodel/VObject.java
+++ b/inception/inception-model-vdoc/src/main/java/de/tudarmstadt/ukp/inception/rendering/vmodel/VObject.java
@@ -36,6 +36,7 @@ public abstract class VObject
     private String color;
     private String label;
     private double score;
+    private boolean hideScore;
     private boolean actionButtons;
 
     public VObject(AnnotationLayer aLayer, VID aVid, Map<String, String> aFeatures)
@@ -115,5 +116,15 @@ public abstract class VObject
     public void setScore(double aScore)
     {
         score = aScore;
+    }
+
+    public boolean isHideScore()
+    {
+        return hideScore;
+    }
+
+    public void setHideScore(boolean aHideScore)
+    {
+        hideScore = aHideScore;
     }
 }

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/SuggestionGroup.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/SuggestionGroup.java
@@ -178,13 +178,9 @@ public class SuggestionGroup<T extends AnnotationSuggestion>
 
         // Determine the maximum score per Label
         Map<LabelMapKey, Double> maxScorePerLabel = new HashMap<>();
-        for (LabelMapKey label : labelMap.keySet()) {
-            double maxScore = 0;
-            for (Entry<Long, T> classifier : labelMap.get(label).entrySet()) {
-                if (classifier.getValue().getScore() > maxScore) {
-                    maxScore = classifier.getValue().getScore();
-                }
-            }
+        for (var label : labelMap.keySet()) {
+            double maxScore = labelMap.get(label).values().stream()
+                    .mapToDouble(AnnotationSuggestion::getScore).max().orElse(0.0d);
             maxScorePerLabel.put(label, maxScore);
         }
 

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/recommender/RecommendationEngineFactory.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/recommender/RecommendationEngineFactory.java
@@ -72,4 +72,16 @@ public interface RecommendationEngineFactory<T>
     T readTraits(Recommender aRecommender);
 
     void writeTraits(Recommender aRecommender, T aTraits);
+
+    /**
+     * The task of a ranker is to provide ordered suggestions instead of scored suggestions. While a
+     * ranker will usually set the score property of a suggestion, that score should not be
+     * displayed prominently in the user interface.
+     * 
+     * @return {@code true} if the recommender is a ranker
+     */
+    default boolean isRanker(Recommender aRecommender)
+    {
+        return false;
+    }
 }

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/RecommendationEditorExtension.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/RecommendationEditorExtension.java
@@ -391,7 +391,7 @@ public class RecommendationEditorExtension
         var details = new VLazyDetailGroup();
         for (var ao : sortedByScore) {
             var items = new ArrayList<String>();
-            if (ao.getScore() != -1) {
+            if (ao.getScore() > 0.0d) {
                 items.add(String.format("Score: %.2f", ao.getScore()));
             }
             if (ao.getScoreExplanation().isPresent()) {

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/render/RecommendationRelationRenderer.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/render/RecommendationRelationRenderer.java
@@ -23,6 +23,7 @@ import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
 import static org.apache.uima.fit.util.CasUtil.selectAt;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.uima.cas.Type;
@@ -108,6 +109,8 @@ public class RecommendationRelationRenderer
         var features = annotationService.listSupportedFeatures(layer).stream()
                 .collect(toMap(AnnotationFeature::getName, identity()));
 
+        var rankerCache = new HashMap<Long, Boolean>();
+
         for (SuggestionGroup<RelationSuggestion> group : groupedPredictions) {
             for (RelationSuggestion suggestion : group.bestSuggestions(pref)) {
 
@@ -142,9 +145,19 @@ public class RecommendationRelationRenderer
                         ? Map.of(suggestion.getFeature(), annotation)
                         : Map.of();
 
+                var isRanker = rankerCache.computeIfAbsent(suggestion.getRecommenderId(), id -> {
+                    var recommender = recommendationService.getRecommender(id);
+                    if (recommender != null) {
+                        var factory = recommendationService.getRecommenderFactory(recommender);
+                        return factory.map(f -> f.isRanker(recommender)).orElse(false);
+                    }
+                    return false;
+                });
+
                 VArc arc = new VArc(layer, suggestion.getVID(), VID.of(source), VID.of(target),
                         "\uD83E\uDD16 " + suggestion.getUiLabel(), featureAnnotation, COLOR);
                 arc.setScore(suggestion.getScore());
+                arc.setHideScore(isRanker);
 
                 aVDoc.add(arc);
             }

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/render/RecommendationSpanRenderer.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/render/RecommendationSpanRenderer.java
@@ -21,6 +21,7 @@ import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.util.WebAnnoCasUt
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
@@ -102,6 +103,8 @@ public class RecommendationSpanRenderer
         var features = annotationService.listSupportedFeatures(layer).stream()
                 .collect(toMap(AnnotationFeature::getName, identity()));
 
+        var rankerCache = new HashMap<Long, Boolean>();
+
         for (var suggestionGroup : groups) {
             // Render annotations for each label
             for (var suggestion : suggestionGroup.bestSuggestions(pref)) {
@@ -120,9 +123,19 @@ public class RecommendationSpanRenderer
                         ? Map.of(suggestion.getFeature(), annotation)
                         : Map.of();
 
+                var isRanker = rankerCache.computeIfAbsent(suggestion.getRecommenderId(), id -> {
+                    var recommender = recommendationService.getRecommender(id);
+                    if (recommender != null) {
+                        var factory = recommendationService.getRecommenderFactory(recommender);
+                        return factory.map(f -> f.isRanker(recommender)).orElse(false);
+                    }
+                    return false;
+                });
+
                 var v = new VSpan(layer, suggestion.getVID(), range.get(), featureAnnotation,
                         COLOR);
                 v.setScore(suggestion.getScore());
+                v.setHideScore(isRanker);
                 v.setActionButtons(recommenderProperties.isActionButtonsEnabled());
 
                 vdoc.add(v);


### PR DESCRIPTION
**What's in the PR**
- Added flag to VDoc annotations to indicate if a score should be hidden
- Added a flag to the external recommender that indicates if it is a ranker - for rankers, the score should be hidden
- Hide the score in the annotation sidebar if the hide flag is set

**How to test manually**
* Configure an external recommender
* Set the "ranker" flag on it
* Check the annotation sidebar

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
