### PR TITLE
#916 - Changing URL of remote KB requires server restart

### DIFF
--- a/inception/inception-api-annotation/src/main/resources/META-INF/asciidoc/admin-guide/settings_segmentation.adoc
+++ b/inception/inception-api-annotation/src/main/resources/META-INF/asciidoc/admin-guide/settings_segmentation.adoc
@@ -24,7 +24,7 @@ adding/removing/changing segmentation annotations (i.e. sentences or tokens).
 
 This section describes the global settings related to the support for editable segmentation annotations (i.e. sentences or tokens).
 
-.Knowledge base settings overview
+.Segmentation settings overview
 [cols="4*", options="header"]
 |===
 | Setting
@@ -33,8 +33,8 @@ This section describes the global settings related to the support for editable s
 | Example
 
 
-| ui.sentence-layer-editable=true
+| `ui.sentence-layer-editable`
 | Enable/disable editing sentences
-| false
-| true
+| `false`
+| `true`
 |===


### PR DESCRIPTION
**What's in the PR**
- Inject URL into live objects as part of setting up a connection
- Clear query cache when changing the KB configuration
- Unrelated documentation fix

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
