### PR TITLE
#4386 - User "null" sometimes shows up in recent activity

### DIFF
--- a/inception/inception-ui-dashboard-activity/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/activity/ActivitiesDashletControllerImpl.java
+++ b/inception/inception-ui-dashboard-activity/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/activity/ActivitiesDashletControllerImpl.java
@@ -137,6 +137,7 @@ public class ActivitiesDashletControllerImpl
         return recentEvents.stream() //
                 .filter(Objects::nonNull) //
                 .filter(event -> event.getDocument() != -1l) //
+                .filter(event -> event.getAnnotator() != null) //
                 // Filter out documents which are not annotatable or curatable
                 .filter(event -> {
                     if (CURATION_USER.equals(event.getAnnotator())) {


### PR DESCRIPTION
**What's in the PR**
- Filter out events where the annotator is null - these are not relevant for the recent activity sidebar

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
