### PR TITLE
#4414 - Number of new suggestions not displayed correctly

### DIFF
--- a/inception/inception-recommendation-api/src/test/java/de/tudarmstadt/ukp/inception/recommendation/api/model/PredictionsTest.java
+++ b/inception/inception-recommendation-api/src/test/java/de/tudarmstadt/ukp/inception/recommendation/api/model/PredictionsTest.java
@@ -76,7 +76,7 @@ class PredictionsTest
         var winBegin = sentences.get(Math.round(sentences.size() * 0.25f)).getBegin();
         var winEnd = sentences.get(Math.round(sentences.size() * 0.75f)).getEnd();
 
-        sut.putPredictions(generatePredictions(100, 1, 100));
+        sut.inheritSuggestions(generatePredictions(100, 1, 100));
         assertThat(sut.size()).isEqualTo(10000);
 
         var groups = sut.getGroupedPredictions(SpanSuggestion.class, "doc10", layer, winBegin,
@@ -93,7 +93,7 @@ class PredictionsTest
 
         sut = new Predictions(user, user.getUsername(), project);
         var generatedPredictions = generatePredictions(10_000, 1, 1_000);
-        sut.putPredictions(generatedPredictions);
+        sut.inheritSuggestions(generatedPredictions);
         var documents = generatedPredictions.stream() //
                 .map(AnnotationSuggestion::getDocumentName) //
                 .distinct() //
@@ -114,7 +114,7 @@ class PredictionsTest
     {
         var doc = "doc";
         sut = new Predictions(user, user.getUsername(), project);
-        sut.putPredictions(asList( //
+        sut.putSuggestions(1, 0, 0, asList( //
                 SpanSuggestion.builder() //
                         .withId(AnnotationSuggestion.NEW_ID) //
                         .withDocumentName(doc) //
@@ -126,12 +126,12 @@ class PredictionsTest
 
         var inheritedPredictions = sut.getPredictionsByDocument(doc);
         sut = new Predictions(sut);
-        sut.putPredictions(asList( //
+        sut.putSuggestions(1, 0, 0, asList( //
                 SpanSuggestion.builder() //
                         .withId(AnnotationSuggestion.NEW_ID) //
                         .withDocumentName(doc) //
                         .build()));
-        sut.putPredictions(inheritedPredictions);
+        sut.inheritSuggestions(inheritedPredictions);
 
         assertThat(sut.getPredictionsByDocument(doc)) //
                 .extracting(AnnotationSuggestion::getId) //

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/PredictionTask.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/PredictionTask.java
@@ -108,7 +108,8 @@ public class PredictionTask
                 appEventPublisher.publishEvent(RecommenderTaskNotificationEvent
                         .builder(this, project, sessionOwner.getUsername()) //
                         .withMessage(LogMessage.info(this,
-                                predictions.getNewSuggestionCount() + " new predictions available")) //
+                                predictions.getNewSuggestionCount() + " new predictions available" //
+                                        + " (some may be hidden/merged)")) //
                         .build());
             }
             else {

--- a/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImplTest.java
+++ b/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImplTest.java
@@ -120,7 +120,7 @@ class RecommendationServiceImplTest
                         .withRecommender(rec) //
                         .build());
         var activePredictions = new Predictions(sessionOwner, sessionOwner.getUsername(), project);
-        activePredictions.putPredictions(existingSuggestions);
+        activePredictions.inheritSuggestions(existingSuggestions);
 
         var newSuggestions = Arrays.<AnnotationSuggestion> asList( //
                 SpanSuggestion.builder() //


### PR DESCRIPTION
**What's in the PR**
- Fix aging
- Pass reconciliation result info into the predictions object
- Two methods, one for inheriting suggestions, the other for putting new ones
- Display the number of documents containing new suggestions in the flash message

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
