### PR TITLE
#4430 -Highlight rows may get merged in PDF editor at high scale factors

### DIFF
--- a/inception/inception-pdf-editor2/src/main/ts/src/PdfAnnotationEditor.css
+++ b/inception/inception-pdf-editor2/src/main/ts/src/PdfAnnotationEditor.css
@@ -15,16 +15,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+:root {
+  --marker-focus-width: 2px;
+}
+
  .marker-matchfocus {
  	background-color: rgba(255, 165, 0, 0.4);
   border-color: rgba(255, 165, 0, 1.0);
  }
 
 .anno-span__area.marker-focus {
-  box-shadow: 0 2px 0px 0px rgba(255,165,0) !important;
+  box-shadow: 0 var(--marker-focus-width) 0px 0px rgba(255, 165, 0, 0.6) !important;
 }
 
 .anno-knob.marker-focus {
-  box-shadow: 0 0px 2px 2px rgba(255,165,0) !important;
+  box-shadow: 0 0px 2px 2px rgba(255, 165, 0, 1.0) !important;
 }
 


### PR DESCRIPTION
**What's in the PR**
- Remove the scale factor from the merge margin calculation to fix the issue
- Improve border and selection marker widths as scale factor increases (i.e. do not scale them along linarly)
- Make the border and selection marker a bit more transparent so text is better readable

**How to test manually**
* See issue description / play around with different scale factors in PDF editor

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
