### PR TITLE
#4437 - Reduce memory usage for agreement calculation

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,7 +28,7 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven
-      run: mvn --no-transfer-progress -B clean package --file pom.xml
+      run: mvn --no-transfer-progress -B clean verify --file pom.xml
 
     # Fails with error message - no idea why...
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive

--- a/inception/inception-agreement/pom.xml
+++ b/inception/inception-agreement/pom.xml
@@ -54,11 +54,19 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-annotation-storage</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-model</artifactId>
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-scheduling</artifactId>
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
@@ -75,6 +83,10 @@
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-support-bootstrap</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-annotation-storage-api</artifactId>
     </dependency>
 
     <dependency>
@@ -109,10 +121,6 @@
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.wicket</groupId>
-      <artifactId>wicket-util</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.wicket</groupId>

--- a/inception/inception-agreement/pom.xml
+++ b/inception/inception-agreement/pom.xml
@@ -98,6 +98,10 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-csv</artifactId>
     </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
 
     <!-- Spring dependencies -->
     <dependency>
@@ -133,6 +137,10 @@
     <dependency>
       <groupId>com.googlecode.wicket-jquery-ui</groupId>
       <artifactId>wicket-jquery-ui-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wicketstuff</groupId>
+      <artifactId>wicketstuff-annotationeventdispatcher</artifactId>
     </dependency>
     <dependency>
       <groupId>org.danekja</groupId>

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/BasicAgreementResult.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/BasicAgreementResult.java
@@ -1,0 +1,240 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.agreement;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import de.tudarmstadt.ukp.clarin.webanno.agreement.results.coding.FullCodingAgreementResult;
+import de.tudarmstadt.ukp.clarin.webanno.agreement.results.unitizing.FullUnitizingAgreementResult;
+
+public class BasicAgreementResult
+    implements Serializable
+{
+    private static final long serialVersionUID = 5994827594084192896L;
+
+    private final String type;
+    private final String feature;
+    private final boolean excludeIncomplete;
+    private final List<String> casGroupIds = new ArrayList<>();
+
+    private final List<Double> agreements = new ArrayList<>();
+    private final Set<Object> categories = new LinkedHashSet<>();
+    private final Map<String, Long> itemCounts = new HashMap<>();
+    private final Map<String, Long> nonNullContentCounts = new HashMap<>();
+    private final Map<String, Boolean> allNull = new HashMap<>();
+
+    private boolean empty;
+
+    private int incompleteSetsByPosition;
+    private int incompleteSetsByLabel;
+    private int pluralitySets;
+    private int relevantSetCount;
+    private int completeSetCount;
+
+    public void merge(BasicAgreementResult aResult)
+    {
+        if (!type.equals(aResult.type)) {
+            throw new IllegalArgumentException("All merged results must have the same type [" + type
+                    + "] but encounterd [" + aResult.type + "]");
+        }
+
+        if (!feature.equals(aResult.feature)) {
+            throw new IllegalArgumentException("All merged results must have the same feature ["
+                    + feature + "] but encounterd [" + aResult.feature + "]");
+        }
+
+        if (excludeIncomplete != aResult.excludeIncomplete) {
+            throw new IllegalArgumentException(
+                    "All merged results must have the same excludeIncomplete [" + excludeIncomplete
+                            + "] but encounterd [" + aResult.excludeIncomplete + "]");
+        }
+
+        if (!casGroupIds.equals(aResult.casGroupIds)) {
+            throw new IllegalArgumentException("All merged results must have the same casGroupIds "
+                    + casGroupIds + " but encounterd " + aResult.casGroupIds);
+        }
+
+        agreements.addAll(aResult.agreements);
+        categories.addAll(aResult.categories);
+        for (var e : aResult.itemCounts.entrySet()) {
+            itemCounts.merge(e.getKey(), e.getValue(), Long::sum);
+        }
+        for (var e : aResult.nonNullContentCounts.entrySet()) {
+            nonNullContentCounts.merge(e.getKey(), e.getValue(), Long::sum);
+        }
+        for (var e : aResult.allNull.entrySet()) {
+            allNull.merge(e.getKey(), e.getValue(), Boolean::logicalOr);
+        }
+
+        empty |= aResult.empty;
+
+        if (incompleteSetsByPosition >= 0 && aResult.incompleteSetsByPosition >= 0) {
+            incompleteSetsByPosition += aResult.incompleteSetsByPosition;
+        }
+
+        if (incompleteSetsByLabel >= 0 && aResult.incompleteSetsByLabel >= 0) {
+            incompleteSetsByLabel += aResult.incompleteSetsByLabel;
+        }
+
+        if (pluralitySets >= 0 && aResult.pluralitySets >= 0) {
+            pluralitySets += aResult.pluralitySets;
+        }
+
+        if (relevantSetCount >= 0 && aResult.relevantSetCount >= 0) {
+            relevantSetCount += aResult.relevantSetCount;
+        }
+
+        if (completeSetCount >= 0 && aResult.completeSetCount >= 0) {
+            completeSetCount += aResult.completeSetCount;
+        }
+    }
+
+    public static BasicAgreementResult of(Serializable aResult)
+    {
+        if (aResult instanceof FullCodingAgreementResult result) {
+            return new BasicAgreementResult(result);
+        }
+
+        if (aResult instanceof FullUnitizingAgreementResult result) {
+            return new BasicAgreementResult(result);
+        }
+
+        throw new IllegalArgumentException(
+                "Unsupported result type: [" + aResult.getClass().getName() + "]");
+    }
+
+    public BasicAgreementResult(FullUnitizingAgreementResult aResult)
+    {
+        this((FullAgreementResult_ImplBase<?>) aResult);
+
+        incompleteSetsByLabel = -1;
+        incompleteSetsByPosition = -1;
+        relevantSetCount = -1;
+        completeSetCount = -1;
+        pluralitySets = -1;
+    }
+
+    public BasicAgreementResult(FullCodingAgreementResult aResult)
+    {
+        this((FullAgreementResult_ImplBase<?>) aResult);
+
+        incompleteSetsByLabel = aResult.getIncompleteSetsByLabel().size();
+        incompleteSetsByPosition = aResult.getIncompleteSetsByPosition().size();
+        pluralitySets = aResult.getPluralitySets().size();
+        relevantSetCount = aResult.getRelevantSetCount();
+        completeSetCount = aResult.getCompleteSetCount();
+    }
+
+    private BasicAgreementResult(FullAgreementResult_ImplBase<?> aResult)
+    {
+        type = aResult.getType();
+        feature = aResult.getFeature();
+        excludeIncomplete = isExcludeIncomplete();
+        casGroupIds.addAll(aResult.casGroupIds);
+        agreements.add(aResult.agreement);
+        aResult.getCategories().forEach(categories::add);
+        empty = aResult.isEmpty();
+
+        for (var casGroupId : casGroupIds) {
+            itemCounts.put(casGroupId, aResult.getItemCount(casGroupId));
+            nonNullContentCounts.put(casGroupId, aResult.getNonNullCount(casGroupId));
+            allNull.put(casGroupId, aResult.isAllNull(casGroupId));
+        }
+    }
+
+    public List<String> getCasGroupIds()
+    {
+        return casGroupIds;
+    }
+
+    public double getAgreement()
+    {
+        return agreements.stream().mapToDouble(a -> a).average().orElse(Double.NaN);
+    }
+
+    public String getType()
+    {
+        return type;
+    }
+
+    public String getFeature()
+    {
+        return feature;
+    }
+
+    public boolean isExcludeIncomplete()
+    {
+        return excludeIncomplete;
+    }
+
+    public boolean isEmpty()
+    {
+        return empty;
+    }
+
+    public long getItemCount(String aRater)
+    {
+        return itemCounts.getOrDefault(aRater, 0l);
+    }
+
+    public int getCategoryCount()
+    {
+        return categories.size();
+    }
+
+    public Long getNonNullCount(String aRater)
+    {
+        return nonNullContentCounts.getOrDefault(aRater, 0l);
+    }
+
+    public boolean isAllNull(String aRater)
+    {
+        return allNull.getOrDefault(aRater, true);
+    }
+
+    public int getIncompleteSetsByPosition()
+    {
+        return incompleteSetsByPosition;
+    }
+
+    public int getIncompleteSetsByLabel()
+    {
+        return incompleteSetsByLabel;
+    }
+
+    public int getRelevantSetCount()
+    {
+        return relevantSetCount;
+    }
+
+    public int getCompleteSetCount()
+    {
+        return completeSetCount;
+    }
+
+    public int getPluralitySets()
+    {
+        return pluralitySets;
+    }
+}

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/FullAgreementResult_ImplBase.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/FullAgreementResult_ImplBase.java
@@ -25,9 +25,11 @@ import java.util.List;
 
 import org.dkpro.statistics.agreement.IAnnotationStudy;
 
-public abstract class AgreementResult<T extends IAnnotationStudy>
+public abstract class FullAgreementResult_ImplBase<T extends IAnnotationStudy>
     implements Serializable
 {
+    private static final long serialVersionUID = 8969153082599376637L;
+
     protected final String type;
     protected final String feature;
     protected final T study;
@@ -36,8 +38,8 @@ public abstract class AgreementResult<T extends IAnnotationStudy>
 
     protected double agreement;
 
-    public AgreementResult(String aType, String aFeature, T aStudy, List<String> aCasGroupIds,
-            boolean aExcludeIncomplete)
+    public FullAgreementResult_ImplBase(String aType, String aFeature, T aStudy,
+            List<String> aCasGroupIds, boolean aExcludeIncomplete)
     {
         type = aType;
         feature = aFeature;
@@ -79,5 +81,23 @@ public abstract class AgreementResult<T extends IAnnotationStudy>
     public boolean isExcludeIncomplete()
     {
         return excludeIncomplete;
+    }
+
+    public abstract boolean isEmpty();
+
+    public abstract long getItemCount(String aRater);
+
+    public int getCategoryCount()
+    {
+        return study.getCategoryCount();
+    }
+
+    public abstract boolean isAllNull(String aCasGroupId);
+
+    public abstract long getNonNullCount(String aCasGroupId);
+
+    public Iterable<Object> getCategories()
+    {
+        return study.getCategories();
     }
 }

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/PairwiseAnnotationResult.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/PairwiseAnnotationResult.java
@@ -32,7 +32,7 @@ public class PairwiseAnnotationResult
     private static final long serialVersionUID = -6943850667308982795L;
 
     private final Set<String> raters = new TreeSet<>();
-    private final Map<String, BasicAgreementResult> results = new HashMap<>();
+    private final Map<String, AgreementSummary> results = new HashMap<>();
 
     private final AnnotationFeature feature;
     private final DefaultAgreementTraits traits;
@@ -58,16 +58,23 @@ public class PairwiseAnnotationResult
         return raters;
     }
 
-    public BasicAgreementResult getStudy(String aAnnotator1, String aAnnotator2)
+    public AgreementSummary getResult(String aAnnotator1, String aAnnotator2)
     {
         return results.get(makeKey(aAnnotator1, aAnnotator2));
     }
 
-    public void add(String aAnnotator1, String aAnnotator2, BasicAgreementResult aRes)
+    public void mergeResult(String aAnnotator1, String aAnnotator2, AgreementSummary aRes)
     {
         raters.add(aAnnotator1);
         raters.add(aAnnotator2);
-        results.put(makeKey(aAnnotator1, aAnnotator2), aRes);
+
+        var existingRes = getResult(aAnnotator1, aAnnotator2);
+        if (existingRes != null) {
+            existingRes.merge(aRes);
+        }
+        else {
+            results.put(makeKey(aAnnotator1, aAnnotator2), aRes);
+        }
     }
 
     private String makeKey(String aKey1, String aKey2)

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/PairwiseAnnotationResult.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/PairwiseAnnotationResult.java
@@ -26,20 +26,19 @@ import java.util.TreeSet;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.DefaultAgreementTraits;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 
-public class PairwiseAnnotationResult<R extends Serializable>
+public class PairwiseAnnotationResult
     implements Serializable
 {
     private static final long serialVersionUID = -6943850667308982795L;
 
     private final Set<String> raters = new TreeSet<>();
-    private final Map<String, R> results = new HashMap<>();
+    private final Map<String, BasicAgreementResult> results = new HashMap<>();
 
     private final AnnotationFeature feature;
     private final DefaultAgreementTraits traits;
 
     public PairwiseAnnotationResult(AnnotationFeature aFeature, DefaultAgreementTraits aTraits)
     {
-        super();
         feature = aFeature;
         traits = aTraits;
     }
@@ -59,16 +58,16 @@ public class PairwiseAnnotationResult<R extends Serializable>
         return raters;
     }
 
-    public R getStudy(String aKey1, String aKey2)
+    public BasicAgreementResult getStudy(String aAnnotator1, String aAnnotator2)
     {
-        return results.get(makeKey(aKey1, aKey2));
+        return results.get(makeKey(aAnnotator1, aAnnotator2));
     }
 
-    public void add(String aKey1, String aKey2, R aRes)
+    public void add(String aAnnotator1, String aAnnotator2, BasicAgreementResult aRes)
     {
-        raters.add(aKey1);
-        raters.add(aKey2);
-        results.put(makeKey(aKey1, aKey2), aRes);
+        raters.add(aAnnotator1);
+        raters.add(aAnnotator2);
+        results.put(makeKey(aAnnotator1, aAnnotator2), aRes);
     }
 
     private String makeKey(String aKey1, String aKey2)

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/AgreementMeasure.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/AgreementMeasure.java
@@ -18,7 +18,6 @@
 package de.tudarmstadt.ukp.clarin.webanno.agreement.measures;
 
 import java.io.Serializable;
-import java.util.List;
 import java.util.Map;
 
 import org.apache.uima.cas.CAS;
@@ -27,7 +26,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 
 public interface AgreementMeasure<R extends Serializable>
 {
-    R getAgreement(Map<String, List<CAS>> aCasMap);
+    R getAgreement(Map<String, CAS> aCasMap);
 
     AnnotationFeature getFeature();
 

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/AgreementMeasureSupport.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/AgreementMeasureSupport.java
@@ -17,23 +17,19 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.agreement.measures;
 
-import java.io.Serializable;
-import java.util.List;
-import java.util.Map;
-
-import org.apache.uima.cas.CAS;
 import org.apache.wicket.markup.html.panel.EmptyPanel;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
-import org.danekja.java.util.function.serializable.SerializableSupplier;
 import org.dkpro.statistics.agreement.IAnnotationStudy;
 import org.springframework.beans.factory.BeanNameAware;
 
+import de.tudarmstadt.ukp.clarin.webanno.agreement.FullAgreementResult_ImplBase;
+import de.tudarmstadt.ukp.clarin.webanno.agreement.PairwiseAnnotationResult;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 
 public interface AgreementMeasureSupport<//
         T extends DefaultAgreementTraits, //
-        R extends Serializable, //
+        R extends FullAgreementResult_ImplBase<S>, //
         S extends IAnnotationStudy>
     extends BeanNameAware
 {
@@ -71,6 +67,5 @@ public interface AgreementMeasureSupport<//
 
     T createTraits();
 
-    Panel createResultsPanel(String aId, IModel<R> aResults,
-            SerializableSupplier<Map<String, List<CAS>>> aCasMapSupplier);
+    Panel createResultsPanel(String aId, IModel<PairwiseAnnotationResult> aResults);
 }

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/AgreementMeasureSupport_ImplBase.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/AgreementMeasureSupport_ImplBase.java
@@ -17,17 +17,16 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.agreement.measures;
 
-import java.io.Serializable;
-
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
 import org.dkpro.statistics.agreement.IAnnotationStudy;
 
+import de.tudarmstadt.ukp.clarin.webanno.agreement.FullAgreementResult_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 
 public abstract class AgreementMeasureSupport_ImplBase<//
         T extends DefaultAgreementTraits, //
-        R extends Serializable, //
+        R extends FullAgreementResult_ImplBase<S>, //
         S extends IAnnotationStudy>
     implements AgreementMeasureSupport<T, R, S>
 {

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/cohenkappa/CohenKappaAgreementMeasureSupport.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/cohenkappa/CohenKappaAgreementMeasureSupport.java
@@ -19,11 +19,10 @@ package de.tudarmstadt.ukp.clarin.webanno.agreement.measures.cohenkappa;
 
 import org.springframework.stereotype.Component;
 
-import de.tudarmstadt.ukp.clarin.webanno.agreement.PairwiseAnnotationResult;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.AgreementMeasure;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.DefaultAgreementTraits;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.results.coding.AbstractCodingAgreementMeasureSupport;
-import de.tudarmstadt.ukp.clarin.webanno.agreement.results.coding.CodingAgreementResult;
+import de.tudarmstadt.ukp.clarin.webanno.agreement.results.coding.FullCodingAgreementResult;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 
@@ -35,7 +34,6 @@ public class CohenKappaAgreementMeasureSupport
 
     public CohenKappaAgreementMeasureSupport(AnnotationSchemaService aAnnotationService)
     {
-        super();
         annotationService = aAnnotationService;
     }
 
@@ -46,8 +44,8 @@ public class CohenKappaAgreementMeasureSupport
     }
 
     @Override
-    public AgreementMeasure<PairwiseAnnotationResult<CodingAgreementResult>> createMeasure(
-            AnnotationFeature aFeature, DefaultAgreementTraits aTraits)
+    public AgreementMeasure<FullCodingAgreementResult> createMeasure(AnnotationFeature aFeature,
+            DefaultAgreementTraits aTraits)
     {
         return new CohenKappaAgreementMeasure(aFeature, aTraits, annotationService);
     }

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/fleisskappa/FleissKappaAgreementMeasure.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/fleisskappa/FleissKappaAgreementMeasure.java
@@ -1,5 +1,5 @@
 /*
- * Licensed to the Technische Universität Darmstadt under one
+# * Licensed to the Technische Universität Darmstadt under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
  * regarding copyright ownership.  The Technische Universität Darmstadt 
@@ -24,9 +24,7 @@ import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toCollection;
 
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import org.apache.uima.cas.CAS;
 import org.dkpro.statistics.agreement.coding.FleissKappaAgreement;
@@ -34,9 +32,7 @@ import org.dkpro.statistics.agreement.coding.ICodingAnnotationStudy;
 
 import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.DefaultAgreementTraits;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.results.coding.CodingAgreementMeasure_ImplBase;
-import de.tudarmstadt.ukp.clarin.webanno.agreement.results.coding.CodingAgreementResult;
-import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff;
-import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.api.DiffAdapter;
+import de.tudarmstadt.ukp.clarin.webanno.agreement.results.coding.FullCodingAgreementResult;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.Tag;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
@@ -54,32 +50,31 @@ public class FleissKappaAgreementMeasure
     }
 
     @Override
-    public CodingAgreementResult calculatePairAgreement(Map<String, List<CAS>> aCasMap)
+    public FullCodingAgreementResult getAgreement(Map<String, CAS> aCasMap)
     {
-        AnnotationFeature feature = getFeature();
-        DefaultAgreementTraits traits = getTraits();
+        var feature = getFeature();
+        var traits = getTraits();
 
-        List<DiffAdapter> adapters = getDiffAdapters(annotationService, asList(feature.getLayer()));
+        var adapters = getDiffAdapters(annotationService, asList(feature.getLayer()));
 
-        CasDiff diff = doDiff(adapters, traits.getLinkCompareBehavior(), aCasMap);
+        var diff = doDiff(adapters, traits.getLinkCompareBehavior(), aCasMap);
 
-        Set<String> tagset = annotationService.listTags(feature.getTagset()).stream()
-                .map(Tag::getName).collect(toCollection(LinkedHashSet::new));
+        var tagset = annotationService.listTags(feature.getTagset()).stream() //
+                .map(Tag::getName) //
+                .collect(toCollection(LinkedHashSet::new));
 
-        CodingAgreementResult agreementResult = makeCodingStudy(diff, feature.getLayer().getName(),
-                feature.getName(), tagset, true, aCasMap);
+        var agreementResult = makeCodingStudy(diff, feature.getLayer().getName(), feature.getName(),
+                tagset, true, aCasMap);
 
-        InspectableFleissKappaAgreement agreement = new InspectableFleissKappaAgreement(
-                agreementResult.getStudy());
-
-        if (agreementResult.getStudy().getItemCount() == 0) {
+        if (agreementResult.isEmpty()) {
             agreementResult.setAgreement(Double.NaN);
         }
         else if (agreementResult.getObservedCategories().size() == 1) {
             agreementResult.setAgreement(1.0d);
         }
         else {
-            agreementResult.setAgreement(agreement.calculateAgreement());
+            var measure = new InspectableFleissKappaAgreement(agreementResult.getStudy());
+            agreementResult.setAgreement(measure.calculateAgreement());
         }
 
         return agreementResult;

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/fleisskappa/FleissKappaAgreementMeasureSupport.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/fleisskappa/FleissKappaAgreementMeasureSupport.java
@@ -19,11 +19,10 @@ package de.tudarmstadt.ukp.clarin.webanno.agreement.measures.fleisskappa;
 
 import org.springframework.stereotype.Component;
 
-import de.tudarmstadt.ukp.clarin.webanno.agreement.PairwiseAnnotationResult;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.AgreementMeasure;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.DefaultAgreementTraits;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.results.coding.AbstractCodingAgreementMeasureSupport;
-import de.tudarmstadt.ukp.clarin.webanno.agreement.results.coding.CodingAgreementResult;
+import de.tudarmstadt.ukp.clarin.webanno.agreement.results.coding.FullCodingAgreementResult;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 
@@ -46,8 +45,8 @@ public class FleissKappaAgreementMeasureSupport
     }
 
     @Override
-    public AgreementMeasure<PairwiseAnnotationResult<CodingAgreementResult>> createMeasure(
-            AnnotationFeature aFeature, DefaultAgreementTraits aTraits)
+    public AgreementMeasure<FullCodingAgreementResult> createMeasure(AnnotationFeature aFeature,
+            DefaultAgreementTraits aTraits)
     {
         return new FleissKappaAgreementMeasure(aFeature, aTraits, annotationService);
     }

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/krippendorffalpha/KrippendorffAlphaAgreementMeasureSupport.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/krippendorffalpha/KrippendorffAlphaAgreementMeasureSupport.java
@@ -21,10 +21,9 @@ import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
 import org.springframework.stereotype.Component;
 
-import de.tudarmstadt.ukp.clarin.webanno.agreement.PairwiseAnnotationResult;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.AgreementMeasure;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.results.coding.AbstractCodingAgreementMeasureSupport;
-import de.tudarmstadt.ukp.clarin.webanno.agreement.results.coding.CodingAgreementResult;
+import de.tudarmstadt.ukp.clarin.webanno.agreement.results.coding.FullCodingAgreementResult;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 
@@ -47,8 +46,8 @@ public class KrippendorffAlphaAgreementMeasureSupport
     }
 
     @Override
-    public AgreementMeasure<PairwiseAnnotationResult<CodingAgreementResult>> createMeasure(
-            AnnotationFeature aFeature, KrippendorffAlphaAgreementTraits aTraits)
+    public AgreementMeasure<FullCodingAgreementResult> createMeasure(AnnotationFeature aFeature,
+            KrippendorffAlphaAgreementTraits aTraits)
     {
         return new KrippendorffAlphaAgreementMeasure(aFeature, aTraits, annotationService);
     }

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/krippendorffalphaunitizing/KrippendorffAlphaUnitizingAgreementMeasure.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/krippendorffalphaunitizing/KrippendorffAlphaUnitizingAgreementMeasure.java
@@ -18,136 +18,80 @@
 package de.tudarmstadt.ukp.clarin.webanno.agreement.measures.krippendorffalphaunitizing;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 
 import org.apache.uima.cas.CAS;
-import org.apache.uima.cas.Feature;
-import org.apache.uima.cas.Type;
 import org.apache.uima.cas.text.AnnotationFS;
 import org.apache.uima.fit.util.FSUtil;
-import org.dkpro.statistics.agreement.IAgreementMeasure;
 import org.dkpro.statistics.agreement.unitizing.KrippendorffAlphaUnitizingAgreement;
 import org.dkpro.statistics.agreement.unitizing.UnitizingAnnotationStudy;
 
-import de.tudarmstadt.ukp.clarin.webanno.agreement.PairwiseAnnotationResult;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.AgreementMeasure_ImplBase;
-import de.tudarmstadt.ukp.clarin.webanno.agreement.results.unitizing.UnitizingAgreementResult;
+import de.tudarmstadt.ukp.clarin.webanno.agreement.results.unitizing.FullUnitizingAgreementResult;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
-import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 
 public class KrippendorffAlphaUnitizingAgreementMeasure
     extends AgreementMeasure_ImplBase<//
-            PairwiseAnnotationResult<UnitizingAgreementResult>, //
+            FullUnitizingAgreementResult, //
             KrippendorffAlphaUnitizingAgreementTraits>
 {
-    private final AnnotationSchemaService annotationService;
-
     public KrippendorffAlphaUnitizingAgreementMeasure(AnnotationFeature aFeature,
-            KrippendorffAlphaUnitizingAgreementTraits aTraits,
-            AnnotationSchemaService aAnnotationService)
+            KrippendorffAlphaUnitizingAgreementTraits aTraits)
     {
         super(aFeature, aTraits);
-        annotationService = aAnnotationService;
     }
 
     @Override
-    public PairwiseAnnotationResult<UnitizingAgreementResult> getAgreement(
-            Map<String, List<CAS>> aCasMap)
+    public FullUnitizingAgreementResult getAgreement(Map<String, CAS> aCasMap)
     {
-        PairwiseAnnotationResult<UnitizingAgreementResult> result = new PairwiseAnnotationResult<>(
-                getFeature(), getTraits());
-        List<Entry<String, List<CAS>>> entryList = new ArrayList<>(aCasMap.entrySet());
-        for (int m = 0; m < entryList.size(); m++) {
-            for (int n = 0; n < entryList.size(); n++) {
-                // Triangle matrix mirrored
-                if (n < m) {
-                    Map<String, List<CAS>> pairwiseCasMap = new LinkedHashMap<>();
-                    pairwiseCasMap.put(entryList.get(m).getKey(), entryList.get(m).getValue());
-                    pairwiseCasMap.put(entryList.get(n).getKey(), entryList.get(n).getValue());
-                    UnitizingAgreementResult res = calculatePairAgreement(pairwiseCasMap);
-                    result.add(entryList.get(m).getKey(), entryList.get(n).getKey(), res);
-                }
-            }
-        }
-        return result;
-    }
+        var typeName = getFeature().getLayer().getName();
 
-    public UnitizingAgreementResult calculatePairAgreement(Map<String, List<CAS>> aCasMap)
-    {
-        String typeName = getFeature().getLayer().getName();
-
-        // Calculate a character offset continuum over all CASses. We assume here that the documents
+        // Calculate a character offset continuum. We assume here that the documents
         // all have the same size - since the users cannot change the document sizes, this should be
         // an universally true assumption.
-        List<CAS> firstUserCasses = aCasMap.values().stream().findFirst().get();
-        int docCount = firstUserCasses.size();
-        int[] docSizes = new int[docCount];
-        Arrays.fill(docSizes, 0);
-        for (Entry<String, List<CAS>> set : aCasMap.entrySet()) {
-            int i = 0;
-            for (CAS cas : set.getValue()) {
-                if (cas != null) {
-                    assert docSizes[i] == 0 || docSizes[i] == cas.getDocumentText().length();
-
-                    docSizes[i] = cas.getDocumentText().length();
-                }
-                i++;
-            }
-        }
-        int continuumSize = Arrays.stream(docSizes).sum();
+        var someCas = aCasMap.values().stream().filter(Objects::nonNull).findAny().get();
 
         // Create a unitizing study for that continuum.
-        UnitizingAnnotationStudy study = new UnitizingAnnotationStudy(continuumSize);
+        var study = new UnitizingAnnotationStudy(someCas.getDocumentText().length());
 
         // For each annotator, extract the feature values from all the annotator's CASses and add
         // them to the unitizing study based on character offsets.
-        for (Entry<String, List<CAS>> set : aCasMap.entrySet()) {
+        for (Entry<String, CAS> set : aCasMap.entrySet()) {
             int raterIdx = study.addRater(set.getKey());
-            int docOffset = 0;
-            int i = 0;
-            for (CAS cas : set.getValue()) {
-                // If a user has never worked on a source document, its CAS is null here - we
-                // skip it.
-                if (cas != null) {
-                    Type t = cas.getTypeSystem().getType(typeName);
-                    Feature f = t.getFeatureByBaseName(getFeature().getName());
-                    int currentDocOffset = docOffset;
-                    cas.select(t).map(fs -> (AnnotationFS) fs).forEach(fs -> {
-                        Object featureValue = FSUtil.getFeature(fs, f, Object.class);
-                        if (featureValue instanceof Collection) {
-                            for (Object value : (Collection<?>) featureValue) {
-                                study.addUnit(currentDocOffset + fs.getBegin(),
-                                        fs.getEnd() - fs.getBegin(), raterIdx, value);
-                            }
+            var cas = set.getValue();
+            // If a user has never worked on a source document, its CAS is null here - we
+            // skip it.
+            if (cas != null) {
+                var t = cas.getTypeSystem().getType(typeName);
+                var f = t.getFeatureByBaseName(getFeature().getName());
+                cas.select(t).map(fs -> (AnnotationFS) fs).forEach(fs -> {
+                    var featureValue = FSUtil.getFeature(fs, f, Object.class);
+                    if (featureValue instanceof Collection) {
+                        for (var value : (Collection<?>) featureValue) {
+                            study.addUnit(fs.getBegin(), fs.getEnd() - fs.getBegin(), raterIdx,
+                                    value);
                         }
-                        else {
-                            study.addUnit(currentDocOffset + fs.getBegin(),
-                                    fs.getEnd() - fs.getBegin(), raterIdx, featureValue);
-                        }
-                    });
-                }
-
-                docOffset += docSizes[i];
-                i++;
+                    }
+                    else {
+                        study.addUnit(fs.getBegin(), fs.getEnd() - fs.getBegin(), raterIdx,
+                                featureValue);
+                    }
+                });
             }
         }
 
-        UnitizingAgreementResult result = new UnitizingAgreementResult(typeName,
-                getFeature().getName(), study, new ArrayList<>(aCasMap.keySet()),
-                getTraits().isExcludeIncomplete());
+        var result = new FullUnitizingAgreementResult(typeName, getFeature().getName(), study,
+                new ArrayList<>(aCasMap.keySet()), getTraits().isExcludeIncomplete());
 
-        IAgreementMeasure agreement = new KrippendorffAlphaUnitizingAgreement(study);
-
-        if (result.getStudy().getUnitCount() > 0) {
-            result.setAgreement(agreement.calculateAgreement());
+        if (result.isEmpty()) {
+            result.setAgreement(Double.NaN);
         }
         else {
-            result.setAgreement(Double.NaN);
+            var measure = new KrippendorffAlphaUnitizingAgreement(study);
+            result.setAgreement(measure.calculateAgreement());
         }
 
         return result;

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/krippendorffalphaunitizing/KrippendorffAlphaUnitizingAgreementMeasureSupport.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/krippendorffalphaunitizing/KrippendorffAlphaUnitizingAgreementMeasureSupport.java
@@ -17,21 +17,16 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.agreement.measures.krippendorffalphaunitizing;
 
-import java.util.List;
-import java.util.Map;
-
-import org.apache.uima.cas.CAS;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
-import org.danekja.java.util.function.serializable.SerializableSupplier;
 import org.dkpro.statistics.agreement.unitizing.IUnitizingAnnotationStudy;
 import org.springframework.stereotype.Component;
 
 import de.tudarmstadt.ukp.clarin.webanno.agreement.PairwiseAnnotationResult;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.AgreementMeasure;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.AgreementMeasureSupport_ImplBase;
+import de.tudarmstadt.ukp.clarin.webanno.agreement.results.unitizing.FullUnitizingAgreementResult;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.results.unitizing.PairwiseUnitizingAgreementTable;
-import de.tudarmstadt.ukp.clarin.webanno.agreement.results.unitizing.UnitizingAgreementResult;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.inception.annotation.layer.span.SpanLayerSupport;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
@@ -40,16 +35,13 @@ import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 public class KrippendorffAlphaUnitizingAgreementMeasureSupport
     extends AgreementMeasureSupport_ImplBase<//
             KrippendorffAlphaUnitizingAgreementTraits, //
-            PairwiseAnnotationResult<UnitizingAgreementResult>, //
+            FullUnitizingAgreementResult, //
             IUnitizingAnnotationStudy>
 {
-    private final AnnotationSchemaService annotationService;
-
     public KrippendorffAlphaUnitizingAgreementMeasureSupport(
             AnnotationSchemaService aAnnotationService)
     {
         super();
-        annotationService = aAnnotationService;
     }
 
     @Override
@@ -71,10 +63,10 @@ public class KrippendorffAlphaUnitizingAgreementMeasureSupport
     }
 
     @Override
-    public AgreementMeasure<PairwiseAnnotationResult<UnitizingAgreementResult>> createMeasure(
-            AnnotationFeature aFeature, KrippendorffAlphaUnitizingAgreementTraits aTraits)
+    public AgreementMeasure<FullUnitizingAgreementResult> createMeasure(AnnotationFeature aFeature,
+            KrippendorffAlphaUnitizingAgreementTraits aTraits)
     {
-        return new KrippendorffAlphaUnitizingAgreementMeasure(aFeature, aTraits, annotationService);
+        return new KrippendorffAlphaUnitizingAgreementMeasure(aFeature, aTraits);
     }
 
     @Override
@@ -91,9 +83,7 @@ public class KrippendorffAlphaUnitizingAgreementMeasureSupport
     }
 
     @Override
-    public Panel createResultsPanel(String aId,
-            IModel<PairwiseAnnotationResult<UnitizingAgreementResult>> aResults,
-            SerializableSupplier<Map<String, List<CAS>>> aCasMapSupplier)
+    public Panel createResultsPanel(String aId, IModel<PairwiseAnnotationResult> aResults)
     {
         return new PairwiseUnitizingAgreementTable(aId, aResults);
     }

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/coding/AbstractCodingAgreementMeasureSupport.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/coding/AbstractCodingAgreementMeasureSupport.java
@@ -23,13 +23,8 @@ import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.TOKENS;
 import static de.tudarmstadt.ukp.clarin.webanno.model.LinkMode.NONE;
 import static java.util.Arrays.asList;
 
-import java.util.List;
-import java.util.Map;
-
-import org.apache.uima.cas.CAS;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
-import org.danekja.java.util.function.serializable.SerializableSupplier;
 import org.dkpro.statistics.agreement.coding.ICodingAnnotationStudy;
 
 import de.tudarmstadt.ukp.clarin.webanno.agreement.PairwiseAnnotationResult;
@@ -42,8 +37,7 @@ import de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationLayerSuppo
 import de.tudarmstadt.ukp.inception.annotation.layer.span.SpanLayerSupport;
 
 public abstract class AbstractCodingAgreementMeasureSupport<T extends DefaultAgreementTraits>
-    extends
-    AgreementMeasureSupport_ImplBase<T, PairwiseAnnotationResult<CodingAgreementResult>, ICodingAnnotationStudy>
+    extends AgreementMeasureSupport_ImplBase<T, FullCodingAgreementResult, ICodingAnnotationStudy>
 {
     @Override
     public boolean accepts(AnnotationFeature aFeature)
@@ -59,10 +53,8 @@ public abstract class AbstractCodingAgreementMeasureSupport<T extends DefaultAgr
     }
 
     @Override
-    public Panel createResultsPanel(String aId,
-            IModel<PairwiseAnnotationResult<CodingAgreementResult>> aResults,
-            SerializableSupplier<Map<String, List<CAS>>> aCasMapSupplier)
+    public Panel createResultsPanel(String aId, IModel<PairwiseAnnotationResult> aResults)
     {
-        return new PairwiseCodingAgreementTable(aId, aResults, aCasMapSupplier);
+        return new PairwiseCodingAgreementTable(aId, aResults);
     }
 }

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/coding/CodingAgreementMeasure_ImplBase.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/coding/CodingAgreementMeasure_ImplBase.java
@@ -17,48 +17,15 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.agreement.results.coding;
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-
-import org.apache.uima.cas.CAS;
-
-import de.tudarmstadt.ukp.clarin.webanno.agreement.PairwiseAnnotationResult;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.AgreementMeasure_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.DefaultAgreementTraits;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 
 public abstract class CodingAgreementMeasure_ImplBase<T extends DefaultAgreementTraits>
-    extends AgreementMeasure_ImplBase<PairwiseAnnotationResult<CodingAgreementResult>, T>
+    extends AgreementMeasure_ImplBase<FullCodingAgreementResult, T>
 {
     public CodingAgreementMeasure_ImplBase(AnnotationFeature aFeature, T aTraits)
     {
         super(aFeature, aTraits);
     }
-
-    @Override
-    public PairwiseAnnotationResult<CodingAgreementResult> getAgreement(
-            Map<String, List<CAS>> aCasMap)
-    {
-        PairwiseAnnotationResult<CodingAgreementResult> result = new PairwiseAnnotationResult<>(
-                getFeature(), getTraits());
-        List<Entry<String, List<CAS>>> entryList = new ArrayList<>(aCasMap.entrySet());
-        for (int m = 0; m < entryList.size(); m++) {
-            for (int n = 0; n < entryList.size(); n++) {
-                // Triangle matrix mirrored
-                if (n < m) {
-                    Map<String, List<CAS>> pairwiseCasMap = new LinkedHashMap<>();
-                    pairwiseCasMap.put(entryList.get(m).getKey(), entryList.get(m).getValue());
-                    pairwiseCasMap.put(entryList.get(n).getKey(), entryList.get(n).getValue());
-                    CodingAgreementResult res = calculatePairAgreement(pairwiseCasMap);
-                    result.add(entryList.get(m).getKey(), entryList.get(n).getKey(), res);
-                }
-            }
-        }
-        return result;
-    }
-
-    public abstract CodingAgreementResult calculatePairAgreement(Map<String, List<CAS>> aCasMap);
 }

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/coding/FullCodingAgreementResult.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/coding/FullCodingAgreementResult.java
@@ -28,12 +28,12 @@ import org.dkpro.statistics.agreement.IAnnotationUnit;
 import org.dkpro.statistics.agreement.coding.ICodingAnnotationItem;
 import org.dkpro.statistics.agreement.coding.ICodingAnnotationStudy;
 
-import de.tudarmstadt.ukp.clarin.webanno.agreement.AgreementResult;
+import de.tudarmstadt.ukp.clarin.webanno.agreement.FullAgreementResult_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.ConfigurationSet;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.DiffResult;
 
-public class CodingAgreementResult
-    extends AgreementResult<ICodingAnnotationStudy>
+public class FullCodingAgreementResult
+    extends FullAgreementResult_ImplBase<ICodingAnnotationStudy>
 {
     private static final long serialVersionUID = -1262324752699430461L;
 
@@ -45,7 +45,7 @@ public class CodingAgreementResult
     protected final List<ConfigurationSet> incompleteSetsByLabel;
     protected final List<ConfigurationSet> pluralitySets;
 
-    public CodingAgreementResult(String aType, String aFeature, DiffResult aDiff,
+    public FullCodingAgreementResult(String aType, String aFeature, DiffResult aDiff,
             ICodingAnnotationStudy aStudy, List<String> aCasGroupIds,
             List<ConfigurationSet> aComplete, List<ConfigurationSet> aIrrelevantSets,
             List<ConfigurationSet> aSetsWithDifferences,
@@ -118,7 +118,7 @@ public class CodingAgreementResult
                 + pluralitySets.size();
     }
 
-    public Object getCompleteSetCount()
+    public int getCompleteSetCount()
     {
         return completeSets.size();
     }
@@ -141,7 +141,7 @@ public class CodingAgreementResult
     public Set<Object> getObservedCategories()
     {
         Set<Object> observedCategories = new HashSet<>();
-        for (ICodingAnnotationItem item : getStudy().getItems()) {
+        for (ICodingAnnotationItem item : study.getItems()) {
             for (IAnnotationUnit unit : item.getUnits()) {
                 Object category = unit.getCategory();
                 if (category != null) {
@@ -150,6 +150,41 @@ public class CodingAgreementResult
             }
         }
         return observedCategories;
+    }
+
+    @Override
+    public boolean isAllNull(String aCasGroupId)
+    {
+        for (ICodingAnnotationItem item : study.getItems()) {
+            if (item.getUnit(getCasGroupIds().indexOf(aCasGroupId)).getCategory() != null) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public long getNonNullCount(String aCasGroupId)
+    {
+        long i = 0;
+        for (var item : study.getItems()) {
+            if (item.getUnit(getCasGroupIds().indexOf(aCasGroupId)).getCategory() != null) {
+                i++;
+            }
+        }
+        return i;
+    }
+
+    @Override
+    public boolean isEmpty()
+    {
+        return study.getItemCount() == 0;
+    }
+
+    @Override
+    public long getItemCount(String aRater)
+    {
+        return study.getItemCount();
     }
 
     @Override

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/coding/PairwiseCodingAgreementTable.html
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/coding/PairwiseCodingAgreementTable.html
@@ -33,14 +33,15 @@
         </tr>
       </table>
     </div>
+    <!--  
     <div class="card-footer flex-h-container">
       <div class="flex-content flex-h-container flex-gutter flex-only-internal-gutter">
         <label wicket:for="exportFormat" class="col-form-label text-nowrap" style="margin-right: 10px;">
             <wicket:label key="exportFormat"/></label>
         <select wicket:id="exportFormat" class="form-select" data-container="body"/>
-        <input wicket:id="exportAll" type="submit" class="btn btn-default" wicket:message="value:exportAll"/>
       </div>
     </div>
+    -->
   </div>
   <wicket:fragment wicket:id="th-centered">
     <th class="headers text-center"><div wicket:id="label"></div></th>

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/coding/PairwiseCodingAgreementTable.html
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/coding/PairwiseCodingAgreementTable.html
@@ -20,9 +20,11 @@
   <div class="flex-content card">
     <div class="card-header">
       <wicket:message key="agreement" />
-      <span class="float-end btn btn-link">
-        <a wicket:id="legend" ><wicket:message key="legend"/></a> 
-      </span>
+      <div class="actions">
+        <button wicket:id="legend" class="btn btn-secondary btn-action" type="button">
+          <wicket:message key="legend"/>
+        </button>
+      </div>
     </div>
     <div class="scrolling card-body fit-child-snug" style="padding: 0px;">
       <table style="width: 100%;">

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/coding/PairwiseCodingAgreementTable.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/coding/PairwiseCodingAgreementTable.java
@@ -17,36 +17,17 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.agreement.results.coding;
 
-import static de.tudarmstadt.ukp.clarin.webanno.agreement.AgreementReportExportFormat.CSV;
-import static de.tudarmstadt.ukp.clarin.webanno.agreement.AgreementUtils.makeCodingStudy;
-import static de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.doDiff;
-import static de.tudarmstadt.ukp.inception.support.lambda.LambdaBehavior.enabledWhen;
 import static de.tudarmstadt.ukp.inception.support.lambda.LambdaBehavior.visibleWhen;
-import static java.util.Arrays.asList;
-import static java.util.stream.Collectors.toCollection;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.PrintStream;
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
-import org.apache.uima.cas.CAS;
-import org.apache.wicket.ajax.AjaxEventBehavior;
-import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.behavior.AttributeAppender;
-import org.apache.wicket.behavior.Behavior;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
-import org.apache.wicket.markup.html.form.DropDownChoice;
-import org.apache.wicket.markup.html.form.EnumChoiceRenderer;
 import org.apache.wicket.markup.html.panel.Fragment;
-import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.markup.html.panel.GenericPanel;
 import org.apache.wicket.markup.repeater.Item;
 import org.apache.wicket.markup.repeater.RefreshingView;
 import org.apache.wicket.model.IModel;
@@ -55,107 +36,77 @@ import org.apache.wicket.model.Model;
 import org.apache.wicket.model.ResourceModel;
 import org.apache.wicket.model.StringResourceModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
-import org.apache.wicket.util.resource.AbstractResourceStream;
-import org.apache.wicket.util.resource.IResourceStream;
-import org.apache.wicket.util.resource.ResourceStreamNotFoundException;
-import org.danekja.java.util.function.serializable.SerializableSupplier;
-import org.dkpro.statistics.agreement.coding.ICodingAnnotationItem;
-import org.dkpro.statistics.agreement.coding.ICodingAnnotationStudy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import de.agilecoders.wicket.core.markup.html.bootstrap.components.PopoverConfig;
 import de.agilecoders.wicket.core.markup.html.bootstrap.components.TooltipConfig.Placement;
-import de.tudarmstadt.ukp.clarin.webanno.agreement.AgreementReportExportFormat;
-import de.tudarmstadt.ukp.clarin.webanno.agreement.AgreementResult;
-import de.tudarmstadt.ukp.clarin.webanno.agreement.AgreementUtils;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.PairwiseAnnotationResult;
-import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.DefaultAgreementTraits;
-import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff;
-import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.api.DiffAdapter;
-import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
-import de.tudarmstadt.ukp.clarin.webanno.model.Tag;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
+import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.inception.bootstrap.PopoverBehavior;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.project.api.ProjectService;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
-import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxFormComponentUpdatingBehavior;
-import de.tudarmstadt.ukp.inception.support.wicket.AjaxDownloadBehavior;
-import de.tudarmstadt.ukp.inception.support.wicket.AjaxDownloadLink;
 import de.tudarmstadt.ukp.inception.support.wicket.DefaultRefreshingView;
 import de.tudarmstadt.ukp.inception.support.wicket.DescriptionTooltipBehavior;
 
 public class PairwiseCodingAgreementTable
-    extends Panel
+    extends GenericPanel<PairwiseAnnotationResult>
 {
     private static final long serialVersionUID = 571396822546125376L;
 
-    private final static Logger LOG = LoggerFactory.getLogger(PairwiseCodingAgreementTable.class);
+    private final static Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private @SpringBean AnnotationSchemaService annotationService;
     private @SpringBean DocumentService documentService;
     private @SpringBean ProjectService projectService;
     private @SpringBean UserDao userRepository;
 
-    private final RefreshingView<String> rows;
-    private final AjaxDownloadLink exportAllButton;
-    private final DropDownChoice<AgreementReportExportFormat> formatField;
+    private final RefreshingView<User> rows;
 
-    private final SerializableSupplier<Map<String, List<CAS>>> casMapSupplier;
-
-    public PairwiseCodingAgreementTable(String aId,
-            IModel<PairwiseAnnotationResult<CodingAgreementResult>> aModel,
-            SerializableSupplier<Map<String, List<CAS>>> aCasMapSupplier)
+    public PairwiseCodingAgreementTable(String aId, IModel<PairwiseAnnotationResult> aModel)
     {
         super(aId, aModel);
 
-        casMapSupplier = aCasMapSupplier;
-
         setOutputMarkupId(true);
 
-        PopoverConfig config = new PopoverConfig().withPlacement(Placement.left).withHtml(true);
-        WebMarkupContainer legend = new WebMarkupContainer("legend");
+        var config = new PopoverConfig().withPlacement(Placement.left).withHtml(true);
+        var legend = new WebMarkupContainer("legend");
         legend.add(new PopoverBehavior(new ResourceModel("legend"),
                 new StringResourceModel("legend.content", legend), config));
         add(legend);
 
         // This model makes sure we add a "null" dummy rater which accounts for the header columns
         // of the table.
-        final IModel<List<String>> ratersAdapter = LoadableDetachableModel.of(() -> {
-            List<String> raters = new ArrayList<>();
+        final IModel<List<User>> ratersAdapter = LoadableDetachableModel.of(() -> {
+            var raters = new ArrayList<User>();
             if (getModelObject() != null) {
                 raters.add(null);
-                raters.addAll(getModelObject().getRaters());
+                for (var rater : getModelObject().getRaters()) {
+                    var user = userRepository.get(rater);
+                    if (user != null) {
+                        raters.add(user);
+                    }
+                }
             }
             return raters;
         });
 
-        add(formatField = new DropDownChoice<AgreementReportExportFormat>("exportFormat",
-                Model.of(CSV), asList(AgreementReportExportFormat.values()),
-                new EnumChoiceRenderer<>(this)));
-        formatField.add(new LambdaAjaxFormComponentUpdatingBehavior("change"));
-
-        exportAllButton = new AjaxDownloadLink("exportAll",
-                () -> "agreement" + formatField.getModelObject().getExtension(),
-                this::exportAllAgreements);
-        exportAllButton.add(enabledWhen(() -> formatField.getModelObject() != null));
-        add(exportAllButton);
-
-        rows = new DefaultRefreshingView<String>("rows", ratersAdapter)
+        rows = new DefaultRefreshingView<User>("rows", ratersAdapter)
         {
             private static final long serialVersionUID = 1L;
 
             @Override
-            protected void populateItem(final Item<String> aRowItem)
+            protected void populateItem(final Item<User> aRowItem)
             {
                 // Render regular row
-                aRowItem.add(new DefaultRefreshingView<String>("cells", ratersAdapter)
+                aRowItem.add(new DefaultRefreshingView<User>("cells", ratersAdapter)
                 {
                     private static final long serialVersionUID = 1L;
 
                     @Override
-                    protected void populateItem(Item<String> aCellItem)
+                    protected void populateItem(Item<User> aCellItem)
                     {
                         aCellItem.setRenderBodyOnly(true);
 
@@ -180,13 +131,11 @@ public class PairwiseCodingAgreementTable
                         }
                         // Raters header horizontally
                         else if (aRowItem.getIndex() == 0 && aCellItem.getIndex() != 0) {
-                            cell.add(new Label("label",
-                                    userRepository.get(aCellItem.getModelObject()).getUiName()));
+                            cell.add(new Label("label", aCellItem.getModelObject().getUiName()));
                         }
                         // Raters header vertically
                         else if (aRowItem.getIndex() != 0 && aCellItem.getIndex() == 0) {
-                            cell.add(new Label("label",
-                                    userRepository.get(aRowItem.getModelObject()).getUiName()));
+                            cell.add(new Label("label", aRowItem.getModelObject().getUiName()));
                         }
                         // Upper diagonal
                         else if (aCellItem.getIndex() > aRowItem.getIndex()) {
@@ -211,59 +160,69 @@ public class PairwiseCodingAgreementTable
                         (aRowItem.getIndex() % 2 == 0) ? "odd" : "even"));
             }
         };
+
         this.add(visibleWhen(
                 () -> (getModelObject() != null && !getModelObject().getRaters().isEmpty())));
         add(rows);
     }
 
-    private Label makeLowerDiagonalCellLabel(String aRater1, String aRater2)
+    private Label makeLowerDiagonalCellLabel(User aRater1, User aRater2)
     {
-        CodingAgreementResult result = getModelObject().getStudy(aRater1, aRater2);
+        var result = getModelObject().getStudy(aRater1.getUsername(), aRater2.getUsername());
 
-        String label = String.format("%d/%d", result.getCompleteSetCount(),
+        if (result == null) {
+            return new Label("label", "-");
+        }
+
+        var label = String.format("%d/%d", result.getCompleteSetCount(),
                 result.getRelevantSetCount());
 
-        String tooltipTitle = "Details about annotations excluded from agreement calculation";
+        var tooltipTitle = "Details about annotations excluded from agreement calculation";
 
-        StringBuilder tooltipContent = new StringBuilder();
+        var tooltipContent = new StringBuilder();
         if (result.isExcludeIncomplete()) {
             tooltipContent.append(String.format("- Incomplete (missing): %d%n",
-                    result.getIncompleteSetsByPosition().size()));
+                    result.getIncompleteSetsByPosition()));
             tooltipContent.append(String.format("- Incomplete (not labeled): %d%n",
-                    result.getIncompleteSetsByLabel().size()));
+                    result.getIncompleteSetsByLabel()));
         }
-        tooltipContent.append(String.format("- Plurality: %d", result.getPluralitySets().size()));
+        tooltipContent.append(String.format("- Plurality: %d", result.getPluralitySets()));
 
-        Label l = new Label("label", Model.of(label));
-        DescriptionTooltipBehavior tooltip = new DescriptionTooltipBehavior(tooltipTitle,
-                tooltipContent.toString());
+        var l = new Label("label", Model.of(label));
+        var tooltip = new DescriptionTooltipBehavior(tooltipTitle, tooltipContent.toString());
         tooltip.setOption("position", (Object) null);
         l.add(tooltip);
         l.add(new AttributeAppender("style", "cursor: help", ";"));
         return l;
     }
 
-    private Label makeUpperDiagonalCellLabel(String aRater1, String aRater2)
+    private Label makeUpperDiagonalCellLabel(User aRater1, User aRater2)
     {
-        CodingAgreementResult result = getModelObject().getStudy(aRater1, aRater2);
+        var result = getModelObject().getStudy(aRater1.getUsername(), aRater2.getUsername());
 
-        boolean noDataRater0 = isAllNull(result, result.getCasGroupIds().get(0));
-        boolean noDataRater1 = isAllNull(result, result.getCasGroupIds().get(1));
-        int incPos = result.getIncompleteSetsByPosition().size();
-        int incLabel = result.getIncompleteSetsByLabel().size();
+        if (result == null) {
+            return new Label("label", "no data");
+        }
+
+        var casGroupId1 = result.getCasGroupIds().get(0);
+        var casGroupId2 = result.getCasGroupIds().get(1);
+        var noDataRater1 = result.isAllNull(casGroupId1);
+        var noDataRater2 = result.isAllNull(casGroupId2);
+        var incPos = result.getIncompleteSetsByPosition();
+        var incLabel = result.getIncompleteSetsByLabel();
 
         String label;
-        if (result.getStudy().getItemCount() == 0) {
+        if (result.isEmpty()) {
             label = "no positions";
         }
-        else if (noDataRater0 && noDataRater1) {
+        else if (noDataRater1 && noDataRater2) {
             label = "no labels";
         }
-        else if (noDataRater0) {
-            label = "no labels from " + result.getCasGroupIds().get(0);
-        }
         else if (noDataRater1) {
-            label = "no labels from " + result.getCasGroupIds().get(1);
+            label = "no labels from " + aRater1.getUiName();
+        }
+        else if (noDataRater2) {
+            label = "no labels from " + aRater2.getUiName();
         }
         else if (incPos == result.getRelevantSetCount()) {
             label = "positions disjunct";
@@ -278,173 +237,21 @@ public class PairwiseCodingAgreementTable
             label = String.format("%.2f", result.getAgreement());
         }
 
-        String tooltipTitle = result.getCasGroupIds().get(0) + '/' + result.getCasGroupIds().get(1);
+        var tooltipTitle = aRater1.getUiName() + " ↔ " + aRater2.getUiName();
 
-        String tooltipContent = "Positions annotated:\n"
-                + String.format("- %s: %d/%d%n", result.getCasGroupIds().get(0),
-                        getNonNullCount(result, result.getCasGroupIds().get(0)),
-                        result.getStudy().getItemCount())
-                + String.format("- %s: %d/%d%n", result.getCasGroupIds().get(1),
-                        getNonNullCount(result, result.getCasGroupIds().get(1)),
-                        result.getStudy().getItemCount())
-                + String.format("Distinct labels: %d%n", result.getStudy().getCategoryCount());
+        var tooltipContent = "Positions annotated:\n"
+                + String.format("- %s: %d/%d%n", aRater1.getUiName(),
+                        result.getNonNullCount(casGroupId1), result.getItemCount(casGroupId1))
+                + String.format("- %s: %d/%d%n", aRater2.getUiName(),
+                        result.getNonNullCount(casGroupId2), result.getItemCount(casGroupId2))
+                + String.format("Distinct labels: %d%n", result.getCategoryCount());
 
-        Label l = new Label("label", Model.of(label));
-        l.add(makeDownloadBehavior(aRater1, aRater2));
-        DescriptionTooltipBehavior tooltip = new DescriptionTooltipBehavior(tooltipTitle,
-                tooltipContent);
+        var l = new Label("label", Model.of(label));
+        var tooltip = new DescriptionTooltipBehavior(tooltipTitle, tooltipContent);
         tooltip.setOption("position", (Object) null);
         l.add(tooltip);
         l.add(new AttributeAppender("style", "cursor: pointer", ";"));
 
         return l;
-    }
-
-    public boolean isAllNull(AgreementResult<ICodingAnnotationStudy> aResult, String aCasGroupId)
-    {
-        for (ICodingAnnotationItem item : aResult.getStudy().getItems()) {
-            if (item.getUnit(aResult.getCasGroupIds().indexOf(aCasGroupId)).getCategory() != null) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    public int getNonNullCount(AgreementResult<ICodingAnnotationStudy> aResult, String aCasGroupId)
-    {
-        int i = 0;
-        for (ICodingAnnotationItem item : aResult.getStudy().getItems()) {
-            if (item.getUnit(aResult.getCasGroupIds().indexOf(aCasGroupId)).getCategory() != null) {
-                i++;
-            }
-        }
-        return i;
-    }
-
-    private Behavior makeDownloadBehavior(final String aKey1, final String aKey2)
-    {
-        return new AjaxEventBehavior("click")
-        {
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            protected void onEvent(AjaxRequestTarget aTarget)
-            {
-                AjaxDownloadBehavior download = new AjaxDownloadBehavior(
-                        LoadableDetachableModel.of(PairwiseCodingAgreementTable.this::getFilename),
-                        LoadableDetachableModel.of(() -> getAgreementTableData(aKey1, aKey2)));
-                getComponent().add(download);
-                download.initiate(aTarget);
-            }
-        };
-    }
-
-    private AbstractResourceStream getAgreementTableData(final String aKey1, final String aKey2)
-    {
-        return new AbstractResourceStream()
-        {
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public InputStream getInputStream() throws ResourceStreamNotFoundException
-            {
-                try {
-                    CodingAgreementResult result = PairwiseCodingAgreementTable.this
-                            .getModelObject().getStudy(aKey1, aKey2);
-
-                    switch (formatField.getModelObject()) {
-                    case CSV:
-                        return AgreementUtils.generateCsvReport(result);
-                    case DEBUG:
-                        return generateDebugReport(result);
-                    default:
-                        throw new IllegalStateException(
-                                "Unknown export format [" + formatField.getModelObject() + "]");
-                    }
-                }
-                catch (Exception e) {
-                    // FIXME Is there some better error handling here?
-                    LOG.error("Unable to generate agreement report", e);
-                    throw new ResourceStreamNotFoundException(e);
-                }
-            }
-
-            @Override
-            public void close() throws IOException
-            {
-                // Nothing to do
-            }
-        };
-    }
-
-    private String getFilename()
-    {
-        return "agreement" + formatField.getModelObject().getExtension();
-    }
-
-    private InputStream generateDebugReport(CodingAgreementResult aResult)
-    {
-        ByteArrayOutputStream buf = new ByteArrayOutputStream();
-        AgreementUtils.dumpAgreementStudy(new PrintStream(buf), aResult);
-        return new ByteArrayInputStream(buf.toByteArray());
-    }
-
-    @SuppressWarnings("unchecked")
-    public PairwiseAnnotationResult<CodingAgreementResult> getModelObject()
-    {
-        return (PairwiseAnnotationResult<CodingAgreementResult>) getDefaultModelObject();
-    }
-
-    public void setModelObject(PairwiseAnnotationResult<ICodingAnnotationStudy> aAgreements2)
-    {
-        setDefaultModelObject(aAgreements2);
-    }
-
-    private IResourceStream exportAllAgreements()
-    {
-        return new AbstractResourceStream()
-        {
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            public InputStream getInputStream() throws ResourceStreamNotFoundException
-            {
-                AnnotationFeature feature = getModelObject().getFeature();
-                DefaultAgreementTraits traits = getModelObject().getTraits();
-
-                Map<String, List<CAS>> casMap = casMapSupplier.get();
-
-                List<DiffAdapter> adapters = CasDiff.getDiffAdapters(annotationService,
-                        asList(feature.getLayer()));
-
-                CasDiff diff = doDiff(adapters, traits.getLinkCompareBehavior(), casMap);
-
-                Set<String> tagset = annotationService.listTags(feature.getTagset()).stream()
-                        .map(Tag::getName).collect(toCollection(LinkedHashSet::new));
-
-                // AgreementResult agreementResult = AgreementUtils.makeStudy(diff,
-                // feature.getLayer().getName(), feature.getName(),
-                // pref.excludeIncomplete, casMap);
-                // TODO: for the moment, we always include incomplete annotations during this
-                // export.
-                CodingAgreementResult agreementResult = makeCodingStudy(diff,
-                        feature.getLayer().getName(), feature.getName(), tagset, false, casMap);
-
-                try {
-                    return AgreementUtils.generateCsvReport(agreementResult);
-                }
-                catch (Exception e) {
-                    // FIXME Is there some better error handling here?
-                    LOG.error("Unable to generate report", e);
-                    throw new ResourceStreamNotFoundException(e);
-                }
-            }
-
-            @Override
-            public void close() throws IOException
-            {
-                // Nothing to do
-            }
-        };
     }
 }

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/coding/PairwiseCodingAgreementTable.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/coding/PairwiseCodingAgreementTable.java
@@ -17,12 +17,16 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.agreement.results.coding;
 
+import static de.tudarmstadt.ukp.inception.support.lambda.HtmlElementEvents.CLICK;
 import static de.tudarmstadt.ukp.inception.support.lambda.LambdaBehavior.visibleWhen;
+import static org.apache.wicket.event.Broadcast.BUBBLE;
 
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.wicket.ajax.AjaxEventBehavior;
+import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
@@ -42,6 +46,7 @@ import org.slf4j.LoggerFactory;
 import de.agilecoders.wicket.core.markup.html.bootstrap.components.PopoverConfig;
 import de.agilecoders.wicket.core.markup.html.bootstrap.components.TooltipConfig.Placement;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.PairwiseAnnotationResult;
+import de.tudarmstadt.ukp.clarin.webanno.agreement.results.coding.event.PairwiseAgreementScoreClickedEvent;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.inception.bootstrap.PopoverBehavior;
@@ -168,7 +173,7 @@ public class PairwiseCodingAgreementTable
 
     private Label makeLowerDiagonalCellLabel(User aRater1, User aRater2)
     {
-        var result = getModelObject().getStudy(aRater1.getUsername(), aRater2.getUsername());
+        var result = getModelObject().getResult(aRater1.getUsername(), aRater2.getUsername());
 
         if (result == null) {
             return new Label("label", "-");
@@ -198,7 +203,7 @@ public class PairwiseCodingAgreementTable
 
     private Label makeUpperDiagonalCellLabel(User aRater1, User aRater2)
     {
-        var result = getModelObject().getStudy(aRater1.getUsername(), aRater2.getUsername());
+        var result = getModelObject().getResult(aRater1.getUsername(), aRater2.getUsername());
 
         if (result == null) {
             return new Label("label", "no data");
@@ -252,6 +257,15 @@ public class PairwiseCodingAgreementTable
         l.add(tooltip);
         l.add(new AttributeAppender("style", "cursor: pointer", ";"));
 
+        l.add(AjaxEventBehavior.onEvent(CLICK,
+                _target -> actionScoreClicked(_target, aRater1, aRater2)));
+
         return l;
+    }
+
+    private void actionScoreClicked(AjaxRequestTarget aTarget, User aRater1, User aRater2)
+    {
+        send(this, BUBBLE, new PairwiseAgreementScoreClickedEvent(aTarget, aRater1.getUsername(),
+                aRater2.getUsername()));
     }
 }

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/coding/event/PairwiseAgreementScoreClickedEvent.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/coding/event/PairwiseAgreementScoreClickedEvent.java
@@ -15,14 +15,36 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package de.tudarmstadt.ukp.inception.documents.api;
+package de.tudarmstadt.ukp.clarin.webanno.agreement.results.coding.event;
 
-import java.io.File;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.wicketstuff.event.annotation.AbstractAjaxAwareEvent;
 
-public interface RepositoryProperties
+/**
+ * Fired when a user clicks on a pairwise agreement score.
+ */
+public class PairwiseAgreementScoreClickedEvent
+    extends AbstractAjaxAwareEvent
 {
-    File getPath();
+    private final String annotator1;
+    private final String annotator2;
 
-    @Deprecated
-    void setPath(File aPath);
+    public PairwiseAgreementScoreClickedEvent(AjaxRequestTarget aTarget, String aAnnotator1,
+            String aAnnotator2)
+    {
+        super(aTarget);
+
+        annotator1 = aAnnotator1;
+        annotator2 = aAnnotator2;
+    }
+
+    public String getAnnotator1()
+    {
+        return annotator1;
+    }
+
+    public String getAnnotator2()
+    {
+        return annotator2;
+    }
 }

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/unitizing/AbstractUnitizingAgreementMeasureSupport.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/unitizing/AbstractUnitizingAgreementMeasureSupport.java
@@ -17,14 +17,9 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.agreement.results.unitizing;
 
-import java.util.List;
-import java.util.Map;
-
-import org.apache.uima.cas.CAS;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
-import org.danekja.java.util.function.serializable.SerializableSupplier;
-import org.dkpro.statistics.agreement.coding.ICodingAnnotationStudy;
+import org.dkpro.statistics.agreement.unitizing.IUnitizingAnnotationStudy;
 
 import de.tudarmstadt.ukp.clarin.webanno.agreement.PairwiseAnnotationResult;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.AgreementMeasureSupport_ImplBase;
@@ -32,12 +27,10 @@ import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.DefaultAgreementTrai
 
 public abstract class AbstractUnitizingAgreementMeasureSupport<T extends DefaultAgreementTraits>
     extends
-    AgreementMeasureSupport_ImplBase<T, PairwiseAnnotationResult<UnitizingAgreementResult>, ICodingAnnotationStudy>
+    AgreementMeasureSupport_ImplBase<T, FullUnitizingAgreementResult, IUnitizingAnnotationStudy>
 {
     @Override
-    public Panel createResultsPanel(String aId,
-            IModel<PairwiseAnnotationResult<UnitizingAgreementResult>> aResults,
-            SerializableSupplier<Map<String, List<CAS>>> aCasMapSupplier)
+    public Panel createResultsPanel(String aId, IModel<PairwiseAnnotationResult> aResults)
     {
         return new PairwiseUnitizingAgreementTable(aId, aResults);
     }

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/unitizing/FullUnitizingAgreementResult.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/unitizing/FullUnitizingAgreementResult.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.agreement.results.unitizing;
+
+import java.util.List;
+
+import org.dkpro.statistics.agreement.unitizing.IUnitizingAnnotationStudy;
+
+import de.tudarmstadt.ukp.clarin.webanno.agreement.FullAgreementResult_ImplBase;
+
+public class FullUnitizingAgreementResult
+    extends FullAgreementResult_ImplBase<IUnitizingAnnotationStudy>
+{
+    private static final long serialVersionUID = 2092691057728349705L;
+
+    public FullUnitizingAgreementResult(String aType, String aFeature, IUnitizingAnnotationStudy aStudy,
+            List<String> aCasGroupIds, boolean aExcludeIncomplete)
+    {
+        super(aType, aFeature, aStudy, aCasGroupIds, aExcludeIncomplete);
+    }
+
+    public boolean isAllNull(String aRater)
+    {
+        var raterIdx = getCasGroupIds().indexOf(aRater);
+
+        return study.getUnits().stream()
+                .noneMatch(u -> u.getRaterIdx() == raterIdx && u.getCategory() != null);
+    }
+
+    public long getNonNullCount(String aRater)
+    {
+        var raterIdx = getCasGroupIds().indexOf(aRater);
+
+        return study.getUnits().stream() //
+                .filter(u -> u.getRaterIdx() == raterIdx && u.getCategory() != null) //
+                .count();
+    }
+
+    @Override
+    public long getItemCount(String aRater)
+    {
+        var raterIdx = getCasGroupIds().indexOf(aRater);
+        return study.getUnitCount(raterIdx);
+    }
+
+    @Override
+    public boolean isEmpty()
+    {
+        return study.getUnitCount() == 0;
+    }
+}

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/unitizing/PairwiseUnitizingAgreementTable.html
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/unitizing/PairwiseUnitizingAgreementTable.html
@@ -20,9 +20,11 @@
   <div class="flex-content card">
     <div class="card-header">
       <wicket:message key="agreement" />
-      <span class="float-end btn btn-link">
-        <a wicket:id="legend"><wicket:message key="legend" /></a> 
-      </span>
+      <div class="actions">
+        <button wicket:id="legend" class="btn btn-secondary btn-action" type="button">
+          <wicket:message key="legend"/>
+        </button>
+      </div>
     </div>
     <div class="scrolling card-body fit-child-snug" style="padding: 0px;">
       <table style="width: 100%;">

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/task/CalculatePairwiseAgreementTask.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/task/CalculatePairwiseAgreementTask.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.agreement.task;
+
+import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode.SHARED_READ_ONLY_ACCESS;
+import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasUpgradeMode.AUTO_CAS_UPGRADE;
+import static java.util.Comparator.comparing;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.uima.cas.CAS;
+import org.apache.uima.fit.util.FSUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import de.tudarmstadt.ukp.clarin.webanno.agreement.BasicAgreementResult;
+import de.tudarmstadt.ukp.clarin.webanno.agreement.PairwiseAnnotationResult;
+import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.AgreementMeasure;
+import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.DefaultAgreementTraits;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
+import de.tudarmstadt.ukp.inception.annotation.storage.CasStorageSession;
+import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
+import de.tudarmstadt.ukp.inception.scheduling.Task;
+import de.tudarmstadt.ukp.inception.support.logging.LogMessage;
+import de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil;
+
+public class CalculatePairwiseAgreementTask
+    extends Task
+{
+    public static final String TYPE = "CalculatePairwiseAgreementTask";
+
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    private @Autowired DocumentService documentService;
+
+    private final List<User> annotators;
+    private final DefaultAgreementTraits traits;
+    private final AnnotationFeature feature;
+    private final AgreementMeasure<?> measure;
+    private final Map<SourceDocument, List<AnnotationDocument>> allAnnDocs;
+
+    private PairwiseAnnotationResult result;
+
+    public CalculatePairwiseAgreementTask(Builder<? extends Builder<?>> aBuilder)
+    {
+        super(aBuilder.withType(TYPE));
+
+        annotators = aBuilder.annotators;
+        traits = aBuilder.traits;
+        feature = aBuilder.feature;
+        measure = aBuilder.measure;
+        allAnnDocs = aBuilder.allAnnDocs;
+    }
+
+    @Override
+    public void execute()
+    {
+        result = new PairwiseAnnotationResult(feature, traits);
+
+        var maxProgress = allAnnDocs.size();
+        var progress = 0;
+
+        var docs = allAnnDocs.keySet().stream() //
+                .sorted(comparing(SourceDocument::getName)) //
+                .toList();
+        for (var doc : docs) {
+            var monitor = getMonitor();
+            if (monitor.isCancelled()) {
+                break;
+            }
+
+            var annDocs = allAnnDocs.get(doc);
+
+            monitor.setProgressWithMessage(progress, maxProgress,
+                    LogMessage.info(this, doc.getName()));
+
+            try (var session = CasStorageSession.openNested()) {
+                for (int m = 0; m < annotators.size(); m++) {
+                    var annotator1 = annotators.get(m).getUsername();
+                    if (annDocs.stream().noneMatch(a -> annotator1.equals(a.getUser()))) {
+                        continue;
+                    }
+
+                    var cas1 = loadCas(doc, annotator1);
+
+                    for (int n = 0; n < annotators.size(); n++) {
+                        var annotator2 = annotators.get(n).getUsername();
+
+                        var cas2 = loadCas(doc, annotator2);
+
+                        // Triangle matrix mirrored
+                        if (n < m) {
+                            var casMap = new LinkedHashMap<String, CAS>();
+                            casMap.put(annotator1, cas1);
+                            casMap.put(annotator2, cas2);
+                            var res = BasicAgreementResult.of(measure.getAgreement(casMap));
+
+                            var existingRes = result.getStudy(annotators.get(m).getUsername(),
+                                    annotators.get(n).getUsername());
+                            if (existingRes != null) {
+                                existingRes.merge(res);
+                            }
+                            else {
+                                result.add(annotators.get(m).getUsername(),
+                                        annotators.get(n).getUsername(), res);
+                            }
+                        }
+                    }
+                }
+
+                progress++;
+            }
+            catch (Exception e) {
+                LOG.error("Unable to load data", e);
+            }
+        }
+    }
+
+    private CAS loadCas(SourceDocument doc, String annotator1) throws IOException
+    {
+        var cas = documentService.readAnnotationCas(doc, annotator1, AUTO_CAS_UPGRADE,
+                SHARED_READ_ONLY_ACCESS);
+
+        // Set the CAS name in the DocumentMetaData so that we can pick it
+        // up in the Diff position for the purpose of debugging / transparency.
+        var dmd = WebAnnoCasUtil.getDocumentMetadata(cas);
+        FSUtil.setFeature(dmd, "documentId", doc.getName());
+        FSUtil.setFeature(dmd, "collectionId", doc.getProject().getName());
+
+        return cas;
+    }
+
+    public PairwiseAnnotationResult getResult()
+    {
+        return result;
+    }
+
+    public static Builder<Builder<?>> builder()
+    {
+        return new Builder<>();
+    }
+
+    public static class Builder<T extends Builder<?>>
+        extends Task.Builder<T>
+    {
+        private List<User> annotators;
+        private DefaultAgreementTraits traits;
+        private AnnotationFeature feature;
+        private AgreementMeasure<?> measure;
+        private Map<SourceDocument, List<AnnotationDocument>> allAnnDocs;
+
+        protected Builder()
+        {
+            withCancellable(true);
+        }
+
+        @SuppressWarnings("unchecked")
+        public T withAnnotators(List<User> aAnnotators)
+        {
+            annotators = aAnnotators;
+            return (T) this;
+        }
+
+        @SuppressWarnings("unchecked")
+        public T withTraits(DefaultAgreementTraits aTraits)
+        {
+            traits = aTraits;
+            return (T) this;
+        }
+
+        @SuppressWarnings("unchecked")
+        public T withFeature(AnnotationFeature aFeature)
+        {
+            feature = aFeature;
+            return (T) this;
+        }
+
+        @SuppressWarnings("unchecked")
+        public T withMeasure(AgreementMeasure<?> aMeasure)
+        {
+            measure = aMeasure;
+            return (T) this;
+        }
+
+        @SuppressWarnings("unchecked")
+        public T withDocuments(Map<SourceDocument, List<AnnotationDocument>> aAllAnnDocs)
+        {
+            allAnnDocs = aAllAnnDocs;
+            return (T) this;
+        }
+
+        public CalculatePairwiseAgreementTask build()
+        {
+            return new CalculatePairwiseAgreementTask(this);
+        }
+    }
+}

--- a/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/AgreementMeasureTestSuite_ImplBase.java
+++ b/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/AgreementMeasureTestSuite_ImplBase.java
@@ -37,7 +37,6 @@ import static org.apache.uima.fit.factory.CasFactory.createCas;
 import static org.apache.uima.fit.factory.CasFactory.createText;
 import static org.apache.uima.fit.factory.JCasFactory.createJCas;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -52,6 +51,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import de.tudarmstadt.ukp.clarin.webanno.agreement.FullAgreementResult_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
@@ -104,7 +104,7 @@ public class AgreementMeasureTestSuite_ImplBase
         layerRegistry.init();
     }
 
-    public <R extends Serializable, T extends DefaultAgreementTraits, S extends IAnnotationStudy> //
+    public <R extends FullAgreementResult_ImplBase<S>, T extends DefaultAgreementTraits, S extends IAnnotationStudy> //
     R multiLinkWithRoleLabelDifferenceTest(AgreementMeasureSupport<T, R, S> aSupport)
         throws Exception
     {
@@ -133,16 +133,16 @@ public class AgreementMeasureTestSuite_ImplBase
         jcasB.setDocumentText("This is a test.");
         makeLinkHostFS(jcasB, 0, 0, makeLinkFS(jcasB, "slot2", 0, 0));
 
-        Map<String, List<CAS>> casByUser = new LinkedHashMap<>();
-        casByUser.put("user1", asList(jcasA.getCas()));
-        casByUser.put("user2", asList(jcasB.getCas()));
+        var casByUser = new LinkedHashMap<String, CAS>();
+        casByUser.put("user1", jcasA.getCas());
+        casByUser.put("user2", jcasB.getCas());
 
         AgreementMeasure<R> measure = aSupport.createMeasure(feature, traits);
 
         return measure.getAgreement(casByUser);
     }
 
-    public <R extends Serializable, T extends DefaultAgreementTraits, S extends IAnnotationStudy> //
+    public <R extends FullAgreementResult_ImplBase<S>, T extends DefaultAgreementTraits, S extends IAnnotationStudy> //
     R multiValueStringPartialAgreement(AgreementMeasureSupport<T, R, S> aSupport) throws Exception
     {
         AnnotationLayer layer = new AnnotationLayer(MULTI_VALUE_SPAN_TYPE, MULTI_VALUE_SPAN_TYPE,
@@ -177,11 +177,11 @@ public class AgreementMeasureTestSuite_ImplBase
         AgreementMeasure<R> measure = aSupport.createMeasure(feature, traits);
 
         return measure.getAgreement(Map.of( //
-                "user1", asList(user1), //
-                "user2", asList(user2)));
+                "user1", user1, //
+                "user2", user2));
     }
 
-    public <R extends Serializable, T extends DefaultAgreementTraits, S extends IAnnotationStudy> //
+    public <R extends FullAgreementResult_ImplBase<S>, T extends DefaultAgreementTraits, S extends IAnnotationStudy> //
     R twoEmptyCasTest(AgreementMeasureSupport<T, R, S> aSupport) throws Exception
     {
         var layer = new AnnotationLayer(Lemma.class.getName(), Lemma.class.getSimpleName(),
@@ -202,17 +202,17 @@ public class AgreementMeasureTestSuite_ImplBase
 
         CAS user2Cas = JCasFactory.createText(text).getCas();
 
-        Map<String, List<CAS>> casByUser = new LinkedHashMap<>();
-        casByUser.put("user1", asList(user1Cas));
-        casByUser.put("user2", asList(user2Cas));
+        var casByUser = new LinkedHashMap<String, CAS>();
+        casByUser.put("user1", user1Cas);
+        casByUser.put("user2", user2Cas);
 
         AgreementMeasure<R> measure = aSupport.createMeasure(feature, traits);
 
         return measure.getAgreement(casByUser);
     }
 
-    public <R extends Serializable, T extends DefaultAgreementTraits, S extends IAnnotationStudy> //
-    R singleNoDifferencesWithAdditionalCasTest(AgreementMeasureSupport<T, R, S> aSupport)
+    public <R extends FullAgreementResult_ImplBase<S>, T extends DefaultAgreementTraits, S extends IAnnotationStudy> //
+    R threeCasesWithAnnotationOnlyInThird(AgreementMeasureSupport<T, R, S> aSupport)
         throws Exception
     {
         var layer = new AnnotationLayer(POS.class.getName(), POS.class.getSimpleName(),
@@ -220,7 +220,7 @@ public class AgreementMeasureTestSuite_ImplBase
         layer.setId(1l);
         layers.add(layer);
 
-        AnnotationFeature feature = new AnnotationFeature(project, layer, POS._FeatName_PosValue,
+        var feature = new AnnotationFeature(project, layer, POS._FeatName_PosValue,
                 POS._FeatName_PosValue, TYPE_NAME_STRING);
         feature.setId(1l);
         features.add(feature);
@@ -235,12 +235,12 @@ public class AgreementMeasureTestSuite_ImplBase
         AgreementMeasure<R> measure = aSupport.createMeasure(feature, aSupport.createTraits());
 
         return measure.getAgreement(Map.of( //
-                "user1", asList(user1), //
-                "user2", asList(user2), //
-                "user3", asList(user3)));
+                "user1", user1, //
+                "user2", user2, //
+                "user3", user3));
     }
 
-    public <R extends Serializable, T extends DefaultAgreementTraits, S extends IAnnotationStudy> //
+    public <R extends FullAgreementResult_ImplBase<S>, T extends DefaultAgreementTraits, S extends IAnnotationStudy> //
     R twoWithoutLabelTest(AgreementMeasureSupport<T, R, S> aSupport, T aTraits) throws Exception
     {
         var layer = new AnnotationLayer(POS.class.getName(), POS.class.getSimpleName(),
@@ -269,20 +269,20 @@ public class AgreementMeasureTestSuite_ImplBase
         p2.setPosValue("B");
         p2.addToIndexes();
 
-        Map<String, List<CAS>> casByUser = new LinkedHashMap<>();
-        casByUser.put("user1", asList(user1.getCas()));
-        casByUser.put("user2", asList(user2.getCas()));
+        var casByUser = new LinkedHashMap<String, CAS>();
+        casByUser.put("user1", user1.getCas());
+        casByUser.put("user2", user2.getCas());
 
         AgreementMeasure<R> measure = aSupport.createMeasure(feature, aTraits);
 
         return measure.getAgreement(casByUser);
     }
 
-    public <R extends Serializable, T extends DefaultAgreementTraits, S extends IAnnotationStudy> //
+    public <R extends FullAgreementResult_ImplBase<S>, T extends DefaultAgreementTraits, S extends IAnnotationStudy> //
     R fullSingleCategoryAgreementWithTagset(AgreementMeasureSupport<T, R, S> aSupport, T aTraits)
         throws Exception
     {
-        TagSet tagset = new TagSet(project, "tagset");
+        var tagset = new TagSet(project, "tagset");
 
         var layer = new AnnotationLayer(POS.class.getName(), POS.class.getSimpleName(),
                 SpanLayerSupport.TYPE, project, false, SINGLE_TOKEN, NO_OVERLAP);
@@ -295,55 +295,20 @@ public class AgreementMeasureTestSuite_ImplBase
         feature.setTagset(tagset);
         features.add(feature);
 
-        CAS user1 = createText("test");
+        var user1 = createText("test");
 
         buildAnnotation(user1, POS.class).at(0, 1) //
                 .withFeature(POS._FeatName_PosValue, "+") //
                 .buildAndAddToIndexes();
 
-        CAS user2 = createText("test");
+        var user2 = createText("test");
 
         buildAnnotation(user2, POS.class).at(0, 1) //
                 .withFeature(POS._FeatName_PosValue, "+") //
                 .buildAndAddToIndexes();
 
         return aSupport.createMeasure(feature, aTraits).getAgreement(Map.of( //
-                "user1", asList(user1), //
-                "user2", asList(user2)));
-    }
-
-    public <R extends Serializable, T extends DefaultAgreementTraits, S extends IAnnotationStudy> //
-    R twoDocumentsNoOverlap(AgreementMeasureSupport<T, R, S> aSupport, T aTraits) throws Exception
-    {
-        TagSet tagset = new TagSet(project, "tagset");
-
-        var layer = new AnnotationLayer(POS.class.getName(), POS.class.getSimpleName(),
-                SpanLayerSupport.TYPE, project, false, SINGLE_TOKEN, NO_OVERLAP);
-        layer.setId(1l);
-        layers.add(layer);
-
-        AnnotationFeature feature = new AnnotationFeature(project, layer, "PosValue", "PosValue",
-                CAS.TYPE_NAME_STRING);
-        feature.setId(1l);
-        feature.setTagset(tagset);
-        features.add(feature);
-
-        CAS user1a = createText("test");
-        CAS user1b = createText("test");
-
-        buildAnnotation(user1a, POS.class).at(0, 1) //
-                .withFeature(POS._FeatName_PosValue, "+") //
-                .buildAndAddToIndexes();
-
-        CAS user2a = createText("test");
-        CAS user2b = createText("test");
-
-        buildAnnotation(user2b, POS.class).at(0, 1) //
-                .withFeature(POS._FeatName_PosValue, "+") //
-                .buildAndAddToIndexes();
-
-        return aSupport.createMeasure(feature, aTraits).getAgreement(Map.of( //
-                "user1", asList(user1a, user1b), //
-                "user2", asList(user2a, user2b)));
+                "user1", user1, //
+                "user2", user2));
     }
 }

--- a/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/AgreementTestUtils.java
+++ b/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/AgreementTestUtils.java
@@ -50,10 +50,9 @@ import org.apache.uima.resource.metadata.impl.TypeSystemDescription_impl;
 import org.apache.uima.util.CasCreationUtils;
 import org.dkpro.core.io.conll.Conll2006Reader;
 import org.dkpro.core.io.xmi.XmiReader;
-import org.dkpro.statistics.agreement.IAgreementMeasure;
 import org.dkpro.statistics.agreement.InsufficientDataException;
 
-import de.tudarmstadt.ukp.clarin.webanno.agreement.results.coding.CodingAgreementResult;
+import de.tudarmstadt.ukp.clarin.webanno.agreement.results.coding.FullCodingAgreementResult;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff;
 import de.tudarmstadt.ukp.clarin.webanno.tsv.WebannoTsv2Reader;
 import de.tudarmstadt.ukp.clarin.webanno.tsv.WebannoTsv3XReader;
@@ -345,27 +344,27 @@ public class AgreementTestUtils
     }
 
     @Deprecated
-    public static CodingAgreementResult getCohenKappaAgreement(CasDiff aDiff, String aType,
-            String aFeature, Map<String, List<CAS>> aCasMap)
+    public static FullCodingAgreementResult getCohenKappaAgreement(CasDiff aDiff, String aType,
+            String aFeature, Map<String, CAS> aCasMap)
     {
         return getAgreement(COHEN_KAPPA_AGREEMENT, true, aDiff, aType, aFeature, aCasMap);
     }
 
     @Deprecated
-    public static CodingAgreementResult getAgreement(ConcreteAgreementMeasure aMeasure,
+    public static FullCodingAgreementResult getAgreement(ConcreteAgreementMeasure aMeasure,
             boolean aExcludeIncomplete, CasDiff aDiff, String aType, String aFeature,
-            Map<String, List<CAS>> aCasMap)
+            Map<String, CAS> aCasMap)
     {
         if (aCasMap.size() != 2) {
             throw new IllegalArgumentException("CAS map must contain exactly two CASes");
         }
 
-        CodingAgreementResult agreementResult = makeCodingStudy(aDiff, aType, aFeature, emptySet(),
+        var agreementResult = makeCodingStudy(aDiff, aType, aFeature, emptySet(),
                 aExcludeIncomplete, aCasMap);
         try {
-            IAgreementMeasure agreement = aMeasure.make(agreementResult.getStudy());
+            var agreement = aMeasure.make(agreementResult.getStudy());
 
-            if (agreementResult.getStudy().getItemCount() > 0) {
+            if (!agreementResult.isEmpty()) {
                 agreementResult.setAgreement(agreement.calculateAgreement());
             }
             else {

--- a/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/FleissKappaAgreementMeasureTest.java
+++ b/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/FleissKappaAgreementMeasureTest.java
@@ -18,7 +18,6 @@
 package de.tudarmstadt.ukp.clarin.webanno.agreement.measures;
 
 import static java.lang.Double.NaN;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -28,17 +27,15 @@ import org.dkpro.statistics.agreement.coding.ICodingAnnotationStudy;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import de.tudarmstadt.ukp.clarin.webanno.agreement.PairwiseAnnotationResult;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.fleisskappa.FleissKappaAgreementMeasureSupport;
-import de.tudarmstadt.ukp.clarin.webanno.agreement.results.coding.CodingAgreementResult;
-import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.DiffResult;
+import de.tudarmstadt.ukp.clarin.webanno.agreement.results.coding.FullCodingAgreementResult;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 
 public class FleissKappaAgreementMeasureTest
     extends AgreementMeasureTestSuite_ImplBase
 {
     private AgreementMeasureSupport<DefaultAgreementTraits, //
-            PairwiseAnnotationResult<CodingAgreementResult>, ICodingAnnotationStudy> sut;
+            FullCodingAgreementResult, ICodingAnnotationStudy> sut;
     private DefaultAgreementTraits traits;
 
     @Override
@@ -56,11 +53,9 @@ public class FleissKappaAgreementMeasureTest
     {
         when(annotationService.listSupportedFeatures(any(Project.class))).thenReturn(features);
 
-        var agreement = multiLinkWithRoleLabelDifferenceTest(sut);
+        var result = multiLinkWithRoleLabelDifferenceTest(sut);
 
-        CodingAgreementResult result = agreement.getStudy("user1", "user2");
-
-        DiffResult diff = result.getDiff();
+        var diff = result.getDiff();
 
         diff.print(System.out);
 
@@ -74,11 +69,9 @@ public class FleissKappaAgreementMeasureTest
     @Test
     public void twoEmptyCasTest() throws Exception
     {
-        PairwiseAnnotationResult<CodingAgreementResult> agreement = twoEmptyCasTest(sut);
+        var result = twoEmptyCasTest(sut);
 
-        CodingAgreementResult result = agreement.getStudy("user1", "user2");
-
-        DiffResult diff = result.getDiff();
+        var diff = result.getDiff();
 
         assertEquals(0, diff.size());
         assertEquals(0, diff.getDifferingConfigurationSets().size());
@@ -88,34 +81,32 @@ public class FleissKappaAgreementMeasureTest
         assertEquals(0, result.getIncompleteSetsByPosition().size());
     }
 
-    @Test
-    public void singleNoDifferencesWithAdditionalCasTest() throws Exception
-    {
-        PairwiseAnnotationResult<CodingAgreementResult> agreement = singleNoDifferencesWithAdditionalCasTest(
-                sut);
-
-        CodingAgreementResult result1 = agreement.getStudy("user1", "user2");
-        assertEquals(0, result1.getTotalSetCount());
-        assertEquals(0, result1.getIrrelevantSets().size());
-        assertEquals(0, result1.getRelevantSetCount());
-
-        CodingAgreementResult result2 = agreement.getStudy("user1", "user3");
-        assertEquals(1, result2.getTotalSetCount());
-        assertEquals(0, result2.getIrrelevantSets().size());
-        assertEquals(1, result2.getRelevantSetCount());
-
-        assertEquals(NaN, agreement.getStudy("user1", "user2").getAgreement(), 0.01);
-        assertEquals(NaN, agreement.getStudy("user1", "user3").getAgreement(), 0.01);
-        assertEquals(NaN, agreement.getStudy("user2", "user3").getAgreement(), 0.01);
-    }
+    // @Test
+    // public void singleNoDifferencesWithAdditionalCasTest() throws Exception
+    // {
+    // PairwiseAnnotationResult<CodingAgreementResult> agreement =
+    // singleNoDifferencesWithAdditionalCasTest(
+    // sut);
+    //
+    // CodingAgreementResult result1 = agreement.getStudy("user1", "user2");
+    // assertEquals(0, result1.getTotalSetCount());
+    // assertEquals(0, result1.getIrrelevantSets().size());
+    // assertEquals(0, result1.getRelevantSetCount());
+    //
+    // CodingAgreementResult result2 = agreement.getStudy("user1", "user3");
+    // assertEquals(1, result2.getTotalSetCount());
+    // assertEquals(0, result2.getIrrelevantSets().size());
+    // assertEquals(1, result2.getRelevantSetCount());
+    //
+    // assertEquals(NaN, agreement.getStudy("user1", "user2").getAgreement(), 0.01);
+    // assertEquals(NaN, agreement.getStudy("user1", "user3").getAgreement(), 0.01);
+    // assertEquals(NaN, agreement.getStudy("user2", "user3").getAgreement(), 0.01);
+    // }
 
     @Test
     public void twoWithoutLabelTest() throws Exception
     {
-        PairwiseAnnotationResult<CodingAgreementResult> agreement = twoWithoutLabelTest(sut,
-                traits);
-
-        CodingAgreementResult result = agreement.getStudy("user1", "user2");
+        var result = twoWithoutLabelTest(sut, traits);
 
         ICodingAnnotationItem item1 = result.getStudy().getItem(0);
         ICodingAnnotationItem item2 = result.getStudy().getItem(1);
@@ -135,10 +126,7 @@ public class FleissKappaAgreementMeasureTest
     @Test
     public void fullSingleCategoryAgreementWithTagsetTest() throws Exception
     {
-        PairwiseAnnotationResult<CodingAgreementResult> agreement = fullSingleCategoryAgreementWithTagset(
-                sut, traits);
-
-        CodingAgreementResult result = agreement.getStudy("user1", "user2");
+        var result = fullSingleCategoryAgreementWithTagset(sut, traits);
 
         ICodingAnnotationItem item1 = result.getStudy().getItem(0);
         assertEquals("+", item1.getUnit(0).getCategory());
@@ -150,16 +138,5 @@ public class FleissKappaAgreementMeasureTest
         assertEquals(0, result.getSetsWithDifferences().size());
         assertEquals(1, result.getRelevantSetCount());
         assertEquals(1.0, result.getAgreement(), 0.01);
-    }
-
-    @Test
-    public void twoDocumentsNoOverlapTest() throws Exception
-    {
-        PairwiseAnnotationResult<CodingAgreementResult> agreement = twoDocumentsNoOverlap(sut,
-                traits);
-
-        CodingAgreementResult result = agreement.getStudy("user1", "user2");
-
-        assertThat(result.getAgreement()).isNaN();
     }
 }

--- a/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/KrippendorffAlphaNominalAgreementMeasureTest.java
+++ b/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/KrippendorffAlphaNominalAgreementMeasureTest.java
@@ -19,7 +19,6 @@ package de.tudarmstadt.ukp.clarin.webanno.agreement.measures;
 
 import static java.lang.Double.NaN;
 import static java.util.Arrays.asList;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -29,10 +28,9 @@ import org.dkpro.statistics.agreement.coding.ICodingAnnotationStudy;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import de.tudarmstadt.ukp.clarin.webanno.agreement.PairwiseAnnotationResult;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.krippendorffalpha.KrippendorffAlphaAgreementMeasureSupport;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.krippendorffalpha.KrippendorffAlphaAgreementTraits;
-import de.tudarmstadt.ukp.clarin.webanno.agreement.results.coding.CodingAgreementResult;
+import de.tudarmstadt.ukp.clarin.webanno.agreement.results.coding.FullCodingAgreementResult;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.DiffResult;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.Tag;
@@ -42,7 +40,7 @@ public class KrippendorffAlphaNominalAgreementMeasureTest
     extends AgreementMeasureTestSuite_ImplBase
 {
     private AgreementMeasureSupport<KrippendorffAlphaAgreementTraits, //
-            PairwiseAnnotationResult<CodingAgreementResult>, ICodingAnnotationStudy> sut;
+            FullCodingAgreementResult, ICodingAnnotationStudy> sut;
     private KrippendorffAlphaAgreementTraits traits;
 
     @Override
@@ -60,9 +58,7 @@ public class KrippendorffAlphaNominalAgreementMeasureTest
     {
         when(annotationService.listSupportedFeatures(any(Project.class))).thenReturn(features);
 
-        var agreement = multiLinkWithRoleLabelDifferenceTest(sut);
-
-        CodingAgreementResult result = agreement.getStudy("user1", "user2");
+        var result = multiLinkWithRoleLabelDifferenceTest(sut);
 
         DiffResult diff = result.getDiff();
 
@@ -78,9 +74,7 @@ public class KrippendorffAlphaNominalAgreementMeasureTest
     @Test
     public void twoEmptyCasTest() throws Exception
     {
-        PairwiseAnnotationResult<CodingAgreementResult> agreement = twoEmptyCasTest(sut);
-
-        CodingAgreementResult result = agreement.getStudy("user1", "user2");
+        var result = twoEmptyCasTest(sut);
 
         DiffResult diff = result.getDiff();
 
@@ -92,36 +86,32 @@ public class KrippendorffAlphaNominalAgreementMeasureTest
         assertEquals(0, result.getIncompleteSetsByPosition().size());
     }
 
-    @Test
-    public void singleNoDifferencesWithAdditionalCasTest() throws Exception
-    {
-        PairwiseAnnotationResult<CodingAgreementResult> agreement = singleNoDifferencesWithAdditionalCasTest(
-                sut);
-
-        CodingAgreementResult result1 = agreement.getStudy("user1", "user2");
-        assertEquals(0, result1.getTotalSetCount());
-        assertEquals(0, result1.getIrrelevantSets().size());
-        assertEquals(0, result1.getRelevantSetCount());
-
-        CodingAgreementResult result2 = agreement.getStudy("user1", "user3");
-        assertEquals(1, result2.getTotalSetCount());
-        assertEquals(0, result2.getIrrelevantSets().size());
-        assertEquals(1, result2.getRelevantSetCount());
-
-        assertEquals(NaN, agreement.getStudy("user1", "user2").getAgreement(), 0.01);
-        assertEquals(NaN, agreement.getStudy("user1", "user3").getAgreement(), 0.01);
-        assertEquals(NaN, agreement.getStudy("user2", "user3").getAgreement(), 0.01);
-    }
+    // @Test
+    // public void singleNoDifferencesWithAdditionalCasTest() throws Exception
+    // {
+    // var result = singleNoDifferencesWithAdditionalCasTest(sut);
+    //
+    // CodingAgreementResult result1 = agreement.getStudy("user1", "user2");
+    // assertEquals(0, result1.getTotalSetCount());
+    // assertEquals(0, result1.getIrrelevantSets().size());
+    // assertEquals(0, result1.getRelevantSetCount());
+    //
+    // CodingAgreementResult result2 = agreement.getStudy("user1", "user3");
+    // assertEquals(1, result2.getTotalSetCount());
+    // assertEquals(0, result2.getIrrelevantSets().size());
+    // assertEquals(1, result2.getRelevantSetCount());
+    //
+    // assertEquals(NaN, agreement.getStudy("user1", "user2").getAgreement(), 0.01);
+    // assertEquals(NaN, agreement.getStudy("user1", "user3").getAgreement(), 0.01);
+    // assertEquals(NaN, agreement.getStudy("user2", "user3").getAgreement(), 0.01);
+    // }
 
     @Test
     public void testTwoWithoutLabel_noExcludeIncomplete() throws Exception
     {
         traits.setExcludeIncomplete(false);
 
-        PairwiseAnnotationResult<CodingAgreementResult> agreement = twoWithoutLabelTest(sut,
-                traits);
-
-        CodingAgreementResult result = agreement.getStudy("user1", "user2");
+        var result = twoWithoutLabelTest(sut, traits);
 
         ICodingAnnotationItem item1 = result.getStudy().getItem(0);
         ICodingAnnotationItem item2 = result.getStudy().getItem(1);
@@ -152,9 +142,7 @@ public class KrippendorffAlphaNominalAgreementMeasureTest
         when(annotationService.listTags(tagset)).thenReturn(asList(tag1, tag2));
         when(annotationService.listSupportedFeatures(any(Project.class))).thenReturn(features);
 
-        var agreement = fullSingleCategoryAgreementWithTagset(sut, traits);
-
-        CodingAgreementResult result = agreement.getStudy("user1", "user2");
+        var result = fullSingleCategoryAgreementWithTagset(sut, traits);
 
         ICodingAnnotationItem item1 = result.getStudy().getItem(0);
         assertEquals("+", item1.getUnit(0).getCategory());
@@ -166,16 +154,5 @@ public class KrippendorffAlphaNominalAgreementMeasureTest
         assertEquals(0, result.getSetsWithDifferences().size());
         assertEquals(1, result.getRelevantSetCount());
         assertEquals(1.0, result.getAgreement(), 0.01);
-    }
-
-    @Test
-    public void twoDocumentsNoOverlapTest() throws Exception
-    {
-        PairwiseAnnotationResult<CodingAgreementResult> agreement = twoDocumentsNoOverlap(sut,
-                traits);
-
-        CodingAgreementResult result = agreement.getStudy("user1", "user2");
-
-        assertThat(result.getAgreement()).isNaN();
     }
 }

--- a/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/KrippendorffAlphaUnitizingAgreementMeasureTest.java
+++ b/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/KrippendorffAlphaUnitizingAgreementMeasureTest.java
@@ -24,16 +24,15 @@ import org.dkpro.statistics.agreement.unitizing.IUnitizingAnnotationStudy;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import de.tudarmstadt.ukp.clarin.webanno.agreement.PairwiseAnnotationResult;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.krippendorffalphaunitizing.KrippendorffAlphaUnitizingAgreementMeasureSupport;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.krippendorffalphaunitizing.KrippendorffAlphaUnitizingAgreementTraits;
-import de.tudarmstadt.ukp.clarin.webanno.agreement.results.unitizing.UnitizingAgreementResult;
+import de.tudarmstadt.ukp.clarin.webanno.agreement.results.unitizing.FullUnitizingAgreementResult;
 
 public class KrippendorffAlphaUnitizingAgreementMeasureTest
     extends AgreementMeasureTestSuite_ImplBase
 {
     private AgreementMeasureSupport_ImplBase<KrippendorffAlphaUnitizingAgreementTraits, //
-            PairwiseAnnotationResult<UnitizingAgreementResult>, IUnitizingAnnotationStudy> sut;
+            FullUnitizingAgreementResult, IUnitizingAnnotationStudy> sut;
     private KrippendorffAlphaUnitizingAgreementTraits traits;
 
     @Override
@@ -49,9 +48,7 @@ public class KrippendorffAlphaUnitizingAgreementMeasureTest
     @Test
     public void multiLinkWithRoleLabelDifference() throws Exception
     {
-        var agreement = multiLinkWithRoleLabelDifferenceTest(sut);
-
-        var result = agreement.getStudy("user1", "user2");
+        var result = multiLinkWithRoleLabelDifferenceTest(sut);
 
         assertEquals(0.0, result.getAgreement(), 0.00001d);
     }
@@ -59,31 +56,27 @@ public class KrippendorffAlphaUnitizingAgreementMeasureTest
     @Test
     public void twoEmptyCasTest() throws Exception
     {
-        var agreement = twoEmptyCasTest(sut);
-
-        var result = agreement.getStudy("user1", "user2");
+        var result = twoEmptyCasTest(sut);
 
         assertThat(result.getAgreement()).isNaN();
     }
 
-    @Test
-    public void singleNoDifferencesWithAdditionalCasTest() throws Exception
-    {
-        var agreement = singleNoDifferencesWithAdditionalCasTest(sut);
-
-        assertThat(agreement.getStudy("user1", "user2").getAgreement()).isNaN();
-        assertThat(agreement.getStudy("user1", "user3").getAgreement()).isEqualTo(-4.5d);
-        assertThat(agreement.getStudy("user2", "user3").getAgreement()).isEqualTo(-4.5d);
-    }
+    // @Test
+    // public void singleNoDifferencesWithAdditionalCasTest() throws Exception
+    // {
+    // var agreement = singleNoDifferencesWithAdditionalCasTest(sut);
+    //
+    // assertThat(agreement.getStudy("user1", "user2").getAgreement()).isNaN();
+    // assertThat(agreement.getStudy("user1", "user3").getAgreement()).isEqualTo(-4.5d);
+    // assertThat(agreement.getStudy("user2", "user3").getAgreement()).isEqualTo(-4.5d);
+    // }
 
     @Test
     public void testTwoWithoutLabel_noExcludeIncomplete() throws Exception
     {
         traits.setExcludeIncomplete(false);
 
-        var agreement = twoWithoutLabelTest(sut, traits);
-
-        var result = agreement.getStudy("user1", "user2");
+        var result = twoWithoutLabelTest(sut, traits);
 
         assertEquals(0.0, result.getAgreement(), 0.01);
     }
@@ -91,29 +84,15 @@ public class KrippendorffAlphaUnitizingAgreementMeasureTest
     @Test
     public void fullSingleCategoryAgreementWithTagsetTest() throws Exception
     {
-        var agreement = fullSingleCategoryAgreementWithTagset(sut, traits);
-
-        var result = agreement.getStudy("user1", "user2");
+        var result = fullSingleCategoryAgreementWithTagset(sut, traits);
 
         assertEquals(1.0, result.getAgreement(), 0.01);
     }
 
     @Test
-    public void twoDocumentsNoOverlapTest() throws Exception
-    {
-        var agreement = twoDocumentsNoOverlap(sut, traits);
-
-        var result = agreement.getStudy("user1", "user2");
-
-        assertEquals(-0.0714, result.getAgreement(), 0.001);
-    }
-
-    @Test
     public void multiValueStringPartialAgreementTest() throws Exception
     {
-        var agreement = multiValueStringPartialAgreement(sut);
-
-        var result = agreement.getStudy("user1", "user2");
+        var result = multiValueStringPartialAgreement(sut);
 
         assertEquals(0.4893, result.getAgreement(), 0.001);
     }

--- a/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/TwoPairedKappaTest.java
+++ b/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/TwoPairedKappaTest.java
@@ -30,7 +30,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import org.apache.uima.cas.CAS;
 import org.apache.uima.collection.CollectionReader;
@@ -38,9 +37,9 @@ import org.apache.uima.fit.factory.JCasFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import de.tudarmstadt.ukp.clarin.webanno.agreement.AgreementResult;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.AgreementUtils;
-import de.tudarmstadt.ukp.clarin.webanno.agreement.results.coding.CodingAgreementResult;
+import de.tudarmstadt.ukp.clarin.webanno.agreement.FullAgreementResult_ImplBase;
+import de.tudarmstadt.ukp.clarin.webanno.agreement.results.coding.FullCodingAgreementResult;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.DiffResult;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
@@ -116,8 +115,8 @@ public class TwoPairedKappaTest
         // Check against new impl
         CasDiff diff = doDiff(asList(POS_DIFF_ADAPTER), LINK_TARGET_AS_LABEL, convert(userCases));
         DiffResult result = diff.toResult();
-        AgreementResult agreement = getCohenKappaAgreement(diff, POS.class.getName(), "PosValue",
-                convert(userCases));
+        FullAgreementResult_ImplBase agreement = getCohenKappaAgreement(diff, POS.class.getName(),
+                "PosValue", convert(userCases));
 
         // Asserts
         System.out.printf("Agreement: %s%n", agreement.toString());
@@ -129,11 +128,11 @@ public class TwoPairedKappaTest
         assertEquals(0, result.getIncompleteConfigurationSets().size());
     }
 
-    private Map<String, List<CAS>> convert(Map<User, CAS> aMap)
+    private Map<String, CAS> convert(Map<User, CAS> aMap)
     {
-        Map<String, List<CAS>> map = new LinkedHashMap<>();
-        for (Entry<User, CAS> e : aMap.entrySet()) {
-            map.put(e.getKey().getUsername(), asList(e.getValue()));
+        var map = new LinkedHashMap<String, CAS>();
+        for (var e : aMap.entrySet()) {
+            map.put(e.getKey().getUsername(), e.getValue());
         }
         return map;
     }
@@ -156,8 +155,8 @@ public class TwoPairedKappaTest
         CasDiff diff = doDiff(asList(DEPENDENCY_DIFF_ADAPTER), LINK_TARGET_AS_LABEL,
                 convert(userCases));
         DiffResult result = diff.toResult();
-        AgreementResult agreement = getCohenKappaAgreement(diff, Dependency.class.getName(),
-                "DependencyType", convert(userCases));
+        FullAgreementResult_ImplBase agreement = getCohenKappaAgreement(diff,
+                Dependency.class.getName(), "DependencyType", convert(userCases));
 
         // Asserts
         System.out.printf("Agreement: %s%n", agreement.toString());
@@ -186,8 +185,8 @@ public class TwoPairedKappaTest
         // Check against new impl
         CasDiff diff = doDiff(asList(POS_DIFF_ADAPTER), LINK_TARGET_AS_LABEL, convert(userCases));
         DiffResult result = diff.toResult();
-        AgreementResult agreement = getCohenKappaAgreement(diff, POS.class.getName(), "PosValue",
-                convert(userCases));
+        FullAgreementResult_ImplBase agreement = getCohenKappaAgreement(diff, POS.class.getName(),
+                "PosValue", convert(userCases));
 
         // Asserts
         System.out.printf("Agreement: %s%n", agreement.toString());
@@ -217,8 +216,8 @@ public class TwoPairedKappaTest
         CasDiff diff = doDiff(asList(DEPENDENCY_DIFF_ADAPTER), LINK_TARGET_AS_LABEL,
                 convert(userCases));
         DiffResult result = diff.toResult();
-        CodingAgreementResult agreement = getCohenKappaAgreement(diff, Dependency.class.getName(),
-                "DependencyType", convert(userCases));
+        FullCodingAgreementResult agreement = getCohenKappaAgreement(diff,
+                Dependency.class.getName(), "DependencyType", convert(userCases));
 
         // Asserts
         System.out.printf("Agreement: %s%n", agreement.toString());
@@ -239,7 +238,7 @@ public class TwoPairedKappaTest
         userDocs.put(user2, asList(document));
         userDocs.put(user3, asList(document));
 
-        Map<User, CAS> userCases = new HashMap<>();
+        var userCases = new HashMap<User, CAS>();
         userCases.put(user1, kappatestCas);
         userCases.put(user2, kappaspandiff);
         userCases.put(user3, kappaspanarcdiff);
@@ -252,20 +251,20 @@ public class TwoPairedKappaTest
                 LINK_TARGET_AS_LABEL, convert(userCases));
         DiffResult result = diff.toResult();
 
-        Map<String, List<CAS>> user1and2 = convert(userCases);
+        var user1and2 = convert(userCases);
         user1and2.remove("user3");
-        AgreementResult agreement12 = getCohenKappaAgreement(diff, Dependency.class.getName(),
-                "DependencyType", user1and2);
+        FullAgreementResult_ImplBase agreement12 = getCohenKappaAgreement(diff,
+                Dependency.class.getName(), "DependencyType", user1and2);
 
-        Map<String, List<CAS>> user2and3 = convert(userCases);
+        var user2and3 = convert(userCases);
         user2and3.remove("user1");
-        AgreementResult agreement23 = getCohenKappaAgreement(diff, Dependency.class.getName(),
-                "DependencyType", user2and3);
+        FullAgreementResult_ImplBase agreement23 = getCohenKappaAgreement(diff,
+                Dependency.class.getName(), "DependencyType", user2and3);
 
-        Map<String, List<CAS>> user1and3 = convert(userCases);
+        var user1and3 = convert(userCases);
         user1and3.remove("user2");
-        AgreementResult agreement13 = getCohenKappaAgreement(diff, Dependency.class.getName(),
-                "DependencyType", user1and3);
+        FullAgreementResult_ImplBase agreement13 = getCohenKappaAgreement(diff,
+                Dependency.class.getName(), "DependencyType", user1and3);
 
         // Asserts
         result.print(System.out);

--- a/inception/inception-annotation-storage/src/test/java/de/tudarmstadt/ukp/inception/annotation/storage/CasStorageServiceImplTest.java
+++ b/inception/inception-annotation-storage/src/test/java/de/tudarmstadt/ukp/inception/annotation/storage/CasStorageServiceImplTest.java
@@ -69,6 +69,7 @@ import de.tudarmstadt.ukp.inception.annotation.storage.config.CasStorageCachePro
 import de.tudarmstadt.ukp.inception.annotation.storage.config.CasStoragePropertiesImpl;
 import de.tudarmstadt.ukp.inception.annotation.storage.driver.filesystem.FileSystemCasStorageDriver;
 import de.tudarmstadt.ukp.inception.documents.api.RepositoryProperties;
+import de.tudarmstadt.ukp.inception.documents.api.RepositoryPropertiesImpl;
 import de.tudarmstadt.ukp.inception.schema.api.event.LayerConfigurationChangedEvent;
 import de.tudarmstadt.ukp.inception.support.logging.Logging;
 import de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil;
@@ -105,7 +106,7 @@ public class CasStorageServiceImplTest
         deleteCounter.set(0);
         deleteInitialCounter.set(0);
 
-        repositoryProperties = new RepositoryProperties();
+        repositoryProperties = new RepositoryPropertiesImpl();
         repositoryProperties.setPath(testFolder);
 
         MDC.put(Logging.KEY_REPOSITORY_PATH, repositoryProperties.getPath().toString());

--- a/inception/inception-concept-linking/src/test/java/de/tudarmstadt/ukp/inception/conceptlinking/service/ConceptLinkingServiceImplTest.java
+++ b/inception/inception-concept-linking/src/test/java/de/tudarmstadt/ukp/inception/conceptlinking/service/ConceptLinkingServiceImplTest.java
@@ -44,6 +44,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.inception.conceptlinking.config.EntityLinkingPropertiesImpl;
 import de.tudarmstadt.ukp.inception.conceptlinking.util.TestFixtures;
 import de.tudarmstadt.ukp.inception.documents.api.RepositoryProperties;
+import de.tudarmstadt.ukp.inception.documents.api.RepositoryPropertiesImpl;
 import de.tudarmstadt.ukp.inception.kb.KnowledgeBaseService;
 import de.tudarmstadt.ukp.inception.kb.KnowledgeBaseServiceImpl;
 import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBaseProperties;
@@ -79,7 +80,7 @@ public class ConceptLinkingServiceImplTest
     @BeforeEach
     public void setUp() throws Exception
     {
-        RepositoryProperties repoProps = new RepositoryProperties();
+        RepositoryProperties repoProps = new RepositoryPropertiesImpl();
         KnowledgeBaseProperties kbProperties = new KnowledgeBasePropertiesImpl();
         repoProps.setPath(temporaryFolder);
         EntityManager entityManager = testEntityManager.getEntityManager();

--- a/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/CasDiff.java
+++ b/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/CasDiff.java
@@ -19,13 +19,13 @@ package de.tudarmstadt.ukp.clarin.webanno.curation.casdiff;
 
 import static de.tudarmstadt.ukp.clarin.webanno.model.LinkMode.NONE;
 import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.RELATION_TYPE;
+import static de.tudarmstadt.ukp.inception.support.uima.ICasUtil.selectFsByAddr;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.collections4.CollectionUtils.subtract;
-import static org.apache.commons.lang3.StringUtils.abbreviateMiddle;
 import static org.apache.uima.fit.util.CasUtil.select;
 
 import java.io.PrintStream;
@@ -35,7 +35,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -60,10 +59,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.api.DiffAdapter;
+import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.api.DiffAdapter;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.api.DiffAdapter_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.api.Position;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.internal.AID;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.relation.RelationDiffAdapter;
+import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.span.SpanDiffAdapter;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.span.SpanDiffAdapter;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
@@ -78,7 +79,7 @@ public class CasDiff
 {
     private final static Logger LOG = LoggerFactory.getLogger(CasDiff.class);
 
-    private Map<String, List<CAS>> cases = new LinkedHashMap<>();
+    private Map<String, CAS> cases = new LinkedHashMap<>();
 
     private final Map<Position, ConfigurationSet> configSets = new TreeMap<>();
 
@@ -98,40 +99,12 @@ public class CasDiff
         begin = aBegin;
         end = aEnd;
         linkCompareBehavior = aLinkCompareBehavior;
+
         if (aAdapters != null) {
-            for (DiffAdapter adapter : aAdapters) {
+            for (var adapter : aAdapters) {
                 diffAdapters.put(adapter.getType(), adapter);
             }
         }
-    }
-
-    /**
-     * Calculate the differences between CASes. This method scopes the calculation of differences to
-     * a span instead of calculating them on the whole text.
-     * 
-     * @param aAdapters
-     *            a set of diff adapters telling how the diff algorithm should handle different
-     *            features
-     * @param aLinkCompareBehavior
-     *            the link comparison mode
-     * @param aCasMap
-     *            a set of CASes, each associated with an ID
-     * @param aBegin
-     *            begin of the span for which differences should be calculated.
-     * @param aEnd
-     *            end of the span for which differences should be calculated.
-     * @return a diff result.
-     */
-    public static CasDiff doDiffSingle(Iterable<? extends DiffAdapter> aAdapters,
-            LinkCompareBehavior aLinkCompareBehavior, Map<String, CAS> aCasMap, int aBegin,
-            int aEnd)
-    {
-        Map<String, List<CAS>> casMap = new LinkedHashMap<>();
-        for (Entry<String, CAS> e : aCasMap.entrySet()) {
-            casMap.put(e.getKey(), asList(e.getValue()));
-        }
-
-        return doDiff(aAdapters, aLinkCompareBehavior, casMap, aBegin, aEnd);
     }
 
     /**
@@ -146,7 +119,7 @@ public class CasDiff
      * @return a diff result.
      */
     public static CasDiff doDiff(Iterable<? extends DiffAdapter> aAdapters,
-            LinkCompareBehavior aLinkCompareBehavior, Map<String, List<CAS>> aCasMap)
+            LinkCompareBehavior aLinkCompareBehavior, Map<String, CAS> aCasMap)
     {
         return doDiff(aAdapters, aLinkCompareBehavior, aCasMap, -1, -1);
     }
@@ -169,32 +142,22 @@ public class CasDiff
      * @return a diff.
      */
     public static CasDiff doDiff(Iterable<? extends DiffAdapter> aAdapters,
-            LinkCompareBehavior aLinkCompareBehavior, Map<String, List<CAS>> aCasMap, int aBegin,
+            LinkCompareBehavior aLinkCompareBehavior, Map<String, CAS> aCasMap, int aBegin,
             int aEnd)
     {
         if (aCasMap.isEmpty()) {
             return new CasDiff(0, 0, aAdapters, aLinkCompareBehavior);
         }
 
-        List<CAS> casList = aCasMap.values().iterator().next();
-        if (casList.isEmpty()) {
-            return new CasDiff(0, 0, aAdapters, aLinkCompareBehavior);
-        }
+        var startTime = System.currentTimeMillis();
 
-        long startTime = System.currentTimeMillis();
+        var diff = new CasDiff(aBegin, aEnd, aAdapters, aLinkCompareBehavior);
 
-        sanityCheck(aCasMap);
-
-        CasDiff diff = new CasDiff(aBegin, aEnd, aAdapters, aLinkCompareBehavior);
-
-        for (Entry<String, List<CAS>> e : aCasMap.entrySet()) {
-            int casId = 0;
-            for (CAS cas : e.getValue()) {
-                for (DiffAdapter adapter : aAdapters) {
-                    // null elements in the list can occur if a user has never worked on a CAS
-                    diff.addCas(e.getKey(), casId, cas != null ? cas : null, adapter.getType());
-                }
-                casId++;
+        for (Entry<String, CAS> e : aCasMap.entrySet()) {
+            var cas = e.getValue();
+            for (var adapter : aAdapters) {
+                // null elements in the list can occur if a user has never worked on a CAS
+                diff.addCas(e.getKey(), cas != null ? cas : null, adapter.getType());
             }
         }
 
@@ -203,52 +166,9 @@ public class CasDiff
         return diff;
     }
 
-    /**
-     * Sanity check - all CASes should have the same text.
-     */
-    private static void sanityCheck(Map<String, List<CAS>> aCasMap)
-    {
-        if (aCasMap.isEmpty()) {
-            return;
-        }
-
-        // little hack to check if asserts are enabled
-        boolean assertsEnabled = false;
-        assert assertsEnabled = true; // Intentional side effect!
-        if (assertsEnabled) {
-            Iterator<Entry<String, List<CAS>>> i = aCasMap.entrySet().iterator();
-
-            Entry<String, List<CAS>> ref = i.next();
-            String refUser = ref.getKey();
-            List<CAS> refCASes = ref.getValue();
-            while (i.hasNext()) {
-                Entry<String, List<CAS>> cur = i.next();
-                String curUser = cur.getKey();
-                List<CAS> curCASes = cur.getValue();
-                assert refCASes.size() == curCASes.size() : "CAS list sizes differ: "
-                        + refCASes.size() + " vs " + curCASes.size();
-                for (int n = 0; n < refCASes.size(); n++) {
-                    CAS refCas = refCASes.get(n);
-                    CAS curCas = curCASes.get(n);
-                    // null elements in the list can occur if a user has never worked on a CAS
-                    assert !(refCas != null && curCas != null) || StringUtils.equals(
-                            refCas.getDocumentText(),
-                            curCas.getDocumentText()) : "Trying to compare CASes with different document texts: ["
-                                    + curUser + "] having ["
-                                    + abbreviateMiddle(curCas.getDocumentText(), "...", 40)
-                                    + "] (length: " + curCas.getDocumentText().length() + ") vs ["
-                                    + refUser + "] having ["
-                                    + abbreviateMiddle(refCas.getDocumentText(), "...", 40)
-                                    + "] (length: " + refCas.getDocumentText().length() + ")";
-                }
-            }
-        }
-        // End sanity check
-    }
-
     private DiffAdapter getAdapter(String aType)
     {
-        DiffAdapter adapter = diffAdapters.get(aType);
+        var adapter = diffAdapters.get(aType);
         if (adapter == null) {
             LOG.warn("No diff adapter for type [" + aType + "] -- treating as without features");
             adapter = new SpanDiffAdapter(aType, emptySet());
@@ -262,7 +182,7 @@ public class CasDiff
         return diffAdapters;
     }
 
-    public Map<String, List<CAS>> getCasMap()
+    public Map<String, CAS> getCasMap()
     {
         return cases;
     }
@@ -279,35 +199,20 @@ public class CasDiff
      * @param aType
      *            the type on which to calculate the diff.
      */
-    private void addCas(String aCasGroupId, int aCasId, CAS aCas, String aType)
+    private void addCas(String aCasGroupId, CAS aCas, String aType)
     {
         // Remember that we have already seen this CAS.
-        List<CAS> casList = cases.get(aCasGroupId);
-        if (casList == null) {
-            casList = new ArrayList<>();
-            cases.put(aCasGroupId, casList);
-        }
-
-        // Avoid adding same CAS twice in cases where we add multiple types from a CAS. If the
-        // current CAS ID is greater than the size of the current CAS list, then we did not add
-        // it yet. Before, we checked whether the casList already contained the current CAS, but
-        // that failed when we had multiple "null" CASes.
-        if ((casList.size() - 1) < aCasId) {
-            casList.add(aCas);
-        }
-        assert (casList.size() - 1) == aCasId : "Expected CAS ID [" + (casList.size() - 1)
-                + "] but was [" + aCasId + "]";
+        cases.put(aCasGroupId, aCas);
 
         // null elements in the list can occur if a user has never worked on a CAS
         // We add these to the internal list above, but then we bail out here.
         if (aCas == null) {
-            LOG.debug("CAS group [" + aCasGroupId + "] does not contain a CAS at index [" + aCasId
-                    + "].");
+            LOG.debug("CAS group [" + aCasGroupId + "] does not contain a CAS");
             return;
         }
 
         if (LOG.isDebugEnabled()) {
-            LOG.debug("Processing CAS group [" + aCasGroupId + "] CAS [" + aCasId + "].");
+            LOG.debug("Processing CAS group [" + aCasGroupId + "]");
 
             String collectionId = null;
             String documentId = null;
@@ -325,8 +230,8 @@ public class CasDiff
 
         Type type = aCas.getTypeSystem().getType(aType);
         if (type == null) {
-            LOG.debug("CAS group [" + aCasGroupId + "] CAS [" + aCasId
-                    + "] contains no annotations of type [" + aType + "]");
+            LOG.debug("CAS group [" + aCasGroupId + "] contains no annotations of type [" + aType
+                    + "]");
             return;
         }
 
@@ -341,27 +246,27 @@ public class CasDiff
         }
 
         if (annotations.isEmpty()) {
-            LOG.debug("CAS group [" + aCasGroupId + "] CAS [" + aCasId
-                    + "] contains no annotations of type [" + aType + "]");
+            LOG.debug("CAS group [" + aCasGroupId + "] contains no annotations of type [" + aType
+                    + "]");
             return;
         }
 
-        LOG.debug("CAS group [" + aCasGroupId + "] CAS [" + aCasId + "] contains ["
-                + annotations.size() + "] annotations of type [" + aType + "]");
+        LOG.debug("CAS group [" + aCasGroupId + "] contains [" + annotations.size()
+                + "] annotations of type [" + aType + "]");
 
         int posBefore = configSets.keySet().size();
         LOG.debug("Positions before: [{}]", posBefore);
 
-        for (AnnotationFS fs : annotations) {
-            List<Position> positions = new ArrayList<>();
+        for (var fs : annotations) {
+            var positions = new ArrayList<Position>();
 
             // Get/create configuration set at the current position
-            positions.add(adapter.getPosition(aCasId, fs));
+            positions.add(adapter.getPosition(fs));
 
             // Generate secondary positions for multi-link features
-            positions.addAll(adapter.generateSubPositions(aCasId, fs, linkCompareBehavior));
+            positions.addAll(adapter.generateSubPositions(fs, linkCompareBehavior));
 
-            for (Position pos : positions) {
+            for (var pos : positions) {
                 ConfigurationSet configSet = configSets.get(pos);
                 if (configSet == null) {
                     configSet = new ConfigurationSet(pos);
@@ -418,10 +323,10 @@ public class CasDiff
             // corresponding configuration
 
             var links = FSUtil.getFeature(aFS, feat, ArrayFS.class);
-            for (int i = 0; i < links.size(); i++) {
-                FeatureStructure link = links.get(i);
-                DiffAdapter adapter = getAdapter(aFS.getType().getName());
-                LinkFeatureDecl decl = adapter.getLinkFeature(aSet.position.getFeature());
+            for (var i = 0; i < links.size(); i++) {
+                var link = links.get(i);
+                var adapter = getAdapter(aFS.getType().getName());
+                var decl = adapter.getLinkFeature(aSet.position.getFeature());
 
                 // Check if this configuration is already present
                 Configuration configuration = null;
@@ -639,7 +544,7 @@ public class CasDiff
             return false;
         }
 
-        DiffAdapter adapter = diffAdapters.get(type1.getName());
+        var adapter = diffAdapters.get(type1.getName());
 
         if (adapter == null) {
             LOG.warn("No diff adapter for type [" + type1.getName() + "] -- ignoring!");
@@ -667,9 +572,9 @@ public class CasDiff
             sortedFeatures.removeIf(f -> adapter.getLinkFeature(f) != null);
         }
 
-        nextFeature: for (String feature : sortedFeatures) {
-            Feature f1 = type1.getFeatureByBaseName(feature);
-            Feature f2 = type2.getFeatureByBaseName(feature);
+        nextFeature: for (var feature : sortedFeatures) {
+            var f1 = type1.getFeatureByBaseName(feature);
+            var f2 = type2.getFeatureByBaseName(feature);
 
             Type range = (f1 != null) ? f1.getRange() : (f2 != null ? f2.getRange() : null);
 
@@ -820,9 +725,9 @@ public class CasDiff
         }
 
         // Position check
-        DiffAdapter adapter = getAdapter(aFS1.getType().getName());
-        Position pos1 = adapter.getPosition(0, aFS1);
-        Position pos2 = adapter.getPosition(0, aFS2);
+        var adapter = getAdapter(aFS1.getType().getName());
+        var pos1 = adapter.getPosition(aFS1);
+        var pos2 = adapter.getPosition(aFS2);
 
         return pos1.compareTo(pos2) == 0;
     }
@@ -894,15 +799,14 @@ public class CasDiff
 
         public AID getRepresentativeAID()
         {
-            Entry<String, AID> e = fsAddresses.entrySet().iterator().next();
+            var e = fsAddresses.entrySet().iterator().next();
             return e.getValue();
         }
 
-        public FeatureStructure getRepresentative(Map<String, List<CAS>> aCasMap)
+        public FeatureStructure getRepresentative(Map<String, CAS> aCasMap)
         {
-            Entry<String, AID> e = fsAddresses.entrySet().iterator().next();
-            return ICasUtil.selectFsByAddr(aCasMap.get(e.getKey()).get(position.getCasId()),
-                    e.getValue().addr);
+            var e = fsAddresses.entrySet().iterator().next();
+            return selectFsByAddr(aCasMap.get(e.getKey()), e.getValue().addr);
         }
 
         private Map<String, AID> getAddressByCasId()
@@ -925,20 +829,15 @@ public class CasDiff
             return aAID.equals(fsAddresses.get(aCasGroupId));
         }
 
-        public <T extends FeatureStructure> FeatureStructure getFs(String aCasGroupId, int aCasId,
-                Class<T> aClass, Map<String, List<CAS>> aCasMap)
+        public <T extends FeatureStructure> FeatureStructure getFs(String aCasGroupId,
+                Class<T> aClass, Map<String, CAS> aCasMap)
         {
             AID aid = fsAddresses.get(aCasGroupId);
             if (aid == null) {
                 return null;
             }
 
-            List<CAS> casses = aCasMap.get(aCasGroupId);
-            if (casses == null) {
-                return null;
-            }
-
-            CAS cas = casses.get(aCasId);
+            CAS cas = aCasMap.get(aCasGroupId);
             if (cas == null) {
                 return null;
             }
@@ -946,20 +845,9 @@ public class CasDiff
             return ICasUtil.selectFsByAddr(cas, aid.addr);
         }
 
-        // FIXME aCasId parameter should not be required as we can get it from the position
-        public FeatureStructure getFs(String aCasGroupId, int aCasId,
-                Map<String, List<CAS>> aCasMap)
-        {
-            return getFs(aCasGroupId, aCasId, FeatureStructure.class, aCasMap);
-        }
-
         public FeatureStructure getFs(String aCasGroupId, Map<String, CAS> aCasMap)
         {
-            Map<String, List<CAS>> casMap = new LinkedHashMap<>();
-            for (Entry<String, CAS> e : aCasMap.entrySet()) {
-                casMap.put(e.getKey(), asList(e.getValue()));
-            }
-            return getFs(aCasGroupId, 0, FeatureStructure.class, casMap);
+            return getFs(aCasGroupId, FeatureStructure.class, aCasMap);
         }
 
         @Override
@@ -1173,8 +1061,8 @@ public class CasDiff
         public Map<Position, ConfigurationSet> getDifferingConfigurationSetsWithExceptions(
                 String... aCasGroupIDsToIgnore)
         {
-            Map<Position, ConfigurationSet> diffs = new LinkedHashMap<>();
-            for (Entry<Position, ConfigurationSet> e : data.entrySet()) {
+            var diffs = new LinkedHashMap<Position, ConfigurationSet>();
+            for (var e : data.entrySet()) {
                 if (!isAgreementWithExceptions(e.getValue(), aCasGroupIDsToIgnore)) {
                     diffs.put(e.getKey(), e.getValue());
                 }
@@ -1196,8 +1084,8 @@ public class CasDiff
         public Map<Position, ConfigurationSet> getIncompleteConfigurationSetsWithExceptions(
                 String... aCasGroupIDsToIgnore)
         {
-            Map<Position, ConfigurationSet> diffs = new LinkedHashMap<>();
-            for (Entry<Position, ConfigurationSet> e : data.entrySet()) {
+            var diffs = new LinkedHashMap<Position, ConfigurationSet>();
+            for (var e : data.entrySet()) {
                 if (!isCompleteWithExceptions(e.getValue(), aCasGroupIDsToIgnore)) {
                     diffs.put(e.getKey(), e.getValue());
                 }
@@ -1214,7 +1102,7 @@ public class CasDiff
         public int size(String aType)
         {
             int n = 0;
-            for (Position pos : data.keySet()) {
+            for (var pos : data.keySet()) {
                 if (pos.getType().equals(aType)) {
                     n++;
                 }
@@ -1225,8 +1113,8 @@ public class CasDiff
 
         public void print(PrintStream aOut)
         {
-            for (Position p : getPositions()) {
-                ConfigurationSet configurationSet = getConfigurationSet(p);
+            for (var p : getPositions()) {
+                var configurationSet = getConfigurationSet(p);
                 aOut.printf("=== %s -> %s %s%n", p,
                         isAgreement(configurationSet) ? "AGREE" : "DISAGREE",
                         isComplete(configurationSet) ? "COMPLETE" : "INCOMPLETE");

--- a/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/api/DiffAdapter.java
+++ b/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/api/DiffAdapter.java
@@ -35,17 +35,17 @@ public interface DiffAdapter
      */
     String getType();
 
-    Collection<? extends Position> generateSubPositions(int aCasId, AnnotationFS aFs,
+    Collection<? extends Position> generateSubPositions(AnnotationFS aFs,
             LinkCompareBehavior aLinkCompareBehavior);
 
     LinkFeatureDecl getLinkFeature(String aFeature);
 
     Set<String> getLabelFeatures();
 
-    Position getPosition(int aCasId, FeatureStructure aFS);
+    Position getPosition(FeatureStructure aFS);
 
-    Position getPosition(int aCasId, FeatureStructure aFS, String aFeature, String aRole,
-            int aLinkTargetBegin, int aLinkTargetEnd, LinkCompareBehavior aLinkCompareBehavior);
+    Position getPosition(FeatureStructure aFS, String aFeature, String aRole, int aLinkTargetBegin,
+            int aLinkTargetEnd, LinkCompareBehavior aLinkCompareBehavior);
 
     List<AnnotationFS> selectAnnotationsInWindow(CAS aCas, int aWindowBegin, int aWindowEnd);
 }

--- a/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/api/DiffAdapter_ImplBase.java
+++ b/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/api/DiffAdapter_ImplBase.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.uima.cas.ArrayFS;
-import org.apache.uima.cas.Feature;
 import org.apache.uima.cas.FeatureStructure;
 import org.apache.uima.cas.text.AnnotationFS;
 import org.apache.uima.fit.util.FSUtil;
@@ -76,32 +75,32 @@ public abstract class DiffAdapter_ImplBase
     }
 
     @Override
-    public Position getPosition(int aCasId, FeatureStructure aFS)
+    public Position getPosition(FeatureStructure aFS)
     {
-        return getPosition(aCasId, aFS, null, null, -1, -1, null);
+        return getPosition(aFS, null, null, -1, -1, null);
     }
 
     @Override
-    public List<? extends Position> generateSubPositions(int aCasId, AnnotationFS aFs,
+    public List<? extends Position> generateSubPositions(AnnotationFS aFs,
             LinkCompareBehavior aLinkCompareBehavior)
     {
-        List<Position> subPositions = new ArrayList<>();
+        var subPositions = new ArrayList<Position>();
 
-        for (LinkFeatureDecl decl : linkFeatures) {
-            Feature linkFeature = aFs.getType().getFeatureByBaseName(decl.getName());
+        for (var decl : linkFeatures) {
+            var linkFeature = aFs.getType().getFeatureByBaseName(decl.getName());
             var array = FSUtil.getFeature(aFs, linkFeature, ArrayFS.class);
 
             if (array == null) {
                 continue;
             }
 
-            for (FeatureStructure linkFS : array.toArray()) {
-                String role = linkFS.getStringValue(
+            for (var linkFS : array.toArray()) {
+                var role = linkFS.getStringValue(
                         linkFS.getType().getFeatureByBaseName(decl.getRoleFeature()));
-                AnnotationFS target = (AnnotationFS) linkFS.getFeatureValue(
+                var target = (AnnotationFS) linkFS.getFeatureValue(
                         linkFS.getType().getFeatureByBaseName(decl.getTargetFeature()));
-                Position pos = getPosition(aCasId, aFs, decl.getName(), role, target.getBegin(),
-                        target.getEnd(), aLinkCompareBehavior);
+                var pos = getPosition(aFs, decl.getName(), role, target.getBegin(), target.getEnd(),
+                        aLinkCompareBehavior);
                 subPositions.add(pos);
             }
         }

--- a/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/api/Position.java
+++ b/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/api/Position.java
@@ -30,11 +30,6 @@ public interface Position
     extends Comparable<Position>, Serializable
 {
     /**
-     * @return the CAS id.
-     */
-    int getCasId();
-
-    /**
      * @return the type.
      */
     String getType();

--- a/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/api/Position_ImplBase.java
+++ b/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/api/Position_ImplBase.java
@@ -28,7 +28,6 @@ public abstract class Position_ImplBase
     private static final long serialVersionUID = -1237180459049008357L;
 
     private final String type;
-    private final int casId;
     private final String feature;
 
     private final String role;
@@ -42,12 +41,11 @@ public abstract class Position_ImplBase
     private final String collectionId;
     private final String documentId;
 
-    public Position_ImplBase(String aCollectionId, String aDocumentId, int aCasId, String aType,
+    public Position_ImplBase(String aCollectionId, String aDocumentId, String aType,
             String aFeature, String aRole, int aLinkTargetBegin, int aLinkTargetEnd,
             String aLinkTargetText, LinkCompareBehavior aBehavior)
     {
         type = aType;
-        casId = aCasId;
         feature = aFeature;
 
         linkCompareBehavior = aBehavior;
@@ -65,12 +63,6 @@ public abstract class Position_ImplBase
     public String getType()
     {
         return type;
-    }
-
-    @Override
-    public int getCasId()
-    {
-        return casId;
     }
 
     @Override
@@ -123,10 +115,6 @@ public abstract class Position_ImplBase
     @Override
     public int compareTo(Position aOther)
     {
-        if (casId != aOther.getCasId()) {
-            return casId - aOther.getCasId();
-        }
-
         int typeCmp = type.compareTo(aOther.getType());
         if (typeCmp != 0) {
             return typeCmp;
@@ -173,8 +161,6 @@ public abstract class Position_ImplBase
 
     protected void toStringFragment(StringBuilder builder)
     {
-        builder.append("cas=");
-        builder.append(getCasId());
         if (getCollectionId() != null) {
             builder.append(", coll=");
             builder.append(getCollectionId());

--- a/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/relation/RelationDiffAdapter.java
+++ b/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/relation/RelationDiffAdapter.java
@@ -80,7 +80,7 @@ public class RelationDiffAdapter
     }
 
     @Override
-    public Position getPosition(int aCasId, FeatureStructure aFS, String aFeature, String aRole,
+    public Position getPosition(FeatureStructure aFS, String aFeature, String aRole,
             int aLinkTargetBegin, int aLinkTargetEnd, LinkCompareBehavior aLinkCompareBehavior)
     {
         Type type = aFS.getType();
@@ -107,7 +107,7 @@ public class RelationDiffAdapter
                     aLinkTargetEnd);
         }
 
-        return new RelationPosition(collectionId, documentId, aCasId, getType(),
+        return new RelationPosition(collectionId, documentId, getType(),
                 sourceFS != null ? sourceFS.getBegin() : -1,
                 sourceFS != null ? sourceFS.getEnd() : -1,
                 sourceFS != null ? sourceFS.getCoveredText() : null,

--- a/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/relation/RelationPosition.java
+++ b/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/relation/RelationPosition.java
@@ -36,13 +36,13 @@ public class RelationPosition
     private final int targetEnd;
     private final String targetText;
 
-    public RelationPosition(String aCollectionId, String aDocumentId, int aCasId, String aType,
+    public RelationPosition(String aCollectionId, String aDocumentId, String aType,
             int aSourceBegin, int aSourceEnd, String aSourceText, int aTargetBegin, int aTargetEnd,
             String aTargetText, String aFeature, String aRole, int aLinkTargetBegin,
             int aLinkTargetEnd, String aLinkTargetText, LinkCompareBehavior aLinkCompareBehavior)
     {
-        super(aCollectionId, aDocumentId, aCasId, aType, aFeature, aRole, aLinkTargetBegin,
-                aLinkTargetEnd, aLinkTargetText, aLinkCompareBehavior);
+        super(aCollectionId, aDocumentId, aType, aFeature, aRole, aLinkTargetBegin, aLinkTargetEnd,
+                aLinkTargetText, aLinkCompareBehavior);
         sourceBegin = aSourceBegin;
         sourceEnd = aSourceEnd;
         sourceText = aSourceText;

--- a/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/span/SpanDiffAdapter.java
+++ b/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/span/SpanDiffAdapter.java
@@ -49,8 +49,8 @@ public class SpanDiffAdapter
     public static final SpanDiffAdapter SENTENCE_DIFF_ADAPTER = new SpanDiffAdapter(
             Sentence.class.getName());
 
-    public static final SpanDiffAdapter POS_DIFF_ADAPTER = new SpanDiffAdapter(POS.class.getName(),
-            "PosValue", "coarseValue");
+    public static final SpanDiffAdapter POS_DIFF_ADAPTER = new SpanDiffAdapter(
+            POS.class.getName(), "PosValue", "coarseValue");
 
     public static final SpanDiffAdapter NER_DIFF_ADAPTER = new SpanDiffAdapter(
             NamedEntity.class.getName(), "value", "identifier");
@@ -78,7 +78,7 @@ public class SpanDiffAdapter
     }
 
     @Override
-    public Position getPosition(int aCasId, FeatureStructure aFS, String aFeature, String aRole,
+    public Position getPosition(FeatureStructure aFS, String aFeature, String aRole,
             int aLinkTargetBegin, int aLinkTargetEnd, LinkCompareBehavior aLinkCompareBehavior)
     {
         AnnotationFS annoFS = (AnnotationFS) aFS;
@@ -101,7 +101,7 @@ public class SpanDiffAdapter
                     aLinkTargetEnd);
         }
 
-        return new SpanPosition(collectionId, documentId, aCasId, getType(), annoFS.getBegin(),
+        return new SpanPosition(collectionId, documentId, getType(), annoFS.getBegin(),
                 annoFS.getEnd(), annoFS.getCoveredText(), aFeature, aRole, aLinkTargetBegin,
                 aLinkTargetEnd, linkTargetText, aLinkCompareBehavior);
     }

--- a/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/span/SpanPosition.java
+++ b/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/span/SpanPosition.java
@@ -33,12 +33,12 @@ public class SpanPosition
     private final int end;
     private final String text;
 
-    public SpanPosition(String aCollectionId, String aDocumentId, int aCasId, String aType,
-            int aBegin, int aEnd, String aText, String aFeature, String aRole, int aLinkTargetBegin,
+    public SpanPosition(String aCollectionId, String aDocumentId, String aType, int aBegin,
+            int aEnd, String aText, String aFeature, String aRole, int aLinkTargetBegin,
             int aLinkTargetEnd, String aLinkTargetText, LinkCompareBehavior aLinkCompareBehavior)
     {
-        super(aCollectionId, aDocumentId, aCasId, aType, aFeature, aRole, aLinkTargetBegin,
-                aLinkTargetEnd, aLinkTargetText, aLinkCompareBehavior);
+        super(aCollectionId, aDocumentId, aType, aFeature, aRole, aLinkTargetBegin, aLinkTargetEnd,
+                aLinkTargetText, aLinkCompareBehavior);
         begin = aBegin;
         end = aEnd;
         text = aText;

--- a/inception/inception-curation-legacy/src/test/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/CasDiffTest.java
+++ b/inception/inception-curation-legacy/src/test/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/CasDiffTest.java
@@ -45,6 +45,7 @@ import java.util.Map;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.Type;
 import org.apache.uima.cas.text.AnnotationFS;
+import org.apache.uima.fit.factory.CasFactory;
 import org.apache.uima.fit.factory.JCasFactory;
 import org.apache.uima.fit.factory.TypeSystemDescriptionFactory;
 import org.apache.uima.fit.testing.factory.TokenBuilder;
@@ -54,7 +55,6 @@ import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.apache.uima.util.CasCreationUtils;
 import org.junit.jupiter.api.Test;
 
-import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.DiffResult;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.api.DiffAdapter;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.relation.RelationDiffAdapter;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.span.SpanDiffAdapter;
@@ -71,11 +71,11 @@ public class CasDiffTest
     @Test
     public void noDataTest() throws Exception
     {
-        List<DiffAdapter> diffAdapters = new ArrayList<>();
+        var diffAdapters = new ArrayList<DiffAdapter>();
 
-        Map<String, List<CAS>> casByUser = new LinkedHashMap<>();
+        var casByUser = new LinkedHashMap<String, CAS>();
 
-        DiffResult result = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser).toResult();
+        var result = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser).toResult();
 
         // result.print(System.out);
 
@@ -89,15 +89,14 @@ public class CasDiffTest
     {
         String text = "";
 
-        CAS user1Cas = JCasFactory.createJCas().getCas();
+        var user1Cas = CasFactory.createCas();
         user1Cas.setDocumentText(text);
 
-        Map<String, List<CAS>> casByUser = new LinkedHashMap<>();
-        casByUser.put("user1", asList(user1Cas));
+        var casByUser = Map.of("user1", user1Cas);
 
-        List<SpanDiffAdapter> diffAdapters = asList(new SpanDiffAdapter(Token.class.getName()));
+        var diffAdapters = asList(new SpanDiffAdapter(Token.class.getName()));
 
-        DiffResult result = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser).toResult();
+        var result = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser).toResult();
 
         // result.print(System.out);
 
@@ -111,22 +110,16 @@ public class CasDiffTest
         String text = "";
 
         CAS user1Cas1 = null;
-        CAS user1Cas2 = null;
-        CAS user1Cas3 = createText(text);
-        CAS user1Cas4 = createText(text);
         CAS user2Cas1 = createText(text);
-        CAS user2Cas2 = null;
-        CAS user2Cas3 = null;
-        CAS user2Cas4 = createText(text);
 
-        Map<String, List<CAS>> casByUser = new LinkedHashMap<>();
-        casByUser.put("user1", asList(user1Cas1, user1Cas2, user1Cas3, user1Cas4));
-        casByUser.put("user2", asList(user2Cas1, user2Cas2, user2Cas3, user2Cas4));
+        var casByUser = new LinkedHashMap<String, CAS>();
+        casByUser.put("user1", user1Cas1);
+        casByUser.put("user2", user2Cas1);
 
-        List<SpanDiffAdapter> diffAdapters = asList(new SpanDiffAdapter(Lemma.class.getName()));
+        var diffAdapters = asList(new SpanDiffAdapter(Lemma.class.getName()));
 
-        CasDiff diff = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser);
-        DiffResult result = diff.toResult();
+        var diff = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser);
+        var result = diff.toResult();
 
         // result.print(System.out);
 
@@ -144,13 +137,14 @@ public class CasDiffTest
     @Test
     public void noDifferencesPosTest() throws Exception
     {
-        Map<String, List<CAS>> casByUser = load("casdiff/noDifferences/data.conll",
+        var casByUser = load( //
+                "casdiff/noDifferences/data.conll", //
                 "casdiff/noDifferences/data.conll");
 
-        List<SpanDiffAdapter> diffAdapters = asList(POS_DIFF_ADAPTER);
+        var diffAdapters = asList(POS_DIFF_ADAPTER);
 
-        CasDiff diff = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser);
-        DiffResult result = diff.toResult();
+        var diff = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser);
+        var result = diff.toResult();
 
         // result.print(System.out);
 
@@ -168,13 +162,14 @@ public class CasDiffTest
     @Test
     public void noDifferencesDependencyTest() throws Exception
     {
-        Map<String, List<CAS>> casByUser = load("casdiff/noDifferences/data.conll",
+        Map<String, CAS> casByUser = load( //
+                "casdiff/noDifferences/data.conll", //
                 "casdiff/noDifferences/data.conll");
 
-        List<? extends DiffAdapter> diffAdapters = asList(DEPENDENCY_DIFF_ADAPTER);
+        var diffAdapters = asList(DEPENDENCY_DIFF_ADAPTER);
 
-        CasDiff diff = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser);
-        DiffResult result = diff.toResult();
+        var diff = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser);
+        var result = diff.toResult();
 
         // result.print(System.out);
 
@@ -192,14 +187,14 @@ public class CasDiffTest
     @Test
     public void noDifferencesPosDependencyTest() throws Exception
     {
-        Map<String, List<CAS>> casByUser = load("casdiff/noDifferences/data.conll",
+        var casByUser = load( //
+                "casdiff/noDifferences/data.conll", //
                 "casdiff/noDifferences/data.conll");
 
-        List<? extends DiffAdapter> diffAdapters = asList(POS_DIFF_ADAPTER,
-                DEPENDENCY_DIFF_ADAPTER);
+        var diffAdapters = asList(POS_DIFF_ADAPTER, DEPENDENCY_DIFF_ADAPTER);
 
-        CasDiff diff = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser);
-        DiffResult result = diff.toResult();
+        var diff = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser);
+        var result = diff.toResult();
 
         // result.print(System.out);
 
@@ -219,13 +214,14 @@ public class CasDiffTest
     @Test
     public void singleDifferencesTest() throws Exception
     {
-        Map<String, List<CAS>> casByUser = load("casdiff/singleSpanDifference/user1.conll",
+        var casByUser = load( //
+                "casdiff/singleSpanDifference/user1.conll", //
                 "casdiff/singleSpanDifference/user2.conll");
 
-        List<SpanDiffAdapter> diffAdapters = asList(SpanDiffAdapter.POS_DIFF_ADAPTER);
+        var diffAdapters = asList(POS_DIFF_ADAPTER);
 
-        CasDiff diff = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser);
-        DiffResult result = diff.toResult();
+        var diff = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser);
+        var result = diff.toResult();
 
         // result.print(System.out);
 
@@ -243,13 +239,14 @@ public class CasDiffTest
     @Test
     public void someDifferencesTest() throws Exception
     {
-        Map<String, List<CAS>> casByUser = load("casdiff/someDifferences/user1.conll",
+        var casByUser = load( //
+                "casdiff/someDifferences/user1.conll", //
                 "casdiff/someDifferences/user2.conll");
 
-        List<SpanDiffAdapter> diffAdapters = asList(POS_DIFF_ADAPTER);
+        var diffAdapters = asList(POS_DIFF_ADAPTER);
 
-        CasDiff diff = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser);
-        DiffResult result = diff.toResult();
+        var diff = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser);
+        var result = diff.toResult();
 
         // result.print(System.out);
 
@@ -267,14 +264,14 @@ public class CasDiffTest
     @Test
     public void singleNoDifferencesTest() throws Exception
     {
-        Map<String, List<CAS>> casByUser = load("casdiff/singleSpanNoDifference/data.conll",
+        var casByUser = load( //
+                "casdiff/singleSpanNoDifference/data.conll", //
                 "casdiff/singleSpanNoDifference/data.conll");
 
-        List<? extends DiffAdapter> diffAdapters = asList(
-                new SpanDiffAdapter(POS.class.getName(), "PosValue"));
+        var diffAdapters = asList(new SpanDiffAdapter(POS.class.getName(), "PosValue"));
 
-        CasDiff diff = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser);
-        DiffResult result = diff.toResult();
+        var diff = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser);
+        var result = diff.toResult();
 
         // result.print(System.out);
 
@@ -292,14 +289,15 @@ public class CasDiffTest
     @Test
     public void relationDistanceTest() throws Exception
     {
-        Map<String, List<CAS>> casByUser = load("casdiff/relationDistance/user1.conll",
+        var casByUser = load( //
+                "casdiff/relationDistance/user1.conll", //
                 "casdiff/relationDistance/user2.conll");
 
-        List<? extends DiffAdapter> diffAdapters = asList(new RelationDiffAdapter(
-                Dependency.class.getName(), "Dependent", "Governor", "DependencyType"));
+        var diffAdapters = asList(new RelationDiffAdapter(Dependency.class.getName(), "Dependent",
+                "Governor", "DependencyType"));
 
-        CasDiff diff = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser);
-        DiffResult result = diff.toResult();
+        var diff = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser);
+        var result = diff.toResult();
 
         // result.print(System.out);
 
@@ -317,14 +315,14 @@ public class CasDiffTest
     @Test
     public void spanLabelLabelTest() throws Exception
     {
-        Map<String, List<CAS>> casByUser = load("casdiff/spanLabel/user1.conll",
+        var casByUser = load( //
+                "casdiff/spanLabel/user1.conll", //
                 "casdiff/spanLabel/user2.conll");
 
-        List<? extends DiffAdapter> diffAdapters = asList(
-                new SpanDiffAdapter(POS.class.getName(), "PosValue"));
+        var diffAdapters = asList(new SpanDiffAdapter(POS.class.getName(), "PosValue"));
 
-        CasDiff diff = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser);
-        DiffResult result = diff.toResult();
+        var diff = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser);
+        var result = diff.toResult();
 
         // result.print(System.out);
 
@@ -342,17 +340,15 @@ public class CasDiffTest
     @Test
     public void relationLabelTest() throws Exception
     {
-        Map<String, List<CAS>> casByUser = new HashMap<>();
-        casByUser.put("user1",
-                asList(loadWebAnnoTsv3("casdiff/relationLabelTest/user1.tsv").getCas()));
-        casByUser.put("user2",
-                asList(loadWebAnnoTsv3("casdiff/relationLabelTest/user2.tsv").getCas()));
+        var casByUser = new HashMap<String, CAS>();
+        casByUser.put("user1", loadWebAnnoTsv3("casdiff/relationLabelTest/user1.tsv").getCas());
+        casByUser.put("user2", loadWebAnnoTsv3("casdiff/relationLabelTest/user2.tsv").getCas());
 
-        List<? extends DiffAdapter> diffAdapters = asList(new RelationDiffAdapter(
-                Dependency.class.getName(), "Dependent", "Governor", "DependencyType"));
+        var diffAdapters = asList(new RelationDiffAdapter(Dependency.class.getName(), "Dependent",
+                "Governor", "DependencyType"));
 
-        CasDiff diff = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser);
-        DiffResult result = diff.toResult();
+        var diff = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser);
+        var result = diff.toResult();
 
         // result.print(System.out);
 
@@ -428,16 +424,15 @@ public class CasDiffTest
             casB.addFsToIndexes(fs1B);
         }
 
-        Map<String, List<CAS>> casByUser = new LinkedHashMap<>();
-        casByUser.put("user1", asList(jcasA.getCas()));
-        casByUser.put("user2", asList(jcasB.getCas()));
+        var casByUser = new LinkedHashMap<String, CAS>();
+        casByUser.put("user1", jcasA.getCas());
+        casByUser.put("user2", jcasB.getCas());
 
-        List<? extends DiffAdapter> diffAdapters = asList(
-                new RelationDiffAdapter("webanno.custom.Relation", WebAnnoConst.FEAT_REL_TARGET,
-                        WebAnnoConst.FEAT_REL_SOURCE, "value"));
+        var diffAdapters = asList(new RelationDiffAdapter("webanno.custom.Relation",
+                WebAnnoConst.FEAT_REL_TARGET, WebAnnoConst.FEAT_REL_SOURCE, "value"));
 
-        CasDiff diff = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser);
-        DiffResult result = diff.toResult();
+        var diff = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser);
+        var result = diff.toResult();
 
         // result.print(System.out);
 
@@ -469,13 +464,13 @@ public class CasDiffTest
                 .buildAndAddToIndexes();
 
         var casByUser = Map.of( //
-                "user1", asList(cas1), //
-                "user2", asList(cas2));
+                "user1", cas1, //
+                "user2", cas2);
 
-        SpanDiffAdapter adapter = new SpanDiffAdapter("webanno.custom.SpanMultiValue", "values");
+        var adapter = new SpanDiffAdapter("webanno.custom.SpanMultiValue", "values");
 
-        CasDiff diff = doDiff(asList(adapter), LINK_TARGET_AS_LABEL, casByUser);
-        DiffResult result = diff.toResult();
+        var diff = doDiff(asList(adapter), LINK_TARGET_AS_LABEL, casByUser);
+        var result = diff.toResult();
 
         // result.print(System.out);
 
@@ -498,13 +493,13 @@ public class CasDiffTest
                 .buildAndAddToIndexes();
 
         var casByUser = Map.of( //
-                "user1", asList(cas1), //
-                "user2", asList(cas2));
+                "user1", cas1, //
+                "user2", cas2);
 
-        SpanDiffAdapter adapter = new SpanDiffAdapter("webanno.custom.SpanMultiValue", "values");
+        var adapter = new SpanDiffAdapter("webanno.custom.SpanMultiValue", "values");
 
-        CasDiff diff = doDiff(asList(adapter), LINK_TARGET_AS_LABEL, casByUser);
-        DiffResult result = diff.toResult();
+        var diff = doDiff(asList(adapter), LINK_TARGET_AS_LABEL, casByUser);
+        var result = diff.toResult();
 
         // result.print(System.out);
 
@@ -527,13 +522,13 @@ public class CasDiffTest
                 .buildAndAddToIndexes();
 
         var casByUser = Map.of( //
-                "user1", asList(cas1), //
-                "user2", asList(cas2));
+                "user1", cas1, //
+                "user2", cas2);
 
-        SpanDiffAdapter adapter = new SpanDiffAdapter("webanno.custom.SpanMultiValue", "values");
+        var adapter = new SpanDiffAdapter("webanno.custom.SpanMultiValue", "values");
 
-        CasDiff diff = doDiff(asList(adapter), LINK_TARGET_AS_LABEL, casByUser);
-        DiffResult result = diff.toResult();
+        var diff = doDiff(asList(adapter), LINK_TARGET_AS_LABEL, casByUser);
+        var result = diff.toResult();
 
         // result.print(System.out);
 
@@ -553,14 +548,14 @@ public class CasDiffTest
         makeLinkHostFS(jcasB, 0, 0, makeLinkFS(jcasB, "slot1", 0, 0));
         makeLinkHostFS(jcasB, 10, 10, makeLinkFS(jcasB, "slot1", 10, 10));
 
-        Map<String, List<CAS>> casByUser = new LinkedHashMap<>();
-        casByUser.put("user1", asList(jcasA.getCas()));
-        casByUser.put("user2", asList(jcasB.getCas()));
+        var casByUser = new LinkedHashMap<String, CAS>();
+        casByUser.put("user1", jcasA.getCas());
+        casByUser.put("user2", jcasB.getCas());
 
-        SpanDiffAdapter adapter = new SpanDiffAdapter(HOST_TYPE);
+        var adapter = new SpanDiffAdapter(HOST_TYPE);
         adapter.addLinkFeature("links", "role", "target");
-        CasDiff diff = doDiff(asList(adapter), LINK_TARGET_AS_LABEL, casByUser);
-        DiffResult result = diff.toResult();
+        var diff = doDiff(asList(adapter), LINK_TARGET_AS_LABEL, casByUser);
+        var result = diff.toResult();
 
         // result.print(System.out);
 
@@ -588,16 +583,16 @@ public class CasDiffTest
         JCas jcasB = createJCas(createMultiLinkWithRoleTestTypeSystem());
         makeLinkHostFS(jcasB, 0, 0, makeLinkFS(jcasB, "slot2", 0, 0));
 
-        Map<String, List<CAS>> casByUser = new LinkedHashMap<>();
-        casByUser.put("user1", asList(jcasA.getCas()));
-        casByUser.put("user2", asList(jcasB.getCas()));
+        var casByUser = new LinkedHashMap<String, CAS>();
+        casByUser.put("user1", jcasA.getCas());
+        casByUser.put("user2", jcasB.getCas());
 
-        SpanDiffAdapter adapter = new SpanDiffAdapter(HOST_TYPE);
+        var adapter = new SpanDiffAdapter(HOST_TYPE);
         adapter.addLinkFeature("links", "role", "target");
-        List<? extends DiffAdapter> diffAdapters = asList(adapter);
+        var diffAdapters = asList(adapter);
 
-        CasDiff diff = doDiff(diffAdapters, LINK_ROLE_AS_LABEL, casByUser);
-        DiffResult result = diff.toResult();
+        var diff = doDiff(diffAdapters, LINK_ROLE_AS_LABEL, casByUser);
+        var result = diff.toResult();
 
         // result.print(System.out);
 
@@ -619,22 +614,22 @@ public class CasDiffTest
     @Test
     public void multiLinkWithRoleTargetDifferenceTest() throws Exception
     {
-        JCas jcasA = createJCas(createMultiLinkWithRoleTestTypeSystem());
+        var jcasA = createJCas(createMultiLinkWithRoleTestTypeSystem());
         makeLinkHostFS(jcasA, 0, 0, makeLinkFS(jcasA, "slot1", 0, 0));
 
-        JCas jcasB = createJCas(createMultiLinkWithRoleTestTypeSystem());
+        var jcasB = createJCas(createMultiLinkWithRoleTestTypeSystem());
         makeLinkHostFS(jcasB, 0, 0, makeLinkFS(jcasB, "slot1", 10, 10));
 
-        Map<String, List<CAS>> casByUser = new LinkedHashMap<>();
-        casByUser.put("user1", asList(jcasA.getCas()));
-        casByUser.put("user2", asList(jcasB.getCas()));
+        var casByUser = new LinkedHashMap<String, CAS>();
+        casByUser.put("user1", jcasA.getCas());
+        casByUser.put("user2", jcasB.getCas());
 
-        SpanDiffAdapter adapter = new SpanDiffAdapter(HOST_TYPE);
+        var adapter = new SpanDiffAdapter(HOST_TYPE);
         adapter.addLinkFeature("links", "role", "target");
-        List<? extends DiffAdapter> diffAdapters = asList(adapter);
+        var diffAdapters = asList(adapter);
 
-        CasDiff diff = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser);
-        DiffResult result = diff.toResult();
+        var diff = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser);
+        var result = diff.toResult();
 
         // result.print(System.out);
 
@@ -656,22 +651,22 @@ public class CasDiffTest
     @Test
     public void multiLinkWithRoleMultiTargetDifferenceTest() throws Exception
     {
-        JCas jcasA = JCasFactory.createJCas(createMultiLinkWithRoleTestTypeSystem());
+        var jcasA = JCasFactory.createJCas(createMultiLinkWithRoleTestTypeSystem());
         makeLinkHostFS(jcasA, 0, 0, makeLinkFS(jcasA, "slot1", 0, 0),
                 makeLinkFS(jcasA, "slot1", 10, 10));
 
-        JCas jcasB = JCasFactory.createJCas(createMultiLinkWithRoleTestTypeSystem());
+        var jcasB = JCasFactory.createJCas(createMultiLinkWithRoleTestTypeSystem());
         makeLinkHostFS(jcasB, 0, 0, makeLinkFS(jcasB, "slot1", 10, 10));
 
-        Map<String, List<CAS>> casByUser = new LinkedHashMap<>();
-        casByUser.put("user1", asList(jcasA.getCas()));
-        casByUser.put("user2", asList(jcasB.getCas()));
+        var casByUser = new LinkedHashMap<String, CAS>();
+        casByUser.put("user1", jcasA.getCas());
+        casByUser.put("user2", jcasB.getCas());
 
-        SpanDiffAdapter adapter = new SpanDiffAdapter(HOST_TYPE);
+        var adapter = new SpanDiffAdapter(HOST_TYPE);
         adapter.addLinkFeature("links", "role", "target");
-        List<? extends DiffAdapter> diffAdapters = asList(adapter);
+        var diffAdapters = asList(adapter);
 
-        DiffResult diff = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser).toResult();
+        var diff = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser).toResult();
 
         // diff.print(System.out);
 
@@ -694,22 +689,22 @@ public class CasDiffTest
     @Test
     public void multiLinkWithRoleMultiTargetDifferenceTest2() throws Exception
     {
-        JCas jcasA = JCasFactory.createJCas(createMultiLinkWithRoleTestTypeSystem());
+        var jcasA = JCasFactory.createJCas(createMultiLinkWithRoleTestTypeSystem());
         makeLinkHostFS(jcasA, 0, 0, makeLinkFS(jcasA, "slot1", 0, 0),
                 makeLinkFS(jcasA, "slot1", 10, 10));
 
-        JCas jcasB = JCasFactory.createJCas(createMultiLinkWithRoleTestTypeSystem());
+        var jcasB = JCasFactory.createJCas(createMultiLinkWithRoleTestTypeSystem());
         makeLinkHostFS(jcasB, 0, 0, makeLinkFS(jcasB, "slot2", 10, 10));
 
-        Map<String, List<CAS>> casByUser = new LinkedHashMap<>();
-        casByUser.put("user1", asList(jcasA.getCas()));
-        casByUser.put("user2", asList(jcasB.getCas()));
+        var casByUser = new LinkedHashMap<String, CAS>();
+        casByUser.put("user1", jcasA.getCas());
+        casByUser.put("user2", jcasB.getCas());
 
-        SpanDiffAdapter adapter = new SpanDiffAdapter(HOST_TYPE);
+        var adapter = new SpanDiffAdapter(HOST_TYPE);
         adapter.addLinkFeature("links", "role", "target");
-        List<? extends DiffAdapter> diffAdapters = asList(adapter);
+        var diffAdapters = asList(adapter);
 
-        DiffResult diff = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser).toResult();
+        var diff = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser).toResult();
 
         // diff.print(System.out);
 

--- a/inception/inception-curation-legacy/src/test/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/CurationTestUtils.java
+++ b/inception/inception-curation-legacy/src/test/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/CurationTestUtils.java
@@ -77,13 +77,13 @@ public class CurationTestUtils
         return jcas;
     }
 
-    public static Map<String, List<CAS>> load(String... aPaths) throws UIMAException, IOException
+    public static Map<String, CAS> load(String... aPaths) throws UIMAException, IOException
     {
-        Map<String, List<CAS>> casByUser = new LinkedHashMap<>();
+        var casByUser = new LinkedHashMap<String, CAS>();
         int n = 1;
-        for (String path : aPaths) {
-            CAS cas = readConll2006(path);
-            casByUser.put("user" + n, asList(cas));
+        for (var path : aPaths) {
+            var cas = readConll2006(path);
+            casByUser.put("user" + n, cas);
             n++;
         }
         return casByUser;

--- a/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/service/CurationMergeServiceImpl.java
+++ b/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/service/CurationMergeServiceImpl.java
@@ -17,7 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.curation.service;
 
-import static de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.doDiffSingle;
+import static de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.doDiff;
 import static de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.getDiffAdapters;
 import static de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.LinkCompareBehavior.LINK_ROLE_AS_LABEL;
 import static java.lang.Integer.MAX_VALUE;
@@ -103,8 +103,7 @@ public class CurationMergeServiceImpl
 
         DiffResult diff;
         try (StopWatch watch = new StopWatch(LOG, "CasDiff")) {
-            diff = doDiffSingle(adapters, LINK_ROLE_AS_LABEL, aCassesToMerge, 0, MAX_VALUE)
-                    .toResult();
+            diff = doDiff(adapters, LINK_ROLE_AS_LABEL, aCassesToMerge, 0, MAX_VALUE).toResult();
         }
 
         try (StopWatch watch = new StopWatch(LOG, "CasMerge")) {

--- a/inception/inception-curation/src/test/java/de/tudarmstadt/ukp/inception/curation/export/CuratedDocumentsExporterTest.java
+++ b/inception/inception-curation/src/test/java/de/tudarmstadt/ukp/inception/curation/export/CuratedDocumentsExporterTest.java
@@ -56,6 +56,7 @@ import de.tudarmstadt.ukp.inception.annotation.storage.driver.CasStorageDriver;
 import de.tudarmstadt.ukp.inception.annotation.storage.driver.filesystem.FileSystemCasStorageDriver;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.documents.api.RepositoryProperties;
+import de.tudarmstadt.ukp.inception.documents.api.RepositoryPropertiesImpl;
 import de.tudarmstadt.ukp.inception.export.DocumentImportExportServiceImpl;
 import de.tudarmstadt.ukp.inception.export.config.DocumentImportExportServiceProperties;
 import de.tudarmstadt.ukp.inception.export.config.DocumentImportExportServicePropertiesImpl;
@@ -95,7 +96,7 @@ public class CuratedDocumentsExporterTest
 
         DocumentImportExportServiceProperties properties = new DocumentImportExportServicePropertiesImpl();
 
-        repositoryProperties = new RepositoryProperties();
+        repositoryProperties = new RepositoryPropertiesImpl();
         repositoryProperties.setPath(workFolder);
 
         CasStorageDriver driver = new FileSystemCasStorageDriver(repositoryProperties,

--- a/inception/inception-curation/src/test/java/de/tudarmstadt/ukp/inception/curation/merge/CasDiffLinkFeaturesTest.java
+++ b/inception/inception-curation/src/test/java/de/tudarmstadt/ukp/inception/curation/merge/CasDiffLinkFeaturesTest.java
@@ -29,18 +29,9 @@ import static org.apache.uima.fit.factory.JCasFactory.createJCas;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
 
 import org.apache.uima.cas.CAS;
-import org.apache.uima.cas.Feature;
-import org.apache.uima.cas.FeatureStructure;
-import org.apache.uima.cas.Type;
-import org.apache.uima.cas.text.AnnotationFS;
-import org.apache.uima.jcas.JCas;
 import org.junit.jupiter.api.Test;
-
-import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.DiffResult;
 
 public class CasDiffLinkFeaturesTest
     extends CasMergeTestBase
@@ -49,22 +40,22 @@ public class CasDiffLinkFeaturesTest
     public void copyLinkToEmptyTest() throws Exception
     {
         // Set up target CAS
-        JCas targetCas = createJCas(createMultiLinkWithRoleTestTypeSystem("f1"));
-        Type type = targetCas.getTypeSystem().getType(HOST_TYPE);
-        Feature feature = type.getFeatureByBaseName("f1");
-        AnnotationFS mergeFs = makeLinkHostFS(targetCas, 0, 0, feature, "A");
-        FeatureStructure linkFs = makeLinkFS(targetCas, "slot1", 0, 0);
+        var targetCas = createJCas(createMultiLinkWithRoleTestTypeSystem("f1"));
+        var type = targetCas.getTypeSystem().getType(HOST_TYPE);
+        var feature = type.getFeatureByBaseName("f1");
+        var mergeFs = makeLinkHostFS(targetCas, 0, 0, feature, "A");
+        var linkFs = makeLinkFS(targetCas, "slot1", 0, 0);
         setLinkFeatureValue(mergeFs, type.getFeatureByBaseName("links"), asList(linkFs));
 
         // Set up source CAS
-        JCas sourceCas = createJCas(createMultiLinkWithRoleTestTypeSystem("f1"));
+        var sourceCas = createJCas(createMultiLinkWithRoleTestTypeSystem("f1"));
         makeLinkHostFS(sourceCas, 0, 0, feature, "A", makeLinkFS(sourceCas, "slot1", 0, 0));
 
         // Perform diff
-        Map<String, List<CAS>> casByUser = new LinkedHashMap<>();
-        casByUser.put("user1", asList(targetCas.getCas()));
-        casByUser.put("user2", asList(sourceCas.getCas()));
-        DiffResult diff = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser).toResult();
+        var casByUser = new LinkedHashMap<String, CAS>();
+        casByUser.put("user1", targetCas.getCas());
+        casByUser.put("user2", sourceCas.getCas());
+        var diff = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser).toResult();
 
         assertThat(diff.getDifferingConfigurationSets()).isEmpty();
         assertThat(diff.getIncompleteConfigurationSets()).isEmpty();
@@ -74,23 +65,23 @@ public class CasDiffLinkFeaturesTest
     public void copyLinkToExistingButDiffLinkTest() throws Exception
     {
         // Set up target CAS
-        JCas targetCas = createJCas(createMultiLinkWithRoleTestTypeSystem("f1"));
-        Type type = targetCas.getTypeSystem().getType(HOST_TYPE);
-        Feature feature = type.getFeatureByBaseName("f1");
-        AnnotationFS mergeFs = makeLinkHostFS(targetCas, 0, 0, feature, "A",
+        var targetCas = createJCas(createMultiLinkWithRoleTestTypeSystem("f1"));
+        var type = targetCas.getTypeSystem().getType(HOST_TYPE);
+        var feature = type.getFeatureByBaseName("f1");
+        var mergeFs = makeLinkHostFS(targetCas, 0, 0, feature, "A",
                 makeLinkFS(targetCas, "slot1", 0, 0));
-        FeatureStructure linkFs = makeLinkFS(targetCas, "slot2", 0, 0);
+        var linkFs = makeLinkFS(targetCas, "slot2", 0, 0);
         setLinkFeatureValue(mergeFs, type.getFeatureByBaseName("links"), asList(linkFs));
 
         // Set up source CAS
-        JCas sourceCas = createJCas(createMultiLinkWithRoleTestTypeSystem("f1"));
+        var sourceCas = createJCas(createMultiLinkWithRoleTestTypeSystem("f1"));
         makeLinkHostFS(sourceCas, 0, 0, feature, "A", makeLinkFS(sourceCas, "slot1", 0, 0));
 
         // Perform diff
-        Map<String, List<CAS>> casByUser = new LinkedHashMap<>();
-        casByUser.put("user1", asList(targetCas.getCas()));
-        casByUser.put("user2", asList(sourceCas.getCas()));
-        DiffResult diff = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser).toResult();
+        var casByUser = new LinkedHashMap<String, CAS>();
+        casByUser.put("user1", targetCas.getCas());
+        casByUser.put("user2", sourceCas.getCas());
+        var diff = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser).toResult();
 
         assertThat(diff.getDifferingConfigurationSets()).isEmpty();
         assertThat(diff.getIncompleteConfigurationSets()).hasSize(2);

--- a/inception/inception-curation/src/test/java/de/tudarmstadt/ukp/inception/curation/merge/CasMergeSuiteTest.java
+++ b/inception/inception-curation/src/test/java/de/tudarmstadt/ukp/inception/curation/merge/CasMergeSuiteTest.java
@@ -29,10 +29,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.File;
 import java.io.FilenameFilter;
-import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.RegexFileFilter;
@@ -41,7 +38,6 @@ import org.apache.uima.cas.CAS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.DiffResult;
 import de.tudarmstadt.ukp.clarin.webanno.tsv.WebannoTsv3XWriter;
 import de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData;
 
@@ -59,55 +55,44 @@ public class CasMergeSuiteTest
     @MethodSource("tsvFiles")
     public void runTest(File aReferenceFolder) throws Exception
     {
-        Map<String, List<CAS>> casByUser = new HashMap<>();
+        var casByUser = new HashMap<String, CAS>();
 
-        File[] inputFiles = aReferenceFolder
+        var inputFiles = aReferenceFolder
                 .listFiles((FilenameFilter) new RegexFileFilter("user.*\\.tsv"));
 
-        for (File inputFile : inputFiles) {
-            casByUser.put(inputFile.getName(), List.of(loadWebAnnoTsv3(inputFile).getCas()));
+        for (var inputFile : inputFiles) {
+            casByUser.put(inputFile.getName(), loadWebAnnoTsv3(inputFile).getCas());
         }
 
-        CAS curatorCas = createText(casByUser.values().stream().flatMap(Collection::stream)
-                .findFirst().get().getDocumentText());
+        var curatorCas = createText(
+                casByUser.values().stream().findFirst().get().getDocumentText());
 
-        DiffResult result = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser).toResult();
+        var result = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser).toResult();
 
-        sut.reMergeCas(result, document, "dummyTargetUser", curatorCas,
-                getSingleCasByUser(casByUser));
+        sut.reMergeCas(result, document, "dummyTargetUser", curatorCas, casByUser);
 
         writeAndAssertEquals(curatorCas, aReferenceFolder);
     }
 
-    private Map<String, CAS> getSingleCasByUser(Map<String, List<CAS>> aCasByUserSingle)
-    {
-        Map<String, CAS> casByUserSingle = new HashMap<>();
-        for (String user : aCasByUserSingle.keySet()) {
-            casByUserSingle.put(user, aCasByUserSingle.get(user).get(0));
-        }
-
-        return casByUserSingle;
-    }
-
     private void writeAndAssertEquals(CAS curatorCas, File aReferenceFolder) throws Exception
     {
-        String targetFolder = "target/test-output/" + getClass().getSimpleName() + "/"
+        var targetFolder = "target/test-output/" + getClass().getSimpleName() + "/"
                 + aReferenceFolder.getName();
 
-        DocumentMetaData dmd = DocumentMetaData.get(curatorCas);
+        var dmd = DocumentMetaData.get(curatorCas);
         dmd.setDocumentId("curator");
         runPipeline(curatorCas,
                 createEngineDescription(WebannoTsv3XWriter.class,
                         WebannoTsv3XWriter.PARAM_TARGET_LOCATION, targetFolder,
                         WebannoTsv3XWriter.PARAM_OVERWRITE, true));
 
-        File referenceFile = new File(aReferenceFolder, "curator.tsv");
+        var referenceFile = new File(aReferenceFolder, "curator.tsv");
         assumeTrue(referenceFile.exists(), "No reference data available for this test.");
 
-        File actualFile = new File(targetFolder, "curator.tsv");
+        var actualFile = new File(targetFolder, "curator.tsv");
 
-        String reference = FileUtils.readFileToString(referenceFile, "UTF-8");
-        String actual = FileUtils.readFileToString(actualFile, "UTF-8");
+        var reference = FileUtils.readFileToString(referenceFile, "UTF-8");
+        var actual = FileUtils.readFileToString(actualFile, "UTF-8");
 
         assertThat(actual).isEqualToNormalizingNewlines(reference);
     }

--- a/inception/inception-documents-api/src/main/java/de/tudarmstadt/ukp/inception/documents/api/RepositoryAutoConfiguration.java
+++ b/inception/inception-documents-api/src/main/java/de/tudarmstadt/ukp/inception/documents/api/RepositoryAutoConfiguration.java
@@ -21,7 +21,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@EnableConfigurationProperties({ RepositoryProperties.class })
+@EnableConfigurationProperties({ RepositoryPropertiesImpl.class })
 public class RepositoryAutoConfiguration
 {
     // No Beans

--- a/inception/inception-documents-api/src/main/java/de/tudarmstadt/ukp/inception/documents/api/RepositoryPropertiesImpl.java
+++ b/inception/inception-documents-api/src/main/java/de/tudarmstadt/ukp/inception/documents/api/RepositoryPropertiesImpl.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.documents.api;
+
+import java.io.File;
+
+import org.slf4j.MDC;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.jmx.export.annotation.ManagedResource;
+
+import de.tudarmstadt.ukp.inception.support.SettingsUtil;
+import de.tudarmstadt.ukp.inception.support.logging.Logging;
+
+/**
+ * <p>
+ * This class is exposed as a Spring Component via {@link RepositoryAutoConfiguration}.
+ * </p>
+ */
+@ConfigurationProperties("repository")
+@ManagedResource
+public class RepositoryPropertiesImpl implements RepositoryProperties
+{
+    private File path;
+
+    @Override
+    public File getPath()
+    {
+        if (path != null) {
+            return path;
+        }
+
+        return new File(System.getProperty(SettingsUtil.getPropApplicationHome(),
+                System.getProperty("user.home") + "/"
+                        + SettingsUtil.getApplicationUserHomeSubdir()),
+                "repository");
+    }
+
+    public void setPath(File aPath)
+    {
+        path = aPath;
+
+        // This is mainly a convenience for unit tests. For production environments, it must be made
+        // sure that the MDC is configured e.g. on the worker threads for incoming requests and
+        // such.
+        MDC.put(Logging.KEY_REPOSITORY_PATH, aPath.getPath().toString());
+    }
+}

--- a/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/DocumentStateWatcher.java
+++ b/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/DocumentStateWatcher.java
@@ -59,6 +59,9 @@ public class DocumentStateWatcher
 
     private void recalculateProjectState(Project aProject)
     {
-        schedulingService.enqueue(new UpdateProjectStateTask(aProject, getClass().getSimpleName()));
+        schedulingService.enqueue(UpdateProjectStateTask.builder() //
+                .withProject(aProject) //
+                .withTrigger(getClass().getSimpleName()) //
+                .build());
     }
 }

--- a/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/UpdateProjectStateTask.java
+++ b/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/UpdateProjectStateTask.java
@@ -36,13 +36,15 @@ import de.tudarmstadt.ukp.inception.scheduling.DebouncingTask;
 public class UpdateProjectStateTask
     extends DebouncingTask
 {
+    public static final String TYPE = "UpdateProjectStateTask";
+
     private @PersistenceContext EntityManager entityManager;
     private @Autowired ProjectService projectService;
     private @Autowired DocumentService documentService;
 
-    public UpdateProjectStateTask(Project aProject, String aTrigger)
+    public UpdateProjectStateTask(Builder<? extends Builder<?>> aBuilder)
     {
-        super(aProject, aTrigger, ofSeconds(3));
+        super(aBuilder.withType(TYPE));
     }
 
     @Override
@@ -87,5 +89,24 @@ public class UpdateProjectStateTask
     public int hashCode()
     {
         return Objects.hash(getProject());
+    }
+
+    public static Builder<Builder<?>> builder()
+    {
+        return new Builder<>();
+    }
+
+    public static class Builder<T extends Builder<?>>
+        extends DebouncingTask.Builder<T>
+    {
+        protected Builder()
+        {
+            withDebounceMillis(ofSeconds(3));
+        }
+
+        public UpdateProjectStateTask build()
+        {
+            return new UpdateProjectStateTask(this);
+        }
     }
 }

--- a/inception/inception-documents/src/test/java/de/tudarmstadt/ukp/inception/documents/DocumentServiceImplConcurrencyTest.java
+++ b/inception/inception-documents/src/test/java/de/tudarmstadt/ukp/inception/documents/DocumentServiceImplConcurrencyTest.java
@@ -74,6 +74,7 @@ import de.tudarmstadt.ukp.inception.annotation.storage.driver.CasStorageDriver;
 import de.tudarmstadt.ukp.inception.annotation.storage.driver.filesystem.FileSystemCasStorageDriver;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.documents.api.RepositoryProperties;
+import de.tudarmstadt.ukp.inception.documents.api.RepositoryPropertiesImpl;
 import de.tudarmstadt.ukp.inception.project.api.ProjectService;
 import de.tudarmstadt.ukp.inception.support.logging.Logging;
 
@@ -115,7 +116,7 @@ public class DocumentServiceImplConcurrencyTest
         deleteCounter.set(0);
         deleteInitialCounter.set(0);
 
-        repositoryProperties = new RepositoryProperties();
+        repositoryProperties = new RepositoryPropertiesImpl();
         repositoryProperties.setPath(testFolder);
         MDC.put(Logging.KEY_REPOSITORY_PATH, repositoryProperties.getPath().toString());
 

--- a/inception/inception-documents/src/test/java/de/tudarmstadt/ukp/inception/documents/exporters/SourceDocumentExporterTest.java
+++ b/inception/inception-documents/src/test/java/de/tudarmstadt/ukp/inception/documents/exporters/SourceDocumentExporterTest.java
@@ -47,6 +47,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.documents.api.RepositoryProperties;
+import de.tudarmstadt.ukp.inception.documents.api.RepositoryPropertiesImpl;
 import de.tudarmstadt.ukp.inception.support.io.ZipUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -68,7 +69,7 @@ public class SourceDocumentExporterTest
                 .withName("Test Project") //
                 .build();
 
-        repositoryProperties = new RepositoryProperties();
+        repositoryProperties = new RepositoryPropertiesImpl();
 
         when(documentService.listSourceDocuments(any())).then(invocation -> {
             return sourceDocuments();

--- a/inception/inception-export/src/test/java/de/tudarmstadt/ukp/inception/export/DocumentImportExportServiceImplTest.java
+++ b/inception/inception-export/src/test/java/de/tudarmstadt/ukp/inception/export/DocumentImportExportServiceImplTest.java
@@ -81,7 +81,7 @@ import de.tudarmstadt.ukp.inception.annotation.storage.config.CasStorageBackupPr
 import de.tudarmstadt.ukp.inception.annotation.storage.config.CasStorageCachePropertiesImpl;
 import de.tudarmstadt.ukp.inception.annotation.storage.config.CasStoragePropertiesImpl;
 import de.tudarmstadt.ukp.inception.annotation.storage.driver.filesystem.FileSystemCasStorageDriver;
-import de.tudarmstadt.ukp.inception.documents.api.RepositoryProperties;
+import de.tudarmstadt.ukp.inception.documents.api.RepositoryPropertiesImpl;
 import de.tudarmstadt.ukp.inception.export.config.DocumentImportExportServiceProperties;
 import de.tudarmstadt.ukp.inception.export.config.DocumentImportExportServicePropertiesImpl;
 import de.tudarmstadt.ukp.inception.io.xmi.XmiFormatSupport;
@@ -114,7 +114,7 @@ public class DocumentImportExportServiceImplTest
 
         DocumentImportExportServiceProperties properties = new DocumentImportExportServicePropertiesImpl();
 
-        var repositoryProperties = new RepositoryProperties();
+        var repositoryProperties = new RepositoryPropertiesImpl();
         repositoryProperties.setPath(testFolder);
 
         MDC.put(Logging.KEY_REPOSITORY_PATH, repositoryProperties.getPath().toString());

--- a/inception/inception-imls-stringmatch/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/span/gazeteer/GazeteerServiceImplTest.java
+++ b/inception/inception-imls-stringmatch/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/span/gazeteer/GazeteerServiceImplTest.java
@@ -58,6 +58,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.inception.documents.api.RepositoryProperties;
+import de.tudarmstadt.ukp.inception.documents.api.RepositoryPropertiesImpl;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
 import de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.span.gazeteer.model.Gazeteer;
 import de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.span.gazeteer.model.GazeteerEntry;
@@ -90,7 +91,7 @@ public class GazeteerServiceImplTest
     {
         EntityManager em = testEntityManager.getEntityManager();
 
-        RepositoryProperties repoProps = new RepositoryProperties();
+        RepositoryProperties repoProps = new RepositoryPropertiesImpl();
         repoProps.setPath(temporaryFolder);
         MDC.put(Logging.KEY_REPOSITORY_PATH, repoProps.getPath().toString());
 

--- a/inception/inception-imls-weblicht/pom.xml
+++ b/inception/inception-imls-weblicht/pom.xml
@@ -27,6 +27,10 @@
   <name>INCEpTION - ML - WebLicht</name>
   <dependencies>
     <dependency>
+      <groupId>javax.persistence</groupId>
+      <artifactId>javax.persistence-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>eu.clarin.weblicht</groupId>
       <artifactId>wlfxb</artifactId>
     </dependency>
@@ -168,10 +172,6 @@
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>javax.persistence</groupId>
-      <artifactId>javax.persistence-api</artifactId>
     </dependency>
     
     <dependency>

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/FullTextIndexUpgradeTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/FullTextIndexUpgradeTest.java
@@ -47,6 +47,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.inception.documents.api.RepositoryProperties;
+import de.tudarmstadt.ukp.inception.documents.api.RepositoryPropertiesImpl;
 import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBaseProperties;
 import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBasePropertiesImpl;
 import de.tudarmstadt.ukp.inception.kb.graph.KBHandle;
@@ -104,7 +105,7 @@ public class FullTextIndexUpgradeTest
         project = new Project("test");
         entityManager.persist(project);
 
-        repoProperties = new RepositoryProperties();
+        repoProperties = new RepositoryPropertiesImpl();
         kbProperties = new KnowledgeBasePropertiesImpl();
         repoProperties.setPath(new File(WORK_DIR));
     }

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplImportExportIntegrationTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplImportExportIntegrationTest.java
@@ -47,6 +47,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.inception.documents.api.RepositoryProperties;
+import de.tudarmstadt.ukp.inception.documents.api.RepositoryPropertiesImpl;
 import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBaseProperties;
 import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBasePropertiesImpl;
 import de.tudarmstadt.ukp.inception.kb.graph.KBConcept;
@@ -93,7 +94,7 @@ public class KnowledgeBaseServiceImplImportExportIntegrationTest
     @BeforeEach
     public void setUp()
     {
-        RepositoryProperties repoProps = new RepositoryProperties();
+        RepositoryProperties repoProps = new RepositoryPropertiesImpl();
         repoProps.setPath(temporaryFolder);
         KnowledgeBaseProperties kbProperties = new KnowledgeBasePropertiesImpl();
         EntityManager entityManager = testEntityManager.getEntityManager();

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplIntegrationTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplIntegrationTest.java
@@ -64,6 +64,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.inception.documents.api.RepositoryProperties;
+import de.tudarmstadt.ukp.inception.documents.api.RepositoryPropertiesImpl;
 import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBaseProperties;
 import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBasePropertiesImpl;
 import de.tudarmstadt.ukp.inception.kb.graph.KBConcept;
@@ -118,7 +119,7 @@ public class KnowledgeBaseServiceImplIntegrationTest
 
     public void setUp(Reification reification) throws Exception
     {
-        RepositoryProperties repoProps = new RepositoryProperties();
+        RepositoryProperties repoProps = new RepositoryPropertiesImpl();
         repoProps.setPath(temporaryFolder);
         KnowledgeBaseProperties kbProperties = new KnowledgeBasePropertiesImpl();
         EntityManager entityManager = testEntityManager.getEntityManager();

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplQualifierIntegrationTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplQualifierIntegrationTest.java
@@ -44,6 +44,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.inception.documents.api.RepositoryProperties;
+import de.tudarmstadt.ukp.inception.documents.api.RepositoryPropertiesImpl;
 import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBaseProperties;
 import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBasePropertiesImpl;
 import de.tudarmstadt.ukp.inception.kb.graph.KBConcept;
@@ -90,7 +91,7 @@ public class KnowledgeBaseServiceImplQualifierIntegrationTest
     @BeforeEach
     public void setUp() throws Exception
     {
-        RepositoryProperties repoProps = new RepositoryProperties();
+        RepositoryProperties repoProps = new RepositoryPropertiesImpl();
         repoProps.setPath(temporaryFolder);
         KnowledgeBaseProperties kbProperties = new KnowledgeBasePropertiesImpl();
         EntityManager entityManager = testEntityManager.getEntityManager();

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplWikiDataIntegrationTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplWikiDataIntegrationTest.java
@@ -49,6 +49,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.inception.documents.api.RepositoryProperties;
+import de.tudarmstadt.ukp.inception.documents.api.RepositoryPropertiesImpl;
 import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBaseProperties;
 import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBasePropertiesImpl;
 import de.tudarmstadt.ukp.inception.kb.graph.KBConcept;
@@ -105,7 +106,7 @@ public class KnowledgeBaseServiceImplWikiDataIntegrationTest
         String wikidataAccessUrl = PROFILES.get("wikidata").getAccess().getAccessUrl();
         assumeEndpointIsAvailable(wikidataAccessUrl);
 
-        RepositoryProperties repoProps = new RepositoryProperties();
+        RepositoryProperties repoProps = new RepositoryPropertiesImpl();
         repoProps.setPath(tempDir);
         KnowledgeBaseProperties kbProperties = new KnowledgeBasePropertiesImpl();
         EntityManager entityManager = testEntityManager.getEntityManager();

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceRemoteTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceRemoteTest.java
@@ -57,6 +57,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.inception.documents.api.RepositoryProperties;
+import de.tudarmstadt.ukp.inception.documents.api.RepositoryPropertiesImpl;
 import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBaseProperties;
 import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBasePropertiesImpl;
 import de.tudarmstadt.ukp.inception.kb.graph.KBHandle;
@@ -108,7 +109,7 @@ public class KnowledgeBaseServiceRemoteTest
 
         KnowledgeBase kb = aSutConfig.getKnowledgeBase();
 
-        RepositoryProperties repoProps = new RepositoryProperties();
+        RepositoryProperties repoProps = new RepositoryPropertiesImpl();
         repoProps.setPath(repoPath);
         KnowledgeBaseProperties kbProperties = new KnowledgeBasePropertiesImpl();
         EntityManager entityManager = testEntityManager.getEntityManager();

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseSubPropertyLabelTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseSubPropertyLabelTest.java
@@ -49,6 +49,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.inception.documents.api.RepositoryProperties;
+import de.tudarmstadt.ukp.inception.documents.api.RepositoryPropertiesImpl;
 import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBaseProperties;
 import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBasePropertiesImpl;
 import de.tudarmstadt.ukp.inception.kb.graph.KBHandle;
@@ -98,7 +99,7 @@ public class KnowledgeBaseSubPropertyLabelTest
     @BeforeEach
     public void setUp()
     {
-        RepositoryProperties repoProps = new RepositoryProperties();
+        RepositoryProperties repoProps = new RepositoryPropertiesImpl();
         repoProps.setPath(tempDir);
         KnowledgeBaseProperties kbProperties = new KnowledgeBasePropertiesImpl();
         EntityManager entityManager = testEntityManager.getEntityManager();

--- a/inception/inception-project-export/src/test/java/de/tudarmstadt/ukp/inception/project/export/AnnotationDocumentsExporterTest.java
+++ b/inception/inception-project-export/src/test/java/de/tudarmstadt/ukp/inception/project/export/AnnotationDocumentsExporterTest.java
@@ -51,7 +51,7 @@ import de.tudarmstadt.ukp.inception.annotation.storage.config.CasStorageCachePro
 import de.tudarmstadt.ukp.inception.annotation.storage.config.CasStoragePropertiesImpl;
 import de.tudarmstadt.ukp.inception.annotation.storage.driver.filesystem.FileSystemCasStorageDriver;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
-import de.tudarmstadt.ukp.inception.documents.api.RepositoryProperties;
+import de.tudarmstadt.ukp.inception.documents.api.RepositoryPropertiesImpl;
 import de.tudarmstadt.ukp.inception.export.DocumentImportExportServiceImpl;
 import de.tudarmstadt.ukp.inception.export.config.DocumentImportExportServiceProperties;
 import de.tudarmstadt.ukp.inception.export.config.DocumentImportExportServicePropertiesImpl;
@@ -65,7 +65,7 @@ public class AnnotationDocumentsExporterTest
 {
     public @TempDir File tempFolder;
 
-    private RepositoryProperties repositoryProperties;
+    private RepositoryPropertiesImpl repositoryProperties;
     private DocumentImportExportService importExportSerivce;
     private FileSystemCasStorageDriver driver;
     private CasStorageServiceImpl casStorageService;
@@ -91,7 +91,7 @@ public class AnnotationDocumentsExporterTest
 
         DocumentImportExportServiceProperties properties = new DocumentImportExportServicePropertiesImpl();
 
-        repositoryProperties = new RepositoryProperties();
+        repositoryProperties = new RepositoryPropertiesImpl();
         repositoryProperties.setPath(workFolder);
 
         driver = new FileSystemCasStorageDriver(repositoryProperties,

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/processor/BulkProcessingPanel.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/processor/BulkProcessingPanel.java
@@ -80,8 +80,12 @@ public class BulkProcessingPanel
     private void actionStartProcessing(AjaxRequestTarget aTarget, Form<FormData> aForm)
     {
         var formData = aForm.getModelObject();
-        schedulingService.enqueue(new BulkPredictionTask(userService.getCurrentUser(),
-                formData.recommender, "User request", formData.user.getUsername()));
+        schedulingService.enqueue(BulkPredictionTask.builder() //
+                .withSessionOwner(userService.getCurrentUser()) //
+                .withRecommender(formData.recommender) //
+                .withTrigger("User request") //
+                .withDataOwner(formData.user.getUsername()) //
+                .build());
     }
 
     private List<User> listUsers()

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
@@ -501,8 +501,11 @@ public class RecommendationServiceImpl
         var trigger = aEvent.getClass().getSimpleName();
         if (!predictionSessionExistedOnOpen) {
             // Activate all non-trainable recommenders - execute synchronously - blocking
-            schedulingService.executeSync(
-                    new NonTrainableRecommenderActivationTask(sessionOwner, project, trigger));
+            schedulingService.executeSync(NonTrainableRecommenderActivationTask.builder() //
+                    .withSessionOwner(sessionOwner) //
+                    .withProject(project) //
+                    .withTrigger(trigger) //
+                    .build());
         }
 
         // Check if we need to wait for the initial recommender run before displaying the document
@@ -556,7 +559,12 @@ public class RecommendationServiceImpl
         }
 
         LOG.trace("Running sync prediction for non-trainable recommenders");
-        schedulingService.executeSync(new PredictionTask(aSessionOwner, trigger, doc, aDataOwner));
+        schedulingService.executeSync(PredictionTask.builder() //
+                .withSessionOwner(aSessionOwner) //
+                .withTrigger(trigger) //
+                .withCurrentDocument(doc) //
+                .withDataOwner(aDataOwner) //
+                .build());
         switchPredictions(aSessionOwner.getUsername(), doc.getProject());
 
         return true;
@@ -795,7 +803,12 @@ public class RecommendationServiceImpl
             return;
         }
 
-        schedulingService.enqueue(new PredictionTask(user, aEventName, aDocument, aDataOwner));
+        schedulingService.enqueue(PredictionTask.builder() //
+                .withSessionOwner(user) //
+                .withTrigger(aEventName) //
+                .withCurrentDocument(aDocument) //
+                .withDataOwner(aDataOwner) //
+                .build());
     }
 
     @Override
@@ -839,8 +852,13 @@ public class RecommendationServiceImpl
             // If it is time for a selection task, we just start a selection task.
             // The selection task then will start the training once its finished,
             // i.e. we do not start it here.
-            schedulingService.enqueue(
-                    new SelectionTask(user, aProject, aEventName, aCurrentDocument, aDataOwner));
+            schedulingService.enqueue(SelectionTask.builder() //
+                    .withSessionOwner(user) //
+                    .withProject(aProject) //
+                    .withTrigger(aEventName) //
+                    .withCurrentDocument(aCurrentDocument) //
+                    .withDataOwner(aDataOwner) //
+                    .build());
 
             var state = getState(aSessionOwner, aProject);
             synchronized (state) {
@@ -851,8 +869,13 @@ public class RecommendationServiceImpl
             return;
         }
 
-        schedulingService.enqueue(
-                new TrainingTask(user, aProject, aEventName, aCurrentDocument, aDataOwner));
+        schedulingService.enqueue(TrainingTask.builder() //
+                .withSessionOwner(user) //
+                .withProject(aProject) //
+                .withTrigger(aEventName) //
+                .withCurrentDocument(aCurrentDocument) //
+                .withDataOwner(aDataOwner) //
+                .build());
 
         var state = getState(aSessionOwner, aProject);
         synchronized (state) {

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/NonTrainableRecommenderActivationTask.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/NonTrainableRecommenderActivationTask.java
@@ -21,6 +21,7 @@ import static de.tudarmstadt.ukp.inception.recommendation.api.recommender.Traini
 import static de.tudarmstadt.ukp.inception.support.logging.LogLevel.ERROR;
 import static java.lang.System.currentTimeMillis;
 
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -34,7 +35,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
-import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.EvaluatedRecommender;
@@ -53,15 +53,17 @@ import de.tudarmstadt.ukp.inception.support.logging.LogMessage;
 public class NonTrainableRecommenderActivationTask
     extends RecommendationTask_ImplBase
 {
-    private final Logger log = LoggerFactory.getLogger(getClass());
+    public static final String TYPE = "NonTrainableRecommenderActivationTask";
+
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private @Autowired AnnotationSchemaService annoService;
     private @Autowired RecommendationService recommendationService;
     private @Autowired ApplicationEventPublisher appEventPublisher;
 
-    public NonTrainableRecommenderActivationTask(User aUser, Project aProject, String aTrigger)
+    public NonTrainableRecommenderActivationTask(Builder<? extends Builder<?>> aBuilder)
     {
-        super(aUser, aProject, aTrigger);
+        super(aBuilder.withType(TYPE));
     }
 
     @Override
@@ -112,7 +114,7 @@ public class NonTrainableRecommenderActivationTask
                 catch (Throwable e) {
                     // Catching Throwable is intentional here as we want to continue the execution
                     // even if a particular recommender fails.
-                    log.error("[{}][{}]: Failed", user.getUsername(), recommenderName, e);
+                    LOG.error("[{}][{}]: Failed", user.getUsername(), recommenderName, e);
                     appEventPublisher.publishEvent(RecommenderTaskNotificationEvent
                             .builder(this, getProject(), user.getUsername()) //
                             .withMessage(new LogMessage(this, ERROR, e.getMessage())) //
@@ -165,7 +167,7 @@ public class NonTrainableRecommenderActivationTask
         recommendationService.putContext(user, recommender, ctx);
 
         String recommenderName = recommender.getName();
-        log.debug("[{}][{}]: Activating [{}] non-trainable recommender", user.getUsername(),
+        LOG.debug("[{}][{}]: Activating [{}] non-trainable recommender", user.getUsername(),
                 recommenderName, recommenderName);
         info("Recommender [%s] activated because it is not trainable", recommenderName);
         return EvaluatedRecommender.makeActiveWithoutEvaluation(recommender);
@@ -174,7 +176,7 @@ public class NonTrainableRecommenderActivationTask
     private EvaluatedRecommender skipTrainableRecommender(User user, Recommender recommender)
     {
         String recommenderName = recommender.getName();
-        log.debug(
+        LOG.debug(
                 "[{}][{}]: Recommender requires training - deferring activation to selection task",
                 user.getUsername(), recommenderName);
         info("Recommender [%s] requires training - deferring activation to selection task",
@@ -186,7 +188,7 @@ public class NonTrainableRecommenderActivationTask
             Recommender recommender)
     {
         String recommenderName = recommender.getName();
-        log.info("[{}][{}]: Recommender configured with invalid layer or feature "
+        LOG.info("[{}][{}]: Recommender configured with invalid layer or feature "
                 + "- skipping recommender", user.getUsername(), recommenderName);
         info("Recommender [%s] configured with invalid layer or feature - skipping recommender",
                 recommenderName);
@@ -196,7 +198,7 @@ public class NonTrainableRecommenderActivationTask
 
     private void sendMissingFactoryNotification(User user, Recommender recommender)
     {
-        log.error("[{}][{}]: No recommender factory available for [{}]", user.getUsername(),
+        LOG.error("[{}][{}]: No recommender factory available for [{}]", user.getUsername(),
                 recommender.getName(), recommender.getTool());
         appEventPublisher.publishEvent(
                 RecommenderTaskNotificationEvent.builder(this, getProject(), user.getUsername()) //
@@ -214,17 +216,31 @@ public class NonTrainableRecommenderActivationTask
             recommender = recommendationService.getRecommender(r.getId());
         }
         catch (NoResultException e) {
-            log.info("[{}][{}]: Recommender no longer available - skipping", aUser.getUsername(),
+            LOG.info("[{}][{}]: Recommender no longer available - skipping", aUser.getUsername(),
                     r.getName());
             return Optional.empty();
         }
 
         if (!recommender.isEnabled()) {
-            log.debug("[{}][{}]: Recommender is disabled - skipping", aUser.getUsername(),
+            LOG.debug("[{}][{}]: Recommender is disabled - skipping", aUser.getUsername(),
                     recommender.getName());
             return Optional.empty();
         }
 
         return Optional.of(recommender);
+    }
+
+    public static Builder<Builder<?>> builder()
+    {
+        return new Builder<>();
+    }
+
+    public static class Builder<T extends Builder<?>>
+        extends RecommendationTask_ImplBase.Builder<T>
+    {
+        public NonTrainableRecommenderActivationTask build()
+        {
+            return new NonTrainableRecommenderActivationTask(this);
+        }
     }
 }

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/RecommendationTask_ImplBase.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/RecommendationTask_ImplBase.java
@@ -22,8 +22,6 @@ import static java.util.Collections.unmodifiableList;
 import java.util.ArrayList;
 import java.util.List;
 
-import de.tudarmstadt.ukp.clarin.webanno.model.Project;
-import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.inception.scheduling.Task;
 import de.tudarmstadt.ukp.inception.support.logging.LogMessage;
 
@@ -32,14 +30,9 @@ public abstract class RecommendationTask_ImplBase
 {
     private final List<LogMessage> logMessages = new ArrayList<>();
 
-    public RecommendationTask_ImplBase(Project aProject, String aTrigger)
+    protected RecommendationTask_ImplBase(Builder<? extends Builder<?>> aBuilder)
     {
-        super(aProject, aTrigger);
-    }
-
-    public RecommendationTask_ImplBase(User aSessionOwner, Project aProject, String aTrigger)
-    {
-        super(aSessionOwner, aProject, aTrigger);
+        super(aBuilder);
     }
 
     public void inheritLog(List<LogMessage> aLogMessages)
@@ -75,5 +68,11 @@ public abstract class RecommendationTask_ImplBase
     public void log(LogMessage aMessage)
     {
         logMessages.add(aMessage);
+    }
+
+    public static abstract class Builder<T extends Builder<?>>
+        extends Task.Builder<T>
+    {
+        // No changes
     }
 }

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/TrainingTask.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/TrainingTask.java
@@ -27,6 +27,7 @@ import java.util.List;
 
 import javax.persistence.NoResultException;
 
+import org.apache.commons.lang3.Validate;
 import org.apache.commons.lang3.concurrent.ConcurrentException;
 import org.apache.uima.cas.CAS;
 import org.slf4j.Logger;
@@ -34,7 +35,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 
-import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.inception.annotation.storage.CasStorageSession;
@@ -52,6 +52,8 @@ import de.tudarmstadt.ukp.inception.support.logging.LogMessage;
 public class TrainingTask
     extends RecommendationTask_ImplBase
 {
+    public static final String TYPE = "TrainingTask";
+
     private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private @Autowired DocumentService documentService;
@@ -65,33 +67,12 @@ public class TrainingTask
     private boolean seenSuccessfulTraining = false;
     private boolean seenNonTrainingRecommender = false;
 
-    /**
-     * Create a new training task.
-     * 
-     * @param aUser
-     *            the user owning the training session.
-     * @param aProject
-     *            the project to perform the selection on.
-     * @param aTrigger
-     *            the trigger that caused the selection to be scheduled.
-     * @param aCurrentDocument
-     *            the document currently open in the editor.
-     * @param aDataOwner
-     *            the user owning the annotations currently shown in the editor (this can differ
-     *            from the user owning the session e.g. if a manager views another users annotations
-     *            or a curator is performing curation to the {@link WebAnnoConst#CURATION_USER})
-     */
-    public TrainingTask(User aUser, Project aProject, String aTrigger,
-            SourceDocument aCurrentDocument, String aDataOwner)
+    public TrainingTask(Builder<? extends Builder<?>> aBuilder)
     {
-        super(aUser, aProject, aTrigger);
+        super(aBuilder.withType(TYPE));
 
-        if (getUser().isEmpty()) {
-            throw new IllegalArgumentException("TrainingTask requires a user");
-        }
-
-        currentDocument = aCurrentDocument;
-        dataOwner = aDataOwner;
+        currentDocument = aBuilder.currentDocument;
+        dataOwner = aBuilder.dataOwner;
     }
 
     @Override
@@ -252,8 +233,12 @@ public class TrainingTask
 
     private void schedulePredictionTask()
     {
-        var predictionTask = new PredictionTask(getSessionOwner(),
-                String.format("TrainingTask %s complete", getId()), currentDocument, dataOwner);
+        var predictionTask = PredictionTask.builder() //
+                .withSessionOwner(getSessionOwner()) //
+                .withTrigger(String.format("TrainingTask %s complete", getId())) //
+                .withCurrentDocument(currentDocument) //
+                .withDataOwner(dataOwner) //
+                .build();
 
         predictionTask.inheritLog(this);
 
@@ -418,5 +403,49 @@ public class TrainingTask
                 .builder(this, getProject(), getSessionOwner().getUsername()) //
                 .withMessage(LogMessage.error(this, "Training failed with %s", e.getMessage()))
                 .build());
+    }
+
+    public static Builder<Builder<?>> builder()
+    {
+        return new Builder<>();
+    }
+
+    public static class Builder<T extends Builder<?>>
+        extends RecommendationTask_ImplBase.Builder<T>
+    {
+        private SourceDocument currentDocument;
+        private String dataOwner;
+
+        /**
+         * @param aCurrentDocuemnt
+         *            the document currently open in the editor of the user triggering the task.
+         */
+        @SuppressWarnings("unchecked")
+        public T withCurrentDocument(SourceDocument aCurrentDocuemnt)
+        {
+            currentDocument = aCurrentDocuemnt;
+            return (T) this;
+        }
+
+        /**
+         * @param aDataOwner
+         *            the user owning the annotations currently shown in the editor (this can differ
+         *            from the user owning the session e.g. if a manager views another users
+         *            annotations or a curator is performing curation to the
+         *            {@link WebAnnoConst#CURATION_USER})
+         */
+        @SuppressWarnings("unchecked")
+        public T withDataOwner(String aDataOwner)
+        {
+            dataOwner = aDataOwner;
+            return (T) this;
+        }
+
+        public TrainingTask build()
+        {
+            Validate.notNull(sessionOwner, "TrainingTask requires a user");
+
+            return new TrainingTask(this);
+        }
     }
 }

--- a/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/tasks/PredictionTaskTest.java
+++ b/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/tasks/PredictionTaskTest.java
@@ -88,7 +88,12 @@ class PredictionTaskTest
     {
         var schemaService = Mockito.mock(AnnotationSchemaServiceImpl.class);
 
-        var sut = new PredictionTask(sessionOwner, TRIGGER, document, DATA_OWNER);
+        var sut = PredictionTask.builder() //
+                .withSessionOwner(sessionOwner) //
+                .withTrigger(TRIGGER) //
+                .withCurrentDocument(document) //
+                .withDataOwner(DATA_OWNER) //
+                .build();
         sut.setSchemaService(schemaService);
 
         var jCas = createText("I am text CAS", "de");

--- a/inception/inception-scheduling/src/main/java/de/tudarmstadt/ukp/inception/scheduling/NotifyingTaskMonitor.java
+++ b/inception/inception-scheduling/src/main/java/de/tudarmstadt/ukp/inception/scheduling/NotifyingTaskMonitor.java
@@ -32,10 +32,9 @@ public class NotifyingTaskMonitor
 
     private MTaskStateUpdate lastUpdate;
 
-    public NotifyingTaskMonitor(TaskHandle aHandle, String aUser, String aTitle,
-            SimpMessagingTemplate aMsgTemplate)
+    public NotifyingTaskMonitor(TaskHandle aHandle, Task aTask, SimpMessagingTemplate aMsgTemplate)
     {
-        super(aHandle, aUser, aTitle);
+        super(aHandle, aTask);
         msgTemplate = aMsgTemplate;
     }
 

--- a/inception/inception-scheduling/src/main/java/de/tudarmstadt/ukp/inception/scheduling/SchedulingService.java
+++ b/inception/inception-scheduling/src/main/java/de/tudarmstadt/ukp/inception/scheduling/SchedulingService.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.inception.scheduling;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
@@ -39,6 +40,11 @@ public interface SchedulingService
      */
     List<Task> getRunningTasks();
 
+    /**
+     * @return tasks which are no longer running (completed, failed).
+     */
+    List<Task> getEndedTasks();
+
     List<Task> getScheduledAndRunningTasks();
 
     List<Task> getAllTasks();
@@ -58,6 +64,8 @@ public interface SchedulingService
      *            the task to be enqueued.
      */
     void enqueue(Task aTask);
+
+    Optional<Task> findTask(Predicate<Task> aPredicate);
 
     /**
      * Removes all task for the user with name {@code aUsername} from the scheduler's queue.

--- a/inception/inception-scheduling/src/main/java/de/tudarmstadt/ukp/inception/scheduling/Task.java
+++ b/inception/inception-scheduling/src/main/java/de/tudarmstadt/ukp/inception/scheduling/Task.java
@@ -48,27 +48,31 @@ public abstract class Task
     private final Project project;
     private final String trigger;
     private final int id;
+    private final String type;
+    private final boolean cancellable;
 
     private TaskMonitor monitor;
     private Task parentTask;
 
-    private boolean cancelled;
+    private TaskScope scope;
 
-    public Task(Project aProject, String aTrigger)
+    protected Task(Builder<? extends Builder<?>> builder)
     {
-        this(null, aProject, aTrigger);
-    }
-
-    public Task(User aSessionOwner, Project aProject, String aTrigger)
-    {
-        notNull(aProject, "Project must be specified");
-        notNull(aTrigger, "Trigger must be specified");
+        notNull(builder.project, "Project must be specified");
+        notNull(builder.trigger, "Trigger must be specified");
+        notNull(builder.scope, "Scope must be specified");
+        notNull(builder.type, "Type must be specified");
 
         id = nextId.getAndIncrement();
         handle = new TaskHandle(id);
-        sessionOwner = aSessionOwner;
-        project = aProject;
-        trigger = aTrigger;
+        sessionOwner = builder.sessionOwner;
+        project = builder.project;
+        trigger = builder.trigger;
+        type = builder.type;
+
+        cancellable = builder.cancellable;
+        parentTask = builder.parentTask;
+        scope = builder.scope;
     }
 
     @Override
@@ -77,27 +81,26 @@ public abstract class Task
         // For tasks that have a parent task, we use a non-notifying monitor. Also, we do not report
         // such subtasks ia the SchedulerControllerImpl - they are internal.
         if (msgTemplate != null && sessionOwner != null && parentTask == null) {
-            monitor = new NotifyingTaskMonitor(handle, sessionOwner.getUsername(), getTitle(),
-                    msgTemplate);
+            monitor = new NotifyingTaskMonitor(handle, this, msgTemplate);
         }
         else {
-            monitor = new TaskMonitor(handle,
-                    sessionOwner != null ? sessionOwner.getUsername() : null, getTitle());
+            monitor = new TaskMonitor(handle, this);
         }
     }
 
-    /**
-     * @param aParentTask
-     *            parent task for this task.
-     */
-    public void setParentTask(Task aParentTask)
+    public boolean isCancellable()
     {
-        parentTask = aParentTask;
+        return cancellable;
     }
 
     public Task getParentTask()
     {
         return parentTask;
+    }
+
+    public String getType()
+    {
+        return type;
     }
 
     public String getTitle()
@@ -140,14 +143,9 @@ public abstract class Task
         return true;
     }
 
-    public void cancel()
+    public TaskScope getScope()
     {
-        cancelled = true;
-    }
-
-    public boolean isCancelled()
-    {
-        return cancelled;
+        return scope;
     }
 
     void destroy()
@@ -172,11 +170,7 @@ public abstract class Task
                 MDC.put(KEY_PROJECT_ID, String.valueOf(getProject().getId()));
             }
 
-            monitor.setState(TaskState.RUNNING);
-            execute();
-            if (monitor.getState() == TaskState.RUNNING) {
-                monitor.setState(TaskState.COMPLETED);
-            }
+            runSync();
         }
         finally {
             destroy();
@@ -186,17 +180,26 @@ public abstract class Task
         }
     }
 
+    public void runSync()
+    {
+        monitor.setState(TaskState.RUNNING);
+        execute();
+        if (monitor.getState() == TaskState.RUNNING) {
+            monitor.setState(TaskState.COMPLETED);
+        }
+    }
+
     public abstract void execute();
 
     @Override
     public String toString()
     {
         StringBuilder sb = new StringBuilder(getName());
-        sb.append('{');
+        sb.append('[');
         sb.append("user=").append(sessionOwner != null ? sessionOwner.getUsername() : "<SYSTEM>");
         sb.append(", project=").append(project.getName());
         sb.append(", trigger=\"").append(trigger);
-        sb.append("\"}");
+        sb.append("\"]");
         return sb.toString();
     }
 
@@ -217,5 +220,85 @@ public abstract class Task
     public int hashCode()
     {
         return Objects.hash(sessionOwner, project);
+    }
+
+    public static abstract class Builder<T extends Builder<?>>
+    {
+        protected User sessionOwner;
+        protected Project project;
+        protected String trigger;
+        protected String type;
+        protected boolean cancellable;
+        protected Task parentTask;
+        protected TaskScope scope = TaskScope.EPHEMERAL;
+
+        protected Builder()
+        {
+        }
+
+        /**
+         * @param aSessionOwner
+         *            the user owning the task.
+         */
+        @SuppressWarnings("unchecked")
+        public T withSessionOwner(User aSessionOwner)
+        {
+            this.sessionOwner = aSessionOwner;
+            return (T) this;
+        }
+
+        /**
+         * @param aProject
+         *            the project on which the task operates.
+         */
+        @SuppressWarnings("unchecked")
+        public T withProject(Project aProject)
+        {
+            this.project = aProject;
+            return (T) this;
+        }
+
+        /**
+         * @param aTrigger
+         *            the trigger that caused the selection to be scheduled.
+         */
+        @SuppressWarnings("unchecked")
+        public T withTrigger(String aTrigger)
+        {
+            this.trigger = aTrigger;
+            return (T) this;
+        }
+
+        @SuppressWarnings("unchecked")
+        public T withType(String aType)
+        {
+            this.type = aType;
+            return (T) this;
+        }
+
+        @SuppressWarnings("unchecked")
+        public T withCancellable(boolean aCancellable)
+        {
+            this.cancellable = aCancellable;
+            return (T) this;
+        }
+
+        /**
+         * @param aParentTask
+         *            parent task for this task.
+         */
+        @SuppressWarnings("unchecked")
+        public T withParentTask(Task aParentTask)
+        {
+            this.parentTask = aParentTask;
+            return (T) this;
+        }
+
+        @SuppressWarnings("unchecked")
+        public T withScope(TaskScope aScope)
+        {
+            this.scope = aScope;
+            return (T) this;
+        }
     }
 }

--- a/inception/inception-scheduling/src/main/java/de/tudarmstadt/ukp/inception/scheduling/TaskMonitor.java
+++ b/inception/inception-scheduling/src/main/java/de/tudarmstadt/ukp/inception/scheduling/TaskMonitor.java
@@ -26,6 +26,7 @@ import static java.util.Arrays.asList;
 import java.util.Deque;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
+import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.inception.support.logging.LogMessage;
 
 public class TaskMonitor
@@ -35,22 +36,29 @@ public class TaskMonitor
     private final TaskHandle handle;
     private final String user;
     private final String title;
+    private final String type;
 
-    private long createTime;
+    private final long createTime;
     private long startTime = -1;
     private long endTime = -1;
+
     private int progress = 0;
     private int maxProgress = 0;
+
     private TaskState state = NOT_STARTED;
 
+    private final boolean cancellable;
+    private boolean cancelled = false;
     private boolean destroyed = false;
 
-    public TaskMonitor(TaskHandle aHandle, String aUser, String aTitle)
+    public TaskMonitor(TaskHandle aHandle, Task aTask)
     {
         handle = aHandle;
-        user = aUser;
-        title = aTitle;
+        type = aTask.getType();
+        user = aTask.getUser().map(User::getUsername).orElse(null);
+        title = aTask.getTitle();
         createTime = System.currentTimeMillis();
+        cancellable = aTask.isCancellable();
     }
 
     public TaskHandle getHandle()
@@ -73,6 +81,11 @@ public class TaskMonitor
         return title;
     }
 
+    public String getType()
+    {
+        return type;
+    }
+
     public synchronized void setState(TaskState aState)
     {
         state = aState;
@@ -89,11 +102,6 @@ public class TaskMonitor
     public synchronized long getCreateTime()
     {
         return createTime;
-    }
-
-    public synchronized void setCreateTime(long aCreateTime)
-    {
-        createTime = aCreateTime;
     }
 
     public synchronized long getStartTime()
@@ -178,8 +186,23 @@ public class TaskMonitor
         // By default do nothing
     }
 
-    protected boolean isDestroyed()
+    public boolean isDestroyed()
     {
         return destroyed;
+    }
+
+    public boolean isCancellable()
+    {
+        return cancellable;
+    }
+
+    public void cancel()
+    {
+        cancelled = true;
+    }
+
+    public boolean isCancelled()
+    {
+        return cancelled;
     }
 }

--- a/inception/inception-scheduling/src/main/java/de/tudarmstadt/ukp/inception/scheduling/TaskScope.java
+++ b/inception/inception-scheduling/src/main/java/de/tudarmstadt/ukp/inception/scheduling/TaskScope.java
@@ -17,41 +17,36 @@
  */
 package de.tudarmstadt.ukp.inception.scheduling;
 
-import java.time.Duration;
-
-public abstract class DebouncingTask
-    extends Task
+public enum TaskScope
 {
-    private final long runnableAfter;
+    /**
+     * Task can be cleared as soon as it has ended.
+     */
+    EPHEMERAL,
 
-    protected DebouncingTask(Builder<? extends Builder<?>> aBuilder)
+    /**
+     * Task can be cleared when the last session of the user is cleared or when the system is
+     * restarted.
+     */
+    LAST_USER_SESSION,
+
+    /**
+     * Task can be cleared when the project is deleted or when the system is restarted.
+     */
+    PROJECT;
+
+    boolean isKeepAfterEnded()
     {
-        super(aBuilder);
-
-        runnableAfter = System.currentTimeMillis() + aBuilder.debounceMillis;
+        return this != EPHEMERAL;
     }
 
-    @Override
-    public boolean isReadyToStart()
+    boolean isRemoveWhenUserSessionEnds()
     {
-        return System.currentTimeMillis() > runnableAfter;
+        return this == EPHEMERAL;
     }
 
-    public static abstract class Builder<T extends Builder<?>>
-        extends Task.Builder<T>
+    boolean isRemoveWhenLastUserSessionEnds()
     {
-        private long debounceMillis;
-
-        public T withDebounceMillis(Duration aDebounceDelay)
-        {
-            debounceMillis = aDebounceDelay.toMillis();
-            return (T) this;
-        }
-
-        public T withDebounceMillis(long aDebounceMillis)
-        {
-            debounceMillis = aDebounceMillis;
-            return (T) this;
-        }
+        return this == LAST_USER_SESSION || this == EPHEMERAL;
     }
 }

--- a/inception/inception-scheduling/src/main/java/de/tudarmstadt/ukp/inception/scheduling/controller/model/MTaskStateUpdate.java
+++ b/inception/inception-scheduling/src/main/java/de/tudarmstadt/ukp/inception/scheduling/controller/model/MTaskStateUpdate.java
@@ -31,11 +31,15 @@ public class MTaskStateUpdate
 {
     private final long timestamp;
     private final int id;
+    private final String type;
     private final int progress;
     private final int maxProgress;
     private final TaskState state;
     private final String title;
     private final int messageCount;
+
+    @JsonInclude(Include.NON_DEFAULT)
+    private final boolean cancellable;
 
     @JsonInclude(Include.NON_DEFAULT)
     private final boolean removed;
@@ -53,12 +57,14 @@ public class MTaskStateUpdate
         timestamp = System.currentTimeMillis();
         title = aMonitor.getTitle();
         id = aMonitor.getHandle().getId();
+        type = aMonitor.getType();
         progress = aMonitor.getProgress();
         maxProgress = aMonitor.getMaxProgress();
         state = aMonitor.getState();
         messageCount = aMonitor.getMessages().size();
         latestMessage = aMonitor.getMessages().peekLast();
         removed = aRemoved;
+        cancellable = aMonitor.isCancellable();
     }
 
     public String getTitle()
@@ -86,6 +92,11 @@ public class MTaskStateUpdate
         return state;
     }
 
+    public String getType()
+    {
+        return type;
+    }
+
     public LogMessage getLatestMessage()
     {
         return latestMessage;
@@ -99,6 +110,11 @@ public class MTaskStateUpdate
     public boolean isRemoved()
     {
         return removed;
+    }
+
+    public boolean isCancellable()
+    {
+        return cancellable;
     }
 
     @Override

--- a/inception/inception-scheduling/src/test/java/de/tudarmstadt/ukp/inception/scheduling/SchedulingServiceTest.java
+++ b/inception/inception-scheduling/src/test/java/de/tudarmstadt/ukp/inception/scheduling/SchedulingServiceTest.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.scheduling;
 
+import static java.time.Duration.ofSeconds;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -127,7 +128,8 @@ public class SchedulingServiceTest
 
     private Task buildDummyTask(String aUsername, String aProjectName)
     {
-        var task = new DummyTask(buildUser(aUsername), buildProject(aProjectName));
+        var task = DummyTask.builder().withSessionOwner(buildUser(aUsername))
+                .withProject(buildProject(aProjectName)).build();
         task.afterPropertiesSet();
         return task;
     }
@@ -139,9 +141,11 @@ public class SchedulingServiceTest
     private static class DummyTask
         extends Task
     {
-        DummyTask(User aUser, Project aProject)
+        private static final String TYPE = "DummyTask";
+
+        DummyTask(Builder<? extends Builder<?>> aBuilder)
         {
-            super(aUser, aProject, "JUnit");
+            super(aBuilder.withType(TYPE).withTrigger("test"));
         }
 
         @Override
@@ -154,6 +158,25 @@ public class SchedulingServiceTest
                 catch (InterruptedException e) {
                     break;
                 }
+            }
+        }
+
+        public static Builder<Builder<?>> builder()
+        {
+            return new Builder<>();
+        }
+
+        public static class Builder<T extends Builder<?>>
+            extends DebouncingTask.Builder<T>
+        {
+            protected Builder()
+            {
+                withDebounceMillis(ofSeconds(3));
+            }
+
+            public DummyTask build()
+            {
+                return new DummyTask(this);
             }
         }
     }

--- a/inception/inception-search-core/pom.xml
+++ b/inception/inception-search-core/pom.xml
@@ -126,6 +126,11 @@
     
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-api-annotation</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-schema</artifactId>
       <scope>test</scope>
     </dependency>

--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchService.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchService.java
@@ -166,5 +166,5 @@ public interface SearchService
             int aMinTokenPerDoc, int aMaxTokenPerDoc, Set<AnnotationFeature> aFeatures)
         throws ExecutionException, IOException;
 
-    void enqueueReindexTask(Project aProject, String aUser, String aTrigger);
+    void enqueueReindexTask(Project aProject, User aUser, String aTrigger);
 }

--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchServiceImpl.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchServiceImpl.java
@@ -838,24 +838,37 @@ public class SearchServiceImpl
 
     private void enqueueReindexTask(Project aProject, String aTrigger)
     {
-        enqueue(new ReindexTask(aProject, null, aTrigger));
+        enqueue(ReindexTask.builder() //
+                .withProject(aProject) //
+                .withTrigger(aTrigger) //
+                .build());
     }
 
     @Override
     @Transactional
-    public void enqueueReindexTask(Project aProject, String aUser, String aTrigger)
+    public void enqueueReindexTask(Project aProject, User aUser, String aTrigger)
     {
-        enqueue(new ReindexTask(aProject, aUser, aTrigger));
+        enqueue(ReindexTask.builder() //
+                .withProject(aProject) //
+                .withSessionOwner(aUser) //
+                .withTrigger(aTrigger) //
+                .build());
     }
 
     private void enqueueIndexDocument(SourceDocument aSourceDocument, String aTrigger)
     {
-        enqueue(new IndexSourceDocumentTask(aSourceDocument, aTrigger));
+        enqueue(IndexSourceDocumentTask.builder() //
+                .withSourceDocument(aSourceDocument) //
+                .withTrigger(aTrigger) //
+                .build());
     }
 
     private void enqueueIndexDocument(AnnotationDocument aAnnotationDocument, String aTrigger)
     {
-        enqueue(new IndexAnnotationDocumentTask(aAnnotationDocument, aTrigger));
+        enqueue(IndexAnnotationDocumentTask.builder() //
+                .withAnnotationDocument(aAnnotationDocument) //
+                .withTrigger(aTrigger) //
+                .build());
     }
 
     /**

--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/scheduling/tasks/IndexSourceDocumentTask.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/scheduling/tasks/IndexSourceDocumentTask.java
@@ -28,13 +28,14 @@ import static de.tudarmstadt.ukp.inception.scheduling.MatchResult.NO_MATCH;
 import static de.tudarmstadt.ukp.inception.scheduling.MatchResult.UNQUEUE_EXISTING_AND_QUEUE_THIS;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.util.Objects;
 
+import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.annotation.storage.CasStorageSession;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.scheduling.MatchResult;
@@ -49,16 +50,20 @@ import de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil;
 public class IndexSourceDocumentTask
     extends IndexingTask_ImplBase
 {
-    private final Logger log = LoggerFactory.getLogger(getClass());
+    public static final String TYPE = "IndexSourceDocumentTask";
+
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private @Autowired SearchService searchService;
     private @Autowired DocumentService documentService;
 
     private int done = 0;
 
-    public IndexSourceDocumentTask(SourceDocument aSourceDocument, String aTrigger)
+    public IndexSourceDocumentTask(Builder<? extends Builder<?>> aBuilder)
     {
-        super(aSourceDocument, aTrigger);
+        super(aBuilder //
+                .withProject(aBuilder.sourceDocument.getProject()) //
+                .withType(TYPE));
     }
 
     @Override
@@ -76,7 +81,7 @@ public class IndexSourceDocumentTask
             searchService.indexDocument(getSourceDocument(), WebAnnoCasUtil.casToByteArray(cas));
         }
         catch (IOException e) {
-            log.error("Error indexing source document {}", getSourceDocument(), e);
+            LOG.error("Error indexing source document {}", getSourceDocument(), e);
         }
 
         done++;
@@ -108,5 +113,21 @@ public class IndexSourceDocumentTask
         }
 
         return NO_MATCH;
+    }
+
+    public static Builder<Builder<?>> builder()
+    {
+        return new Builder<>();
+    }
+
+    public static class Builder<T extends Builder<?>>
+        extends IndexingTask_ImplBase.Builder<T>
+    {
+        public IndexSourceDocumentTask build()
+        {
+            Validate.notNull(sourceDocument, "Annotation document must be specified");
+
+            return new IndexSourceDocumentTask(this);
+        }
     }
 }

--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/scheduling/tasks/IndexingTask_ImplBase.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/scheduling/tasks/IndexingTask_ImplBase.java
@@ -20,9 +20,7 @@ package de.tudarmstadt.ukp.inception.search.scheduling.tasks;
 import java.util.Objects;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
-import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
-import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.inception.scheduling.MatchableTask;
 import de.tudarmstadt.ukp.inception.scheduling.Task;
 import de.tudarmstadt.ukp.inception.search.model.Progress;
@@ -37,28 +35,12 @@ public abstract class IndexingTask_ImplBase
     private final SourceDocument sourceDocument;
     private final AnnotationDocument annotationDocument;
 
-    public IndexingTask_ImplBase(Project aProject, String aUser, String aTrigger)
+    protected IndexingTask_ImplBase(Builder<? extends Builder<?>> aBuilder)
     {
-        super(new User(aUser), aProject, aTrigger);
+        super(aBuilder);
 
-        sourceDocument = null;
-        annotationDocument = null;
-    }
-
-    public IndexingTask_ImplBase(SourceDocument aSourceDocument, String aTrigger)
-    {
-        super(aSourceDocument.getProject(), aTrigger);
-
-        sourceDocument = aSourceDocument;
-        annotationDocument = null;
-    }
-
-    public IndexingTask_ImplBase(AnnotationDocument aAnnotationDocument, String aTrigger)
-    {
-        super(new User(aAnnotationDocument.getUser()), aAnnotationDocument.getProject(), aTrigger);
-
-        sourceDocument = null;
-        annotationDocument = aAnnotationDocument;
+        sourceDocument = aBuilder.sourceDocument;
+        annotationDocument = aBuilder.annotationDocument;
     }
 
     public SourceDocument getSourceDocument()
@@ -110,5 +92,30 @@ public abstract class IndexingTask_ImplBase
     public int hashCode()
     {
         return Objects.hash(super.hashCode(), sourceDocument, annotationDocument);
+    }
+
+    public static abstract class Builder<T extends Builder<?>>
+        extends Task.Builder<T>
+    {
+        protected SourceDocument sourceDocument;
+        protected AnnotationDocument annotationDocument;
+
+        protected Builder()
+        {
+        }
+
+        @SuppressWarnings("unchecked")
+        public T withSourceDocument(SourceDocument aSourceDocument)
+        {
+            this.sourceDocument = aSourceDocument;
+            return (T) this;
+        }
+
+        @SuppressWarnings("unchecked")
+        public T withAnnotationDocument(AnnotationDocument aAnnotationDocument)
+        {
+            this.annotationDocument = aAnnotationDocument;
+            return (T) this;
+        }
     }
 }

--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/scheduling/tasks/ReindexTask.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/scheduling/tasks/ReindexTask.java
@@ -25,13 +25,13 @@ import static de.tudarmstadt.ukp.inception.scheduling.MatchResult.NO_MATCH;
 import static de.tudarmstadt.ukp.inception.scheduling.MatchResult.UNQUEUE_EXISTING_AND_QUEUE_THIS;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.util.Objects;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.inception.scheduling.MatchResult;
 import de.tudarmstadt.ukp.inception.scheduling.Task;
 import de.tudarmstadt.ukp.inception.search.SearchService;
@@ -44,15 +44,17 @@ import de.tudarmstadt.ukp.inception.search.model.Progress;
 public class ReindexTask
     extends IndexingTask_ImplBase
 {
-    private Logger log = LoggerFactory.getLogger(getClass());
+    public static final String TYPE = "ReindexTask";
+
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private @Autowired SearchService searchService;
 
     private Monitor monitor = new Monitor();
 
-    public ReindexTask(Project aProject, String aUser, String aTrigger)
+    public ReindexTask(Builder<? extends Builder<?>> aBuilder)
     {
-        super(aProject, aUser, aTrigger);
+        super(aBuilder.withType(TYPE));
     }
 
     @Override
@@ -68,7 +70,7 @@ public class ReindexTask
             searchService.reindex(super.getProject(), monitor);
         }
         catch (IOException e) {
-            log.error("Unable to reindex project [{}]({})", getProject().getName(),
+            LOG.error("Unable to reindex project [{}]({})", getProject().getName(),
                     getProject().getId(), e);
         }
     }
@@ -92,5 +94,19 @@ public class ReindexTask
         }
 
         return NO_MATCH;
+    }
+
+    public static Builder<Builder<?>> builder()
+    {
+        return new Builder<>();
+    }
+
+    public static class Builder<T extends Builder<?>>
+        extends IndexingTask_ImplBase.Builder<T>
+    {
+        public ReindexTask build()
+        {
+            return new ReindexTask(this);
+        }
     }
 }

--- a/inception/inception-search-mtas/src/test/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasUpgradeTest.java
+++ b/inception/inception-search-mtas/src/test/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasUpgradeTest.java
@@ -50,6 +50,7 @@ import de.tudarmstadt.ukp.clarin.webanno.text.TextFormatSupport;
 import de.tudarmstadt.ukp.inception.annotation.storage.config.CasStorageServiceAutoConfiguration;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.documents.api.RepositoryProperties;
+import de.tudarmstadt.ukp.inception.documents.api.RepositoryPropertiesImpl;
 import de.tudarmstadt.ukp.inception.documents.config.DocumentServiceAutoConfiguration;
 import de.tudarmstadt.ukp.inception.export.config.DocumentImportExportServiceAutoConfiguration;
 import de.tudarmstadt.ukp.inception.io.xmi.XmiFormatSupport;
@@ -185,7 +186,7 @@ public class MtasUpgradeTest
         @Bean
         RepositoryProperties repositoryProperties()
         {
-            var props = new RepositoryProperties();
+            var props = new RepositoryPropertiesImpl();
             props.setPath(new File(WORK_DIR));
             return props;
         }

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/lambda/LambdaAjaxBehavior.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/lambda/LambdaAjaxBehavior.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.support.lambda;
+
+import org.apache.wicket.ajax.AbstractDefaultAjaxBehavior;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.ajax.attributes.AjaxRequestAttributes;
+import org.apache.wicket.feedback.IFeedback;
+import org.apache.wicket.request.RequestHandlerExecutor.ReplaceHandlerException;
+import org.slf4j.LoggerFactory;
+
+public class LambdaAjaxBehavior
+    extends AbstractDefaultAjaxBehavior
+{
+    private static final long serialVersionUID = 4211352559572747320L;
+
+    private AjaxCallback action;
+    private AjaxExceptionHandler exceptionHandler;
+    private boolean preventDefault = false;
+
+    public LambdaAjaxBehavior()
+    {
+        this(null, null);
+    }
+
+    public LambdaAjaxBehavior(AjaxCallback aAction)
+    {
+        this(aAction, null);
+    }
+
+    public LambdaAjaxBehavior(AjaxCallback aAction, AjaxExceptionHandler aExceptionHandler)
+    {
+        action = aAction;
+        exceptionHandler = aExceptionHandler;
+    }
+
+    public void setAction(AjaxCallback aAction)
+    {
+        action = aAction;
+    }
+
+    public void setExceptionHandler(AjaxExceptionHandler aExceptionHandler)
+    {
+        exceptionHandler = aExceptionHandler;
+    }
+
+    @Override
+    protected void respond(AjaxRequestTarget aTarget)
+    {
+        if (action == null) {
+            return;
+        }
+
+        try {
+            action.accept(aTarget);
+        }
+        catch (ReplaceHandlerException e) {
+            // Let Wicket redirects still work
+            throw e;
+        }
+        catch (Exception e) {
+            if (exceptionHandler != null) {
+                exceptionHandler.accept(aTarget, e);
+            }
+            else {
+                LoggerFactory.getLogger(getComponent().getPage().getClass())
+                        .error("Error: " + e.getMessage(), e);
+                getComponent().error("Error: " + e.getMessage());
+                aTarget.addChildren(getComponent().getPage(), IFeedback.class);
+            }
+        }
+    }
+
+    public LambdaAjaxBehavior setPreventDefault(boolean aPreventDefault)
+    {
+        preventDefault = aPreventDefault;
+        return this;
+    }
+
+    @Override
+    protected void updateAjaxAttributes(AjaxRequestAttributes aAttributes)
+    {
+        super.updateAjaxAttributes(aAttributes);
+        aAttributes.setPreventDefault(preventDefault);
+    };
+}

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/wicket/AjaxDownloadBehavior.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/wicket/AjaxDownloadBehavior.java
@@ -19,6 +19,7 @@ package de.tudarmstadt.ukp.inception.support.wicket;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.behavior.AbstractAjaxBehavior;
 import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
 import org.apache.wicket.request.handler.resource.ResourceStreamRequestHandler;
 import org.apache.wicket.request.resource.ContentDisposition;
 import org.apache.wicket.util.resource.FileResourceStream;
@@ -42,6 +43,11 @@ public class AjaxDownloadBehavior
     private IModel<IResourceStream> data;
 
     private boolean addAntiCache = true;
+
+    public AjaxDownloadBehavior()
+    {
+        this(null, Model.of());
+    }
 
     public AjaxDownloadBehavior(IModel<IResourceStream> aData)
     {
@@ -71,6 +77,13 @@ public class AjaxDownloadBehavior
 
         // the timeout is needed to let Wicket release the channel
         aTarget.appendJavaScript("setTimeout(\"window.location.href='" + url + "'\", 100);");
+    }
+
+    public void initiate(AjaxRequestTarget aTarget, String aFilename, IResourceStream aStream)
+    {
+        filename = Model.of(aFilename);
+        data = Model.of(aStream);
+        initiate(aTarget);
     }
 
     @Override

--- a/inception/inception-ui-agreement/pom.xml
+++ b/inception/inception-ui-agreement/pom.xml
@@ -41,6 +41,14 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-annotation-storage</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-annotation-storage-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-agreement</artifactId>
     </dependency>
     <dependency>
@@ -85,6 +93,15 @@
       <artifactId>spring-context</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.uima</groupId>
+      <artifactId>uimaj-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.uima</groupId>
+      <artifactId>uimafit-core</artifactId>
+    </dependency>
+
     <!-- DKPro Core dependencies -->
 
     <dependency>
@@ -99,11 +116,19 @@
     </dependency>
     <dependency>
       <groupId>org.apache.wicket</groupId>
+      <artifactId>wicket-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-request</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-spring</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wicketstuff</groupId>
+      <artifactId>wicketstuff-annotationeventdispatcher</artifactId>
     </dependency>
     <dependency>
       <groupId>org.wicketstuff</groupId>

--- a/inception/inception-ui-agreement/pom.xml
+++ b/inception/inception-ui-agreement/pom.xml
@@ -45,11 +45,11 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
-      <artifactId>inception-annotation-storage-api</artifactId>
+      <artifactId>inception-schema-api</artifactId>
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
-      <artifactId>inception-schema-api</artifactId>
+      <artifactId>inception-scheduling</artifactId>
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
@@ -83,17 +83,6 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
-    </dependency>
-
-    <!-- UIMA dependencies -->
-
-    <dependency>
-      <groupId>org.apache.uima</groupId>
-      <artifactId>uimaj-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.uima</groupId>
-      <artifactId>uimafit-core</artifactId>
     </dependency>
 
     <!-- DKPro Core dependencies -->

--- a/inception/inception-ui-agreement/src/main/java/de/tudarmstadt/ukp/inception/ui/agreement/page/AgreementPage.html
+++ b/inception/inception-ui-agreement/src/main/java/de/tudarmstadt/ukp/inception/ui/agreement/page/AgreementPage.html
@@ -20,8 +20,8 @@
 <body>
   <wicket:extend>
     <div class="flex-content flex-h-container flex-gutter">
-      <div class="flex-content flex-v-container">
-        <form wicket:id="agreementForm" class="flex-v-container flex-gutter">
+      <div class="flex-content flex-v-container flex-gutter">
+        <form wicket:id="agreementForm" class="flex-v-container flex-gutter flex-only-internal-gutter">
           <div class="page-header">
             <h1><wicket:container wicket:id="name"/></h1>
           </div>

--- a/inception/inception-ui-agreement/src/main/java/de/tudarmstadt/ukp/inception/ui/agreement/page/AgreementPage.java
+++ b/inception/inception-ui-agreement/src/main/java/de/tudarmstadt/ukp/inception/ui/agreement/page/AgreementPage.java
@@ -17,29 +17,21 @@
  */
 package de.tudarmstadt.ukp.inception.ui.agreement.page;
 
-import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode.SHARED_READ_ONLY_ACCESS;
-import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasUpgradeMode.AUTO_CAS_UPGRADE;
-import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState.FINISHED;
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.ANNOTATOR;
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.CURATOR;
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.MANAGER;
 import static de.tudarmstadt.ukp.clarin.webanno.ui.core.page.ProjectPageBase.NS_PROJECT;
 import static de.tudarmstadt.ukp.clarin.webanno.ui.core.page.ProjectPageBase.PAGE_PARAM_PROJECT;
 import static de.tudarmstadt.ukp.inception.support.lambda.LambdaBehavior.enabledWhen;
+import static java.util.stream.Collectors.groupingBy;
 
 import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.uima.cas.CAS;
-import org.apache.uima.cas.FeatureStructure;
-import org.apache.uima.fit.util.FSUtil;
 import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.feedback.IFeedback;
@@ -59,27 +51,28 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wicketstuff.annotation.mount.MountPath;
 
-import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.AgreementMeasure;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.AgreementMeasureSupport;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.AgreementMeasureSupportRegistry;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.DefaultAgreementTraits;
+import de.tudarmstadt.ukp.clarin.webanno.agreement.task.CalculatePairwiseAgreementTask;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
-import de.tudarmstadt.ukp.clarin.webanno.model.Project;
-import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
-import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.clarin.webanno.ui.core.page.ProjectPageBase;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.project.api.ProjectService;
+import de.tudarmstadt.ukp.inception.scheduling.SchedulingService;
+import de.tudarmstadt.ukp.inception.scheduling.TaskScope;
+import de.tudarmstadt.ukp.inception.scheduling.TaskState;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.support.WebAnnoConst;
 import de.tudarmstadt.ukp.inception.support.help.DocLink;
+import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxBehavior;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxButton;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxFormComponentUpdatingBehavior;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaChoiceRenderer;
-import de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil;
 
 @MountPath(NS_PROJECT + "/${" + PAGE_PARAM_PROJECT + "}/agreement")
 public class AgreementPage
@@ -87,7 +80,7 @@ public class AgreementPage
 {
     private static final long serialVersionUID = 5333662917247971912L;
 
-    private static final Logger LOG = LoggerFactory.getLogger(AgreementPage.class);
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private static final String MID_TRAITS_CONTAINER = "traitsContainer";
     private static final String MID_TRAITS = "traits";
@@ -98,9 +91,11 @@ public class AgreementPage
     private @SpringBean AnnotationSchemaService annotationService;
     private @SpringBean UserDao userRepository;
     private @SpringBean AgreementMeasureSupportRegistry agreementRegistry;
+    private @SpringBean SchedulingService schedulingService;
 
     private AgreementForm agreementForm;
     private WebMarkupContainer resultsContainer;
+    private LambdaAjaxBehavior refreshResultsBehavior;
 
     public AgreementPage(final PageParameters aPageParameters)
     {
@@ -112,7 +107,7 @@ public class AgreementPage
     {
         super.onInitialize();
 
-        User user = userRepository.getCurrentUser();
+        var user = userRepository.getCurrentUser();
 
         requireProjectRole(user, MANAGER, CURATOR);
 
@@ -121,6 +116,44 @@ public class AgreementPage
         add(resultsContainer = new WebMarkupContainer("resultsContainer"));
         resultsContainer.setOutputMarkupPlaceholderTag(true);
         resultsContainer.add(new EmptyPanel(MID_RESULTS));
+
+        // add(new TaskMonitorPanel("runningProcesses") //
+        // .setPopupMode(false) //
+        // .setTypePattern(CalculatePairwiseAgreementTask.TYPE) //
+        // .setKeepRemovedTasks(true));
+        //
+        // refreshResultsBehavior = new LambdaAjaxBehavior(this::actionRefreshResults);
+        // add(refreshResultsBehavior);
+    }
+
+    private CalculatePairwiseAgreementTask getCurrentTask()
+    {
+        var maybeTask = schedulingService.findTask(t -> t instanceof CalculatePairwiseAgreementTask
+                && t.getUser().map(userRepository.getCurationUser()::equals).orElse(false)
+                && getProject().equals(t.getProject()));
+
+        if (maybeTask.isEmpty()) {
+            return null;
+        }
+
+        return (CalculatePairwiseAgreementTask) maybeTask.get();
+
+    }
+
+    private void actionRefreshResults(AjaxRequestTarget aTarget,
+            CalculatePairwiseAgreementTask aTask)
+    {
+        // var task = getCurrentTask();
+        var task = aTask;
+        if (task != null && task.getMonitor().getState() == TaskState.COMPLETED) {
+            AgreementMeasureSupport<?, ?, ?> ams = agreementRegistry.getAgreementMeasureSupport(
+                    agreementForm.measureDropDown.getModelObject().getKey());
+
+            var result = task.getResult();
+            var resultsPanel = ams.createResultsPanel(MID_RESULTS, Model.of(result));
+            resultsContainer.addOrReplace(resultsPanel);
+            aTarget.add(resultsContainer);
+        }
     }
 
     private class AgreementForm
@@ -201,9 +234,10 @@ public class AgreementPage
             // If the currently selected measure is not compatible with the selected feature, then
             // we clear the measure selection.
             AnnotationFeature selectedFeature = featureList.getModelObject();
-            boolean measureCompatibleWithFeature = measureDropDown.getModel()
-                    .map(k -> agreementRegistry.getAgreementMeasureSupport(k.getKey()))
-                    .map(s -> selectedFeature != null && s.accepts(selectedFeature)).orElse(false)
+            boolean measureCompatibleWithFeature = measureDropDown.getModel() //
+                    .map(k -> agreementRegistry.getAgreementMeasureSupport(k.getKey())) //
+                    .map(s -> selectedFeature != null && s.accepts(selectedFeature)) //
+                    .orElse(false) //
                     .getObject();
             if (!measureCompatibleWithFeature) {
                 measureDropDown.setModelObject(null);
@@ -215,34 +249,59 @@ public class AgreementPage
         @SuppressWarnings({ "rawtypes", "unchecked" })
         private void actionRunCalculations(AjaxRequestTarget aTarget, Form<?> aForm)
         {
-            AnnotationFeature feature = featureList.getModelObject();
-            Pair<String, String> measureHandle = measureDropDown.getModelObject();
+            var feature = featureList.getModelObject();
+            var measureHandle = measureDropDown.getModelObject();
 
             // Do not do any agreement if no feature or measure has been selected yet.
             if (feature == null || measureHandle == null) {
                 return;
             }
 
+            var traits = (DefaultAgreementTraits) agreementForm.traitsContainer.get(MID_TRAITS)
+                    .getDefaultModelObject();
+
             AgreementMeasureSupport ams = agreementRegistry
                     .getAgreementMeasureSupport(measureDropDown.getModelObject().getKey());
 
-            AgreementMeasure measure = ams.createMeasure(feature,
-                    (DefaultAgreementTraits) traitsContainer.get(MID_TRAITS)
-                            .getDefaultModelObject());
+            var measure = ams.createMeasure(feature, traits);
 
-            Map<String, List<CAS>> casMap = getCasMap();
+            var states = new ArrayList<AnnotationDocumentState>();
+            states.add(AnnotationDocumentState.FINISHED);
+            if (!traits.isLimitToFinishedDocuments()) {
+                states.add(AnnotationDocumentState.IN_PROGRESS);
+            }
 
-            if (casMap.values().stream().allMatch(list -> list == null || list.isEmpty())) {
+            var allAnnDocs = documentService.listAnnotationDocumentsInState(getProject(), //
+                    states.toArray(AnnotationDocumentState[]::new)).stream() //
+                    .collect(groupingBy(AnnotationDocument::getDocument));
+
+            if (allAnnDocs.isEmpty()) {
                 error("No documents with annotations were found.");
                 aTarget.addChildren(getPage(), IFeedback.class);
-            }
-            else {
-                Serializable result = measure.getAgreement(casMap);
-                resultsContainer.addOrReplace(ams.createResultsPanel(MID_RESULTS, Model.of(result),
-                        AgreementPage.this::getCasMap));
-                aTarget.add(resultsContainer);
+                return;
             }
 
+            var aAnnotators = projectService.listProjectUsersWithPermissions(getProject(),
+                    ANNOTATOR);
+
+            var task = CalculatePairwiseAgreementTask.builder() //
+                    .withSessionOwner(userRepository.getCurrentUser()) //
+                    .withProject(getProject()) //
+                    .withTrigger("Agreement page") //
+                    .withAnnotators(aAnnotators) //
+                    .withTraits(traits) //
+                    .withFeature(feature) //
+                    .withMeasure(measure) //
+                    .withDocuments(allAnnDocs) //
+                    .withScope(TaskScope.LAST_USER_SESSION) //
+                    // When running sync, we cannot cancel because the browser will still be in an
+                    // AJAX request when we try to fire a second one and that second one will fail
+                    // then. This would only work if the cancel action would be sent through
+                    // WebSocket
+                    .withCancellable(false).build();
+
+            schedulingService.executeSync(task);
+            actionRefreshResults(aTarget, task);
         }
 
         List<Pair<String, String>> listMeasures()
@@ -252,15 +311,15 @@ public class AgreementPage
             }
 
             return agreementRegistry.getAgreementMeasureSupports(getModelObject().feature).stream()
-                    .map(s -> Pair.of(s.getId(), s.getName())).collect(Collectors.toList());
+                    .map(s -> Pair.of(s.getId(), s.getName())) //
+                    .toList();
         }
 
         private List<AnnotationFeature> getEligibleFeatures()
         {
-            List<AnnotationFeature> features = annotationService
-                    .listAnnotationFeature(getProject());
-            List<AnnotationFeature> unusedFeatures = new ArrayList<>();
-            for (AnnotationFeature feature : features) {
+            var features = annotationService.listAnnotationFeature(getProject());
+            var unusedFeatures = new ArrayList<AnnotationFeature>();
+            for (var feature : features) {
                 if (feature.getLayer().getName().equals(Token.class.getName())
                         || feature.getLayer().getName().equals(WebAnnoConst.COREFERENCE_LAYER)) {
                     unusedFeatures.add(feature);
@@ -281,93 +340,79 @@ public class AgreementPage
         Pair<String, String> measure;
     }
 
-    // The CASes cannot be serialized, so we make them transient here. However, it does not matter
-    // as we do not access the field directly but via getCases() which will re-load them if
-    // necessary, e.g. if the transient field is empty after a session is restored from a
-    // persisted state.
-    private transient Map<String, List<CAS>> cachedCASes;
-    private transient Project cachedProject;
-    private transient boolean cachedLimitToFinishedDocuments;
+    // private final DropDownChoice<AgreementReportExportFormat> formatField;
 
-    public Map<String, List<CAS>> getCasMap()
-    {
-        if (agreementForm.featureList.getModelObject() == null) {
-            return Collections.emptyMap();
-        }
+    // add(formatField = new DropDownChoice<AgreementReportExportFormat>("exportFormat",
+    // Model.of(CSV), asList(AgreementReportExportFormat.values()),
+    // new EnumChoiceRenderer<>(this)));
+    // formatField.add(new LambdaAjaxFormComponentUpdatingBehavior("change"));
+    //
 
-        Project project = agreementForm.featureList.getModelObject().getProject();
-
-        DefaultAgreementTraits traits = (DefaultAgreementTraits) agreementForm.traitsContainer
-                .get(MID_TRAITS).getDefaultModelObject();
-
-        // Avoid reloading the CASes when switching features within the same project
-        if (cachedCASes != null && project.equals(cachedProject)
-                && cachedLimitToFinishedDocuments == traits.isLimitToFinishedDocuments()) {
-            return cachedCASes;
-        }
-
-        List<User> users = projectService.listProjectUsersWithPermissions(project, ANNOTATOR);
-
-        List<SourceDocument> sourceDocuments = documentService.listSourceDocuments(project);
-
-        cachedCASes = new LinkedHashMap<>();
-        for (User user : users) {
-            List<CAS> cases = new ArrayList<>();
-
-            // Bulk-fetch all source documents for which there is already an annotation document for
-            // the user which is faster then checking for their existence individually
-            List<SourceDocument> docsForUser = documentService
-                    .listAnnotationDocuments(project, user).stream()
-                    .map(AnnotationDocument::getDocument).distinct().collect(Collectors.toList());
-
-            nextDocument: for (SourceDocument document : sourceDocuments) {
-                CAS cas = null;
-
-                try {
-                    if (docsForUser.contains(document)) {
-                        AnnotationDocument annotationDocument = documentService
-                                .getAnnotationDocument(document, user);
-
-                        if (traits.isLimitToFinishedDocuments()
-                                && !annotationDocument.getState().equals(FINISHED)) {
-                            // Add a skip marker (null) for the current CAS to the CAS list - this
-                            // is necessary because we expect the CAS lists for all users to have
-                            // the same size
-                            cases.add(null);
-                            continue nextDocument;
-                        }
-                    }
-
-                    // Reads the user's annotation document or the initial source document -
-                    // depending on what is available
-                    cas = documentService.readAnnotationCas(document, user.getUsername(),
-                            AUTO_CAS_UPGRADE, SHARED_READ_ONLY_ACCESS);
-                }
-                catch (Exception e) {
-                    error("Unable to load data: " + ExceptionUtils.getRootCauseMessage(e));
-                    LOG.error("Unable to load data", e);
-                }
-
-                if (cas != null) {
-                    // Set the CAS name in the DocumentMetaData so that we can pick it
-                    // up in the Diff position for the purpose of debugging / transparency.
-                    FeatureStructure dmd = WebAnnoCasUtil.getDocumentMetadata(cas);
-                    FSUtil.setFeature(dmd, "documentId", document.getName());
-                    FSUtil.setFeature(dmd, "collectionId", document.getProject().getName());
-
-                }
-
-                // The next line can enter null values into the list if a user didn't work on this
-                // source document yet.
-                cases.add(cas);
-            }
-
-            cachedCASes.put(user.getUsername(), cases);
-        }
-
-        cachedProject = project;
-        cachedLimitToFinishedDocuments = traits.isLimitToFinishedDocuments();
-
-        return cachedCASes;
-    }
+    // private Behavior makeDownloadBehavior(final String aKey1, final String aKey2)
+    // {
+    // return new AjaxEventBehavior("click")
+    // {
+    // private static final long serialVersionUID = 1L;
+    //
+    // @Override
+    // protected void onEvent(AjaxRequestTarget aTarget)
+    // {
+    // var download = new AjaxDownloadBehavior(
+    // LoadableDetachableModel.of(PairwiseCodingAgreementTable.this::getFilename),
+    // LoadableDetachableModel.of(() -> getAgreementTableData(aKey1, aKey2)));
+    // getComponent().add(download);
+    // download.initiate(aTarget);
+    // }
+    // };
+    // }
+    //
+    // private AbstractResourceStream getAgreementTableData(final String aKey1, final String aKey2)
+    // {
+    // return new AbstractResourceStream()
+    // {
+    // private static final long serialVersionUID = 1L;
+    //
+    // @Override
+    // public InputStream getInputStream() throws ResourceStreamNotFoundException
+    // {
+    // try {
+    // var result = PairwiseCodingAgreementTable.this.getModelObject().getStudy(aKey1,
+    // aKey2);
+    //
+    // switch (formatField.getModelObject()) {
+    // case CSV:
+    // return AgreementUtils.generateCsvReport(result);
+    // case DEBUG:
+    // return generateDebugReport(result);
+    // default:
+    // throw new IllegalStateException(
+    // "Unknown export format [" + formatField.getModelObject() + "]");
+    // }
+    // }
+    // catch (Exception e) {
+    // // FIXME Is there some better error handling here?
+    // LOG.error("Unable to generate agreement report", e);
+    // throw new ResourceStreamNotFoundException(e);
+    // }
+    // }
+    //
+    // @Override
+    // public void close() throws IOException
+    // {
+    // // Nothing to do
+    // }
+    // };
+    // }
+    //
+    // private String getFilename()
+    // {
+    // return "agreement" + formatField.getModelObject().getExtension();
+    // }
+    //
+    // private InputStream generateDebugReport(FullCodingAgreementResult aResult)
+    // {
+    // var buf = new ByteArrayOutputStream();
+    // AgreementUtils.dumpAgreementStudy(new PrintStream(buf), aResult);
+    // return new ByteArrayInputStream(buf.toByteArray());
+    // }
 }

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/open/AnnotationDocumentOpenActionColumn.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/open/AnnotationDocumentOpenActionColumn.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.open;
 
+import static de.tudarmstadt.ukp.inception.support.lambda.HtmlElementEvents.CLICK;
 import static org.apache.wicket.event.Broadcast.BUBBLE;
 
 import org.apache.wicket.AttributeModifier;
@@ -58,7 +59,7 @@ public class AnnotationDocumentOpenActionColumn
         var fragment = new Fragment(aComponentId, FID_OPEN_DOCUMENT_COLUMN, fragmentProvider);
         fragment.queue(new Label("name", aRowModel.map(AnnotationDocument::getName)));
         aItem.add(AttributeModifier.replace("role", "button"));
-        aItem.add(AjaxEventBehavior.onEvent("click",
+        aItem.add(AjaxEventBehavior.onEvent(CLICK,
                 _target -> actionOpenDocument(_target, aItem, aRowModel.getObject())));
         aItem.add(fragment);
     }

--- a/inception/inception-ui-curation/pom.xml
+++ b/inception/inception-ui-curation/pom.xml
@@ -27,6 +27,10 @@
   <packaging>jar</packaging>
   <dependencies>
     <dependency>
+      <groupId>javax.persistence</groupId>
+      <artifactId>javax.persistence-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
@@ -237,11 +241,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>javax.persistence</groupId>
-      <artifactId>javax.persistence-api</artifactId>
     </dependency>
 
     <dependency>

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/AnnotatorsPanel.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/AnnotatorsPanel.java
@@ -17,7 +17,7 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.ui.curation.component;
 
-import static de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.doDiffSingle;
+import static de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.doDiff;
 import static de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.getDiffAdapters;
 import static de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.LinkCompareBehavior.LINK_ROLE_AS_LABEL;
 import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.CURATION_FINISHED;
@@ -68,8 +68,6 @@ import com.googlecode.wicket.jquery.ui.widget.menu.IMenuItem;
 import de.tudarmstadt.ukp.clarin.webanno.brat.schema.BratSchemaGenerator;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.Configuration;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.ConfigurationSet;
-import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.DiffResult;
-import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.api.DiffAdapter;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
@@ -457,9 +455,9 @@ public class AnnotatorsPanel
     private Map<String, Map<VID, AnnotationState>> calculateAnnotationStates(AnnotatorState aState,
             Map<String, CAS> aCasses)
     {
-        List<DiffAdapter> adapters = getDiffAdapters(schemaService, aState.getAnnotationLayers());
-        DiffResult diff = doDiffSingle(adapters, LINK_ROLE_AS_LABEL, aCasses,
-                aState.getWindowBeginOffset(), aState.getWindowEndOffset()).toResult();
+        var adapters = getDiffAdapters(schemaService, aState.getAnnotationLayers());
+        var diff = doDiff(adapters, LINK_ROLE_AS_LABEL, aCasses, aState.getWindowBeginOffset(),
+                aState.getWindowEndOffset()).toResult();
 
         var differingSets = diff.getDifferingConfigurationSetsWithExceptions(CURATION_USER)
                 .values();
@@ -467,12 +465,12 @@ public class AnnotatorsPanel
                 .values();
         differingSets.removeAll(incompleteSets);
 
-        List<ConfigurationSet> completeAgreementSets = new ArrayList<>();
+        var completeAgreementSets = new ArrayList<ConfigurationSet>();
         completeAgreementSets.addAll(diff.getConfigurationSets());
         completeAgreementSets.removeAll(differingSets);
         completeAgreementSets.removeAll(incompleteSets);
 
-        Map<String, Map<VID, AnnotationState>> annoStates = new HashMap<>();
+        var annoStates = new HashMap<String, Map<VID, AnnotationState>>();
         for (String casGroupId : aCasses.keySet()) {
             annoStates.put(casGroupId, new HashMap<>());
         }

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/CurationPage.html
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/CurationPage.html
@@ -106,7 +106,7 @@
               <span class="dropdown" aria-haspopup="true" aria-expanded="false">
                 <span class="btn-group" role="group">
                   <button class="btn btn-secondary btn-action" type="button">
-                    Legend
+                    <wicket:message key="legend"/>
                   </button>
                   <button class="btn btn-secondary btn-action dropdown-toggle flex-content border-start" type="button" data-bs-toggle="dropdown"></button>
                   <ul class="dropdown-menu shadow-lg" role="menu" style="min-width: 20em;">

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/CurationPage.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/CurationPage.java
@@ -20,7 +20,7 @@ package de.tudarmstadt.ukp.clarin.webanno.ui.curation.page;
 import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase.PAGE_PARAM_DOCUMENT;
 import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode.UNMANAGED_ACCESS;
 import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasUpgradeMode.FORCE_CAS_UPGRADE;
-import static de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.doDiffSingle;
+import static de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.doDiff;
 import static de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.getDiffAdapters;
 import static de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.LinkCompareBehavior.LINK_ROLE_AS_LABEL;
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.CURATOR;
@@ -726,7 +726,7 @@ public class CurationPage
                 LOG.debug("Processing differences: {} of {} units...", unitIndex, units.size());
             }
 
-            DiffResult diff = doDiffSingle(adapters, LINK_ROLE_AS_LABEL, casses, unit.getBegin(),
+            DiffResult diff = doDiff(adapters, LINK_ROLE_AS_LABEL, casses, unit.getBegin(),
                     unit.getEnd()).toResult();
 
             CurationUnit curationUnit = new CurationUnit(unit.getBegin(), unit.getEnd(), unitIndex);

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/render/CurationSidebarRenderer.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/render/CurationSidebarRenderer.java
@@ -17,7 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.ui.curation.sidebar.render;
 
-import static de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.doDiffSingle;
+import static de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.doDiff;
 import static de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.getDiffAdapters;
 import static de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.LinkCompareBehavior.LINK_ROLE_AS_LABEL;
 import static de.tudarmstadt.ukp.clarin.webanno.model.Mode.ANNOTATION;
@@ -159,7 +159,7 @@ public class CurationSidebarRenderer
 
         List<DiffAdapter> adapters = getDiffAdapters(annotationService,
                 aRequest.getVisibleLayers());
-        CasDiff casDiff = doDiffSingle(adapters, LINK_ROLE_AS_LABEL, casses,
+        CasDiff casDiff = doDiff(adapters, LINK_ROLE_AS_LABEL, casses,
                 aRequest.getWindowBeginOffset(), aRequest.getWindowEndOffset());
         DiffResult diff = casDiff.toResult();
 

--- a/inception/inception-ui-dashboard-activity/pom.xml
+++ b/inception/inception-ui-dashboard-activity/pom.xml
@@ -27,6 +27,11 @@
   <packaging>jar</packaging>
   <dependencies>
     <dependency>
+      <groupId>javax.persistence</groupId>
+      <artifactId>javax.persistence-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-documents-api</artifactId>
     </dependency>
@@ -125,11 +130,6 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-collections4</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>javax.persistence</groupId>
-      <artifactId>javax.persistence-api</artifactId>
     </dependency>
 
     <dependency>

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/AnnotationSearchStatePanel.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/AnnotationSearchStatePanel.java
@@ -79,7 +79,7 @@ public class AnnotationSearchStatePanel
 
     private void actionRebuildIndex(AjaxRequestTarget aTarget)
     {
-        searchService.enqueueReindexTask(getModel().getObject(), userService.getCurrentUsername(),
+        searchService.enqueueReindexTask(getModel().getObject(), userService.getCurrentUser(),
                 "Project settings");
         info("Starting index rebuild... this may take a while. You can work as usual but search "
                 + "results will only become available once the process is complete.");

--- a/inception/inception-ui-scheduling/pom.xml
+++ b/inception/inception-ui-scheduling/pom.xml
@@ -97,6 +97,11 @@
       <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-auth-roles</artifactId>
     </dependency>
+    
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/inception/inception-ui-scheduling/src/main/java/de/tudarmstadt/ukp/inception/ui/scheduling/TaskMonitorPanel.java
+++ b/inception/inception-ui-scheduling/src/main/java/de/tudarmstadt/ukp/inception/ui/scheduling/TaskMonitorPanel.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import javax.servlet.ServletContext;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.wicket.authorization.Action;
 import org.apache.wicket.authroles.authorization.strategies.role.annotations.AuthorizeAction;
 import org.apache.wicket.markup.html.WebMarkupContainer;
@@ -48,6 +49,7 @@ public class TaskMonitorPanel
 
     private boolean popupMode = true;
     private boolean keepRemovedTasks = false;
+    private String typePattern = "";
 
     public TaskMonitorPanel(String aId)
     {
@@ -67,6 +69,18 @@ public class TaskMonitorPanel
         return this;
     }
 
+    public TaskMonitorPanel setTypePattern(String aTypePattern)
+    {
+        if (StringUtils.isBlank(aTypePattern)) {
+            typePattern = "";
+        }
+        else {
+            typePattern = aTypePattern;
+        }
+
+        return this;
+    }
+
     @Override
     protected void onConfigure()
     {
@@ -76,6 +90,7 @@ public class TaskMonitorPanel
                 "csrfToken", getCsrfTokenFromSession(), //
                 "popupMode", popupMode, //
                 "keepRemovedTasks", keepRemovedTasks, //
+                "typePattern", typePattern, //
                 "endpointUrl", constructEndpointUrl(), //
                 "wsEndpointUrl", constructWsEndpointUrl(), //
                 "topicChannel", SchedulerWebsocketController.BASE_TOPIC)));

--- a/inception/inception-ui-scheduling/src/main/ts/src/MTaskStateUpdate.ts
+++ b/inception/inception-ui-scheduling/src/main/ts/src/MTaskStateUpdate.ts
@@ -21,10 +21,12 @@ import { RLogMessage } from './RLogMessage'
 export interface MTaskStateUpdate {
   timestamp: number
   id: string
+  type: string
   progress: number
   maxProgress: number
   state: 'NOT_STARTED' | 'RUNNING' | 'COMPLETED' | 'CANCELLED' | 'FAILED'
   title: string
   removed?: boolean
+  cancellable?: boolean
   latestMessage?: RLogMessage
 }

--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/event/DynamicWorkloadStateWatcher.java
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/event/DynamicWorkloadStateWatcher.java
@@ -48,7 +48,10 @@ public class DynamicWorkloadStateWatcher
 
     private void recalculateDocumentState(AnnotationDocument aAnnotationDocument)
     {
-        schedulingService.enqueue(new DynamicWorkloadUpdateDocumentStateTask(
-                aAnnotationDocument.getDocument(), getClass().getSimpleName()));
+        var task = DynamicWorkloadUpdateDocumentStateTask.builder() //
+                .withDocument(aAnnotationDocument.getDocument()) //
+                .withTrigger(getClass().getSimpleName()) //
+                .build();
+        schedulingService.enqueue(task);
     }
 }

--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/event/DynamicWorkloadUpdateDocumentStateTask.java
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/event/DynamicWorkloadUpdateDocumentStateTask.java
@@ -43,6 +43,8 @@ import de.tudarmstadt.ukp.inception.workload.model.WorkloadManager;
 public class DynamicWorkloadUpdateDocumentStateTask
     extends DebouncingTask
 {
+    public static final String TYPE = "DynamicWorkloadUpdateDocumentStateTask";
+
     private @PersistenceContext EntityManager entityManager;
     private @Autowired ProjectService projectService;
     private @Autowired DocumentService documentService;
@@ -51,16 +53,23 @@ public class DynamicWorkloadUpdateDocumentStateTask
 
     private final SourceDocument document;
 
-    public DynamicWorkloadUpdateDocumentStateTask(SourceDocument aDocument, String aTrigger)
+    public DynamicWorkloadUpdateDocumentStateTask(Builder<? extends Builder<?>> aBuilder)
     {
-        super(aDocument.getProject(), aTrigger, ofSeconds(2));
-        document = aDocument;
+        super(aBuilder //
+                .withProject(aBuilder.document.getProject()) //
+                .withType(TYPE));
+        document = aBuilder.document;
     }
 
     @Override
     public String getTitle()
     {
         return "Updating document states...";
+    }
+
+    public SourceDocument getDocument()
+    {
+        return document;
     }
 
     @Override
@@ -116,5 +125,33 @@ public class DynamicWorkloadUpdateDocumentStateTask
     public int hashCode()
     {
         return Objects.hash(document, getProject());
+    }
+
+    public static Builder<Builder<?>> builder()
+    {
+        return new Builder<>();
+    }
+
+    public static class Builder<T extends Builder<?>>
+        extends DebouncingTask.Builder<T>
+    {
+        private SourceDocument document;
+
+        protected Builder()
+        {
+            withDebounceMillis(ofSeconds(2));
+        }
+
+        @SuppressWarnings("unchecked")
+        public T withDocument(SourceDocument aDocument)
+        {
+            document = aDocument;
+            return (T) this;
+        }
+
+        public DynamicWorkloadUpdateDocumentStateTask build()
+        {
+            return new DynamicWorkloadUpdateDocumentStateTask(this);
+        }
     }
 }

--- a/inception/inception-workload-dynamic/src/test/java/de/tudarmstadt/ukp/inception/workload/dynamic/event/DynamicWorkloadUpdateDocumentStateTaskTest.java
+++ b/inception/inception-workload-dynamic/src/test/java/de/tudarmstadt/ukp/inception/workload/dynamic/event/DynamicWorkloadUpdateDocumentStateTaskTest.java
@@ -15,22 +15,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package de.tudarmstadt.ukp.clarin.webanno.agreement.results.unitizing;
+package de.tudarmstadt.ukp.inception.workload.dynamic.event;
 
-import java.util.List;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.dkpro.statistics.agreement.unitizing.IUnitizingAnnotationStudy;
+import org.junit.jupiter.api.Test;
 
-import de.tudarmstadt.ukp.clarin.webanno.agreement.AgreementResult;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 
-public class UnitizingAgreementResult
-    extends AgreementResult<IUnitizingAnnotationStudy>
+class DynamicWorkloadUpdateDocumentStateTaskTest
 {
-    private static final long serialVersionUID = 2092691057728349705L;
-
-    public UnitizingAgreementResult(String aType, String aFeature, IUnitizingAnnotationStudy aStudy,
-            List<String> aCasGroupIds, boolean aExcludeIncomplete)
+    @Test
+    void testBuilder()
     {
-        super(aType, aFeature, aStudy, aCasGroupIds, aExcludeIncomplete);
+        var project = Project.builder().withName("My Project").build();
+        var doc = SourceDocument.builder().withProject(project).withName("My Document").build();
+        var task = DynamicWorkloadUpdateDocumentStateTask.builder().withDocument(doc)
+                .withTrigger("Test").build();
+
+        assertThat(task.getProject()).isEqualTo(project);
+        assertThat(task.getDocument()).isEqualTo(doc);
     }
+
 }

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/event/MatrixWorkloadStateWatcher.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/event/MatrixWorkloadStateWatcher.java
@@ -44,14 +44,19 @@ public class MatrixWorkloadStateWatcher
     @EventListener
     public void onProjectPermissionsChangedEvent(ProjectPermissionsChangedEvent aEvent)
     {
-        schedulingService.enqueue(new RecalculateProjectStateTask(aEvent.getProject(),
-                "onProjectPermissionsChangedEvent"));
+        schedulingService.enqueue(RecalculateProjectStateTask.builder() //
+                .withProject(aEvent.getProject()) //
+                .withTrigger("onProjectPermissionsChangedEvent") //
+                .build());
     }
 
     @EventListener
     public void onAnnotationStateChangeEvent(AnnotationStateChangeEvent aEvent)
     {
-        schedulingService.enqueue(new MatrixWorkloadUpdateDocumentStateTask(aEvent.getDocument(),
-                getClass().getSimpleName()));
+        var task = MatrixWorkloadUpdateDocumentStateTask.builder() //
+                .withDocument(aEvent.getDocument()) //
+                .withTrigger(getClass().getSimpleName()) //
+                .build();
+        schedulingService.enqueue(task);
     }
 }

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/event/MatrixWorkloadUpdateDocumentStateTask.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/event/MatrixWorkloadUpdateDocumentStateTask.java
@@ -41,6 +41,8 @@ import de.tudarmstadt.ukp.inception.workload.model.WorkloadManagementService;
 public class MatrixWorkloadUpdateDocumentStateTask
     extends DebouncingTask
 {
+    public static final String TYPE = "MatrixWorkloadUpdateDocumentStateTask";
+
     private @PersistenceContext EntityManager entityManager;
     private @Autowired ProjectService projectService;
     private @Autowired DocumentService documentService;
@@ -49,10 +51,12 @@ public class MatrixWorkloadUpdateDocumentStateTask
 
     private final SourceDocument document;
 
-    public MatrixWorkloadUpdateDocumentStateTask(SourceDocument aDocument, String aTrigger)
+    public MatrixWorkloadUpdateDocumentStateTask(Builder<? extends Builder<?>> aBuilder)
     {
-        super(aDocument.getProject(), aTrigger, ofSeconds(2));
-        document = aDocument;
+        super(aBuilder //
+                .withProject(aBuilder.document.getProject()) //
+                .withType(TYPE));
+        document = aBuilder.document;
     }
 
     @Override
@@ -112,5 +116,33 @@ public class MatrixWorkloadUpdateDocumentStateTask
     public int hashCode()
     {
         return Objects.hash(document, getProject());
+    }
+
+    public static Builder<Builder<?>> builder()
+    {
+        return new Builder<>();
+    }
+
+    public static class Builder<T extends Builder<?>>
+        extends DebouncingTask.Builder<T>
+    {
+        private SourceDocument document;
+
+        protected Builder()
+        {
+            withDebounceMillis(ofSeconds(2));
+        }
+
+        @SuppressWarnings("unchecked")
+        public T withDocument(SourceDocument aDocument)
+        {
+            document = aDocument;
+            return (T) this;
+        }
+
+        public MatrixWorkloadUpdateDocumentStateTask build()
+        {
+            return new MatrixWorkloadUpdateDocumentStateTask(this);
+        }
     }
 }

--- a/inception/inception-workload/src/main/java/de/tudarmstadt/ukp/inception/workload/event/RecalculateProjectStateTask.java
+++ b/inception/inception-workload/src/main/java/de/tudarmstadt/ukp/inception/workload/event/RecalculateProjectStateTask.java
@@ -34,12 +34,14 @@ import de.tudarmstadt.ukp.inception.workload.model.WorkloadManagementService;
 public class RecalculateProjectStateTask
     extends DebouncingTask
 {
+    public static final String TYPE = "RecalculateProjectStateTask";
+
     private @Autowired ProjectService projectService;
     private @Autowired WorkloadManagementService workloadService;
 
-    public RecalculateProjectStateTask(Project aProject, String aTrigger)
+    public RecalculateProjectStateTask(Builder<? extends Builder<?>> aBuilder)
     {
-        super(aProject, aTrigger, ofSeconds(3));
+        super(aBuilder.withType(TYPE));
     }
 
     @Override
@@ -83,5 +85,24 @@ public class RecalculateProjectStateTask
     public int hashCode()
     {
         return Objects.hash(getProject());
+    }
+
+    public static Builder<Builder<?>> builder()
+    {
+        return new Builder<>();
+    }
+
+    public static class Builder<T extends Builder<?>>
+        extends DebouncingTask.Builder<T>
+    {
+        protected Builder()
+        {
+            withDebounceMillis(ofSeconds(3));
+        }
+
+        public RecalculateProjectStateTask build()
+        {
+            return new RecalculateProjectStateTask(this);
+        }
     }
 }

--- a/inception/inception-workload/src/main/java/de/tudarmstadt/ukp/inception/workload/model/WorkloadManagementServiceImpl.java
+++ b/inception/inception-workload/src/main/java/de/tudarmstadt/ukp/inception/workload/model/WorkloadManagementServiceImpl.java
@@ -131,8 +131,10 @@ public class WorkloadManagementServiceImpl
                 .setParameter("projectID", aManager.getProject()) //
                 .executeUpdate();
 
-        schedulingService.enqueue(new RecalculateProjectStateTask(aManager.getProject(),
-                "Workload configuration changed"));
+        schedulingService.enqueue(RecalculateProjectStateTask.builder() //
+                .withProject(aManager.getProject()) //
+                .withTrigger("Workload configuration changed") //
+                .build());
     }
 
     /**


### PR DESCRIPTION
**What's in the PR**
- Turn agreement calculation into a synchronously running background task so we can see progress in the task monitor
- Add cleanup task to scheduler to remove stopped tasks when sessions end
- Switch tasks to using builder pattern
- Major refactoring of agreement measures and CasDiff

**How to test manually**
* Try running agreement on a larger project

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
