### PR TITLE
#4436 - Change default dynamic workload annotator number to uneven

### DIFF
--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/trait/DynamicWorkloadTraits.java
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/trait/DynamicWorkloadTraits.java
@@ -47,7 +47,7 @@ public class DynamicWorkloadTraits
     public DynamicWorkloadTraits()
     {
         workflowType = DefaultWorkflowExtension.DEFAULT_WORKFLOW;
-        defaultNumberOfAnnotations = 6;
+        defaultNumberOfAnnotations = 3;
     }
 
     public DynamicWorkloadTraits(String aWorkflowType, int aDefaultNumberOfAnnotations)


### PR DESCRIPTION
**What's in the PR**
- Changed the default number of annotators in dynamic workload to 3

**How to test manually**
* Create new project with dynamic workload and check number of annotators on workload management page

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
