### PR TITLE
#4379 - Suppress or mark concepts in the search that are marked as owl:deprecated

### DIFF
--- a/inception/inception-concept-linking/src/test/java/de/tudarmstadt/ukp/inception/conceptlinking/util/TestFixtures.java
+++ b/inception/inception-concept-linking/src/test/java/de/tudarmstadt/ukp/inception/conceptlinking/util/TestFixtures.java
@@ -19,6 +19,7 @@ package de.tudarmstadt.ukp.inception.conceptlinking.util;
 
 import java.util.ArrayList;
 
+import org.eclipse.rdf4j.model.vocabulary.OWL;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
@@ -61,6 +62,7 @@ public class TestFixtures
         kb.setPropertyLabelIri(RDFS.LABEL.stringValue());
         kb.setPropertyDescriptionIri(RDFS.COMMENT.stringValue());
         kb.setSubPropertyIri(RDFS.SUBPROPERTYOF.stringValue());
+        kb.setDeprecationPropertyIri(OWL.DEPRECATED.stringValue());
         kb.setRootConcepts(new ArrayList<>());
         kb.setReification(reification);
         kb.setMaxResults(1000);

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/IriConstants.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/IriConstants.java
@@ -98,6 +98,7 @@ public class IriConstants
     public static final List<IRI> PROPERTY_TYPE_IRIS;
     public static final List<IRI> PROPERTY_LABEL_IRIS;
     public static final List<IRI> PROPERTY_DESCRIPTION_IRIS;
+    public static final List<IRI> DEPRECATION_PROPERTY_IRIS;
     public static final List<IRI> FTS_IRIS;
 
     static {
@@ -126,6 +127,7 @@ public class IriConstants
         PROPERTY_TYPE_IRIS = asList(RDF.PROPERTY, WIKIDATA_PROPERTY_TYPE);
         PROPERTY_LABEL_IRIS = asList(RDFS.LABEL, SKOS.PREF_LABEL);
         PROPERTY_DESCRIPTION_IRIS = asList(RDFS.COMMENT, SCHEMA_DESCRIPTION);
+        DEPRECATION_PROPERTY_IRIS = asList(OWL.DEPRECATED);
         FTS_IRIS = asList(FTS_FUSEKI, FTS_VIRTUOSO, FTS_WIKIDATA, FTS_LUCENE, FTS_STARDOG);
     }
 

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
@@ -66,7 +66,6 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.lucene.index.IndexFormatTooNewException;
 import org.eclipse.rdf4j.common.transaction.IsolationLevels;
 import org.eclipse.rdf4j.model.Statement;
-import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.eclipse.rdf4j.query.QueryEvaluationException;
@@ -339,7 +338,7 @@ public class KnowledgeBaseServiceImpl
             var readOnly = aKB.isReadOnly();
             aKB.setReadOnly(false);
             try {
-                ValueFactory vf = SimpleValueFactory.getInstance();
+                var vf = SimpleValueFactory.getInstance();
 
                 createBaseProperty(aKB, new KBProperty(aKB.getSubclassIri(),
                         vf.createIRI(aKB.getSubclassIri()).getLocalName()));

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/SchemaProfile.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/SchemaProfile.java
@@ -26,26 +26,25 @@ import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.model.vocabulary.SKOS;
 
 import de.tudarmstadt.ukp.inception.kb.model.KnowledgeBase;
-import de.tudarmstadt.ukp.inception.kb.yaml.KnowledgeBaseMapping;
 import de.tudarmstadt.ukp.inception.kb.yaml.KnowledgeBaseProfile;
 
 public enum SchemaProfile
 {
     RDFSCHEMA("RDF", RDFS.CLASS, RDFS.SUBCLASSOF, RDF.TYPE, RDFS.SUBPROPERTYOF, RDFS.COMMENT,
-            RDFS.LABEL, RDF.PROPERTY, RDFS.LABEL, RDFS.COMMENT),
+            RDFS.LABEL, RDF.PROPERTY, RDFS.LABEL, RDFS.COMMENT, OWL.DEPRECATED),
 
     WIKIDATASCHEMA("WIKIDATA", IriConstants.WIKIDATA_CLASS, IriConstants.WIKIDATA_SUBCLASS,
             IriConstants.WIKIDATA_TYPE, RDFS.SUBPROPERTYOF, RDFS.COMMENT, RDFS.LABEL,
-            IriConstants.WIKIDATA_PROPERTY_TYPE, RDFS.LABEL, RDFS.COMMENT),
+            IriConstants.WIKIDATA_PROPERTY_TYPE, RDFS.LABEL, RDFS.COMMENT, OWL.DEPRECATED),
 
     OWLSCHEMA("OWL", OWL.CLASS, RDFS.SUBCLASSOF, RDF.TYPE, RDFS.SUBPROPERTYOF, RDFS.COMMENT,
-            RDFS.LABEL, RDF.PROPERTY, RDFS.LABEL, RDFS.COMMENT),
+            RDFS.LABEL, RDF.PROPERTY, RDFS.LABEL, RDFS.COMMENT, OWL.DEPRECATED),
 
     SKOSSCHEMA("SKOS", SKOS.CONCEPT, SKOS.BROADER, RDF.TYPE, RDFS.SUBPROPERTYOF, RDFS.COMMENT,
-            SKOS.PREF_LABEL, RDF.PROPERTY, SKOS.PREF_LABEL, RDFS.COMMENT),
+            SKOS.PREF_LABEL, RDF.PROPERTY, SKOS.PREF_LABEL, RDFS.COMMENT, OWL.DEPRECATED),
 
     CUSTOMSCHEMA("CUSTOM", RDFS.CLASS, RDFS.SUBCLASSOF, RDF.TYPE, RDFS.SUBPROPERTYOF, RDFS.COMMENT,
-            RDFS.LABEL, RDF.PROPERTY, RDFS.LABEL, RDFS.COMMENT);
+            RDFS.LABEL, RDF.PROPERTY, RDFS.LABEL, RDFS.COMMENT, OWL.DEPRECATED);
 
     private final String uiLabel;
     private final String classIri;
@@ -57,10 +56,11 @@ public enum SchemaProfile
     private final String propertyTypeIri;
     private final String propertyLabelIri;
     private final String propertyDescriptionIri;
+    private final String deprecationPropertyIri;
 
     private SchemaProfile(String aUiLabel, IRI aClassIri, IRI aSubclassIri, IRI aTypeIri,
             IRI aSubPropertyIri, IRI aDescriptionIri, IRI aLabelIri, IRI aPropertyTypeIri,
-            IRI aPropertyLabelIri, IRI aPropertyDescriptionIri)
+            IRI aPropertyLabelIri, IRI aPropertyDescriptionIri, IRI aDeprecationPropertyIri)
     {
         uiLabel = aUiLabel;
         classIri = aClassIri.stringValue();
@@ -72,11 +72,13 @@ public enum SchemaProfile
         propertyTypeIri = aPropertyTypeIri.stringValue();
         propertyLabelIri = aPropertyLabelIri.stringValue();
         propertyDescriptionIri = aPropertyDescriptionIri.stringValue();
+        deprecationPropertyIri = aDeprecationPropertyIri.stringValue();
     }
 
     private SchemaProfile(String aUiLabel, String aClassIri, String aSubclassIri, String aTypeIri,
             String aSubPropertyIri, String aDescriptionIri, String aLabelIri,
-            String aPropertyTypeIri, String aPropertyLabelIri, String aPropertyDescriptionIri)
+            String aPropertyTypeIri, String aPropertyLabelIri, String aPropertyDescriptionIri,
+            String aDeprecationPropertyIri)
     {
         uiLabel = aUiLabel;
         classIri = aClassIri;
@@ -88,6 +90,7 @@ public enum SchemaProfile
         propertyTypeIri = aPropertyTypeIri;
         propertyLabelIri = aPropertyLabelIri;
         propertyDescriptionIri = aPropertyDescriptionIri;
+        deprecationPropertyIri = aDeprecationPropertyIri;
     }
 
     public String getUiLabel()
@@ -140,6 +143,11 @@ public enum SchemaProfile
         return propertyDescriptionIri;
     }
 
+    public String getDeprecationPropertyIri()
+    {
+        return deprecationPropertyIri;
+    }
+
     /**
      * Check if the given profile equals one of the schema profiles defined in {@link SchemaProfile}
      * 
@@ -149,14 +157,15 @@ public enum SchemaProfile
     @SuppressWarnings("javadoc")
     public static SchemaProfile checkSchemaProfile(KnowledgeBaseProfile aProfile)
     {
-        SchemaProfile[] profiles = SchemaProfile.values();
-        KnowledgeBaseMapping mapping = aProfile.getMapping();
-        for (int i = 0; i < profiles.length; i++) {
+        var profiles = SchemaProfile.values();
+        var mapping = aProfile.getMapping();
+        for (var i = 0; i < profiles.length; i++) {
             // Check if kb profile corresponds to a known schema profile
             if (equalsSchemaProfile(profiles[i], mapping.getClassIri(), mapping.getSubclassIri(),
                     mapping.getTypeIri(), mapping.getSubPropertyIri(), mapping.getDescriptionIri(),
                     mapping.getLabelIri(), mapping.getPropertyTypeIri(),
-                    mapping.getPropertyLabelIri(), mapping.getPropertyDescriptionIri())) {
+                    mapping.getPropertyLabelIri(), mapping.getPropertyDescriptionIri(),
+                    mapping.getDeprecationPropertyIri())) {
                 return profiles[i];
             }
         }
@@ -174,13 +183,13 @@ public enum SchemaProfile
     @SuppressWarnings("javadoc")
     public static SchemaProfile checkSchemaProfile(KnowledgeBase aKb)
     {
-        SchemaProfile[] profiles = SchemaProfile.values();
-        for (int i = 0; i < profiles.length; i++) {
+        var profiles = SchemaProfile.values();
+        for (var i = 0; i < profiles.length; i++) {
             // Check if kb has a known schema profile
             if (equalsSchemaProfile(profiles[i], aKb.getClassIri(), aKb.getSubclassIri(),
                     aKb.getTypeIri(), aKb.getSubPropertyIri(), aKb.getDescriptionIri(),
                     aKb.getLabelIri(), aKb.getPropertyTypeIri(), aKb.getPropertyLabelIri(),
-                    aKb.getPropertyDescriptionIri())) {
+                    aKb.getPropertyDescriptionIri(), aKb.getDeprecationPropertyIri())) {
                 return profiles[i];
             }
         }
@@ -195,7 +204,7 @@ public enum SchemaProfile
     private static boolean equalsSchemaProfile(SchemaProfile profile, String classIri,
             String subclassIri, String typeIri, String subPropertyIri, String descriptionIri,
             String labelIri, String propertyTypeIri, String propertyLabelIri,
-            String propertyDescriptionIri)
+            String propertyDescriptionIri, String deprecationPropertyIri)
     {
         return Objects.equals(profile.getClassIri(), classIri)
                 && Objects.equals(profile.getSubclassIri(), subclassIri)
@@ -205,6 +214,7 @@ public enum SchemaProfile
                 && Objects.equals(profile.getLabelIri(), labelIri)
                 && Objects.equals(profile.getPropertyTypeIri(), propertyTypeIri)
                 && Objects.equals(profile.getPropertyLabelIri(), propertyLabelIri)
-                && Objects.equals(profile.getPropertyDescriptionIri(), propertyDescriptionIri);
+                && Objects.equals(profile.getPropertyDescriptionIri(), propertyDescriptionIri)
+                && Objects.equals(profile.getDeprecationPropertyIri(), deprecationPropertyIri);
     }
 }

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/exporter/ExportedKnowledgeBase.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/exporter/ExportedKnowledgeBase.java
@@ -60,6 +60,9 @@ public class ExportedKnowledgeBase
     @JsonProperty("property_description_iri")
     private String propertyDescriptionIri;
 
+    @JsonProperty("deprecation_property_iri")
+    private String deprecationPropertyIri;
+
     @JsonProperty("full_text_search_iri")
     private String fullTextSearchIri;
 
@@ -227,6 +230,16 @@ public class ExportedKnowledgeBase
     public void setFullTextSearchIri(String aFullTextSearchIri)
     {
         fullTextSearchIri = aFullTextSearchIri;
+    }
+
+    public String getDeprecationPropertyIri()
+    {
+        return deprecationPropertyIri;
+    }
+
+    public void setDeprecationPropertyIri(String aDeprecationPropertyIri)
+    {
+        deprecationPropertyIri = aDeprecationPropertyIri;
     }
 
     public boolean isReadOnly()

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/exporter/KnowledgeBaseExporter.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/exporter/KnowledgeBaseExporter.java
@@ -125,6 +125,7 @@ public class KnowledgeBaseExporter
             exportedKB.setPropertyTypeIri(kb.getPropertyTypeIri());
             exportedKB.setPropertyLabelIri(kb.getPropertyLabelIri());
             exportedKB.setPropertyDescriptionIri(kb.getPropertyDescriptionIri());
+            exportedKB.setDeprecationPropertyIri(kb.getDeprecationPropertyIri());
             exportedKB.setFullTextSearchIri(kb.getFullTextSearchIri());
             exportedKB.setReadOnly(kb.isReadOnly());
             exportedKB.setUseFuzzy(kb.isUseFuzzy());
@@ -181,11 +182,10 @@ public class KnowledgeBaseExporter
             ExportedProject aExProject, ZipFile aZip)
         throws Exception
     {
-        ExportedKnowledgeBase[] knowledgeBases = aExProject.getArrayProperty(KEY,
-                ExportedKnowledgeBase.class);
+        var knowledgeBases = aExProject.getArrayProperty(KEY, ExportedKnowledgeBase.class);
 
-        for (ExportedKnowledgeBase exportedKB : knowledgeBases) {
-            KnowledgeBase kb = new KnowledgeBase();
+        for (var exportedKB : knowledgeBases) {
+            var kb = new KnowledgeBase();
             kb.setName(exportedKB.getName());
             kb.setType(RepositoryType.valueOf(exportedKB.getType()));
             // set default value for IRIs if no value is present in
@@ -217,15 +217,18 @@ public class KnowledgeBaseExporter
             kb.setSubPropertyIri(exportedKB.getSubPropertyIri() != null //
                     ? exportedKB.getSubPropertyIri() //
                     : DEFAULTPROFILE.getSubPropertyIri());
+            kb.setDeprecationPropertyIri(exportedKB.getDeprecationPropertyIri() != null //
+                    ? exportedKB.getDeprecationPropertyIri() //
+                    : DEFAULTPROFILE.getDeprecationPropertyIri());
+
             // The imported project may date from a time where we did not yet have the FTS IRI.
             // In that case we use concept linking support as an indicator that we dealt with a
             // remote Virtuoso.
             if (exportedKB.isSupportConceptLinking() && exportedKB.getFullTextSearchIri() == null) {
                 kb.setFullTextSearchIri(IriConstants.FTS_VIRTUOSO.stringValue());
             }
-            kb.setFullTextSearchIri(
-                    exportedKB.getFullTextSearchIri() != null ? exportedKB.getFullTextSearchIri() //
-                            : null);
+            kb.setFullTextSearchIri(exportedKB.getFullTextSearchIri() != null ? //
+                    exportedKB.getFullTextSearchIri() : null);
 
             kb.setEnabled(exportedKB.isEnabled());
             kb.setUseFuzzy(exportedKB.isUseFuzzy());

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/KBHandle.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/KBHandle.java
@@ -21,6 +21,7 @@ import static java.util.Collections.emptySet;
 import static org.apache.commons.lang3.builder.ToStringStyle.SHORT_PREFIX_STYLE;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -44,6 +45,7 @@ public class KBHandle
     private String description;
     private KnowledgeBase kb;
     private String language;
+    private boolean deprecated;
 
     private int rank;
     private double score;
@@ -55,6 +57,23 @@ public class KBHandle
 
     @Deprecated
     private String range;
+
+    private KBHandle(Builder builder)
+    {
+        identifier = builder.identifier;
+        name = builder.name;
+        queryBestMatchTerm = builder.queryBestMatchTerm;
+        matchTerms = builder.matchTerms;
+        description = builder.description;
+        kb = builder.kb;
+        language = builder.language;
+        deprecated = builder.deprecated;
+        rank = builder.rank;
+        score = builder.score;
+        debugInfo = builder.debugInfo;
+        domain = builder.domain;
+        range = builder.range;
+    }
 
     public KBHandle()
     {
@@ -96,6 +115,16 @@ public class KBHandle
         language = aLanguage;
         domain = aDomain;
         range = aRange;
+    }
+
+    public void setDeprecated(boolean aDeprecated)
+    {
+        deprecated = aDeprecated;
+    }
+
+    public boolean isDeprecated()
+    {
+        return deprecated;
     }
 
     @Deprecated
@@ -338,6 +367,120 @@ public class KBHandle
         if (score != 0.0) {
             builder.append("score", score);
         }
+        if (deprecated) {
+            builder.append("deprecated", deprecated);
+        }
         return builder.toString();
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static final class Builder
+    {
+        private String identifier;
+        private String name;
+        private String queryBestMatchTerm;
+        private Set<Pair<String, String>> matchTerms = Collections.emptySet();
+        private String description;
+        private KnowledgeBase kb;
+        private String language;
+        private boolean deprecated;
+        private int rank;
+        private double score;
+        private String debugInfo;
+        private String domain;
+        private String range;
+
+        private Builder()
+        {
+        }
+
+        public Builder withIdentifier(String aIdentifier)
+        {
+            identifier = aIdentifier;
+            return this;
+        }
+
+        public Builder withName(String aName)
+        {
+            name = aName;
+            return this;
+        }
+
+        public Builder withQueryBestMatchTerm(String aQueryBestMatchTerm)
+        {
+            queryBestMatchTerm = aQueryBestMatchTerm;
+            return this;
+        }
+
+        public Builder withMatchTerms(Set<Pair<String, String>> aMatchTerms)
+        {
+            matchTerms = aMatchTerms;
+            return this;
+        }
+
+        public Builder withDescription(String aDescription)
+        {
+            description = aDescription;
+            return this;
+        }
+
+        public Builder withKb(KnowledgeBase aKb)
+        {
+            this.kb = aKb;
+            return this;
+        }
+
+        public Builder withLanguage(String aLanguage)
+        {
+            language = aLanguage;
+            return this;
+        }
+
+        public Builder withDeprecated(boolean aDeprecated)
+        {
+            deprecated = aDeprecated;
+            return this;
+        }
+
+        public Builder withRank(int aRank)
+        {
+            rank = aRank;
+            return this;
+        }
+
+        public Builder withScore(double aScore)
+        {
+            score = aScore;
+            return this;
+        }
+
+        public Builder withDebugInfo(String aDebugInfo)
+        {
+            debugInfo = aDebugInfo;
+            return this;
+        }
+
+        @Deprecated
+        public Builder withDomain(String aDomain)
+        {
+            domain = aDomain;
+            return this;
+        }
+
+        @Deprecated
+        public Builder withRange(String aRange)
+        {
+            range = aRange;
+            return this;
+        }
+
+        public KBHandle build()
+        {
+            return new KBHandle(this);
+        }
     }
 }

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/KBObject.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/KBObject.java
@@ -26,9 +26,7 @@ import java.io.Serializable;
 import de.tudarmstadt.ukp.inception.kb.model.KnowledgeBase;
 
 /**
- * A {@code KnowledgeGraphItem} represents any element (entity, type, relation, etc.) in the
- * knowledge graph. {@code KnowledgeGraphItem}s can be identified by a {@code String} identifier.
- * {@code KnowledgeGraphItem}s feature a label, a human-readable {@code String}.
+ * Represents any element (class, instance, property, etc.) in the knowledge base.
  */
 public interface KBObject
     extends Serializable

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/model/KnowledgeBase.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/model/KnowledgeBase.java
@@ -151,6 +151,12 @@ public class KnowledgeBase
     private String propertyDescriptionIri;
 
     /**
+     * The IRI for a property marking a resources as deprecated
+     */
+    @Column(nullable = false)
+    private String deprecationPropertyIri;
+
+    /**
      * The IRI of the default dataset
      */
     @Column(nullable = true)
@@ -363,6 +369,16 @@ public class KnowledgeBase
         return propertyDescriptionIri;
     }
 
+    public void setDeprecationPropertyIri(String aDeprecationPropertyIri)
+    {
+        deprecationPropertyIri = aDeprecationPropertyIri;
+    }
+
+    public String getDeprecationPropertyIri()
+    {
+        return deprecationPropertyIri;
+    }
+
     public boolean isReadOnly()
     {
         return readOnly;
@@ -448,6 +464,7 @@ public class KnowledgeBase
         setPropertyTypeIri(aMapping.getPropertyTypeIri());
         setPropertyLabelIri(aMapping.getPropertyLabelIri());
         setPropertyDescriptionIri(aMapping.getPropertyDescriptionIri());
+        setDeprecationPropertyIri(aMapping.getDeprecationPropertyIri());
     }
 
     public void applyRootConcepts(KnowledgeBaseProfile aProfile)

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryOptionalElements.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryOptionalElements.java
@@ -36,6 +36,8 @@ public interface SPARQLQueryOptionalElements
 
     SPARQLQueryOptionalElements retrieveDomainAndRange();
 
+    SPARQLQueryOptionalElements retrieveDeprecation();
+
     SPARQLQueryOptionalElements limit(int aLimit);
 
     SPARQLQueryOptionalElements caseSensitive();

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/yaml/KnowledgeBaseMapping.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/yaml/KnowledgeBaseMapping.java
@@ -55,6 +55,9 @@ public class KnowledgeBaseMapping
     @JsonProperty("property-description")
     private String propertyDescriptionIri;
 
+    @JsonProperty("deprecation-property")
+    private String deprecationPropertyIri;
+
     @JsonCreator
     public KnowledgeBaseMapping(@JsonProperty("class") String aClassIri,
             @JsonProperty("subclass-of") String aSubclassIri,
@@ -64,7 +67,8 @@ public class KnowledgeBaseMapping
             @JsonProperty("label") String aLabelIri,
             @JsonProperty("property-type") String aPropertyTypeIri,
             @JsonProperty("property-label") String aPropertyLabelIri,
-            @JsonProperty("property-description") String aPropertyDescriptionIri)
+            @JsonProperty("property-description") String aPropertyDescriptionIri,
+            @JsonProperty("deprecation-property") String aDeprecationPropertyIri)
 
     {
         classIri = aClassIri;
@@ -76,6 +80,7 @@ public class KnowledgeBaseMapping
         propertyTypeIri = aPropertyTypeIri;
         propertyLabelIri = aPropertyLabelIri;
         propertyDescriptionIri = aPropertyDescriptionIri;
+        deprecationPropertyIri = aDeprecationPropertyIri;
     }
 
     public KnowledgeBaseMapping()
@@ -171,5 +176,15 @@ public class KnowledgeBaseMapping
     public void setPropertyDescriptionIri(String aPropertyDescriptionIri)
     {
         propertyDescriptionIri = aPropertyDescriptionIri;
+    }
+
+    public void setDeprecationPropertyIri(String aDeprecationPropertyIri)
+    {
+        deprecationPropertyIri = aDeprecationPropertyIri;
+    }
+
+    public String getDeprecationPropertyIri()
+    {
+        return deprecationPropertyIri;
     }
 }

--- a/inception/inception-kb/src/main/resources/de/tudarmstadt/ukp/inception/kb/model/db-changelog.xml
+++ b/inception/inception-kb/src/main/resources/de/tudarmstadt/ukp/inception/kb/model/db-changelog.xml
@@ -474,4 +474,20 @@
       </column>
     </addColumn>
   </changeSet>
+
+  <changeSet author="INCEpTION Team" id="20240128-1">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="knowledgebase" columnName="deprecationPropertyIri"/>
+      </not>
+    </preConditions>
+
+    <addColumn tableName="knowledgebase">
+      <column name="deprecationPropertyIri"
+              type="VARCHAR(255)"
+              defaultValue="http://www.w3.org/2002/07/owl#deprecated">
+        <constraints nullable="false" />
+      </column>
+    </addColumn>
+  </changeSet>
 </databaseChangeLog>

--- a/inception/inception-kb/src/main/resources/de/tudarmstadt/ukp/inception/kb/yaml/knowledgebase-profiles.yaml
+++ b/inception/inception-kb/src/main/resources/de/tudarmstadt/ukp/inception/kb/yaml/knowledgebase-profiles.yaml
@@ -37,6 +37,7 @@ babel_net:
     property-label: http://www.w3.org/2000/01/rdf-schema#label
     property-description: http://www.w3.org/2000/01/rdf-schema#comment
     subproperty-of: http://www.w3.org/2000/01/rdf-schema#subPropertyOf
+    deprecation-property: http://www.w3.org/2002/07/owl#deprecated
   info:
     description: |
       BabelNet is a multilingual lexicalized semantic network and ontology that was automatically 
@@ -63,6 +64,7 @@ db_pedia:
     property-label: http://www.w3.org/2000/01/rdf-schema#label
     property-description: http://www.w3.org/2000/01/rdf-schema#comment
     subproperty-of: http://www.w3.org/2000/01/rdf-schema#subPropertyOf
+    deprecation-property: http://www.w3.org/2002/07/owl#deprecated
   info:
     description: |
       DBpedia is a crowd-sourced community effort to extract structured content from the information 
@@ -91,6 +93,7 @@ wikidata:
     property-label: http://www.w3.org/2000/01/rdf-schema#label
     property-description: http://www.w3.org/2000/01/rdf-schema#comment
     subproperty-of: http://www.wikidata.org/prop/direct/P1647
+    deprecation-property: http://www.w3.org/2002/07/owl#deprecated
   info:
     description: |
       Wikidata is a free and open knowledge base and acts as central storage for the structured data
@@ -120,6 +123,7 @@ yago:
     property-label: http://www.w3.org/2000/01/rdf-schema#label
     property-description: http://www.w3.org/2000/01/rdf-schema#comment
     subproperty-of: http://www.w3.org/2000/01/rdf-schema#subPropertyOf
+    deprecation-property: http://www.w3.org/2002/07/owl#deprecated
   info:
     description: YAGO is a semantic knowledge base, derived from Wikipedia WordNet and GeoNames.
     host-institution-name: Max-Planck-Institute Saarbrücken
@@ -146,6 +150,7 @@ zbw-stw-economics:
     property-label: http://www.w3.org/2004/02/skos/core#prefLabel
     property-description: http://www.w3.org/2000/01/rdf-schema#comment
     subproperty-of: http://www.w3.org/2000/01/rdf-schema#subPropertyOf
+    deprecation-property: http://www.w3.org/2002/07/owl#deprecated
   info:
     description: |
       Thesaurus that provides vocabulary on any economic subject. Almost 6,000 standardized subject
@@ -172,6 +177,7 @@ zbw-gnd:
     property-label: http://www.w3.org/2000/01/rdf-schema#label
     property-description: http://www.w3.org/2000/01/rdf-schema#comment
     subproperty-of: http://www.w3.org/2000/01/rdf-schema#subPropertyOf
+    deprecation-property: http://www.w3.org/2002/07/owl#deprecated
   info:
     description: |
       Mapping Integrated Authority File (GND).The Integrated Authority File (GND) is a controlled 
@@ -200,6 +206,7 @@ agrovoc:
     subproperty-of: http://www.w3.org/2000/01/rdf-schema#subPropertyOf
     property-label: http://www.w3.org/2004/02/skos/core#prefLabel
     property-description: http://www.w3.org/2000/01/rdf-schema#comment
+    deprecation-property: http://www.w3.org/2002/07/owl#deprecated
   additional-matching-properties:
     - http://www.w3.org/2004/02/skos/core#altLabel
   info:
@@ -250,6 +257,7 @@ wine_ontology:
     property-label: http://www.w3.org/2000/01/rdf-schema#label
     property-description: http://www.w3.org/2000/01/rdf-schema#comment
     subproperty-of: http://www.w3.org/2000/01/rdf-schema#subPropertyOf
+    deprecation-property: http://www.w3.org/2002/07/owl#deprecated
   info:
     description: |
       An example OWL ontology. Derived from the DAML Wine ontology at 
@@ -276,6 +284,7 @@ olia_penn.owl:
     property-label: http://www.w3.org/2000/01/rdf-schema#label
     property-description: http://www.w3.org/2000/01/rdf-schema#comment
     subproperty-of: http://www.w3.org/2000/01/rdf-schema#subPropertyOf
+    deprecation-property: http://www.w3.org/2002/07/owl#deprecated
   info:
     description: |
       Ontologies of Linguistic Annotation (OLiA)
@@ -301,6 +310,7 @@ iao:
     property-label: http://www.w3.org/2000/01/rdf-schema#label
     property-description: http://www.w3.org/2000/01/rdf-schema#comment
     subproperty-of: http://www.w3.org/2000/01/rdf-schema#subPropertyOf
+    deprecation-property: http://www.w3.org/2002/07/owl#deprecated
   info:
     description: |
       The Information Artifact Ontology (IAO) is a new ontology of information entities, originally driven by work by 
@@ -309,7 +319,7 @@ iao:
       For more information, please refer to the project's website.
     website-url: https://github.com/information-artifact-ontology/IAO/
     
-hpo-2024-01-16:
+hpo:
   name: Human Phenotype Ontology (v2024-01-16)
   type: LOCAL
   default-language: en
@@ -327,6 +337,7 @@ hpo-2024-01-16:
     subproperty-of: http://www.w3.org/2000/01/rdf-schema#subPropertyOf
     property-label: http://www.w3.org/2000/01/rdf-schema#label
     property-description: http://www.w3.org/2000/01/rdf-schema#comment
+    deprecation-property: http://www.w3.org/2002/07/owl#deprecated
   additional-matching-properties:
     - http://www.geneontology.org/formats/oboInOwl#hasExactSynonym
   info:
@@ -358,6 +369,7 @@ snomed-ct:
     subproperty-of: http://www.w3.org/2000/01/rdf-schema#subPropertyOf
     property-label: http://www.w3.org/2000/01/rdf-schema#label
     property-description: http://www.w3.org/2000/01/rdf-schema#comment
+    deprecation-property: http://www.w3.org/2002/07/owl#deprecated
   root-concepts:
     - http://snomed.info/id/138875005
   additional-matching-properties:

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseExporterTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseExporterTest.java
@@ -31,7 +31,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.zip.ZipFile;
@@ -104,24 +103,22 @@ public class KnowledgeBaseExporterTest
     public void thatExportingWorks() throws Exception
     {
         // Export the project
-        FullProjectExportRequest exportRequest = new FullProjectExportRequest(sourceProject, null,
-                false);
-        ProjectExportTaskMonitor monitor = new ProjectExportTaskMonitor(sourceProject, null,
-                "test");
-        ExportedProject exportedProject = new ExportedProject();
+        var exportRequest = new FullProjectExportRequest(sourceProject, null, false);
+        var monitor = new ProjectExportTaskMonitor(sourceProject, null, "test");
+        var exportedProject = new ExportedProject();
         sut.exportData(exportRequest, monitor, exportedProject, temporaryFolder);
 
         // Import the project again
-        ArgumentCaptor<KnowledgeBase> exportKbCaptor = ArgumentCaptor.forClass(KnowledgeBase.class);
+        var exportKbCaptor = ArgumentCaptor.forClass(KnowledgeBase.class);
         doNothing().when(kbService).registerKnowledgeBase(exportKbCaptor.capture(), any());
 
-        ProjectImportRequest importRequest = new ProjectImportRequest(true);
-        ZipFile zipFile = mock(ZipFile.class);
+        var importRequest = new ProjectImportRequest(true);
+        var zipFile = mock(ZipFile.class);
 
         sut.importData(importRequest, targetProject, exportedProject, zipFile);
 
         // Check how many localKBs have been exported
-        List<KnowledgeBase> exportedKbs = exportKbCaptor.getAllValues();
+        var exportedKbs = exportKbCaptor.getAllValues();
         int numOfLocalKBs = exportedKbs.stream()
                 .filter(kb -> kb.getType().equals(RepositoryType.LOCAL))
                 .collect(Collectors.toList()).size();
@@ -139,11 +136,9 @@ public class KnowledgeBaseExporterTest
     public void thatRemappingConceptFeaturesOnImportWorks() throws Exception
     {
         // Export the project
-        FullProjectExportRequest exportRequest = new FullProjectExportRequest(sourceProject, null,
-                false);
-        ProjectExportTaskMonitor monitor = new ProjectExportTaskMonitor(sourceProject, null,
-                "test");
-        ExportedProject exportedProject = new ExportedProject();
+        var exportRequest = new FullProjectExportRequest(sourceProject, null, false);
+        var monitor = new ProjectExportTaskMonitor(sourceProject, null, "test");
+        var exportedProject = new ExportedProject();
         sut.exportData(exportRequest, monitor, exportedProject, temporaryFolder);
 
         // Mock that the KB ID changes during import when registerKnowledgeBase is called
@@ -158,13 +153,12 @@ public class KnowledgeBaseExporterTest
                 .thenReturn(features(targetProject));
 
         // Capture remapped features
-        ArgumentCaptor<AnnotationFeature> importedAnnotationFeatureCaptor = ArgumentCaptor
-                .forClass(AnnotationFeature.class);
+        var importedAnnotationFeatureCaptor = ArgumentCaptor.forClass(AnnotationFeature.class);
         doNothing().when(schemaService).createFeature(importedAnnotationFeatureCaptor.capture());
 
         // Import the project again
-        ProjectImportRequest importRequest = new ProjectImportRequest(true);
-        ZipFile zipFile = mock(ZipFile.class);
+        var importRequest = new ProjectImportRequest(true);
+        var zipFile = mock(ZipFile.class);
         sut.importData(importRequest, targetProject, exportedProject, zipFile);
 
         // Verify that features were actually processed
@@ -182,38 +176,37 @@ public class KnowledgeBaseExporterTest
 
     private List<KnowledgeBase> knowledgeBases() throws Exception
     {
-        KnowledgeBase kb1 = buildKnowledgeBase("kb1");
+        var kb1 = buildKnowledgeBase("kb1");
         kb1.setType(RepositoryType.LOCAL);
         kb1.setClassIri(WIKIDATA_CLASS.stringValue());
 
-        KnowledgeBase kb2 = buildKnowledgeBase("kb2");
+        var kb2 = buildKnowledgeBase("kb2");
         kb2.setType(RepositoryType.REMOTE);
         kb2.setClassIri(OWL.CLASS.stringValue());
 
-        KnowledgeBase kb3 = buildKnowledgeBase("kb3");
+        var kb3 = buildKnowledgeBase("kb3");
         kb3.setType(RepositoryType.REMOTE);
         kb3.setClassIri(RDFS.CLASS.stringValue());
 
-        KnowledgeBase kb4 = buildKnowledgeBase("kb4");
+        var kb4 = buildKnowledgeBase("kb4");
         kb4.setType(RepositoryType.LOCAL);
         kb4.setClassIri(RDFS.CLASS.stringValue());
 
-        return Arrays.asList(kb1, kb2, kb3);
+        return asList(kb1, kb2, kb3);
     }
 
     private List<AnnotationFeature> features(Project aProject) throws Exception
     {
-        AnnotationLayer layer1 = new AnnotationLayer("layer", "layer", WebAnnoConst.SPAN_TYPE,
-                aProject, false, TOKENS, NO_OVERLAP);
+        var layer1 = new AnnotationLayer("layer", "layer", WebAnnoConst.SPAN_TYPE, aProject, false,
+                TOKENS, NO_OVERLAP);
 
-        AnnotationFeature feat1 = new AnnotationFeature(1, layer1, "conceptFeature", "kb:conceptA");
-        ConceptFeatureTraits traits1 = new ConceptFeatureTraits();
+        var feat1 = new AnnotationFeature(1, layer1, "conceptFeature", "kb:conceptA");
+        var traits1 = new ConceptFeatureTraits();
         traits1.setRepositoryId("id-kb1");
         feat1.setTraits(JSONUtil.toJsonString(traits1));
 
-        AnnotationFeature feat2 = new AnnotationFeature(1, layer1, "conceptFeature",
-                "kb-multi:conceptA");
-        ConceptFeatureTraits traits2 = new ConceptFeatureTraits();
+        var feat2 = new AnnotationFeature(1, layer1, "conceptFeature", "kb-multi:conceptA");
+        var traits2 = new ConceptFeatureTraits();
         traits2.setRepositoryId("id-kb1");
         feat2.setTraits(JSONUtil.toJsonString(traits1));
 
@@ -222,7 +215,7 @@ public class KnowledgeBaseExporterTest
 
     private KnowledgeBase buildKnowledgeBase(String name) throws Exception
     {
-        KnowledgeBase kb = new KnowledgeBase();
+        var kb = new KnowledgeBase();
         kb.setRepositoryId("id-" + name);
         kb.setName(name);
         kb.setProject(sourceProject);
@@ -234,6 +227,7 @@ public class KnowledgeBaseExporterTest
         kb.setPropertyLabelIri(RDFS.LABEL.stringValue());
         kb.setPropertyDescriptionIri(RDFS.COMMENT.stringValue());
         kb.setSubPropertyIri(RDFS.SUBPROPERTYOF.stringValue());
+        kb.setDeprecationPropertyIri(OWL.DEPRECATED.stringValue());
         kb.setMaxResults(1000);
         kb.setRootConcepts(asList("http://www.ics.forth.gr/isl/CRMinf/I1_Argumentation",
                 "http://www.ics.forth.gr/isl/CRMinf/I1_Argumentation"));

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseProfileDeserializationTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseProfileDeserializationTest.java
@@ -17,15 +17,14 @@
  */
 package de.tudarmstadt.ukp.inception.kb;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.io.Reader;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 
@@ -46,13 +45,13 @@ public class KnowledgeBaseProfileDeserializationTest
     @Test
     public void checkThatDeserializationWorks() throws IOException
     {
-        String name = "Test KB";
-        List<String> rootConcepts = new ArrayList<>();
-        RepositoryType type = RepositoryType.LOCAL;
-        Reification reification = Reification.WIKIDATA;
-        String defaultLanguage = "en";
+        var name = "Test KB";
+        var rootConcepts = new ArrayList<String>();
+        var type = RepositoryType.LOCAL;
+        var reification = Reification.WIKIDATA;
+        var defaultLanguage = "en";
 
-        KnowledgeBaseProfile referenceProfile = new KnowledgeBaseProfile();
+        var referenceProfile = new KnowledgeBaseProfile();
 
         referenceProfile.setName(name);
         referenceProfile.setType(type);
@@ -63,56 +62,52 @@ public class KnowledgeBaseProfileDeserializationTest
         referenceProfile.setAccess(createReferenceAccess());
         referenceProfile.setInfo(createReferenceInfo());
 
-        PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
+        var resolver = new PathMatchingResourcePatternResolver();
         Map<String, KnowledgeBaseProfile> profiles;
-        try (Reader r = new InputStreamReader(
+        try (var r = new InputStreamReader(
                 resolver.getResource(KNOWLEDGEBASE_TEST_PROFILES_YAML).getInputStream())) {
-            ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
+            var mapper = new ObjectMapper(new YAMLFactory());
             profiles = mapper.readValue(r,
                     new TypeReference<HashMap<String, KnowledgeBaseProfile>>()
                     {
                     });
         }
-        KnowledgeBaseProfile testProfile = profiles.get("test_profile");
-        Assertions.assertThat(testProfile).usingRecursiveComparison().isEqualTo(referenceProfile);
+        var testProfile = profiles.get("test_profile");
+        assertThat(testProfile).usingRecursiveComparison().isEqualTo(referenceProfile);
     }
 
     private KnowledgeBaseInfo createReferenceInfo()
     {
-        String description = "This is a knowledge base for testing the kb profiles";
-        String host = "a host";
-        String author = "INCEpTION team";
-        String website = "https://inception-project.github.io/";
-        KnowledgeBaseInfo referenceInfo = new KnowledgeBaseInfo();
-        referenceInfo.setDescription(description);
-        referenceInfo.setAuthorName(author);
-        referenceInfo.setHostInstitutionName(host);
-        referenceInfo.setWebsiteUrl(website);
+        var referenceInfo = new KnowledgeBaseInfo();
+        referenceInfo.setDescription("This is a knowledge base for testing the kb profiles");
+        referenceInfo.setAuthorName("INCEpTION team");
+        referenceInfo.setHostInstitutionName("a host");
+        referenceInfo.setWebsiteUrl("https://inception-project.github.io/");
         return referenceInfo;
     }
 
     private KnowledgeBaseMapping createReferenceMapping()
     {
-        String classIri = "http://www.w3.org/2000/01/rdf-schema#Class";
-        String subclassIri = "http://www.w3.org/2000/01/rdf-schema#subClassOf";
-        String typeIri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
-        String subPropertyIri = "http://www.w3.org/2000/01/rdf-schema#subPropertyOf";
-        String label = "http://www.w3.org/2000/01/rdf-schema#label";
-        String propertyTypeIri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property";
-        String descriptionIri = "http://www.w3.org/2000/01/rdf-schema#comment";
-        String propertyLabelIri = "http://www.w3.org/2000/01/rdf-schema#label";
-        String propertyDescriptionIri = "http://www.w3.org/2000/01/rdf-schema#comment";
-        KnowledgeBaseMapping referenceMapping = new KnowledgeBaseMapping(classIri, subclassIri,
-                typeIri, subPropertyIri, descriptionIri, label, propertyTypeIri, propertyLabelIri,
-                propertyDescriptionIri);
+        var classIri = "http://www.w3.org/2000/01/rdf-schema#Class";
+        var subclassIri = "http://www.w3.org/2000/01/rdf-schema#subClassOf";
+        var typeIri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+        var subPropertyIri = "http://www.w3.org/2000/01/rdf-schema#subPropertyOf";
+        var label = "http://www.w3.org/2000/01/rdf-schema#label";
+        var propertyTypeIri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property";
+        var descriptionIri = "http://www.w3.org/2000/01/rdf-schema#comment";
+        var propertyLabelIri = "http://www.w3.org/2000/01/rdf-schema#label";
+        var propertyDescriptionIri = "http://www.w3.org/2000/01/rdf-schema#comment";
+        var deprecationPropertyIri = "http://www.w3.org/2002/07/owl#deprecated";
+        var referenceMapping = new KnowledgeBaseMapping(classIri, subclassIri, typeIri,
+                subPropertyIri, descriptionIri, label, propertyTypeIri, propertyLabelIri,
+                propertyDescriptionIri, deprecationPropertyIri);
         return referenceMapping;
     }
 
     private KnowledgeBaseAccess createReferenceAccess()
     {
-        String url = "http://someurl/sparql";
-        String fullTextSearchIri = "http://www.openrdf.org/contrib/lucenesail#matches";
-        KnowledgeBaseAccess referenceAccess = new KnowledgeBaseAccess(url, fullTextSearchIri);
-        return referenceAccess;
+        var url = "http://someurl/sparql";
+        var fullTextSearchIri = "http://www.openrdf.org/contrib/lucenesail#matches";
+        return new KnowledgeBaseAccess(url, fullTextSearchIri);
     }
 }

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplIntegrationTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplIntegrationTest.java
@@ -42,8 +42,6 @@ import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-import javax.persistence.EntityManager;
-
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.vocabulary.OWL;
@@ -63,9 +61,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
-import de.tudarmstadt.ukp.inception.documents.api.RepositoryProperties;
 import de.tudarmstadt.ukp.inception.documents.api.RepositoryPropertiesImpl;
-import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBaseProperties;
 import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBasePropertiesImpl;
 import de.tudarmstadt.ukp.inception.kb.graph.KBConcept;
 import de.tudarmstadt.ukp.inception.kb.graph.KBHandle;
@@ -119,10 +115,10 @@ public class KnowledgeBaseServiceImplIntegrationTest
 
     public void setUp(Reification reification) throws Exception
     {
-        RepositoryProperties repoProps = new RepositoryPropertiesImpl();
+        var repoProps = new RepositoryPropertiesImpl();
         repoProps.setPath(temporaryFolder);
-        KnowledgeBaseProperties kbProperties = new KnowledgeBasePropertiesImpl();
-        EntityManager entityManager = testEntityManager.getEntityManager();
+        var kbProperties = new KnowledgeBasePropertiesImpl();
+        var entityManager = testEntityManager.getEntityManager();
         testFixtures = new TestFixtures(testEntityManager);
         sut = new KnowledgeBaseServiceImpl(repoProps, kbProperties, entityManager);
         project = createProject(PROJECT_NAME);

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnwoledgeBaseSchemaProfileTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnwoledgeBaseSchemaProfileTest.java
@@ -25,30 +25,31 @@ import de.tudarmstadt.ukp.inception.kb.model.KnowledgeBase;
 import de.tudarmstadt.ukp.inception.kb.yaml.KnowledgeBaseMapping;
 import de.tudarmstadt.ukp.inception.kb.yaml.KnowledgeBaseProfile;
 
-public class KnwoledgeBaseSchemaProfileTest
+class KnwoledgeBaseSchemaProfileTest
 {
     @Test
-    public void checkKBProfileAndKBObject_ShouldReturnMatchingSchemaProfile()
+    void checkKBProfileAndKBObject_ShouldReturnMatchingSchemaProfile()
     {
-        String name = "Test KB";
-        String classIri = "http://www.w3.org/2002/07/owl#Class";
-        String subclassIri = "http://www.w3.org/2000/01/rdf-schema#subClassOf";
-        String typeIri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
-        String subPropertyIri = "http://www.w3.org/2000/01/rdf-schema#subPropertyOf";
-        String label = "http://www.w3.org/2000/01/rdf-schema#label";
-        String propertyTypeIri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property";
-        String descriptionIri = "http://www.w3.org/2000/01/rdf-schema#comment";
-        String propertyLabelIri = "http://www.w3.org/2000/01/rdf-schema#label";
-        String propertyDescriptionIri = "http://www.w3.org/2000/01/rdf-schema#comment";
+        var name = "Test KB";
+        var classIri = "http://www.w3.org/2002/07/owl#Class";
+        var subclassIri = "http://www.w3.org/2000/01/rdf-schema#subClassOf";
+        var typeIri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+        var subPropertyIri = "http://www.w3.org/2000/01/rdf-schema#subPropertyOf";
+        var label = "http://www.w3.org/2000/01/rdf-schema#label";
+        var propertyTypeIri = "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property";
+        var descriptionIri = "http://www.w3.org/2000/01/rdf-schema#comment";
+        var propertyLabelIri = "http://www.w3.org/2000/01/rdf-schema#label";
+        var propertyDescriptionIri = "http://www.w3.org/2000/01/rdf-schema#comment";
+        var deprecationPropertyIri = "http://www.w3.org/2002/07/owl#deprecated";
 
-        KnowledgeBaseMapping testMapping = new KnowledgeBaseMapping(classIri, subclassIri, typeIri,
-                subPropertyIri, descriptionIri, label, propertyTypeIri, propertyLabelIri,
-                propertyDescriptionIri);
-        KnowledgeBaseProfile testProfile = new KnowledgeBaseProfile();
+        var testMapping = new KnowledgeBaseMapping(classIri, subclassIri, typeIri, subPropertyIri,
+                descriptionIri, label, propertyTypeIri, propertyLabelIri, propertyDescriptionIri,
+                deprecationPropertyIri);
+        var testProfile = new KnowledgeBaseProfile();
         testProfile.setName(name);
         testProfile.setMapping(testMapping);
 
-        KnowledgeBase testKb = new KnowledgeBase();
+        var testKb = new KnowledgeBase();
         testKb.applyMapping(testMapping);
 
         assertThat(SchemaProfile.checkSchemaProfile(testProfile))

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderGenericTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderGenericTest.java
@@ -31,11 +31,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
 
-import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,22 +40,21 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import de.tudarmstadt.ukp.inception.kb.graph.KBHandle;
-import de.tudarmstadt.ukp.inception.kb.model.KnowledgeBase;
 import de.tudarmstadt.ukp.inception.kb.yaml.KnowledgeBaseProfile;
 
 @Tag("slow")
 public class SPARQLQueryBuilderGenericTest
 {
     // YAGO seems to have problem atm 29-04-2023
-    private static final List<String> SKIPPED_PROFILES = asList("babel_net", "yago");
+    private static final List<String> SKIPPED_PROFILES = asList("babel_net", "yago", "hpo",
+            "snomed-ct");
 
     public static List<KnowledgeBaseProfile> data() throws Exception
     {
-        Map<String, KnowledgeBaseProfile> profiles = KnowledgeBaseProfile
-                .readKnowledgeBaseProfiles();
+        var profiles = KnowledgeBaseProfile.readKnowledgeBaseProfiles();
 
-        List<KnowledgeBaseProfile> dataList = new ArrayList<>();
-        for (Entry<String, KnowledgeBaseProfile> entry : profiles.entrySet()) {
+        var dataList = new ArrayList<KnowledgeBaseProfile>();
+        for (var entry : profiles.entrySet()) {
             if (SKIPPED_PROFILES.contains(entry.getKey())) {
                 continue;
             }
@@ -73,10 +68,10 @@ public class SPARQLQueryBuilderGenericTest
     @MethodSource("data")
     public void thatRootConceptsCanBeRetrieved(KnowledgeBaseProfile aProfile) throws IOException
     {
-        KnowledgeBase kb = buildKnowledgeBase(aProfile);
-        Repository repo = buildRepository(aProfile);
+        var kb = buildKnowledgeBase(aProfile);
+        var repo = buildRepository(aProfile);
 
-        List<KBHandle> roots = asHandles(repo, SPARQLQueryBuilder.forClasses(kb).roots());
+        var roots = asHandles(repo, SPARQLQueryBuilder.forClasses(kb).roots());
 
         assertThat(roots).isNotEmpty();
     }
@@ -98,11 +93,11 @@ public class SPARQLQueryBuilderGenericTest
     public void thatChildrenOfRootConceptHaveRootConceptAsParent(KnowledgeBaseProfile aProfile)
         throws IOException
     {
-        KnowledgeBase kb = buildKnowledgeBase(aProfile);
-        Repository repo = buildRepository(aProfile);
+        var kb = buildKnowledgeBase(aProfile);
+        var repo = buildRepository(aProfile);
 
-        List<KBHandle> roots = asHandles(repo, SPARQLQueryBuilder.forClasses(kb).roots().limit(3));
-        Set<String> rootIdentifiers = roots.stream().map(KBHandle::getIdentifier).collect(toSet());
+        var roots = asHandles(repo, SPARQLQueryBuilder.forClasses(kb).roots().limit(3));
+        var rootIdentifiers = roots.stream().map(KBHandle::getIdentifier).collect(toSet());
 
         assertThat(roots).extracting(KBHandle::getIdentifier).allMatch(_root -> {
             try (RepositoryConnection conn = repo.getConnection()) {
@@ -130,11 +125,11 @@ public class SPARQLQueryBuilderGenericTest
     @MethodSource("data")
     public void thatRegexMetaCharactersAreSafe(KnowledgeBaseProfile aProfile) throws IOException
     {
-        KnowledgeBase kb = buildKnowledgeBase(aProfile);
-        Repository repo = buildRepository(aProfile);
+        var kb = buildKnowledgeBase(aProfile);
+        var repo = buildRepository(aProfile);
 
-        try (RepositoryConnection conn = repo.getConnection()) {
-            SPARQLQueryOptionalElements builder = SPARQLQueryBuilder.forItems(kb)
+        try (var conn = repo.getConnection()) {
+            var builder = SPARQLQueryBuilder.forItems(kb)
                     .withLabelMatchingExactlyAnyOf(".[]*+{}()lala").limit(3);
 
             System.out.printf("Query   : %n");
@@ -153,15 +148,15 @@ public class SPARQLQueryBuilderGenericTest
     public void thatLineBreaksAndWhitespaceAreSafe_noFts(KnowledgeBaseProfile aProfile)
         throws IOException
     {
-        KnowledgeBase kb = buildKnowledgeBase(aProfile);
-        Repository repo = buildRepository(aProfile);
+        var kb = buildKnowledgeBase(aProfile);
+        var repo = buildRepository(aProfile);
 
-        String originalFtsIri = kb.getFullTextSearchIri();
+        var originalFtsIri = kb.getFullTextSearchIri();
 
-        try (RepositoryConnection conn = repo.getConnection()) {
+        try (var conn = repo.getConnection()) {
             kb.setFullTextSearchIri(FTS_NONE.stringValue());
 
-            SPARQLQueryOptionalElements builder = SPARQLQueryBuilder //
+            var builder = SPARQLQueryBuilder //
                     .forItems(kb) //
                     .withLabelMatchingExactlyAnyOf("Lord\n\r\tLady") //
                     .limit(3);

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/util/TestFixtures.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/util/TestFixtures.java
@@ -42,6 +42,7 @@ import org.apache.commons.compress.compressors.CompressorStreamFactory;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.OWL;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.model.vocabulary.SKOS;
@@ -107,6 +108,7 @@ public class TestFixtures
         // querying for properties with the class label.
         kb.setPropertyLabelIri(SKOS.PREF_LABEL.stringValue());
         kb.setPropertyDescriptionIri(SKOS.DEFINITION.stringValue());
+        kb.setDeprecationPropertyIri(OWL.DEPRECATED.stringValue());
         kb.setRootConcepts(new ArrayList<>());
         kb.setReification(reification);
         kb.setMaxResults(1000);

--- a/inception/inception-kb/src/test/resources/kb_test_profiles.yaml
+++ b/inception/inception-kb/src/test/resources/kb_test_profiles.yaml
@@ -17,6 +17,7 @@ test_profile:
       property-label: http://www.w3.org/2000/01/rdf-schema#label
       property-description: http://www.w3.org/2000/01/rdf-schema#comment
       subproperty-of: http://www.w3.org/2000/01/rdf-schema#subPropertyOf
+      deprecation-property: http://www.w3.org/2002/07/owl#deprecated
   info:
     description: This is a knowledge base for testing the kb profiles
     host-institution-name: a host

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/KBHandleTemplate.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/KBHandleTemplate.java
@@ -34,10 +34,14 @@ final class KBHandleTemplate
     @Override
     public String getText()
     {
-        StringBuilder sb = new StringBuilder();
+        var sb = new StringBuilder();
         sb.append("<span class=\"item-title\">");
         // We cannot use && here because that causes an XML parse error in the browser - so we nest
         // the if clauses...
+        sb.append("  # if (data.deprecated != 'false') { #");
+        sb.append(
+                "    <span class=\"ms-1 float-end badge rounded-pill text-secondary border border-seecondary\">deprecated</span>");
+        sb.append("  # } #");
         sb.append("  # if (data.rank) { if (data.rank != '0') { #");
         sb.append("    <span class=\"item-rank\">[${ data.rank }]</span>");
         sb.append("  # } } #");
@@ -65,10 +69,11 @@ final class KBHandleTemplate
     @Override
     public List<String> getTextProperties()
     {
-        List<String> properties = new ArrayList<>();
+        var properties = new ArrayList<String>();
         properties.add("identifier");
         properties.add("description");
         properties.add("rank");
+        properties.add("deprecated");
         properties.add("queryBestMatchTerm");
         if (DEVELOPMENT.equals(Application.get().getConfigurationType())) {
             properties.add("debugInfo");

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/KnowledgeBaseIriPanel.html
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/KnowledgeBaseIriPanel.html
@@ -78,19 +78,19 @@
 
     <div class="row form-row">
       <label class="col-form-label col-sm-3">
-        <wicket:message key="kb.iri.descriptionIri"/>
+        <wicket:message key="kb.iri.labelIri"/>
       </label>
       <div class="col-sm-9">
-        <input wicket:id="descriptionIri"/>
+        <input wicket:id="labelIri"/>
       </div>
     </div>
 
     <div class="row form-row">
       <label class="col-form-label col-sm-3">
-        <wicket:message key="kb.iri.labelIri"/>
+        <wicket:message key="kb.iri.descriptionIri"/>
       </label>
       <div class="col-sm-9">
-        <input wicket:id="labelIri"/>
+        <input wicket:id="descriptionIri"/>
       </div>
     </div>
 
@@ -132,6 +132,15 @@
       </label>
       <div class="col-sm-9">
         <input wicket:id="propertyDescriptionIri"/>
+      </div>
+    </div>
+    
+    <div class="row form-row">
+      <label class="col-form-label col-sm-3">
+        <wicket:message key="kb.iri.deprecationPropertyIri"/>
+      </label>
+      <div class="col-sm-9">
+        <input wicket:id="deprecationPropertyIri"/>
       </div>
     </div>
   </div>

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/KnowledgeBaseIriPanel.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/KnowledgeBaseIriPanel.java
@@ -26,7 +26,6 @@ import static de.tudarmstadt.ukp.inception.ui.kb.project.validators.Validators.I
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.apache.wicket.markup.html.WebMarkupContainer;
@@ -65,44 +64,45 @@ public class KnowledgeBaseIriPanel
 
         kbModel = aModel;
 
-        DropDownChoice<Reification> reificationChoice = selectReificationStrategy("reification",
-                "kb.reification");
+        var reificationChoice = selectReificationStrategy("reification", "kb.reification");
         add(reificationChoice);
 
         // The Kendo comboboxes do not redraw properly when added directly to an
         // AjaxRequestTarget (for each combobox, a text field and a dropdown will be shown).
         // Instead, wrap all of them in a WMC and redraw that.
-        WebMarkupContainer comboBoxWrapper = new WebMarkupContainer("comboBoxWrapper");
+        var comboBoxWrapper = new WebMarkupContainer("comboBoxWrapper");
         comboBoxWrapper.setOutputMarkupId(true);
         add(comboBoxWrapper);
 
         // Add comboboxes for classIri, subclassIri, typeIri and descriptionIri
-        ComboBox<String> classField = buildComboBox("classIri", kbModel.bind("kb.classIri"),
+        var classField = buildComboBox("classIri", kbModel.bind("kb.classIri"),
                 IriConstants.CLASS_IRIS);
-        ComboBox<String> subclassField = buildComboBox("subclassIri",
-                kbModel.bind("kb.subclassIri"), IriConstants.SUBCLASS_IRIS);
-        ComboBox<String> typeField = buildComboBox("typeIri", kbModel.bind("kb.typeIri"),
+        var subclassField = buildComboBox("subclassIri", kbModel.bind("kb.subclassIri"),
+                IriConstants.SUBCLASS_IRIS);
+        var typeField = buildComboBox("typeIri", kbModel.bind("kb.typeIri"),
                 IriConstants.TYPE_IRIS);
-        ComboBox<String> subPropertyField = buildComboBox("subPropertyIri",
-                kbModel.bind("kb.subPropertyIri"), IriConstants.SUBPROPERTY_IRIS);
-        ComboBox<String> descriptionField = buildComboBox("descriptionIri",
-                kbModel.bind("kb.descriptionIri"), IriConstants.DESCRIPTION_IRIS);
-        ComboBox<String> labelField = buildComboBox("labelIri", kbModel.bind("kb.labelIri"),
+        var subPropertyField = buildComboBox("subPropertyIri", kbModel.bind("kb.subPropertyIri"),
+                IriConstants.SUBPROPERTY_IRIS);
+        var descriptionField = buildComboBox("descriptionIri", kbModel.bind("kb.descriptionIri"),
+                IriConstants.DESCRIPTION_IRIS);
+        var labelField = buildComboBox("labelIri", kbModel.bind("kb.labelIri"),
                 IriConstants.LABEL_IRIS);
-        ComboBox<String> propertyTypeField = buildComboBox("propertyTypeIri",
-                kbModel.bind("kb.propertyTypeIri"), IriConstants.PROPERTY_TYPE_IRIS);
-        ComboBox<String> propertyLabelField = buildComboBox("propertyLabelIri",
+        var propertyTypeField = buildComboBox("propertyTypeIri", kbModel.bind("kb.propertyTypeIri"),
+                IriConstants.PROPERTY_TYPE_IRIS);
+        var propertyLabelField = buildComboBox("propertyLabelIri",
                 kbModel.bind("kb.propertyLabelIri"), IriConstants.PROPERTY_LABEL_IRIS);
-        ComboBox<String> propertyDescriptionField = buildComboBox("propertyDescriptionIri",
+        var propertyDescriptionField = buildComboBox("propertyDescriptionIri",
                 kbModel.bind("kb.propertyDescriptionIri"), IriConstants.PROPERTY_DESCRIPTION_IRIS);
+        var deprecationPropertyField = buildComboBox("deprecationPropertyIri",
+                kbModel.bind("kb.deprecationPropertyIri"), IriConstants.DEPRECATION_PROPERTY_IRIS);
+
         comboBoxWrapper.add(classField, subclassField, typeField, subPropertyField,
                 descriptionField, labelField, propertyTypeField, propertyLabelField,
-                propertyDescriptionField);
+                propertyDescriptionField, deprecationPropertyField);
 
         // RadioGroup to select the IriSchemaType
-        DropDownChoice<SchemaProfile> iriSchemaChoice = new DropDownChoice<SchemaProfile>(
-                "iriSchema", selectedSchemaProfile, Arrays.asList(SchemaProfile.values()),
-                new EnumChoiceRenderer<>(this))
+        var iriSchemaChoice = new DropDownChoice<SchemaProfile>("iriSchema", selectedSchemaProfile,
+                asList(SchemaProfile.values()), new EnumChoiceRenderer<>(this))
         {
             private static final long serialVersionUID = 3863260896285332033L;
 
@@ -133,6 +133,7 @@ public class KnowledgeBaseIriPanel
                 propertyTypeField.setModelObject(profile.getPropertyTypeIri());
                 propertyLabelField.setModelObject(profile.getPropertyLabelIri());
                 propertyDescriptionField.setModelObject(profile.getPropertyDescriptionIri());
+                deprecationPropertyField.setModelObject(profile.getDeprecationPropertyIri());
             }
             _target.add(comboBoxWrapper, iriSchemaChoice, reificationChoice);
         }));

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/ProjectKnowledgeBasePanel.properties
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/ProjectKnowledgeBasePanel.properties
@@ -36,6 +36,7 @@ kb.iri.labelIri=Label IRI
 kb.iri.propertyTypeIri=Property type IRI
 kb.iri.propertyLabelIri=Property label IRI
 kb.iri.propertyDescriptionIri=Property description IRI
+kb.iri.deprecationPropertyIri=Deprecation property IRI
 kb.iri.fullTextSearchIri=Full text search mode
 fullTextSearchIri.nullValid=No full text search support
 kb.iri.basePrefix=Base Prefix


### PR DESCRIPTION
**What's in the PR**
- Add a new configurable IRI for a property that - when present - marks a concept, property or instance as deprecated

**How to test manually**
* Import e.g. the HPO ontology using the new HPO local profile
* On the knowledge-base page search for "obsolete" - that should mostly (only) return items that are deprecated and they should be marked as such

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
