### PR TITLE
#4379 - Suppress or mark concepts in the search that are marked as owl:deprecated

### DIFF
--- a/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/model/CandidateEntity.java
+++ b/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/model/CandidateEntity.java
@@ -195,6 +195,11 @@ public class CandidateEntity
         return handle.getLanguage();
     }
 
+    public boolean isDeprecated()
+    {
+        return handle.isDeprecated();
+    }
+
     @SuppressWarnings("unchecked")
     public <T> Optional<T> get(Key<T> aKey)
     {

--- a/inception/inception-concept-linking/src/test/java/de/tudarmstadt/ukp/inception/conceptlinking/NamedEntityLinkerTest.java
+++ b/inception/inception-concept-linking/src/test/java/de/tudarmstadt/ukp/inception/conceptlinking/NamedEntityLinkerTest.java
@@ -112,14 +112,23 @@ public class NamedEntityLinkerTest
     @Test
     public void thatPredictionWorks() throws Exception
     {
-        List<KBHandle> mockResult = asList(
-                new KBHandle("https://www.wikidata.org/wiki/Q76", "Barack Obama",
-                        "44th President of the United States of America"),
-                new KBHandle("https://www.wikidata.org/wiki/Q26446735", "Obama",
-                        "Japanese Family Name"),
-                new KBHandle("https://www.wikidata.org/wiki/Q18355807", "Obama", "genus of worms"),
-                new KBHandle("https://www.wikidata.org/wiki/Q41773", "Obama",
-                        "city in Fukui prefecture, Japan"));
+        var mockResult = asList(
+                KBHandle.builder().withIdentifier("https://www.wikidata.org/wiki/Q76") //
+                        .withName("Barack Obama") //
+                        .withDescription("44th President of the United States of America") //
+                        .build(),
+                KBHandle.builder().withIdentifier("https://www.wikidata.org/wiki/Q26446735") //
+                        .withName("Obama") //
+                        .withDescription("Japanese Family Name") //
+                        .build(),
+                KBHandle.builder().withIdentifier("https://www.wikidata.org/wiki/Q18355807") //
+                        .withName("Obama") //
+                        .withDescription("genus of worms") //
+                        .build(),
+                KBHandle.builder().withIdentifier("https://www.wikidata.org/wiki/Q41773") //
+                        .withName("Obama") //
+                        .withDescription("city in Fukui prefecture, Japan") //
+                        .build());
 
         KnowledgeBaseService kbService = mock(KnowledgeBaseService.class);
         KnowledgeBase kb = new KnowledgeBase();

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
@@ -696,7 +696,8 @@ public class KnowledgeBaseServiceImpl
                     .withIdentifier(aIdentifier) //
                     .excludeInferred() //
                     .retrieveLabel() //
-                    .retrieveDescription();
+                    .retrieveDescription() //
+                    .retrieveDeprecation();
 
             Optional<KBHandle> result;
             if (aKB.isReadOnly()) {
@@ -750,6 +751,7 @@ public class KnowledgeBaseServiceImpl
             var query = SPARQLQueryBuilder.forClasses(aKB) //
                     .retrieveLabel() //
                     .retrieveDescription() //
+                    .retrieveDeprecation() //
                     .excludeInferred();
 
             List<KBHandle> result;
@@ -786,7 +788,7 @@ public class KnowledgeBaseServiceImpl
                     .withIdentifier(aIdentifier) //
                     .retrieveDescription() //
                     .retrieveLabel() //
-                    .retrieveDomainAndRange() //
+                    .retrieveDeprecation().retrieveDomainAndRange() //
                     .excludeInferred();
 
             Optional<KBHandle> result;
@@ -835,6 +837,7 @@ public class KnowledgeBaseServiceImpl
             var query = SPARQLQueryBuilder.forProperties(aKB) //
                     .retrieveLabel() //
                     .retrieveDescription() //
+                    .retrieveDeprecation() //
                     .retrieveDomainAndRange() //
                     .includeInferred(aIncludeInferred);
 
@@ -873,7 +876,7 @@ public class KnowledgeBaseServiceImpl
                     .withIdentifier(aIdentifier) //
                     .retrieveDescription() //
                     .retrieveLabel() //
-                    .excludeInferred();
+                    .retrieveDeprecation().excludeInferred();
 
             Optional<KBHandle> result;
             if (aKB.isReadOnly()) {
@@ -926,7 +929,8 @@ public class KnowledgeBaseServiceImpl
             var query = SPARQLQueryBuilder.forInstances(aKB) //
                     .childrenOf(aConceptIri) //
                     .retrieveLabel() //
-                    .retrieveDescription();
+                    .retrieveDescription() //
+                    .retrieveDeprecation();
 
             List<KBHandle> result;
             if (aKB.isReadOnly()) {
@@ -1034,6 +1038,7 @@ public class KnowledgeBaseServiceImpl
                     .matchingDomain(aDomain) //
                     .retrieveLabel() //
                     .retrieveDescription() //
+                    .retrieveDeprecation() //
                     .retrieveDomainAndRange() //
                     .includeInferred(aIncludeInferred);
 
@@ -1056,7 +1061,8 @@ public class KnowledgeBaseServiceImpl
     {
         try (var watch = new StopWatch(LOG, "listRootConcepts()")) {
             var query = SPARQLQueryBuilder.forClasses(aKB).roots().retrieveLabel()
-                    .retrieveDescription();
+                    .retrieveDescription() //
+                    .retrieveDeprecation();
 
             List<KBHandle> result;
             if (aKB.isReadOnly()) {
@@ -1095,7 +1101,8 @@ public class KnowledgeBaseServiceImpl
             var query = SPARQLQueryBuilder.forClasses(aKB) //
                     .parentsOf(aIdentifier) //
                     .retrieveLabel() //
-                    .retrieveDescription();
+                    .retrieveDescription() //
+                    .retrieveDeprecation();
 
             List<KBHandle> result;
             if (aKB.isReadOnly()) {
@@ -1117,7 +1124,8 @@ public class KnowledgeBaseServiceImpl
             var query = SPARQLQueryBuilder.forClasses(aKB) //
                     .ancestorsOf(aIdentifier) //
                     .retrieveLabel() //
-                    .retrieveDescription();
+                    .retrieveDescription() //
+                    .retrieveDeprecation();
 
             List<KBHandle> result;
             if (aKB.isReadOnly()) {
@@ -1141,6 +1149,7 @@ public class KnowledgeBaseServiceImpl
                     .childrenOf(aParentIdentifier) //
                     .retrieveLabel() //
                     .retrieveDescription() //
+                    .retrieveDeprecation() //
                     .limit(aLimit);
 
             List<KBHandle> result;
@@ -1264,7 +1273,8 @@ public class KnowledgeBaseServiceImpl
             var query = SPARQLQueryBuilder.forItems(aKB) //
                     .withIdentifier(aIdentifier) //
                     .retrieveLabel() //
-                    .retrieveDescription();
+                    .retrieveDescription() //
+                    .retrieveDeprecation();
 
             Optional<KBHandle> result;
             if (aKB.isReadOnly()) {

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/KBConcept.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/KBConcept.java
@@ -39,6 +39,7 @@ public class KBConcept
     private String identifier;
     private String name;
     private String description;
+    private boolean deprecated;
     private KnowledgeBase kb;
     private String language;
 
@@ -164,6 +165,17 @@ public class KBConcept
     public void setDescription(String aDescription)
     {
         description = aDescription;
+    }
+
+    public void setDeprecated(boolean aDeprecated)
+    {
+        deprecated = aDeprecated;
+    }
+
+    @Override
+    public boolean isDeprecated()
+    {
+        return deprecated;
     }
 
     @Override

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/KBHandle.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/KBHandle.java
@@ -75,22 +75,42 @@ public class KBHandle
         range = builder.range;
     }
 
+    public KBHandle(KBHandle aOther)
+    {
+        identifier = aOther.identifier;
+        name = aOther.name;
+        queryBestMatchTerm = aOther.queryBestMatchTerm;
+        matchTerms = aOther.matchTerms;
+        description = aOther.description;
+        kb = aOther.kb;
+        language = aOther.language;
+        deprecated = aOther.deprecated;
+        rank = aOther.rank;
+        score = aOther.score;
+        debugInfo = aOther.debugInfo;
+        domain = aOther.domain;
+        range = aOther.range;
+    }
+
+    @Deprecated
     public KBHandle()
     {
         this(null, null);
     }
 
+    @Deprecated
     public KBHandle(String aIdentifier)
     {
         this(aIdentifier, null);
     }
 
+    @Deprecated
     public KBHandle(String aIdentifier, String aLabel)
     {
-        this(aIdentifier, aLabel, null);
+        this(aIdentifier, aLabel, null, null);
     }
 
-    public KBHandle(String aIdentifier, String aLabel, String aDescription)
+    protected KBHandle(String aIdentifier, String aLabel, String aDescription)
     {
         identifier = aIdentifier;
         name = aLabel;
@@ -122,6 +142,7 @@ public class KBHandle
         deprecated = aDeprecated;
     }
 
+    @Override
     public boolean isDeprecated()
     {
         return deprecated;
@@ -283,6 +304,7 @@ public class KBHandle
             concept.setKB(aHandle.getKB());
             concept.setLanguage(aHandle.getLanguage());
             concept.setDescription(aHandle.getDescription());
+            concept.setDeprecated(aHandle.isDeprecated());
             concept.setName(aHandle.getName());
             return (T) concept;
         }
@@ -292,6 +314,7 @@ public class KBHandle
             instance.setKB(aHandle.getKB());
             instance.setLanguage(aHandle.getLanguage());
             instance.setDescription(aHandle.getDescription());
+            instance.setDeprecated(aHandle.isDeprecated());
             instance.setName(aHandle.getName());
             return (T) instance;
         }
@@ -301,6 +324,7 @@ public class KBHandle
             property.setKB(aHandle.getKB());
             property.setLanguage(aHandle.getLanguage());
             property.setDescription(aHandle.getDescription());
+            property.setDeprecated(aHandle.isDeprecated());
             property.setName(aHandle.getName());
             property.setRange(aHandle.getRange());
             property.setDomain(aHandle.getDomain());

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/KBInstance.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/KBInstance.java
@@ -41,6 +41,7 @@ public class KBInstance
     private String identifier;
     private String name;
     private String description;
+    private boolean deprecated;
     private URI type;
     private List<Statement> originalStatements = new ArrayList<>();
     private String language;
@@ -113,6 +114,17 @@ public class KBInstance
     public void setDescription(String aDescription)
     {
         description = aDescription;
+    }
+
+    public void setDeprecated(boolean aDeprecated)
+    {
+        deprecated = aDeprecated;
+    }
+
+    @Override
+    public boolean isDeprecated()
+    {
+        return deprecated;
     }
 
     public List<Statement> getOriginalStatements()

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/KBObject.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/KBObject.java
@@ -67,6 +67,8 @@ public interface KBObject
 
     void setDescription(String label);
 
+    boolean isDeprecated();
+
     /**
      * @return the language (e.g. of label and description) of this element.
      */
@@ -120,6 +122,7 @@ public interface KBObject
         handle.setName(getName());
         handle.setLanguage(getLanguage());
         handle.setDescription(getDescription());
+        handle.setDeprecated(isDeprecated());
         handle.setKB(getKB());
         return handle;
     }

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/KBProperty.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/KBProperty.java
@@ -44,6 +44,7 @@ public class KBProperty
     private String identifier;
     private String name;
     private String description;
+    private boolean deprecated;
     private String domain;
     private KnowledgeBase kb;
     private String range;
@@ -119,6 +120,17 @@ public class KBProperty
     public void setDescription(String aDescription)
     {
         description = aDescription;
+    }
+
+    public void setDeprecated(boolean aDeprecated)
+    {
+        deprecated = aDeprecated;
+    }
+
+    @Override
+    public boolean isDeprecated()
+    {
+        return deprecated;
     }
 
     public String getDomain()

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/Queries.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/Queries.java
@@ -50,6 +50,7 @@ public class Queries
                     .withIdentifier(propertyIris) //
                     .retrieveLabel() //
                     .retrieveDescription() //
+                    .retrieveDeprecation() //
                     .retrieveDomainAndRange() //
                     .asHandles(aConn, true) //
                     .stream() //

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderTest.java
@@ -443,8 +443,9 @@ public class SPARQLQueryBuilderTest
         assertThat(results)
                 .usingRecursiveFieldByFieldElementComparatorOnFields("identifier", "name",
                         "description", "language")
-                .containsExactlyInAnyOrder(new KBHandle("http://example.org/#green-goblin",
-                        "Green Goblin", "Little green monster"));
+                .containsExactlyInAnyOrder(KBHandle.builder()
+                        .withIdentifier("http://example.org/#green-goblin").withName("Green Goblin")
+                        .withDescription("Little green monster").build());
     }
 
     /**
@@ -652,11 +653,11 @@ public class SPARQLQueryBuilderTest
                 .retrieveDescription());
 
         assertThat(results).isNotEmpty();
-        assertThat(results)
-                .usingRecursiveFieldByFieldElementComparatorOnFields("identifier", "name",
-                        "description", "language")
-                .containsExactlyInAnyOrder(new KBHandle("http://example.org/#red-goblin",
-                        "Red Goblin", "Little red monster"));
+        assertThat(results).usingRecursiveFieldByFieldElementComparatorOnFields("identifier",
+                "name", "description", "language")
+                .containsExactlyInAnyOrder(KBHandle.builder()
+                        .withIdentifier("http://example.org/#red-goblin").withName("Red Goblin")
+                        .withDescription("Little red monster").build());
     }
 
     @SuppressWarnings("deprecation")
@@ -682,12 +683,14 @@ public class SPARQLQueryBuilderTest
                         new KBHandle("http://example.org/#property-2", "Property 2", "Property Two",
                                 null, "http://example.org/#subclass1",
                                 "http://www.w3.org/2001/XMLSchema#Integer"),
-                        new KBHandle("http://example.org/#property-3", "Property 3",
-                                "Property Three"),
-                        new KBHandle("http://example.org/#subproperty-1-1", "Subproperty 1-1",
-                                "Property One-One"),
-                        new KBHandle("http://example.org/#subproperty-1-1-1", "Subproperty 1-1-1",
-                                "Property One-One-One"));
+                        KBHandle.builder().withIdentifier("http://example.org/#property-3")
+                                .withName("Property 3").withDescription("Property Three").build(),
+                        KBHandle.builder().withIdentifier("http://example.org/#subproperty-1-1")
+                                .withName("Subproperty 1-1").withDescription("Property One-One")
+                                .build(),
+                        KBHandle.builder().withIdentifier("http://example.org/#subproperty-1-1-1")
+                                .withName("Subproperty 1-1-1")
+                                .withDescription("Property One-One-One").build());
     }
 
     static void thatDeprecationStatusCanBeRetrieved(Repository aRepository, KnowledgeBase aKB)

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/reification/NoReificationTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/reification/NoReificationTest.java
@@ -26,11 +26,11 @@ import java.util.List;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.eclipse.rdf4j.model.vocabulary.OWL;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.eclipse.rdf4j.model.vocabulary.SKOS;
 import org.eclipse.rdf4j.repository.Repository;
-import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.sail.lucene.LuceneSail;
@@ -105,7 +105,7 @@ public class NoReificationTest
         importDataFromString(RDFFormat.TURTLE, TURTLE_PREFIX,
                 DATA_LABELS_AND_DESCRIPTIONS_WITH_LANGUAGE);
 
-        List<KBStatement> result = listStatements(rdf4jLocalRepo,
+        var result = listStatements(rdf4jLocalRepo,
                 new KBHandle("http://example.org/#green-goblin"));
 
         assertThat(result) //
@@ -116,10 +116,10 @@ public class NoReificationTest
 
     public List<KBStatement> listStatements(Repository aRepo, KBHandle aItem) throws Exception
     {
-        try (RepositoryConnection conn = aRepo.getConnection()) {
-            long startTime = System.currentTimeMillis();
+        try (var conn = aRepo.getConnection()) {
+            var startTime = System.currentTimeMillis();
 
-            List<KBStatement> results = sut.listStatements(conn, kb, aItem, true);
+            var results = sut.listStatements(conn, kb, aItem, true);
 
             System.out.printf("Results : %d in %dms%n", results.size(),
                     System.currentTimeMillis() - startTime);
@@ -131,21 +131,21 @@ public class NoReificationTest
 
     private void importDataFromString(RDFFormat aFormat, String... aRdfData) throws IOException
     {
-        String data = String.join("\n", aRdfData);
+        var data = String.join("\n", aRdfData);
 
         // Load files into the repository
-        try (InputStream is = IOUtils.toInputStream(data, UTF_8)) {
+        try (var is = IOUtils.toInputStream(data, UTF_8)) {
             importData(aFormat, is);
         }
     }
 
     private void importData(RDFFormat aFormat, InputStream aIS) throws IOException
     {
-        try (RepositoryConnection conn = rdf4jLocalRepo.getConnection()) {
+        try (var conn = rdf4jLocalRepo.getConnection()) {
             // If the RDF file contains relative URLs, then they probably start with a hash.
             // To avoid having two hashes here, we drop the hash from the base prefix configured
             // by the user.
-            String prefix = StringUtils.removeEnd(kb.getBasePrefix(), "#");
+            var prefix = StringUtils.removeEnd(kb.getBasePrefix(), "#");
             conn.add(aIS, prefix, aFormat);
         }
     }
@@ -164,6 +164,7 @@ public class NoReificationTest
         // We are intentionally not using RDFS.COMMENT here to ensure we can test the description
         // and property description separately
         kb.setPropertyDescriptionIri("http://schema.org/description");
+        kb.setDeprecationPropertyIri(OWL.DEPRECATED.stringValue());
         kb.setSubPropertyIri(RDFS.SUBPROPERTYOF.stringValue());
     }
 }

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/reification/WikiDataReificationTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/reification/WikiDataReificationTest.java
@@ -29,6 +29,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.OWL;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
@@ -96,6 +97,7 @@ public class WikiDataReificationTest
         kb.setDescriptionIri("http://schema.org/description");
         kb.setPropertyLabelIri("http://www.w3.org/2000/01/rdf-schema#label");
         kb.setPropertyDescriptionIri("http://www.w3.org/2000/01/rdf-schema#comment");
+        kb.setDeprecationPropertyIri(OWL.DEPRECATED.stringValue());
         kb.setSubPropertyIri("http://www.wikidata.org/prop/direct/P1647");
 
         // Local in-memory store - this should be used for most tests because we can

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
@@ -390,7 +390,7 @@ public class AnnotationPage
             documentService
                     .verifyAnnotationCasTimestamp(state.getDocument(),
                             state.getUser().getUsername(),
-                            state.getAnnotationDocumentTimestamp().get(), "reading")
+                            state.getAnnotationDocumentTimestamp().get(), "reading the editor CAS")
                     .ifPresent(state::setAnnotationDocumentTimestamp);
         }
 

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureEditor.html
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureEditor.html
@@ -22,12 +22,13 @@
   <div class="row form-row" wicket:enclosure="value">
     <label wicket:for="value" wicket:enclosure="feature" class="feature-editor-label col-form-label">
       <span wicket:id="feature"/>
-      <span class="float-end">
-        <span wicket:id="disabledKBWarning"/>
-      </span>
-      <a wicket:id="openIri" class="float-end" target="_blank">
+      <a wicket:id="openIri" class="float-end ms-2" target="_blank">
         <i class="fas fa-external-link-alt"/>
       </a>
+      <span class="float-end">
+        <span wicket:id="deprecationMarker" class="badge rounded-pill text-secondary border border-secondary">deprecated</span>
+        <span wicket:id="disabledKBWarning"/>
+      </span>
     </label>
     <div class="feature-editor-value">
       <div class="input-group">
@@ -39,8 +40,10 @@
         </button>
         <input class="flex-content" wicket:id="value" type="text"/>
       </div>
-      <div wicket:id="descriptionContainer" class="scrolling border border-top-0 rounded-bottom p-1" style="max-height: 4.5rem; word-wrap: break-word;" readonly>
-        <small class="text-muted" wicket:id="description"/>
+      <div wicket:id="descriptionContainer" class="border border-top-0 rounded-bottom overflow-hidden" readonly>
+        <div class="scrolling p-1 text-muted small" style="max-height: 4.5rem; word-wrap: break-word;">
+          <span wicket:id="description"/>
+        </div>
       </div>
       <div wicket:id="keyBindings" class="col-sm-12"/>
     </div>

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureEditor.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureEditor.java
@@ -83,6 +83,7 @@ public class ConceptFeatureEditor
     private @SpringBean KnowledgeBaseService knowledgeBaseService;
 
     private AutoCompleteField focusComponent;
+    private WebMarkupContainer deprecationMarker;
     private WebMarkupContainer descriptionContainer;
     private Label description;
     private IriInfoBadge iriBadge;
@@ -109,6 +110,11 @@ public class ConceptFeatureEditor
         openIriLink.setOutputMarkupPlaceholderTag(true);
         openIriLink.add(visibleWhen(() -> isNotBlank(iriBadge.getModelObject())));
         add(openIriLink);
+
+        deprecationMarker = new WebMarkupContainer("deprecationMarker");
+        deprecationMarker.setOutputMarkupPlaceholderTag(true);
+        deprecationMarker.add(visibleWhen(this::isDeprecated));
+        add(deprecationMarker);
 
         descriptionContainer = new WebMarkupContainer("descriptionContainer");
         descriptionContainer.setOutputMarkupPlaceholderTag(true);
@@ -162,12 +168,22 @@ public class ConceptFeatureEditor
         dialog.open(content, aTarget);
     }
 
-    private String descriptionValue()
+    private boolean isDeprecated()
     {
         return getModel().map(FeatureState::getValue)//
                 .map(value -> (KBHandle) value)//
-                .map(KBHandle::getDescription)//
-                .map(value -> StringUtils.abbreviate(value, 130))//
+                .map(KBHandle::isDeprecated) //
+                .orElse(false)//
+                .getObject();
+
+    }
+
+    private String descriptionValue()
+    {
+        return getModel().map(FeatureState::getValue) //
+                .map(value -> (KBHandle) value) //
+                .map(KBHandle::getDescription) //
+                .map(value -> StringUtils.abbreviate(value, 1000)) //
                 .orElse("no description")//
                 .getObject();
     }
@@ -184,7 +200,7 @@ public class ConceptFeatureEditor
     @OnEvent
     public void onFeatureEditorValueChanged(FeatureEditorValueChangedEvent aEvent)
     {
-        aEvent.getTarget().add(descriptionContainer, iriBadge, openIriLink);
+        aEvent.getTarget().add(descriptionContainer, iriBadge, openIriLink, deprecationMarker);
     }
 
     @OnEvent

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureSupport.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureSupport.java
@@ -168,7 +168,8 @@ public class ConceptFeatureSupport
             String identifier = (String) aValue;
             ConceptFeatureTraits traits = readTraits(aFeature);
             KBHandle chbk = getConceptHandle(aFeature, identifier, traits);
-            var clone = new KBHandle(identifier, chbk.getUiLabel(), chbk.getDescription());
+            // Clone the cached original so we can override the KB
+            var clone = new KBHandle(chbk);
             clone.setKB(chbk.getKB());
             return clone;
         }

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/KBHandleTemplate.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/KBHandleTemplate.java
@@ -40,7 +40,7 @@ final class KBHandleTemplate
         // the if clauses...
         sb.append("  # if (data.deprecated != 'false') { #");
         sb.append(
-                "    <span class=\"ms-1 float-end badge rounded-pill text-secondary border border-seecondary\">deprecated</span>");
+                "    <span class=\"ms-1 float-end badge rounded-pill text-secondary border border-secondary\">deprecated</span>");
         sb.append("  # } #");
         sb.append("  # if (data.rank) { if (data.rank != '0') { #");
         sb.append("    <span class=\"item-rank\">[${ data.rank }]</span>");


### PR DESCRIPTION
**What's in the PR**
- Properly pass the deprecation status through the different conversions from/to KBHandle
- Also show deprecation status in the concept feature editor (only in the single-value editor for the time being)

**How to test manually**
* Select a deprecated concept in a single-value concept feature editor and check it the deprecation marker appears

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
