### PR TITLE
#4377 - Configure include and exclude patterns for logged events

### DIFF
--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/EventLoggingListener.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/EventLoggingListener.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.DisposableBean;
@@ -82,15 +83,17 @@ public class EventLoggingListener
             return eventCache.get(aEventName);
         }
 
-        boolean shouldLog = false;
+        boolean shouldLog;
 
-        if (properties.getIncludePatterns() != null && !properties.getIncludePatterns().isEmpty()) {
+        if (CollectionUtils.isEmpty(properties.getIncludePatterns())) {
+            shouldLog = true;
+        }
+        else {
             shouldLog = properties.getIncludePatterns().stream()
                     .anyMatch(pattern -> Pattern.matches(pattern, aEventName));
         }
 
-        if (shouldLog && properties.getExcludePatterns() != null
-                && !properties.getExcludePatterns().isEmpty()) {
+        if (shouldLog && !CollectionUtils.isEmpty(properties.getExcludePatterns())) {
             shouldLog = properties.getExcludePatterns().stream()
                     .noneMatch(pattern -> Pattern.matches(pattern, aEventName));
         }

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/EventLoggingListener.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/EventLoggingListener.java
@@ -83,10 +83,11 @@ public class EventLoggingListener
         if (!maybeAdapter.isPresent()) {
             return;
         }
+        
 
         var adapter = maybeAdapter.get();
 
-        if (properties.getExcludeEvents().contains(adapter.getEvent(aEvent))) {
+        if (!properties.shouldLogEvent(adapter.getEvent(aEvent))) {
             return;
         }
 

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/EventLoggingListener.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/EventLoggingListener.java
@@ -83,7 +83,6 @@ public class EventLoggingListener
         if (!maybeAdapter.isPresent()) {
             return;
         }
-        
 
         var adapter = maybeAdapter.get();
 

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingProperties.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingProperties.java
@@ -46,11 +46,4 @@ public interface EventLoggingProperties
      *            Set of regex exclude patterns
      */
     void setExcludePatterns(Set<String> excludePatterns);
-
-    /**
-     * @param eventName
-     *            Name of the event to check.
-     * @return true if the event should be logged, false otherwise.
-     */
-    boolean shouldLogEvent(String eventName);
 }

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingProperties.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingProperties.java
@@ -25,11 +25,30 @@ public interface EventLoggingProperties
 
     boolean isEnabled();
 
-    Set<String> getExcludeEvents();
+    /**
+     * @return Set of regex include patterns
+     */
+    Set<String> getIncludePatterns();
 
     /**
-     * @param aExcludeEvents
-     *            events never to be written to the event log.
+     * @param includePatterns Set of regex include patterns
      */
-    void setExcludeEvents(Set<String> aExcludeEvents);
+    void setIncludePatterns(Set<String> includePatterns);
+
+    /**
+     * @return Set of regex exclude patterns
+     */
+    Set<String> getExcludePatterns();
+
+    /**
+     * @param excludePatterns Set of regex exclude patterns
+     */
+    void setExcludePatterns(Set<String> excludePatterns);
+
+    /**
+     * @param eventName Name of the event to check.
+     * @return true if the event should be logged, false otherwise.
+     */
+    boolean shouldLogEvent(String eventName);
 }
+

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingProperties.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingProperties.java
@@ -31,7 +31,8 @@ public interface EventLoggingProperties
     Set<String> getIncludePatterns();
 
     /**
-     * @param includePatterns Set of regex include patterns
+     * @param includePatterns
+     *            Set of regex include patterns
      */
     void setIncludePatterns(Set<String> includePatterns);
 
@@ -41,14 +42,15 @@ public interface EventLoggingProperties
     Set<String> getExcludePatterns();
 
     /**
-     * @param excludePatterns Set of regex exclude patterns
+     * @param excludePatterns
+     *            Set of regex exclude patterns
      */
     void setExcludePatterns(Set<String> excludePatterns);
 
     /**
-     * @param eventName Name of the event to check.
+     * @param eventName
+     *            Name of the event to check.
      * @return true if the event should be logged, false otherwise.
      */
     boolean shouldLogEvent(String eventName);
 }
-

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingPropertiesImpl.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingPropertiesImpl.java
@@ -28,54 +28,60 @@ import de.tudarmstadt.ukp.inception.annotation.events.PreparingToOpenDocumentEve
 import de.tudarmstadt.ukp.inception.documents.event.AfterCasWrittenEvent;
 
 @ConfigurationProperties("event-logging")
-public class EventLoggingPropertiesImpl implements EventLoggingProperties {
-	private boolean enabled;
+public class EventLoggingPropertiesImpl
+    implements EventLoggingProperties
+{
+    private boolean enabled;
 
-	private Set<String> includePatterns = Set.of(".*"); // Default include everything
-	
-	private Set<String> excludePatterns = Set.of(
-			AfterCasWrittenEvent.class.getSimpleName(),
-			AvailabilityChangeEvent.class.getSimpleName(),
-			"RecommenderTaskNotificationEvent",
-			BeforeDocumentOpenedEvent.class.getSimpleName(),
-			PreparingToOpenDocumentEvent.class.getSimpleName(),
-			"BrokerAvailabilityEvent",
-			"ShutdownDialogAvailableEvent");
+    private Set<String> includePatterns = Set.of(".*"); // Default include everything
 
-	@Override
-	public boolean isEnabled() {
-		return enabled;
-	}
+    private Set<String> excludePatterns = Set.of(AfterCasWrittenEvent.class.getSimpleName(),
+            AvailabilityChangeEvent.class.getSimpleName(), "RecommenderTaskNotificationEvent",
+            BeforeDocumentOpenedEvent.class.getSimpleName(),
+            PreparingToOpenDocumentEvent.class.getSimpleName(), "BrokerAvailabilityEvent",
+            "ShutdownDialogAvailableEvent");
 
-	@Override
-	public void setEnabled(boolean aEnabled) {
-		enabled = aEnabled;
-	}
+    @Override
+    public boolean isEnabled()
+    {
+        return enabled;
+    }
 
-	@Override
-	public Set<String> getIncludePatterns() {
-		return includePatterns;
-	}
+    @Override
+    public void setEnabled(boolean aEnabled)
+    {
+        enabled = aEnabled;
+    }
 
-	@Override
-	public void setIncludePatterns(Set<String> includePatterns) {
-		this.includePatterns = includePatterns;
-	}
+    @Override
+    public Set<String> getIncludePatterns()
+    {
+        return includePatterns;
+    }
 
-	@Override
-	public Set<String> getExcludePatterns() {
-		return excludePatterns;
-	}
+    @Override
+    public void setIncludePatterns(Set<String> includePatterns)
+    {
+        this.includePatterns = includePatterns;
+    }
 
-	@Override
-	public void setExcludePatterns(Set<String> excludePatterns) {
-		this.excludePatterns = excludePatterns;
-	}
+    @Override
+    public Set<String> getExcludePatterns()
+    {
+        return excludePatterns;
+    }
 
-	@Override
-	public boolean shouldLogEvent(String eventName) {
-		return includePatterns.stream().anyMatch(pattern -> Pattern.matches(pattern, eventName))
-				&& excludePatterns.stream().noneMatch(pattern -> Pattern.matches(pattern, eventName));
-	}
+    @Override
+    public void setExcludePatterns(Set<String> excludePatterns)
+    {
+        this.excludePatterns = excludePatterns;
+    }
 
+    @Override
+    public boolean shouldLogEvent(String eventName)
+    {
+        return includePatterns.stream().anyMatch(pattern -> Pattern.matches(pattern, eventName))
+                && excludePatterns.stream()
+                        .noneMatch(pattern -> Pattern.matches(pattern, eventName));
+    }
 }

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingPropertiesImpl.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingPropertiesImpl.java
@@ -60,9 +60,9 @@ public class EventLoggingPropertiesImpl
     }
 
     @Override
-    public void setIncludePatterns(Set<String> includePatterns)
+    public void setIncludePatterns(Set<String> aIncludePatterns)
     {
-        this.includePatterns = includePatterns;
+        this.includePatterns = aIncludePatterns;
     }
 
     @Override

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingPropertiesImpl.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingPropertiesImpl.java
@@ -17,6 +17,8 @@
  */
 package de.tudarmstadt.ukp.inception.log.config;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -32,6 +34,8 @@ public class EventLoggingPropertiesImpl
     implements EventLoggingProperties
 {
     private boolean enabled;
+
+    private Map<String, Boolean> eventCache = new HashMap<>();
 
     private Set<String> includePatterns = Set.of(".*"); // Default include everything
 
@@ -78,10 +82,26 @@ public class EventLoggingPropertiesImpl
     }
 
     @Override
-    public boolean shouldLogEvent(String eventName)
+    public boolean shouldLogEvent(String aEventName)
     {
-        return includePatterns.stream().anyMatch(pattern -> Pattern.matches(pattern, eventName))
-                && excludePatterns.stream()
-                        .noneMatch(pattern -> Pattern.matches(pattern, eventName));
+        if (eventCache.containsKey(aEventName)) {
+            return eventCache.get(aEventName);
+        }
+
+        boolean shouldLog = false;
+
+        if (includePatterns != null && !includePatterns.isEmpty()) {
+            shouldLog = includePatterns.stream()
+                    .anyMatch(pattern -> Pattern.matches(pattern, aEventName));
+        }
+
+        if (shouldLog && excludePatterns != null && !excludePatterns.isEmpty()) {
+            shouldLog = excludePatterns.stream()
+                    .noneMatch(pattern -> Pattern.matches(pattern, aEventName));
+        }
+
+        eventCache.put(aEventName, shouldLog);
+
+        return shouldLog;
     }
 }

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingPropertiesImpl.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingPropertiesImpl.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.log.config;
 
+import java.util.Collections;
 import java.util.Set;
 
 import org.springframework.boot.availability.AvailabilityChangeEvent;
@@ -32,12 +33,15 @@ public class EventLoggingPropertiesImpl
 {
     private boolean enabled;
 
-    private Set<String> includePatterns = Set.of(".*"); // Default include everything
+    private Set<String> includePatterns = Collections.emptySet(); // Default include everything
 
-    private Set<String> excludePatterns = Set.of(AfterCasWrittenEvent.class.getSimpleName(),
-            AvailabilityChangeEvent.class.getSimpleName(), "RecommenderTaskNotificationEvent",
-            BeforeDocumentOpenedEvent.class.getSimpleName(),
-            PreparingToOpenDocumentEvent.class.getSimpleName(), "BrokerAvailabilityEvent",
+    private Set<String> excludePatterns = Set.of( //
+            AfterCasWrittenEvent.class.getSimpleName(), //
+            AvailabilityChangeEvent.class.getSimpleName(), //
+            "RecommenderTaskNotificationEvent", //
+            BeforeDocumentOpenedEvent.class.getSimpleName(), //
+            PreparingToOpenDocumentEvent.class.getSimpleName(), //
+            "BrokerAvailabilityEvent", //
             "ShutdownDialogAvailableEvent");
 
     @Override

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingPropertiesImpl.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingPropertiesImpl.java
@@ -76,9 +76,9 @@ public class EventLoggingPropertiesImpl
     }
 
     @Override
-    public void setExcludePatterns(Set<String> excludePatterns)
+    public void setExcludePatterns(Set<String> aExcludePatterns)
     {
-        this.excludePatterns = excludePatterns;
+        this.excludePatterns = aExcludePatterns;
     }
 
     @Override

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingPropertiesImpl.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingPropertiesImpl.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.inception.log.config;
 
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import org.springframework.boot.availability.AvailabilityChangeEvent;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -27,42 +28,54 @@ import de.tudarmstadt.ukp.inception.annotation.events.PreparingToOpenDocumentEve
 import de.tudarmstadt.ukp.inception.documents.event.AfterCasWrittenEvent;
 
 @ConfigurationProperties("event-logging")
-public class EventLoggingPropertiesImpl
-    implements EventLoggingProperties
-{
-    private boolean enabled;
+public class EventLoggingPropertiesImpl implements EventLoggingProperties {
+	private boolean enabled;
 
-    private Set<String> excludeEvents = Set.of( //
-            // Do not log this by default - hardly any information value
-            AfterCasWrittenEvent.class.getSimpleName(), //
-            AvailabilityChangeEvent.class.getSimpleName(), //
-            "RecommenderTaskNotificationEvent", //
-            BeforeDocumentOpenedEvent.class.getSimpleName(), //
-            PreparingToOpenDocumentEvent.class.getSimpleName(), //
-            "BrokerAvailabilityEvent", //
-            "ShutdownDialogAvailableEvent");
+	private Set<String> includePatterns = Set.of(".*"); // Default include everything
+	
+	private Set<String> excludePatterns = Set.of(
+			AfterCasWrittenEvent.class.getSimpleName(),
+			AvailabilityChangeEvent.class.getSimpleName(),
+			"RecommenderTaskNotificationEvent",
+			BeforeDocumentOpenedEvent.class.getSimpleName(),
+			PreparingToOpenDocumentEvent.class.getSimpleName(),
+			"BrokerAvailabilityEvent",
+			"ShutdownDialogAvailableEvent");
 
-    @Override
-    public boolean isEnabled()
-    {
-        return enabled;
-    }
+	@Override
+	public boolean isEnabled() {
+		return enabled;
+	}
 
-    @Override
-    public void setEnabled(boolean aEnabled)
-    {
-        enabled = aEnabled;
-    }
+	@Override
+	public void setEnabled(boolean aEnabled) {
+		enabled = aEnabled;
+	}
 
-    @Override
-    public Set<String> getExcludeEvents()
-    {
-        return excludeEvents;
-    }
+	@Override
+	public Set<String> getIncludePatterns() {
+		return includePatterns;
+	}
 
-    @Override
-    public void setExcludeEvents(Set<String> aExcludeEvents)
-    {
-        excludeEvents = aExcludeEvents;
-    }
+	@Override
+	public void setIncludePatterns(Set<String> includePatterns) {
+		this.includePatterns = includePatterns;
+	}
+
+	@Override
+	public Set<String> getExcludePatterns() {
+		return excludePatterns;
+	}
+
+	@Override
+	public void setExcludePatterns(Set<String> excludePatterns) {
+		this.excludePatterns = excludePatterns;
+	}
+
+	@Override
+	public boolean shouldLogEvent(String eventName) {
+		return includePatterns.stream().anyMatch(pattern -> Pattern.matches(pattern, eventName))
+				&& excludePatterns.stream().noneMatch(pattern -> Pattern.matches(pattern, eventName));
+	}
+
 }

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingPropertiesImpl.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingPropertiesImpl.java
@@ -17,10 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.log.config;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Set;
-import java.util.regex.Pattern;
 
 import org.springframework.boot.availability.AvailabilityChangeEvent;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -34,8 +31,6 @@ public class EventLoggingPropertiesImpl
     implements EventLoggingProperties
 {
     private boolean enabled;
-
-    private Map<String, Boolean> eventCache = new HashMap<>();
 
     private Set<String> includePatterns = Set.of(".*"); // Default include everything
 
@@ -79,29 +74,5 @@ public class EventLoggingPropertiesImpl
     public void setExcludePatterns(Set<String> aExcludePatterns)
     {
         this.excludePatterns = aExcludePatterns;
-    }
-
-    @Override
-    public boolean shouldLogEvent(String aEventName)
-    {
-        if (eventCache.containsKey(aEventName)) {
-            return eventCache.get(aEventName);
-        }
-
-        boolean shouldLog = false;
-
-        if (includePatterns != null && !includePatterns.isEmpty()) {
-            shouldLog = includePatterns.stream()
-                    .anyMatch(pattern -> Pattern.matches(pattern, aEventName));
-        }
-
-        if (shouldLog && excludePatterns != null && !excludePatterns.isEmpty()) {
-            shouldLog = excludePatterns.stream()
-                    .noneMatch(pattern -> Pattern.matches(pattern, aEventName));
-        }
-
-        eventCache.put(aEventName, shouldLog);
-
-        return shouldLog;
     }
 }

--- a/inception/inception-log/src/test/java/de/tudarmstadt/ukp/inception/log/EventLoggingListenerTest.java
+++ b/inception/inception-log/src/test/java/de/tudarmstadt/ukp/inception/log/EventLoggingListenerTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.tudarmstadt.ukp.inception.log;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/inception/inception-log/src/test/java/de/tudarmstadt/ukp/inception/log/EventLoggingListenerTest.java
+++ b/inception/inception-log/src/test/java/de/tudarmstadt/ukp/inception/log/EventLoggingListenerTest.java
@@ -1,21 +1,4 @@
-/*
- * Licensed to the Technische Universität Darmstadt under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The Technische Universität Darmstadt 
- * licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.
- *  
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-package de.tudarmstadt.ukp.inception.log.config;
+package de.tudarmstadt.ukp.inception.log;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -28,22 +11,24 @@ import org.springframework.boot.availability.AvailabilityChangeEvent;
 import de.tudarmstadt.ukp.inception.annotation.events.BeforeDocumentOpenedEvent;
 import de.tudarmstadt.ukp.inception.annotation.events.PreparingToOpenDocumentEvent;
 import de.tudarmstadt.ukp.inception.documents.event.AfterCasWrittenEvent;
+import de.tudarmstadt.ukp.inception.log.config.EventLoggingPropertiesImpl;
 
-class EventLoggingPropertiesImplTest
+class EventLoggingListenerTest
 {
 
+    private EventLoggingListener listener;
     private EventLoggingPropertiesImpl properties;
 
     @BeforeEach
-    public void setUp()
+    void setUp() throws Exception
     {
         properties = new EventLoggingPropertiesImpl();
+        listener = new EventLoggingListener(null, properties, null);
     }
 
     @Test
     public void shouldLogEvent_defaultExcludeInternalList_ReturnsFalse()
     {
-        // Test events
         String eventAfterCasWritten = AfterCasWrittenEvent.class.getSimpleName();
         String eventAvailabilityChange = AvailabilityChangeEvent.class.getSimpleName();
         String eventRecommenderTaskNotification = "RecommenderTaskNotificationEvent";
@@ -52,53 +37,44 @@ class EventLoggingPropertiesImplTest
         String eventBrokerAvailability = "BrokerAvailabilityEvent";
         String eventShutdownDialogAvailable = "ShutdownDialogAvailableEvent";
 
-        // Assert
-        assertThat(properties.shouldLogEvent(eventAfterCasWritten)).isFalse();
-        assertThat(properties.shouldLogEvent(eventAvailabilityChange)).isFalse();
-        assertThat(properties.shouldLogEvent(eventRecommenderTaskNotification)).isFalse();
-        assertThat(properties.shouldLogEvent(eventBeforeDocumentOpened)).isFalse();
-        assertThat(properties.shouldLogEvent(eventPreparingToOpenDocument)).isFalse();
-        assertThat(properties.shouldLogEvent(eventBrokerAvailability)).isFalse();
-        assertThat(properties.shouldLogEvent(eventShutdownDialogAvailable)).isFalse();
+        assertThat(listener.shouldLogEvent(eventAfterCasWritten)).isFalse();
+        assertThat(listener.shouldLogEvent(eventAvailabilityChange)).isFalse();
+        assertThat(listener.shouldLogEvent(eventRecommenderTaskNotification)).isFalse();
+        assertThat(listener.shouldLogEvent(eventBeforeDocumentOpened)).isFalse();
+        assertThat(listener.shouldLogEvent(eventPreparingToOpenDocument)).isFalse();
+        assertThat(listener.shouldLogEvent(eventBrokerAvailability)).isFalse();
+        assertThat(listener.shouldLogEvent(eventShutdownDialogAvailable)).isFalse();
     }
 
     @Test
     public void shouldLogEvent_EventNotInExcludeLists_ReturnsTrue()
     {
-        // Test events
         String eventAfterDocumentOpened = "AfterDocumentOpenedEvent";
 
-        // Assert
-        assertThat(properties.shouldLogEvent(eventAfterDocumentOpened)).isTrue();
+        assertThat(listener.shouldLogEvent(eventAfterDocumentOpened)).isTrue();
         assertThat(properties.getExcludePatterns()).doesNotContain(eventAfterDocumentOpened);
     }
 
     @Test
     public void shouldLogEvent_setExcludeWorksAndEventsGetExcludedTrue()
     {
-        // Set exclude patterns
         properties.setExcludePatterns(Set.of("AfterDocumentOpenedEvent"));
 
-        // Test events
         String eventAfterDocumentOpened = "AfterDocumentOpenedEvent";
 
-        // Assert
-        assertThat(properties.shouldLogEvent(eventAfterDocumentOpened)).isFalse();
+        assertThat(listener.shouldLogEvent(eventAfterDocumentOpened)).isFalse();
     }
 
     @Test
     public void shouldLogEvent_setIncludeWorksAndOnlyEventsSetIncludedWork()
     {
-        // Set include patterns
         properties.setIncludePatterns(Set.of("AfterDocumentOpenedEvent"));
 
-        // Test events
         String eventAfterDocumentOpened = "AfterDocumentOpenedEvent";
         String eventDocumentStateChanged = "DocumentStateChangedEvent";
 
-        // Assert
-        assertThat(properties.shouldLogEvent(eventAfterDocumentOpened)).isTrue();
-        assertThat(properties.shouldLogEvent(eventDocumentStateChanged)).isFalse();
+        assertThat(listener.shouldLogEvent(eventAfterDocumentOpened)).isTrue();
+        assertThat(listener.shouldLogEvent(eventDocumentStateChanged)).isFalse();
     }
 
 }

--- a/inception/inception-log/src/test/java/de/tudarmstadt/ukp/inception/log/EventLoggingListenerTest.java
+++ b/inception/inception-log/src/test/java/de/tudarmstadt/ukp/inception/log/EventLoggingListenerTest.java
@@ -46,27 +46,22 @@ class EventLoggingListenerTest
     @Test
     public void shouldLogEvent_defaultExcludeInternalList_ReturnsFalse()
     {
-        String eventAfterCasWritten = AfterCasWrittenEvent.class.getSimpleName();
-        String eventAvailabilityChange = AvailabilityChangeEvent.class.getSimpleName();
-        String eventRecommenderTaskNotification = "RecommenderTaskNotificationEvent";
-        String eventBeforeDocumentOpened = BeforeDocumentOpenedEvent.class.getSimpleName();
-        String eventPreparingToOpenDocument = PreparingToOpenDocumentEvent.class.getSimpleName();
-        String eventBrokerAvailability = "BrokerAvailabilityEvent";
-        String eventShutdownDialogAvailable = "ShutdownDialogAvailableEvent";
-
-        assertThat(listener.shouldLogEvent(eventAfterCasWritten)).isFalse();
-        assertThat(listener.shouldLogEvent(eventAvailabilityChange)).isFalse();
-        assertThat(listener.shouldLogEvent(eventRecommenderTaskNotification)).isFalse();
-        assertThat(listener.shouldLogEvent(eventBeforeDocumentOpened)).isFalse();
-        assertThat(listener.shouldLogEvent(eventPreparingToOpenDocument)).isFalse();
-        assertThat(listener.shouldLogEvent(eventBrokerAvailability)).isFalse();
-        assertThat(listener.shouldLogEvent(eventShutdownDialogAvailable)).isFalse();
+        assertThat(listener.shouldLogEvent(AfterCasWrittenEvent.class.getSimpleName())).isFalse();
+        assertThat(listener.shouldLogEvent(AvailabilityChangeEvent.class.getSimpleName()))
+                .isFalse();
+        assertThat(listener.shouldLogEvent("RecommenderTaskNotificationEvent")).isFalse();
+        assertThat(listener.shouldLogEvent(BeforeDocumentOpenedEvent.class.getSimpleName()))
+                .isFalse();
+        assertThat(listener.shouldLogEvent(PreparingToOpenDocumentEvent.class.getSimpleName()))
+                .isFalse();
+        assertThat(listener.shouldLogEvent("BrokerAvailabilityEvent")).isFalse();
+        assertThat(listener.shouldLogEvent("ShutdownDialogAvailableEvent")).isFalse();
     }
 
     @Test
     public void shouldLogEvent_EventNotInExcludeLists_ReturnsTrue()
     {
-        String eventAfterDocumentOpened = "AfterDocumentOpenedEvent";
+        var eventAfterDocumentOpened = "AfterDocumentOpenedEvent";
 
         assertThat(listener.shouldLogEvent(eventAfterDocumentOpened)).isTrue();
         assertThat(properties.getExcludePatterns()).doesNotContain(eventAfterDocumentOpened);
@@ -75,23 +70,22 @@ class EventLoggingListenerTest
     @Test
     public void shouldLogEvent_setExcludeWorksAndEventsGetExcludedTrue()
     {
-        properties.setExcludePatterns(Set.of("AfterDocumentOpenedEvent"));
+        var excludedEvent = "ExcludedEvent";
 
-        String eventAfterDocumentOpened = "AfterDocumentOpenedEvent";
+        properties.setExcludePatterns(Set.of(excludedEvent));
 
-        assertThat(listener.shouldLogEvent(eventAfterDocumentOpened)).isFalse();
+        assertThat(listener.shouldLogEvent(excludedEvent)).isFalse();
     }
 
     @Test
     public void shouldLogEvent_setIncludeWorksAndOnlyEventsSetIncludedWork()
     {
-        properties.setIncludePatterns(Set.of("AfterDocumentOpenedEvent"));
+        var includedEvent = "IncludedEvent";
+        var notIncludedEvent = "NotIncludedEvent";
 
-        String eventAfterDocumentOpened = "AfterDocumentOpenedEvent";
-        String eventDocumentStateChanged = "DocumentStateChangedEvent";
+        properties.setIncludePatterns(Set.of(includedEvent));
 
-        assertThat(listener.shouldLogEvent(eventAfterDocumentOpened)).isTrue();
-        assertThat(listener.shouldLogEvent(eventDocumentStateChanged)).isFalse();
+        assertThat(listener.shouldLogEvent(includedEvent)).isTrue();
+        assertThat(listener.shouldLogEvent(notIncludedEvent)).isFalse();
     }
-
 }

--- a/inception/inception-log/src/test/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingPropertiesImplTest.java
+++ b/inception/inception-log/src/test/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingPropertiesImplTest.java
@@ -1,0 +1,81 @@
+package de.tudarmstadt.ukp.inception.log.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.availability.AvailabilityChangeEvent;
+
+import de.tudarmstadt.ukp.inception.annotation.events.BeforeDocumentOpenedEvent;
+import de.tudarmstadt.ukp.inception.annotation.events.PreparingToOpenDocumentEvent;
+import de.tudarmstadt.ukp.inception.documents.event.AfterCasWrittenEvent;
+
+import java.util.Set;
+
+class EventLoggingPropertiesImplTest {
+	
+    private EventLoggingPropertiesImpl properties;
+
+    @BeforeEach
+    public void setUp() {
+        properties = new EventLoggingPropertiesImpl();
+    }
+
+    @Test
+    public void shouldLogEvent_defaultExcludeInternalList_ReturnsFalse() {
+        // Test events
+    	String eventAfterCasWritten = AfterCasWrittenEvent.class.getSimpleName();
+    	String eventAvailabilityChange = AvailabilityChangeEvent.class.getSimpleName();
+    	String eventRecommenderTaskNotification = "RecommenderTaskNotificationEvent";
+    	String eventBeforeDocumentOpened = BeforeDocumentOpenedEvent.class.getSimpleName();
+    	String eventPreparingToOpenDocument = PreparingToOpenDocumentEvent.class.getSimpleName();
+    	String eventBrokerAvailability = "BrokerAvailabilityEvent";
+    	String eventShutdownDialogAvailable = "ShutdownDialogAvailableEvent";
+    	
+        
+        // Assert
+        assertThat(properties.shouldLogEvent(eventAfterCasWritten)).isFalse();
+        assertThat(properties.shouldLogEvent(eventAvailabilityChange)).isFalse();
+        assertThat(properties.shouldLogEvent(eventRecommenderTaskNotification)).isFalse();
+        assertThat(properties.shouldLogEvent(eventBeforeDocumentOpened)).isFalse();
+        assertThat(properties.shouldLogEvent(eventPreparingToOpenDocument)).isFalse();
+        assertThat(properties.shouldLogEvent(eventBrokerAvailability)).isFalse();
+        assertThat(properties.shouldLogEvent(eventShutdownDialogAvailable)).isFalse();
+    }
+    
+    @Test
+    public void shouldLogEvent_EventNotInExcludeLists_ReturnsTrue() {
+        // Test events
+        String eventAfterDocumentOpened = "AfterDocumentOpenedEvent";
+
+        // Assert
+        assertThat(properties.shouldLogEvent(eventAfterDocumentOpened)).isTrue();
+    }
+    
+    @Test
+    public void shouldLogEvent_setExcludeWorksAndEventsGetExcludedTrue() {
+        // Set exclude patterns
+        properties.setExcludePatterns(Set.of("AfterDocumentOpenedEvent"));
+
+        // Test events
+        String eventAfterDocumentOpened = "AfterDocumentOpenedEvent";
+
+        // Assert
+        assertThat(properties.shouldLogEvent(eventAfterDocumentOpened)).isFalse();
+    }
+    
+    @Test
+    public void shouldLogEvent_setIncludeWorksAndOnlyEventsSetIncludedWork() {
+        // Set include patterns
+        properties.setIncludePatterns(Set.of("AfterDocumentOpenedEvent"));
+
+        // Test events
+        String eventAfterDocumentOpened = "AfterDocumentOpenedEvent";
+        String eventDocumentStateChanged = "DocumentStateChangedEvent";
+
+        // Assert
+        assertThat(properties.shouldLogEvent(eventAfterDocumentOpened)).isTrue();
+        assertThat(properties.shouldLogEvent(eventDocumentStateChanged)).isFalse();
+    }
+
+
+}

--- a/inception/inception-log/src/test/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingPropertiesImplTest.java
+++ b/inception/inception-log/src/test/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingPropertiesImplTest.java
@@ -18,6 +18,9 @@
 package de.tudarmstadt.ukp.inception.log.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.availability.AvailabilityChangeEvent;
@@ -26,29 +29,29 @@ import de.tudarmstadt.ukp.inception.annotation.events.BeforeDocumentOpenedEvent;
 import de.tudarmstadt.ukp.inception.annotation.events.PreparingToOpenDocumentEvent;
 import de.tudarmstadt.ukp.inception.documents.event.AfterCasWrittenEvent;
 
-import java.util.Set;
+class EventLoggingPropertiesImplTest
+{
 
-class EventLoggingPropertiesImplTest {
-	
     private EventLoggingPropertiesImpl properties;
 
     @BeforeEach
-    public void setUp() {
+    public void setUp()
+    {
         properties = new EventLoggingPropertiesImpl();
     }
 
     @Test
-    public void shouldLogEvent_defaultExcludeInternalList_ReturnsFalse() {
+    public void shouldLogEvent_defaultExcludeInternalList_ReturnsFalse()
+    {
         // Test events
-    	String eventAfterCasWritten = AfterCasWrittenEvent.class.getSimpleName();
-    	String eventAvailabilityChange = AvailabilityChangeEvent.class.getSimpleName();
-    	String eventRecommenderTaskNotification = "RecommenderTaskNotificationEvent";
-    	String eventBeforeDocumentOpened = BeforeDocumentOpenedEvent.class.getSimpleName();
-    	String eventPreparingToOpenDocument = PreparingToOpenDocumentEvent.class.getSimpleName();
-    	String eventBrokerAvailability = "BrokerAvailabilityEvent";
-    	String eventShutdownDialogAvailable = "ShutdownDialogAvailableEvent";
-    	
-    	
+        String eventAfterCasWritten = AfterCasWrittenEvent.class.getSimpleName();
+        String eventAvailabilityChange = AvailabilityChangeEvent.class.getSimpleName();
+        String eventRecommenderTaskNotification = "RecommenderTaskNotificationEvent";
+        String eventBeforeDocumentOpened = BeforeDocumentOpenedEvent.class.getSimpleName();
+        String eventPreparingToOpenDocument = PreparingToOpenDocumentEvent.class.getSimpleName();
+        String eventBrokerAvailability = "BrokerAvailabilityEvent";
+        String eventShutdownDialogAvailable = "ShutdownDialogAvailableEvent";
+
         // Assert
         assertThat(properties.shouldLogEvent(eventAfterCasWritten)).isFalse();
         assertThat(properties.shouldLogEvent(eventAvailabilityChange)).isFalse();
@@ -58,18 +61,20 @@ class EventLoggingPropertiesImplTest {
         assertThat(properties.shouldLogEvent(eventBrokerAvailability)).isFalse();
         assertThat(properties.shouldLogEvent(eventShutdownDialogAvailable)).isFalse();
     }
-    
+
     @Test
-    public void shouldLogEvent_EventNotInExcludeLists_ReturnsTrue() {
+    public void shouldLogEvent_EventNotInExcludeLists_ReturnsTrue()
+    {
         // Test events
         String eventAfterDocumentOpened = "AfterDocumentOpenedEvent";
 
         // Assert
         assertThat(properties.shouldLogEvent(eventAfterDocumentOpened)).isTrue();
     }
-    
+
     @Test
-    public void shouldLogEvent_setExcludeWorksAndEventsGetExcludedTrue() {
+    public void shouldLogEvent_setExcludeWorksAndEventsGetExcludedTrue()
+    {
         // Set exclude patterns
         properties.setExcludePatterns(Set.of("AfterDocumentOpenedEvent"));
 
@@ -79,9 +84,10 @@ class EventLoggingPropertiesImplTest {
         // Assert
         assertThat(properties.shouldLogEvent(eventAfterDocumentOpened)).isFalse();
     }
-    
+
     @Test
-    public void shouldLogEvent_setIncludeWorksAndOnlyEventsSetIncludedWork() {
+    public void shouldLogEvent_setIncludeWorksAndOnlyEventsSetIncludedWork()
+    {
         // Set include patterns
         properties.setIncludePatterns(Set.of("AfterDocumentOpenedEvent"));
 
@@ -93,6 +99,5 @@ class EventLoggingPropertiesImplTest {
         assertThat(properties.shouldLogEvent(eventAfterDocumentOpened)).isTrue();
         assertThat(properties.shouldLogEvent(eventDocumentStateChanged)).isFalse();
     }
-
 
 }

--- a/inception/inception-log/src/test/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingPropertiesImplTest.java
+++ b/inception/inception-log/src/test/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingPropertiesImplTest.java
@@ -70,6 +70,7 @@ class EventLoggingPropertiesImplTest
 
         // Assert
         assertThat(properties.shouldLogEvent(eventAfterDocumentOpened)).isTrue();
+        assertThat(properties.getExcludePatterns()).doesNotContain(eventAfterDocumentOpened);
     }
 
     @Test

--- a/inception/inception-log/src/test/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingPropertiesImplTest.java
+++ b/inception/inception-log/src/test/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingPropertiesImplTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package de.tudarmstadt.ukp.inception.log.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,7 +48,7 @@ class EventLoggingPropertiesImplTest {
     	String eventBrokerAvailability = "BrokerAvailabilityEvent";
     	String eventShutdownDialogAvailable = "ShutdownDialogAvailableEvent";
     	
-        
+    	
         // Assert
         assertThat(properties.shouldLogEvent(eventAfterCasWritten)).isFalse();
         assertThat(properties.shouldLogEvent(eventAvailabilityChange)).isFalse();


### PR DESCRIPTION
**What's in the PR**
* Deprecated exclude events.
* Introduced include and exclude patterns.
* Including everything (.*) by default, and excluding a predefined set of events by default.
* Refactored EventLoggingListener to use the new include and exclude patterns.
* Added tests.

**How to test manually**
* N/A

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
