### PR TITLE
#4513 - Support full text search in knowledge bases running on Blazegraph

### DIFF
--- a/inception/inception-dependencies/pom.xml
+++ b/inception/inception-dependencies/pom.xml
@@ -141,6 +141,13 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers-bom</artifactId>
+        <version>${testcontainers.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
         <version>${assertj.version}</version>

--- a/inception/inception-kb/pom.xml
+++ b/inception/inception-kb/pom.xml
@@ -336,6 +336,16 @@
       <artifactId>spring-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <pluginManagement>

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/IriConstants.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/IriConstants.java
@@ -47,6 +47,7 @@ public class IriConstants
     public static final String PREFIX_LUCENE_SEARCH = "http://www.openrdf.org/contrib/lucenesail#";
     public static final String PREFIX_MWAPI = "https://www.mediawiki.org/ontology#API/";
     public static final String PREFIX_STARDOG = "tag:stardog:api:search:";
+    public static final String PREFIX_BLAZEGRAPH = "http://www.bigdata.com/rdf/search#";
 
     public static final String UKP_WIKIDATA_SPARQL_ENDPOINT = "http://knowledgebase.ukp.informatik.tu-darmstadt.de:8890/sparql";
     public static final Set<String> IMPLICIT_NAMESPACES = Set.of(RDF.NAMESPACE, RDFS.NAMESPACE,
@@ -87,6 +88,7 @@ public class IriConstants
     public static final IRI FTS_VIRTUOSO;
     public static final IRI FTS_WIKIDATA;
     public static final IRI FTS_STARDOG;
+    public static final IRI FTS_BLAZEGRAPH;
     public static final IRI FTS_NONE;
 
     public static final List<IRI> CLASS_IRIS;
@@ -116,6 +118,7 @@ public class IriConstants
         FTS_LUCENE = vf.createIRI(PREFIX_LUCENE_SEARCH, "matches");
         FTS_WIKIDATA = vf.createIRI(PREFIX_MWAPI, "search");
         FTS_STARDOG = vf.createIRI(PREFIX_STARDOG, "textMatch");
+        FTS_BLAZEGRAPH = vf.createIRI(PREFIX_BLAZEGRAPH, "search");
         FTS_NONE = vf.createIRI("FTS:NONE");
 
         CLASS_IRIS = asList(RDFS.CLASS, OWL.CLASS, WIKIDATA_CLASS, SKOS.CONCEPT);

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/yaml/KnowledgeBaseMapping.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/yaml/KnowledgeBaseMapping.java
@@ -19,6 +19,10 @@ package de.tudarmstadt.ukp.inception.kb.yaml;
 
 import java.io.Serializable;
 
+import org.eclipse.rdf4j.model.vocabulary.OWL;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -29,34 +33,34 @@ public class KnowledgeBaseMapping
     private static final long serialVersionUID = 8967034943386456692L;
 
     @JsonProperty("class")
-    private String classIri;
+    private String classIri = RDFS.CLASS.stringValue();
 
     @JsonProperty("subclass-of")
-    private String subclassIri;
+    private String subclassIri = RDFS.SUBCLASSOF.stringValue();
 
     @JsonProperty("instance-of")
-    private String typeIri;
+    private String typeIri = RDF.TYPE.stringValue();
 
     @JsonProperty("subproperty-of")
-    private String subPropertyIri;
+    private String subPropertyIri = RDFS.SUBPROPERTYOF.stringValue();
 
     @JsonProperty("description")
-    private String descriptionIri;
+    private String descriptionIri = RDFS.COMMENT.stringValue();
 
     @JsonProperty("label")
-    private String labelIri;
+    private String labelIri = RDFS.LABEL.stringValue();
 
     @JsonProperty("property-type")
-    private String propertyTypeIri;
+    private String propertyTypeIri = RDF.PROPERTY.stringValue();
 
     @JsonProperty("property-label")
-    private String propertyLabelIri;
+    private String propertyLabelIri = RDFS.LABEL.stringValue();
 
     @JsonProperty("property-description")
-    private String propertyDescriptionIri;
+    private String propertyDescriptionIri = RDFS.COMMENT.stringValue();
 
     @JsonProperty("deprecation-property")
-    private String deprecationPropertyIri;
+    private String deprecationPropertyIri = OWL.DEPRECATED.stringValue();
 
     @JsonCreator
     public KnowledgeBaseMapping(@JsonProperty("class") String aClassIri,

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/yaml/KnowledgeBaseProfile.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/yaml/KnowledgeBaseProfile.java
@@ -46,7 +46,7 @@ public class KnowledgeBaseProfile
     private String name;
 
     @JsonProperty("disabled")
-    private boolean disabled;
+    private boolean disabled = false;
 
     @JsonProperty("type")
     private RepositoryType type;
@@ -55,7 +55,7 @@ public class KnowledgeBaseProfile
     private KnowledgeBaseAccess access;
 
     @JsonProperty("mapping")
-    private KnowledgeBaseMapping mapping;
+    private KnowledgeBaseMapping mapping = new KnowledgeBaseMapping();
 
     @JsonProperty("root-concepts")
     private List<String> rootConcepts;
@@ -67,7 +67,7 @@ public class KnowledgeBaseProfile
     private KnowledgeBaseInfo info;
 
     @JsonProperty("reification")
-    private Reification reification;
+    private Reification reification = Reification.NONE;
 
     @JsonProperty("default-language")
     private String defaultLanguage;

--- a/inception/inception-kb/src/main/resources/de/tudarmstadt/ukp/inception/kb/yaml/knowledgebase-profiles.yaml
+++ b/inception/inception-kb/src/main/resources/de/tudarmstadt/ukp/inception/kb/yaml/knowledgebase-profiles.yaml
@@ -23,7 +23,6 @@ babel_net:
   type: REMOTE
   default-language: en
   default-dataset: http://babelnet.org/rdf/
-  reification: NONE
   access:
     access-url: http://babelnet.org/sparql/
     full-text-search: bif:contains
@@ -50,7 +49,6 @@ db_pedia:
   name: DBpedia (German)
   type: REMOTE
   default-language: de
-  reification: NONE
   access:
     access-url: http://de.dbpedia.org/sparql
     full-text-search: bif:contains
@@ -79,7 +77,6 @@ wikidata:
   name: Wikidata (direct mapping)
   type: REMOTE
   default-language: en
-  reification: NONE
   access:
     access-url: https://query.wikidata.org/sparql
     full-text-search: https://www.mediawiki.org/ontology#API/search
@@ -108,7 +105,6 @@ yago:
   name: YAGO v4
   type: REMOTE
   default-language: de
-  reification: NONE
   access:
     access-url: https://yago-knowledge.org/sparql/query
     # YAGO runs BlazeGraph these days and they seem not to have set up a full text index
@@ -136,7 +132,6 @@ zbw-stw-economics:
   name: STW Thesaurus for Economics
   type: REMOTE
   default-language: en
-  reification: NONE
   access:
     access-url: http://zbw.eu/beta/sparql/stw/query
     full-text-search: text:query
@@ -163,7 +158,6 @@ zbw-gnd:
   name: Integrated Authority File (GND)
   type: REMOTE
   default-language: en
-  reification: NONE
   access:
     access-url: http://zbw.eu/beta/sparql/gnd/query
     full-text-search: text:query
@@ -192,7 +186,6 @@ agrovoc:
   name: AGROVOC Thesaurus
   type: REMOTE
   default-language: en
-  reification: NONE
   access:
     access-url: https://agrovoc.fao.org/sparql
     full-text-search: text:query
@@ -243,7 +236,6 @@ wine_ontology:
   name: Wine Ontology
   type: LOCAL
   default-language: en
-  reification: NONE
   access:
     access-url: classpath:de/tudarmstadt/ukp/inception/kb/pre-defined-knowledge-bases/wine.rdf
     full-text-search: http://www.openrdf.org/contrib/lucenesail#matches
@@ -270,7 +262,6 @@ olia_penn.owl:
   name: OLiA - Penn Treebank tagset (morphosyntax)
   type: LOCAL
   default-language: en
-  reification: NONE
   access:
     access-url: http://purl.org/olia/penn.owl
     full-text-search: http://www.openrdf.org/contrib/lucenesail#matches
@@ -296,7 +287,6 @@ iao:
   name: Information Artifact Ontology (IAO) (v2022-11-07)
   type: LOCAL
   default-language: en
-  reification: NONE
   access:
     access-url: https://raw.githubusercontent.com/information-artifact-ontology/IAO/v2022-11-07/iao.owl
     full-text-search: http://www.openrdf.org/contrib/lucenesail#matches
@@ -323,7 +313,6 @@ hpo:
   name: Human Phenotype Ontology
   type: LOCAL
   default-language: en
-  reification: NONE
   access:
     access-url: https://purl.obolibrary.org/obo/hp/hp-simple-non-classified.owl
     full-text-search: http://www.openrdf.org/contrib/lucenesail#matches
@@ -354,7 +343,6 @@ snomed-ct:
   name: SNOMED Clinical Terms (manual steps required!)
   type: LOCAL
   default-language: en
-  reification: NONE
   access:
     full-text-search: http://www.openrdf.org/contrib/lucenesail#matches
   mapping:

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/BlazegraphRepositoryTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/BlazegraphRepositoryTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.kb.querybuilder;
+
+import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_BLAZEGRAPH;
+import static de.tudarmstadt.ukp.inception.kb.http.PerThreadSslCheckingHttpClientUtils.restoreSslVerification;
+import static de.tudarmstadt.ukp.inception.kb.http.PerThreadSslCheckingHttpClientUtils.suspendSslVerification;
+import static de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilderTest.buildSparqlRepository;
+import static java.time.Duration.ofMinutes;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.eclipse.rdf4j.repository.Repository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import de.tudarmstadt.ukp.inception.kb.RepositoryType;
+import de.tudarmstadt.ukp.inception.kb.model.KnowledgeBase;
+import de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilderTest.Scenario;
+
+@Testcontainers(disabledWithoutDocker = true)
+public class BlazegraphRepositoryTest
+{
+    private static final int BLAZEGRAPH_PORT = 8080;
+
+    private @TempDir Path temp;
+    private Repository repository;
+    private KnowledgeBase kb;
+
+    @Container
+    private static final GenericContainer<?> blazegraph = new GenericContainer<>(
+            "islandora/blazegraph:3.1.3") //
+                    .withExposedPorts(BLAZEGRAPH_PORT).withEnv("BLAZEGRAPH_HOST", "0.0.0.0")
+                    .waitingFor(Wait.forHttp("/bigdata/sparql").forPort(BLAZEGRAPH_PORT)
+                            .withStartupTimeout(ofMinutes(2)));
+
+    @BeforeEach
+    public void setUp(TestInfo aTestInfo) throws Exception
+    {
+        String methodName = aTestInfo.getTestMethod().map(Method::getName).orElse("<unknown>");
+        System.out.printf("\n=== %s === %s =====================\n", methodName,
+                aTestInfo.getDisplayName());
+
+        suspendSslVerification();
+
+        assertThat(blazegraph.isRunning()).isTrue();
+
+        forceFtsCreation();
+
+        kb = new KnowledgeBase();
+        kb.setDefaultLanguage("en");
+        kb.setType(RepositoryType.REMOTE);
+        kb.setFullTextSearchIri(FTS_BLAZEGRAPH.stringValue());
+        kb.setMaxResults(100);
+
+        SPARQLQueryBuilderTest.initRdfsMapping(kb);
+
+        repository = buildSparqlRepository("http://" + blazegraph.getHost() + ":"
+                + blazegraph.getMappedPort(BLAZEGRAPH_PORT) + "/bigdata/sparql");
+
+        try (var conn = repository.getConnection()) {
+            conn.clear();
+        }
+    }
+
+    private void forceFtsCreation() throws URISyntaxException, IOException, InterruptedException
+    {
+        var httpClient = HttpClient.newBuilder().build();
+
+        var namespace = "kb"; // Default namespace
+
+        var request = HttpRequest.newBuilder()
+                .uri(new URI("http://" + blazegraph.getHost() + ":"
+                        + blazegraph.getMappedPort(BLAZEGRAPH_PORT) + "/bigdata/namespace/"
+                        + namespace + "/textIndex?force-index-create=true"))
+                .POST(HttpRequest.BodyPublishers.noBody()).build();
+
+        var response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+        assertThat(response.statusCode()).isEqualTo(200);
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception
+    {
+        restoreSslVerification();
+    }
+
+    private static List<Arguments> tests() throws Exception
+    {
+        var exclusions = asList( //
+                // Not really clear why this one does not return any results. But since the FTS
+                // version of the test passes, I assume it is not critical - we will usually search
+                // with FTS enabled
+                "testWithLabelMatchingExactlyAnyOf_subproperty_noFTS");
+
+        return SPARQLQueryBuilderTest.tests().stream() //
+                .filter(scenario -> !exclusions.contains(scenario.name)) //
+                .map(scenario -> Arguments.of(scenario.name, scenario)) //
+                .toList();
+    }
+
+    @ParameterizedTest(name = "{index}: test {0}")
+    @MethodSource("tests")
+    public void runTests(String aScenarioName, Scenario aScenario) throws Exception
+    {
+        aScenario.implementation.accept(repository, kb);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
     <mockito.version>5.7.0</mockito.version>
     <assertj.version>3.24.2</assertj.version>
     <xmlunit.version>2.9.1</xmlunit.version>
+    <testcontainers.version>1.19.5</testcontainers.version>
 
     <awaitility.version>4.2.0</awaitility.version>
 


### PR DESCRIPTION
**What's in the PR**
- Add Blazegraph FTS mode
- Added unit tests (running on testcontainers)

**How to test manually**
* Try on https://ubergraph.apps.renci.org/sparql

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
