### PR TITLE
#2879 - Improve multi-value features

### DIFF
--- a/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/ActiveLearningServiceImpl.java
+++ b/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/ActiveLearningServiceImpl.java
@@ -28,15 +28,18 @@ import static java.util.stream.Collectors.toList;
 import java.io.IOException;
 import java.io.Serializable;
 import java.lang.invoke.MethodHandles;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.uima.cas.CAS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.transaction.annotation.Transactional;
 
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
@@ -44,7 +47,6 @@ import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.inception.active.learning.config.ActiveLearningAutoConfiguration;
 import de.tudarmstadt.ukp.inception.active.learning.event.ActiveLearningRecommendationEvent;
 import de.tudarmstadt.ukp.inception.active.learning.strategy.ActiveLearningStrategy;
-import de.tudarmstadt.ukp.inception.annotation.layer.span.SpanAdapter;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.recommendation.api.LearningRecordService;
 import de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService;
@@ -54,6 +56,7 @@ import de.tudarmstadt.ukp.inception.recommendation.api.model.SuggestionGroup;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.SuggestionGroup.Delta;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.AnnotationException;
+import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureSupport;
 import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureSupportRegistry;
 
 /**
@@ -191,7 +194,6 @@ public class ActiveLearningServiceImpl
                 .orElseThrow(() -> new IllegalArgumentException(
                         "No such layer: [" + aSuggestion.getLayerId() + "]"));
         var feature = schemaService.getFeature(aSuggestion.getFeature(), layer);
-        var adapter = (SpanAdapter) schemaService.getAdapter(layer);
 
         // Load CAS in which to create the annotation. This might be different from the one that
         // is currently viewed by the user, e.g. if the user switched to another document after
@@ -202,7 +204,8 @@ public class ActiveLearningServiceImpl
 
         // Create AnnotationFeature and FeatureSupport
         var featureSupport = featureSupportRegistry.findExtension(feature).orElseThrow();
-        var label = (String) featureSupport.unwrapFeatureValue(feature, cas, aValue);
+
+        var label = unwrapLabel(aValue, feature, cas, featureSupport);
 
         // Clone of the original suggestion with the selected by the user
         var suggestionWithUserSelectedLabel = aSuggestion.toBuilder().withLabel(label).build();
@@ -234,6 +237,23 @@ public class ActiveLearningServiceImpl
         applicationEventPublisher.publishEvent(new ActiveLearningRecommendationEvent(this,
                 aDocument, suggestionWithUserSelectedLabel, dataOwner, feature.getLayer(),
                 suggestionWithUserSelectedLabel.getFeature(), action, alternativeSuggestions));
+    }
+
+    private String unwrapLabel(Object aValue, AnnotationFeature feature, CAS cas,
+            FeatureSupport<Object> featureSupport)
+    {
+        String label;
+        Object rawLabel = featureSupport.unwrapFeatureValue(feature, cas, aValue);
+        if (rawLabel instanceof Collection collectionValue) {
+            rawLabel = collectionValue.iterator().next();
+        }
+        if (rawLabel instanceof String) {
+            label = (String) rawLabel;
+        }
+        else {
+            throw new IllegalArgumentException("Non-string suggestions are not supported");
+        }
+        return label;
     }
 
     @Override

--- a/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.java
+++ b/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.java
@@ -863,10 +863,7 @@ public class ActiveLearningSidebar
 
     private Form<?> createLearningHistory()
     {
-        Form<?> learningHistoryForm = new Form<Void>(CID_LEARNING_HISTORY_FORM)
-        {
-            private static final long serialVersionUID = -961690443085882064L;
-        };
+        var learningHistoryForm = new Form<Void>(CID_LEARNING_HISTORY_FORM);
         learningHistoryForm.add(LambdaBehavior.onConfigure(
                 component -> component.setVisible(alStateModel.getObject().isSessionActive())));
         learningHistoryForm.setOutputMarkupPlaceholderTag(true);
@@ -878,8 +875,7 @@ public class ActiveLearningSidebar
 
     private ListView<LearningRecord> createLearningHistoryListView()
     {
-        ListView<LearningRecord> learningHistory = new ListView<LearningRecord>(
-                CID_HISTORY_LISTVIEW)
+        var learningHistory = new ListView<LearningRecord>(CID_HISTORY_LISTVIEW)
         {
             private static final long serialVersionUID = 5594228545985423567L;
 
@@ -1385,7 +1381,7 @@ public class ActiveLearningSidebar
     public void onDocumentOpenedEvent(DocumentOpenedEvent aEvent)
     {
         // If active learning is not active, update the sidebar in case the session auto-terminated
-        ActiveLearningUserState alState = alStateModel.getObject();
+        var alState = alStateModel.getObject();
         if (!alState.isSessionActive()) {
             aEvent.getRequestTarget().ifPresent(target -> target.add(alMainContainer));
             return;

--- a/inception/inception-annotation-storage/src/test/resources/log4j2-test.xml
+++ b/inception/inception-annotation-storage/src/test/resources/log4j2-test.xml
@@ -6,13 +6,11 @@
     </Console>
   </Appenders>
   <Loggers>
-    <Logger name="de.tudarmstadt" level="INFO"/>
-    <!--
-    <Logger name="de.tudarmstadt.ukp.clarin.webanno.api.dao.CasMetadataUtils" level="TRACE"/>
-		<logger name="de.tudarmstadt.ukp.clarin.webanno.api.dao.CasStorageServiceImpl" level="TRACE"/>
-		<Logger name="de.tudarmstadt.ukp.clarin.webanno.api.dao.casstorage.CasStorageSession" level="TRACE"/>
-		-->
-    <Root level="warn">
+<!--     <Logger name="de.tudarmstadt" level="INFO"/> -->
+<!--     <Logger name="de.tudarmstadt.ukp.clarin.webanno.api.dao.CasMetadataUtils" level="TRACE"/> -->
+<!-- 		<logger name="de.tudarmstadt.ukp.clarin.webanno.api.dao.CasStorageServiceImpl" level="TRACE"/> -->
+<!-- 		<Logger name="de.tudarmstadt.ukp.clarin.webanno.api.dao.casstorage.CasStorageSession" level="TRACE"/> -->
+    <Root level="WARN">
       <AppenderRef ref="ConsoleAppender" />
     </Root>
   </Loggers>

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiValueStringFeatureSupport.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiValueStringFeatureSupport.java
@@ -22,8 +22,11 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.uima.cas.CAS.TYPE_NAME_STRING_ARRAY;
 
 import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -32,6 +35,7 @@ import org.apache.uima.cas.Feature;
 import org.apache.uima.cas.FeatureStructure;
 import org.apache.uima.cas.StringArrayFS;
 import org.apache.uima.fit.util.FSUtil;
+import org.apache.uima.jcas.cas.StringArray;
 import org.apache.wicket.MarkupContainer;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
@@ -50,6 +54,7 @@ import de.tudarmstadt.ukp.inception.rendering.editorstate.FeatureState;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VLazyDetail;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VLazyDetailGroup;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
+import de.tudarmstadt.ukp.inception.schema.api.adapter.AnnotationException;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.IllegalFeatureValueException;
 import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureEditor;
 import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureType;
@@ -128,6 +133,29 @@ public class MultiValueStringFeatureSupport
     }
 
     @Override
+    public Serializable wrapFeatureValue(AnnotationFeature aFeature, CAS aCAS, Object aValue)
+    {
+        if (aValue == null) {
+            return null;
+        }
+
+        if (aValue instanceof StringArray value) {
+            return new ArrayList<>(asList(value.toArray()));
+        }
+
+        if (aValue instanceof String value) {
+            return new ArrayList<>(asList(value));
+        }
+
+        if (aValue instanceof Collection) {
+            return (Serializable) aValue;
+        }
+
+        throw new IllegalArgumentException(
+                "Unable to handle value [" + aValue + "] of type [" + aValue.getClass() + "]");
+    }
+
+    @Override
     public void setFeatureValue(CAS aCas, AnnotationFeature aFeature, int aAddress, Object aValue)
         throws IllegalFeatureValueException
     {
@@ -135,8 +163,8 @@ public class MultiValueStringFeatureSupport
             throw unsupportedFeatureTypeException(aFeature);
         }
 
-        FeatureStructure fs = getFS(aCas, aFeature, aAddress);
-        List<String> values = unwrapFeatureValue(aFeature, fs.getCAS(), aValue);
+        var fs = getFS(aCas, aFeature, aAddress);
+        var values = unwrapFeatureValue(aFeature, fs.getCAS(), aValue);
         if (values == null || values.isEmpty()) {
             FSUtil.setFeature(fs, aFeature.getName(), (Collection<String>) null);
             return;
@@ -147,7 +175,7 @@ public class MultiValueStringFeatureSupport
         }
 
         // Create a new array if size differs otherwise re-use existing one
-        StringArrayFS array = FSUtil.getFeature(fs, aFeature.getName(), StringArrayFS.class);
+        var array = FSUtil.getFeature(fs, aFeature.getName(), StringArrayFS.class);
         if (array == null || (array.size() != values.size())) {
             array = fs.getCAS().createStringArrayFS(values.size());
         }
@@ -156,6 +184,46 @@ public class MultiValueStringFeatureSupport
         array.copyFromArray(values.toArray(new String[values.size()]), 0, 0, values.size());
 
         fs.setFeatureValue(fs.getType().getFeatureByBaseName(aFeature.getName()), array);
+    }
+
+    @Override
+    public void pushFeatureValue(CAS aCas, AnnotationFeature aFeature, int aAddress, Object aValue)
+        throws AnnotationException
+    {
+        if (!accepts(aFeature)) {
+            throw unsupportedFeatureTypeException(aFeature);
+        }
+
+        var fs = getFS(aCas, aFeature, aAddress);
+        var newValues = unwrapFeatureValue(aFeature, fs.getCAS(), aValue);
+        if (newValues == null || newValues.isEmpty()) {
+            return;
+        }
+
+        for (String value : newValues) {
+            schemaService.createMissingTag(aFeature, value);
+        }
+
+        var feature = fs.getType().getFeatureByBaseName(aFeature.getName());
+        var oldValues = (Collection<String>) wrapFeatureValue(aFeature, fs.getCAS(),
+                fs.getFeatureValue(feature));
+
+        var mergedValues = new LinkedHashSet<String>();
+        if (oldValues != null) {
+            mergedValues.addAll(oldValues);
+        }
+        mergedValues.addAll(newValues);
+
+        // Create a new array if size differs otherwise re-use existing one
+        var array = FSUtil.getFeature(fs, aFeature.getName(), StringArrayFS.class);
+        if (array == null || (array.size() != mergedValues.size())) {
+            array = fs.getCAS().createStringArrayFS(mergedValues.size());
+        }
+
+        array.copyFromArray(mergedValues.toArray(new String[mergedValues.size()]), 0, 0,
+                mergedValues.size());
+
+        fs.setFeatureValue(feature, array);
     }
 
     @Override

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/TypeAdapter_ImplBase.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/TypeAdapter_ImplBase.java
@@ -144,17 +144,38 @@ public abstract class TypeAdapter_ImplBase
     }
 
     @Override
-    public void setFeatureValue(SourceDocument aDocument, String aUsername, CAS aCas, int aAddress,
-            AnnotationFeature aFeature, Object aValue)
+    public final void setFeatureValue(SourceDocument aDocument, String aUsername, CAS aCas,
+            int aAddress, AnnotationFeature aFeature, Object aValue)
         throws AnnotationException
     {
         var featureSupport = featureSupportRegistry.findExtension(aFeature).orElseThrow();
 
-        FeatureStructure fs = selectFsByAddr(aCas, aAddress);
+        var fs = selectFsByAddr(aCas, aAddress);
 
         var oldValue = featureSupport.getFeatureValue(aFeature, fs);
 
         featureSupport.setFeatureValue(aCas, aFeature, aAddress, aValue);
+
+        var newValue = featureSupport.getFeatureValue(aFeature, fs);
+
+        if (!Objects.equals(oldValue, newValue)) {
+            publishEvent(() -> new FeatureValueUpdatedEvent(this, aDocument, aUsername, getLayer(),
+                    fs, aFeature, newValue, oldValue));
+        }
+    }
+
+    @Override
+    public final void pushFeatureValue(SourceDocument aDocument, String aUsername, CAS aCas,
+            int aAddress, AnnotationFeature aFeature, Object aValue)
+        throws AnnotationException
+    {
+        var featureSupport = featureSupportRegistry.findExtension(aFeature).orElseThrow();
+
+        var fs = selectFsByAddr(aCas, aAddress);
+
+        var oldValue = featureSupport.getFeatureValue(aFeature, fs);
+
+        featureSupport.pushFeatureValue(aCas, aFeature, aAddress, aValue);
 
         var newValue = featureSupport.getFeatureValue(aFeature, fs);
 

--- a/inception/inception-concept-linking/src/test/resources/log4j2-test.xml
+++ b/inception/inception-concept-linking/src/test/resources/log4j2-test.xml
@@ -8,10 +8,10 @@
   </Appenders>
 
   <Loggers>
-    <Logger name="de.tudarmstadt.ukp.inception.conceptlinking" level="TRACE"/>
-    <Logger name="de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilder" level="TRACE"/>
-    <Logger name="org.eclipse.rdf4j.sail.lucene" level="INFO"/>
-    <Root level="warn">
+<!--     <Logger name="de.tudarmstadt.ukp.inception.conceptlinking" level="TRACE"/> -->
+<!--     <Logger name="de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilder" level="TRACE"/> -->
+<!--     <Logger name="org.eclipse.rdf4j.sail.lucene" level="INFO"/> -->
+    <Root level="WARN">
       <AppenderRef ref="ConsoleAppender" />
     </Root>
   </Loggers>

--- a/inception/inception-curation-legacy/src/test/resources/log4j2-test.xml
+++ b/inception/inception-curation-legacy/src/test/resources/log4j2-test.xml
@@ -6,9 +6,9 @@
     </Console>
   </Appenders>
   <Loggers>
-    <Logger name="de.tudarmstadt" level="DEBUG"/>
-    <Logger name="de.tudarmstadt.ukp.clarin.webanno.curation.casmerge.CasMerge" level="TRACE"/>
-    <Root level="warn">
+<!--     <Logger name="de.tudarmstadt" level="DEBUG"/> -->
+<!--     <Logger name="de.tudarmstadt.ukp.clarin.webanno.curation.casmerge.CasMerge" level="TRACE"/> -->
+    <Root level="WARN">
       <AppenderRef ref="ConsoleAppender" />
     </Root>
   </Loggers>

--- a/inception/inception-documents/src/test/resources/log4j2-test.xml
+++ b/inception/inception-documents/src/test/resources/log4j2-test.xml
@@ -6,13 +6,11 @@
     </Console>
   </Appenders>
   <Loggers>
-    <Logger name="de.tudarmstadt" level="INFO"/>
-    <!--
-    <Logger name="de.tudarmstadt.ukp.clarin.webanno.api.dao.CasMetadataUtils" level="TRACE"/>
-		<logger name="de.tudarmstadt.ukp.clarin.webanno.api.dao.CasStorageServiceImpl" level="TRACE"/>
-		<Logger name="de.tudarmstadt.ukp.clarin.webanno.api.dao.casstorage.CasStorageSession" level="TRACE"/>
-		-->
-    <Root level="warn">
+<!--     <Logger name="de.tudarmstadt" level="INFO"/> -->
+<!--     <Logger name="de.tudarmstadt.ukp.clarin.webanno.api.dao.CasMetadataUtils" level="TRACE"/> -->
+<!-- 		<logger name="de.tudarmstadt.ukp.clarin.webanno.api.dao.CasStorageServiceImpl" level="TRACE"/> -->
+<!-- 		<Logger name="de.tudarmstadt.ukp.clarin.webanno.api.dao.casstorage.CasStorageSession" level="TRACE"/> -->
+    <Root level="WARN">
       <AppenderRef ref="ConsoleAppender" />
     </Root>
   </Loggers>

--- a/inception/inception-external-editor/src/test/resources/log4j2-test.xml
+++ b/inception/inception-external-editor/src/test/resources/log4j2-test.xml
@@ -8,10 +8,10 @@
   </Appenders>
 
   <Loggers>
-    <Logger name="de.tudarmstadt.ukp.clarin.webanno.support.WatchedResourceFile" level="TRACE"/>
-    <Logger name="de.tudarmstadt.ukp.inception.externaleditor.policy.SafetyNetDocumentPolicyTest" level="TRACE"/>
+<!--     <Logger name="de.tudarmstadt.ukp.clarin.webanno.support.WatchedResourceFile" level="TRACE"/> -->
+<!--     <Logger name="de.tudarmstadt.ukp.inception.externaleditor.policy.SafetyNetDocumentPolicyTest" level="TRACE"/> -->
     
-    <Root level="warn">
+    <Root level="WARN">
       <AppenderRef ref="ConsoleAppender" />
     </Root>
   </Loggers>

--- a/inception/inception-external-search-solr/src/test/resources/log4j2-test.xml
+++ b/inception/inception-external-search-solr/src/test/resources/log4j2-test.xml
@@ -8,8 +8,8 @@
 
   <Loggers>
 <!--     <Logger name="org" level="DEBUG"/> -->
-    <Logger name="de.tudarmstadt.ukp.inception.recommendation" level="TRACE"/>
-    <Root level="ERROR">
+<!--     <Logger name="de.tudarmstadt.ukp.inception.recommendation" level="TRACE"/> -->
+    <Root level="WARN">
       <AppenderRef ref="ConsoleAppender" />
     </Root>
   </Loggers>

--- a/inception/inception-imls-ollama/src/test/resources/log4j2-test.xml
+++ b/inception/inception-imls-ollama/src/test/resources/log4j2-test.xml
@@ -7,7 +7,7 @@
   </Appenders>
 
   <Loggers>
-    <Logger name="de.tudarmstadt.ukp.inception.recommendation.imls.ollama" level="TRACE"/>
+<!--     <Logger name="de.tudarmstadt.ukp.inception.recommendation.imls.ollama" level="TRACE"/> -->
 
     <Root level="ERROR">
       <AppenderRef ref="ConsoleAppender" />

--- a/inception/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/span/StringMatchingRecommender.java
+++ b/inception/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/span/StringMatchingRecommender.java
@@ -178,8 +178,11 @@ public class StringMatchingRecommender
 
             for (var ann : select(cas, predictedType)) {
                 if (isMultiValue) {
-                    for (var label : FSUtil.getFeature(ann, predictedFeature, String[].class)) {
-                        learn(dict, ann.getCoveredText(), label);
+                    var labels = FSUtil.getFeature(ann, predictedFeature, String[].class);
+                    if (labels != null) {
+                        for (var label : labels) {
+                            learn(dict, ann.getCoveredText(), label);
+                        }
                     }
                 }
                 else {
@@ -427,9 +430,11 @@ public class StringMatchingRecommender
                     }
 
                     if (isMultiValue) {
-                        Stream.of(FSUtil.getFeature(ann, predictedFeature, String[].class))
-                                .distinct() //
-                                .forEach(l -> spans.add(new Span(ann, l)));
+                        var value = FSUtil.getFeature(ann, predictedFeature, String[].class);
+                        if (value != null) {
+                            Stream.of(value).distinct() //
+                                    .forEach(l -> spans.add(new Span(ann, l)));
+                        }
                     }
                     else {
                         spans.add(new Span(ann, ann.getFeatureValueAsString(predictedFeature)));

--- a/inception/inception-imls-stringmatch/src/test/resources/log4j2-test.xml
+++ b/inception/inception-imls-stringmatch/src/test/resources/log4j2-test.xml
@@ -7,9 +7,9 @@
   </Appenders>
 
   <Loggers>
-    <Logger name="org.deeplearning4j.optimize.listeners" level="INFO"/>
-    <Logger name="de.tudarmstadt.ukp.inception.recommendation" level="TRACE"/>
-    <Root level="ERROR">
+<!--     <Logger name="org.deeplearning4j.optimize.listeners" level="INFO"/> -->
+<!--     <Logger name="de.tudarmstadt.ukp.inception.recommendation" level="TRACE"/> -->
+    <Root level="WARN">
       <AppenderRef ref="ConsoleAppender" />
     </Root>
   </Loggers>

--- a/inception/inception-project-export/src/test/resources/log4j2-test.xml
+++ b/inception/inception-project-export/src/test/resources/log4j2-test.xml
@@ -6,17 +6,15 @@
     </Console>
   </Appenders>
   <Loggers>
-    <Logger name="de.tudarmstadt" level="INFO"/>
-    <!--
-    <Logger name="de.tudarmstadt.ukp.clarin.webanno.api.dao.CasMetadataUtils" level="TRACE"/>
-    <logger name="de.tudarmstadt.ukp.clarin.webanno.api.dao.CasStorageServiceImpl" level="TRACE"/>
-    <Logger name="de.tudarmstadt.ukp.clarin.webanno.api.dao.casstorage.CasStorageSession" level="TRACE"/>
-    <Logger name="org.springframework.messaging.simp.broker.SimpleBrokerMessageHandler" level="DEBUG"/>
-    <Logger name="org.springframework.web.socket" level="TRACE" />
-    <Logger name="org.springframework.security" level="TRACE" />
-    -->
+<!--     <Logger name="de.tudarmstadt" level="INFO"/> -->
+<!--     <Logger name="de.tudarmstadt.ukp.clarin.webanno.api.dao.CasMetadataUtils" level="TRACE"/> -->
+<!--     <logger name="de.tudarmstadt.ukp.clarin.webanno.api.dao.CasStorageServiceImpl" level="TRACE"/> -->
+<!--     <Logger name="de.tudarmstadt.ukp.clarin.webanno.api.dao.casstorage.CasStorageSession" level="TRACE"/> -->
+<!--     <Logger name="org.springframework.messaging.simp.broker.SimpleBrokerMessageHandler" level="DEBUG"/> -->
+<!--     <Logger name="org.springframework.web.socket" level="TRACE" /> -->
+<!--     <Logger name="org.springframework.security" level="TRACE" /> -->
    
-    <Root level="warn">
+    <Root level="WARN">
       <AppenderRef ref="ConsoleAppender" />
     </Root>
   </Loggers>

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/SuggestionSupport_ImplBase.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/SuggestionSupport_ImplBase.java
@@ -80,13 +80,13 @@ public abstract class SuggestionSupport_ImplBase
         return id;
     }
 
-    protected void commitLabel(SourceDocument aDocument, String aDataOwner, CAS aCas,
+    protected final void commitLabel(SourceDocument aDocument, String aDataOwner, CAS aCas,
             TypeAdapter aAdapter, AnnotationFeature aFeature, String aValue,
             AnnotationBaseFS annotation)
         throws AnnotationException
     {
         // Update the feature value
-        aAdapter.setFeatureValue(aDocument, aDataOwner, aCas, ICasUtil.getAddr(annotation),
+        aAdapter.pushFeatureValue(aDocument, aDataOwner, aCas, ICasUtil.getAddr(annotation),
                 aFeature, aValue);
     }
 

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/relation/RelationSuggestionSupport.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/relation/RelationSuggestionSupport.java
@@ -96,7 +96,9 @@ public class RelationSuggestionSupport
         }
 
         var feature = aContext.getFeature();
-        if (CAS.TYPE_NAME_STRING.equals(feature.getType()) || feature.isVirtualFeature()) {
+        if (CAS.TYPE_NAME_STRING.equals(feature.getType())
+                || CAS.TYPE_NAME_STRING_ARRAY.equals(feature.getType())
+                || feature.isVirtualFeature()) {
             return true;
         }
 

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/span/SpanSuggestionSupport.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/span/SpanSuggestionSupport.java
@@ -306,6 +306,9 @@ public class SpanSuggestionSupport
                 for (var labelObject : labelObjects) {
                     var label = labelObject != null ? String.valueOf(labelObject) : null;
 
+                    var stackableSuggestions = feature.getLayer().isAllowStacking()
+                            || feature.getMultiValueMode() != MultiValueMode.NONE;
+
                     for (var suggestion : group) {
                         // The suggestion would just create an annotation and not set any
                         // feature
@@ -324,7 +327,7 @@ public class SpanSuggestionSupport
 
                             // If stacking is enabled, we do allow suggestions that create an
                             // annotation with no label, but only if the offsets differ
-                            if (!(feature.getLayer().isAllowStacking() && !colocated)) {
+                            if (!(stackableSuggestions && !colocated)) {
                                 suggestion.hide(FLAG_OVERLAP);
                                 hiddenForOverlap.add(suggestion);
                                 continue;
@@ -351,8 +354,7 @@ public class SpanSuggestionSupport
 
                             // Would accepting the suggestion create a new annotation but
                             // stacking is not enabled - then we need to hide
-                            if (!feature.getLayer().isAllowStacking()
-                                    && feature.getMultiValueMode() == MultiValueMode.NONE) {
+                            if (!stackableSuggestions) {
                                 suggestion.hide(FLAG_OVERLAP);
                                 hiddenForOverlap.add(suggestion);
                                 continue;

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/span/SpanSuggestionSupport.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/span/SpanSuggestionSupport.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.recommendation.span;
 
+import static de.tudarmstadt.ukp.clarin.webanno.model.MultiValueMode.NONE;
 import static de.tudarmstadt.ukp.inception.recommendation.api.model.AnnotationSuggestion.FLAG_OVERLAP;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
@@ -157,7 +158,8 @@ public class SpanSuggestionSupport
                 // If there is an annotation where the predicted feature is unset, use it ...
                 annotation = candidateWithEmptyLabel.get();
             }
-            else if (candidates.isEmpty() || aAdapter.getLayer().isAllowStacking()) {
+            else if (candidates.isEmpty() || (aAdapter.getLayer().isAllowStacking()
+                    && aFeature.getMultiValueMode() == NONE)) {
                 // ... if not or if stacking is allowed, then we create a new annotation - this also
                 // takes care of attaching to an annotation if necessary
                 annotation = aAdapter.add(aDocument, aDataOwner, aCas, aBegin, aEnd);
@@ -283,6 +285,9 @@ public class SpanSuggestionSupport
         // the keys in a TreeSet - and the annotation offsets are sorted in the same way manually
         var oi = new OverlapIterator(new ArrayList<>(suggestions.keySet()), sortedAnnotationKeys);
 
+        var stackableSuggestions = feature.getLayer().isAllowStacking()
+                || feature.getMultiValueMode() != MultiValueMode.NONE;
+
         // Bulk-hide any groups that overlap with existing annotations on the current layer
         // and for the current feature
         var hiddenForOverlap = new ArrayList<AnnotationSuggestion>();
@@ -305,9 +310,6 @@ public class SpanSuggestionSupport
 
                 for (var labelObject : labelObjects) {
                     var label = labelObject != null ? String.valueOf(labelObject) : null;
-
-                    var stackableSuggestions = feature.getLayer().isAllowStacking()
-                            || feature.getMultiValueMode() != MultiValueMode.NONE;
 
                     for (var suggestion : group) {
                         // The suggestion would just create an annotation and not set any

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/span/SpanSuggestionSupport.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/span/SpanSuggestionSupport.java
@@ -20,6 +20,7 @@ package de.tudarmstadt.ukp.inception.recommendation.span;
 import static de.tudarmstadt.ukp.inception.recommendation.api.model.AnnotationSuggestion.FLAG_OVERLAP;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
+import static java.util.Arrays.asList;
 import static java.util.Comparator.comparingInt;
 import static org.apache.uima.cas.text.AnnotationPredicates.colocated;
 import static org.apache.uima.fit.util.CasUtil.getType;
@@ -52,6 +53,7 @@ import org.springframework.lang.Nullable;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.MultiValueMode;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.TrimUtils;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
@@ -110,7 +112,9 @@ public class SpanSuggestionSupport
         }
 
         var feature = aContext.getFeature();
-        if (CAS.TYPE_NAME_STRING.equals(feature.getType()) || feature.isVirtualFeature()) {
+        if (CAS.TYPE_NAME_STRING.equals(feature.getType())
+                || CAS.TYPE_NAME_STRING_ARRAY.equals(feature.getType())
+                || feature.isVirtualFeature()) {
             return true;
         }
 
@@ -209,7 +213,7 @@ public class SpanSuggestionSupport
                 .filter(group -> group.getLayerId() == aLayer.getId())
                 // ... and in the given window
                 .filter(group -> {
-                    Offset offset = (Offset) group.getPosition();
+                    var offset = (Offset) group.getPosition();
                     return AnnotationPredicates.coveredBy(offset.getBegin(), offset.getEnd(),
                             aWindowBegin, aWindowEnd);
                 }) //
@@ -289,56 +293,70 @@ public class SpanSuggestionSupport
             // Fetch the current suggestion and annotation
             var group = suggestions.get(suggestionOffset);
             for (var annotation : annotations.get(annotationOffset)) {
-                var label = annotation.getFeatureValueAsString(feat);
-                for (var suggestion : group) {
-                    // The suggestion would just create an annotation and not set any
-                    // feature
-                    var colocated = colocated(annotation, suggestion.getBegin(),
-                            suggestion.getEnd());
-                    if (suggestion.getLabel() == null) {
-                        // If there is already an annotation, then we hide any suggestions
-                        // that would just trigger the creation of the same annotation and
-                        // not set any new feature. This applies whether stacking is allowed
-                        // or not.
-                        if (colocated) {
-                            suggestion.hide(FLAG_OVERLAP);
-                            hiddenForOverlap.add(suggestion);
-                            continue;
-                        }
+                Iterable<Object> labelObjects;
+                var value = featureSupportRegistry.findExtension(feature).get()
+                        .getFeatureValue(feature, annotation);
+                if (value instanceof Iterable iterableValues) {
+                    labelObjects = iterableValues;
+                }
+                else {
+                    labelObjects = asList(value);
+                }
 
-                        // If stacking is enabled, we do allow suggestions that create an
-                        // annotation with no label, but only if the offsets differ
-                        if (!(feature.getLayer().isAllowStacking() && !colocated)) {
-                            suggestion.hide(FLAG_OVERLAP);
-                            hiddenForOverlap.add(suggestion);
-                            continue;
-                        }
-                    }
-                    // The suggestion would merge the suggested feature value into an
-                    // existing annotation or create a new annotation with the feature if
-                    // stacking were enabled.
-                    else {
-                        // Is the feature still unset in the current annotation - i.e. would
-                        // accepting the suggestion merge the feature into it? If yes, we do
-                        // not hide
-                        if (label == null && suggestion.getLabel() != null && colocated) {
-                            continue;
-                        }
+                for (var labelObject : labelObjects) {
+                    var label = labelObject != null ? String.valueOf(labelObject) : null;
 
-                        // Does the suggested label match the label of an existing annotation
-                        // at the same position then we hide
-                        if (label != null && label.equals(suggestion.getLabel()) && colocated) {
-                            suggestion.hide(FLAG_OVERLAP);
-                            hiddenForOverlap.add(suggestion);
-                            continue;
-                        }
+                    for (var suggestion : group) {
+                        // The suggestion would just create an annotation and not set any
+                        // feature
+                        var colocated = colocated(annotation, suggestion.getBegin(),
+                                suggestion.getEnd());
+                        if (suggestion.getLabel() == null) {
+                            // If there is already an annotation, then we hide any suggestions
+                            // that would just trigger the creation of the same annotation and
+                            // not set any new feature. This applies whether stacking is allowed
+                            // or not.
+                            if (colocated) {
+                                suggestion.hide(FLAG_OVERLAP);
+                                hiddenForOverlap.add(suggestion);
+                                continue;
+                            }
 
-                        // Would accepting the suggestion create a new annotation but
-                        // stacking is not enabled - then we need to hide
-                        if (!feature.getLayer().isAllowStacking()) {
-                            suggestion.hide(FLAG_OVERLAP);
-                            hiddenForOverlap.add(suggestion);
-                            continue;
+                            // If stacking is enabled, we do allow suggestions that create an
+                            // annotation with no label, but only if the offsets differ
+                            if (!(feature.getLayer().isAllowStacking() && !colocated)) {
+                                suggestion.hide(FLAG_OVERLAP);
+                                hiddenForOverlap.add(suggestion);
+                                continue;
+                            }
+                        }
+                        // The suggestion would merge the suggested feature value into an
+                        // existing annotation or create a new annotation with the feature if
+                        // stacking were enabled.
+                        else {
+                            // Is the feature still unset in the current annotation - i.e. would
+                            // accepting the suggestion merge the feature into it? If yes, we do
+                            // not hide
+                            if (label == null && suggestion.getLabel() != null && colocated) {
+                                continue;
+                            }
+
+                            // Does the suggested label match the label of an existing annotation
+                            // at the same position then we hide
+                            if (label != null && label.equals(suggestion.getLabel()) && colocated) {
+                                suggestion.hide(FLAG_OVERLAP);
+                                hiddenForOverlap.add(suggestion);
+                                continue;
+                            }
+
+                            // Would accepting the suggestion create a new annotation but
+                            // stacking is not enabled - then we need to hide
+                            if (!feature.getLayer().isAllowStacking()
+                                    && feature.getMultiValueMode() == MultiValueMode.NONE) {
+                                suggestion.hide(FLAG_OVERLAP);
+                                hiddenForOverlap.add(suggestion);
+                                continue;
+                            }
                         }
                     }
                 }

--- a/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/span/MultiValueFeatureSuggestionVisibilityCalculationTest.java
+++ b/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/span/MultiValueFeatureSuggestionVisibilityCalculationTest.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.span;
+
+import static de.tudarmstadt.ukp.inception.recommendation.service.Fixtures.getInvisibleSuggestions;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+import org.apache.uima.cas.CAS;
+import org.apache.uima.fit.factory.CasFactory;
+import org.apache.uima.fit.util.FSUtil;
+import org.apache.uima.resource.metadata.FeatureDescription;
+import org.apache.uima.resource.metadata.TypeDescription;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
+import org.apache.uima.resource.metadata.impl.TypeSystemDescription_impl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.MultiValueMode;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.inception.annotation.feature.multistring.MultiValueStringFeatureSupport;
+import de.tudarmstadt.ukp.inception.annotation.feature.string.StringFeatureSupport;
+import de.tudarmstadt.ukp.inception.recommendation.api.LearningRecordService;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.SpanSuggestion;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.SuggestionDocumentGroup;
+import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
+import de.tudarmstadt.ukp.inception.schema.service.FeatureSupportRegistryImpl;
+
+@ExtendWith(MockitoExtension.class)
+public class MultiValueFeatureSuggestionVisibilityCalculationTest
+{
+    private static final String TEST_USER = "Testuser";
+
+    private @Mock AnnotationSchemaService annoService;
+    private @Mock LearningRecordService learningRecordService;
+
+    private Project project;
+    private SourceDocument doc;
+
+    private TypeSystemDescription tsd;
+    private TypeDescription typeDesc;
+    private FeatureDescription featureDesc;
+    private AnnotationLayer layer;
+    private AnnotationFeature feature;
+    private Recommender rec;
+    private CAS cas;
+    private SpanSuggestion.Builder suggestionTemplate;
+
+    private SpanSuggestionSupport sut;
+
+    @BeforeEach
+    public void setUp() throws Exception
+    {
+        project = Project.builder().withName("Test Project").build();
+
+        doc = SourceDocument.builder().withId(12l).withName("doc").withProject(project).build();
+
+        var featureSupportRegistry = new FeatureSupportRegistryImpl(
+                asList(new StringFeatureSupport(), new MultiValueStringFeatureSupport()));
+        featureSupportRegistry.init();
+
+        sut = new SpanSuggestionSupport(null, learningRecordService, null, annoService,
+                featureSupportRegistry, null);
+
+        tsd = new TypeSystemDescription_impl();
+        typeDesc = tsd.addType("Span", null, CAS.TYPE_NAME_ANNOTATION);
+        featureDesc = typeDesc.addFeature("values", null, CAS.TYPE_NAME_STRING_ARRAY,
+                CAS.TYPE_NAME_STRING, false);
+        layer = AnnotationLayer.builder().withId(44l).withName(typeDesc.getName()).build();
+        feature = AnnotationFeature.builder().withId(4l) //
+                .withLayer(layer) //
+                .withName(featureDesc.getName()) //
+                .withMultiValueMode(MultiValueMode.ARRAY) //
+                .withType(CAS.TYPE_NAME_STRING_ARRAY) //
+                .build();
+
+        rec = Recommender.builder().withId(123l).withName("rec").withLayer(layer)
+                .withFeature(feature).build();
+
+        cas = CasFactory.createCas(tsd);
+
+        doReturn(emptyList()).when(learningRecordService).listLearningRecords(TEST_USER, TEST_USER,
+                layer);
+        when(annoService.listSupportedFeatures(layer)).thenReturn(asList(feature));
+
+        suggestionTemplate = SpanSuggestion.builder() //
+                .withDocument(doc) //
+                .withRecommender(rec) //
+                .withId(1) //
+                .withPosition(0, 1);
+    }
+
+    @Test
+    public void collocatedWithAnnotationWithoutLabelAreNotHidden() throws Exception
+    {
+        var suggestion = suggestionTemplate.withLabel("blah").build();
+
+        // Add annotation without label at same location as suggestion
+        var ann = cas.createAnnotation(cas.getTypeSystem().getType(typeDesc.getName()),
+                suggestion.getBegin(), suggestion.getEnd());
+        cas.addFsToIndexes(ann);
+
+        var documentSuggestions = SuggestionDocumentGroup.groupsOfType(SpanSuggestion.class,
+                asList(suggestion));
+        sut.calculateSuggestionVisibility(TEST_USER, doc, cas, TEST_USER, layer,
+                documentSuggestions, 0, 2);
+
+        assertThat(getInvisibleSuggestions(documentSuggestions)) //
+                .as("Hidden suggestions") //
+                .isEmpty();
+    }
+
+    @Test
+    public void collocatedWithAnnotationWithSameLabelAreHidden() throws Exception
+    {
+        var suggestion = suggestionTemplate.withLabel("blah").build();
+
+        // Add annotation with label at same location as suggestion
+        var ann = cas.createAnnotation(cas.getTypeSystem().getType(typeDesc.getName()),
+                suggestion.getBegin(), suggestion.getEnd());
+        FSUtil.setFeature(ann, "values", asList(suggestion.getLabel()));
+        cas.addFsToIndexes(ann);
+
+        var documentSuggestions = calculateVisibility(suggestion);
+
+        assertThat(getInvisibleSuggestions(documentSuggestions)) //
+                .as("Hidden suggestions") //
+                .containsExactly(suggestion);
+    }
+
+    @Test
+    public void collocatedWithAnnotationWithDifferentLabelAreNotHidden() throws Exception
+    {
+        var suggestion = suggestionTemplate.withLabel("blah").build();
+
+        // Add annotation with alternative label at same location as suggestion
+        var ann = cas.createAnnotation(cas.getTypeSystem().getType(typeDesc.getName()),
+                suggestion.getBegin(), suggestion.getEnd());
+        FSUtil.setFeature(ann, "values", asList(suggestion.getLabel() + "_other"));
+        cas.addFsToIndexes(ann);
+
+        var documentSuggestions = calculateVisibility(suggestion);
+
+        assertThat(getInvisibleSuggestions(documentSuggestions)) //
+                .as("Hidden suggestions") //
+                .isEmpty();
+    }
+
+    @Test
+    public void withoutLabelCollocatedWithAnnotationWithLabelAreHidden() throws Exception
+    {
+        var suggestion = suggestionTemplate.withLabel(null).build();
+
+        // Add annotation with alternative label at same location as suggestion
+        var ann = cas.createAnnotation(cas.getTypeSystem().getType(typeDesc.getName()),
+                suggestion.getBegin(), suggestion.getEnd());
+        FSUtil.setFeature(ann, "values", asList("blah"));
+        cas.addFsToIndexes(ann);
+
+        var documentSuggestions = calculateVisibility(suggestion);
+
+        assertThat(getInvisibleSuggestions(documentSuggestions)) //
+                .as("Hidden suggestions") //
+                .containsExactly(suggestion);
+    }
+
+    @Test
+    public void withoutLabelOverlappingWithAnnotationWithLabelAreNotHidden() throws Exception
+    {
+        var suggestion = suggestionTemplate.withLabel(null).build();
+
+        // Add annotation with alternative label at overlapping location as suggestion
+        var ann = cas.createAnnotation(cas.getTypeSystem().getType(typeDesc.getName()),
+                suggestion.getBegin(), suggestion.getEnd() - 1);
+        FSUtil.setFeature(ann, "values", asList("blah"));
+        cas.addFsToIndexes(ann);
+
+        var documentSuggestions = calculateVisibility(suggestion);
+
+        assertThat(getInvisibleSuggestions(documentSuggestions)) //
+                .as("Hidden suggestions") //
+                .isEmpty();
+    }
+
+    private SuggestionDocumentGroup<SpanSuggestion> calculateVisibility(SpanSuggestion suggestion)
+    {
+        var documentSuggestions = SuggestionDocumentGroup.groupsOfType(SpanSuggestion.class,
+                asList(suggestion));
+        sut.calculateSuggestionVisibility(TEST_USER, doc, cas, TEST_USER, layer,
+                documentSuggestions, 0, 2);
+        return documentSuggestions;
+    }
+}

--- a/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/span/SpanSuggestionMultiValueFeatureSuggestionVisibilityCalculationTest.java
+++ b/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/span/SpanSuggestionMultiValueFeatureSuggestionVisibilityCalculationTest.java
@@ -52,7 +52,7 @@ import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.service.FeatureSupportRegistryImpl;
 
 @ExtendWith(MockitoExtension.class)
-public class MultiValueFeatureSuggestionVisibilityCalculationTest
+public class SpanSuggestionMultiValueFeatureSuggestionVisibilityCalculationTest
 {
     private static final String TEST_USER = "Testuser";
 

--- a/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/span/SpanSuggestionVisibilityCalculationTest.java
+++ b/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/span/SpanSuggestionVisibilityCalculationTest.java
@@ -30,20 +30,12 @@ import static org.apache.uima.cas.CAS.TYPE_NAME_STRING;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 
 import org.apache.uima.cas.CAS;
-import org.apache.uima.fit.factory.CasFactory;
 import org.apache.uima.fit.factory.JCasFactory;
-import org.apache.uima.fit.util.FSUtil;
-import org.apache.uima.resource.metadata.FeatureDescription;
-import org.apache.uima.resource.metadata.TypeDescription;
-import org.apache.uima.resource.metadata.TypeSystemDescription;
-import org.apache.uima.resource.metadata.impl.TypeSystemDescription_impl;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -51,7 +43,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
-import de.tudarmstadt.ukp.clarin.webanno.model.MultiValueMode;
 import de.tudarmstadt.ukp.clarin.webanno.model.OverlapMode;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;

--- a/inception/inception-recommendation/src/test/resources/log4j2-test.xml
+++ b/inception/inception-recommendation/src/test/resources/log4j2-test.xml
@@ -7,7 +7,7 @@
   </Appenders>
 
   <Loggers>
-    <Logger name="de.tudarmstadt.ukp.inception.recommendation" level="TRACE"/>
+<!--     <Logger name="de.tudarmstadt.ukp.inception.recommendation" level="TRACE"/> -->
     <Root level="WARN">
       <AppenderRef ref="ConsoleAppender" />
     </Root>

--- a/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/AnnotationSchemaService.java
+++ b/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/AnnotationSchemaService.java
@@ -161,7 +161,7 @@ public interface AnnotationSchemaService
      *            the project.
      * @return if a layer exists.
      */
-    boolean existsLayer(Project aModelObject);
+    boolean existsLayer(Project project);
 
     /**
      * Check if an {@link AnnotationLayer} exists with this name in the given {@link Project}.
@@ -187,7 +187,7 @@ public interface AnnotationSchemaService
      */
     boolean existsLayer(String name, String type, Project project);
 
-    boolean existsEnabledLayerOfType(Project aProject, String aType);
+    boolean existsEnabledLayerOfType(Project project, String type);
 
     /**
      * Check if this {@link AnnotationFeature} already exists

--- a/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/AnnotationSchemaService.java
+++ b/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/AnnotationSchemaService.java
@@ -155,6 +155,15 @@ public interface AnnotationSchemaService
     boolean existsTagSet(Project project);
 
     /**
+     * Check if any {@link AnnotationLayer} exists with this name in the given {@link Project}.
+     * 
+     * @param project
+     *            the project.
+     * @return if a layer exists.
+     */
+    boolean existsLayer(Project aModelObject);
+
+    /**
      * Check if an {@link AnnotationLayer} exists with this name in the given {@link Project}.
      * 
      * @param name

--- a/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/adapter/TypeAdapter.java
+++ b/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/adapter/TypeAdapter.java
@@ -163,6 +163,19 @@ public interface TypeAdapter
                 aValue);
     }
 
+    void pushFeatureValue(SourceDocument aDocument, String aUsername, CAS aCas, int aAddress,
+            AnnotationFeature aFeature, Object aValue)
+        throws AnnotationException;
+
+    default void pushFeatureValue(SourceDocument aDocument, String aDocumentOwner,
+            FeatureStructure aFs, AnnotationFeature aFeature, Object aValue)
+        throws AnnotationException
+
+    {
+        pushFeatureValue(aDocument, aDocumentOwner, aFs.getCAS(), aFs.getAddress(), aFeature,
+                aValue);
+    }
+
     /**
      * Get the value of the given feature.
      * 

--- a/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/feature/FeatureSupport.java
+++ b/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/feature/FeatureSupport.java
@@ -274,6 +274,12 @@ public interface FeatureSupport<T>
         setFeature(fs, aFeature, value);
     }
 
+    default void pushFeatureValue(CAS aCas, AnnotationFeature aFeature, int aAddress, Object aValue)
+        throws AnnotationException
+    {
+        setFeatureValue(aCas, aFeature, aAddress, aValue);
+    }
+
     @SuppressWarnings("unchecked")
     default <V> V getFeatureValue(AnnotationFeature aFeature, FeatureStructure aFS)
     {

--- a/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/service/AnnotationSchemaServiceImpl.java
+++ b/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/service/AnnotationSchemaServiceImpl.java
@@ -398,13 +398,26 @@ public class AnnotationSchemaServiceImpl
 
     @Override
     @Transactional(noRollbackFor = NoResultException.class)
+    public boolean existsLayer(Project aProject)
+    {
+        return entityManager.createQuery(
+                "SELECT COUNT(*) FROM AnnotationLayer WHERE project = :project AND name NOT IN (:excluded)",
+                Long.class) //
+                .setParameter("project", aProject) //
+                .setParameter("excluded", asList(Token._TypeName, Sentence._TypeName)) //
+                .getSingleResult() > 0;
+    }
+
+    @Override
+    @Transactional(noRollbackFor = NoResultException.class)
     public boolean existsLayer(String aName, Project aProject)
     {
         try {
             entityManager
                     .createQuery("FROM AnnotationLayer WHERE name = :name AND project = :project",
                             AnnotationLayer.class)
-                    .setParameter("name", aName).setParameter("project", aProject)
+                    .setParameter("name", aName) //
+                    .setParameter("project", aProject) //
                     .getSingleResult();
             return true;
         }
@@ -420,13 +433,15 @@ public class AnnotationSchemaServiceImpl
         try {
             entityManager.createQuery(
                     "FROM AnnotationLayer WHERE name = :name AND type = :type AND project = :project",
-                    AnnotationLayer.class).setParameter("name", aName).setParameter("type", aType)
-                    .setParameter("project", aProject).getSingleResult();
+                    AnnotationLayer.class) //
+                    .setParameter("name", aName) //
+                    .setParameter("type", aType) //
+                    .setParameter("project", aProject) //
+                    .getSingleResult();
             return true;
         }
         catch (NoResultException e) {
             return false;
-
         }
     }
 

--- a/inception/inception-ui-dashboard/pom.xml
+++ b/inception/inception-ui-dashboard/pom.xml
@@ -32,6 +32,10 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-schema-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-support</artifactId>
     </dependency>
     <dependency>

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/dashlet/LayerHintDashlet.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/dashlet/LayerHintDashlet.java
@@ -24,7 +24,7 @@ import org.apache.wicket.spring.injection.annot.SpringBean;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.project.ProjectAccess;
-import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
+import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.ui.core.dashboard.settings.documents.ProjectDocumentsPage;
 import de.tudarmstadt.ukp.inception.ui.core.dashboard.settings.layers.ProjectLayersPage;
 
@@ -33,7 +33,7 @@ public class LayerHintDashlet
 {
     private static final long serialVersionUID = -2039509339561190091L;
 
-    private @SpringBean DocumentService documentService;
+    private @SpringBean AnnotationSchemaService schemaService;
     private @SpringBean ProjectAccess projectAccess;
 
     public LayerHintDashlet(String aId, IModel<Project> aProject)
@@ -56,6 +56,6 @@ public class LayerHintDashlet
         super.onConfigure();
 
         setVisible(projectAccess.canManageProject(Long.toString(getModelObject().getId()))
-                && !documentService.existsSourceDocument(getModelObject()));
+                && !schemaService.existsLayer(getModelObject()));
     }
 }

--- a/inception/inception-ui-kb/pom.xml
+++ b/inception/inception-ui-kb/pom.xml
@@ -67,10 +67,6 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
-      <artifactId>inception-schema-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-project-initializers</artifactId>
     </dependency>
     <dependency>

--- a/inception/inception-ui-kb/pom.xml
+++ b/inception/inception-ui-kb/pom.xml
@@ -39,6 +39,10 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-schema-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-ui-core</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
**What's in the PR**
- Recommenders: When a recommendation is on a multi-value feature, do not hide overlapping suggestions (same as when stacking is enabled) - unless label matches existing annotation

**How to test manually**
* Create span layer with multi-value string feature
* Create string matching recommender for that feature
* Annotate a word in a text with two labels on the same annotation
* Check suggestions projected onto other instances of the same word

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
