### PR TITLE
#4519 - Trying to add a subclass on the knowledge base page creates an error

### DIFF
--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseService.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseService.java
@@ -149,6 +149,10 @@ public interface KnowledgeBaseService
     /**
      * Creates a new concept in the given knowledge base. Does nothing if the knowledge base is read
      * only.
+     * <p>
+     * <b>Note:</b> This method binds the concept to the knowledge base by generating an new
+     * {@link KBConcept#setIdentifier(String) identifier} and setting the
+     * {@link KBConcept#setKB(KnowledgeBase) knowledge base} property.
      * 
      * @param kb
      *            The knowledge base to which the new concept will be added
@@ -195,6 +199,10 @@ public interface KnowledgeBaseService
     /**
      * Creates a new property in the given knowledge base. Does nothing if the knowledge base is
      * read only.
+     * <p>
+     * <b>Note:</b> This method binds the concept to the knowledge base by generating an new
+     * {@link KBConcept#setIdentifier(String) identifier} and setting the
+     * {@link KBConcept#setKB(KnowledgeBase) knowledge base} property.
      * 
      * @param kb
      *            The knowledge base to which the new property will be added
@@ -255,6 +263,10 @@ public interface KnowledgeBaseService
     /**
      * Creates a new instance in the given knowledge base. Does nothing if the knowledge base is
      * read only.
+     * <p>
+     * <b>Note:</b> This method binds the concept to the knowledge base by generating an new
+     * {@link KBConcept#setIdentifier(String) identifier} and setting the
+     * {@link KBConcept#setKB(KnowledgeBase) knowledge base} property.
      * 
      * @param kb
      *            The knowledge base to which the new instance will be added

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
@@ -666,24 +666,25 @@ public class KnowledgeBaseServiceImpl
     }
 
     @Override
-    public boolean isEmpty(KnowledgeBase kb)
+    public boolean isEmpty(KnowledgeBase aKB)
     {
-        try (var conn = getConnection(kb)) {
+        try (var conn = getConnection(aKB)) {
             return conn.isEmpty();
         }
     }
 
     @Override
-    public void createConcept(KnowledgeBase kb, KBConcept aConcept)
+    public void createConcept(KnowledgeBase aKB, KBConcept aConcept)
     {
         if (isNotEmpty(aConcept.getIdentifier())) {
             throw new IllegalArgumentException("Identifier must be empty on create");
         }
 
-        update(kb, (conn) -> {
-            String identifier = getReificationStrategy(kb).generateConceptIdentifier(conn, kb);
+        update(aKB, (conn) -> {
+            var identifier = getReificationStrategy(aKB).generateConceptIdentifier(conn, aKB);
             aConcept.setIdentifier(identifier);
-            aConcept.write(conn, kb);
+            aConcept.setKB(aKB);
+            aConcept.write(conn, aKB);
         });
     }
 
@@ -767,16 +768,17 @@ public class KnowledgeBaseServiceImpl
     }
 
     @Override
-    public void createProperty(KnowledgeBase kb, KBProperty aProperty)
+    public void createProperty(KnowledgeBase aKB, KBProperty aProperty)
     {
         if (isNotEmpty(aProperty.getIdentifier())) {
             throw new IllegalArgumentException("Identifier must be empty on create");
         }
 
-        update(kb, (conn) -> {
-            String identifier = getReificationStrategy(kb).generatePropertyIdentifier(conn, kb);
+        update(aKB, (conn) -> {
+            String identifier = getReificationStrategy(aKB).generatePropertyIdentifier(conn, aKB);
             aProperty.setIdentifier(identifier);
-            aProperty.write(conn, kb);
+            aProperty.setKB(aKB);
+            aProperty.write(conn, aKB);
         });
     }
 
@@ -854,16 +856,17 @@ public class KnowledgeBaseServiceImpl
     }
 
     @Override
-    public void createInstance(KnowledgeBase kb, KBInstance aInstance)
+    public void createInstance(KnowledgeBase aKB, KBInstance aInstance)
     {
         if (isNotEmpty(aInstance.getIdentifier())) {
             throw new IllegalArgumentException("Identifier must be empty on create");
         }
 
-        update(kb, (conn) -> {
-            String identifier = getReificationStrategy(kb).generateInstanceIdentifier(conn, kb);
+        update(aKB, (conn) -> {
+            String identifier = getReificationStrategy(aKB).generateInstanceIdentifier(conn, aKB);
             aInstance.setIdentifier(identifier);
-            aInstance.write(conn, kb);
+            aInstance.setKB(aKB);
+            aInstance.write(conn, aKB);
         });
     }
 


### PR DESCRIPTION
**What's in the PR**
- Fix issue by setting the knowledge base on KB items (concepts, properties, instances) when creating them in a KB.

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
