### PR TITLE
#4517 - Multi-value features are not included in BioC output

### DIFF
--- a/inception/inception-io-bioc/src/main/java/de/tudarmstadt/ukp/inception/io/bioc/BioCXmlDocumentFormatSupport.java
+++ b/inception/inception-io-bioc/src/main/java/de/tudarmstadt/ukp/inception/io/bioc/BioCXmlDocumentFormatSupport.java
@@ -36,7 +36,10 @@ import de.tudarmstadt.ukp.inception.io.bioc.config.BioCAutoConfiguration;
  * This class is exposed as a Spring Component via
  * {@link BioCAutoConfiguration#bioCXmlDocumentFormatSupport}.
  * </p>
+ *
+ * @deprecated Experimental code that was deprecated in favor of {@link BioCFormatSupport}
  */
+@Deprecated
 public class BioCXmlDocumentFormatSupport
     implements FormatSupport
 {

--- a/inception/inception-io-bioc/src/main/java/de/tudarmstadt/ukp/inception/io/bioc/BioCXmlDocumentReader.java
+++ b/inception/inception-io-bioc/src/main/java/de/tudarmstadt/ukp/inception/io/bioc/BioCXmlDocumentReader.java
@@ -42,6 +42,10 @@ import de.tudarmstadt.ukp.inception.io.xml.dkprocore.CasXmlHandler;
 import de.tudarmstadt.ukp.inception.io.xml.dkprocore.CasXmlHandler.ElementListener;
 import de.tudarmstadt.ukp.inception.support.xml.XmlParserUtils;
 
+/**
+ * @deprecated Experimental code that was deprecated in favor of {@link BioCReader}
+ */
+@Deprecated
 public class BioCXmlDocumentReader
     extends BioCReaderImplBase
 {

--- a/inception/inception-io-bioc/src/main/java/de/tudarmstadt/ukp/inception/io/bioc/BioCXmlDocumentWriter.java
+++ b/inception/inception-io-bioc/src/main/java/de/tudarmstadt/ukp/inception/io/bioc/BioCXmlDocumentWriter.java
@@ -40,6 +40,10 @@ import org.xml.sax.SAXException;
 import de.tudarmstadt.ukp.inception.io.bioc.xml.Cas2BioCSaxEvents;
 import de.tudarmstadt.ukp.inception.support.xml.XmlParserUtils;
 
+/**
+ * @deprecated Experimental code that was deprecated in favor of {@link BioCWriter}
+ */
+@Deprecated
 public class BioCXmlDocumentWriter
     extends JCasFileWriter_ImplBase
 {

--- a/inception/inception-io-bioc/src/main/java/de/tudarmstadt/ukp/inception/io/bioc/model/BioCObject.java
+++ b/inception/inception-io-bioc/src/main/java/de/tudarmstadt/ukp/inception/io/bioc/model/BioCObject.java
@@ -17,9 +17,8 @@
  */
 package de.tudarmstadt.ukp.inception.io.bioc.model;
 
-import static java.util.stream.Collectors.toMap;
-
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -63,8 +62,15 @@ public abstract class BioCObject
                 .map(BioCInfon::getValue);
     }
 
-    public Map<String, String> infonMap()
+    public Map<String, List<String>> infonMap()
     {
-        return infons.stream().collect(toMap(BioCInfon::getKey, BioCInfon::getValue));
+        var map = new LinkedHashMap<String, List<String>>();
+
+        for (var infon : infons) {
+            var list = map.computeIfAbsent(infon.getKey(), $ -> new ArrayList<>());
+            list.add(infon.getValue());
+        }
+
+        return map;
     }
 }

--- a/inception/inception-io-bioc/src/main/java/de/tudarmstadt/ukp/inception/io/bioc/model/CasToBioC.java
+++ b/inception/inception-io-bioc/src/main/java/de/tudarmstadt/ukp/inception/io/bioc/model/CasToBioC.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.text.AnnotationFS;
 import org.apache.uima.fit.util.FSUtil;
 import org.apache.uima.jcas.JCas;
@@ -197,6 +198,17 @@ public class CasToBioC
                 var value = aAnnotation.getFeatureValueAsString(feature);
                 if (value != null) {
                     aBioCAnnotation.addInfon(feature.getShortName(), value);
+                }
+            }
+
+            if (CAS.TYPE_NAME_STRING_ARRAY.equals(feature.getRange().getName())) {
+                var values = FSUtil.getFeature(aAnnotation, feature, String[].class);
+                if (values != null) {
+                    for (var value : values) {
+                        if (value != null) {
+                            aBioCAnnotation.addInfon(feature.getShortName(), value);
+                        }
+                    }
                 }
             }
         }

--- a/inception/inception-io-bioc/src/main/java/de/tudarmstadt/ukp/inception/io/bioc/xml/BioCXmlUtils.java
+++ b/inception/inception-io-bioc/src/main/java/de/tudarmstadt/ukp/inception/io/bioc/xml/BioCXmlUtils.java
@@ -24,6 +24,10 @@ import java.util.Optional;
 
 import org.dkpro.core.api.xml.type.XmlElement;
 
+/**
+ * @deprecated Experimental code that was deprecated.
+ */
+@Deprecated
 public class BioCXmlUtils
 {
     public static Optional<XmlElement> getChildTextElement(XmlElement aContainer)

--- a/inception/inception-io-bioc/src/main/java/de/tudarmstadt/ukp/inception/io/bioc/xml/Cas2BioCSaxEvents.java
+++ b/inception/inception-io-bioc/src/main/java/de/tudarmstadt/ukp/inception/io/bioc/xml/Cas2BioCSaxEvents.java
@@ -69,8 +69,13 @@ import de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData;
 import de.tudarmstadt.ukp.dkpro.core.api.metadata.type.MetaDataStringField;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
+import de.tudarmstadt.ukp.inception.io.bioc.model.CasToBioC;
 import de.tudarmstadt.ukp.inception.io.xml.dkprocore.Cas2SaxEvents;
 
+/**
+ * @deprecated Experimental code that was deprecated in favor of {@link CasToBioC}
+ */
+@Deprecated
 public class Cas2BioCSaxEvents
     extends Cas2SaxEvents
 {

--- a/inception/inception-io-bioc/src/main/java/de/tudarmstadt/ukp/inception/io/bioc/xml/DocumentWrappingXmlInputReader.java
+++ b/inception/inception-io-bioc/src/main/java/de/tudarmstadt/ukp/inception/io/bioc/xml/DocumentWrappingXmlInputReader.java
@@ -25,6 +25,10 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.events.XMLEvent;
 import javax.xml.stream.util.EventReaderDelegate;
 
+/**
+ * @deprecated Experimental code that was deprecated.
+ */
+@Deprecated
 public class DocumentWrappingXmlInputReader
     extends EventReaderDelegate
 {

--- a/inception/inception-io-bioc/src/main/java/de/tudarmstadt/ukp/inception/io/bioc/xml/SplittingContentHandler.java
+++ b/inception/inception-io-bioc/src/main/java/de/tudarmstadt/ukp/inception/io/bioc/xml/SplittingContentHandler.java
@@ -22,6 +22,10 @@ import org.xml.sax.ContentHandler;
 import org.xml.sax.Locator;
 import org.xml.sax.SAXException;
 
+/**
+ * @deprecated Experimental code that was deprecated.
+ */
+@Deprecated
 public class SplittingContentHandler
     implements ContentHandler
 {

--- a/inception/inception-io-bioc/src/main/resources/META-INF/asciidoc/user-guide/formats-bioc.adoc
+++ b/inception/inception-io-bioc/src/main/resources/META-INF/asciidoc/user-guide/formats-bioc.adoc
@@ -46,6 +46,12 @@ NOTE: This format dynamically maps information from the imported files to the la
 * If a document has not been imported from a BioC file containing passages and does not contain
   `Div` annotations from any other source either, then on export a single passage containing the
   entire document is created.
+* Multi-value features are supported. They are serialized as a sequence of infons using the same key
+  (but different values). They can also be deserialized from those infons. When there are multiple
+  infons with the same key during deserialization but the target feature is not multi-valued, then
+  only the first infon is considered and the others are ignored.
+
+.Unsupported features  
 * Cross-passage relations are not supported.
 * Sentence-level infons are not supported.
 * Passage-level infons are not supported.

--- a/inception/inception-io-bioc/src/test/java/de/tudarmstadt/ukp/inception/io/bioc/BioCReaderWriterTest.java
+++ b/inception/inception-io-bioc/src/test/java/de/tudarmstadt/ukp/inception/io/bioc/BioCReaderWriterTest.java
@@ -38,9 +38,7 @@ import static org.assertj.core.api.Assertions.contentOf;
 import java.io.File;
 
 import org.apache.uima.UIMAFramework;
-import org.apache.uima.analysis_engine.AnalysisEngineDescription;
 import org.apache.uima.cas.CAS;
-import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.fit.pipeline.SimplePipeline;
 import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
@@ -63,21 +61,21 @@ public class BioCReaderWriterTest
     @MethodSource("testSuiteFiles")
     public void runTest(File aReferenceFolder) throws Exception
     {
-        TypeSystemDescription merged = createTestTypeSystem(aReferenceFolder);
+        var merged = createTestTypeSystem(aReferenceFolder);
 
-        String targetFolder = "target/test-output/bioc-suite/" + aReferenceFolder.getName();
+        var targetFolder = "target/test-output/bioc-suite/" + aReferenceFolder.getName();
 
-        CollectionReaderDescription reader = createReaderDescription( //
+        var reader = createReaderDescription( //
                 BioCReader.class, merged, BioCReader.PARAM_SOURCE_LOCATION, aReferenceFolder, //
                 BioCReader.PARAM_PATTERNS, DATA_XML);
 
-        AnalysisEngineDescription writer = createEngineDescription( //
+        var writer = createEngineDescription( //
                 BioCWriter.class, merged, //
                 BioCWriter.PARAM_TARGET_LOCATION, targetFolder, //
                 BioCWriter.PARAM_STRIP_EXTENSION, true, //
                 BioCWriter.PARAM_OVERWRITE, true);
 
-        AnalysisEngineDescription xmiWriter = createEngineDescription( //
+        var xmiWriter = createEngineDescription( //
                 XmiWriter.class, merged, //
                 XmiWriter.PARAM_TARGET_LOCATION, targetFolder, //
                 XmiWriter.PARAM_STRIP_EXTENSION, true, //
@@ -95,7 +93,7 @@ public class BioCReaderWriterTest
     private TypeSystemDescription createTestTypeSystem(File aReferenceFolder)
         throws ResourceInitializationException
     {
-        TypeSystemDescription global = createTypeSystemDescription();
+        var global = createTypeSystemDescription();
 
         TypeSystemDescription local;
         if (new File(aReferenceFolder, TYPESYSTEM_XML).exists()) {
@@ -114,6 +112,7 @@ public class BioCReaderWriterTest
         var tsd = UIMAFramework.getResourceSpecifierFactory().createTypeSystemDescription();
         var basicSpanType = tsd.addType(BASIC_SPAN_LAYER_NAME, null, TYPE_NAME_ANNOTATION);
         basicSpanType.addFeature(BASIC_SPAN_LABEL_FEATURE_NAME, null, TYPE_NAME_STRING);
+        basicSpanType.addFeature("values", null, CAS.TYPE_NAME_STRING_ARRAY);
 
         var basicRelationType = tsd.addType(BASIC_RELATION_LAYER_NAME, null, TYPE_NAME_ANNOTATION);
         basicRelationType.addFeature(FEAT_REL_SOURCE, null, CAS.TYPE_NAME_ANNOTATION);

--- a/inception/inception-io-bioc/src/test/java/de/tudarmstadt/ukp/inception/io/bioc/BioCXmlDocumentReaderTest.java
+++ b/inception/inception-io-bioc/src/test/java/de/tudarmstadt/ukp/inception/io/bioc/BioCXmlDocumentReaderTest.java
@@ -29,6 +29,10 @@ import org.junit.jupiter.api.Test;
 
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
 
+/**
+ * @deprecated Experimental code that was deprecated.
+ */
+@Deprecated
 public class BioCXmlDocumentReaderTest
 {
     @Test

--- a/inception/inception-io-bioc/src/test/java/de/tudarmstadt/ukp/inception/io/bioc/BioCXmlDocumentReaderWriterTest.java
+++ b/inception/inception-io-bioc/src/test/java/de/tudarmstadt/ukp/inception/io/bioc/BioCXmlDocumentReaderWriterTest.java
@@ -41,6 +41,10 @@ import org.dkpro.core.testing.IOTestRunner;
 import org.dkpro.core.testing.TestOptions;
 import org.junit.jupiter.api.Test;
 
+/**
+ * @deprecated Experimental code that was deprecated.
+ */
+@Deprecated
 public class BioCXmlDocumentReaderWriterTest
 {
     @Test

--- a/inception/inception-io-bioc/src/test/resources/bioc-suite/annotation-with-single-multi-valued-feature-typed/data.xml
+++ b/inception/inception-io-bioc/src/test/resources/bioc-suite/annotation-with-single-multi-valued-feature-typed/data.xml
@@ -1,0 +1,23 @@
+<collection>
+    <source>example</source>
+    <date>2023-01-01</date>
+    <key>example.key</key>
+    <document>
+        <id>doc-1</id>
+        <passage>
+            <infon key="type">abstract</infon>
+            <offset>0</offset>
+            <sentence>
+                <offset>0</offset>
+                <text>Sentence 1.</text>
+                <annotation id="1">
+                    <infon key="type">custom.Span</infon>
+                    <infon key="values">PER</infon>
+                    <infon key="values">LOC</infon>
+                    <location length="8" offset="0"/>
+                    <text>Sentence</text>
+                </annotation>
+            </sentence>
+        </passage>
+    </document>
+</collection>

--- a/inception/inception-io-bioc/src/test/resources/bioc-suite/annotation-with-single-multi-valued-feature-typed/reference.xml
+++ b/inception/inception-io-bioc/src/test/resources/bioc-suite/annotation-with-single-multi-valued-feature-typed/reference.xml
@@ -1,0 +1,23 @@
+<collection>
+    <source>example</source>
+    <date>2023-01-01</date>
+    <key>example.key</key>
+    <document>
+        <id>doc-1</id>
+        <passage>
+            <infon key="type">abstract</infon>
+            <offset>0</offset>
+            <sentence>
+                <offset>0</offset>
+                <text>Sentence 1.</text>
+                <annotation id="1">
+                    <infon key="type">custom.Span</infon>
+                    <infon key="values">PER</infon>
+                    <infon key="values">LOC</infon>
+                    <location length="8" offset="0"/>
+                    <text>Sentence</text>
+                </annotation>
+            </sentence>
+        </passage>
+    </document>
+</collection>

--- a/inception/inception-ui-tagsets/pom.xml
+++ b/inception/inception-ui-tagsets/pom.xml
@@ -101,8 +101,8 @@
       <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
-      <groupId>commons-collections</groupId>
-      <artifactId>commons-collections</artifactId>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-collections4</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/inception/inception-ui-tagsets/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/tagsets/TagSetImportPanel.java
+++ b/inception/inception-ui-tagsets/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/tagsets/TagSetImportPanel.java
@@ -17,7 +17,7 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.ui.tagsets;
 
-import static org.apache.commons.collections.CollectionUtils.isEmpty;
+import static org.apache.commons.collections4.CollectionUtils.isEmpty;
 import static org.apache.commons.io.IOUtils.buffer;
 
 import java.io.Serializable;


### PR DESCRIPTION
**What's in the PR**
- Added support for loading and saving multi-value string features

**How to test manually**
* Create project with a multi-value string annotation feature (or multi-value concept feature)
* Annotate some text with multiple feature values
* Export the document to BioC to check if the multiple values are exported
* Import the document as BioC to see if the values properly come back

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
