### PR TITLE
#4530 - Keyboard shortcuts for feature values may not work in certain editors

### DIFF
--- a/inception/inception-external-editor/src/main/ts/src/ExternalEditorFactory.ts
+++ b/inception/inception-external-editor/src/main/ts/src/ExternalEditorFactory.ts
@@ -107,17 +107,20 @@ export class ExternalEditorFactory implements AnnotationEditorFactory {
       if (source !== target) {
         source.addEventListener('keydown', event => {
           console.debug(`Forwarding keydown event: ${event.key}`)
-          target.document.dispatchEvent(new KeyboardEvent('keydown', event))
+          const delegate = target.document.body || target.document
+          delegate.dispatchEvent(new KeyboardEvent('keydown', event))
         })
 
         source.addEventListener('keyup', event => {
           console.debug(`Forwarding keyup event: ${event.key}`)
-          target.document.dispatchEvent(new KeyboardEvent('keyup', event))
+          const delegate = target.document.body || target.document
+          delegate.dispatchEvent(new KeyboardEvent('keyup', event))
         })
 
         source.addEventListener('keypress', event => {
           console.debug(`Forwarding keypress event: ${event.key}`)
-          target.document.dispatchEvent(new KeyboardEvent('kekeypressyup', event))
+          const delegate = target.document.body || target.document
+          delegate.dispatchEvent(new KeyboardEvent('kekeypressyup', event))
         })
       }
 


### PR DESCRIPTION
**What's in the PR**
- shortcut.js fails if the keyboard event target is the document node - try dispatching the event through the body instead

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
