### PR TITLE
#4541 - Upgrade dependencies

### DIFF
--- a/inception/inception-dependencies/pom.xml
+++ b/inception/inception-dependencies/pom.xml
@@ -175,7 +175,7 @@
       <dependency>
         <groupId>com.nimbusds</groupId>
         <artifactId>nimbus-jose-jwt</artifactId>
-        <version>9.37.1</version>
+        <version>9.37.3</version>
       </dependency>
       <dependency>
         <groupId>org.awaitility</groupId>
@@ -427,7 +427,7 @@
       <dependency>
         <groupId>com.hubspot.jinjava</groupId>
         <artifactId>jinjava</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.2</version>
       </dependency>
 
       <dependency>
@@ -630,7 +630,7 @@
       <dependency>
         <groupId>it.unimi.dsi</groupId>
         <artifactId>fastutil</artifactId>
-        <version>8.5.12</version>
+        <version>8.5.13</version>
       </dependency>
 
       <dependency>
@@ -682,12 +682,12 @@
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy</artifactId>
-        <version>1.14.10</version>
+        <version>1.14.12</version>
       </dependency>
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy-agent</artifactId>
-        <version>1.14.10</version>
+        <version>1.14.12</version>
       </dependency>
       <dependency>
         <groupId>org.wicketstuff</groupId>
@@ -733,7 +733,7 @@
       <dependency>
         <groupId>com.networknt</groupId>
         <artifactId>json-schema-validator</artifactId>
-        <version>1.0.87</version>
+        <version>1.0.88</version>
       </dependency>
       
       <!-- SPRING SECURITY -->
@@ -980,7 +980,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.15.0</version>
+        <version>2.15.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -1000,7 +1000,7 @@
       <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
-        <version>1.16.0</version>
+        <version>1.16.1</version>
       </dependency>
       <dependency>
         <groupId>commons-validator</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -67,8 +67,8 @@
   </distributionManagement>
 
   <properties>
-    <junit-jupiter.version>5.10.1</junit-jupiter.version>
-    <junit-platform.version>1.10.1</junit-platform.version>
+    <junit-jupiter.version>5.10.2</junit-jupiter.version>
+    <junit-platform.version>1.10.2</junit-platform.version>
     <mockito.version>5.7.0</mockito.version>
     <assertj.version>3.24.2</assertj.version>
     <xmlunit.version>2.9.1</xmlunit.version>
@@ -82,24 +82,24 @@
 
     <pdfbox.version>2.0.30</pdfbox.version>
 
-    <spring.version>5.3.31</spring.version>
+    <spring.version>5.3.32</spring.version>
     <spring.boot.version>2.7.18</spring.boot.version>
     <spring.data.version>2.7.18</spring.data.version>
-    <spring.security.version>5.8.8</spring.security.version>
+    <spring.security.version>5.8.10</spring.security.version>
     <springdoc.version>1.7.0</springdoc.version>
-    <swagger.version>2.2.19</swagger.version>
-    <jjwt.version>0.12.3</jjwt.version>
+    <swagger.version>2.2.20</swagger.version>
+    <jjwt.version>0.12.5</jjwt.version>
 
-    <slf4j.version>2.0.9</slf4j.version>
-    <log4j2.version>2.22.0</log4j2.version>
+    <slf4j.version>2.0.12</slf4j.version>
+    <log4j2.version>2.22.1</log4j2.version>
     <jboss.logging.version>3.5.3.Final</jboss.logging.version>
     <sentry.version>6.34.0</sentry.version>
 
-    <tomcat.version>9.0.83</tomcat.version>
+    <tomcat.version>9.0.86</tomcat.version>
     <servlet-api.version>4.0.1</servlet-api.version>
 
-    <mariadb.driver.version>2.7.10</mariadb.driver.version>
-    <postgres.driver.version>42.6.0</postgres.driver.version>
+    <mariadb.driver.version>2.7.12</mariadb.driver.version>
+    <postgres.driver.version>42.6.1</postgres.driver.version>
     <hibernate.version>5.6.15.Final</hibernate.version>
     <hibernate.validator.version>6.2.5.Final</hibernate.validator.version>
 
@@ -115,13 +115,13 @@
     <!--
       - These are all interconnected - because they share the dependency on Lucene.
       -->
-    <lucene.version>8.11.2</lucene.version>
-    <solr.version>8.11.2</solr.version>
+    <lucene.version>8.11.3</lucene.version>
+    <solr.version>8.11.3</solr.version>
     <mtas.version>8.11.1.0</mtas.version> 
     <!-- * 8.11.1.0 depends on Lucene 8.11.1 -->
     <!--   no mtas  depends on Lucene 9.x -->
 
-    <elasticsearch.version>7.17.15</elasticsearch.version> 
+    <elasticsearch.version>7.17.18</elasticsearch.version> 
     <!--   7.10.x   depends on Lucene 8.7.0 - last ASL 2.0 version! -->
     <!-- * 7.17.x   depends on Lucene 8.11.1 -->
     <!--   8.1.x    depends on Lucene 9.0.0 -->
@@ -130,7 +130,7 @@
     <!-- * 1.3.5    depends on Lucene 8.10.1 -->
     <!--   2.x      depends on Lucene 9.x -->
 
-    <rdf4j.version>4.3.8</rdf4j.version> 
+    <rdf4j.version>4.3.9</rdf4j.version> 
     <!-- * 4.3.x depends on Lucene 8.9.x -->
 
     <jena.version>4.6.1</jena.version>
@@ -143,7 +143,7 @@
 
     <json.version>20230227</json.version>
     <pf4j.version>2.6.0</pf4j.version>
-    <jackson.version>2.16.0</jackson.version>
+    <jackson.version>2.16.1</jackson.version>
     <snakeyaml.version>1.33</snakeyaml.version>
     <okhttp.version>4.12.0</okhttp.version>
     <okio.version>3.6.0</okio.version>


### PR DESCRIPTION
**What's in the PR**
- nimbus-jose-jwt 9.37.1 -> 9.37.3
- jinjava 2.7.1 -> 2.7.2
- fastutil 8.5.12 -> 8.2.13
- byte-buddy 1.14.10 -> 1.14.12
- json-schema-validator 1.0.87 -> 1.0.88
- commons-io 2.15.0 -> 2.15.1
- commons-codec 1.16.0 -> 1.16.1
- junit 5.10.1 -> 5.10.2
- junit-platform 1.10.1 -> 1.10.2
- spring 5.3.31 -> 5.3.32
- spring-security 5.8.8 -> 5.8.10
- swagger 2.2.19 -> 2.2.20
- jjwt 0.12.3 -> 1.12.5
- slf4j 2.0.9 -> 2.0.12
- log4j 2.22.0 -> 2.22.1
- tomcat 9.0.83 -> 9.0.86
- mariadb-driver 2.7.10 -> 2.7.12
- postgres 42.6.0 -> 42.6.1
- lucene 8.11.2 -> 8.11.3
- solr 8.11.2 -> 8.11.3
- elasticsearch 7.17.15 -> 7.17.18
- opensearch 1.3.13 -> 1.3.14
- rdf4j 4.3.8 -> 4.3.9
- jackson 2.16.0 -> 2.16.1

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
