### PR TITLE
#4554 - Allow displaying comments from annotators on hover when curating using curation sidebar on the annotation page

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/StringFeatureSupport.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/StringFeatureSupport.java
@@ -233,9 +233,9 @@ public class StringFeatureSupport
     @Override
     public List<VLazyDetailGroup> lookupLazyDetails(AnnotationFeature aFeature, Object aValue)
     {
-        if (aValue instanceof String) {
-            var value = (String) aValue;
+        if (aValue instanceof String value) {
             var tag = schemaService.getTag(value, aFeature.getTagset());
+
             if (isNotBlank(value) && aFeature.getTagset() != null && tag.isEmpty()) {
                 return asList(new VLazyDetailGroup(new VLazyDetail(value, "Tag not in tagset")));
             }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/RelationRenderer.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/RelationRenderer.java
@@ -252,8 +252,7 @@ public class RelationRenderer
     }
 
     @Override
-    public List<VLazyDetailGroup> lookupLazyDetails(CAS aCas, VID aVid, int aWindowBeginOffset,
-            int aWindowEndOffset)
+    public List<VLazyDetailGroup> lookupLazyDetails(CAS aCas, VID aVid)
     {
         if (!checkTypeSystem(aCas)) {
             return Collections.emptyList();
@@ -278,7 +277,7 @@ public class RelationRenderer
         renderYield(fs).ifPresent(
                 yield -> group.addDetail(new VLazyDetail("Yield", abbreviate(yield, "...", 300))));
 
-        var details = super.lookupLazyDetails(aCas, aVid, aWindowBeginOffset, aWindowEndOffset);
+        var details = super.lookupLazyDetails(aCas, aVid);
         if (!group.getDetails().isEmpty()) {
             details.add(0, group);
         }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanRenderer.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanRenderer.java
@@ -99,8 +99,7 @@ public class SpanRenderer
     }
 
     @Override
-    public List<VLazyDetailGroup> lookupLazyDetails(CAS aCas, VID aVid, int aWindowBeginOffset,
-            int aWindowEndOffset)
+    public List<VLazyDetailGroup> lookupLazyDetails(CAS aCas, VID aVid)
     {
         if (!checkTypeSystem(aCas)) {
             return Collections.emptyList();
@@ -112,7 +111,7 @@ public class SpanRenderer
         group.addDetail(
                 new VLazyDetail("Text", abbreviate(fs.getCoveredText(), MAX_HOVER_TEXT_LENGTH)));
 
-        var details = super.lookupLazyDetails(aCas, aVid, aWindowBeginOffset, aWindowEndOffset);
+        var details = super.lookupLazyDetails(aCas, aVid);
         if (!group.getDetails().isEmpty()) {
             details.add(0, group);
         }

--- a/inception/inception-api-editor/src/main/java/de/tudarmstadt/ukp/inception/editor/AnnotationEditorExtension.java
+++ b/inception/inception-api-editor/src/main/java/de/tudarmstadt/ukp/inception/editor/AnnotationEditorExtension.java
@@ -27,6 +27,7 @@ import org.apache.wicket.ajax.AjaxRequestTarget;
 import com.googlecode.wicket.jquery.ui.widget.menu.IMenuItem;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.inception.editor.action.AnnotationActionHandler;
@@ -79,8 +80,8 @@ public interface AnnotationEditorExtension
         // Do nothing by default
     }
 
-    default List<VLazyDetailGroup> lookupLazyDetails(SourceDocument aDocument, User aUser, VID aVid,
-            AnnotationFeature aFeature)
+    default List<VLazyDetailGroup> lookupLazyDetails(SourceDocument aDocument, User aUser, CAS aCas,
+            VID aVid, AnnotationLayer aLayer)
     {
         return Collections.emptyList();
     }

--- a/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/CasDiff.java
+++ b/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/CasDiff.java
@@ -59,16 +59,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.api.DiffAdapter;
-import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.api.DiffAdapter;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.api.DiffAdapter_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.api.Position;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.internal.AID;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.relation.RelationDiffAdapter;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.span.SpanDiffAdapter;
-import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.span.SpanDiffAdapter;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
-import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationAdapter;
 import de.tudarmstadt.ukp.inception.annotation.layer.span.SpanLayerSupport;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
@@ -930,9 +927,21 @@ public class CasDiff
 
         public Optional<Configuration> findConfiguration(String aRepresentativeCasGroupId, AID aAid)
         {
-            for (ConfigurationSet cfgSet : getConfigurationSets()) {
-                Optional<Configuration> cfg = cfgSet.findConfiguration(aRepresentativeCasGroupId,
-                        aAid);
+            for (var cfgSet : getConfigurationSets()) {
+                var cfg = cfgSet.findConfiguration(aRepresentativeCasGroupId, aAid);
+                if (cfg.isPresent()) {
+                    return cfg;
+                }
+            }
+
+            return Optional.empty();
+        }
+
+        public Optional<Configuration> findConfiguration(String aRepresentativeCasGroupId,
+                FeatureStructure aFS)
+        {
+            for (var cfgSet : getConfigurationSets()) {
+                var cfg = cfgSet.findConfiguration(aRepresentativeCasGroupId, aFS);
                 if (cfg.isPresent()) {
                     return cfg;
                 }
@@ -1139,18 +1148,18 @@ public class CasDiff
             return emptyList();
         }
 
-        Project project = aLayers.iterator().next().getProject();
+        var project = aLayers.iterator().next().getProject();
 
         var featuresByLayer = schemaService.listSupportedFeatures(project).stream() //
                 .collect(groupingBy(AnnotationFeature::getLayer));
 
-        List<DiffAdapter> adapters = new ArrayList<>();
+        var adapters = new ArrayList<DiffAdapter>();
         nextLayer: for (AnnotationLayer layer : aLayers) {
             if (!layer.isEnabled()) {
                 continue nextLayer;
             }
 
-            Set<String> labelFeatures = new LinkedHashSet<>();
+            var labelFeatures = new LinkedHashSet<String>();
             nextFeature: for (var f : featuresByLayer.getOrDefault(layer, emptyList())) {
                 if (!f.isEnabled() || !f.isCuratable()) {
                     continue nextFeature;

--- a/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/merge/CasMerge.java
+++ b/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/merge/CasMerge.java
@@ -31,7 +31,6 @@ import static de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil.isPrimiti
 import static de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil.selectSentences;
 import static de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil.selectTokens;
 import static java.util.function.Function.identity;
-import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static org.apache.uima.fit.util.CasUtil.getType;
 import static org.apache.uima.fit.util.CasUtil.selectAt;
@@ -53,7 +52,6 @@ import org.apache.uima.UIMAException;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.Feature;
 import org.apache.uima.cas.FeatureStructure;
-import org.apache.uima.cas.Type;
 import org.apache.uima.cas.text.AnnotationFS;
 import org.apache.uima.fit.util.CasUtil;
 import org.apache.uima.fit.util.FSUtil;
@@ -68,7 +66,6 @@ import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.Configuration;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.ConfigurationSet;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.DiffResult;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.api.Position;
-import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.internal.AID;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.relation.RelationPosition;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.span.SpanPosition;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
@@ -207,9 +204,9 @@ public class CasMerge
     {
         silenceEvents = true;
 
-        int updated = 0;
-        int created = 0;
-        Set<LogMessage> messages = new LinkedHashSet<>();
+        var updated = 0;
+        var created = 0;
+        var messages = new LinkedHashSet<LogMessage>();
 
         // Remove any annotations from the target CAS - keep type system, sentences and tokens
         clearAnnotations(aTargetDocument.getProject(), aTargetCas);
@@ -221,13 +218,12 @@ public class CasMerge
 
         // Set up a cache for resolving type to layer to avoid hammering the DB as we process each
         // position
-        Map<String, AnnotationLayer> type2layer = aDiff.getPositions().stream()
-                .map(Position::getType) //
+        var type2layer = aDiff.getPositions().stream().map(Position::getType) //
                 .distinct() //
                 .map(type -> schemaService.findLayer(aTargetDocument.getProject(), type))
                 .collect(toMap(AnnotationLayer::getName, identity()));
 
-        List<String> layerNames = new ArrayList<>(type2layer.keySet());
+        var layerNames = new ArrayList<>(type2layer.keySet());
 
         // Move token layer to front
         if (layerNames.contains(Token.class.getName())) {
@@ -245,14 +241,14 @@ public class CasMerge
         // or as relation layers).
         // We process layer by layer so that we can order the layers (important to process tokens
         // and sentences before the others)
-        for (String layerName : layerNames) {
-            List<SpanPosition> positions = aDiff.getPositions().stream()
+        for (var layerName : layerNames) {
+            var positions = aDiff.getPositions().stream()
                     .filter(pos -> layerName.equals(pos.getType()))
                     .filter(pos -> pos instanceof SpanPosition) //
                     .map(pos -> (SpanPosition) pos)
                     // We don't process slot features here (they are span sub-positions)
                     .filter(pos -> pos.getFeature() == null) //
-                    .collect(toList());
+                    .toList();
 
             if (positions.isEmpty()) {
                 continue;
@@ -300,14 +296,14 @@ public class CasMerge
         }
 
         // After the spans are in place, we can merge the slot features
-        for (String layerName : layerNames) {
-            List<SpanPosition> positions = aDiff.getPositions().stream()
+        for (var layerName : layerNames) {
+            var positions = aDiff.getPositions().stream()
                     .filter(pos -> layerName.equals(pos.getType()))
                     .filter(pos -> pos instanceof SpanPosition) //
                     .map(pos -> (SpanPosition) pos)
                     // We only process slot features here
                     .filter(pos -> pos.getFeature() != null) //
-                    .collect(Collectors.toList());
+                    .toList();
 
             if (positions.isEmpty()) {
                 continue;
@@ -315,7 +311,7 @@ public class CasMerge
 
             LOG.debug("Processing {} slot positions on layer [{}]", positions.size(), layerName);
 
-            for (SpanPosition position : positions) {
+            for (var position : positions) {
                 LOG.trace(" |   processing {}", position);
                 var layer = type2layer.get(position.getType());
                 var cfgs = aDiff.getConfigurationSet(position);
@@ -328,9 +324,8 @@ public class CasMerge
 
                 for (var cfgToMerge : cfgsToMerge) {
                     try {
-                        AnnotationFS sourceFS = (AnnotationFS) cfgToMerge
-                                .getRepresentative(aCasMap);
-                        AID sourceFsAid = cfgs.getConfigurations().get(0).getRepresentativeAID();
+                        var sourceFS = (AnnotationFS) cfgToMerge.getRepresentative(aCasMap);
+                        var sourceFsAid = cfgs.getConfigurations().get(0).getRepresentativeAID();
                         mergeSlotFeature(aTargetDocument, aTargetUsername,
                                 type2layer.get(position.getType()), aTargetCas, sourceFS,
                                 sourceFsAid.feature, sourceFsAid.index);
@@ -345,8 +340,8 @@ public class CasMerge
         }
 
         // Finally, we merge the relations
-        for (String layerName : layerNames) {
-            List<RelationPosition> positions = aDiff.getPositions().stream()
+        for (var layerName : layerNames) {
+            var positions = aDiff.getPositions().stream()
                     .filter(pos -> layerName.equals(pos.getType()))
                     .filter(pos -> pos instanceof RelationPosition)
                     .map(pos -> (RelationPosition) pos) //
@@ -420,7 +415,7 @@ public class CasMerge
     private void clearAnnotations(Project aProject, CAS aCas) throws UIMAException
     {
         // Copy the CAS - basically we do this just to keep the full type system information
-        CAS backup = WebAnnoCasUtil.createCasCopy(aCas);
+        var backup = WebAnnoCasUtil.createCasCopy(aCas);
 
         // Remove all annotations from the target CAS but we keep the type system!
         aCas.reset();
@@ -432,6 +427,7 @@ public class CasMerge
         else {
             createDocumentMetadata(aCas);
         }
+
         aCas.setDocumentLanguage(backup.getDocumentLanguage()); // DKPro Core Issue 435
         aCas.setDocumentText(backup.getDocumentText());
 
@@ -446,14 +442,14 @@ public class CasMerge
     {
         if (!schemaService.isTokenLayerEditable(aProject)) {
             // Transfer token boundaries
-            for (AnnotationFS t : selectTokens(backup)) {
+            for (var t : selectTokens(backup)) {
                 aCas.addFsToIndexes(createToken(aCas, t.getBegin(), t.getEnd()));
             }
         }
 
         if (!schemaService.isSentenceLayerEditable(aProject)) {
             // Transfer sentence boundaries
-            for (AnnotationFS s : selectSentences(backup)) {
+            for (var s : selectSentences(backup)) {
                 aCas.addFsToIndexes(createSentence(aCas, s.getBegin(), s.getEnd()));
             }
         }
@@ -461,7 +457,7 @@ public class CasMerge
 
     private static boolean existsEquivalentAt(CAS aCas, TypeAdapter aAdapter, AnnotationFS aFs)
     {
-        Type targetType = CasUtil.getType(aCas, aFs.getType().getName());
+        var targetType = CasUtil.getType(aCas, aFs.getType().getName());
         return selectAt(aCas, targetType, aFs.getBegin(), aFs.getEnd()).stream() //
                 .filter(cand -> aAdapter.equivalents(aFs, cand,
                         (_fs, _f) -> !shouldIgnoreFeatureOnMerge(_f))) //
@@ -472,15 +468,14 @@ public class CasMerge
     private static List<AnnotationFS> selectCandidateRelationsAt(CAS aTargetCas,
             AnnotationFS aSourceFs, AnnotationFS aSourceOriginFs, AnnotationFS aSourceTargetFs)
     {
-        Type type = aSourceFs.getType();
-        Type targetType = CasUtil.getType(aTargetCas, aSourceFs.getType().getName());
-        Feature sourceFeat = type.getFeatureByBaseName(FEAT_REL_SOURCE);
-        Feature targetFeat = type.getFeatureByBaseName(FEAT_REL_TARGET);
+        var type = aSourceFs.getType();
+        var targetType = CasUtil.getType(aTargetCas, aSourceFs.getType().getName());
+        var sourceFeat = type.getFeatureByBaseName(FEAT_REL_SOURCE);
+        var targetFeat = type.getFeatureByBaseName(FEAT_REL_TARGET);
         return selectCovered(aTargetCas, targetType, aSourceFs.getBegin(), aSourceFs.getEnd())
-                .stream()
-                .filter(fs -> fs.getFeatureValue(sourceFeat).equals(aSourceOriginFs)
+                .stream().filter(fs -> fs.getFeatureValue(sourceFeat).equals(aSourceOriginFs)
                         && fs.getFeatureValue(targetFeat).equals(aSourceTargetFs))
-                .collect(toList());
+                .toList();
     }
 
     private void copyFeatures(SourceDocument aDocument, String aUsername, TypeAdapter aAdapter,
@@ -488,15 +483,15 @@ public class CasMerge
         throws AnnotationException
     {
         // Cache the feature list instead of hammering the database
-        List<AnnotationFeature> features = featureCache.computeIfAbsent(aAdapter.getLayer(),
+        var features = featureCache.computeIfAbsent(aAdapter.getLayer(),
                 key -> schemaService.listSupportedFeatures(key));
-        for (AnnotationFeature feature : features) {
+        for (var feature : features) {
             if (!feature.isCuratable()) {
                 continue;
             }
 
-            Type sourceFsType = aAdapter.getAnnotationType(aSourceFs.getCAS());
-            Feature sourceFeature = sourceFsType.getFeatureByBaseName(feature.getName());
+            var sourceFsType = aAdapter.getAnnotationType(aSourceFs.getCAS());
+            var sourceFeature = sourceFsType.getFeatureByBaseName(feature.getName());
 
             if (sourceFeature == null) {
                 throw new IllegalStateException("Target CAS type [" + sourceFsType.getName()
@@ -507,7 +502,7 @@ public class CasMerge
                 continue;
             }
 
-            Object value = aAdapter.getFeatureValue(feature, aSourceFs);
+            var value = aAdapter.getFeatureValue(feature, aSourceFs);
 
             try {
                 aAdapter.setFeatureValue(aDocument, aUsername, aTargetFS.getCAS(),
@@ -525,11 +520,11 @@ public class CasMerge
     private static List<AnnotationFS> getCandidateAnnotations(CAS aTargetCas, TypeAdapter aAdapter,
             AnnotationFS aSource)
     {
-        Type targetType = CasUtil.getType(aTargetCas, aSource.getType().getName());
+        var targetType = CasUtil.getType(aTargetCas, aSource.getType().getName());
         return selectCovered(aTargetCas, targetType, aSource.getBegin(), aSource.getEnd()).stream()
                 .filter(fs -> aAdapter.equivalents(fs, aSource,
                         (_fs, _f) -> !shouldIgnoreFeatureOnMerge(_f)))
-                .collect(toList());
+                .toList();
     }
 
     public CasMergeOperationResult mergeSpanAnnotation(SourceDocument aDocument, String aUsername,
@@ -548,7 +543,7 @@ public class CasMerge
         }
 
         // a) if stacking allowed add this new annotation to the mergeview
-        Type targetType = CasUtil.getType(aTargetCas, adapter.getAnnotationTypeName());
+        var targetType = CasUtil.getType(aTargetCas, adapter.getAnnotationTypeName());
         var existingAnnos = selectAt(aTargetCas, targetType, aSourceFs.getBegin(),
                 aSourceFs.getEnd());
         if (existingAnnos.isEmpty() || aAllowStacking) {
@@ -557,7 +552,7 @@ public class CasMerge
             var mergedSpan = adapter.add(aDocument, aUsername, aTargetCas, aSourceFs.getBegin(),
                     aSourceFs.getEnd());
 
-            int mergedSpanAddr = -1;
+            var mergedSpanAddr = -1;
             try {
                 copyFeatures(aDocument, aUsername, adapter, mergedSpan, aSourceFs);
                 mergedSpanAddr = getAddr(mergedSpan);
@@ -573,9 +568,9 @@ public class CasMerge
         }
         // b) if stacking is not allowed, modify the existing annotation with this one
         else {
-            AnnotationFS annoToUpdate = existingAnnos.get(0);
+            var annoToUpdate = existingAnnos.get(0);
             copyFeatures(aDocument, aUsername, adapter, annoToUpdate, aSourceFs);
-            int mergedSpanAddr = getAddr(annoToUpdate);
+            var mergedSpanAddr = getAddr(annoToUpdate);
             return new CasMergeOperationResult(CasMergeOperationResult.ResultState.UPDATED,
                     mergedSpanAddr);
         }
@@ -586,7 +581,7 @@ public class CasMerge
             AnnotationFS aSourceFs, boolean aAllowStacking)
         throws AnnotationException
     {
-        RelationAdapter relationAdapter = (RelationAdapter) adapterCache.get(aAnnotationLayer);
+        var relationAdapter = (RelationAdapter) adapterCache.get(aAnnotationLayer);
         if (silenceEvents) {
             relationAdapter.silenceEvents();
         }
@@ -596,12 +591,12 @@ public class CasMerge
                     "The annotation already exists in the target document.");
         }
 
-        AnnotationFS originFsClicked = getFeature(aSourceFs, relationAdapter.getSourceFeatureName(),
+        var originFsClicked = getFeature(aSourceFs, relationAdapter.getSourceFeatureName(),
                 AnnotationFS.class);
-        AnnotationFS targetFsClicked = getFeature(aSourceFs, relationAdapter.getTargetFeatureName(),
+        var targetFsClicked = getFeature(aSourceFs, relationAdapter.getTargetFeatureName(),
                 AnnotationFS.class);
 
-        SpanAdapter spanAdapter = (SpanAdapter) adapterCache.get(aAnnotationLayer.getAttachType());
+        var spanAdapter = (SpanAdapter) adapterCache.get(aAnnotationLayer.getAttachType());
 
         var candidateOrigins = getCandidateAnnotations(aTargetCas, spanAdapter, originFsClicked);
         var candidateTargets = getCandidateAnnotations(aTargetCas, spanAdapter, targetFsClicked);
@@ -622,13 +617,13 @@ public class CasMerge
                     "Stacked targets exist in the target document. Cannot merge this relation.");
         }
 
-        AnnotationFS originFs = candidateOrigins.get(0);
-        AnnotationFS targetFs = candidateTargets.get(0);
+        var originFs = candidateOrigins.get(0);
+        var targetFs = candidateTargets.get(0);
 
         if (relationAdapter.getAttachFeatureName() != null) {
-            AnnotationFS originAttachAnnotation = FSUtil.getFeature(originFs,
+            var originAttachAnnotation = FSUtil.getFeature(originFs,
                     relationAdapter.getAttachFeatureName(), AnnotationFS.class);
-            AnnotationFS targetAttachAnnotation = FSUtil.getFeature(targetFs,
+            var targetAttachAnnotation = FSUtil.getFeature(targetFs,
                     relationAdapter.getAttachFeatureName(), AnnotationFS.class);
 
             if (originAttachAnnotation == null || targetAttachAnnotation == null) {
@@ -637,11 +632,10 @@ public class CasMerge
             }
         }
 
-        List<AnnotationFS> existingAnnos = selectCandidateRelationsAt(aTargetCas, aSourceFs,
-                originFs, targetFs);
+        var existingAnnos = selectCandidateRelationsAt(aTargetCas, aSourceFs, originFs, targetFs);
         if (existingAnnos.isEmpty() || aAllowStacking) {
-            AnnotationFS mergedRelation = relationAdapter.add(aDocument, aUsername, originFs,
-                    targetFs, aTargetCas);
+            var mergedRelation = relationAdapter.add(aDocument, aUsername, originFs, targetFs,
+                    aTargetCas);
             try {
                 copyFeatures(aDocument, aUsername, relationAdapter, mergedRelation, aSourceFs);
             }
@@ -654,7 +648,7 @@ public class CasMerge
                     getAddr(mergedRelation));
         }
         else {
-            AnnotationFS mergeTargetFS = existingAnnos.get(0);
+            var mergeTargetFS = existingAnnos.get(0);
             copyFeatures(aDocument, aUsername, relationAdapter, mergeTargetFS, aSourceFs);
             return new CasMergeOperationResult(CasMergeOperationResult.ResultState.UPDATED,
                     getAddr(mergeTargetFS));
@@ -666,12 +660,12 @@ public class CasMerge
             String aSourceFeature, int aSourceSlotIndex)
         throws AnnotationException
     {
-        TypeAdapter adapter = adapterCache.get(aAnnotationLayer);
+        var adapter = adapterCache.get(aAnnotationLayer);
         if (silenceEvents) {
             adapter.silenceEvents();
         }
 
-        List<AnnotationFS> candidateHosts = getCandidateAnnotations(aTargetCas, adapter, aSourceFs);
+        var candidateHosts = getCandidateAnnotations(aTargetCas, adapter, aSourceFs);
 
         if (candidateHosts.size() == 0) {
             throw new UnfulfilledPrerequisitesException(
@@ -679,7 +673,7 @@ public class CasMerge
                             + aSourceFs.getBegin() + "," + aSourceFs.getEnd()
                             + "] into which the link could be merged. Please add one first.");
         }
-        AnnotationFS mergeFs = candidateHosts.get(0);
+        var mergeFs = candidateHosts.get(0);
         int liIndex = aSourceSlotIndex;
 
         var slotFeature = adapter.listFeatures().stream() //
@@ -693,14 +687,14 @@ public class CasMerge
         }
 
         List<LinkWithRoleModel> sourceLinks = adapter.getFeatureValue(slotFeature, aSourceFs);
-        List<AnnotationFS> targets = checkAndGetTargets(aTargetCas,
+        var targets = checkAndGetTargets(aTargetCas,
                 selectAnnotationByAddr(aSourceFs.getCAS(), sourceLinks.get(liIndex).targetAddr));
 
         if (targets.isEmpty()) {
             throw new AnnotationException("No suitable merge target found");
         }
 
-        LinkWithRoleModel newLink = new LinkWithRoleModel(sourceLinks.get(liIndex));
+        var newLink = new LinkWithRoleModel(sourceLinks.get(liIndex));
         newLink.targetAddr = getAddr(targets.get(0));
 
         List<LinkWithRoleModel> links = adapter.getFeatureValue(slotFeature, mergeFs);
@@ -720,7 +714,7 @@ public class CasMerge
                 }
             }
             else {
-                LinkWithRoleModel existing = existingLinkWithTarget(newLink, links);
+                var existing = existingLinkWithTarget(newLink, links);
                 if (existing != null && existing.equals(newLink)) {
                     throw new AlreadyMergedException(
                             "The slot has already been filled with this annotation in the target document.");
@@ -743,7 +737,7 @@ public class CasMerge
     private LinkWithRoleModel existingLinkWithTarget(LinkWithRoleModel aLink,
             List<LinkWithRoleModel> aLinks)
     {
-        for (LinkWithRoleModel lr : aLinks) {
+        for (var lr : aLinks) {
             if (lr.targetAddr == aLink.targetAddr) {
                 return lr;
             }
@@ -754,14 +748,12 @@ public class CasMerge
     private static List<AnnotationFS> checkAndGetTargets(CAS aCas, AnnotationFS aOldTarget)
         throws UnfulfilledPrerequisitesException
     {
-        Type casType = CasUtil.getType(aCas, aOldTarget.getType().getName());
-        List<AnnotationFS> targets = selectCovered(aCas, casType, aOldTarget.getBegin(),
-                aOldTarget.getEnd())
-                        .stream()
-                        .filter(fs -> AnnotationComparisonUtils.isEquivalentSpanAnnotation(fs,
-                                aOldTarget,
-                                (FeatureFilter) (_fs, _f) -> !shouldIgnoreFeatureOnMerge(_f)))
-                        .collect(Collectors.toList());
+        var casType = CasUtil.getType(aCas, aOldTarget.getType().getName());
+        var targets = selectCovered(aCas, casType, aOldTarget.getBegin(), aOldTarget.getEnd())
+                .stream()
+                .filter(fs -> AnnotationComparisonUtils.isEquivalentSpanAnnotation(fs, aOldTarget,
+                        (FeatureFilter) (_fs, _f) -> !shouldIgnoreFeatureOnMerge(_f)))
+                .collect(Collectors.toList());
 
         if (targets.size() == 0) {
             throw new UnfulfilledPrerequisitesException(

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/lazydetails/LazyDetailsLookupService.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/lazydetails/LazyDetailsLookupService.java
@@ -20,12 +20,16 @@ package de.tudarmstadt.ukp.inception.diam.editor.lazydetails;
 import java.io.IOException;
 import java.util.List;
 
+import org.apache.uima.cas.CAS;
 import org.apache.wicket.request.IRequestParameters;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasProvider;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
+import de.tudarmstadt.ukp.inception.rendering.vmodel.VLazyDetailGroup;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.AnnotationException;
 
 public interface LazyDetailsLookupService
@@ -35,4 +39,12 @@ public interface LazyDetailsLookupService
             int windowEndOffset)
         throws AnnotationException, IOException;
 
+    List<VLazyDetailGroup> lookupAnnotationLevelDetails(VID aVid, SourceDocument aDocument,
+            User aUser, AnnotationLayer aLayer, CAS aCas)
+        throws AnnotationException, IOException;
+
+    List<VLazyDetailGroup> lookupFeatureLevelDetails(VID aVid, CAS aCas,
+            AnnotationFeature aFeature);
+
+    List<VLazyDetailGroup> lookupLayerLevelDetails(VID aVid, CAS aCas, AnnotationLayer aLayer);
 }

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/lazydetails/LazyDetailsLookupServiceImpl.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/lazydetails/LazyDetailsLookupServiceImpl.java
@@ -35,7 +35,6 @@ import org.apache.wicket.util.string.StringValue;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasProvider;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
-import de.tudarmstadt.ukp.clarin.webanno.model.LinkMode;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
@@ -88,37 +87,59 @@ public class LazyDetailsLookupServiceImpl
 
         var cas = aCas.get();
 
-        var detailGroups = new ArrayList<VLazyDetailGroup>();
-        if (isSentence(cas, aVid)) {
-            var fs = selectFsByAddr(cas, aVid.getId());
-            var id = FSUtil.getFeature(fs, Sentence._FeatName_id, String.class);
-            if (StringUtils.isNotBlank(id)) {
-                var group = new VLazyDetailGroup();
-                group.addDetail(new VLazyDetail(Sentence._FeatName_id, id));
-                detailGroups.add(group);
-            }
-        }
-        else {
-            var layer = findLayer(aVid, cas, layerParam, aDocument.getProject());
-
-            lookupLayerLevelDetails(aVid, cas, windowBeginOffset, windowEndOffset, layer)
-                    .forEach(detailGroups::add);
-
-            for (var feature : annotationService.listAnnotationFeature(layer)) {
-                lookupExtensionLevelDetails(aVid, aDocument, cas, aUser, feature)
-                        .forEach(detailGroups::add);
-
-                // FIXME: We would like to get feature-level lazy details for the annotation label
-                // provided by the extension or said otherwise, we want to e.g. get KB details for a
-                // concept feature suggestion... this worked when we used the "query", but now is
-                // broken!
-                lookupFeatureLevelDetail(aVid, cas, feature).forEach(detailGroups::add);
-            }
-        }
+        var detailGroups = lookLazyDetails(aVid, aDocument, aUser, layerParam, cas);
 
         return detailGroups.stream() //
                 .map(this::toExternalForm) //
                 .collect(toList());
+    }
+
+    private List<VLazyDetailGroup> lookLazyDetails(VID aVid, SourceDocument aDocument, User aUser,
+            StringValue aLayerParam, CAS aCas)
+        throws AnnotationException, IOException
+    {
+        if (isSentence(aCas, aVid)) {
+            return lookupSentenceLevelLazyDetails(aVid, aCas);
+        }
+
+        var layer = findLayer(aVid, aCas, aLayerParam, aDocument.getProject());
+        return lookupAnnotationLevelDetails(aVid, aDocument, aUser, layer, aCas);
+    }
+
+    @Override
+    public List<VLazyDetailGroup> lookupAnnotationLevelDetails(VID aVid, SourceDocument aDocument,
+            User aUser, AnnotationLayer aLayer, CAS aCas)
+        throws AnnotationException, IOException
+    {
+        var detailGroups = new ArrayList<VLazyDetailGroup>();
+
+        lookupLayerLevelDetails(aVid, aCas, aLayer).forEach(detailGroups::add);
+
+        if (aVid.isSynthetic()) {
+            lookupExtensionLevelDetails(aVid, aDocument, aCas, aUser, aLayer)
+                    .forEach(detailGroups::add);
+        }
+        else {
+            for (var feature : annotationService.listAnnotationFeature(aLayer)) {
+                lookupFeatureLevelDetails(aVid, aCas, feature).forEach(detailGroups::add);
+            }
+        }
+
+        return detailGroups;
+    }
+
+    private List<VLazyDetailGroup> lookupSentenceLevelLazyDetails(VID aVid, CAS cas)
+    {
+        var detailGroups = new ArrayList<VLazyDetailGroup>();
+        var fs = selectFsByAddr(cas, aVid.getId());
+        var id = FSUtil.getFeature(fs, Sentence._FeatName_id, String.class);
+        if (StringUtils.isNotBlank(id)) {
+            var group = new VLazyDetailGroup();
+            group.addDetail(new VLazyDetail(Sentence._FeatName_id, id));
+            detailGroups.add(group);
+        }
+
+        return detailGroups;
     }
 
     private boolean isSentence(CAS aCas, VID aVid)
@@ -154,7 +175,8 @@ public class LazyDetailsLookupServiceImpl
         return annotationService.findLayer(project, fs);
     }
 
-    private List<VLazyDetailGroup> lookupFeatureLevelDetail(VID aVid, CAS aCas,
+    @Override
+    public List<VLazyDetailGroup> lookupFeatureLevelDetails(VID aVid, CAS aCas,
             AnnotationFeature aFeature)
     {
         if (aVid.isSynthetic()) {
@@ -166,8 +188,9 @@ public class LazyDetailsLookupServiceImpl
         return ext.lookupLazyDetails(aFeature, ext.getFeatureValue(aFeature, fs));
     }
 
-    private List<VLazyDetailGroup> lookupLayerLevelDetails(VID aVid, CAS aCas,
-            int windowBeginOffset, int windowEndOffset, AnnotationLayer aLayer)
+    @Override
+    public List<VLazyDetailGroup> lookupLayerLevelDetails(VID aVid, CAS aCas,
+            AnnotationLayer aLayer)
     {
         if (aVid.isSynthetic()) {
             return emptyList();
@@ -175,28 +198,19 @@ public class LazyDetailsLookupServiceImpl
 
         return layerSupportRegistry.getLayerSupport(aLayer)
                 .createRenderer(aLayer, () -> annotationService.listAnnotationFeature(aLayer))
-                .lookupLazyDetails(aCas, aVid, windowBeginOffset, windowEndOffset);
+                .lookupLazyDetails(aCas, aVid);
 
     }
 
     private List<VLazyDetailGroup> lookupExtensionLevelDetails(VID aVid, SourceDocument aDocument,
-            CAS aCas, User aUser, AnnotationFeature aFeature)
+            CAS aCas, User aUser, AnnotationLayer aLayer)
         throws IOException
     {
         if (!aVid.isSynthetic()) {
             return emptyList();
         }
 
-        if (aFeature.getLinkMode() == LinkMode.WITH_ROLE) {
-            return emptyList();
-        }
-
-        var result = new ArrayList<VLazyDetailGroup>();
         var extension = extensionRegistry.getExtension(aVid.getExtensionId());
-        var value = extension.getFeatureValue(aDocument, aUser, aCas, aVid, aFeature);
-        featureSupportRegistry.findExtension(aFeature).orElseThrow()
-                .lookupLazyDetails(aFeature, value).forEach(result::add);
-        extension.lookupLazyDetails(aDocument, aUser, aVid, aFeature).forEach(result::add);
-        return result;
+        return extension.lookupLazyDetails(aDocument, aUser, aCas, aVid, aLayer);
     }
 }

--- a/inception/inception-js-api/src/main/ts/src/widget/AnnotationDetailPopOver.svelte
+++ b/inception/inception-js-api/src/main/ts/src/widget/AnnotationDetailPopOver.svelte
@@ -187,14 +187,17 @@
         <div class="text-body-secondary px-1">ID: {annotation?.vid}</div>
     </div>
     {#if annotation}
-        <div class="popover-body p-1">
+        <div class="popover-body p-0">
             {#if annotation.comments}
-                {#each annotation.comments as comment}
-                    <div class="i7n-marker-{comment.type}">{comment.comment}</div>
-                {/each}
+                <div class="p-1">
+                    {#each annotation.comments as comment}
+                        <div class="i7n-marker-{comment.type}">{comment.comment}</div>
+                    {/each}
+                </div>
             {/if}
+
             {#if loading}
-                <div class="d-flex flex-column justify-content-center">
+                <div class="d-flex flex-column justify-content-center" class:border-top={annotation.comments}>
                     <div class="d-flex flex-row justify-content-center">
                         <div class="spinner-border spinner-border-sm text-muted" role="status">
                             <span class="visually-hidden">Loading...</span>
@@ -202,17 +205,21 @@
                     </div>
                 </div>
             {:else if detailGroups}
-                {#each detailGroups as detailGroup}
-                    {#if detailGroup.title}
-                        <div class="fw-bold">{detailGroup.title}</div>
-                    {/if}
-                    {#each detailGroup.details as detail}
-                        <div>
-                            <span class="fw-semibold">{detail.label}:</span>
-                            {detail.value}
-                        </div>
+                <ul class="list-group list-group-flush" class:border-top={annotation.comments}>
+                    {#each detailGroups as detailGroup}
+                        <li class="list-group-item p-1">
+                            {#if detailGroup.title}
+                                <div class="fw-bold">{detailGroup.title}</div>
+                            {/if}
+                            {#each detailGroup.details as detail}
+                                <div class:ps-2={detailGroup.title}>
+                                    <span class="fw-semibold">{detail.label}:</span>
+                                    {detail.value}
+                                </div>
+                            {/each}
+                        </li>
                     {/each}
-                {/each}
+               </ul>
             {/if}
         </div>
     {/if}

--- a/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/rendering/Renderer.java
+++ b/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/rendering/Renderer.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.FeatureStructure;
 import org.apache.uima.cas.text.AnnotationFS;
@@ -75,15 +76,15 @@ public interface Renderer
     default Map<String, String> renderLabelFeatureValues(TypeAdapter aAdapter, FeatureStructure aFs,
             List<AnnotationFeature> aFeatures)
     {
-        FeatureSupportRegistry fsr = getFeatureSupportRegistry();
-        Map<String, String> features = new LinkedHashMap<>();
+        var fsr = getFeatureSupportRegistry();
+        var features = new LinkedHashMap<String, String>();
 
-        for (AnnotationFeature feature : aFeatures) {
+        for (var feature : aFeatures) {
             if (!feature.isEnabled() || !feature.isVisible()) {
                 continue;
             }
 
-            String label = defaultString(fsr.findExtension(feature)
+            var label = defaultString(fsr.findExtension(feature)
                     .orElseThrow(() -> new NoSuchElementException(
                             "No feature support found for feature " + feature))
                     .renderFeatureValue(feature, aFs));
@@ -97,7 +98,7 @@ public interface Renderer
     default void renderRequiredFeatureErrors(List<AnnotationFeature> aFeatures,
             FeatureStructure aFS, VDocument aResponse)
     {
-        for (AnnotationFeature f : aFeatures) {
+        for (var f : aFeatures) {
             if (!f.isEnabled()) {
                 continue;
             }
@@ -109,8 +110,7 @@ public interface Renderer
         }
     }
 
-    default List<VLazyDetailGroup> lookupLazyDetails(CAS aCas, VID aVid, int windowBeginOffset,
-            int windowEndOffset)
+    default List<VLazyDetailGroup> lookupLazyDetails(CAS aCas, VID aVid)
     {
         var fsr = getFeatureSupportRegistry();
 
@@ -130,12 +130,13 @@ public interface Renderer
                 continue;
             }
 
-            String text = defaultString(
-                    fsr.findExtension(feature).orElseThrow().renderFeatureValue(feature, aFs));
+            var label = fsr.findExtension(feature).orElseThrow().renderFeatureValue(feature, aFs);
 
-            var group = new VLazyDetailGroup();
-            group.addDetail(new VLazyDetail(feature.getName(), text));
-            details.add(group);
+            if (StringUtils.isNotBlank(label)) {
+                var group = new VLazyDetailGroup();
+                group.addDetail(new VLazyDetail(feature.getName(), label));
+                details.add(group);
+            }
         }
     }
 }

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebar.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebar.java
@@ -33,10 +33,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import org.apache.uima.UIMAException;
-import org.apache.uima.cas.CAS;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.feedback.IFeedback;
 import org.apache.wicket.markup.html.WebMarkupContainer;
@@ -46,7 +44,6 @@ import org.apache.wicket.markup.html.form.CheckBox;
 import org.apache.wicket.markup.html.form.CheckGroup;
 import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.markup.html.form.Form;
-import org.apache.wicket.markup.html.form.IChoiceRenderer;
 import org.apache.wicket.markup.html.form.LambdaChoiceRenderer;
 import org.apache.wicket.markup.html.list.ListItem;
 import org.apache.wicket.markup.html.list.ListView;
@@ -62,8 +59,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasProvider;
-import de.tudarmstadt.ukp.clarin.webanno.model.Project;
-import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.AnnotationPage;
@@ -126,7 +121,7 @@ public class CurationSidebar
     {
         super(aId, aModel, aActionHandler, aCasProvider, aAnnotationPage);
 
-        AnnotatorState state = aModel.getObject();
+        var state = aModel.getObject();
 
         var notCuratableNotice = new WebMarkupContainer("notCuratableNotice");
         notCuratableNotice.setOutputMarkupId(true);
@@ -176,8 +171,8 @@ public class CurationSidebar
     private boolean isViewingPotentialCurationTarget()
     {
         // Curation sidebar is not allowed when viewing another users annotations
-        String currentUsername = userRepository.getCurrentUsername();
-        AnnotatorState state = getModelObject();
+        var currentUsername = userRepository.getCurrentUsername();
+        var state = getModelObject();
         return asList(CURATION_USER, currentUsername).contains(state.getUser().getUsername());
     }
 
@@ -197,7 +192,7 @@ public class CurationSidebar
 
     private void actionMerge(AjaxRequestTarget aTarget, Form<State> aForm)
     {
-        AnnotatorState state = getModelObject();
+        var state = getModelObject();
 
         if (aForm.getModelObject().isSaveSettingsAsDefault()) {
             curationService.createOrUpdateCurationWorkflow(curationWorkflowModel.getObject());
@@ -224,13 +219,13 @@ public class CurationSidebar
     private void doMerge(AnnotatorState aState, String aCurator, Collection<User> aUsers)
         throws IOException, UIMAException
     {
-        SourceDocument doc = aState.getDocument();
-        CAS aTargetCas = curationSidebarService
+        var doc = aState.getDocument();
+        var aTargetCas = curationSidebarService
                 .retrieveCurationCAS(aCurator, aState.getProject().getId(), doc)
                 .orElseThrow(() -> new IllegalArgumentException(
                         "No target CAS configured in curation state"));
 
-        Map<String, CAS> userCases = documentService.readAllCasesSharedNoUpgrade(doc, aUsers);
+        var userCases = documentService.readAllCasesSharedNoUpgrade(doc, aUsers);
 
         // FIXME: should merging not overwrite the current users annos? (can result in
         // deleting the users annotations!!!), currently fixed by warn message to user
@@ -252,7 +247,7 @@ public class CurationSidebar
 
         form.setOutputMarkupId(true);
 
-        IChoiceRenderer<String> targetChoiceRenderer = new LambdaChoiceRenderer<>(
+        var targetChoiceRenderer = new LambdaChoiceRenderer<>(
                 aUsername -> CURATION_USER.equals(aUsername) ? "curation document" : "my document");
 
         var curationTargets = new ArrayList<String>();
@@ -325,8 +320,8 @@ public class CurationSidebar
 
     private Form<Void> createUserSelection(String aId)
     {
-        String sessionOwner = userRepository.getCurrentUsername();
-        Project project = getModelObject().getProject();
+        var sessionOwner = userRepository.getCurrentUsername();
+        var project = getModelObject().getProject();
 
         var form = new Form<Void>(aId);
         form.setOutputMarkupPlaceholderTag(true);
@@ -363,7 +358,7 @@ public class CurationSidebar
 
     private IModel<String> maybeAnonymizeUsername(ListItem<User> aUserListItem)
     {
-        Project project = getModelObject().getProject();
+        var project = getModelObject().getProject();
         if (project.isAnonymousCuration()
                 && !projectService.hasRole(userRepository.getCurrentUser(), project, MANAGER)) {
             return Model.of("Anonymized annotator " + (aUserListItem.getIndex() + 1));

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/config/CurationSidebarAutoConfiguration.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/config/CurationSidebarAutoConfiguration.java
@@ -29,6 +29,7 @@ import org.springframework.security.core.session.SessionRegistry;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasStorageService;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
+import de.tudarmstadt.ukp.inception.diam.editor.lazydetails.LazyDetailsLookupService;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.project.api.ProjectService;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
@@ -63,11 +64,12 @@ public class CurationSidebarAutoConfiguration
             AnnotationSchemaService aAnnotationService, DocumentService aDocumentService,
             ApplicationEventPublisher aApplicationEventPublisher, UserDao aUserRepository,
             CurationSidebarService aCurationSidebarService,
-            FeatureSupportRegistry aFeatureSupportRegistry)
+            FeatureSupportRegistry aFeatureSupportRegistry,
+            LazyDetailsLookupService aDetailsLookupService)
     {
         return new CurationEditorExtension(aAnnotationService, aDocumentService,
                 aApplicationEventPublisher, aUserRepository, aCurationSidebarService,
-                aFeatureSupportRegistry);
+                aFeatureSupportRegistry, aDetailsLookupService);
     }
 
     @Bean("curationSidebar")


### PR DESCRIPTION
**What's in the PR**
- Display non-curatable featues that are show-in-hover in curation suggestions
- Improve layout of the annotation detail popover

**How to test manually**
* Try curating using the annotation sidebar
* Configure a string feature `comment` that is non-curatable, not showing in the label and has show-on-hover enabled.

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
