### PR TITLE
#4567 - Add support for a generic CAS RDF export format

### DIFF
--- a/inception/inception-app-webapp/pom.xml
+++ b/inception/inception-app-webapp/pom.xml
@@ -359,38 +359,6 @@
     <!-- READER/WRITER DEPENDENCIES -->
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
-      <artifactId>inception-io-json</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
-      <artifactId>inception-io-webanno-tsv</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
-      <artifactId>inception-io-text</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
-      <artifactId>inception-io-tcf</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
-      <artifactId>inception-io-nif</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
-      <artifactId>inception-io-imscwb</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
-      <artifactId>inception-io-intertext</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
-      <artifactId>inception-io-perseus</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-io-bioc</artifactId>
     </dependency>
     <dependency>
@@ -403,16 +371,51 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
-      <artifactId>inception-io-xmi</artifactId>
+      <artifactId>inception-io-imscwb</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-io-html</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-io-intertext</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-io-json</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-io-nif</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-io-perseus</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-io-rdf</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-io-tcf</artifactId>
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-io-tei</artifactId>
     </dependency>
-
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-io-text</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-io-webanno-tsv</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-io-xmi</artifactId>
     </dependency>
 
     <!-- UIMA DEPENDENCIES -->
@@ -420,7 +423,6 @@
       <groupId>org.apache.uima</groupId>
       <artifactId>uimaj-core</artifactId>
     </dependency>
-
 
     <!-- WICKET DEPENDENCIES -->
     <dependency>
@@ -549,8 +551,8 @@
       <artifactId>sentry-spring-boot-starter</artifactId>
     </dependency>
     <dependency>
-        <groupId>io.sentry</groupId>
-        <artifactId>sentry-log4j2</artifactId>
+      <groupId>io.sentry</groupId>
+      <artifactId>sentry-log4j2</artifactId>
     </dependency>
 
     <!-- DATABASE / HIBERNATE -->
@@ -663,6 +665,11 @@
     <dependency>
       <groupId>info.picocli</groupId>
       <artifactId>picocli-spring-boot-starter</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
     </dependency>
     
     <dependency>
@@ -953,17 +960,19 @@
               <!-- INCEpTION IO Modules - used via Spring -->
               <usedDependency>de.tudarmstadt.ukp.inception.app:inception-io-bioc</usedDependency>
               <usedDependency>de.tudarmstadt.ukp.inception.app:inception-io-brat</usedDependency>
-              <usedDependency>de.tudarmstadt.ukp.inception.app:inception-io-nif</usedDependency>
-              <usedDependency>de.tudarmstadt.ukp.inception.app:inception-io-intertext</usedDependency>
-              <usedDependency>de.tudarmstadt.ukp.inception.app:inception-io-imscwb</usedDependency>
-              <usedDependency>de.tudarmstadt.ukp.inception.app:inception-io-perseus</usedDependency>
-              <usedDependency>de.tudarmstadt.ukp.inception.app:inception-io-json</usedDependency>
-              <usedDependency>de.tudarmstadt.ukp.inception.app:inception-io-webanno-tsv</usedDependency>
-              <usedDependency>de.tudarmstadt.ukp.inception.app:inception-io-tcf</usedDependency>
-              <usedDependency>de.tudarmstadt.ukp.inception.app:inception-io-xmi</usedDependency>
               <usedDependency>de.tudarmstadt.ukp.inception.app:inception-io-conll</usedDependency>
+              <usedDependency>de.tudarmstadt.ukp.inception.app:inception-io-imscwb</usedDependency>
+              <usedDependency>de.tudarmstadt.ukp.inception.app:inception-io-html</usedDependency>
+              <usedDependency>de.tudarmstadt.ukp.inception.app:inception-io-intertext</usedDependency>
+              <usedDependency>de.tudarmstadt.ukp.inception.app:inception-io-json</usedDependency>
+              <usedDependency>de.tudarmstadt.ukp.inception.app:inception-io-nif</usedDependency>
+              <usedDependency>de.tudarmstadt.ukp.inception.app:inception-io-perseus</usedDependency>
+              <usedDependency>de.tudarmstadt.ukp.inception.app:inception-io-rdf</usedDependency>
+              <usedDependency>de.tudarmstadt.ukp.inception.app:inception-io-tcf</usedDependency>
               <usedDependency>de.tudarmstadt.ukp.inception.app:inception-io-tei</usedDependency>
               <usedDependency>de.tudarmstadt.ukp.inception.app:inception-io-text</usedDependency>
+              <usedDependency>de.tudarmstadt.ukp.inception.app:inception-io-webanno-tsv</usedDependency>
+              <usedDependency>de.tudarmstadt.ukp.inception.app:inception-io-xmi</usedDependency>
               <!-- Documentation modules - needed but no Java dependency -->
               <usedDependency>de.tudarmstadt.ukp.inception.app:inception-doc</usedDependency>
               <!-- WebAnno backend modules - used via Spring -->

--- a/inception/inception-bom/pom.xml
+++ b/inception/inception-bom/pom.xml
@@ -425,17 +425,12 @@
       </dependency>
       <dependency>
         <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+        <artifactId>inception-io-conll</artifactId>
+        <version>32.0-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>de.tudarmstadt.ukp.inception.app</groupId>
         <artifactId>inception-io-brat</artifactId>
-        <version>32.0-SNAPSHOT</version>
-      </dependency>
-      <dependency>
-        <groupId>de.tudarmstadt.ukp.inception.app</groupId>
-        <artifactId>inception-io-json</artifactId>
-        <version>32.0-SNAPSHOT</version>
-      </dependency>
-      <dependency>
-        <groupId>de.tudarmstadt.ukp.inception.app</groupId>
-        <artifactId>inception-io-text</artifactId>
         <version>32.0-SNAPSHOT</version>
       </dependency>
       <dependency>
@@ -445,17 +440,12 @@
       </dependency>
       <dependency>
         <groupId>de.tudarmstadt.ukp.inception.app</groupId>
-        <artifactId>inception-io-webanno-tsv</artifactId>
+        <artifactId>inception-io-intertext</artifactId>
         <version>32.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>de.tudarmstadt.ukp.inception.app</groupId>
-        <artifactId>inception-io-tei</artifactId>
-        <version>32.0-SNAPSHOT</version>
-      </dependency>
-      <dependency>
-        <groupId>de.tudarmstadt.ukp.inception.app</groupId>
-        <artifactId>inception-io-conll</artifactId>
+        <artifactId>inception-io-json</artifactId>
         <version>32.0-SNAPSHOT</version>
       </dependency>
       <dependency>
@@ -465,12 +455,7 @@
       </dependency>
       <dependency>
         <groupId>de.tudarmstadt.ukp.inception.app</groupId>
-        <artifactId>inception-io-intertext</artifactId>
-        <version>32.0-SNAPSHOT</version>
-      </dependency>
-      <dependency>
-        <groupId>de.tudarmstadt.ukp.inception.app</groupId>
-        <artifactId>inception-io-perseus</artifactId>
+        <artifactId>inception-io-lif</artifactId>
         <version>32.0-SNAPSHOT</version>
       </dependency>
       <dependency>
@@ -480,7 +465,12 @@
       </dependency>
       <dependency>
         <groupId>de.tudarmstadt.ukp.inception.app</groupId>
-        <artifactId>inception-io-lif</artifactId>
+        <artifactId>inception-io-perseus</artifactId>
+        <version>32.0-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+        <artifactId>inception-io-rdf</artifactId>
         <version>32.0-SNAPSHOT</version>
       </dependency>
       <dependency>
@@ -490,9 +480,25 @@
       </dependency>
       <dependency>
         <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+        <artifactId>inception-io-tei</artifactId>
+        <version>32.0-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+        <artifactId>inception-io-text</artifactId>
+        <version>32.0-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+        <artifactId>inception-io-webanno-tsv</artifactId>
+        <version>32.0-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>de.tudarmstadt.ukp.inception.app</groupId>
         <artifactId>inception-io-xmi</artifactId>
         <version>32.0-SNAPSHOT</version>
       </dependency>
+
       <dependency>
         <groupId>de.tudarmstadt.ukp.inception.app</groupId>
         <artifactId>inception-telemetry</artifactId>

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/user-guide.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/user-guide.adoc
@@ -284,6 +284,8 @@ include::{include-dir}formats-uimajson.adoc[leveloffset=+2]
 
 include::{include-dir}formats-uimajson-legacy.adoc[leveloffset=+2]
 
+include::{include-dir}formats-rdfcas.adoc.adoc[leveloffset=+2]
+
 include::{include-dir}formats-uimaxmi.adoc[leveloffset=+2]
 
 include::{include-dir}formats-webannotsv1.adoc[leveloffset=+2]

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/user-guide/formats.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/user-guide/formats.adoc
@@ -140,6 +140,10 @@ data in a particular format. The **feature flag** column shows which flags you c
 | `json`
 | `format.json-cas-legacy.enabled`
 
+| <<sect_formats_rdfcas,UIMA CAS RDF>>
+| `rdfcas`
+| `format.rdf-cas.enabled`
+
 | <<sect_formats_uimaxmi,UIMA XMI CAS (XML 1.0)>>
 | `xmi`
 | `format.uima-xmi.enabled`

--- a/inception/inception-io-rdf/LICENSE.txt
+++ b/inception/inception-io-rdf/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/inception/inception-io-rdf/pom.xml
+++ b/inception/inception-io-rdf/pom.xml
@@ -1,0 +1,91 @@
+<!--
+  Licensed to the Technische Universität Darmstadt under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The Technische Universität Darmstadt 
+  licenses this file to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.
+   
+  http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+    <artifactId>inception-app</artifactId>
+    <version>32.0-SNAPSHOT</version>
+  </parent>
+  
+  <artifactId>inception-io-rdf</artifactId>
+
+  <name>INCEpTION - IO - RDF</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.uima</groupId>
+      <artifactId>uimaj-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.uima</groupId>
+      <artifactId>uimafit-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.dkpro.core</groupId>
+      <artifactId>dkpro-core-api-parameter-asl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.dkpro.core</groupId>
+      <artifactId>dkpro-core-api-io-asl</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.jena</groupId>
+      <artifactId>jena-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jena</groupId>
+      <artifactId>jena-arq</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-collections4</artifactId>
+    </dependency>
+    
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-diag</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-ui-kb</artifactId>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.dkpro.core</groupId>
+      <artifactId>dkpro-core-testing-asl</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.dkpro.core</groupId>
+      <artifactId>dkpro-core-api-ner-asl</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.dkpro.core</groupId>
+      <artifactId>dkpro-core-io-conll-asl</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/inception/inception-io-rdf/pom.xml
+++ b/inception/inception-io-rdf/pom.xml
@@ -50,12 +50,24 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.jena</groupId>
-      <artifactId>jena-core</artifactId>
+      <groupId>org.eclipse.rdf4j</groupId>
+      <artifactId>rdf4j-model</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.jena</groupId>
-      <artifactId>jena-arq</artifactId>
+      <groupId>org.eclipse.rdf4j</groupId>
+      <artifactId>rdf4j-model-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.rdf4j</groupId>
+      <artifactId>rdf4j-rio-rdfxml</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.rdf4j</groupId>
+      <artifactId>rdf4j-rio-ntriples</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.rdf4j</groupId>
+      <artifactId>rdf4j-model-vocabulary</artifactId>
     </dependency>
 
     <dependency>

--- a/inception/inception-io-rdf/pom.xml
+++ b/inception/inception-io-rdf/pom.xml
@@ -32,12 +32,47 @@
 
   <dependencies>
     <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-diag</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-ui-kb</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-model</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-schema-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-api-formats</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.uima</groupId>
       <artifactId>uimaj-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.uima</groupId>
       <artifactId>uimafit-core</artifactId>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
     </dependency>
 
     <dependency>
@@ -48,7 +83,19 @@
       <groupId>org.dkpro.core</groupId>
       <artifactId>dkpro-core-api-io-asl</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.dkpro.core</groupId>
+      <artifactId>dkpro-core-api-resources-asl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.dkpro.core</groupId>
+      <artifactId>dkpro-core-api-metadata-asl</artifactId>
+    </dependency>
 
+    <dependency>
+      <groupId>org.eclipse.rdf4j</groupId>
+      <artifactId>rdf4j-rio-api</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.eclipse.rdf4j</groupId>
       <artifactId>rdf4j-model</artifactId>
@@ -69,20 +116,6 @@
       <groupId>org.eclipse.rdf4j</groupId>
       <artifactId>rdf4j-model-vocabulary</artifactId>
     </dependency>
-
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-collections4</artifactId>
-    </dependency>
-    
-    <dependency>
-      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
-      <artifactId>inception-diag</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
-      <artifactId>inception-ui-kb</artifactId>
-    </dependency>
     
     <dependency>
       <groupId>org.dkpro.core</groupId>
@@ -100,4 +133,22 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <configuration>
+            <usedDependencies>
+              <!-- File formats - used via reflection / optional -->
+              <usedDependency>org.eclipse.rdf4j:rdf4j-rio-rdfxml</usedDependency>
+              <usedDependency>org.eclipse.rdf4j:rdf4j-rio-ntriples</usedDependency>
+            </usedDependencies>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>

--- a/inception/inception-io-rdf/src/main/java/de/tudarmstadt/ukp/inception/io/rdf/RdfReader.java
+++ b/inception/inception-io-rdf/src/main/java/de/tudarmstadt/ukp/inception/io/rdf/RdfReader.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.io.rdf;
+
+import static org.dkpro.core.api.resources.CompressionUtils.getInputStream;
+import java.io.IOException;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.StmtIterator;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.riot.RDFLanguages;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.uima.UimaContext;
+import org.apache.uima.cas.CASException;
+import org.apache.uima.collection.CollectionException;
+import org.apache.uima.fit.descriptor.MimeTypeCapability;
+import org.apache.uima.fit.descriptor.ResourceMetaData;
+import org.apache.uima.jcas.JCas;
+import org.apache.uima.resource.ResourceInitializationException;
+import org.dkpro.core.api.io.JCasResourceCollectionReader_ImplBase;
+import org.dkpro.core.api.parameter.MimeTypes;
+import org.dkpro.core.api.resources.CompressionUtils;
+import de.tudarmstadt.ukp.inception.io.rdf.internal.Rdf2Uima;
+import de.tudarmstadt.ukp.inception.io.rdf.internal.RdfCas;
+import eu.openminted.share.annotations.api.DocumentationResource;
+
+/**
+ * Reads a CAS serialized as RDF.
+ */
+@ResourceMetaData(name = "UIMA CAS RDF Reader")
+@DocumentationResource("${docbase}/format-reference.html#format-${command}")
+@MimeTypeCapability({ MimeTypes.APPLICATION_X_UIMA_RDF })
+public class RdfReader
+    extends JCasResourceCollectionReader_ImplBase
+{
+    private Resource res;
+    private Model model;
+    private StmtIterator contextIterator;
+
+    @Override
+    public void initialize(UimaContext aContext) throws ResourceInitializationException
+    {
+        super.initialize(aContext);
+
+        // Seek first article
+        try {
+            step();
+        }
+        catch (IOException e) {
+            throw new ResourceInitializationException(e);
+        }
+    }
+
+    @Override
+    public void getNext(JCas aJCas) throws IOException, CollectionException
+    {
+        initCas(aJCas, res);
+
+        var context = contextIterator.next();
+        try {
+            Rdf2Uima.convert(context, aJCas);
+        }
+        catch (CASException e) {
+            throw new CollectionException(e);
+        }
+
+        // inFileCount++;
+        step();
+    }
+
+    private void closeAll()
+    {
+        res = null;
+        contextIterator = null;
+    }
+
+    @Override
+    public void destroy()
+    {
+        closeAll();
+        super.destroy();
+    }
+
+    @Override
+    public boolean hasNext() throws IOException, CollectionException
+    {
+        // If there is still an iterator, then there is still data. This requires that we call
+        // step() already during initialization.
+        return contextIterator != null;
+    }
+
+    /**
+     * Seek article in file. Stop once article element has been found without reading it.
+     */
+    private void step() throws IOException
+    {
+        // Open next file
+        while (true) {
+            if (res == null) {
+                // Call to super here because we want to know about the resources, not the articles
+                if (getResourceIterator().hasNext()) {
+                    // There are still resources left to read
+                    res = nextFile();
+                    // inFileCount = 0;
+                    try (var is = getInputStream(res.getLocation(), res.getInputStream())) {
+                        model = ModelFactory.createOntologyModel();
+                        RDFDataMgr.read(model, is, RDFLanguages.filenameToLang(
+                                CompressionUtils.stripCompressionExtension(res.getLocation())));
+                    }
+                    contextIterator = model.listStatements(null, RDF.type,
+                            model.createResource(RdfCas.TYPE_VIEW));
+                }
+                else {
+                    // No more files to read
+                    return;
+                }
+            }
+
+            if (contextIterator.hasNext()) {
+                return;
+            }
+
+            // End of file reached
+            closeAll();
+        }
+    }
+}

--- a/inception/inception-io-rdf/src/main/java/de/tudarmstadt/ukp/inception/io/rdf/RdfReader.java
+++ b/inception/inception-io-rdf/src/main/java/de/tudarmstadt/ukp/inception/io/rdf/RdfReader.java
@@ -42,13 +42,12 @@ import org.eclipse.rdf4j.rio.Rio;
 
 import de.tudarmstadt.ukp.inception.io.rdf.internal.Rdf2Uima;
 import de.tudarmstadt.ukp.inception.io.rdf.internal.RdfCas;
-import eu.openminted.share.annotations.api.DocumentationResource;
 
 /**
  * Reads a CAS serialized as RDF.
  */
 @ResourceMetaData(name = "UIMA CAS RDF Reader")
-@DocumentationResource("${docbase}/format-reference.html#format-${command}")
+// @DocumentationResource("${docbase}/format-reference.html#format-${command}")
 @MimeTypeCapability({ MimeTypes.APPLICATION_X_UIMA_RDF })
 public class RdfReader
     extends JCasResourceCollectionReader_ImplBase
@@ -129,9 +128,9 @@ public class RdfReader
                                         .stripCompressionExtension(res.getLocation()))
                                 .orElse(RDFXML);
                         model = Rio.parse(is, res.getLocation().toString(), format);
-                    }                    
-                    
-                    contextIterator = model.filter(null, RDF.TYPE, vf.createIRI(RdfCas.TYPE_VIEW)).iterator();
+                    }
+
+                    contextIterator = model.filter(null, RDF.TYPE, RdfCas.TYPE_VIEW).iterator();
                 }
                 else {
                     // No more files to read

--- a/inception/inception-io-rdf/src/main/java/de/tudarmstadt/ukp/inception/io/rdf/RdfWriter.java
+++ b/inception/inception-io-rdf/src/main/java/de/tudarmstadt/ukp/inception/io/rdf/RdfWriter.java
@@ -49,8 +49,6 @@ public class RdfWriter
     /**
      * Specify the suffix of output files. Default value <code>.ttl</code>. The file format will be
      * chosen depending on the file suffice.
-     * 
-     * @see RDFLanguages
      */
     public static final String PARAM_FILENAME_EXTENSION = ComponentParameters.PARAM_FILENAME_EXTENSION;
     @ConfigurationParameter(name = PARAM_FILENAME_EXTENSION, mandatory = true, defaultValue = ".ttl")
@@ -61,20 +59,20 @@ public class RdfWriter
     private Set<String> iriFeatures;
 
     private Uima2Rdf uima2rdf;
-    
+
     @Override
     public void initialize(UimaContext aContext) throws ResourceInitializationException
     {
         super.initialize(aContext);
-        
+
         uima2rdf = new Uima2Rdf(iriFeatures);
     }
-    
+
     @Override
     public void process(JCas aJCas) throws AnalysisEngineProcessException
     {
         var model = new DynamicModelFactory().createEmptyModel();
-        
+
         try {
             uima2rdf.convert(aJCas, model);
         }
@@ -83,10 +81,8 @@ public class RdfWriter
         }
 
         try (var docOS = getOutputStream(aJCas, filenameSuffix)) {
-            var format = Rio
-                    .getParserFormatForFileName(filenameSuffix)
-                    .orElse(RDFXML);
-            Rio.write(model, docOS, format);            
+            var format = Rio.getParserFormatForFileName(filenameSuffix).orElse(RDFXML);
+            Rio.write(model, docOS, format);
         }
         catch (Exception e) {
             throw new AnalysisEngineProcessException(e);

--- a/inception/inception-io-rdf/src/main/java/de/tudarmstadt/ukp/inception/io/rdf/RdfWriter.java
+++ b/inception/inception-io-rdf/src/main/java/de/tudarmstadt/ukp/inception/io/rdf/RdfWriter.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.io.rdf;
+
+import static org.apache.jena.riot.RDFLanguages.fileExtToLang;
+
+import java.util.Set;
+
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.riot.RDFLanguages;
+import org.apache.uima.UimaContext;
+import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
+import org.apache.uima.cas.CASException;
+import org.apache.uima.fit.descriptor.ConfigurationParameter;
+import org.apache.uima.fit.descriptor.MimeTypeCapability;
+import org.apache.uima.fit.descriptor.ResourceMetaData;
+import org.apache.uima.jcas.JCas;
+import org.apache.uima.resource.ResourceInitializationException;
+import org.dkpro.core.api.io.JCasFileWriter_ImplBase;
+import org.dkpro.core.api.parameter.ComponentParameters;
+import org.dkpro.core.api.parameter.MimeTypes;
+
+import de.tudarmstadt.ukp.inception.io.rdf.internal.Uima2Rdf;
+
+/**
+ * Writes the CAS out as RDF.
+ */
+@ResourceMetaData(name = "UIMA CAS RDF Writer")
+// @DocumentationResource("${docbase}/format-reference.html#format-${command}")
+@MimeTypeCapability({ MimeTypes.APPLICATION_X_UIMA_RDF })
+public class RdfWriter
+    extends JCasFileWriter_ImplBase
+{
+    /**
+     * Specify the suffix of output files. Default value <code>.ttl</code>. The file format will be
+     * chosen depending on the file suffice.
+     * 
+     * @see RDFLanguages
+     */
+    public static final String PARAM_FILENAME_EXTENSION = ComponentParameters.PARAM_FILENAME_EXTENSION;
+    @ConfigurationParameter(name = PARAM_FILENAME_EXTENSION, mandatory = true, defaultValue = ".ttl")
+    private String filenameSuffix;
+
+    public static final String PARAM_IRI_FEATURES = "iriFeatures";
+    @ConfigurationParameter(name = PARAM_IRI_FEATURES, mandatory = false)
+    private Set<String> iriFeatures;
+
+    private Uima2Rdf uima2rdf;
+    
+    @Override
+    public void initialize(UimaContext aContext) throws ResourceInitializationException
+    {
+        super.initialize(aContext);
+        
+        uima2rdf = new Uima2Rdf(iriFeatures);
+    }
+    
+    @Override
+    public void process(JCas aJCas) throws AnalysisEngineProcessException
+    {
+        var model = ModelFactory.createOntologyModel();
+
+        try {
+            uima2rdf.convert(aJCas, model);
+        }
+        catch (CASException e) {
+            throw new AnalysisEngineProcessException(e);
+        }
+
+        try (var docOS = getOutputStream(aJCas, filenameSuffix)) {
+            RDFDataMgr.write(docOS, model.getBaseModel(), fileExtToLang(filenameSuffix));
+        }
+        catch (Exception e) {
+            throw new AnalysisEngineProcessException(e);
+        }
+    }
+}

--- a/inception/inception-io-rdf/src/main/java/de/tudarmstadt/ukp/inception/io/rdf/UimaRdfCasFormatSupport.java
+++ b/inception/inception-io-rdf/src/main/java/de/tudarmstadt/ukp/inception/io/rdf/UimaRdfCasFormatSupport.java
@@ -91,8 +91,7 @@ public class UimaRdfCasFormatSupport
     {
         var iriFeatures = schemaService.listAnnotationFeature(aProject).stream()
                 .filter(f -> f.getType().startsWith(ConceptFeatureSupport.PREFIX))
-                .map(f -> f.getLayer().getName() + ":" + f.getName())
-                .collect(toUnmodifiableSet());
+                .map(f -> f.getLayer().getName() + ":" + f.getName()).collect(toUnmodifiableSet());
 
         return createEngineDescription(RdfWriter.class, aTSD, //
                 RdfWriter.PARAM_IRI_FEATURES, iriFeatures);

--- a/inception/inception-io-rdf/src/main/java/de/tudarmstadt/ukp/inception/io/rdf/UimaRdfCasFormatSupport.java
+++ b/inception/inception-io-rdf/src/main/java/de/tudarmstadt/ukp/inception/io/rdf/UimaRdfCasFormatSupport.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.io.rdf;
+
+import static java.util.stream.Collectors.toUnmodifiableSet;
+import static org.apache.uima.fit.factory.AnalysisEngineFactory.createEngineDescription;
+import static org.apache.uima.fit.factory.CollectionReaderFactory.createReaderDescription;
+
+import org.apache.uima.analysis_engine.AnalysisEngineDescription;
+import org.apache.uima.cas.CAS;
+import org.apache.uima.collection.CollectionReaderDescription;
+import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.inception.io.rdf.config.RdfFormatAutoConfiguration;
+import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
+import de.tudarmstadt.ukp.inception.ui.kb.feature.ConceptFeatureSupport;
+
+/**
+ * <p>
+ * This class is exposed as a Spring Component via
+ * {@link RdfFormatAutoConfiguration#uimaRdfCasFormatSupport}.
+ * </p>
+ */
+public class UimaRdfCasFormatSupport
+    implements FormatSupport
+{
+    public static final String ID = "rdfcas";
+    public static final String NAME = "UIMA CAS RDF";
+
+    private final AnnotationSchemaService schemaService;
+
+    public UimaRdfCasFormatSupport(AnnotationSchemaService aSchemaService)
+    {
+        schemaService = aSchemaService;
+    }
+
+    @Override
+    public String getId()
+    {
+        return ID;
+    }
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public boolean isReadable()
+    {
+        return true;
+    }
+
+    @Override
+    public boolean isWritable()
+    {
+        return true;
+    }
+
+    @Override
+    public CollectionReaderDescription getReaderDescription(Project aProject,
+            TypeSystemDescription aTSD)
+        throws ResourceInitializationException
+    {
+        return createReaderDescription(RdfReader.class, aTSD);
+    }
+
+    @Override
+    public AnalysisEngineDescription getWriterDescription(Project aProject,
+            TypeSystemDescription aTSD, CAS aCAS)
+        throws ResourceInitializationException
+    {
+        var iriFeatures = schemaService.listAnnotationFeature(aProject).stream()
+                .filter(f -> f.getType().startsWith(ConceptFeatureSupport.PREFIX))
+                .map(f -> f.getLayer().getName() + ":" + f.getName())
+                .collect(toUnmodifiableSet());
+
+        return createEngineDescription(RdfWriter.class, aTSD, //
+                RdfWriter.PARAM_IRI_FEATURES, iriFeatures);
+    }
+}

--- a/inception/inception-io-rdf/src/main/java/de/tudarmstadt/ukp/inception/io/rdf/config/RdfFormatAutoConfiguration.java
+++ b/inception/inception-io-rdf/src/main/java/de/tudarmstadt/ukp/inception/io/rdf/config/RdfFormatAutoConfiguration.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.io.rdf.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import de.tudarmstadt.ukp.inception.io.rdf.UimaRdfCasFormatSupport;
+import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
+import de.tudarmstadt.ukp.inception.ui.kb.feature.ConceptFeatureSupport;
+
+@Configuration
+public class RdfFormatAutoConfiguration
+{
+    @ConditionalOnProperty(prefix = "format.rdf-cas", name = "enabled", //
+            havingValue = "true", matchIfMissing = false)
+    @Bean
+    public UimaRdfCasFormatSupport uimaRdfCasFormatSupport(AnnotationSchemaService aSchemaService,
+            ConceptFeatureSupport aConceptFeatureSupport)
+    {
+        return new UimaRdfCasFormatSupport(aSchemaService);
+    }
+}

--- a/inception/inception-io-rdf/src/main/java/de/tudarmstadt/ukp/inception/io/rdf/internal/BasicIRI.java
+++ b/inception/inception-io-rdf/src/main/java/de/tudarmstadt/ukp/inception/io/rdf/internal/BasicIRI.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.io.rdf.internal;
+
+import org.eclipse.rdf4j.model.base.AbstractIRI;
+
+public class BasicIRI
+    extends AbstractIRI
+{
+    private static final long serialVersionUID = 4794310809421877727L;
+
+    private final String namespace;
+    private final String localName;
+
+    public BasicIRI(String aNamespace, String aLocalName)
+    {
+        namespace = aNamespace;
+        localName = aLocalName;
+    }
+
+    @Override
+    public String getNamespace()
+    {
+        return namespace;
+    }
+
+    @Override
+    public String getLocalName()
+    {
+        return localName;
+    }
+}

--- a/inception/inception-io-rdf/src/main/java/de/tudarmstadt/ukp/inception/io/rdf/internal/Rdf2Uima.java
+++ b/inception/inception-io-rdf/src/main/java/de/tudarmstadt/ukp/inception/io/rdf/internal/Rdf2Uima.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.io.rdf.internal;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.commons.collections4.iterators.IteratorIterable;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.jena.ontology.OntResource;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.Statement;
+import org.apache.jena.vocabulary.RDF;
+import org.apache.uima.cas.CAS;
+import org.apache.uima.cas.CASException;
+import org.apache.uima.cas.FeatureStructure;
+import org.apache.uima.fit.util.CasUtil;
+import org.apache.uima.fit.util.JCasUtil;
+import org.apache.uima.jcas.JCas;
+
+import de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData;
+
+public class Rdf2Uima
+{
+    public static void convert(Statement aContext, JCas aJCas) throws CASException
+    {
+        var m = aContext.getModel();
+
+        // Set up names
+        var tView = m.createResource(RdfCas.TYPE_VIEW);
+        var tFeatureStructure = m.createResource(RdfCas.TYPE_FEATURE_STRUCTURE);
+        var pIndexedIn = m.createProperty(RdfCas.PROP_INDEXED_IN);
+
+        var fsIndex = new HashMap<Resource, FeatureStructure>();
+
+        // Convert the views/SofAs
+        var viewIndex = new HashMap<Resource, JCas>();
+        var viewIter = m.listSubjectsWithProperty(RDF.type, tView);
+        for (var view : new IteratorIterable<Resource>(viewIter)) {
+            var viewJCas = convertView(view, aJCas);
+            viewIndex.put(view, viewJCas);
+            fsIndex.put(view, viewJCas.getSofa());
+        }
+
+        // Convert the FSes but without setting their feature values yet - we cannot fill
+        // the feature values just set because some of them may point to FSes not yet created
+        var fses = m.listSubjectsWithProperty(RDF.type, tFeatureStructure).toList();
+        for (var fs : fses) {
+            var uimaFS = initFS(fs.as(OntResource.class), aJCas);
+            fsIndex.put(fs, uimaFS);
+        }
+
+        // Now fill the FSes with their feature values
+        for (var fs : fses) {
+            convertFS(fs.as(OntResource.class), aJCas, fsIndex);
+        }
+
+        // Finally add the FSes to the indexes of the respective views
+        for (var fs : fses) {
+            var indexedInIter = fs.listProperties(pIndexedIn);
+            for (var indexedIn : new IteratorIterable<Statement>(indexedInIter)) {
+                var viewJCas = viewIndex.get(indexedIn.getResource());
+                viewJCas.addFsToIndexes(fsIndex.get(fs));
+            }
+        }
+    }
+
+    public static JCas convertView(Resource aView, JCas aJCas) throws CASException
+    {
+        var m = aView.getModel();
+
+        // Set up names
+        var pSofaID = m.createProperty(RdfCas.PROP_SOFA_ID);
+        var pSofaString = m.createProperty(RdfCas.PROP_SOFA_STRING);
+        var pSofaMimeType = m.createProperty(RdfCas.PROP_SOFA_MIME_TYPE);
+
+        // Get the values
+        var viewName = aView.getProperty(pSofaID).getString();
+        var sofaString = aView.getProperty(pSofaString).getString();
+        var sofaMimeType = aView.getProperty(pSofaMimeType).getString();
+
+        // Instantiate the view/SofA
+        var view = JCasUtil.getView(aJCas, viewName, true);
+        view.setSofaDataString(sofaString, sofaMimeType);
+
+        return view;
+    }
+
+    public static FeatureStructure initFS(OntResource aFS, JCas aJCas)
+    {
+        var cas = aJCas.getCas();
+
+        // Figure out the UIMA type - there can be only one type per FS
+        var types = aFS.listRDFTypes(true).toSet();
+        types.removeIf(res -> res.getURI().startsWith(RdfCas.NS_RDFCAS));
+        assert types.size() == 1;
+        var type = CasUtil.getType(cas,
+                types.iterator().next().getURI().substring(RdfCas.NS_UIMA.length()));
+
+        FeatureStructure fs;
+        if (type.getName().equals(DocumentMetaData.class.getName())) {
+            // Special handling to avoid ending up with two document annotations in the CAS
+            fs = DocumentMetaData.get(aJCas);
+        }
+        else {
+            fs = cas.createFS(type);
+        }
+
+        return fs;
+    }
+
+    public static FeatureStructure convertFS(OntResource aFS, JCas aJCas,
+            Map<Resource, FeatureStructure> aFsIndex)
+    {
+        var fs = aFsIndex.get(aFS);
+
+        var stmtIter = aFS.listProperties();
+        for (var stmt : new IteratorIterable<Statement>(stmtIter)) {
+            // Skip all non-features
+            if (!stmt.getPredicate().getURI().startsWith("uima:")) {
+                continue;
+            }
+
+            var featureName = StringUtils.substringAfterLast(stmt.getPredicate().getURI(), "-");
+            var uimaFeat = fs.getType().getFeatureByBaseName(featureName);
+
+            // Cannot update start/end of document annotation because that FS is already indexed, so
+            // we skip those
+            if (fs == aJCas.getDocumentAnnotationFs()
+                    && (CAS.FEATURE_BASE_NAME_BEGIN.equals(featureName)
+                            || CAS.FEATURE_BASE_NAME_END.equals(featureName))) {
+                continue;
+            }
+
+            if (uimaFeat.getRange().isPrimitive()) {
+                switch (uimaFeat.getRange().getName()) {
+                case CAS.TYPE_NAME_BOOLEAN:
+                    fs.setBooleanValue(uimaFeat, stmt.getObject().asLiteral().getBoolean());
+                    break;
+                case CAS.TYPE_NAME_BYTE:
+                    fs.setByteValue(uimaFeat, stmt.getObject().asLiteral().getByte());
+                    break;
+                case CAS.TYPE_NAME_DOUBLE:
+                    fs.setDoubleValue(uimaFeat, stmt.getObject().asLiteral().getDouble());
+                    break;
+                case CAS.TYPE_NAME_FLOAT:
+                    fs.setFloatValue(uimaFeat, stmt.getObject().asLiteral().getFloat());
+                    break;
+                case CAS.TYPE_NAME_INTEGER:
+                    fs.setIntValue(uimaFeat, stmt.getObject().asLiteral().getInt());
+                    break;
+                case CAS.TYPE_NAME_LONG:
+                    fs.setLongValue(uimaFeat, stmt.getObject().asLiteral().getLong());
+                    break;
+                case CAS.TYPE_NAME_SHORT:
+                    fs.setShortValue(uimaFeat, stmt.getObject().asLiteral().getShort());
+                    break;
+                case CAS.TYPE_NAME_STRING: {
+                    if (stmt.getObject().isLiteral()) {
+                        fs.setStringValue(uimaFeat, stmt.getObject().asLiteral().getString());
+                    }
+                    else {
+                       fs.setStringValue(uimaFeat, stmt.getObject().asResource().getURI());
+                    }
+                    break;
+                }
+                default:
+                    throw new IllegalArgumentException(
+                            "Feature [" + uimaFeat.getName() + "] has unsupported primitive type ["
+                                    + uimaFeat.getRange().getName() + "]");
+                }
+            }
+            else {
+                FeatureStructure targetUimaFS = aFsIndex.get(stmt.getObject().asResource());
+                if (targetUimaFS == null) {
+                    throw new IllegalStateException("No UIMA FS found for ["
+                            + stmt.getObject().asResource().getURI() + "]");
+                }
+                fs.setFeatureValue(uimaFeat, targetUimaFS);
+            }
+        }
+
+        return fs;
+    }
+}

--- a/inception/inception-io-rdf/src/main/java/de/tudarmstadt/ukp/inception/io/rdf/internal/RdfCas.java
+++ b/inception/inception-io-rdf/src/main/java/de/tudarmstadt/ukp/inception/io/rdf/internal/RdfCas.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.inception.io.rdf.internal;
 
 import org.apache.uima.cas.CAS;
+import org.eclipse.rdf4j.model.IRI;
 
 /**
  * RDF CAS vocabulary.
@@ -27,19 +28,18 @@ public class RdfCas
     public static final String PREFIX_RDFCAS = "rdfcas";
 
     public static final String NS_RDFCAS = "http://uima.apache.org/rdf/cas#";
-    public static final String NS_UIMA = "uima:";
+    public static final String SCHEME_UIMA = "uima:";
 
-    public static final String PROP_VIEW = NS_RDFCAS + "view";
-    public static final String PROP_INDEXED_IN = NS_RDFCAS + "indexedIn";
+    public static final IRI PROP_VIEW = new BasicIRI(NS_RDFCAS, "view");
+    public static final IRI PROP_INDEXED_IN = new BasicIRI(NS_RDFCAS, "indexedIn");
 
-    // public static final String TYPE_CAS = NS_RDFCAS + "CAS";
-    public static final String TYPE_VIEW = NS_RDFCAS + "View";
-    public static final String TYPE_FEATURE_STRUCTURE = NS_RDFCAS + "FeatureStructure";
+    public static final IRI TYPE_VIEW = new BasicIRI(NS_RDFCAS, "View");
+    public static final IRI TYPE_FEATURE_STRUCTURE = new BasicIRI(NS_RDFCAS, "FeatureStructure");
 
-    public static final String PROP_SOFA_ID = NS_UIMA + CAS.TYPE_NAME_SOFA + '-'
-            + CAS.FEATURE_BASE_NAME_SOFAID;
-    public static final String PROP_SOFA_STRING = NS_UIMA + CAS.TYPE_NAME_SOFA + '-'
-            + CAS.FEATURE_BASE_NAME_SOFASTRING;
-    public static final String PROP_SOFA_MIME_TYPE = NS_UIMA + CAS.TYPE_NAME_SOFA + '-'
-            + CAS.FEATURE_BASE_NAME_SOFAMIME;
+    public static final IRI PROP_SOFA_ID = new BasicIRI(SCHEME_UIMA,
+            CAS.TYPE_NAME_SOFA + '-' + CAS.FEATURE_BASE_NAME_SOFAID);
+    public static final IRI PROP_SOFA_STRING = new BasicIRI(SCHEME_UIMA,
+            CAS.TYPE_NAME_SOFA + '-' + CAS.FEATURE_BASE_NAME_SOFASTRING);
+    public static final IRI PROP_SOFA_MIME_TYPE = new BasicIRI(SCHEME_UIMA,
+            CAS.TYPE_NAME_SOFA + '-' + CAS.FEATURE_BASE_NAME_SOFAMIME);
 }

--- a/inception/inception-io-rdf/src/main/java/de/tudarmstadt/ukp/inception/io/rdf/internal/RdfCas.java
+++ b/inception/inception-io-rdf/src/main/java/de/tudarmstadt/ukp/inception/io/rdf/internal/RdfCas.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.io.rdf.internal;
+
+import org.apache.uima.cas.CAS;
+
+/**
+ * RDF CAS vocabulary.
+ */
+public class RdfCas
+{
+    public static final String PREFIX_RDFCAS = "rdfcas";
+
+    public static final String NS_RDFCAS = "http://uima.apache.org/rdf/cas#";
+    public static final String NS_UIMA = "uima:";
+
+    public static final String PROP_VIEW = NS_RDFCAS + "view";
+    public static final String PROP_INDEXED_IN = NS_RDFCAS + "indexedIn";
+
+    // public static final String TYPE_CAS = NS_RDFCAS + "CAS";
+    public static final String TYPE_VIEW = NS_RDFCAS + "View";
+    public static final String TYPE_FEATURE_STRUCTURE = NS_RDFCAS + "FeatureStructure";
+
+    public static final String PROP_SOFA_ID = NS_UIMA + CAS.TYPE_NAME_SOFA + '-'
+            + CAS.FEATURE_BASE_NAME_SOFAID;
+    public static final String PROP_SOFA_STRING = NS_UIMA + CAS.TYPE_NAME_SOFA + '-'
+            + CAS.FEATURE_BASE_NAME_SOFASTRING;
+    public static final String PROP_SOFA_MIME_TYPE = NS_UIMA + CAS.TYPE_NAME_SOFA + '-'
+            + CAS.FEATURE_BASE_NAME_SOFAMIME;
+}

--- a/inception/inception-io-rdf/src/main/java/de/tudarmstadt/ukp/inception/io/rdf/internal/Uima2Rdf.java
+++ b/inception/inception-io-rdf/src/main/java/de/tudarmstadt/ukp/inception/io/rdf/internal/Uima2Rdf.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.io.rdf.internal;
+
+import static java.lang.String.format;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import org.apache.jena.datatypes.xsd.XSDDatatype;
+import org.apache.jena.ontology.Individual;
+import org.apache.jena.ontology.OntModel;
+import org.apache.uima.cas.CAS;
+import org.apache.uima.cas.CASException;
+import org.apache.uima.cas.Feature;
+import org.apache.uima.cas.FeatureStructure;
+import org.apache.uima.cas.Type;
+import org.apache.uima.jcas.JCas;
+
+import de.tudarmstadt.ukp.clarin.webanno.diag.CasDoctorUtils;
+import de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData;
+
+public class Uima2Rdf
+{
+    private static final String DOCUMENT_SCHEME = "doc:";
+
+    private static final Pattern DKPRO_CORE_SCHEME = Pattern.compile(
+            "(?<LONG>de\\.tudarmstadt\\.ukp\\.dkpro\\.core\\.api\\.(?<MODULE>[^.]+)\\.type(\\.(?<INMODULE>.*))?\\.)[^.]+");
+
+    private final Set<String> iriFeatures = new HashSet<>();
+
+    public Uima2Rdf(Set<String> aIriFeatures)
+    {
+        if (aIriFeatures != null) {
+            iriFeatures.addAll(aIriFeatures);
+        }
+    }
+
+    public void convert(JCas aJCas, OntModel aTarget) throws CASException
+    {
+        // Set up prefix mappings
+        var ts = aJCas.getTypeSystem();
+        aTarget.setNsPrefix("cas", RdfCas.NS_UIMA + "uima.cas.");
+        aTarget.setNsPrefix("tcas", RdfCas.NS_UIMA + "uima.tcas.");
+        aTarget.setNsPrefix(RdfCas.PREFIX_RDFCAS, RdfCas.NS_RDFCAS);
+
+        // Additional prefix mappings for DKPro Core typesystems
+        for (var t : ts.getProperlySubsumedTypes(ts.getTopType())) {
+            var nameMatcher = DKPRO_CORE_SCHEME.matcher("");
+            var typeName = t.getName();
+            if (typeName.endsWith("[]")) {
+                typeName = typeName.substring(0, typeName.length() - 2);
+            }
+            nameMatcher.reset(typeName);
+            if (nameMatcher.matches()) {
+                var prefix = nameMatcher.group("MODULE");
+                if (nameMatcher.group("INMODULE") != null) {
+                    prefix = prefix + "-" + nameMatcher.group("INMODULE");
+                }
+                aTarget.setNsPrefix(prefix, RdfCas.NS_UIMA + nameMatcher.group("LONG"));
+            }
+        }
+
+        var viewIterator = aJCas.getViewIterator();
+        while (viewIterator.hasNext()) {
+            convertView(viewIterator.next(), aTarget);
+        }
+    }
+
+    private void convertView(JCas aJCas, OntModel aTarget)
+    {
+        // Shorten down variable name for model
+        var m = aTarget;
+
+        // Set up names
+        var tView = m.createResource(RdfCas.TYPE_VIEW);
+        var tFeatureStructure = m.createResource(RdfCas.TYPE_FEATURE_STRUCTURE);
+        var pIndexedIn = m.createProperty(RdfCas.PROP_INDEXED_IN);
+
+        // Get a URI for the document
+        var dmd = DocumentMetaData.get(aJCas);
+        var docuri = dmd.getDocumentUri() != null ? dmd.getDocumentUri()
+                : DOCUMENT_SCHEME + dmd.getDocumentId();
+
+        // These only collect a single view...
+        var reachable = CasDoctorUtils.collectReachable(aJCas.getCas());
+        var indexed = CasDoctorUtils.collectIndexed(aJCas.getCas());
+        // ... they do not collect the SOFA, so we add that explicitly
+        reachable.add(aJCas.getSofa());
+
+        // Set up the view itself
+        var viewUri = format("%s#%d", docuri, aJCas.getLowLevelCas().ll_getFSRef(aJCas.getSofa()));
+        var rdfView = m.createIndividual(viewUri, tView);
+
+        for (var uimaFS : reachable) {
+            var uri = format("%s#%d", docuri, aJCas.getLowLevelCas().ll_getFSRef(uimaFS));
+            var rdfFS = m.createIndividual(uri, m.createResource(rdfType(uimaFS.getType())));
+
+            // The SoFa is not a regular FS - do not mark it as such
+            if (uimaFS != aJCas.getSofa()) {
+                rdfFS.addOntClass(tFeatureStructure);
+            }
+
+            // Internal UIMA information
+            if (indexed.contains(uimaFS)) {
+                rdfFS.addProperty(pIndexedIn, rdfView);
+            }
+
+            // Convert features
+            convertFeatures(docuri, uimaFS, rdfFS);
+        }
+    }
+
+    private void convertFeatures(String docuri, FeatureStructure uimaFS, Individual rdfFS)
+    {
+        var m = rdfFS.getOntModel();
+
+        for (var uimaFeat : uimaFS.getType().getFeatures()) {
+            var rdfFeat = m.createProperty(rdfFeature(uimaFeat));
+            if (uimaFeat.getRange().isPrimitive()) {
+                switch (uimaFeat.getRange().getName()) {
+                case CAS.TYPE_NAME_BOOLEAN:
+                    rdfFS.addLiteral(rdfFeat, m.createTypedLiteral(uimaFS.getBooleanValue(uimaFeat),
+                            XSDDatatype.XSDboolean));
+                    break;
+                case CAS.TYPE_NAME_BYTE:
+                    rdfFS.addLiteral(rdfFeat, m.createTypedLiteral(uimaFS.getByteValue(uimaFeat),
+                            XSDDatatype.XSDbyte));
+                    break;
+                case CAS.TYPE_NAME_DOUBLE:
+                    rdfFS.addLiteral(rdfFeat, m.createTypedLiteral(uimaFS.getDoubleValue(uimaFeat),
+                            XSDDatatype.XSDdouble));
+                    break;
+                case CAS.TYPE_NAME_FLOAT:
+                    rdfFS.addLiteral(rdfFeat, m.createTypedLiteral(uimaFS.getFloatValue(uimaFeat),
+                            XSDDatatype.XSDfloat));
+                    break;
+                case CAS.TYPE_NAME_INTEGER:
+                    rdfFS.addLiteral(rdfFeat,
+                            m.createTypedLiteral(uimaFS.getIntValue(uimaFeat), XSDDatatype.XSDint));
+                    break;
+                case CAS.TYPE_NAME_LONG:
+                    rdfFS.addLiteral(rdfFeat, m.createTypedLiteral(uimaFS.getLongValue(uimaFeat),
+                            XSDDatatype.XSDlong));
+                    break;
+                case CAS.TYPE_NAME_SHORT:
+                    rdfFS.addLiteral(rdfFeat, m.createTypedLiteral(uimaFS.getShortValue(uimaFeat),
+                            XSDDatatype.XSDshort));
+                    break;
+                case CAS.TYPE_NAME_STRING: {
+                    var s = uimaFS.getStringValue(uimaFeat);
+                    if (s != null) {
+                        if (iriFeatures.contains(uimaFeat.getName())) {
+                            rdfFS.addProperty(rdfFeat, m.createResource(s));
+                        }
+                        else {
+                            rdfFS.addLiteral(rdfFeat,
+                                    m.createTypedLiteral(s, XSDDatatype.XSDstring));
+                        }
+                    }
+                    break;
+                }
+                default:
+                    throw new IllegalArgumentException(
+                            "Feature [" + uimaFeat.getName() + "] has unsupported primitive type ["
+                                    + uimaFeat.getRange().getName() + "]");
+                }
+            }
+            else {
+                var targetUimaFS = uimaFS.getFeatureValue(uimaFeat);
+                if (targetUimaFS != null) {
+                    rdfFS.addProperty(rdfFeat, m.createResource(rdfUri(docuri, targetUimaFS)));
+                }
+            }
+        }
+    }
+
+    private static String rdfUri(String docuri, FeatureStructure uimaFS)
+    {
+        return format("%s#%d", docuri, uimaFS.getCAS().getLowLevelCAS().ll_getFSRef(uimaFS));
+    }
+
+    private static String rdfFeature(Feature aUimaFeature)
+    {
+        return rdfType(aUimaFeature.getDomain()) + "-" + aUimaFeature.getShortName();
+    }
+
+    private static String rdfType(Type aUimaType)
+    {
+        return RdfCas.NS_UIMA + aUimaType.getName();
+    }
+}

--- a/inception/inception-io-rdf/src/main/resources/META-INF/asciidoc/user-guide/formats-rdfcas.adoc
+++ b/inception/inception-io-rdf/src/main/resources/META-INF/asciidoc/user-guide/formats-rdfcas.adoc
@@ -1,0 +1,68 @@
+// Licensed to the Technische Universität Darmstadt under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The Technische Universität Darmstadt 
+// licenses this file to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.
+//  
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+[[sect_formats_rdfcas]]
+= UIMA CAS RDF
+
+This format provides a representation of the annotated document in RDF using the design model of the UIMA CAS. This format is not an official Apache UIMA file format but rather a facility provided by {product-name} for the benefit of users who want to interact with thier annotated data using Semantic Web technology.
+
+[cols="2,1,1,1,3"]
+|====
+| Format | Read | Write | Custom Layers | Description
+
+| UIMA CAS RDF (`rdfcas`)
+| yes
+| yes
+| yes
+| 
+|====
+
+.Example
+[source,turtle]
+----
+{
+<doc:fi-orig.conll#6>
+        a                    cas:Sofa , rdfcas:View ;
+        cas:Sofa-mimeType    "text" ;
+        cas:Sofa-sofaID      "_InitialView" ;
+        cas:Sofa-sofaNum     "1"^^xsd:int ;
+        cas:Sofa-sofaString  "... here be document text ..." .
+
+<doc:fi-orig.conll#1182>
+        a                         rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#1362> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#213> ;
+        segmentation:Token-pos    <doc:fi-orig.conll#1780> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "173"^^xsd:int ;
+        tcas:Annotation-end       "183"^^xsd:int .
+
+<doc:fi-orig.conll#470>
+        a                        syntax-dependency:Dependency , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        syntax-dependency:Dependency-DependencyType
+                "obj" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#1182> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#123> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "173"^^xsd:int ;
+        tcas:Annotation-end      "183"^^xsd:int .
+----

--- a/inception/inception-io-rdf/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/inception/inception-io-rdf/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+de.tudarmstadt.ukp.inception.io.rdf.config.RdfFormatAutoConfiguration

--- a/inception/inception-io-rdf/src/test/java/de/tudarmstadt/ukp/inception/io/rdf/RdfWriterTest.java
+++ b/inception/inception-io-rdf/src/test/java/de/tudarmstadt/ukp/inception/io/rdf/RdfWriterTest.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.io.rdf;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.sort;
+import static org.apache.commons.lang3.StringUtils.join;
+import static org.apache.uima.fit.factory.AnalysisEngineFactory.createEngine;
+import static org.apache.uima.fit.factory.CollectionReaderFactory.createReader;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.contentOf;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.dkpro.core.testing.IOTestRunner.testOneWay;
+import static org.dkpro.core.testing.IOTestRunner.testRoundTrip;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.uima.fit.factory.JCasFactory;
+import org.dkpro.core.io.conll.Conll2006Reader;
+import org.dkpro.core.io.conll.Conll2006Writer;
+import org.dkpro.core.testing.TestOptions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData;
+import de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity;
+
+public class RdfWriterTest
+{
+    @Test
+    void oneWay() throws Exception
+    {
+        testOneWay(Conll2006Reader.class, // the reader
+                RdfWriter.class, // the writer
+                "conll/2006/fi-ref.ttl", // the reference file for the output
+                "conll/2006/fi-orig.conll", // the input file for the test
+                new TestOptions().resultAssertor(this::assertModelEquals));
+    }
+
+    @Test
+    void otherWay() throws Exception
+    {
+        testOneWay(RdfReader.class, // the reader
+                Conll2006Writer.class, // the writer
+                "ttl/fi-ref.conll", // the reference file for the output
+                "ttl/fi-orig.ttl"); // the input file for the test
+    }
+
+    @Test
+    void readWriteWithIriFeatures(@TempDir File aTemp) throws Exception
+    {
+        var cas = JCasFactory.createJCas();
+        cas.setDocumentText("John");
+
+        var dmd = DocumentMetaData.create(cas);
+        dmd.setDocumentId("test.txt");
+
+        var ne = new NamedEntity(cas, 0, 4);
+        ne.setValue("PER");
+        ne.setIdentifier("iri:somewhere");
+        ne.addToIndexes();
+
+        var writer = createEngine( //
+                RdfWriter.class, //
+                RdfWriter.PARAM_IRI_FEATURES,
+                NamedEntity._TypeName + ":" + NamedEntity._FeatName_identifier,
+                RdfWriter.PARAM_STRIP_EXTENSION, true, //
+                RdfWriter.PARAM_TARGET_LOCATION, aTemp);
+
+        writer.process(cas);
+
+        var targetFile = new File(aTemp, "test.ttl");
+        assertThat(contentOf(targetFile, UTF_8)) //
+                .contains("ner:NamedEntity-value       \"PER\" ;")
+                .contains("ner:NamedEntity-identifier  <iri:somewhere> ;");
+
+        cas.reset();
+
+        var reader = createReader( //
+                RdfReader.class, RdfReader.PARAM_SOURCE_LOCATION, targetFile);
+
+        reader.getNext(cas.getCas());
+
+        assertThat(cas.select(NamedEntity.class).asList()) //
+                .extracting(NamedEntity::getIdentifier, NamedEntity::getValue) //
+                .containsExactly(tuple("iri:somewhere", "PER"));
+    }
+
+    @Disabled("Currently does not work because IDs are not stable on round-trips")
+    @Test
+    void roundTrip() throws Exception
+    {
+        testRoundTrip(RdfReader.class, // the reader
+                RdfWriter.class, // the writer
+                "ttl/fi-orig.ttl",
+                // "conll/2006/fi-ref.ttl",
+                new TestOptions().resultAssertor(this::assertModelEquals));
+    }
+
+    private void assertModelEquals(File expected, File actual)
+    {
+        var mExpected = ModelFactory.createDefaultModel();
+        mExpected.read(expected.toURI().toString(), null, "TURTLE");
+        var sExpected = mExpected.listStatements().mapWith(s -> s.toString()).toList();
+        sort(sExpected);
+
+        var mActual = ModelFactory.createDefaultModel();
+        mActual.read(actual.toURI().toString(), null, "TURTLE");
+        var sActual = mActual.listStatements().mapWith(s -> s.toString()).toList();
+        sort(sActual);
+
+        assertEquals(join(sExpected, "\n"), join(sActual, "\n"));
+    }
+}

--- a/inception/inception-io-rdf/src/test/java/de/tudarmstadt/ukp/inception/io/rdf/RdfWriterTest.java
+++ b/inception/inception-io-rdf/src/test/java/de/tudarmstadt/ukp/inception/io/rdf/RdfWriterTest.java
@@ -31,6 +31,7 @@ import static org.dkpro.core.testing.IOTestRunner.testRoundTrip;
 import java.io.File;
 import java.io.FileInputStream;
 import java.util.ArrayList;
+
 import org.apache.uima.fit.factory.JCasFactory;
 import org.dkpro.core.io.conll.Conll2006Reader;
 import org.dkpro.core.io.conll.Conll2006Writer;
@@ -90,8 +91,7 @@ public class RdfWriterTest
 
         var targetFile = new File(aTemp, "test.ttl");
         assertThat(contentOf(targetFile, UTF_8)) //
-                .contains("ner:NamedEntity-value       \"PER\" ;")
-                .contains("ner:NamedEntity-identifier  <iri:somewhere> ;");
+                .contains("\"PER\"").contains("<iri:somewhere>");
 
         cas.reset();
 
@@ -121,16 +121,18 @@ public class RdfWriterTest
         try {
             var sExpected = new ArrayList<String>();
             try (var is = new FileInputStream(expected)) {
-                Rio.parse(is, RDFFormat.TURTLE).forEach(s -> sExpected.add(s.toString()));;
+                Rio.parse(is, RDFFormat.TURTLE).forEach(s -> sExpected.add(s.toString()));
+                ;
             }
             sort(sExpected);
-    
+
             var sActual = new ArrayList<String>();
             try (var is = new FileInputStream(actual)) {
-                Rio.parse(is, RDFFormat.TURTLE).forEach(s -> sActual.add(s.toString()));;
+                Rio.parse(is, RDFFormat.TURTLE).forEach(s -> sActual.add(s.toString()));
+                ;
             }
             sort(sActual);
-    
+
             assertThat(join("\n", sActual)).isEqualTo(join("\n", sExpected));
         }
         catch (Exception e) {

--- a/inception/inception-io-rdf/src/test/resources/conll/2006/README.txt
+++ b/inception/inception-io-rdf/src/test/resources/conll/2006/README.txt
@@ -1,0 +1,7 @@
+fi-orig.conll
+
+  First two sentences from FinnTreeBank 3.1
+  http://www.ling.helsinki.fi/kieliteknologia/tutkimus/treebank/sources/ftb3.1.conllx.gz
+  Creative Commons Attribution 3.0 License  
+
+  

--- a/inception/inception-io-rdf/src/test/resources/conll/2006/fi-orig.conll
+++ b/inception/inception-io-rdf/src/test/resources/conll/2006/fi-orig.conll
@@ -1,0 +1,38 @@
+<s><loc file="JRC_Acquis Corpus/fi/1958/jrc31958Q1101-fi.xml" line="28,29,30,31,32,33" />
+1	NEUVOSTO	neuvosto	N	N	N Nom Sg	2	attr	_	_
+2	EURATOMIN	Euratom	N	N	N Prop Gen Sg	3	attr	_	_
+3	HANKINTAKESKUKSEN	hankinta#keskus	N	N	N Gen Sg	4	attr	_	_
+4	PERUSSÄÄNTÖ	perus#sääntö	N	N	N Nom Sg	7	attr	_	_
+5	EUROOPAN	Eurooppa	N	N	N Prop Gen Sg	6	attr	_	_
+6	ATOMIENERGIAYHTEISÖN	atomi#energia#yhteisö	N	N	N Gen Sg	7	attr	_	_
+7	NEUVOSTO	neuvosto	N	N	N Nom Sg	0	main	_	_
+8	,	,	Punct	Punct	Punct	_	_	_	_
+9	joka	joka	Pron	Pron	Pron Rel Nom Sg	10	subj	_	_
+10	ottaa	ottaa	V	V	V Prs Act Sg3	7	mod	_	_
+11	huomioon	huomio	N	N	N Ill Sg	10	phrv	_	_
+12	perustamissopimuksen	perustamis#sopimus	N	N	N Gen Sg	14	attr	_	_
+13	54	54	Num	Num	Num Digit Nom Sg	14	attr	_	_
+14	artiklan	artikla	N	N	N Gen Sg	10	obj	_	_
+15	,	,	Punct	Punct	Punct	17	phrm	_	_
+16	ja	ja	CC	CC	CC	17	phrm	_	_
+17	ottaa	ottaa	V	V	V Prs Act Sg3	10	conjunct	_	_
+18	huomioon	huomio	N	N	N Ill Sg	17	phrv	_	_
+19	komission	komissio	N	N	N Gen Sg	20	subj	_	_
+20	ehdotuksen	ehdotus	N	N	N Gen Sg	17	obj	_	_
+21	,	,	Punct	Punct	Punct	23	phrm	_	_
+22	ON	olla	V	V	V Prs Act Sg3	23	aux	_	_
+23	PÄÄTTÄNYT	päättää	PrfPrc	PrfPrc	PrfPrc Act Pos Nom Sg	17	conjunct	_	_
+24	antaa	antaa	V	V	V Inf1 Lat	23	obj	_	_
+25	Euratomin	Euratom	N	N	N Prop Gen Sg	26	attr	_	_
+26	hankintakeskuksen	hankinta#keskus	N	N	N Gen Sg	27	attr	_	_
+27	perussäännön	perus#sääntö	N	N	N Gen Sg	24	obj	_	_
+28	seuraavasti	seuraava	Adv	Adv	Adv Pos Man	24	advl	_	_
+29	:	:	Punct	Punct	Punct	_	_	_	_
+</s>
+<s><loc file="JRC_Acquis Corpus/fi/1958/jrc31958Q1101-fi.xml" line="34" />
+1	1	1	Num	Num	Num Digit Nom Sg	2	attr	_	_
+2	artikla	artikla	N	N	N Nom Sg	3	attr	_	_
+3	Nimi	nimi	N	N	N Nom Sg	0	main	_	_
+4	ja	ja	CC	CC	CC	5	phrm	_	_
+5	tarkoitus	tarkoitus	N	N	N Nom Sg	3	conjunct	_	_
+</s>

--- a/inception/inception-io-rdf/src/test/resources/conll/2006/fi-ref.ttl
+++ b/inception/inception-io-rdf/src/test/resources/conll/2006/fi-ref.ttl
@@ -1,0 +1,1796 @@
+@prefix anomaly:            <uima:de.tudarmstadt.ukp.dkpro.core.api.anomaly.type.> .
+@prefix cas:                <uima:uima.cas.> .
+@prefix coref:              <uima:de.tudarmstadt.ukp.dkpro.core.api.coref.type.> .
+@prefix lexmorph-morph:     <uima:de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.morph.> .
+@prefix lexmorph-pos:       <uima:de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.> .
+@prefix lexmorph-pos.tweet: <uima:de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.tweet.> .
+@prefix metadata:           <uima:de.tudarmstadt.ukp.dkpro.core.api.metadata.type.> .
+@prefix ner:                <uima:de.tudarmstadt.ukp.dkpro.core.api.ner.type.> .
+@prefix owl:                <http://www.w3.org/2002/07/owl#> .
+@prefix rdf:                <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfcas:             <http://uima.apache.org/rdf/cas#> .
+@prefix rdfs:               <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix segmentation:       <uima:de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.> .
+@prefix semantics:          <uima:de.tudarmstadt.ukp.dkpro.core.api.semantics.type.> .
+@prefix structure:          <uima:de.tudarmstadt.ukp.dkpro.core.api.structure.type.> .
+@prefix syntax:             <uima:de.tudarmstadt.ukp.dkpro.core.api.syntax.type.> .
+@prefix syntax-chunk:       <uima:de.tudarmstadt.ukp.dkpro.core.api.syntax.type.chunk.> .
+@prefix syntax-constituent: <uima:de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.> .
+@prefix syntax-dependency:  <uima:de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.> .
+@prefix tcas:               <uima:uima.tcas.> .
+@prefix transform:          <uima:de.tudarmstadt.ukp.dkpro.core.api.transform.type.> .
+@prefix xsd:                <http://www.w3.org/2001/XMLSchema#> .
+
+<doc:fi-orig.conll#62>
+        rdf:type                 rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "Punct" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "143"^^xsd:int ;
+        tcas:Annotation-end      "144"^^xsd:int .
+
+<doc:fi-orig.conll#107>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#108> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#110> ;
+        segmentation:Token-order  "0"^^xsd:int ;
+        segmentation:Token-pos    <doc:fi-orig.conll#109> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "233"^^xsd:int ;
+        tcas:Annotation-end       "245"^^xsd:int .
+
+<doc:fi-orig.conll#41>
+        rdf:type                      rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#2> ;
+        lexmorph-pos:POS-PosValue     "V" ;
+        lexmorph-pos:POS-coarseValue  "V" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin         "95"^^xsd:int ;
+        tcas:Annotation-end           "100"^^xsd:int .
+
+<doc:fi-orig.conll#20>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Lemma-value  "Eurooppa" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "49"^^xsd:int ;
+        tcas:Annotation-end       "57"^^xsd:int .
+
+<doc:fi-orig.conll#2>
+        rdf:type             cas:Sofa , rdfcas:View ;
+        cas:Sofa-mimeType    "text" ;
+        cas:Sofa-sofaID      "_InitialView" ;
+        cas:Sofa-sofaNum     "1"^^xsd:int ;
+        cas:Sofa-sofaString  "NEUVOSTO EURATOMIN HANKINTAKESKUKSEN PERUSSÄÄNTÖ EUROOPAN ATOMIENERGIAYHTEISÖN NEUVOSTO , joka ottaa huomioon perustamissopimuksen 54 artiklan , ja ottaa huomioon komission ehdotuksen , ON PÄÄTTÄNYT antaa Euratomin hankintakeskuksen perussäännön seuraavasti :\n1 artikla Nimi ja tarkoitus\n" .
+
+<doc:fi-orig.conll#157>
+        rdf:type                      rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#2> ;
+        lexmorph-pos:POS-PosValue     "N" ;
+        lexmorph-pos:POS-coarseValue  "N" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin         "270"^^xsd:int ;
+        tcas:Annotation-end           "274"^^xsd:int .
+
+<doc:fi-orig.conll#91>
+        rdf:type                  segmentation:Token , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#92> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#94> ;
+        segmentation:Token-order  "0"^^xsd:int ;
+        segmentation:Token-pos    <doc:fi-orig.conll#93> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "189"^^xsd:int ;
+        tcas:Annotation-end       "198"^^xsd:int .
+
+<doc:fi-orig.conll#136>
+        rdf:type                 syntax-dependency:Dependency , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        syntax-dependency:Dependency-DependencyType
+                "subj" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#75> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#79> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "163"^^xsd:int ;
+        tcas:Annotation-end      "172"^^xsd:int .
+
+<doc:fi-orig.conll#70>
+        rdf:type                 rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "V Prs Act Sg3" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "148"^^xsd:int ;
+        tcas:Annotation-end      "153"^^xsd:int .
+
+<doc:fi-orig.conll#115>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#116> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#118> ;
+        segmentation:Token-order  "0"^^xsd:int ;
+        segmentation:Token-pos    <doc:fi-orig.conll#117> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "258"^^xsd:int ;
+        tcas:Annotation-end       "259"^^xsd:int .
+
+<doc:fi-orig.conll#49>
+        rdf:type                      rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#2> ;
+        lexmorph-pos:POS-PosValue     "N" ;
+        lexmorph-pos:POS-coarseValue  "N" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin         "110"^^xsd:int ;
+        tcas:Annotation-end           "130"^^xsd:int .
+
+<doc:fi-orig.conll#28>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Lemma-value  "neuvosto" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "79"^^xsd:int ;
+        tcas:Annotation-end       "87"^^xsd:int .
+
+<doc:fi-orig.conll#165>
+        rdf:type                      rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#2> ;
+        lexmorph-pos:POS-PosValue     "N" ;
+        lexmorph-pos:POS-coarseValue  "N" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin         "278"^^xsd:int ;
+        tcas:Annotation-end           "287"^^xsd:int .
+
+<doc:fi-orig.conll#99>
+        rdf:type                  segmentation:Token , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#100> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#102> ;
+        segmentation:Token-order  "0"^^xsd:int ;
+        segmentation:Token-pos    <doc:fi-orig.conll#101> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "205"^^xsd:int ;
+        tcas:Annotation-end       "214"^^xsd:int .
+
+<doc:fi-orig.conll#144>
+        rdf:type                 rdfcas:FeatureStructure , syntax-dependency:Dependency ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        syntax-dependency:Dependency-DependencyType
+                "obj" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#107> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#95> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "233"^^xsd:int ;
+        tcas:Annotation-end      "245"^^xsd:int .
+
+<doc:fi-orig.conll#78>
+        rdf:type                 rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "N Gen Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "163"^^xsd:int ;
+        tcas:Annotation-end      "172"^^xsd:int .
+
+<doc:fi-orig.conll#123>
+        rdf:type                 rdfcas:FeatureStructure , syntax-dependency:Dependency ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        syntax-dependency:Dependency-DependencyType
+                "attr" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#19> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#23> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "49"^^xsd:int ;
+        tcas:Annotation-end      "57"^^xsd:int .
+
+<doc:fi-orig.conll#57>
+        rdf:type                      rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#2> ;
+        lexmorph-pos:POS-PosValue     "N" ;
+        lexmorph-pos:POS-coarseValue  "N" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin         "134"^^xsd:int ;
+        tcas:Annotation-end           "142"^^xsd:int .
+
+<doc:fi-orig.conll#102>
+        rdf:type                 rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "N Prop Gen Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "205"^^xsd:int ;
+        tcas:Annotation-end      "214"^^xsd:int .
+
+<doc:fi-orig.conll#36>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Lemma-value  "joka" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "90"^^xsd:int ;
+        tcas:Annotation-end       "94"^^xsd:int .
+
+<doc:fi-orig.conll#15>
+        rdf:type                  segmentation:Token , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#16> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#18> ;
+        segmentation:Token-order  "0"^^xsd:int ;
+        segmentation:Token-pos    <doc:fi-orig.conll#17> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "37"^^xsd:int ;
+        tcas:Annotation-end       "48"^^xsd:int .
+
+<doc:fi-orig.conll#152>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Lemma-value  "artikla" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "262"^^xsd:int ;
+        tcas:Annotation-end       "269"^^xsd:int .
+
+<doc:fi-orig.conll#86>
+        rdf:type                 rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "Punct" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "184"^^xsd:int ;
+        tcas:Annotation-end      "185"^^xsd:int .
+
+<doc:fi-orig.conll#131>
+        rdf:type                 syntax-dependency:Dependency , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        syntax-dependency:Dependency-DependencyType
+                "obj" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#55> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#39> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "134"^^xsd:int ;
+        tcas:Annotation-end      "142"^^xsd:int .
+
+<doc:fi-orig.conll#65>
+        rdf:type                      rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#2> ;
+        lexmorph-pos:POS-PosValue     "CC" ;
+        lexmorph-pos:POS-coarseValue  "CC" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin         "145"^^xsd:int ;
+        tcas:Annotation-end           "147"^^xsd:int .
+
+<doc:fi-orig.conll#110>
+        rdf:type                 rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "N Gen Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "233"^^xsd:int ;
+        tcas:Annotation-end      "245"^^xsd:int .
+
+<doc:fi-orig.conll#44>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Lemma-value  "huomio" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "101"^^xsd:int ;
+        tcas:Annotation-end       "109"^^xsd:int .
+
+<doc:fi-orig.conll#23>
+        rdf:type                  segmentation:Token , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#24> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#26> ;
+        segmentation:Token-order  "0"^^xsd:int ;
+        segmentation:Token-pos    <doc:fi-orig.conll#25> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "58"^^xsd:int ;
+        tcas:Annotation-end       "78"^^xsd:int .
+
+<doc:fi-orig.conll#5>
+        rdf:type                      rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#2> ;
+        lexmorph-pos:POS-PosValue     "N" ;
+        lexmorph-pos:POS-coarseValue  "N" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin         "0"^^xsd:int ;
+        tcas:Annotation-end           "8"^^xsd:int .
+
+<doc:fi-orig.conll#160>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Lemma-value  "ja" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "275"^^xsd:int ;
+        tcas:Annotation-end       "277"^^xsd:int .
+
+<doc:fi-orig.conll#94>
+        rdf:type                 rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "PrfPrc Act Pos Nom Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "189"^^xsd:int ;
+        tcas:Annotation-end      "198"^^xsd:int .
+
+<doc:fi-orig.conll#139>
+        rdf:type                 rdfcas:FeatureStructure , syntax-dependency:Dependency ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        syntax-dependency:Dependency-DependencyType
+                "aux" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#87> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#91> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "186"^^xsd:int ;
+        tcas:Annotation-end      "188"^^xsd:int .
+
+<doc:fi-orig.conll#73>
+        rdf:type                      rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#2> ;
+        lexmorph-pos:POS-PosValue     "N" ;
+        lexmorph-pos:POS-coarseValue  "N" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin         "154"^^xsd:int ;
+        tcas:Annotation-end           "162"^^xsd:int .
+
+<doc:fi-orig.conll#118>
+        rdf:type                 rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "Punct" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "258"^^xsd:int ;
+        tcas:Annotation-end      "259"^^xsd:int .
+
+<doc:fi-orig.conll#52>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Lemma-value  "54" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "131"^^xsd:int ;
+        tcas:Annotation-end       "133"^^xsd:int .
+
+<doc:fi-orig.conll#31>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#32> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#34> ;
+        segmentation:Token-order  "0"^^xsd:int ;
+        segmentation:Token-pos    <doc:fi-orig.conll#33> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "88"^^xsd:int ;
+        tcas:Annotation-end       "89"^^xsd:int .
+
+<doc:fi-orig.conll#10>
+        rdf:type                 rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "N Prop Gen Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "9"^^xsd:int ;
+        tcas:Annotation-end      "18"^^xsd:int .
+
+<doc:fi-orig.conll#168>
+        rdf:type                 rdfcas:FeatureStructure , syntax-dependency:Dependency ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        syntax-dependency:Dependency-DependencyType
+                "attr" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#151> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#155> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "262"^^xsd:int ;
+        tcas:Annotation-end      "269"^^xsd:int .
+
+<doc:fi-orig.conll#147>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#148> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#150> ;
+        segmentation:Token-order  "0"^^xsd:int ;
+        segmentation:Token-pos    <doc:fi-orig.conll#149> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "260"^^xsd:int ;
+        tcas:Annotation-end       "261"^^xsd:int .
+
+<doc:fi-orig.conll#81>
+        rdf:type                      rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#2> ;
+        lexmorph-pos:POS-PosValue     "N" ;
+        lexmorph-pos:POS-coarseValue  "N" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin         "173"^^xsd:int ;
+        tcas:Annotation-end           "183"^^xsd:int .
+
+<doc:fi-orig.conll#126>
+        rdf:type                 rdfcas:FeatureStructure , syntax-dependency:Dependency ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        syntax-dependency:Dependency-DependencyType
+                "subj" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#35> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#39> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "90"^^xsd:int ;
+        tcas:Annotation-end      "94"^^xsd:int .
+
+<doc:fi-orig.conll#60>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Lemma-value  "," ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "143"^^xsd:int ;
+        tcas:Annotation-end       "144"^^xsd:int .
+
+<doc:fi-orig.conll#105>
+        rdf:type                      rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#2> ;
+        lexmorph-pos:POS-PosValue     "N" ;
+        lexmorph-pos:POS-coarseValue  "N" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin         "215"^^xsd:int ;
+        tcas:Annotation-end           "232"^^xsd:int .
+
+<doc:fi-orig.conll#39>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#40> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#42> ;
+        segmentation:Token-order  "0"^^xsd:int ;
+        segmentation:Token-pos    <doc:fi-orig.conll#41> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "95"^^xsd:int ;
+        tcas:Annotation-end       "100"^^xsd:int .
+
+<doc:fi-orig.conll#18>
+        rdf:type                 rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "N Nom Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "37"^^xsd:int ;
+        tcas:Annotation-end      "48"^^xsd:int .
+
+<doc:fi-orig.conll#155>
+        rdf:type                  segmentation:Token , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#156> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#158> ;
+        segmentation:Token-order  "0"^^xsd:int ;
+        segmentation:Token-pos    <doc:fi-orig.conll#157> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "270"^^xsd:int ;
+        tcas:Annotation-end       "274"^^xsd:int .
+
+<doc:fi-orig.conll#89>
+        rdf:type                      rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#2> ;
+        lexmorph-pos:POS-PosValue     "V" ;
+        lexmorph-pos:POS-coarseValue  "V" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin         "186"^^xsd:int ;
+        tcas:Annotation-end           "188"^^xsd:int .
+
+<doc:fi-orig.conll#134>
+        rdf:type                 syntax-dependency:Dependency , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        syntax-dependency:Dependency-DependencyType
+                "conjunct" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#67> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#39> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "148"^^xsd:int ;
+        tcas:Annotation-end      "153"^^xsd:int .
+
+<doc:fi-orig.conll#68>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Lemma-value  "ottaa" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "148"^^xsd:int ;
+        tcas:Annotation-end       "153"^^xsd:int .
+
+<doc:fi-orig.conll#113>
+        rdf:type                      rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#2> ;
+        lexmorph-pos:POS-PosValue     "Adv" ;
+        lexmorph-pos:POS-coarseValue  "Adv" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin         "246"^^xsd:int ;
+        tcas:Annotation-end           "257"^^xsd:int .
+
+<doc:fi-orig.conll#47>
+        rdf:type                  segmentation:Token , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#48> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#50> ;
+        segmentation:Token-order  "0"^^xsd:int ;
+        segmentation:Token-pos    <doc:fi-orig.conll#49> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "110"^^xsd:int ;
+        tcas:Annotation-end       "130"^^xsd:int .
+
+<doc:fi-orig.conll#26>
+        rdf:type                 rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "N Gen Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "58"^^xsd:int ;
+        tcas:Annotation-end      "78"^^xsd:int .
+
+<doc:fi-orig.conll#8>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Lemma-value  "Euratom" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "9"^^xsd:int ;
+        tcas:Annotation-end       "18"^^xsd:int .
+
+<doc:fi-orig.conll#163>
+        rdf:type                  segmentation:Token , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#164> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#166> ;
+        segmentation:Token-order  "0"^^xsd:int ;
+        segmentation:Token-pos    <doc:fi-orig.conll#165> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "278"^^xsd:int ;
+        tcas:Annotation-end       "287"^^xsd:int .
+
+<doc:fi-orig.conll#97>
+        rdf:type                      rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#2> ;
+        lexmorph-pos:POS-PosValue     "V" ;
+        lexmorph-pos:POS-coarseValue  "V" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin         "199"^^xsd:int ;
+        tcas:Annotation-end           "204"^^xsd:int .
+
+<doc:fi-orig.conll#142>
+        rdf:type                 rdfcas:FeatureStructure , syntax-dependency:Dependency ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        syntax-dependency:Dependency-DependencyType
+                "attr" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#99> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#103> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "205"^^xsd:int ;
+        tcas:Annotation-end      "214"^^xsd:int .
+
+<doc:fi-orig.conll#76>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Lemma-value  "komissio" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "163"^^xsd:int ;
+        tcas:Annotation-end       "172"^^xsd:int .
+
+<doc:fi-orig.conll#121>
+        rdf:type                 rdfcas:FeatureStructure , syntax-dependency:Dependency ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        syntax-dependency:Dependency-DependencyType
+                "attr" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#11> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#15> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "19"^^xsd:int ;
+        tcas:Annotation-end      "36"^^xsd:int .
+
+<doc:fi-orig.conll#55>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#56> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#58> ;
+        segmentation:Token-order  "0"^^xsd:int ;
+        segmentation:Token-pos    <doc:fi-orig.conll#57> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "134"^^xsd:int ;
+        tcas:Annotation-end       "142"^^xsd:int .
+
+<doc:fi-orig.conll#100>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Lemma-value  "Euratom" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "205"^^xsd:int ;
+        tcas:Annotation-end       "214"^^xsd:int .
+
+<doc:fi-orig.conll#34>
+        rdf:type                 rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "Punct" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "88"^^xsd:int ;
+        tcas:Annotation-end      "89"^^xsd:int .
+
+<doc:fi-orig.conll#13>
+        rdf:type                      rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#2> ;
+        lexmorph-pos:POS-PosValue     "N" ;
+        lexmorph-pos:POS-coarseValue  "N" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin         "19"^^xsd:int ;
+        tcas:Annotation-end           "36"^^xsd:int .
+
+<doc:fi-orig.conll#171>
+        rdf:type                 syntax-dependency:Dependency , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        syntax-dependency:Dependency-DependencyType
+                "conjunct" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#163> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#155> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "278"^^xsd:int ;
+        tcas:Annotation-end      "287"^^xsd:int .
+
+<doc:fi-orig.conll#150>
+        rdf:type                 rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "Num Digit Nom Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "260"^^xsd:int ;
+        tcas:Annotation-end      "261"^^xsd:int .
+
+<doc:fi-orig.conll#84>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Lemma-value  "," ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "184"^^xsd:int ;
+        tcas:Annotation-end       "185"^^xsd:int .
+
+<doc:fi-orig.conll#129>
+        rdf:type                 syntax-dependency:Dependency , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        syntax-dependency:Dependency-DependencyType
+                "attr" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#47> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#55> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "110"^^xsd:int ;
+        tcas:Annotation-end      "130"^^xsd:int .
+
+<doc:fi-orig.conll#63>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#64> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#66> ;
+        segmentation:Token-order  "0"^^xsd:int ;
+        segmentation:Token-pos    <doc:fi-orig.conll#65> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "145"^^xsd:int ;
+        tcas:Annotation-end       "147"^^xsd:int .
+
+<doc:fi-orig.conll#108>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Lemma-value  "perus#sääntö" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "233"^^xsd:int ;
+        tcas:Annotation-end       "245"^^xsd:int .
+
+<doc:fi-orig.conll#42>
+        rdf:type                 rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "V Prs Act Sg3" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "95"^^xsd:int ;
+        tcas:Annotation-end      "100"^^xsd:int .
+
+<doc:fi-orig.conll#21>
+        rdf:type                      rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#2> ;
+        lexmorph-pos:POS-PosValue     "N" ;
+        lexmorph-pos:POS-coarseValue  "N" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin         "49"^^xsd:int ;
+        tcas:Annotation-end           "57"^^xsd:int .
+
+<doc:fi-orig.conll#3>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#4> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#6> ;
+        segmentation:Token-order  "0"^^xsd:int ;
+        segmentation:Token-pos    <doc:fi-orig.conll#5> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "0"^^xsd:int ;
+        tcas:Annotation-end       "8"^^xsd:int .
+
+<doc:fi-orig.conll#158>
+        rdf:type                 rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "N Nom Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "270"^^xsd:int ;
+        tcas:Annotation-end      "274"^^xsd:int .
+
+<doc:fi-orig.conll#92>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Lemma-value  "päättää" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "189"^^xsd:int ;
+        tcas:Annotation-end       "198"^^xsd:int .
+
+<doc:fi-orig.conll#137>
+        rdf:type                 syntax-dependency:Dependency , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        syntax-dependency:Dependency-DependencyType
+                "obj" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#79> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#67> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "173"^^xsd:int ;
+        tcas:Annotation-end      "183"^^xsd:int .
+
+<doc:fi-orig.conll#71>
+        rdf:type                  segmentation:Token , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#72> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#74> ;
+        segmentation:Token-order  "0"^^xsd:int ;
+        segmentation:Token-pos    <doc:fi-orig.conll#73> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "154"^^xsd:int ;
+        tcas:Annotation-end       "162"^^xsd:int .
+
+<doc:fi-orig.conll#116>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Lemma-value  ":" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "258"^^xsd:int ;
+        tcas:Annotation-end       "259"^^xsd:int .
+
+<doc:fi-orig.conll#50>
+        rdf:type                 rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "N Gen Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "110"^^xsd:int ;
+        tcas:Annotation-end      "130"^^xsd:int .
+
+<doc:fi-orig.conll#29>
+        rdf:type                      rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#2> ;
+        lexmorph-pos:POS-PosValue     "N" ;
+        lexmorph-pos:POS-coarseValue  "N" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin         "79"^^xsd:int ;
+        tcas:Annotation-end           "87"^^xsd:int .
+
+<doc:fi-orig.conll#166>
+        rdf:type                 rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "N Nom Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "278"^^xsd:int ;
+        tcas:Annotation-end      "287"^^xsd:int .
+
+<doc:fi-orig.conll#145>
+        rdf:type                 rdfcas:FeatureStructure , syntax-dependency:Dependency ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        syntax-dependency:Dependency-DependencyType
+                "advl" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#111> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#95> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "246"^^xsd:int ;
+        tcas:Annotation-end      "257"^^xsd:int .
+
+<doc:fi-orig.conll#79>
+        rdf:type                  segmentation:Token , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#80> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#82> ;
+        segmentation:Token-order  "0"^^xsd:int ;
+        segmentation:Token-pos    <doc:fi-orig.conll#81> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "173"^^xsd:int ;
+        tcas:Annotation-end       "183"^^xsd:int .
+
+<doc:fi-orig.conll#124>
+        rdf:type                 rdfcas:FeatureStructure , syntax-dependency:Dependency ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        syntax-dependency:Dependency-DependencyType
+                "attr" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#23> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#27> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "58"^^xsd:int ;
+        tcas:Annotation-end      "78"^^xsd:int .
+
+<doc:fi-orig.conll#58>
+        rdf:type                 rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "N Gen Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "134"^^xsd:int ;
+        tcas:Annotation-end      "142"^^xsd:int .
+
+<doc:fi-orig.conll#103>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#104> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#106> ;
+        segmentation:Token-order  "0"^^xsd:int ;
+        segmentation:Token-pos    <doc:fi-orig.conll#105> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "215"^^xsd:int ;
+        tcas:Annotation-end       "232"^^xsd:int .
+
+<doc:fi-orig.conll#37>
+        rdf:type                      rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#2> ;
+        lexmorph-pos:POS-PosValue     "Pron" ;
+        lexmorph-pos:POS-coarseValue  "Pron" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin         "90"^^xsd:int ;
+        tcas:Annotation-end           "94"^^xsd:int .
+
+<doc:fi-orig.conll#16>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Lemma-value  "perus#sääntö" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "37"^^xsd:int ;
+        tcas:Annotation-end       "48"^^xsd:int .
+
+<doc:fi-orig.conll#153>
+        rdf:type                      rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#2> ;
+        lexmorph-pos:POS-PosValue     "N" ;
+        lexmorph-pos:POS-coarseValue  "N" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin         "262"^^xsd:int ;
+        tcas:Annotation-end           "269"^^xsd:int .
+
+<doc:fi-orig.conll#87>
+        rdf:type                  segmentation:Token , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#88> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#90> ;
+        segmentation:Token-order  "0"^^xsd:int ;
+        segmentation:Token-pos    <doc:fi-orig.conll#89> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "186"^^xsd:int ;
+        tcas:Annotation-end       "188"^^xsd:int .
+
+<doc:fi-orig.conll#132>
+        rdf:type                 syntax-dependency:Dependency , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        syntax-dependency:Dependency-DependencyType
+                "phrm" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#59> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#67> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "143"^^xsd:int ;
+        tcas:Annotation-end      "144"^^xsd:int .
+
+<doc:fi-orig.conll#66>
+        rdf:type                 rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "CC" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "145"^^xsd:int ;
+        tcas:Annotation-end      "147"^^xsd:int .
+
+<doc:fi-orig.conll#111>
+        rdf:type                  segmentation:Token , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#112> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#114> ;
+        segmentation:Token-order  "0"^^xsd:int ;
+        segmentation:Token-pos    <doc:fi-orig.conll#113> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "246"^^xsd:int ;
+        tcas:Annotation-end       "257"^^xsd:int .
+
+<doc:fi-orig.conll#45>
+        rdf:type                      rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#2> ;
+        lexmorph-pos:POS-PosValue     "N" ;
+        lexmorph-pos:POS-coarseValue  "N" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin         "101"^^xsd:int ;
+        tcas:Annotation-end           "109"^^xsd:int .
+
+<doc:fi-orig.conll#24>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Lemma-value  "atomi#energia#yhteisö" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "58"^^xsd:int ;
+        tcas:Annotation-end       "78"^^xsd:int .
+
+<doc:fi-orig.conll#6>
+        rdf:type                 rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "N Nom Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "0"^^xsd:int ;
+        tcas:Annotation-end      "8"^^xsd:int .
+
+<doc:fi-orig.conll#161>
+        rdf:type                      rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#2> ;
+        lexmorph-pos:POS-PosValue     "CC" ;
+        lexmorph-pos:POS-coarseValue  "CC" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin         "275"^^xsd:int ;
+        tcas:Annotation-end           "277"^^xsd:int .
+
+<doc:fi-orig.conll#95>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#96> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#98> ;
+        segmentation:Token-order  "0"^^xsd:int ;
+        segmentation:Token-pos    <doc:fi-orig.conll#97> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "199"^^xsd:int ;
+        tcas:Annotation-end       "204"^^xsd:int .
+
+<doc:fi-orig.conll#140>
+        rdf:type                 rdfcas:FeatureStructure , syntax-dependency:Dependency ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        syntax-dependency:Dependency-DependencyType
+                "conjunct" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#91> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#67> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "189"^^xsd:int ;
+        tcas:Annotation-end      "198"^^xsd:int .
+
+<doc:fi-orig.conll#74>
+        rdf:type                 rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "N Ill Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "154"^^xsd:int ;
+        tcas:Annotation-end      "162"^^xsd:int .
+
+<doc:fi-orig.conll#119>
+        rdf:type                 syntax-dependency:Dependency , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        syntax-dependency:Dependency-DependencyType
+                "attr" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#3> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#7> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "0"^^xsd:int ;
+        tcas:Annotation-end      "8"^^xsd:int .
+
+<doc:fi-orig.conll#53>
+        rdf:type                      rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#2> ;
+        lexmorph-pos:POS-PosValue     "Num" ;
+        lexmorph-pos:POS-coarseValue  "Num" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin         "131"^^xsd:int ;
+        tcas:Annotation-end           "133"^^xsd:int .
+
+<doc:fi-orig.conll#32>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Lemma-value  "," ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "88"^^xsd:int ;
+        tcas:Annotation-end       "89"^^xsd:int .
+
+<doc:fi-orig.conll#11>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#12> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#14> ;
+        segmentation:Token-order  "0"^^xsd:int ;
+        segmentation:Token-pos    <doc:fi-orig.conll#13> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "19"^^xsd:int ;
+        tcas:Annotation-end       "36"^^xsd:int .
+
+<doc:fi-orig.conll#169>
+        rdf:type                 syntax-dependency:ROOT , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        syntax-dependency:Dependency-DependencyType
+                "main" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#155> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#155> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "270"^^xsd:int ;
+        tcas:Annotation-end      "274"^^xsd:int .
+
+<doc:fi-orig.conll#148>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Lemma-value  "1" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "260"^^xsd:int ;
+        tcas:Annotation-end       "261"^^xsd:int .
+
+<doc:fi-orig.conll#82>
+        rdf:type                 rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "N Gen Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "173"^^xsd:int ;
+        tcas:Annotation-end      "183"^^xsd:int .
+
+<doc:fi-orig.conll#127>
+        rdf:type                 syntax-dependency:Dependency , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        syntax-dependency:Dependency-DependencyType
+                "mod" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#39> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#27> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "95"^^xsd:int ;
+        tcas:Annotation-end      "100"^^xsd:int .
+
+<doc:fi-orig.conll#61>
+        rdf:type                      rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#2> ;
+        lexmorph-pos:POS-PosValue     "Punct" ;
+        lexmorph-pos:POS-coarseValue  "Punct" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin         "143"^^xsd:int ;
+        tcas:Annotation-end           "144"^^xsd:int .
+
+<doc:fi-orig.conll#106>
+        rdf:type                 rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "N Gen Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "215"^^xsd:int ;
+        tcas:Annotation-end      "232"^^xsd:int .
+
+<doc:fi-orig.conll#40>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Lemma-value  "ottaa" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "95"^^xsd:int ;
+        tcas:Annotation-end       "100"^^xsd:int .
+
+<doc:fi-orig.conll#19>
+        rdf:type                  segmentation:Token , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#20> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#22> ;
+        segmentation:Token-order  "0"^^xsd:int ;
+        segmentation:Token-pos    <doc:fi-orig.conll#21> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "49"^^xsd:int ;
+        tcas:Annotation-end       "57"^^xsd:int .
+
+<doc:fi-orig.conll#1>
+        rdf:type                 rdfcas:FeatureStructure , metadata:DocumentMetaData ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        metadata:DocumentMetaData-documentId
+                "fi-orig.conll" ;
+        metadata:DocumentMetaData-documentTitle
+                "fi-orig.conll" ;
+        metadata:DocumentMetaData-isLastSegment
+                false ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "0"^^xsd:int ;
+        tcas:Annotation-end      "288"^^xsd:int ;
+        tcas:DocumentAnnotation-language
+                "x-unspecified" .
+
+<doc:fi-orig.conll#156>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Lemma-value  "nimi" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "270"^^xsd:int ;
+        tcas:Annotation-end       "274"^^xsd:int .
+
+<doc:fi-orig.conll#90>
+        rdf:type                 rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "V Prs Act Sg3" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "186"^^xsd:int ;
+        tcas:Annotation-end      "188"^^xsd:int .
+
+<doc:fi-orig.conll#135>
+        rdf:type                 syntax-dependency:Dependency , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        syntax-dependency:Dependency-DependencyType
+                "phrv" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#71> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#67> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "154"^^xsd:int ;
+        tcas:Annotation-end      "162"^^xsd:int .
+
+<doc:fi-orig.conll#69>
+        rdf:type                      rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#2> ;
+        lexmorph-pos:POS-PosValue     "V" ;
+        lexmorph-pos:POS-coarseValue  "V" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin         "148"^^xsd:int ;
+        tcas:Annotation-end           "153"^^xsd:int .
+
+<doc:fi-orig.conll#114>
+        rdf:type                 rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "Adv Pos Man" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "246"^^xsd:int ;
+        tcas:Annotation-end      "257"^^xsd:int .
+
+<doc:fi-orig.conll#48>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Lemma-value  "perustamis#sopimus" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "110"^^xsd:int ;
+        tcas:Annotation-end       "130"^^xsd:int .
+
+<doc:fi-orig.conll#27>
+        rdf:type                  segmentation:Token , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#28> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#30> ;
+        segmentation:Token-order  "0"^^xsd:int ;
+        segmentation:Token-pos    <doc:fi-orig.conll#29> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "79"^^xsd:int ;
+        tcas:Annotation-end       "87"^^xsd:int .
+
+<doc:fi-orig.conll#9>
+        rdf:type                      rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#2> ;
+        lexmorph-pos:POS-PosValue     "N" ;
+        lexmorph-pos:POS-coarseValue  "N" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin         "9"^^xsd:int ;
+        tcas:Annotation-end           "18"^^xsd:int .
+
+<doc:fi-orig.conll#164>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Lemma-value  "tarkoitus" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "278"^^xsd:int ;
+        tcas:Annotation-end       "287"^^xsd:int .
+
+<doc:fi-orig.conll#98>
+        rdf:type                 rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "V Inf1 Lat" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "199"^^xsd:int ;
+        tcas:Annotation-end      "204"^^xsd:int .
+
+<doc:fi-orig.conll#143>
+        rdf:type                 rdfcas:FeatureStructure , syntax-dependency:Dependency ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        syntax-dependency:Dependency-DependencyType
+                "attr" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#103> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#107> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "215"^^xsd:int ;
+        tcas:Annotation-end      "232"^^xsd:int .
+
+<doc:fi-orig.conll#77>
+        rdf:type                      rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#2> ;
+        lexmorph-pos:POS-PosValue     "N" ;
+        lexmorph-pos:POS-coarseValue  "N" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin         "163"^^xsd:int ;
+        tcas:Annotation-end           "172"^^xsd:int .
+
+<doc:fi-orig.conll#122>
+        rdf:type                 syntax-dependency:Dependency , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        syntax-dependency:Dependency-DependencyType
+                "attr" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#15> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#27> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "37"^^xsd:int ;
+        tcas:Annotation-end      "48"^^xsd:int .
+
+<doc:fi-orig.conll#56>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Lemma-value  "artikla" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "134"^^xsd:int ;
+        tcas:Annotation-end       "142"^^xsd:int .
+
+<doc:fi-orig.conll#101>
+        rdf:type                      rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#2> ;
+        lexmorph-pos:POS-PosValue     "N" ;
+        lexmorph-pos:POS-coarseValue  "N" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin         "205"^^xsd:int ;
+        tcas:Annotation-end           "214"^^xsd:int .
+
+<doc:fi-orig.conll#35>
+        rdf:type                  segmentation:Token , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#36> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#38> ;
+        segmentation:Token-order  "0"^^xsd:int ;
+        segmentation:Token-pos    <doc:fi-orig.conll#37> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "90"^^xsd:int ;
+        tcas:Annotation-end       "94"^^xsd:int .
+
+<doc:fi-orig.conll#14>
+        rdf:type                 rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "N Gen Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "19"^^xsd:int ;
+        tcas:Annotation-end      "36"^^xsd:int .
+
+<doc:fi-orig.conll#172>
+        rdf:type                 rdfcas:FeatureStructure , segmentation:Sentence ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "260"^^xsd:int ;
+        tcas:Annotation-end      "287"^^xsd:int .
+
+<doc:fi-orig.conll#151>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#152> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#154> ;
+        segmentation:Token-order  "0"^^xsd:int ;
+        segmentation:Token-pos    <doc:fi-orig.conll#153> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "262"^^xsd:int ;
+        tcas:Annotation-end       "269"^^xsd:int .
+
+<doc:fi-orig.conll#85>
+        rdf:type                      rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#2> ;
+        lexmorph-pos:POS-PosValue     "Punct" ;
+        lexmorph-pos:POS-coarseValue  "Punct" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin         "184"^^xsd:int ;
+        tcas:Annotation-end           "185"^^xsd:int .
+
+<doc:fi-orig.conll#130>
+        rdf:type                 rdfcas:FeatureStructure , syntax-dependency:Dependency ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        syntax-dependency:Dependency-DependencyType
+                "attr" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#51> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#55> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "131"^^xsd:int ;
+        tcas:Annotation-end      "133"^^xsd:int .
+
+<doc:fi-orig.conll#64>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Lemma-value  "ja" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "145"^^xsd:int ;
+        tcas:Annotation-end       "147"^^xsd:int .
+
+<doc:fi-orig.conll#109>
+        rdf:type                      rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#2> ;
+        lexmorph-pos:POS-PosValue     "N" ;
+        lexmorph-pos:POS-coarseValue  "N" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin         "233"^^xsd:int ;
+        tcas:Annotation-end           "245"^^xsd:int .
+
+<doc:fi-orig.conll#43>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#44> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#46> ;
+        segmentation:Token-order  "0"^^xsd:int ;
+        segmentation:Token-pos    <doc:fi-orig.conll#45> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "101"^^xsd:int ;
+        tcas:Annotation-end       "109"^^xsd:int .
+
+<doc:fi-orig.conll#22>
+        rdf:type                 rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "N Prop Gen Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "49"^^xsd:int ;
+        tcas:Annotation-end      "57"^^xsd:int .
+
+<doc:fi-orig.conll#4>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Lemma-value  "neuvosto" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "0"^^xsd:int ;
+        tcas:Annotation-end       "8"^^xsd:int .
+
+<doc:fi-orig.conll#159>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#160> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#162> ;
+        segmentation:Token-order  "0"^^xsd:int ;
+        segmentation:Token-pos    <doc:fi-orig.conll#161> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "275"^^xsd:int ;
+        tcas:Annotation-end       "277"^^xsd:int .
+
+<doc:fi-orig.conll#93>
+        rdf:type                      rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#2> ;
+        lexmorph-pos:POS-PosValue     "PrfPrc" ;
+        lexmorph-pos:POS-coarseValue  "PrfPrc" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin         "189"^^xsd:int ;
+        tcas:Annotation-end           "198"^^xsd:int .
+
+<doc:fi-orig.conll#138>
+        rdf:type                 syntax-dependency:Dependency , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        syntax-dependency:Dependency-DependencyType
+                "phrm" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#83> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#91> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "184"^^xsd:int ;
+        tcas:Annotation-end      "185"^^xsd:int .
+
+<doc:fi-orig.conll#72>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Lemma-value  "huomio" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "154"^^xsd:int ;
+        tcas:Annotation-end       "162"^^xsd:int .
+
+<doc:fi-orig.conll#117>
+        rdf:type                      rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#2> ;
+        lexmorph-pos:POS-PosValue     "Punct" ;
+        lexmorph-pos:POS-coarseValue  "Punct" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin         "258"^^xsd:int ;
+        tcas:Annotation-end           "259"^^xsd:int .
+
+<doc:fi-orig.conll#51>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#52> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#54> ;
+        segmentation:Token-order  "0"^^xsd:int ;
+        segmentation:Token-pos    <doc:fi-orig.conll#53> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "131"^^xsd:int ;
+        tcas:Annotation-end       "133"^^xsd:int .
+
+<doc:fi-orig.conll#30>
+        rdf:type                 rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "N Nom Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "79"^^xsd:int ;
+        tcas:Annotation-end      "87"^^xsd:int .
+
+<doc:fi-orig.conll#167>
+        rdf:type                 syntax-dependency:Dependency , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        syntax-dependency:Dependency-DependencyType
+                "attr" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#147> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#151> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "260"^^xsd:int ;
+        tcas:Annotation-end      "261"^^xsd:int .
+
+<doc:fi-orig.conll#146>
+        rdf:type                 rdfcas:FeatureStructure , segmentation:Sentence ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "0"^^xsd:int ;
+        tcas:Annotation-end      "259"^^xsd:int .
+
+<doc:fi-orig.conll#80>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Lemma-value  "ehdotus" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "173"^^xsd:int ;
+        tcas:Annotation-end       "183"^^xsd:int .
+
+<doc:fi-orig.conll#125>
+        rdf:type                 syntax-dependency:ROOT , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        syntax-dependency:Dependency-DependencyType
+                "main" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#27> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#27> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "79"^^xsd:int ;
+        tcas:Annotation-end      "87"^^xsd:int .
+
+<doc:fi-orig.conll#59>
+        rdf:type                  segmentation:Token , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#60> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#62> ;
+        segmentation:Token-order  "0"^^xsd:int ;
+        segmentation:Token-pos    <doc:fi-orig.conll#61> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "143"^^xsd:int ;
+        tcas:Annotation-end       "144"^^xsd:int .
+
+<doc:fi-orig.conll#104>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Lemma-value  "hankinta#keskus" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "215"^^xsd:int ;
+        tcas:Annotation-end       "232"^^xsd:int .
+
+<doc:fi-orig.conll#38>
+        rdf:type                 rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "Pron Rel Nom Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "90"^^xsd:int ;
+        tcas:Annotation-end      "94"^^xsd:int .
+
+<doc:fi-orig.conll#17>
+        rdf:type                      rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#2> ;
+        lexmorph-pos:POS-PosValue     "N" ;
+        lexmorph-pos:POS-coarseValue  "N" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin         "37"^^xsd:int ;
+        tcas:Annotation-end           "48"^^xsd:int .
+
+<doc:fi-orig.conll#154>
+        rdf:type                 rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "N Nom Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "262"^^xsd:int ;
+        tcas:Annotation-end      "269"^^xsd:int .
+
+<doc:fi-orig.conll#88>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Lemma-value  "olla" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "186"^^xsd:int ;
+        tcas:Annotation-end       "188"^^xsd:int .
+
+<doc:fi-orig.conll#133>
+        rdf:type                 syntax-dependency:Dependency , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        syntax-dependency:Dependency-DependencyType
+                "phrm" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#63> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#67> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "145"^^xsd:int ;
+        tcas:Annotation-end      "147"^^xsd:int .
+
+<doc:fi-orig.conll#67>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#68> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#70> ;
+        segmentation:Token-order  "0"^^xsd:int ;
+        segmentation:Token-pos    <doc:fi-orig.conll#69> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "148"^^xsd:int ;
+        tcas:Annotation-end       "153"^^xsd:int .
+
+<doc:fi-orig.conll#112>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Lemma-value  "seuraava" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "246"^^xsd:int ;
+        tcas:Annotation-end       "257"^^xsd:int .
+
+<doc:fi-orig.conll#46>
+        rdf:type                 rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "N Ill Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "101"^^xsd:int ;
+        tcas:Annotation-end      "109"^^xsd:int .
+
+<doc:fi-orig.conll#25>
+        rdf:type                      rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#2> ;
+        lexmorph-pos:POS-PosValue     "N" ;
+        lexmorph-pos:POS-coarseValue  "N" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin         "58"^^xsd:int ;
+        tcas:Annotation-end           "78"^^xsd:int .
+
+<doc:fi-orig.conll#7>
+        rdf:type                  segmentation:Token , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#8> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#10> ;
+        segmentation:Token-order  "0"^^xsd:int ;
+        segmentation:Token-pos    <doc:fi-orig.conll#9> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "9"^^xsd:int ;
+        tcas:Annotation-end       "18"^^xsd:int .
+
+<doc:fi-orig.conll#162>
+        rdf:type                 rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "CC" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "275"^^xsd:int ;
+        tcas:Annotation-end      "277"^^xsd:int .
+
+<doc:fi-orig.conll#96>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Lemma-value  "antaa" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "199"^^xsd:int ;
+        tcas:Annotation-end       "204"^^xsd:int .
+
+<doc:fi-orig.conll#141>
+        rdf:type                 rdfcas:FeatureStructure , syntax-dependency:Dependency ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        syntax-dependency:Dependency-DependencyType
+                "obj" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#95> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#91> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "199"^^xsd:int ;
+        tcas:Annotation-end      "204"^^xsd:int .
+
+<doc:fi-orig.conll#75>
+        rdf:type                  segmentation:Token , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#76> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#78> ;
+        segmentation:Token-order  "0"^^xsd:int ;
+        segmentation:Token-pos    <doc:fi-orig.conll#77> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "163"^^xsd:int ;
+        tcas:Annotation-end       "172"^^xsd:int .
+
+<doc:fi-orig.conll#120>
+        rdf:type                 syntax-dependency:Dependency , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        syntax-dependency:Dependency-DependencyType
+                "attr" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#7> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#11> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "9"^^xsd:int ;
+        tcas:Annotation-end      "18"^^xsd:int .
+
+<doc:fi-orig.conll#54>
+        rdf:type                 rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "Num Digit Nom Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "131"^^xsd:int ;
+        tcas:Annotation-end      "133"^^xsd:int .
+
+<doc:fi-orig.conll#33>
+        rdf:type                      rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#2> ;
+        lexmorph-pos:POS-PosValue     "Punct" ;
+        lexmorph-pos:POS-coarseValue  "Punct" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin         "88"^^xsd:int ;
+        tcas:Annotation-end           "89"^^xsd:int .
+
+<doc:fi-orig.conll#12>
+        rdf:type                  rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Lemma-value  "hankinta#keskus" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "19"^^xsd:int ;
+        tcas:Annotation-end       "36"^^xsd:int .
+
+<doc:fi-orig.conll#170>
+        rdf:type                 syntax-dependency:Dependency , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        syntax-dependency:Dependency-DependencyType
+                "phrm" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#159> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#163> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "275"^^xsd:int ;
+        tcas:Annotation-end      "277"^^xsd:int .
+
+<doc:fi-orig.conll#149>
+        rdf:type                      rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#2> ;
+        lexmorph-pos:POS-PosValue     "Num" ;
+        lexmorph-pos:POS-coarseValue  "Num" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin         "260"^^xsd:int ;
+        tcas:Annotation-end           "261"^^xsd:int .
+
+<doc:fi-orig.conll#83>
+        rdf:type                  segmentation:Token , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#2> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#84> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#86> ;
+        segmentation:Token-order  "0"^^xsd:int ;
+        segmentation:Token-pos    <doc:fi-orig.conll#85> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin     "184"^^xsd:int ;
+        tcas:Annotation-end       "185"^^xsd:int .
+
+<doc:fi-orig.conll#128>
+        rdf:type                 syntax-dependency:Dependency , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#2> ;
+        syntax-dependency:Dependency-DependencyType
+                "phrv" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#43> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#39> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#2> ;
+        tcas:Annotation-begin    "101"^^xsd:int ;
+        tcas:Annotation-end      "109"^^xsd:int .

--- a/inception/inception-io-rdf/src/test/resources/log4j2-test.xml
+++ b/inception/inception-io-rdf/src/test/resources/log4j2-test.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+  <Appenders>
+    <Console name="ConsoleAppender" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} %level{length=5} %logger{1} - %msg%n" />
+    </Console>
+  </Appenders>
+
+  <Loggers>
+    <Logger name="de.tudarmstadt.ukp.inception.io" level="DEBUG"/>
+    <Logger name="org.dkpro.core.api.resources.ResourceObjectProviderBase" level="INFO"/>
+
+    <Root level="WARN">
+      <AppenderRef ref="ConsoleAppender" />
+    </Root>
+  </Loggers>
+</Configuration>

--- a/inception/inception-io-rdf/src/test/resources/ttl/fi-orig.ttl
+++ b/inception/inception-io-rdf/src/test/resources/ttl/fi-orig.ttl
@@ -1,0 +1,1760 @@
+@prefix coref: <uima:de.tudarmstadt.ukp.dkpro.core.api.coref.type.> .
+@prefix syntax-dependency: <uima:de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.> .
+@prefix syntax-chunk: <uima:de.tudarmstadt.ukp.dkpro.core.api.syntax.type.chunk.> .
+@prefix metadata: <uima:de.tudarmstadt.ukp.dkpro.core.api.metadata.type.> .
+@prefix lexmorph-pos: <uima:de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.> .
+@prefix anomaly: <uima:de.tudarmstadt.ukp.dkpro.core.api.anomaly.type.> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix lexmorph-morph: <uima:de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.morph.> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix semantics: <uima:de.tudarmstadt.ukp.dkpro.core.api.semantics.type.> .
+@prefix lexmorph-pos.tweet: <uima:de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.tweet.> .
+@prefix syntax-constituent: <uima:de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.> .
+@prefix cas:   <uima:uima.cas.> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix tcas:  <uima:uima.tcas.> .
+@prefix rdfcas: <http://uima.apache.org/rdf/cas#> .
+@prefix syntax: <uima:de.tudarmstadt.ukp.dkpro.core.api.syntax.type.> .
+@prefix segmentation: <uima:de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.> .
+@prefix ner:   <uima:de.tudarmstadt.ukp.dkpro.core.api.ner.type.> .
+
+<doc:fi-orig.conll#1535>
+        a                         rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#959> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#1408> ;
+        segmentation:Token-pos    <doc:fi-orig.conll#151> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "262"^^xsd:int ;
+        tcas:Annotation-end       "269"^^xsd:int .
+
+<doc:fi-orig.conll#1706>
+        a                         rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#964> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#359> ;
+        segmentation:Token-pos    <doc:fi-orig.conll#185> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "79"^^xsd:int ;
+        tcas:Annotation-end       "87"^^xsd:int .
+
+<doc:fi-orig.conll#1343>
+        a                         rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#854> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#1307> ;
+        segmentation:Token-pos    <doc:fi-orig.conll#1747> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "258"^^xsd:int ;
+        tcas:Annotation-end       "259"^^xsd:int .
+
+<doc:fi-orig.conll#462>
+        a                        syntax-dependency:Dependency , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        syntax-dependency:Dependency-DependencyType
+                "phrv" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#553> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#1651> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "101"^^xsd:int ;
+        tcas:Annotation-end      "109"^^xsd:int .
+
+<doc:fi-orig.conll#988>
+        a                         rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Lemma-value  "ja" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "145"^^xsd:int ;
+        tcas:Annotation-end       "147"^^xsd:int .
+
+<doc:fi-orig.conll#1464>
+        a                         rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#1546> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#1662> ;
+        segmentation:Token-pos    <doc:fi-orig.conll#1436> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "199"^^xsd:int ;
+        tcas:Annotation-end       "204"^^xsd:int .
+
+<doc:fi-orig.conll#1635>
+        a                         rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Lemma-value  "huomio" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "101"^^xsd:int ;
+        tcas:Annotation-end       "109"^^xsd:int .
+
+<doc:fi-orig.conll#1272>
+        a                         rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Lemma-value  "Euratom" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "9"^^xsd:int ;
+        tcas:Annotation-end       "18"^^xsd:int .
+
+<doc:fi-orig.conll#541>
+        a                             rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#6> ;
+        lexmorph-pos:POS-PosValue     "V" ;
+        lexmorph-pos:POS-coarseValue  "V" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin         "186"^^xsd:int ;
+        tcas:Annotation-end           "188"^^xsd:int .
+
+<doc:fi-orig.conll#157>
+        a                         rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Lemma-value  "neuvosto" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "0"^^xsd:int ;
+        tcas:Annotation-end       "8"^^xsd:int .
+
+<doc:fi-orig.conll#328>
+        a                             rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#6> ;
+        lexmorph-pos:POS-PosValue     "N" ;
+        lexmorph-pos:POS-coarseValue  "N" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin         "9"^^xsd:int ;
+        tcas:Annotation-end           "18"^^xsd:int .
+
+<doc:fi-orig.conll#1372>
+        a                        syntax-dependency:Dependency , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        syntax-dependency:Dependency-DependencyType
+                "attr" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#112> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#1535> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "260"^^xsd:int ;
+        tcas:Annotation-end      "261"^^xsd:int .
+
+<doc:fi-orig.conll#854>
+        a                         rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Lemma-value  ":" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "258"^^xsd:int ;
+        tcas:Annotation-end       "259"^^xsd:int .
+
+<doc:fi-orig.conll#470>
+        a                        syntax-dependency:Dependency , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        syntax-dependency:Dependency-DependencyType
+                "obj" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#1182> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#123> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "173"^^xsd:int ;
+        tcas:Annotation-end      "183"^^xsd:int .
+
+<doc:fi-orig.conll#1501>
+        a                         rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Lemma-value  "päättää" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "189"^^xsd:int ;
+        tcas:Annotation-end       "198"^^xsd:int .
+
+<doc:fi-orig.conll#1138>
+        a                        rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "N Prop Gen Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "49"^^xsd:int ;
+        tcas:Annotation-end      "57"^^xsd:int .
+
+<doc:fi-orig.conll#1430>
+        a                             rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#6> ;
+        lexmorph-pos:POS-PosValue     "N" ;
+        lexmorph-pos:POS-coarseValue  "N" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin         "19"^^xsd:int ;
+        tcas:Annotation-end           "36"^^xsd:int .
+
+<doc:fi-orig.conll#1380>
+        a                         rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#1565> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#679> ;
+        segmentation:Token-pos    <doc:fi-orig.conll#630> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "270"^^xsd:int ;
+        tcas:Annotation-end       "274"^^xsd:int .
+
+<doc:fi-orig.conll#1551>
+        a                        syntax-dependency:Dependency , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        syntax-dependency:Dependency-DependencyType
+                "attr" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#1028> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#1516> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "49"^^xsd:int ;
+        tcas:Annotation-end      "57"^^xsd:int .
+
+<doc:fi-orig.conll#1722>
+        a                             rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#6> ;
+        lexmorph-pos:POS-PosValue     "Pron" ;
+        lexmorph-pos:POS-coarseValue  "Pron" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin         "90"^^xsd:int ;
+        tcas:Annotation-end           "94"^^xsd:int .
+
+<doc:fi-orig.conll#123>
+        a                         rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#287> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#191> ;
+        segmentation:Token-pos    <doc:fi-orig.conll#162> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "148"^^xsd:int ;
+        tcas:Annotation-end       "153"^^xsd:int .
+
+<doc:fi-orig.conll#57>
+        a                        rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "Punct" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "88"^^xsd:int ;
+        tcas:Annotation-end      "89"^^xsd:int .
+
+<doc:fi-orig.conll#478>
+        a                        rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "N Gen Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "215"^^xsd:int ;
+        tcas:Annotation-end      "232"^^xsd:int .
+
+<doc:fi-orig.conll#457>
+        a                         rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Lemma-value  "olla" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "186"^^xsd:int ;
+        tcas:Annotation-end       "188"^^xsd:int .
+
+<doc:fi-orig.conll#265>
+        a                        rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "Punct" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "184"^^xsd:int ;
+        tcas:Annotation-end      "185"^^xsd:int .
+
+<doc:fi-orig.conll#1651>
+        a                         rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#642> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#413> ;
+        segmentation:Token-pos    <doc:fi-orig.conll#1402> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "95"^^xsd:int ;
+        tcas:Annotation-end       "100"^^xsd:int .
+
+<doc:fi-orig.conll#1104>
+        a                             rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#6> ;
+        lexmorph-pos:POS-PosValue     "N" ;
+        lexmorph-pos:POS-coarseValue  "N" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin         "134"^^xsd:int ;
+        tcas:Annotation-end           "142"^^xsd:int .
+
+<doc:fi-orig.conll#536>
+        a                         rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Lemma-value  "1" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "260"^^xsd:int ;
+        tcas:Annotation-end       "261"^^xsd:int .
+
+<doc:fi-orig.conll#1559>
+        a                             rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#6> ;
+        lexmorph-pos:POS-PosValue     "PrfPrc" ;
+        lexmorph-pos:POS-coarseValue  "PrfPrc" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin         "189"^^xsd:int ;
+        tcas:Annotation-end           "198"^^xsd:int .
+
+<doc:fi-orig.conll#302>
+        a                             rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#6> ;
+        lexmorph-pos:POS-PosValue     "N" ;
+        lexmorph-pos:POS-coarseValue  "N" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin         "101"^^xsd:int ;
+        tcas:Annotation-end           "109"^^xsd:int .
+
+<doc:fi-orig.conll#1367>
+        a                         rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Lemma-value  "," ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "88"^^xsd:int ;
+        tcas:Annotation-end       "89"^^xsd:int .
+
+<doc:fi-orig.conll#636>
+        a                             rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#6> ;
+        lexmorph-pos:POS-PosValue     "Adv" ;
+        lexmorph-pos:POS-coarseValue  "Adv" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin         "246"^^xsd:int ;
+        tcas:Annotation-end           "257"^^xsd:int .
+
+<doc:fi-orig.conll#807>
+        a                         rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#1501> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#1684> ;
+        segmentation:Token-pos    <doc:fi-orig.conll#1559> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "189"^^xsd:int ;
+        tcas:Annotation-end       "198"^^xsd:int .
+
+<doc:fi-orig.conll#586>
+        a                         rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#292> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#478> ;
+        segmentation:Token-pos    <doc:fi-orig.conll#1132> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "215"^^xsd:int ;
+        tcas:Annotation-end       "232"^^xsd:int .
+
+<doc:fi-orig.conll#1780>
+        a                             rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#6> ;
+        lexmorph-pos:POS-PosValue     "N" ;
+        lexmorph-pos:POS-coarseValue  "N" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin         "173"^^xsd:int ;
+        tcas:Annotation-end           "183"^^xsd:int .
+
+<doc:fi-orig.conll#1396>
+        a                             rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#6> ;
+        lexmorph-pos:POS-PosValue     "N" ;
+        lexmorph-pos:POS-coarseValue  "N" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin         "205"^^xsd:int ;
+        tcas:Annotation-end           "214"^^xsd:int .
+
+<doc:fi-orig.conll#1020>
+        a                        rdfcas:FeatureStructure , syntax-dependency:Dependency ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        syntax-dependency:Dependency-DependencyType
+                "aux" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#134> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#807> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "186"^^xsd:int ;
+        tcas:Annotation-end      "188"^^xsd:int .
+
+<doc:fi-orig.conll#1546>
+        a                         rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Lemma-value  "antaa" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "199"^^xsd:int ;
+        tcas:Annotation-end       "204"^^xsd:int .
+
+<doc:fi-orig.conll#1717>
+        a                         rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Lemma-value  "Eurooppa" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "49"^^xsd:int ;
+        tcas:Annotation-end       "57"^^xsd:int .
+
+<doc:fi-orig.conll#1354>
+        a                        syntax-dependency:Dependency , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        syntax-dependency:Dependency-DependencyType
+                "phrm" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#1442> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#807> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "184"^^xsd:int ;
+        tcas:Annotation-end      "185"^^xsd:int .
+
+<doc:fi-orig.conll#1475>
+        a                        rdfcas:FeatureStructure , syntax-dependency:Dependency ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        syntax-dependency:Dependency-DependencyType
+                "attr" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#818> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#1706> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "37"^^xsd:int ;
+        tcas:Annotation-end      "48"^^xsd:int .
+
+<doc:fi-orig.conll#381>
+        a                        syntax-dependency:Dependency , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        syntax-dependency:Dependency-DependencyType
+                "attr" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#1516> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#1706> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "58"^^xsd:int ;
+        tcas:Annotation-end      "78"^^xsd:int .
+
+<doc:fi-orig.conll#723>
+        a                        rdfcas:FeatureStructure , syntax-dependency:Dependency ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        syntax-dependency:Dependency-DependencyType
+                "attr" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#168> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#894> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "0"^^xsd:int ;
+        tcas:Annotation-end      "8"^^xsd:int .
+
+<doc:fi-orig.conll#168>
+        a                         rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#157> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#1110> ;
+        segmentation:Token-pos    <doc:fi-orig.conll#179> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "0"^^xsd:int ;
+        tcas:Annotation-end       "8"^^xsd:int .
+
+<doc:fi-orig.conll#1028>
+        a                         rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#1717> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#1138> ;
+        segmentation:Token-pos    <doc:fi-orig.conll#1483> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "49"^^xsd:int ;
+        tcas:Annotation-end       "57"^^xsd:int .
+
+<doc:fi-orig.conll#1362>
+        a                         rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Lemma-value  "ehdotus" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "173"^^xsd:int ;
+        tcas:Annotation-end       "183"^^xsd:int .
+
+<doc:fi-orig.conll#1483>
+        a                             rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#6> ;
+        lexmorph-pos:POS-PosValue     "N" ;
+        lexmorph-pos:POS-coarseValue  "N" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin         "49"^^xsd:int ;
+        tcas:Annotation-end           "57"^^xsd:int .
+
+<doc:fi-orig.conll#752>
+        a                         rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#737> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#785> ;
+        segmentation:Token-pos    <doc:fi-orig.conll#867> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "110"^^xsd:int ;
+        tcas:Annotation-end       "130"^^xsd:int .
+
+<doc:fi-orig.conll#1099>
+        a                         rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Lemma-value  "ja" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "275"^^xsd:int ;
+        tcas:Annotation-end       "277"^^xsd:int .
+
+<doc:fi-orig.conll#389>
+        a                         rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#408> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#435> ;
+        segmentation:Token-pos    <doc:fi-orig.conll#145> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "233"^^xsd:int ;
+        tcas:Annotation-end       "245"^^xsd:int .
+
+<doc:fi-orig.conll#731>
+        a                             rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#6> ;
+        lexmorph-pos:POS-PosValue     "Punct" ;
+        lexmorph-pos:POS-coarseValue  "Punct" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin         "88"^^xsd:int ;
+        tcas:Annotation-end           "89"^^xsd:int .
+
+<doc:fi-orig.conll#1775>
+        a                         rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Lemma-value  "," ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "143"^^xsd:int ;
+        tcas:Annotation-end       "144"^^xsd:int .
+
+<doc:fi-orig.conll#894>
+        a                         rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#1272> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#993> ;
+        segmentation:Token-pos    <doc:fi-orig.conll#328> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "9"^^xsd:int ;
+        tcas:Annotation-end       "18"^^xsd:int .
+
+<doc:fi-orig.conll#1391>
+        a                        rdfcas:FeatureStructure , segmentation:Sentence ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "0"^^xsd:int ;
+        tcas:Annotation-end      "259"^^xsd:int .
+
+<doc:fi-orig.conll#873>
+        a                        rdfcas:FeatureStructure , syntax-dependency:Dependency ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        syntax-dependency:Dependency-DependencyType
+                "obj" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#389> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#1464> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "233"^^xsd:int ;
+        tcas:Annotation-end      "245"^^xsd:int .
+
+<doc:fi-orig.conll#1015>
+        a                         rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Lemma-value  "komissio" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "163"^^xsd:int ;
+        tcas:Annotation-end       "172"^^xsd:int .
+
+<doc:fi-orig.conll#134>
+        a                         rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#457> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#1077> ;
+        segmentation:Token-pos    <doc:fi-orig.conll#541> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "186"^^xsd:int ;
+        tcas:Annotation-end       "188"^^xsd:int .
+
+<doc:fi-orig.conll#1199>
+        a                        rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "N Prop Gen Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "205"^^xsd:int ;
+        tcas:Annotation-end      "214"^^xsd:int .
+
+<doc:fi-orig.conll#297>
+        a                         rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Lemma-value  "hankinta#keskus" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "19"^^xsd:int ;
+        tcas:Annotation-end       "36"^^xsd:int .
+
+<doc:fi-orig.conll#1307>
+        a                        rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "Punct" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "258"^^xsd:int ;
+        tcas:Annotation-end      "259"^^xsd:int .
+
+<doc:fi-orig.conll#1662>
+        a                        rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "V Inf1 Lat" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "199"^^xsd:int ;
+        tcas:Annotation-end      "204"^^xsd:int .
+
+<doc:fi-orig.conll#213>
+        a                        rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "N Gen Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "173"^^xsd:int ;
+        tcas:Annotation-end      "183"^^xsd:int .
+
+<doc:fi-orig.conll#547>
+        a                             rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#6> ;
+        lexmorph-pos:POS-PosValue     "Num" ;
+        lexmorph-pos:POS-coarseValue  "Num" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin         "131"^^xsd:int ;
+        tcas:Annotation-end           "133"^^xsd:int .
+
+<doc:fi-orig.conll#1570>
+        a                        syntax-dependency:Dependency , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        syntax-dependency:Dependency-DependencyType
+                "subj" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#619> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#1182> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "163"^^xsd:int ;
+        tcas:Annotation-end      "172"^^xsd:int .
+
+<doc:fi-orig.conll#881>
+        a                        syntax-dependency:Dependency , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        syntax-dependency:Dependency-DependencyType
+                "conjunct" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#123> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#1651> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "148"^^xsd:int ;
+        tcas:Annotation-end      "153"^^xsd:int .
+
+<doc:fi-orig.conll#334>
+        a                         rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#297> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#564> ;
+        segmentation:Token-pos    <doc:fi-orig.conll#1430> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "19"^^xsd:int ;
+        tcas:Annotation-end       "36"^^xsd:int .
+
+<doc:fi-orig.conll#647>
+        a                        rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "N Gen Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "58"^^xsd:int ;
+        tcas:Annotation-end      "78"^^xsd:int .
+
+<doc:fi-orig.conll#818>
+        a                         rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#1506> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#1285> ;
+        segmentation:Token-pos    <doc:fi-orig.conll#106> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "37"^^xsd:int ;
+        tcas:Annotation-end       "48"^^xsd:int .
+
+<doc:fi-orig.conll#13>
+        a                        metadata:DocumentMetaData , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        metadata:DocumentMetaData-documentId
+                "fi-orig.conll" ;
+        metadata:DocumentMetaData-documentTitle
+                "fi-orig.conll" ;
+        metadata:DocumentMetaData-isLastSegment
+                false ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "0"^^xsd:int ;
+        tcas:Annotation-end      "288"^^xsd:int ;
+        tcas:DocumentAnnotation-language
+                "x-unspecified" .
+
+<doc:fi-orig.conll#413>
+        a                        rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "V Prs Act Sg3" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "95"^^xsd:int ;
+        tcas:Annotation-end      "100"^^xsd:int .
+
+<doc:fi-orig.conll#597>
+        a                        rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "N Ill Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "101"^^xsd:int ;
+        tcas:Annotation-end      "109"^^xsd:int .
+
+<doc:fi-orig.conll#747>
+        a                         rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Lemma-value  "huomio" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "154"^^xsd:int ;
+        tcas:Annotation-end       "162"^^xsd:int .
+
+<doc:fi-orig.conll#1436>
+        a                             rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#6> ;
+        lexmorph-pos:POS-PosValue     "V" ;
+        lexmorph-pos:POS-coarseValue  "V" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin         "199"^^xsd:int ;
+        tcas:Annotation-end           "204"^^xsd:int .
+
+<doc:fi-orig.conll#889>
+        a                         rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Lemma-value  "joka" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "90"^^xsd:int ;
+        tcas:Annotation-end       "94"^^xsd:int .
+
+<doc:fi-orig.conll#1578>
+        a                         rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#742> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#1613> ;
+        segmentation:Token-pos    <doc:fi-orig.conll#547> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "131"^^xsd:int ;
+        tcas:Annotation-end       "133"^^xsd:int .
+
+<doc:fi-orig.conll#84>
+        a                        rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "CC" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "145"^^xsd:int ;
+        tcas:Annotation-end      "147"^^xsd:int .
+
+<doc:fi-orig.conll#1728>
+        a                         rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#889> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#514> ;
+        segmentation:Token-pos    <doc:fi-orig.conll#1722> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "90"^^xsd:int ;
+        tcas:Annotation-end       "94"^^xsd:int .
+
+<doc:fi-orig.conll#292>
+        a                         rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Lemma-value  "hankinta#keskus" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "215"^^xsd:int ;
+        tcas:Annotation-end       "232"^^xsd:int .
+
+<doc:fi-orig.conll#1110>
+        a                        rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "N Nom Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "0"^^xsd:int ;
+        tcas:Annotation-end      "8"^^xsd:int .
+
+<doc:fi-orig.conll#400>
+        a                        rdfcas:FeatureStructure , syntax-dependency:Dependency ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        syntax-dependency:Dependency-DependencyType
+                "attr" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#1640> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#586> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "205"^^xsd:int ;
+        tcas:Annotation-end      "214"^^xsd:int .
+
+<doc:fi-orig.conll#905>
+        a                        syntax-dependency:Dependency , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        syntax-dependency:Dependency-DependencyType
+                "attr" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#334> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#818> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "19"^^xsd:int ;
+        tcas:Annotation-end      "36"^^xsd:int .
+
+<doc:fi-orig.conll#179>
+        a                             rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#6> ;
+        lexmorph-pos:POS-PosValue     "N" ;
+        lexmorph-pos:POS-coarseValue  "N" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin         "0"^^xsd:int ;
+        tcas:Annotation-end           "8"^^xsd:int .
+
+<doc:fi-orig.conll#1402>
+        a                             rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#6> ;
+        lexmorph-pos:POS-PosValue     "V" ;
+        lexmorph-pos:POS-coarseValue  "V" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin         "95"^^xsd:int ;
+        tcas:Annotation-end           "100"^^xsd:int .
+
+<doc:fi-orig.conll#1039>
+        a                         rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#1367> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#57> ;
+        segmentation:Token-pos    <doc:fi-orig.conll#731> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "88"^^xsd:int ;
+        tcas:Annotation-end       "89"^^xsd:int .
+
+<doc:fi-orig.conll#500>
+        a                             rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#6> ;
+        lexmorph-pos:POS-PosValue     "N" ;
+        lexmorph-pos:POS-coarseValue  "N" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin         "58"^^xsd:int ;
+        tcas:Annotation-end           "78"^^xsd:int .
+
+<doc:fi-orig.conll#1565>
+        a                         rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Lemma-value  "nimi" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "270"^^xsd:int ;
+        tcas:Annotation-end       "274"^^xsd:int .
+
+<doc:fi-orig.conll#308>
+        a                             rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#6> ;
+        lexmorph-pos:POS-PosValue     "N" ;
+        lexmorph-pos:POS-coarseValue  "N" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin         "154"^^xsd:int ;
+        tcas:Annotation-end           "162"^^xsd:int .
+
+<doc:fi-orig.conll#1160>
+        a                        rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "N Ill Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "154"^^xsd:int ;
+        tcas:Annotation-end      "162"^^xsd:int .
+
+<doc:fi-orig.conll#642>
+        a                         rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Lemma-value  "ottaa" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "95"^^xsd:int ;
+        tcas:Annotation-end       "100"^^xsd:int .
+
+<doc:fi-orig.conll#408>
+        a                         rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Lemma-value  "perus#sääntö" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "233"^^xsd:int ;
+        tcas:Annotation-end       "245"^^xsd:int .
+
+<doc:fi-orig.conll#763>
+        a                        rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "N Gen Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "163"^^xsd:int ;
+        tcas:Annotation-end      "172"^^xsd:int .
+
+<doc:fi-orig.conll#742>
+        a                         rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Lemma-value  "54" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "131"^^xsd:int ;
+        tcas:Annotation-end       "133"^^xsd:int .
+
+<doc:fi-orig.conll#913>
+        a                        rdfcas:FeatureStructure , syntax-dependency:Dependency ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        syntax-dependency:Dependency-DependencyType
+                "attr" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#1535> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#1380> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "262"^^xsd:int ;
+        tcas:Annotation-end      "269"^^xsd:int .
+
+<doc:fi-orig.conll#145>
+        a                             rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#6> ;
+        lexmorph-pos:POS-PosValue     "N" ;
+        lexmorph-pos:POS-coarseValue  "N" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin         "233"^^xsd:int ;
+        tcas:Annotation-end           "245"^^xsd:int .
+
+<doc:fi-orig.conll#79>
+        a                         rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Lemma-value  "seuraava" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "246"^^xsd:int ;
+        tcas:Annotation-end       "257"^^xsd:int .
+
+<doc:fi-orig.conll#287>
+        a                         rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Lemma-value  "ottaa" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "148"^^xsd:int ;
+        tcas:Annotation-end       "153"^^xsd:int .
+
+<doc:fi-orig.conll#921>
+        a                         rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#1775> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#243> ;
+        segmentation:Token-pos    <doc:fi-orig.conll#1193> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "143"^^xsd:int ;
+        tcas:Annotation-end       "144"^^xsd:int .
+
+<doc:fi-orig.conll#345>
+        a                             rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#6> ;
+        lexmorph-pos:POS-PosValue     "Punct" ;
+        lexmorph-pos:POS-coarseValue  "Punct" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin         "184"^^xsd:int ;
+        tcas:Annotation-end           "185"^^xsd:int .
+
+<doc:fi-orig.conll#679>
+        a                        rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "N Nom Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "270"^^xsd:int ;
+        tcas:Annotation-end      "274"^^xsd:int .
+
+<doc:fi-orig.conll#829>
+        a                        syntax-dependency:Dependency , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        syntax-dependency:Dependency-DependencyType
+                "phrm" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#837> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#977> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "275"^^xsd:int ;
+        tcas:Annotation-end      "277"^^xsd:int .
+
+<doc:fi-orig.conll#24>
+        a                        rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "CC" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "275"^^xsd:int ;
+        tcas:Annotation-end      "277"^^xsd:int .
+
+<doc:fi-orig.conll#6>
+        a                    cas:Sofa , rdfcas:View ;
+        cas:Sofa-mimeType    "text" ;
+        cas:Sofa-sofaID      "_InitialView" ;
+        cas:Sofa-sofaNum     "1"^^xsd:int ;
+        cas:Sofa-sofaString  "NEUVOSTO EURATOMIN HANKINTAKESKUKSEN PERUSSÄÄNTÖ EUROOPAN ATOMIENERGIAYHTEISÖN NEUVOSTO , joka ottaa huomioon perustamissopimuksen 54 artiklan , ja ottaa huomioon komission ehdotuksen , ON PÄÄTTÄNYT antaa Euratomin hankintakeskuksen perussäännön seuraavasti :\n1 artikla Nimi ja tarkoitus\n" .
+
+<doc:fi-orig.conll#1489>
+        a                             rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#6> ;
+        lexmorph-pos:POS-PosValue     "N" ;
+        lexmorph-pos:POS-coarseValue  "N" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin         "163"^^xsd:int ;
+        tcas:Annotation-end           "172"^^xsd:int .
+
+<doc:fi-orig.conll#737>
+        a                         rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Lemma-value  "perustamis#sopimus" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "110"^^xsd:int ;
+        tcas:Annotation-end       "130"^^xsd:int .
+
+<doc:fi-orig.conll#1589>
+        a                         rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#932> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#1753> ;
+        segmentation:Token-pos    <doc:fi-orig.conll#1104> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "134"^^xsd:int ;
+        tcas:Annotation-end       "142"^^xsd:int .
+
+<doc:fi-orig.conll#1739>
+        a                        rdfcas:FeatureStructure , syntax-dependency:Dependency ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        syntax-dependency:Dependency-DependencyType
+                "attr" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#752> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#1589> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "110"^^xsd:int ;
+        tcas:Annotation-end      "130"^^xsd:int .
+
+<doc:fi-orig.conll#837>
+        a                         rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#1099> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#24> ;
+        segmentation:Token-pos    <doc:fi-orig.conll#1337> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "275"^^xsd:int ;
+        tcas:Annotation-end       "277"^^xsd:int .
+
+<doc:fi-orig.conll#937>
+        a                        rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "Adv Pos Man" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "246"^^xsd:int ;
+        tcas:Annotation-end      "257"^^xsd:int .
+
+<doc:fi-orig.conll#1605>
+        a                        syntax-dependency:Dependency , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        syntax-dependency:Dependency-DependencyType
+                "phrm" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#921> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#123> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "143"^^xsd:int ;
+        tcas:Annotation-end      "144"^^xsd:int .
+
+<doc:fi-orig.conll#553>
+        a                         rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#1635> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#597> ;
+        segmentation:Token-pos    <doc:fi-orig.conll#302> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "101"^^xsd:int ;
+        tcas:Annotation-end       "109"^^xsd:int .
+
+<doc:fi-orig.conll#1050>
+        a                         rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#988> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#84> ;
+        segmentation:Token-pos    <doc:fi-orig.conll#1495> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "145"^^xsd:int ;
+        tcas:Annotation-end       "147"^^xsd:int .
+
+<doc:fi-orig.conll#1221>
+        a                        rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "N Nom Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "278"^^xsd:int ;
+        tcas:Annotation-end      "287"^^xsd:int .
+
+<doc:fi-orig.conll#1747>
+        a                             rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#6> ;
+        lexmorph-pos:POS-PosValue     "Punct" ;
+        lexmorph-pos:POS-coarseValue  "Punct" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin         "258"^^xsd:int ;
+        tcas:Annotation-end           "259"^^xsd:int .
+
+<doc:fi-orig.conll#674>
+        a                        rdfcas:FeatureStructure , segmentation:Sentence ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "260"^^xsd:int ;
+        tcas:Annotation-end      "287"^^xsd:int .
+
+<doc:fi-orig.conll#106>
+        a                             rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#6> ;
+        lexmorph-pos:POS-PosValue     "N" ;
+        lexmorph-pos:POS-coarseValue  "N" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin         "37"^^xsd:int ;
+        tcas:Annotation-end           "48"^^xsd:int .
+
+<doc:fi-orig.conll#1442>
+        a                         rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#1600> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#265> ;
+        segmentation:Token-pos    <doc:fi-orig.conll#345> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "184"^^xsd:int ;
+        tcas:Annotation-end       "185"^^xsd:int .
+
+<doc:fi-orig.conll#1613>
+        a                        rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "Num Digit Nom Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "131"^^xsd:int ;
+        tcas:Annotation-end      "133"^^xsd:int .
+
+<doc:fi-orig.conll#1329>
+        a                        rdfcas:FeatureStructure , syntax-dependency:Dependency ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        syntax-dependency:Dependency-DependencyType
+                "attr" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#586> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#389> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "215"^^xsd:int ;
+        tcas:Annotation-end      "232"^^xsd:int .
+
+<doc:fi-orig.conll#1684>
+        a                        rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "PrfPrc Act Pos Nom Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "189"^^xsd:int ;
+        tcas:Annotation-end      "198"^^xsd:int .
+
+<doc:fi-orig.conll#619>
+        a                         rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#1015> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#763> ;
+        segmentation:Token-pos    <doc:fi-orig.conll#1489> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "163"^^xsd:int ;
+        tcas:Annotation-end       "172"^^xsd:int .
+
+<doc:fi-orig.conll#235>
+        a                        rdfcas:FeatureStructure , syntax-dependency:Dependency ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        syntax-dependency:Dependency-DependencyType
+                "obj" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#1464> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#807> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "199"^^xsd:int ;
+        tcas:Annotation-end      "204"^^xsd:int .
+
+<doc:fi-orig.conll#932>
+        a                         rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Lemma-value  "artikla" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "134"^^xsd:int ;
+        tcas:Annotation-end       "142"^^xsd:int .
+
+<doc:fi-orig.conll#1600>
+        a                         rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Lemma-value  "," ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "184"^^xsd:int ;
+        tcas:Annotation-end       "185"^^xsd:int .
+
+<doc:fi-orig.conll#185>
+        a                             rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#6> ;
+        lexmorph-pos:POS-PosValue     "N" ;
+        lexmorph-pos:POS-coarseValue  "N" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin         "79"^^xsd:int ;
+        tcas:Annotation-end           "87"^^xsd:int .
+
+<doc:fi-orig.conll#1408>
+        a                        rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "N Nom Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "262"^^xsd:int ;
+        tcas:Annotation-end      "269"^^xsd:int .
+
+<doc:fi-orig.conll#506>
+        a                        syntax-dependency:Dependency , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        syntax-dependency:Dependency-DependencyType
+                "advl" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#1453> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#1464> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "246"^^xsd:int ;
+        tcas:Annotation-end      "257"^^xsd:int .
+
+<doc:fi-orig.conll#314>
+        a                             rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#6> ;
+        lexmorph-pos:POS-PosValue     "Num" ;
+        lexmorph-pos:POS-coarseValue  "Num" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin         "260"^^xsd:int ;
+        tcas:Annotation-end           "261"^^xsd:int .
+
+<doc:fi-orig.conll#669>
+        a                         rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Lemma-value  "tarkoitus" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "278"^^xsd:int ;
+        tcas:Annotation-end       "287"^^xsd:int .
+
+<doc:fi-orig.conll#1337>
+        a                             rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#6> ;
+        lexmorph-pos:POS-PosValue     "CC" ;
+        lexmorph-pos:POS-coarseValue  "CC" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin         "275"^^xsd:int ;
+        tcas:Annotation-end           "277"^^xsd:int .
+
+<doc:fi-orig.conll#435>
+        a                        rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "N Gen Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "233"^^xsd:int ;
+        tcas:Annotation-end      "245"^^xsd:int .
+
+<doc:fi-orig.conll#243>
+        a                        rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "Punct" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "143"^^xsd:int ;
+        tcas:Annotation-end      "144"^^xsd:int .
+
+<doc:fi-orig.conll#514>
+        a                        rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "Pron Rel Nom Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "90"^^xsd:int ;
+        tcas:Annotation-end      "94"^^xsd:int .
+
+<doc:fi-orig.conll#151>
+        a                             rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#6> ;
+        lexmorph-pos:POS-PosValue     "N" ;
+        lexmorph-pos:POS-coarseValue  "N" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin         "262"^^xsd:int ;
+        tcas:Annotation-end           "269"^^xsd:int .
+
+<doc:fi-orig.conll#848>
+        a                             rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#6> ;
+        lexmorph-pos:POS-PosValue     "N" ;
+        lexmorph-pos:POS-coarseValue  "N" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin         "278"^^xsd:int ;
+        tcas:Annotation-end           "287"^^xsd:int .
+
+<doc:fi-orig.conll#1516>
+        a                         rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#1511> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#647> ;
+        segmentation:Token-pos    <doc:fi-orig.conll#500> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "58"^^xsd:int ;
+        tcas:Annotation-end       "78"^^xsd:int .
+
+<doc:fi-orig.conll#1132>
+        a                             rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#6> ;
+        lexmorph-pos:POS-PosValue     "N" ;
+        lexmorph-pos:POS-coarseValue  "N" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin         "215"^^xsd:int ;
+        tcas:Annotation-end           "232"^^xsd:int .
+
+<doc:fi-orig.conll#969>
+        a                        rdfcas:FeatureStructure , syntax-dependency:Dependency ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        syntax-dependency:Dependency-DependencyType
+                "phrm" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#1050> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#123> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "145"^^xsd:int ;
+        tcas:Annotation-end      "147"^^xsd:int .
+
+<doc:fi-orig.conll#564>
+        a                        rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "N Gen Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "19"^^xsd:int ;
+        tcas:Annotation-end      "36"^^xsd:int .
+
+<doc:fi-orig.conll#1061>
+        a                        rdfcas:FeatureStructure , syntax-dependency:Dependency ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        syntax-dependency:Dependency-DependencyType
+                "obj" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#1589> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#1651> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "134"^^xsd:int ;
+        tcas:Annotation-end      "142"^^xsd:int .
+
+<doc:fi-orig.conll#351>
+        a                        syntax-dependency:Dependency , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        syntax-dependency:Dependency-DependencyType
+                "conjunct" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#807> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#123> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "189"^^xsd:int ;
+        tcas:Annotation-end      "198"^^xsd:int .
+
+<doc:fi-orig.conll#1182>
+        a                         rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#1362> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#213> ;
+        segmentation:Token-pos    <doc:fi-orig.conll#1780> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "173"^^xsd:int ;
+        tcas:Annotation-end       "183"^^xsd:int .
+
+<doc:fi-orig.conll#1495>
+        a                             rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#6> ;
+        lexmorph-pos:POS-PosValue     "CC" ;
+        lexmorph-pos:POS-coarseValue  "CC" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin         "145"^^xsd:int ;
+        tcas:Annotation-end           "147"^^xsd:int .
+
+<doc:fi-orig.conll#977>
+        a                         rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#669> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#1221> ;
+        segmentation:Token-pos    <doc:fi-orig.conll#848> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "278"^^xsd:int ;
+        tcas:Annotation-end       "287"^^xsd:int .
+
+<doc:fi-orig.conll#785>
+        a                        rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "N Gen Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "110"^^xsd:int ;
+        tcas:Annotation-end      "130"^^xsd:int .
+
+<doc:fi-orig.conll#1453>
+        a                         rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#79> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#937> ;
+        segmentation:Token-pos    <doc:fi-orig.conll#636> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "246"^^xsd:int ;
+        tcas:Annotation-end       "257"^^xsd:int .
+
+<doc:fi-orig.conll#1069>
+        a                        syntax-dependency:ROOT , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        syntax-dependency:Dependency-DependencyType
+                "main" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#1380> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#1380> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "270"^^xsd:int ;
+        tcas:Annotation-end      "274"^^xsd:int .
+
+<doc:fi-orig.conll#359>
+        a                        rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "N Nom Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "79"^^xsd:int ;
+        tcas:Annotation-end      "87"^^xsd:int .
+
+<doc:fi-orig.conll#701>
+        a                        rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "Num Digit Nom Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "260"^^xsd:int ;
+        tcas:Annotation-end      "261"^^xsd:int .
+
+<doc:fi-orig.conll#1511>
+        a                         rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Lemma-value  "atomi#energia#yhteisö" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "58"^^xsd:int ;
+        tcas:Annotation-end       "78"^^xsd:int .
+
+<doc:fi-orig.conll#630>
+        a                             rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#6> ;
+        lexmorph-pos:POS-PosValue     "N" ;
+        lexmorph-pos:POS-coarseValue  "N" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin         "270"^^xsd:int ;
+        tcas:Annotation-end           "274"^^xsd:int .
+
+<doc:fi-orig.conll#964>
+        a                         rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Lemma-value  "neuvosto" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "79"^^xsd:int ;
+        tcas:Annotation-end       "87"^^xsd:int .
+
+<doc:fi-orig.conll#1077>
+        a                        rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "V Prs Act Sg3" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "186"^^xsd:int ;
+        tcas:Annotation-end      "188"^^xsd:int .
+
+<doc:fi-orig.conll#1248>
+        a                        rdfcas:FeatureStructure , syntax-dependency:Dependency ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        syntax-dependency:Dependency-DependencyType
+                "conjunct" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#977> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#1380> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "278"^^xsd:int ;
+        tcas:Annotation-end      "287"^^xsd:int .
+
+<doc:fi-orig.conll#1753>
+        a                        rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "N Gen Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "134"^^xsd:int ;
+        tcas:Annotation-end      "142"^^xsd:int .
+
+<doc:fi-orig.conll#112>
+        a                         rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#536> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#701> ;
+        segmentation:Token-pos    <doc:fi-orig.conll#314> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "260"^^xsd:int ;
+        tcas:Annotation-end       "261"^^xsd:int .
+
+<doc:fi-orig.conll#46>
+        a                         rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#747> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#1160> ;
+        segmentation:Token-pos    <doc:fi-orig.conll#308> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "154"^^xsd:int ;
+        tcas:Annotation-end       "162"^^xsd:int .
+
+<doc:fi-orig.conll#993>
+        a                        rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "N Prop Gen Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "9"^^xsd:int ;
+        tcas:Annotation-end      "18"^^xsd:int .
+
+<doc:fi-orig.conll#1640>
+        a                         rdfcas:FeatureStructure , segmentation:Token ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Token-lemma  <doc:fi-orig.conll#1243> ;
+        segmentation:Token-morph  <doc:fi-orig.conll#1199> ;
+        segmentation:Token-pos    <doc:fi-orig.conll#1396> ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "205"^^xsd:int ;
+        tcas:Annotation-end       "214"^^xsd:int .
+
+<doc:fi-orig.conll#1277>
+        a                        syntax-dependency:Dependency , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        syntax-dependency:Dependency-DependencyType
+                "attr" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#1578> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#1589> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "131"^^xsd:int ;
+        tcas:Annotation-end      "133"^^xsd:int .
+
+<doc:fi-orig.conll#1256>
+        a                        syntax-dependency:Dependency , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        syntax-dependency:Dependency-DependencyType
+                "subj" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#1728> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#1651> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "90"^^xsd:int ;
+        tcas:Annotation-end      "94"^^xsd:int .
+
+<doc:fi-orig.conll#162>
+        a                             rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#6> ;
+        lexmorph-pos:POS-PosValue     "V" ;
+        lexmorph-pos:POS-coarseValue  "V" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin         "148"^^xsd:int ;
+        tcas:Annotation-end           "153"^^xsd:int .
+
+<doc:fi-orig.conll#859>
+        a                        syntax-dependency:Dependency , rdfcas:FeatureStructure ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        syntax-dependency:Dependency-DependencyType
+                "mod" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#1651> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#1706> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "95"^^xsd:int ;
+        tcas:Annotation-end      "100"^^xsd:int .
+
+<doc:fi-orig.conll#1527>
+        a                        rdfcas:FeatureStructure , syntax-dependency:Dependency ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        syntax-dependency:Dependency-DependencyType
+                "attr" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#894> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#334> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "9"^^xsd:int ;
+        tcas:Annotation-end      "18"^^xsd:int .
+
+<doc:fi-orig.conll#1506>
+        a                         rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Lemma-value  "perus#sääntö" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "37"^^xsd:int ;
+        tcas:Annotation-end       "48"^^xsd:int .
+
+<doc:fi-orig.conll#959>
+        a                         rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Lemma-value  "artikla" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "262"^^xsd:int ;
+        tcas:Annotation-end       "269"^^xsd:int .
+
+<doc:fi-orig.conll#1285>
+        a                        rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "N Nom Sg" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "37"^^xsd:int ;
+        tcas:Annotation-end      "48"^^xsd:int .
+
+<doc:fi-orig.conll#1264>
+        a                        rdfcas:FeatureStructure , syntax-dependency:ROOT ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        syntax-dependency:Dependency-DependencyType
+                "main" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#1706> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#1706> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "79"^^xsd:int ;
+        tcas:Annotation-end      "87"^^xsd:int .
+
+<doc:fi-orig.conll#1243>
+        a                         rdfcas:FeatureStructure , segmentation:Lemma ;
+        rdfcas:indexedIn          <doc:fi-orig.conll#6> ;
+        segmentation:Lemma-value  "Euratom" ;
+        cas:AnnotationBase-sofa   <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin     "205"^^xsd:int ;
+        tcas:Annotation-end       "214"^^xsd:int .
+
+<doc:fi-orig.conll#191>
+        a                        rdfcas:FeatureStructure , lexmorph-morph:MorphologicalFeatures ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        lexmorph-morph:MorphologicalFeatures-value
+                "V Prs Act Sg3" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "148"^^xsd:int ;
+        tcas:Annotation-end      "153"^^xsd:int .
+
+<doc:fi-orig.conll#320>
+        a                        rdfcas:FeatureStructure , syntax-dependency:Dependency ;
+        rdfcas:indexedIn         <doc:fi-orig.conll#6> ;
+        syntax-dependency:Dependency-DependencyType
+                "phrv" ;
+        syntax-dependency:Dependency-Dependent
+                <doc:fi-orig.conll#46> ;
+        syntax-dependency:Dependency-Governor
+                <doc:fi-orig.conll#123> ;
+        syntax-dependency:Dependency-flavor
+                "basic" ;
+        cas:AnnotationBase-sofa  <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin    "154"^^xsd:int ;
+        tcas:Annotation-end      "162"^^xsd:int .
+
+<doc:fi-orig.conll#867>
+        a                             rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#6> ;
+        lexmorph-pos:POS-PosValue     "N" ;
+        lexmorph-pos:POS-coarseValue  "N" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin         "110"^^xsd:int ;
+        tcas:Annotation-end           "130"^^xsd:int .
+
+<doc:fi-orig.conll#1193>
+        a                             rdfcas:FeatureStructure , lexmorph-pos:POS ;
+        rdfcas:indexedIn              <doc:fi-orig.conll#6> ;
+        lexmorph-pos:POS-PosValue     "Punct" ;
+        lexmorph-pos:POS-coarseValue  "Punct" ;
+        cas:AnnotationBase-sofa       <doc:fi-orig.conll#6> ;
+        tcas:Annotation-begin         "143"^^xsd:int ;
+        tcas:Annotation-end           "144"^^xsd:int .

--- a/inception/inception-io-rdf/src/test/resources/ttl/fi-ref.conll
+++ b/inception/inception-io-rdf/src/test/resources/ttl/fi-ref.conll
@@ -1,0 +1,36 @@
+1	NEUVOSTO	neuvosto	N	N	N Nom Sg	2	attr	_	_
+2	EURATOMIN	Euratom	N	N	N Prop Gen Sg	3	attr	_	_
+3	HANKINTAKESKUKSEN	hankinta#keskus	N	N	N Gen Sg	4	attr	_	_
+4	PERUSSÄÄNTÖ	perus#sääntö	N	N	N Nom Sg	7	attr	_	_
+5	EUROOPAN	Eurooppa	N	N	N Prop Gen Sg	6	attr	_	_
+6	ATOMIENERGIAYHTEISÖN	atomi#energia#yhteisö	N	N	N Gen Sg	7	attr	_	_
+7	NEUVOSTO	neuvosto	N	N	N Nom Sg	0	main	_	_
+8	,	,	Punct	Punct	Punct	_	_	_	_
+9	joka	joka	Pron	Pron	Pron Rel Nom Sg	10	subj	_	_
+10	ottaa	ottaa	V	V	V Prs Act Sg3	7	mod	_	_
+11	huomioon	huomio	N	N	N Ill Sg	10	phrv	_	_
+12	perustamissopimuksen	perustamis#sopimus	N	N	N Gen Sg	14	attr	_	_
+13	54	54	Num	Num	Num Digit Nom Sg	14	attr	_	_
+14	artiklan	artikla	N	N	N Gen Sg	10	obj	_	_
+15	,	,	Punct	Punct	Punct	17	phrm	_	_
+16	ja	ja	CC	CC	CC	17	phrm	_	_
+17	ottaa	ottaa	V	V	V Prs Act Sg3	10	conjunct	_	_
+18	huomioon	huomio	N	N	N Ill Sg	17	phrv	_	_
+19	komission	komissio	N	N	N Gen Sg	20	subj	_	_
+20	ehdotuksen	ehdotus	N	N	N Gen Sg	17	obj	_	_
+21	,	,	Punct	Punct	Punct	23	phrm	_	_
+22	ON	olla	V	V	V Prs Act Sg3	23	aux	_	_
+23	PÄÄTTÄNYT	päättää	PrfPrc	PrfPrc	PrfPrc Act Pos Nom Sg	17	conjunct	_	_
+24	antaa	antaa	V	V	V Inf1 Lat	23	obj	_	_
+25	Euratomin	Euratom	N	N	N Prop Gen Sg	26	attr	_	_
+26	hankintakeskuksen	hankinta#keskus	N	N	N Gen Sg	27	attr	_	_
+27	perussäännön	perus#sääntö	N	N	N Gen Sg	24	obj	_	_
+28	seuraavasti	seuraava	Adv	Adv	Adv Pos Man	24	advl	_	_
+29	:	:	Punct	Punct	Punct	_	_	_	_
+
+1	1	1	Num	Num	Num Digit Nom Sg	2	attr	_	_
+2	artikla	artikla	N	N	N Nom Sg	3	attr	_	_
+3	Nimi	nimi	N	N	N Nom Sg	0	main	_	_
+4	ja	ja	CC	CC	CC	5	phrm	_	_
+5	tarkoitus	tarkoitus	N	N	N Nom Sg	3	conjunct	_	_
+

--- a/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/exporters/LayerExporter.java
+++ b/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/exporters/LayerExporter.java
@@ -178,6 +178,7 @@ public class LayerExporter
         exFeature.setType(feature.getType());
         exFeature.setUiName(feature.getUiName());
         exFeature.setVisible(feature.isVisible());
+        exFeature.setIncludeInHover(feature.isIncludeInHover());
         exFeature.setMultiValueMode(feature.getMultiValueMode());
         exFeature.setLinkMode(feature.getLinkMode());
         exFeature.setLinkTypeName(feature.getLinkTypeName());
@@ -305,6 +306,7 @@ public class LayerExporter
         aFeature.setDescription(aExFeature.getDescription());
         aFeature.setEnabled(aExFeature.isEnabled());
         aFeature.setVisible(aExFeature.isVisible());
+        aFeature.setIncludeInHover(aExFeature.isIncludeInHover());
         aFeature.setUiName(aExFeature.getUiName());
         aFeature.setProject(aProject);
         aFeature.setName(aExFeature.getName());

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureSupport.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureSupport.java
@@ -18,10 +18,10 @@
 package de.tudarmstadt.ukp.inception.ui.kb.feature;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -135,7 +135,7 @@ public class ConceptFeatureSupport
             return null;
         }
 
-        ConceptFeatureTraits traits = readTraits(aFeature);
+        var traits = readTraits(aFeature);
         return getConceptHandle(aFeature, aIdentifier, traits).getUiLabel();
     }
 
@@ -172,9 +172,9 @@ public class ConceptFeatureSupport
         }
 
         if (aValue instanceof String) {
-            String identifier = (String) aValue;
-            ConceptFeatureTraits traits = readTraits(aFeature);
-            KBHandle chbk = getConceptHandle(aFeature, identifier, traits);
+            var identifier = (String) aValue;
+            var traits = readTraits(aFeature);
+            var chbk = getConceptHandle(aFeature, identifier, traits);
             // Clone the cached original so we can override the KB
             var clone = new KBHandle(chbk);
             clone.setKB(chbk.getKB());
@@ -196,25 +196,21 @@ public class ConceptFeatureSupport
             AnnotationActionHandler aHandler, IModel<AnnotatorState> aStateModel,
             IModel<FeatureState> aFeatureStateModel)
     {
-        AnnotationFeature feature = aFeatureStateModel.getObject().feature;
-        FeatureEditor editor;
+        var feature = aFeatureStateModel.getObject().feature;
 
         switch (feature.getMultiValueMode()) {
         case NONE:
             if (feature.getType().startsWith(PREFIX)) {
-                editor = new ConceptFeatureEditor(aId, aOwner, aFeatureStateModel, aStateModel,
+                return new ConceptFeatureEditor(aId, aOwner, aFeatureStateModel, aStateModel,
                         aHandler);
             }
             else {
                 throw unsupportedMultiValueModeException(feature);
             }
-            break;
         case ARRAY: // fall-through
         default:
             throw unsupportedMultiValueModeException(feature);
         }
-
-        return editor;
     }
 
     @Override
@@ -270,8 +266,7 @@ public class ConceptFeatureSupport
     @Override
     public List<VLazyDetailGroup> lookupLazyDetails(AnnotationFeature aFeature, Object aValue)
     {
-        if (aValue instanceof KBHandle) {
-            var handle = (KBHandle) aValue;
+        if (aValue instanceof KBHandle handle) {
             var result = new VLazyDetailGroup(handle.getIdentifier());
             result.addDetail(new VLazyDetail("Label", handle.getUiLabel()));
 
@@ -282,13 +277,13 @@ public class ConceptFeatureSupport
             return asList(result);
         }
 
-        return Collections.emptyList();
+        return emptyList();
     }
 
     @Override
     public boolean suppressAutoFocus(AnnotationFeature aFeature)
     {
-        ConceptFeatureTraits traits = readTraits(aFeature);
+        var traits = readTraits(aFeature);
         return !traits.getKeyBindings().isEmpty();
     }
 }

--- a/inception/pom.xml
+++ b/inception/pom.xml
@@ -210,6 +210,7 @@
     <module>inception-io-perseus</module>
     <module>inception-io-imscwb</module>
     <module>inception-io-intertext</module>
+    <module>inception-io-rdf</module>
     <module>inception-io-tcf</module>
     <module>inception-io-tei</module>
     <module>inception-io-text</module>


### PR DESCRIPTION
**What's in the PR**
- Ported RDF reader/writer from DKPro Core
- Added PARAM_IRI_FEATURES so we can represent KB concepts are proper IRIs in the export instead of strings
- Added test using PARAM_IRI_FEATURES

**How to test manually**
* Export a document as RDF
* Check if the exported TTL looks good
* Import it back again

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
