### PR TITLE
#4570 - Inefficient Knowledge Base SPARQL query for labels

### DIFF
--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
@@ -675,7 +675,7 @@ public class SPARQLQueryBuilder
         Iri pSubProperty = iri(kb.getSubPropertyIri());
         var primaryLabelPattern = aVariable
                 .has(PropertyPathBuilder.of(pSubProperty).zeroOrMore().build(), pLabel);
-        return optional(primaryLabelPattern);
+        return primaryLabelPattern;
     }
 
     /**


### PR DESCRIPTION
**What's in the PR**
- Remove "optional" to speed up query on AllegroGraph backends

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
