### PR TITLE
#4572 - Support full text search in knowledge bases running on AllegroGraph

### DIFF
--- a/inception/inception-concept-linking/src/test/java/de/tudarmstadt/ukp/inception/conceptlinking/util/TestFixtures.java
+++ b/inception/inception-concept-linking/src/test/java/de/tudarmstadt/ukp/inception/conceptlinking/util/TestFixtures.java
@@ -58,7 +58,7 @@ public class TestFixtures
         kb.setLabelIri(RDFS.LABEL.stringValue());
         kb.setPropertyTypeIri(RDF.PROPERTY.stringValue());
         kb.setDescriptionIri(RDFS.COMMENT.stringValue());
-        kb.setFullTextSearchIri(IriConstants.FTS_LUCENE.stringValue());
+        kb.setFullTextSearchIri(IriConstants.FTS_RDF4J_LUCENE.stringValue());
         kb.setPropertyLabelIri(RDFS.LABEL.stringValue());
         kb.setPropertyDescriptionIri(RDFS.COMMENT.stringValue());
         kb.setSubPropertyIri(RDFS.SUBPROPERTYOF.stringValue());

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/IriConstants.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/IriConstants.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.eclipse.rdf4j.model.IRI;
-import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.OWL;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
@@ -44,7 +43,8 @@ public class IriConstants
     public static final String PREFIX_WIKIDATA_DIRECT = "http://www.wikidata.org/prop/direct/";
     public static final String PREFIX_SCHEMA = "http://schema.org/";
     public static final String PREFIX_VIRTUOSO = "http://www.openlinksw.com/schemas/bif#";
-    public static final String PREFIX_LUCENE_SEARCH = "http://www.openrdf.org/contrib/lucenesail#";
+    public static final String PREFIX_RDF4J_LUCENE_SEARCH = "http://www.openrdf.org/contrib/lucenesail#";
+    public static final String PREFIX_ALLEGRO_GRAPH_FTI = "http://franz.com/ns/allegrograph/2.2/textindex/";
     public static final String PREFIX_MWAPI = "https://www.mediawiki.org/ontology#API/";
     public static final String PREFIX_STARDOG = "tag:stardog:api:search:";
     public static final String PREFIX_BLAZEGRAPH = "http://www.bigdata.com/rdf/search#";
@@ -84,7 +84,8 @@ public class IriConstants
     public static final IRI SCHEMA_DESCRIPTION;
 
     public static final IRI FTS_FUSEKI;
-    public static final IRI FTS_LUCENE;
+    public static final IRI FTS_RDF4J_LUCENE;
+    public static final IRI FTS_ALLEGRO_GRAPH;
     public static final IRI FTS_VIRTUOSO;
     public static final IRI FTS_WIKIDATA;
     public static final IRI FTS_STARDOG;
@@ -104,7 +105,7 @@ public class IriConstants
     public static final List<IRI> FTS_IRIS;
 
     static {
-        ValueFactory vf = SimpleValueFactory.getInstance();
+        var vf = SimpleValueFactory.getInstance();
 
         WIKIDATA_CLASS = vf.createIRI(PREFIX_WIKIDATA_ENTITY, "Q35120");
         WIKIDATA_SUBCLASS = vf.createIRI(PREFIX_WIKIDATA_DIRECT, "P279");
@@ -115,7 +116,8 @@ public class IriConstants
 
         FTS_FUSEKI = vf.createIRI("text:query");
         FTS_VIRTUOSO = vf.createIRI("bif:contains");
-        FTS_LUCENE = vf.createIRI(PREFIX_LUCENE_SEARCH, "matches");
+        FTS_ALLEGRO_GRAPH = vf.createIRI(PREFIX_ALLEGRO_GRAPH_FTI, "match");
+        FTS_RDF4J_LUCENE = vf.createIRI(PREFIX_RDF4J_LUCENE_SEARCH, "matches");
         FTS_WIKIDATA = vf.createIRI(PREFIX_MWAPI, "search");
         FTS_STARDOG = vf.createIRI(PREFIX_STARDOG, "textMatch");
         FTS_BLAZEGRAPH = vf.createIRI(PREFIX_BLAZEGRAPH, "search");
@@ -131,8 +133,8 @@ public class IriConstants
         PROPERTY_LABEL_IRIS = asList(RDFS.LABEL, SKOS.PREF_LABEL);
         PROPERTY_DESCRIPTION_IRIS = asList(RDFS.COMMENT, SCHEMA_DESCRIPTION);
         DEPRECATION_PROPERTY_IRIS = asList(OWL.DEPRECATED);
-        FTS_IRIS = asList(FTS_FUSEKI, FTS_BLAZEGRAPH, FTS_VIRTUOSO, FTS_WIKIDATA, FTS_LUCENE,
-                FTS_STARDOG);
+        FTS_IRIS = asList(FTS_FUSEKI, FTS_BLAZEGRAPH, FTS_VIRTUOSO, FTS_WIKIDATA, FTS_RDF4J_LUCENE,
+                FTS_STARDOG, FTS_ALLEGRO_GRAPH);
     }
 
     public static boolean hasImplicitNamespace(KnowledgeBase kb, String s)

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/IriConstants.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/IriConstants.java
@@ -137,6 +137,39 @@ public class IriConstants
                 FTS_STARDOG, FTS_ALLEGRO_GRAPH);
     }
 
+    public static String getFtsBackendName(String aFTS)
+    {
+        if (FTS_FUSEKI.stringValue().equals(aFTS)) {
+            return "Apache Jena Fuseki";
+        }
+
+        if (FTS_BLAZEGRAPH.stringValue().equals(aFTS)) {
+            return "Blazegraph DB";
+        }
+
+        if (FTS_VIRTUOSO.stringValue().equals(aFTS)) {
+            return "Virtuoso";
+        }
+
+        if (FTS_WIKIDATA.stringValue().equals(aFTS)) {
+            return "Wikidata (MediaWiki API Query Service EntitySearch)";
+        }
+
+        if (FTS_RDF4J_LUCENE.stringValue().equals(aFTS)) {
+            return "RDF4J Lucene";
+        }
+
+        if (FTS_STARDOG.stringValue().equals(aFTS)) {
+            return "Stardog";
+        }
+
+        if (FTS_ALLEGRO_GRAPH.stringValue().equals(aFTS)) {
+            return "AllegroGraph";
+        }
+
+        return aFTS;
+    }
+
     public static boolean hasImplicitNamespace(KnowledgeBase kb, String s)
     {
         // Root concepts are never implicit. E.g. if the root concept is owl:Thing, we do not

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/AllegroGraphFtsQuery.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/AllegroGraphFtsQuery.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.kb.querybuilder;
+
+import static de.tudarmstadt.ukp.inception.kb.querybuilder.RdfCollection.collectionOf;
+import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.prefix;
+import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+
+import org.eclipse.rdf4j.sparqlbuilder.core.Prefix;
+import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
+import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPattern;
+import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
+
+import de.tudarmstadt.ukp.inception.kb.IriConstants;
+
+public class AllegroGraphFtsQuery
+    implements GraphPattern
+{
+    private static final Prefix PREFIX_ALLEGRO_GRAPH_FTI = prefix("fti",
+            iri(IriConstants.PREFIX_ALLEGRO_GRAPH_FTI));
+    private static final Iri ALLEGRO_GRAPH_MATCH = PREFIX_ALLEGRO_GRAPH_FTI.iri("match");
+
+    private final Variable subject;
+    private final Variable score;
+    private final Variable matchTerm;
+    private final Variable matchTermProperty;
+    private final String query;
+
+    public AllegroGraphFtsQuery(Variable aSubject, Variable aScore, Variable aMatchTerm,
+            Variable aMatchTermProperty, String aQuery)
+    {
+        subject = aSubject;
+        score = aScore;
+        matchTerm = aMatchTerm;
+        matchTermProperty = aMatchTermProperty;
+        query = aQuery;
+    }
+
+    @Override
+    public String getQueryString()
+    {
+        return collectionOf(subject, matchTerm, matchTermProperty) //
+                .has(ALLEGRO_GRAPH_MATCH, query).getQueryString();
+    }
+
+    @Override
+    public boolean isEmpty()
+    {
+        return false;
+    }
+}

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterFuseki.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterFuseki.java
@@ -19,16 +19,24 @@ package de.tudarmstadt.ukp.inception.kb.querybuilder;
 
 import static de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilder.Priority.PRIMARY;
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.prefix;
 import static org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns.and;
 import static org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns.union;
+import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
 
 import java.util.ArrayList;
 
+import org.eclipse.rdf4j.sparqlbuilder.core.Prefix;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPattern;
+import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
 
 public class FtsAdapterFuseki
     implements FtsAdapter
 {
+    private static final Prefix PREFIX_FUSEKI_SEARCH = prefix("text",
+            iri("http://jena.apache.org/text#"));
+    private static final Iri FUSEKI_QUERY = PREFIX_FUSEKI_SEARCH.iri("query");
+
     private final SPARQLQueryBuilder builder;
 
     public FtsAdapterFuseki(SPARQLQueryBuilder aBuilder)

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterStardog.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterStardog.java
@@ -17,18 +17,24 @@
  */
 package de.tudarmstadt.ukp.inception.kb.querybuilder;
 
+import static de.tudarmstadt.ukp.inception.kb.IriConstants.PREFIX_STARDOG;
 import static de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilder.Priority.PRIMARY;
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.prefix;
 import static org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns.and;
 import static org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns.union;
+import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
 
 import java.util.ArrayList;
 
+import org.eclipse.rdf4j.sparqlbuilder.core.Prefix;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPattern;
 
 public class FtsAdapterStardog
     implements FtsAdapter
 {
+    private final static Prefix PREFIX_STARDOG_SEARCH = prefix("fts", iri(PREFIX_STARDOG));
+
     private final SPARQLQueryBuilder builder;
 
     public FtsAdapterStardog(SPARQLQueryBuilder aBuilder)

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
@@ -17,10 +17,11 @@
  */
 package de.tudarmstadt.ukp.inception.kb.querybuilder;
 
+import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_ALLEGRO_GRAPH;
 import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_BLAZEGRAPH;
 import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_FUSEKI;
-import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_LUCENE;
 import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_NONE;
+import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_RDF4J_LUCENE;
 import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_STARDOG;
 import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_VIRTUOSO;
 import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_WIKIDATA;
@@ -97,7 +98,6 @@ import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.TriplePattern;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf;
-import org.eclipse.rdf4j.sparqlbuilder.rdf.RdfBlankNode.LabeledBlankNode;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.RdfPredicate;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.RdfValue;
 import org.eclipse.rdf4j.sparqlbuilder.util.SparqlBuilderUtils;
@@ -637,11 +637,11 @@ public class SPARQLQueryBuilder
      */
     private GraphPattern bindPrefLabelProperties(Variable aVariable)
     {
-        Iri pLabel = mode.getLabelProperty(kb);
-        Iri pSubProperty = iri(kb.getSubPropertyIri());
+        var pLabel = mode.getLabelProperty(kb);
+        var pSubProperty = iri(kb.getSubPropertyIri());
         var primaryLabelPattern = aVariable
                 .has(PropertyPathBuilder.of(pSubProperty).zeroOrMore().build(), pLabel);
-        return primaryLabelPattern;
+        return optional(primaryLabelPattern);
     }
 
     /**
@@ -650,8 +650,8 @@ public class SPARQLQueryBuilder
      */
     GraphPattern bindMatchTermProperties(Variable aVariable)
     {
-        Iri pLabel = mode.getLabelProperty(kb);
-        Iri pSubProperty = iri(kb.getSubPropertyIri());
+        var pLabel = mode.getLabelProperty(kb);
+        var pSubProperty = iri(kb.getSubPropertyIri());
         var primaryLabelPattern = aVariable
                 .has(PropertyPathBuilder.of(pSubProperty).zeroOrMore().build(), pLabel);
 
@@ -665,7 +665,7 @@ public class SPARQLQueryBuilder
         var patterns = new ArrayList<TriplePattern>();
         patterns.add(primaryLabelPattern);
 
-        for (Iri pAddSearch : mode.getAdditionalMatchingProperties(kb)) {
+        for (var pAddSearch : mode.getAdditionalMatchingProperties(kb)) {
             patterns.add(aVariable.has(PropertyPathBuilder.of(pSubProperty).zeroOrMore().build(),
                     pAddSearch));
         }
@@ -711,9 +711,9 @@ public class SPARQLQueryBuilder
         // , "}"
         // , "LIMIT " + aKB.getMaxResults());
 
-        Iri subClassProperty = iri(kb.getSubclassIri());
-        Iri subPropertyProperty = iri(kb.getSubPropertyIri());
-        LabeledBlankNode superClass = Rdf.bNode("superClass");
+        var subClassProperty = iri(kb.getSubclassIri());
+        var subPropertyProperty = iri(kb.getSubPropertyIri());
+        var superClass = Rdf.bNode("superClass");
 
         addPattern(PRIMARY, union(GraphPatterns.and(
                 // Find all super-classes of the domain type
@@ -754,7 +754,7 @@ public class SPARQLQueryBuilder
     {
         IRI ftsMode = getFtsMode();
 
-        if (FTS_LUCENE.equals(ftsMode)) {
+        if (FTS_RDF4J_LUCENE.equals(ftsMode)) {
             return new FtsAdapterRdf4J(this);
         }
 
@@ -776,6 +776,10 @@ public class SPARQLQueryBuilder
 
         if (FTS_WIKIDATA.equals(ftsMode)) {
             return new FtsAdapterWikidata(this);
+        }
+
+        if (FTS_ALLEGRO_GRAPH.equals(ftsMode)) {
+            return new FtsAdapterAllegroGraph(this);
         }
 
         if (FTS_NONE.equals(ftsMode) || ftsMode == null) {

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLVariables.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLVariables.java
@@ -17,10 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.kb.querybuilder;
 
-import static de.tudarmstadt.ukp.inception.kb.IriConstants.PREFIX_BLAZEGRAPH;
-import static de.tudarmstadt.ukp.inception.kb.IriConstants.PREFIX_STARDOG;
 import static de.tudarmstadt.ukp.inception.kb.IriConstants.PREFIX_VIRTUOSO;
-import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.prefix;
 import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.var;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
 
@@ -28,7 +25,6 @@ import org.eclipse.rdf4j.model.vocabulary.OWL;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.sparqlbuilder.constraint.propertypath.PropertyPath;
 import org.eclipse.rdf4j.sparqlbuilder.constraint.propertypath.builder.PropertyPathBuilder;
-import org.eclipse.rdf4j.sparqlbuilder.core.Prefix;
 import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
 
@@ -61,20 +57,6 @@ public interface SPARQLVariables
     Variable VAR_DESCRIPTION = var(VAR_DESCRIPTION_NAME);
     Variable VAR_DESC_CANDIDATE = var(VAR_DESCRIPTION_CANDIDATE_NAME);
     Variable VAR_DEPRECATION = var(VAR_DEPRECATION_NAME);
-
-    Prefix PREFIX_LUCENE_SEARCH = prefix("search",
-            iri("http://www.openrdf.org/contrib/lucenesail#"));
-    Iri LUCENE_QUERY = PREFIX_LUCENE_SEARCH.iri("query");
-    Iri LUCENE_PROPERTY = PREFIX_LUCENE_SEARCH.iri("property");
-    Iri LUCENE_SCORE = PREFIX_LUCENE_SEARCH.iri("score");
-    Iri LUCENE_SNIPPET = PREFIX_LUCENE_SEARCH.iri("snippet");
-
-    Prefix PREFIX_FUSEKI_SEARCH = prefix("text", iri("http://jena.apache.org/text#"));
-    Iri FUSEKI_QUERY = PREFIX_FUSEKI_SEARCH.iri("query");
-
-    Prefix PREFIX_STARDOG_SEARCH = prefix("fts", iri(PREFIX_STARDOG));
-
-    Prefix PREFIX_BLAZEGRAPH_SEARCH = prefix("bds", iri(PREFIX_BLAZEGRAPH));
 
     // Some versions of Virtuoso do not like it when we declare the bif prefix.
     // Prefix PREFIX_VIRTUOSO_SEARCH = prefix("bif", iri(PREFIX_VIRTUOSO));

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/FullTextIndexUpgradeTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/FullTextIndexUpgradeTest.java
@@ -94,7 +94,7 @@ public class FullTextIndexUpgradeTest
         kb.setLabelIri(RDFS.LABEL.stringValue());
         kb.setPropertyTypeIri(RDF.PROPERTY.stringValue());
         kb.setDescriptionIri(RDFS.COMMENT.stringValue());
-        kb.setFullTextSearchIri(IriConstants.FTS_LUCENE.stringValue());
+        kb.setFullTextSearchIri(IriConstants.FTS_RDF4J_LUCENE.stringValue());
         kb.setPropertyLabelIri(RDFS.LABEL.stringValue());
         kb.setPropertyDescriptionIri(RDFS.COMMENT.stringValue());
         kb.setSubPropertyIri(RDFS.SUBPROPERTYOF.stringValue());

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/AllegroGraphRepositoryTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/AllegroGraphRepositoryTest.java
@@ -41,6 +41,7 @@ import org.eclipse.rdf4j.repository.Repository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -56,6 +57,7 @@ import de.tudarmstadt.ukp.inception.kb.RepositoryType;
 import de.tudarmstadt.ukp.inception.kb.model.KnowledgeBase;
 import de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilderLocalTestScenarios.Scenario;
 
+@Disabled("https://github.com/eclipse-rdf4j/rdf4j/issues/4923")
 @Testcontainers(disabledWithoutDocker = true)
 public class AllegroGraphRepositoryTest
 {

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/AllegroGraphRepositoryTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/AllegroGraphRepositoryTest.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.kb.querybuilder;
+
+import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_ALLEGRO_GRAPH;
+import static de.tudarmstadt.ukp.inception.kb.http.PerThreadSslCheckingHttpClientUtils.restoreSslVerification;
+import static de.tudarmstadt.ukp.inception.kb.http.PerThreadSslCheckingHttpClientUtils.suspendSslVerification;
+import static java.time.Duration.ofMinutes;
+import static java.util.Arrays.asList;
+import static org.apache.commons.lang3.StringUtils.appendIfMissing;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.util.Base64;
+import java.util.List;
+
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.repository.Repository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import de.tudarmstadt.ukp.inception.kb.RepositoryType;
+import de.tudarmstadt.ukp.inception.kb.model.KnowledgeBase;
+import de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilderLocalTestScenarios.Scenario;
+
+@Testcontainers(disabledWithoutDocker = true)
+public class AllegroGraphRepositoryTest
+{
+    private static final String GRAPH_IRI = "http://testgraph";
+
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    private static final String USER = "dba";
+    private static final String PASSWORD = "secret";
+    private static final String CATALOG = "root";
+    private static final String REPOSITORY = "test";
+    private static final int ALLEGRO_GRAPH_PORT = 10035;
+
+    @Container
+    private static final GenericContainer<?> ALLEGRO_GRAPH = new GenericContainer<>(
+            "franzinc/agraph:latest") //
+                    .withSharedMemorySize(1_000_000_000l) //
+                    .withEnv("AGRAPH_SUPER_USER", USER) //
+                    .withEnv("AGRAPH_SUPER_PASSWORD", PASSWORD) //
+                    .withExposedPorts(ALLEGRO_GRAPH_PORT) //
+                    .waitingFor(Wait.forHttp("/").forPort(ALLEGRO_GRAPH_PORT)
+                            .withStartupTimeout(ofMinutes(2)));
+
+    private Repository repository;
+
+    private KnowledgeBase kb;
+
+    @BeforeAll
+    static void setUpClass() throws Exception
+    {
+        assertThat(ALLEGRO_GRAPH.isRunning()).isTrue();
+
+        LOG.info("Creating repository: [{}] ...", REPOSITORY);
+        ALLEGRO_GRAPH.execInContainer("agtool", "repos", "create", REPOSITORY);
+        LOG.info("Created repository: [{}] complete", REPOSITORY);
+
+        LOG.info("Creating freetext index...");
+        createIndex(
+                "http://" + ALLEGRO_GRAPH.getHost() + ":"
+                        + ALLEGRO_GRAPH.getMappedPort(ALLEGRO_GRAPH_PORT),
+                USER, PASSWORD, REPOSITORY, "fti");
+        LOG.info("Creating freetext index... complete");
+    }
+
+    @BeforeEach
+    public void setUp(TestInfo aTestInfo) throws Exception
+    {
+        var methodName = aTestInfo.getTestMethod().map(Method::getName).orElse("<unknown>");
+        System.out.printf("\n=== %s === %s =====================\n", methodName,
+                aTestInfo.getDisplayName());
+
+        suspendSslVerification();
+
+        kb = new KnowledgeBase();
+        kb.setDefaultLanguage("en");
+        kb.setDefaultDatasetIri(GRAPH_IRI);
+        kb.setType(RepositoryType.REMOTE);
+        kb.setFullTextSearchIri(FTS_ALLEGRO_GRAPH.stringValue());
+        kb.setMaxResults(100);
+
+        SPARQLQueryBuilderLocalTestScenarios.initRdfsMapping(kb);
+
+        repository = SPARQLQueryBuilderLocalTestScenarios.buildSparqlRepository(
+                "http://" + USER + ":" + PASSWORD + "@" + ALLEGRO_GRAPH.getHost() + ":"
+                        + ALLEGRO_GRAPH.getMappedPort(ALLEGRO_GRAPH_PORT) + "/catalogs/" + CATALOG
+                        + "/repositories/" + REPOSITORY + "/sparql");
+
+        try (var conn = repository.getConnection()) {
+            var ctx = SimpleValueFactory.getInstance().createIRI(kb.getDefaultDatasetIri());
+            conn.clear(ctx);
+        }
+    }
+
+    @AfterEach
+    public void tearDown()
+    {
+        restoreSslVerification();
+    }
+
+    private static List<Arguments> tests() throws Exception
+    {
+        var exclusions = asList( //
+                // The test assumes that the FTS will also return results that may not contain all
+                // search terms but AllegroGraph will not return such results (e.g. searching for
+                // "hand structure*" will not return "hand") - maybe the test should be changed
+                "thatMatchingAgainstAdditionalSearchPropertiesWorks2");
+
+        return SPARQLQueryBuilderLocalTestScenarios.tests().stream() //
+                .filter(scenario -> !exclusions.contains(scenario.name)) //
+                .map(scenario -> Arguments.of(scenario.name, scenario)) //
+                .toList();
+    }
+
+    @ParameterizedTest(name = "{index}: test {0}")
+    @MethodSource("tests")
+    public void runTests(String aScenarioName, Scenario aScenario) throws Exception
+    {
+        aScenario.implementation.accept(repository, kb);
+    }
+
+    public static void createIndex(String aBaseUrl, String aUsername, String aPassword,
+            String aRepository, String aIndex)
+        throws IOException, InterruptedException
+    {
+        var url = appendIfMissing(aBaseUrl, "/") + "repositories/" + aRepository
+                + "/freetext/indices/" + aIndex + "?minimumWordSize=1";
+
+        var auth = aUsername + ":" + aPassword;
+        var encodedAuth = Base64.getEncoder().encodeToString(auth.getBytes());
+
+        var client = HttpClient.newBuilder().version(HttpClient.Version.HTTP_1_1).build();
+
+        var request = HttpRequest.newBuilder().uri(URI.create(url))
+                .header("Authorization", "Basic " + encodedAuth) //
+                .PUT(BodyPublishers.noBody()) //
+                .build();
+
+        var response = client.send(request, BodyHandlers.ofString());
+        if (response.statusCode() < 200 || response.statusCode() >= 300) {
+            throw new IOException("Unable to create index: " + response.body() + " ("
+                    + response.statusCode() + ")");
+        }
+    }
+}

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/Rdf4JRepositoryTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/Rdf4JRepositoryTest.java
@@ -17,7 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.kb.querybuilder;
 
-import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_LUCENE;
+import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_RDF4J_LUCENE;
 import static de.tudarmstadt.ukp.inception.kb.http.PerThreadSslCheckingHttpClientUtils.restoreSslVerification;
 import static de.tudarmstadt.ukp.inception.kb.http.PerThreadSslCheckingHttpClientUtils.suspendSslVerification;
 import static de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilderLocalTestScenarios.DATA_ADDITIONAL_SEARCH_PROPERTIES_2;
@@ -78,7 +78,7 @@ public class Rdf4JRepositoryTest
         kb = new KnowledgeBase();
         kb.setDefaultLanguage("en");
         kb.setType(RepositoryType.LOCAL);
-        kb.setFullTextSearchIri(FTS_LUCENE.stringValue());
+        kb.setFullTextSearchIri(FTS_RDF4J_LUCENE.stringValue());
         kb.setMaxResults(100);
 
         SPARQLQueryBuilderLocalTestScenarios.initRdfsMapping(kb);

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/util/TestFixtures.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/util/TestFixtures.java
@@ -17,7 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.kb.util;
 
-import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_LUCENE;
+import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_RDF4J_LUCENE;
 import static de.tudarmstadt.ukp.inception.kb.IriConstants.INCEPTION_NAMESPACE;
 import static de.tudarmstadt.ukp.inception.kb.http.PerThreadSslCheckingHttpClientUtils.newPerThreadSslCheckingHttpClientBuilder;
 import static java.net.HttpURLConnection.HTTP_MOVED_PERM;
@@ -102,7 +102,7 @@ public class TestFixtures
         kb.setPropertyTypeIri(RDF.PROPERTY.stringValue());
         kb.setDescriptionIri(RDFS.COMMENT.stringValue());
         kb.setSubPropertyIri(RDFS.SUBPROPERTYOF.stringValue());
-        kb.setFullTextSearchIri(FTS_LUCENE.stringValue());
+        kb.setFullTextSearchIri(FTS_RDF4J_LUCENE.stringValue());
         // Intentionally using different IRIs for label/description and property-label/description
         // to detect cases where we accidentally construct queries using the wrong mapping, e.g.
         // querying for properties with the class label.

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/lambda/LambdaChoiceRenderer.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/lambda/LambdaChoiceRenderer.java
@@ -20,6 +20,10 @@ package de.tudarmstadt.ukp.inception.support.lambda;
 import org.apache.wicket.markup.html.form.ChoiceRenderer;
 import org.danekja.java.util.function.serializable.SerializableFunction;
 
+/**
+ * @deprecated Use {@link org.apache.wicket.markup.html.form.LambdaChoiceRenderer} instead.
+ */
+@Deprecated
 public class LambdaChoiceRenderer<T>
     extends ChoiceRenderer<T>
 {

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/AccessSettingsPanel.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/AccessSettingsPanel.java
@@ -47,7 +47,7 @@ public class AccessSettingsPanel
 
     private DropDownChoice<RepositoryType> createTypeSelection(String id, String property)
     {
-        DropDownChoice<RepositoryType> typeChoice = new DropDownChoice<>(id, kbModel.bind(property),
+        var typeChoice = new DropDownChoice<>(id, kbModel.bind(property),
                 asList(RepositoryType.values()), new EnumChoiceRenderer<>(this));
         typeChoice.setRequired(true);
         return typeChoice;
@@ -55,7 +55,7 @@ public class AccessSettingsPanel
 
     private CheckBox createCheckbox(String aId, String aProperty)
     {
-        CheckBox checkbox = new CheckBox(aId, kbModel.bind(aProperty));
+        var checkbox = new CheckBox(aId, kbModel.bind(aProperty));
         checkbox.setOutputMarkupId(true);
         return checkbox;
     }

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/AccessSpecificSettingsPanel.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/AccessSpecificSettingsPanel.java
@@ -47,7 +47,7 @@ public class AccessSpecificSettingsPanel
 
         aModel.getObject().clearFiles();
 
-        boolean isHandlingLocalRepository = aModel.getObject().getKb().getType() == LOCAL;
+        var isHandlingLocalRepository = aModel.getObject().getKb().getType() == LOCAL;
 
         // container for form components related to local KBs
         local = new LocalRepositorySettingsPanel("localSpecificSettings", aModel,

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/GeneralSettingsPanel.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/GeneralSettingsPanel.java
@@ -17,7 +17,8 @@
  */
 package de.tudarmstadt.ukp.inception.ui.kb.project;
 
-import java.util.Arrays;
+import static java.util.Arrays.asList;
+
 import java.util.List;
 
 import org.apache.wicket.markup.html.form.CheckBox;
@@ -46,7 +47,7 @@ public class GeneralSettingsPanel
 
     private final IModel<Project> projectModel;
     private final CompoundPropertyModel<KnowledgeBaseWrapper> kbModel;
-    private final List<String> languages = Arrays.asList("en", "de");
+    private final List<String> languages = asList("en", "de");
 
     private @SpringBean KnowledgeBaseService kbService;
     private @SpringBean KnowledgeBaseProperties kbproperties;
@@ -68,7 +69,7 @@ public class GeneralSettingsPanel
 
     private TextField<String> nameField(String id, String property)
     {
-        TextField<String> nameField = new RequiredTextField<>(id, kbModel.bind(property));
+        var nameField = new RequiredTextField<String>(id, kbModel.bind(property));
         nameField.add(new KnowledgeBaseNameValidator());
         return nameField;
     }
@@ -80,7 +81,7 @@ public class GeneralSettingsPanel
             aModel.setObject(languages.get(0));
         }
 
-        ComboBox<String> comboBox = new ComboBox<String>(id, aModel, languages);
+        var comboBox = new ComboBox<String>(id, aModel, languages);
         comboBox.setOutputMarkupId(true);
         comboBox.setRequired(true);
         // Do nothing just update the kbModel values
@@ -90,7 +91,7 @@ public class GeneralSettingsPanel
 
     private CheckBox createCheckbox(String aId, String aProperty)
     {
-        CheckBox cb = new CheckBox(aId, kbModel.bind(aProperty));
+        var cb = new CheckBox(aId, kbModel.bind(aProperty));
         cb.setOutputMarkupId(true);
         return cb;
     }
@@ -98,8 +99,8 @@ public class GeneralSettingsPanel
     private ComboBox<String> basePrefixField(String aId, String aProperty)
     {
         // Add textfield and label for basePrefix
-        ComboBox<String> basePrefix = new ComboBox<String>(aId, kbModel.bind(aProperty),
-                Arrays.asList(IriConstants.INCEPTION_NAMESPACE));
+        var basePrefix = new ComboBox<String>(aId, kbModel.bind(aProperty),
+                asList(IriConstants.INCEPTION_NAMESPACE));
         basePrefix.add(new LambdaAjaxFormComponentUpdatingBehavior("change"));
         basePrefix.setConvertEmptyInputStringToNull(false);
         basePrefix.setOutputMarkupId(true);
@@ -114,9 +115,9 @@ public class GeneralSettingsPanel
         @Override
         public void validate(IValidatable<String> aValidatable)
         {
-            String kbName = aValidatable.getValue();
+            var kbName = aValidatable.getValue();
             if (kbService.knowledgeBaseExists(projectModel.getObject(), kbName)) {
-                String message = String.format(
+                var message = String.format(
                         "There already exists a knowledge base in the project with name: [%s]!",
                         kbName);
                 aValidatable.error(new ValidationError(message));

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/KnowledgeBaseIriPanel.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/KnowledgeBaseIriPanel.java
@@ -120,7 +120,7 @@ public class KnowledgeBaseIriPanel
         iriSchemaChoice.setOutputMarkupId(true);
         // OnChange update the model with corresponding iris
         iriSchemaChoice.add(new LambdaAjaxFormComponentUpdatingBehavior("change", _target -> {
-            SchemaProfile profile = iriSchemaChoice.getModelObject();
+            var profile = iriSchemaChoice.getModelObject();
             // If the user switches to the custom profile, we retain the values from the
             // previously selected profile and just make the IRI mapping editable. If the user
             // switches to a pre-defined profile, we reset the values.
@@ -128,9 +128,11 @@ public class KnowledgeBaseIriPanel
                 classField.setModelObject(profile.getClassIri());
                 subclassField.setModelObject(profile.getSubclassIri());
                 typeField.setModelObject(profile.getTypeIri());
-                descriptionField.setModelObject(profile.getDescriptionIri());
                 labelField.setModelObject(profile.getLabelIri());
+                descriptionField.setModelObject(profile.getDescriptionIri());
+
                 propertyTypeField.setModelObject(profile.getPropertyTypeIri());
+                subPropertyField.setModelObject(profile.getSubPropertyIri());
                 propertyLabelField.setModelObject(profile.getPropertyLabelIri());
                 propertyDescriptionField.setModelObject(profile.getPropertyDescriptionIri());
                 deprecationPropertyField.setModelObject(profile.getDeprecationPropertyIri());
@@ -147,9 +149,9 @@ public class KnowledgeBaseIriPanel
             model.setObject(iris.get(0).stringValue());
         }
 
-        List<String> choices = iris.stream().map(IRI::stringValue).collect(toList());
+        var choices = iris.stream().map(IRI::stringValue).collect(toList());
 
-        ComboBox<String> comboBox = new ComboBox<>(id, model, choices);
+        var comboBox = new ComboBox<>(id, model, choices);
         comboBox.add(enabledWhen(() -> CUSTOMSCHEMA.equals(selectedSchemaProfile.getObject())));
         comboBox.setOutputMarkupId(true);
         comboBox.setRequired(true);
@@ -161,8 +163,8 @@ public class KnowledgeBaseIriPanel
 
     private DropDownChoice<Reification> selectReificationStrategy(String id, String property)
     {
-        DropDownChoice<Reification> reificationDropDownChoice = new DropDownChoice<>(id,
-                kbModel.bind(property), asList(Reification.values()));
+        var reificationDropDownChoice = new DropDownChoice<>(id, kbModel.bind(property),
+                asList(Reification.values()));
         reificationDropDownChoice.setRequired(true);
         reificationDropDownChoice.setOutputMarkupPlaceholderTag(true);
 

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/ProjectKnowledgeBasePanel.properties
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/ProjectKnowledgeBasePanel.properties
@@ -38,7 +38,7 @@ kb.iri.propertyLabelIri=Property label IRI
 kb.iri.propertyDescriptionIri=Property description IRI
 kb.iri.deprecationPropertyIri=Deprecation property IRI
 kb.iri.fullTextSearchIri=Full text search mode
-fullTextSearchIri.nullValid=No full text search support
+fullTextSearchIri.nullValid=Unknown / no full text search support
 kb.iri.basePrefix=Base Prefix
 kb.iri.defaultDataset=Default dataset
 

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/QuerySettingsPanel.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/QuerySettingsPanel.java
@@ -17,12 +17,14 @@
  */
 package de.tudarmstadt.ukp.inception.ui.kb.project;
 
-import static java.util.stream.Collectors.toList;
+import static de.tudarmstadt.ukp.inception.kb.IriConstants.getFtsBackendName;
+import static java.util.Comparator.comparing;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.markup.html.form.AjaxCheckBox;
 import org.apache.wicket.markup.html.form.CheckBox;
 import org.apache.wicket.markup.html.form.DropDownChoice;
+import org.apache.wicket.markup.html.form.LambdaChoiceRenderer;
 import org.apache.wicket.markup.html.form.NumberTextField;
 import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.markup.html.panel.Panel;
@@ -91,7 +93,7 @@ public class QuerySettingsPanel
 
     private NumberTextField<Integer> queryLimitField(String id, IModel<Integer> aModel)
     {
-        NumberTextField<Integer> queryLimit = new NumberTextField<>(id, aModel, Integer.class);
+        var queryLimit = new NumberTextField<Integer>(id, aModel, Integer.class);
         queryLimit.setOutputMarkupId(true);
         queryLimit.setRequired(true);
         queryLimit.setMinimum(KnowledgeBasePropertiesImpl.HARD_MIN_RESULTS);
@@ -115,8 +117,13 @@ public class QuerySettingsPanel
 
     private DropDownChoice<String> ftsField(String aId, String aProperty)
     {
-        DropDownChoice<String> ftsField = new DropDownChoice<>(aId, kbModel.bind(aProperty),
-                IriConstants.FTS_IRIS.stream().map(IRI::stringValue).collect(toList()));
+        var choices = IriConstants.FTS_IRIS.stream() //
+                .sorted(comparing(i -> getFtsBackendName(i.stringValue()))) //
+                .map(IRI::stringValue) //
+                .toList();
+
+        var ftsField = new DropDownChoice<String>(aId, kbModel.bind(aProperty), choices);
+        ftsField.setChoiceRenderer(new LambdaChoiceRenderer<>(IriConstants::getFtsBackendName));
         ftsField.setOutputMarkupId(true);
         ftsField.setNullValid(true);
         return ftsField;

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/wizard/KnowledgeBaseCreationWizard.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/wizard/KnowledgeBaseCreationWizard.java
@@ -17,7 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.ui.kb.project.wizard;
 
-import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_LUCENE;
+import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_RDF4J_LUCENE;
 import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_NONE;
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toMap;
@@ -161,7 +161,7 @@ public class KnowledgeBaseCreationWizard
                 // Local KBs are writeable by default
                 kbModel.getObject().getKb().setReadOnly(false);
                 // local KBs are always RDF4J + Lucene, so we can set the FTS mode accordingly
-                kbModel.getObject().getKb().setFullTextSearchIri(FTS_LUCENE.stringValue());
+                kbModel.getObject().getKb().setFullTextSearchIri(FTS_RDF4J_LUCENE.stringValue());
                 break;
             case REMOTE:
                 // Local KBs are read-only

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/wizard/KnowledgeBaseCreationWizard.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/wizard/KnowledgeBaseCreationWizard.java
@@ -17,8 +17,8 @@
  */
 package de.tudarmstadt.ukp.inception.ui.kb.project.wizard;
 
-import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_RDF4J_LUCENE;
 import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_NONE;
+import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_RDF4J_LUCENE;
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toMap;
 

--- a/inception/inception-ui-kb/src/main/resources/META-INF/asciidoc/user-guide/projects_knowledge-base.adoc
+++ b/inception/inception-ui-kb/src/main/resources/META-INF/asciidoc/user-guide/projects_knowledge-base.adoc
@@ -259,15 +259,20 @@ NOTE: Not all remote SPARQL knowledge bases may support additional matching prop
  
 === Full text search
 
-Full text search in knowledge bases enables searching for entities by their textual context, e.g. their label. This is a prerequisite for some advanced features such as re-ranking linking candidates during entity linking. Two full text search modes are supported:
+Full text search in knowledge bases enables searching for entities by their textual context, e.g. their label. This is a prerequisite for some advanced features such as re-ranking linking candidates during entity linking. 
 
-* `http://www.openrdf.org/contrib/lucenesail#matches`: use with local knowledge bases or possibly with remote knowledge bases using the link:https://rdf4j.org/documentation/programming/lucene/[RDF4J Lucene SAIL].
-* `bif:contains`: use with remote link:https://virtuoso.openlinksw.com[Virtuoso SPARQL] endpoints.
-* `http://www.bigdata.com/rdf/search#search`: use with remote link:https://blazegraph.com[Blazegraph] endpoints.
-* `text:query`: use with remote link:https://jena.apache.org/documentation/fuseki2/[Apache Jena Fuseki] SPARQL endpoints.
-* `tag:stardog:api:search:textMatch`: use with link:https://www.stardog.com[Stardog].
-* `https://www.mediawiki.org/ontology#API/`: use with the link:https://www.wikidata.org/wiki/Wikidata:SPARQL_query_service/queries[official Wikidata SPARQL endpoint].
-* `FTS:NONE`: use if there is no full text search support in the triple store - this will be very slow in particular for large KBs.
+Unfortunately, the SPARQL standard does not define a uniform way to perform full text searches. {product-name} offers support for full text search in a broad range of backend servers supporting the SPARQL protocol.
+
+.Supported full text search backends
+* link:https://franz.com/agraph/support/documentation/current/text-index.html[AllegroGraph]
+* link:https://jena.apache.org/documentation/query/text-query.html[Apache Jena Fuseki]
+* link:https://github.com/blazegraph/database/wiki/FullTextSearch[Blazegraph DB]
+* link:https://rdf4j.org/documentation/programming/lucene/[RDF4J Lucene]
+* link:https://docs.stardog.com/query-stardog/full-text-search[Stardog]
+* link:https://docs.openlinksw.com/virtuoso/rdfsparqlrulefulltext/[Virtuoso]
+* link:https://www.mediawiki.org/wiki/Wikidata_Query_Service/User_Manual/MWAPI[Wikidata (MediaWiki API Query Service EntitySearch)]
+
+If you select an FTS support that does not match the SPARQL server you are connecting to, you will likely get errors. If you are not sure, select **Unknown** to fall back to using standard SPARQL operations only - this will be very slow though and unviable for larger knowledge bases.
 
 ==== Apache Jena Fuseki
 


### PR DESCRIPTION
**What's in the PR**
- Added FTS support for AllegroGraph
- Added test suite for AllegroGraph
- Clean up a bit

**How to test manually**
1. Set up a SPARQL KB with endpoint `https://query.wikibus.org/query` (IRI schema RDF)
2. Configure the AllegroGraph FTS support
3. Set up a layer property to use that KB (for example instances-only)
4. Try finding an instance in annotated (type "Yutong")

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
