### PR TITLE
#4578 - Error in document metadata sidebar when document has not yet been upgraded to new layers

### DIFF
--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationSelectionPanel.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationSelectionPanel.java
@@ -40,6 +40,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.uima.UIMAException;
 import org.apache.uima.cas.CAS;
+import org.apache.uima.cas.Type;
 import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.Component;
 import org.apache.wicket.Session;
@@ -478,7 +479,16 @@ public class DocumentMetadataAnnotationSelectionPanel
         var renderer = layerSupport.createRenderer(aLayer,
                 () -> annotationService.listAnnotationFeature(aLayer));
 
-        for (var fs : cas.select(adapter.getAnnotationType(cas))) {
+        Type type;
+        try {
+            type = adapter.getAnnotationType(cas);
+        }
+        catch (IllegalArgumentException e) {
+            // CAS probably has not been upgraded to contain the type - ignore
+            return;
+        }
+
+        for (var fs : cas.select(type)) {
             var renderedFeatures = renderer.renderLabelFeatureValues(adapter, fs, features);
             var labelText = TypeUtil.getUiLabelText(renderedFeatures);
             items.add(new AnnotationListItem(VID.of(fs), labelText, aLayer, singleton, 0.0d));


### PR DESCRIPTION
**What's in the PR**
- Skip listing annottions for layers that do not exist in the CAS yet

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
