### PR TITLE
#4587 - Annotations are misaligned when PDF pages vary in dimensions

### DIFF
--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/render/renderSpan.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/render/renderSpan.ts
@@ -32,7 +32,9 @@ export function mapToDocumentCoordinates (aRectangles: Rectangle[]): Rectangle[]
     const pageTopY = pageContainer.offsetTop / scale + paddingTop + marginBetweenPages
     let leftOffset = 0
 
-    if (firstPageElement.clientWidth > pageContainer.clientWidth) {
+    // If the pages are not rendered left-aligned because one is wider than the other, we need
+    // to adjust the position of the rectangle on the X-axis
+    if (firstPageElement.clientWidth != pageContainer.clientWidth) {
       const firstContainerStyle = getComputedStyle(firstPageElement)
       const firstPageLeft = parseInt(firstContainerStyle.marginLeft) + parseInt(firstContainerStyle.borderLeftWidth)
       const currentPageStyle = getComputedStyle(pageContainer)


### PR DESCRIPTION
**What's in the PR**
- Adjustment has to be made not only if first page is larger but also if first page is smaller than subsequent pages

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
