### PR TITLE
#4595 - Update apache reverse proxy docs to make Web Sockets work

### DIFF
--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/installation_ssl_apache.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/installation_ssl_apache.adoc
@@ -27,13 +27,12 @@ This assumes that you already have the following packages installed:
 * Apache Web Server
 * mod_proxy
 * mod_proxy_http
-* mod_wstunnel
 
 You can enable the two modules with
 
 [source,bash]
 ----
-$ a2enmod proxy proxy_http wstunnel
+$ a2enmod proxy proxy_http
 ----
 
 and check that they are enabled with

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/installation_ssl_apache.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/installation_ssl_apache.adoc
@@ -24,7 +24,7 @@ IMPORTANT: Make sure you have read the <<sect_reverse_proxy,general instructions
 
 This assumes that you already have the following packages installed:
 
-* Apache Web Server
+* Apache Web Server (tested with Apache/2.4.57 on Debian)
 * mod_proxy
 * mod_proxy_http
 

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/installation_ssl_apache.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/installation_ssl_apache.adoc
@@ -61,7 +61,7 @@ ProxyPreserveHost On
 
 ProxyPass /inception/ws ws://localhost:8080/inception/ws
 ProxyPass /inception http://localhost:8080/inception
-ProxyPassReverse /inception https://your.public.domain.name.com/inception
+ProxyPassReverse /inception http://localhost:8080/inception
 ----
 If you use Apache 2.4 without `mod_access_compat` exchange the `<Proxy> … </Proxy>` section from the above example with this:
 +

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/installation_ssl_apache.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/installation_ssl_apache.adoc
@@ -59,8 +59,7 @@ ProxyPreserveHost On
   RequestHeader set "X-Forwarded-SSL" expr=%{HTTPS}
 </Location>
 
-ProxyPass /inception/ws ws://localhost:8080/inception/ws
-ProxyPass /inception http://localhost:8080/inception
+ProxyPass /inception http://localhost:8080/inception upgrade=websocket
 ProxyPassReverse /inception http://localhost:8080/inception
 ----
 If you use Apache 2.4 without `mod_access_compat` exchange the `<Proxy> … </Proxy>` section from the above example with this:

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/installation_ssl_apache.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/installation_ssl_apache.adoc
@@ -48,12 +48,6 @@ $ apachectl -M
 ----
 ProxyPreserveHost On
 
-<Proxy http://localhost/inception >
-  Order Deny,Allow
-  Deny from none
-  Allow from all
-</Proxy>
-
 <Location "/inception">
   RequestHeader set "X-Forwarded-Proto" expr=%{REQUEST_SCHEME}
   RequestHeader set "X-Forwarded-SSL" expr=%{HTTPS}
@@ -62,15 +56,6 @@ ProxyPreserveHost On
 ProxyPass /inception http://localhost:8080/inception upgrade=websocket
 ProxyPassReverse /inception http://localhost:8080/inception
 ----
-If you use Apache 2.4 without `mod_access_compat` exchange the `<Proxy> … </Proxy>` section from the above example with this:
-+
-[source,xml]
-----
-<Proxy http://localhost/inception >
-  require all granted
-</Proxy>
-----
-It is important to not mix both styles in any case throughout your configuration in order to avoid unforseen errors.
 
 * Enable the configuration with
 +


### PR DESCRIPTION
Closes #4595. Changes only documentation.

* Remove the `ProxyPass /inception/ws ws://localhost:8080/inception/ws` directive in favor of adding `upgrade=websocket` to the general `ProxyPass` directive (this allows us to remove the [deprecated `mod_proxy_wstunnel`](https://httpd.apache.org/docs/2.4/mod/mod_proxy_wstunnel.html) and corresponds to the [recommended alternative](https://httpd.apache.org/docs/2.4/mod/mod_proxy.html#wsupgrade))
* Add the tested Apache version
* Remove the `<Proxy>` section because it wasn't needed in my configuration and [seems to only be needed for ForwardProxies](https://httpd.apache.org/docs/2.4/mod/mod_proxy.html#examples)
* Use `ProxyPassReverse` with the same parameters as `ProxyPass` because I think that's how it is used (also corresponds to the [basic example](https://httpd.apache.org/docs/2.4/mod/mod_proxy.html#examples))

I am not 100% certain about the last two points. I have always configured my systems in the way this PR suggests, because I think it is the correct one, but if you know better, please let me know and I'll adjust that (in this PR and my systems :D). I'd in this case probably also add an explanatory comment somewhere.