### PR TITLE
#4602 - Project-specific user preferences may be saved without a user

### DIFF
--- a/inception/inception-preferences/src/main/java/de/tudarmstadt/ukp/inception/preferences/PreferencesServiceImpl.java
+++ b/inception/inception-preferences/src/main/java/de/tudarmstadt/ukp/inception/preferences/PreferencesServiceImpl.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.inception.preferences;
 
 import static de.tudarmstadt.ukp.inception.support.json.JSONUtil.toJsonString;
+import static java.util.Objects.requireNonNull;
 
 import java.io.IOException;
 import java.util.LinkedHashMap;
@@ -64,11 +65,14 @@ public class PreferencesServiceImpl
     @Transactional
     public <T> T loadTraitsForUser(Key<T> aKey, User aUser)
     {
+        requireNonNull(aKey, "Parameter [key] must be specified");
+        requireNonNull(aUser, "Parameter [user] must be specified");
+
         try {
-            Optional<UserPreference> preference = getRawUserPreference(aKey, aUser);
+            var preference = getRawUserPreference(aKey, aUser);
             if (preference.isPresent()) {
-                String json = preference.get().getTraits();
-                T result = JSONUtil.fromJsonString(aKey.getTraitClass(), json);
+                var json = preference.get().getTraits();
+                var result = JSONUtil.fromJsonString(aKey.getTraitClass(), json);
                 LOG.debug("Loaded preferences for key {} and user {}: [{}]", aKey, aUser, result);
                 return result;
             }
@@ -87,9 +91,12 @@ public class PreferencesServiceImpl
     @Transactional
     public <T> void saveTraitsForUser(Key<T> aKey, User aUser, T aTraits)
     {
+        requireNonNull(aKey, "Parameter [key] must be specified");
+        requireNonNull(aUser, "Parameter [user] must be specified");
+        requireNonNull(aTraits, "Parameter [traits] must be specified");
+
         try {
-            UserPreference preference = getRawUserPreference(aKey, aUser)
-                    .orElseGet(UserPreference::new);
+            var preference = getRawUserPreference(aKey, aUser).orElseGet(UserPreference::new);
             preference.setUser(aUser);
             preference.setName(aKey.getName());
             preference.setTraits(toJsonString(aTraits));
@@ -104,6 +111,9 @@ public class PreferencesServiceImpl
 
     private <T> Optional<UserPreference> getRawUserPreference(Key<T> aKey, User aUser)
     {
+        requireNonNull(aKey, "Parameter [key] must be specified");
+        requireNonNull(aUser, "Parameter [user] must be specified");
+
         var query = String.join("\n", //
                 "FROM UserPreference ", //
                 "WHERE user = :user ", //
@@ -149,6 +159,10 @@ public class PreferencesServiceImpl
     @Transactional
     public <T> T loadTraitsForUserAndProject(Key<T> aKey, User aUser, Project aProject)
     {
+        requireNonNull(aKey, "Parameter [key] must be specified");
+        requireNonNull(aUser, "Parameter [user] must be specified");
+        requireNonNull(aProject, "Parameter [project] must be specified");
+
         try {
             var pref = getUserProjectPreference(aKey, aUser, aProject);
             if (pref.isPresent()) {
@@ -173,8 +187,13 @@ public class PreferencesServiceImpl
     public <T> void saveTraitsForUserAndProject(Key<T> aKey, User aUser, Project aProject,
             T aTraits)
     {
+        requireNonNull(aKey, "Parameter [key] must be specified");
+        requireNonNull(aUser, "Parameter [user] must be specified");
+        requireNonNull(aProject, "Parameter [project] must be specified");
+        requireNonNull(aTraits, "Parameter [traits] must be specified");
+
         try {
-            UserProjectPreference preference = getUserProjectPreference(aKey, aUser, aProject)
+            var preference = getUserProjectPreference(aKey, aUser, aProject)
                     .orElseGet(UserProjectPreference::new);
             preference.setUser(aUser);
             preference.setProject(aProject);
@@ -193,14 +212,18 @@ public class PreferencesServiceImpl
     private <T> Optional<UserProjectPreference> getUserProjectPreference(Key<T> aKey, User aUser,
             Project aProject)
     {
-        String query = String.join("\n", //
+        requireNonNull(aKey, "Parameter [key] must be specified");
+        requireNonNull(aUser, "Parameter [user] must be specified");
+        requireNonNull(aProject, "Parameter [project] must be specified");
+
+        var query = String.join("\n", //
                 "FROM UserProjectPreference ", //
                 "WHERE user = :user", //
                 "AND project = :project", //
                 "AND name = :name");
 
         try {
-            UserProjectPreference pref = entityManager //
+            var pref = entityManager //
                     .createQuery(query, UserProjectPreference.class) //
                     .setParameter("user", aUser) //
                     .setParameter("project", aProject) //
@@ -218,6 +241,8 @@ public class PreferencesServiceImpl
     @Transactional
     public List<UserProjectPreference> listUserPreferencesForProject(Project aProject)
     {
+        requireNonNull(aProject, "Parameter [project] must be specified");
+
         String query = String.join("\n", //
                 "FROM UserProjectPreference ", //
                 "WHERE project = :project");
@@ -232,6 +257,8 @@ public class PreferencesServiceImpl
     @Transactional
     public void saveUserProjectPreference(UserProjectPreference aPreference)
     {
+        requireNonNull(aPreference, "Parameter [preference] must be specified");
+
         entityManager.persist(aPreference);
     }
 
@@ -239,11 +266,14 @@ public class PreferencesServiceImpl
     @Transactional
     public <T> T loadDefaultTraitsForProject(Key<T> aKey, Project aProject)
     {
+        requireNonNull(aKey, "Parameter [key] must be specified");
+        requireNonNull(aProject, "Parameter [project] must be specified");
+
         try {
-            Optional<DefaultProjectPreference> pref = getDefaultProjectPreference(aKey, aProject);
+            var pref = getDefaultProjectPreference(aKey, aProject);
             if (pref.isPresent()) {
-                String json = pref.get().getTraits();
-                T result = JSONUtil.fromJsonString(aKey.getTraitClass(), json);
+                var json = pref.get().getTraits();
+                var result = JSONUtil.fromJsonString(aKey.getTraitClass(), json);
                 LOG.debug("Loaded default preferences for key {} and project {}: [{}]", aKey,
                         aProject, result);
                 return result;
@@ -263,8 +293,11 @@ public class PreferencesServiceImpl
     @Transactional
     public <T> void saveDefaultTraitsForProject(Key<T> aKey, Project aProject, T aTraits)
     {
+        requireNonNull(aKey, "Parameter [key] must be specified");
+        requireNonNull(aProject, "Parameter [project] must be specified");
+
         try {
-            DefaultProjectPreference preference = getDefaultProjectPreference(aKey, aProject)
+            var preference = getDefaultProjectPreference(aKey, aProject)
                     .orElseGet(DefaultProjectPreference::new);
             preference.setProject(aProject);
             preference.setName(aKey.getName());
@@ -282,7 +315,10 @@ public class PreferencesServiceImpl
     @Override
     public <T> void clearDefaultTraitsForProject(Key<T> aKey, Project aProject)
     {
-        String query = String.join("\n", //
+        requireNonNull(aKey, "Parameter [key] must be specified");
+        requireNonNull(aProject, "Parameter [project] must be specified");
+
+        var query = String.join("\n", //
                 "DELETE DefaultProjectPreference ", //
                 "WHERE project = :project", //
                 "AND name = :name");
@@ -296,13 +332,16 @@ public class PreferencesServiceImpl
     private <T> Optional<DefaultProjectPreference> getDefaultProjectPreference(Key<T> aKey,
             Project aProject)
     {
-        String query = String.join("\n", //
+        requireNonNull(aKey, "Parameter [key] must be specified");
+        requireNonNull(aProject, "Parameter [project] must be specified");
+
+        var query = String.join("\n", //
                 "FROM DefaultProjectPreference ", //
                 "WHERE project = :project", //
                 "AND name = :name");
 
         try {
-            DefaultProjectPreference pref = entityManager //
+            var pref = entityManager //
                     .createQuery(query, DefaultProjectPreference.class) //
                     .setParameter("project", aProject) //
                     .setParameter("name", aKey.getName()) //
@@ -319,7 +358,9 @@ public class PreferencesServiceImpl
     @Transactional
     public List<DefaultProjectPreference> listDefaultTraitsForProject(Project aProject)
     {
-        String query = String.join("\n", //
+        requireNonNull(aProject, "Parameter [project] must be specified");
+
+        var query = String.join("\n", //
                 "FROM DefaultProjectPreference ", //
                 "WHERE project = :project");
 
@@ -333,26 +374,31 @@ public class PreferencesServiceImpl
     @Transactional
     public void saveDefaultProjectPreference(DefaultProjectPreference aPreference)
     {
+        requireNonNull(aPreference, "Parameter [preference] must be specified");
+
         entityManager.persist(aPreference);
     }
 
     /*
      * Use default constructor of aClass to create new instance of T
      */
+    @SuppressWarnings("unchecked")
     private <T> T buildDefault(Class<T> aClass)
     {
+        requireNonNull(aClass, "Parameter [class] must be specified");
+
         try {
             return aClass.getConstructor().newInstance();
         }
         catch (NoSuchMethodException e) {
             if (Map.class.isAssignableFrom(aClass)) {
-                return (T) new LinkedHashMap();
+                return (T) new LinkedHashMap<>();
             }
 
-            return ExceptionUtils.rethrow(e);
+            return ExceptionUtils.wrapAndThrow(e);
         }
         catch (Exception e) {
-            return ExceptionUtils.rethrow(e);
+            return ExceptionUtils.wrapAndThrow(e);
         }
     }
 }

--- a/inception/inception-preferences/src/main/java/de/tudarmstadt/ukp/inception/preferences/exporter/DefaultProjectPreferencesExporter.java
+++ b/inception/inception-preferences/src/main/java/de/tudarmstadt/ukp/inception/preferences/exporter/DefaultProjectPreferencesExporter.java
@@ -19,7 +19,6 @@ package de.tudarmstadt.ukp.inception.preferences.exporter;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.zip.ZipFile;
 
 import org.slf4j.Logger;
@@ -61,12 +60,11 @@ public class DefaultProjectPreferencesExporter
     public void exportData(FullProjectExportRequest aRequest, ProjectExportTaskMonitor aMonitor,
             ExportedProject aExProject, File aFile)
     {
-        Project project = aRequest.getProject();
+        var project = aRequest.getProject();
 
-        List<ExportedDefaultProjectPreference> exportedDefaultPreferences = new ArrayList<>();
-        for (DefaultProjectPreference defaultPreference : preferencesService
-                .listDefaultTraitsForProject(project)) {
-            ExportedDefaultProjectPreference exportedDefaultPreference = new ExportedDefaultProjectPreference();
+        var exportedDefaultPreferences = new ArrayList<>();
+        for (var defaultPreference : preferencesService.listDefaultTraitsForProject(project)) {
+            var exportedDefaultPreference = new ExportedDefaultProjectPreference();
             exportedDefaultPreference.setName(defaultPreference.getName());
             exportedDefaultPreference.setTraits(defaultPreference.getTraits());
             exportedDefaultPreferences.add(exportedDefaultPreference);
@@ -81,11 +79,11 @@ public class DefaultProjectPreferencesExporter
     public void importData(ProjectImportRequest aRequest, Project aProject,
             ExportedProject aExProject, ZipFile aZip)
     {
-        ExportedDefaultProjectPreference[] exportedDefaultPreferences = aExProject
-                .getArrayProperty(KEY, ExportedDefaultProjectPreference.class);
+        var exportedDefaultPreferences = aExProject.getArrayProperty(KEY,
+                ExportedDefaultProjectPreference.class);
 
-        for (ExportedDefaultProjectPreference exportedDefaultPreference : exportedDefaultPreferences) {
-            DefaultProjectPreference defaultPreference = new DefaultProjectPreference();
+        for (var exportedDefaultPreference : exportedDefaultPreferences) {
+            var defaultPreference = new DefaultProjectPreference();
             defaultPreference.setProject(aProject);
             defaultPreference.setName(exportedDefaultPreference.getName());
             defaultPreference.setTraits(exportedDefaultPreference.getTraits());

--- a/inception/inception-preferences/src/main/java/de/tudarmstadt/ukp/inception/preferences/exporter/UserProjectPreferencesExporter.java
+++ b/inception/inception-preferences/src/main/java/de/tudarmstadt/ukp/inception/preferences/exporter/UserProjectPreferencesExporter.java
@@ -36,7 +36,6 @@ import de.tudarmstadt.ukp.clarin.webanno.export.model.ExportedProject;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.project.exporters.ProjectPermissionsExporter;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
-import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.inception.preferences.PreferencesService;
 import de.tudarmstadt.ukp.inception.preferences.config.PreferencesServiceAutoConfig;
 import de.tudarmstadt.ukp.inception.preferences.model.UserProjectPreference;
@@ -74,12 +73,11 @@ public class UserProjectPreferencesExporter
     public void exportData(FullProjectExportRequest aRequest, ProjectExportTaskMonitor aMonitor,
             ExportedProject aExProject, File aFile)
     {
-        Project project = aRequest.getProject();
+        var project = aRequest.getProject();
 
-        List<ExportedUserProjectPreference> exportedDefaultPreferences = new ArrayList<>();
-        for (UserProjectPreference userPreference : preferencesService
-                .listUserPreferencesForProject(project)) {
-            ExportedUserProjectPreference exportedDefaultPreference = new ExportedUserProjectPreference();
+        var exportedDefaultPreferences = new ArrayList<ExportedUserProjectPreference>();
+        for (var userPreference : preferencesService.listUserPreferencesForProject(project)) {
+            var exportedDefaultPreference = new ExportedUserProjectPreference();
             exportedDefaultPreference.setUser(userPreference.getUser().getUsername());
             exportedDefaultPreference.setName(userPreference.getName());
             exportedDefaultPreference.setTraits(userPreference.getTraits());
@@ -95,19 +93,19 @@ public class UserProjectPreferencesExporter
     public void importData(ProjectImportRequest aRequest, Project aProject,
             ExportedProject aExProject, ZipFile aZip)
     {
-        ExportedUserProjectPreference[] exportedDefaultPreferences = aExProject
-                .getArrayProperty(KEY, ExportedUserProjectPreference.class);
+        var exportedDefaultPreferences = aExProject.getArrayProperty(KEY,
+                ExportedUserProjectPreference.class);
 
-        int importedPreferences = 0;
-        int missingUsers = 0;
-        for (ExportedUserProjectPreference exportedDefaultPreference : exportedDefaultPreferences) {
-            User user = userRepository.get(exportedDefaultPreference.getUser());
+        var importedPreferences = 0;
+        var missingUsers = 0;
+        for (var exportedDefaultPreference : exportedDefaultPreferences) {
+            var user = userRepository.get(exportedDefaultPreference.getUser());
             if (user == null) {
                 missingUsers++;
                 continue;
             }
 
-            UserProjectPreference userPreference = new UserProjectPreference();
+            var userPreference = new UserProjectPreference();
             userPreference.setProject(aProject);
             userPreference.setUser(user);
             userPreference.setName(exportedDefaultPreference.getName());

--- a/inception/inception-preferences/src/main/resources/de/tudarmstadt/ukp/inception/preferences/model/db-changelog.xml
+++ b/inception/inception-preferences/src/main/resources/de/tudarmstadt/ukp/inception/preferences/model/db-changelog.xml
@@ -115,4 +115,44 @@
       constraintName="UK_default_project_preference_name_project"
       tableName="default_project_preference" columnNames="project, name" />
   </changeSet>
+
+  <changeSet author="INCEpTION Team" id="20240307-1">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="user_project_preference" />
+      </not>
+    </preConditions>
+    <delete tableName="user_project_preference">
+      <where>user IS NULL</where>
+    </delete>
+    <delete tableName="user_project_preference">
+      <where>project IS NULL</where>
+    </delete>
+    <addNotNullConstraint tableName="user_project_preference" columnName="user" columnDataType="VARCHAR(255)"/>
+    <addNotNullConstraint tableName="user_project_preference" columnName="project" columnDataType="BIGINT"/>
+  </changeSet>
+
+  <changeSet author="INCEpTION Team" id="20240307-2">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="user_preference" />
+      </not>
+    </preConditions>
+    <delete tableName="user_project_preference">
+      <where>user IS NULL</where>
+    </delete>
+    <addNotNullConstraint tableName="user_preference" columnName="user" columnDataType="VARCHAR(255)"/>
+  </changeSet>
+
+  <changeSet author="INCEpTION Team" id="20240307-3">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="default_project_preference" />
+      </not>
+    </preConditions>
+    <delete tableName="user_project_preference">
+      <where>project IS NULL</where>
+    </delete>
+    <addNotNullConstraint tableName="default_project_preference" columnName="project" columnDataType="BIGINT"/>
+  </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
**What's in the PR**
- Add non-null constraints to user and project columns in the preferences tables
- Add null-checks to the Preferences service to be able to catch nulls early

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
