### PR TITLE
#4616 - Option to disable displaying suggestions in sidebar curation mode

### DIFF
--- a/inception/inception-active-learning/pom.xml
+++ b/inception/inception-active-learning/pom.xml
@@ -68,6 +68,10 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-preferences</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-support-bootstrap</artifactId>
     </dependency>
     <dependency>

--- a/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/config/ActiveLearningAutoConfiguration.java
+++ b/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/config/ActiveLearningAutoConfiguration.java
@@ -31,6 +31,7 @@ import de.tudarmstadt.ukp.inception.active.learning.log.ActiveLearningRecommenda
 import de.tudarmstadt.ukp.inception.active.learning.log.ActiveLearningSuggestionOfferedAdapter;
 import de.tudarmstadt.ukp.inception.active.learning.sidebar.ActiveLearningSidebarFactory;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
+import de.tudarmstadt.ukp.inception.preferences.PreferencesService;
 import de.tudarmstadt.ukp.inception.recommendation.api.LearningRecordService;
 import de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService;
 import de.tudarmstadt.ukp.inception.recommendation.config.RecommenderServiceAutoConfiguration;
@@ -73,7 +74,8 @@ public class ActiveLearningAutoConfiguration
 
     @Bean
     public ActiveLearningSidebarFactory activeLearningSidebarFactory(
-            RecommendationService aRecommendationService)
+            RecommendationService aRecommendationService, PreferencesService aPreferencesService,
+            UserDao aUserService)
     {
         return new ActiveLearningSidebarFactory(aRecommendationService);
     }

--- a/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.html
+++ b/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.html
@@ -26,6 +26,10 @@
       </div>
       <div class="scrolling card-body flex-v-container">
       
+        <span wicket:id="notAvailableNotice" class="flex-content no-data-notice">
+          <wicket:message key="notAvailableNotice"/>
+        </span>
+      
         <form wicket:id="sessionControlForm">
           <div class="input-group">
             <select class="form-select flex-content" wicket:id="selectLayer" data-container="body"/>

--- a/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.properties
+++ b/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.properties
@@ -23,3 +23,4 @@ delta=\u0394
 history=History
 session=Session
 activeLearning=Active Learning
+notAvailableNotice=Currently not available

--- a/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebarFactory.java
+++ b/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebarFactory.java
@@ -19,7 +19,6 @@ package de.tudarmstadt.ukp.inception.active.learning.sidebar;
 
 import org.apache.wicket.Component;
 import org.apache.wicket.model.IModel;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.Order;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasProvider;
@@ -44,7 +43,6 @@ public class ActiveLearningSidebarFactory
 {
     private final RecommendationService recommendationService;
 
-    @Autowired
     public ActiveLearningSidebarFactory(RecommendationService aRecommendationService)
     {
         recommendationService = aRecommendationService;

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/RecommendationService.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/RecommendationService.java
@@ -320,4 +320,13 @@ public interface RecommendationService
     boolean isSuspended(String aUser, Project aProject);
 
     void setSuspended(String aUser, Project aProject, boolean aState);
+
+    /**
+     * @return if the curation sidebar mode is available.
+     * @deprecated This obviously shouldn't be here, but this is the easiest way to access this
+     *             information from the recommender settings. Should be removed when the curation
+     *             sidebar leaves experimental mode.
+     */
+    @Deprecated
+    boolean isCurationSidebarEnabled();
 }

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/RecommenderGeneralSettings.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/RecommenderGeneralSettings.java
@@ -26,6 +26,10 @@ public class RecommenderGeneralSettings
 
     private boolean waitForRecommendersOnOpenDocument = false;
 
+    private boolean showRecommendationsWhenViewingOtherUser = true;
+
+    private boolean showRecommendationsWhenViewingCurationUser = true;
+
     public boolean isWaitForRecommendersOnOpenDocument()
     {
         return waitForRecommendersOnOpenDocument;
@@ -34,5 +38,27 @@ public class RecommenderGeneralSettings
     public void setWaitForRecommendersOnOpenDocument(boolean aWaitForRecommendersOnOpenDocument)
     {
         waitForRecommendersOnOpenDocument = aWaitForRecommendersOnOpenDocument;
+    }
+
+    public boolean isShowRecommendationsWhenViewingOtherUser()
+    {
+        return showRecommendationsWhenViewingOtherUser;
+    }
+
+    public void setShowRecommendationsWhenViewingOtherUser(
+            boolean aShowRecommendationsWhenViewingOtherUser)
+    {
+        showRecommendationsWhenViewingOtherUser = aShowRecommendationsWhenViewingOtherUser;
+    }
+
+    public boolean isShowRecommendationsWhenViewingCurationUser()
+    {
+        return showRecommendationsWhenViewingCurationUser;
+    }
+
+    public void setShowRecommendationsWhenViewingCurationUser(
+            boolean aShowRecommendationsWhenViewingCurationUser)
+    {
+        showRecommendationsWhenViewingCurationUser = aShowRecommendationsWhenViewingCurationUser;
     }
 }

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/config/RecommenderServiceAutoConfiguration.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/config/RecommenderServiceAutoConfiguration.java
@@ -145,7 +145,8 @@ public class RecommenderServiceAutoConfiguration
             havingValue = "true", matchIfMissing = true)
     @Bean
     public RecommendationSidebarFactory recommendationSidebarFactory(
-            RecommendationService aRecommendationService)
+            RecommendationService aRecommendationService, PreferencesService aPreferencesService,
+            UserDao aUserService)
     {
         return new RecommendationSidebarFactory(aRecommendationService);
     }
@@ -188,12 +189,13 @@ public class RecommenderServiceAutoConfiguration
     }
 
     @Bean
-    public RecommendationRenderer recommendationRenderer(AnnotationSchemaService aAnnotationService,
+    public RecommendationRenderer recommendationRenderer(
             RecommendationService aRecommendationService,
-            SuggestionSupportRegistry aSuggestionSupportRegistry)
+            SuggestionSupportRegistry aSuggestionSupportRegistry,
+            PreferencesService aPreferencesService, UserDao aUserService)
     {
-        return new RecommendationRenderer(aAnnotationService, aRecommendationService,
-                aSuggestionSupportRegistry);
+        return new RecommendationRenderer(aRecommendationService, aSuggestionSupportRegistry,
+                aPreferencesService, aUserService);
     }
 
     @Bean

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/event/RecommendersResumedEvent.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/event/RecommendersResumedEvent.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.event;
+
+import org.springframework.context.ApplicationEvent;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.inception.support.wicket.event.HybridApplicationUIEvent;
+
+public class RecommendersResumedEvent
+    extends ApplicationEvent
+    implements HybridApplicationUIEvent
+{
+    private static final long serialVersionUID = -4736560772442881663L;
+
+    private final Project project;
+    private final String sessionOwner;
+
+    public RecommendersResumedEvent(Object source, Project aProject, String aSessionOwner)
+    {
+        super(source);
+        project = aProject;
+        sessionOwner = aSessionOwner;
+    }
+
+    public Project getProject()
+    {
+        return project;
+    }
+
+    public String getUser()
+    {
+        return sessionOwner;
+    }
+}

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/event/RecommendersSuspendedEvent.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/event/RecommendersSuspendedEvent.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.event;
+
+import org.springframework.context.ApplicationEvent;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.inception.support.wicket.event.HybridApplicationUIEvent;
+
+public class RecommendersSuspendedEvent
+    extends ApplicationEvent
+    implements HybridApplicationUIEvent
+{
+    private static final long serialVersionUID = -4736560772442881663L;
+
+    private final Project project;
+    private final String sessionOwner;
+
+    public RecommendersSuspendedEvent(Object source, Project aProject, String aSessionOwner)
+    {
+        super(source);
+        project = aProject;
+        sessionOwner = aSessionOwner;
+    }
+
+    public Project getProject()
+    {
+        return project;
+    }
+
+    public String getUser()
+    {
+        return sessionOwner;
+    }
+}

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderListPanel.html
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderListPanel.html
@@ -25,33 +25,40 @@
         <div class="actions">
           <span class="dropdown" aria-haspopup="true" aria-expanded="false">
             <button class="btn btn-action btn-secondary dropdown-toggle flex-content" type="button" data-bs-toggle="dropdown">
-              <i class="fas fa-cog"></i>
+              <i class="fas fa-cog me-1"/><wicket:message key="settings"/>
             </button>
             <div class="dropdown-menu shadow-lg pt-0 pb-0" role="menu" style="min-width: 440px;">
               <form wicket:id="form" class="card">
                 <div class="card-body">
-                  <div class="row form-row" wicket:enclosure="waitForRecommendersOnOpenDocument">
-                    <div class="col-sm-12">
-                      <div class="form-check">
-                        <input wicket:id="waitForRecommendersOnOpenDocument" class="form-check-input" type="checkbox"/>
-                        <label wicket:for="waitForRecommendersOnOpenDocument">
-                          <wicket:message key="waitForRecommendersOnOpenDocument"/>
-                        </label>
-                      </div>
-                    </div>
+                  <div class="form-check form-switch" wicket:enclosure="waitForRecommendersOnOpenDocument">
+                    <input wicket:id="waitForRecommendersOnOpenDocument" class="form-check-input" type="checkbox"/>
+                    <label wicket:for="waitForRecommendersOnOpenDocument">
+                      <wicket:message key="waitForRecommendersOnOpenDocument"/>
+                    </label>
+                  </div>
+                  <div class="form-check form-switch" wicket:enclosure="showRecommendationsWhenViewingOtherUser">
+                    <input wicket:id="showRecommendationsWhenViewingOtherUser" class="form-check-input" type="checkbox"/>
+                    <label wicket:for="showRecommendationsWhenViewingOtherUser">
+                      <wicket:message key="showRecommendationsWhenViewingOtherUser"/>
+                    </label>
+                  </div>
+                  <div class="form-check form-switch" wicket:enclosure="showRecommendationsWhenViewingCurationUser">
+                    <input wicket:id="showRecommendationsWhenViewingCurationUser" class="form-check-input" type="checkbox"/>
+                    <label wicket:for="showRecommendationsWhenViewingCurationUser">
+                      <wicket:message key="showRecommendationsWhenViewingCurationUser"/>
+                    </label>
                   </div>
                 </div>
                 <div class="card-footer text-end">
                   <button wicket:id="save" class="btn btn-primary">
-                    <i class="fas fa-save"></i>&nbsp;
-                    <wicket:message key="save"/>
+                    <i class="fas fa-save me-2"/><wicket:message key="save"/>
                   </button> 
                 </div>
               </form>
             </div>
           </span>
           <button wicket:id="create" class="btn btn-primary">
-            <i class="fas fa-plus-square"></i>&nbsp;<wicket:message key="create"/>
+            <i class="fas fa-plus-square me-1"/><wicket:message key="create"/>
           </button>
         </div>
       </div>

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderListPanel.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderListPanel.java
@@ -75,16 +75,22 @@ public class RecommenderListPanel
         overviewList.add(new LambdaAjaxFormComponentUpdatingBehavior("change", this::onChange));
         add(overviewList);
 
-        LambdaAjaxLink lambdaAjaxLink = new LambdaAjaxLink(MID_CREATE_BUTTON, this::actionCreate);
+        var lambdaAjaxLink = new LambdaAjaxLink(MID_CREATE_BUTTON, this::actionCreate);
         lambdaAjaxLink.setVisible(showCreateButton);
         add(lambdaAjaxLink);
 
-        RecommenderGeneralSettings settings = preferencesService.loadDefaultTraitsForProject(
+        var settings = preferencesService.loadDefaultTraitsForProject(
                 KEY_RECOMMENDER_GENERAL_SETTINGS, projectModel.getObject());
 
         var form = new Form<>("form", CompoundPropertyModel.of(settings));
         form.setOutputMarkupId(true);
-        form.add(new CheckBox("waitForRecommendersOnOpenDocument").setOutputMarkupId(true));
+        form.add(new CheckBox("waitForRecommendersOnOpenDocument") //
+                .setOutputMarkupId(true));
+        form.add(new CheckBox("showRecommendationsWhenViewingOtherUser") //
+                .setOutputMarkupId(true));
+        form.add(new CheckBox("showRecommendationsWhenViewingCurationUser") //
+                .setOutputMarkupId(true) //
+                .setVisible(recommendationService.isCurationSidebarEnabled()));
         form.add(new LambdaAjaxButton<>("save", this::actionSaveSettings));
         add(form);
     }

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderListPanel.properties
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/project/RecommenderListPanel.properties
@@ -15,4 +15,7 @@
 # limitations under the License.
 
 recommenders=Recommenders
+settings=Settings
 waitForRecommendersOnOpenDocument=Wait for suggestions from non-trainable recommenders when opening document
+showRecommendationsWhenViewingOtherUser=Show suggestions when viewing annotations from another user
+showRecommendationsWhenViewingCurationUser=Show suggestions when viewing curation annotations

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/render/RecommendationRenderer.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/render/RecommendationRenderer.java
@@ -18,16 +18,20 @@
 package de.tudarmstadt.ukp.inception.recommendation.render;
 
 import static de.tudarmstadt.ukp.clarin.webanno.model.Mode.ANNOTATION;
+import static de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService.KEY_RECOMMENDER_GENERAL_SETTINGS;
 import static de.tudarmstadt.ukp.inception.recommendation.api.model.SuggestionDocumentGroup.groupByType;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.groupingBy;
 
 import java.util.HashMap;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.core.annotation.Order;
 
+import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
+import de.tudarmstadt.ukp.inception.preferences.PreferencesService;
 import de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService;
 import de.tudarmstadt.ukp.inception.recommendation.api.SuggestionSupport;
 import de.tudarmstadt.ukp.inception.recommendation.api.SuggestionSupportRegistry;
@@ -37,7 +41,6 @@ import de.tudarmstadt.ukp.inception.recommendation.config.RecommenderServiceAuto
 import de.tudarmstadt.ukp.inception.rendering.pipeline.RenderStep;
 import de.tudarmstadt.ukp.inception.rendering.request.RenderRequest;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VDocument;
-import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 
 /**
  * <p>
@@ -51,17 +54,19 @@ public class RecommendationRenderer
 {
     public static final String ID = "RecommendationRenderer";
 
-    private final AnnotationSchemaService annotationService;
     private final RecommendationService recommendationService;
     private final SuggestionSupportRegistry suggestionSupportRegistry;
+    private final PreferencesService preferencesService;
+    private final UserDao userService;
 
-    public RecommendationRenderer(AnnotationSchemaService aAnnotationService,
-            RecommendationService aRecommendationService,
-            SuggestionSupportRegistry aSuggestionSupportRegistry)
+    public RecommendationRenderer(RecommendationService aRecommendationService,
+            SuggestionSupportRegistry aSuggestionSupportRegistry,
+            PreferencesService aPreferencesService, UserDao aUserService)
     {
-        annotationService = aAnnotationService;
         recommendationService = aRecommendationService;
         suggestionSupportRegistry = aSuggestionSupportRegistry;
+        preferencesService = aPreferencesService;
+        userService = aUserService;
     }
 
     @Override
@@ -81,6 +86,21 @@ public class RecommendationRenderer
 
         // Do not show predictions on curation page
         if (state != null && state.getMode() != ANNOTATION) {
+            return false;
+        }
+
+        var prefs = preferencesService.loadDefaultTraitsForProject(KEY_RECOMMENDER_GENERAL_SETTINGS,
+                aRequest.getProject());
+
+        // Do not show predictions when viewing annotations of another user
+        if (!prefs.isShowRecommendationsWhenViewingOtherUser()
+                && !Objects.equals(aRequest.getAnnotationUser(), aRequest.getSessionOwner())) {
+            return false;
+        }
+
+        // Do not show predictions when viewing annotations of curation user
+        if (!prefs.isShowRecommendationsWhenViewingCurationUser()
+                && Objects.equals(aRequest.getAnnotationUser(), userService.getCurationUser())) {
             return false;
         }
 

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommendationSidebar.html
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommendationSidebar.html
@@ -77,16 +77,24 @@
           </span>
         </div>
       </div>
-      <div class="card-body flex-grow-0 d-flex flex-row justify-content-between">
-        <div class="form-check form-switch">
-          <input wicket:id="enabled" class="form-check-input" type="checkbox" role="switch">
-          <label class="form-check-label" wicket:for="enabled">Update suggestions</label>
-        </div>
-        <div wicket:id="progress"/>
-      </div>
-      <div class="scrolling card-body flex-v-container">
+      
+      <div class="card-body flex-v-container">
+        <span wicket:id="notAvailableNotice" class="flex-content no-data-notice">
+          <wicket:message key="notAvailableNotice"/>
+        </span>
         <span class="flex-content no-data-notice" wicket:id="noRecommendersLabel"></span>
-        <div wicket:id="recommenders" ></div>
+        <div wicket:id="mainContainer" class="flex-content flex-v-container">
+          <div class="flex-grow-0 d-flex flex-row justify-content-between">
+            <div class="form-check form-switch">
+              <input wicket:id="enabled" class="form-check-input" type="checkbox" role="switch">
+              <label class="form-check-label" wicket:for="enabled">Update suggestions</label>
+            </div>
+            <div wicket:id="progress"/>
+          </div>
+          <div class="scrolling flex-content">
+            <div wicket:id="recommenders" ></div>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommendationSidebar.properties
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommendationSidebar.properties
@@ -25,3 +25,4 @@ retrain=Retrain
 showLog=Log
 noRecommenders=None of the layers have any recommenders configured. Please set the recommenders first in the Project Settings.
 progressTowardsEvaluation=Progress towards next evaluation
+notAvailableNotice=Currently not available

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommendationSidebarFactory.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommendationSidebarFactory.java
@@ -22,8 +22,6 @@ import org.apache.wicket.model.IModel;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.Order;
 
-import de.agilecoders.wicket.core.markup.html.bootstrap.image.Icon;
-import de.agilecoders.wicket.extensions.markup.html.bootstrap.icon.FontAwesome5IconType;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasProvider;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.AnnotationPage;
@@ -68,7 +66,7 @@ public class RecommendationSidebarFactory
     @Override
     public Component createIcon(String aId, IModel<AnnotatorState> aState)
     {
-        return new Icon(aId, FontAwesome5IconType.chart_line_s);
+        return new RecommenderSidebarIcon(aId, aState);
     }
 
     @Override

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommenderSidebarIcon.html
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommenderSidebarIcon.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<!--
+  Licensed to the Technische Universität Darmstadt under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The Technische Universität Darmstadt 
+  licenses this file to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.
+   
+  http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<html xmlns:wicket="http://wicket.apache.org">
+<wicket:panel>
+  <span wicket:id="icon"/>
+  <span wicket:id="badge" class="icon-badge"/>
+</wicket:panel>
+</html>

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommenderSidebarIcon.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommenderSidebarIcon.java
@@ -15,9 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package de.tudarmstadt.ukp.inception.active.learning.sidebar;
-
-import static de.tudarmstadt.ukp.inception.active.learning.sidebar.ActiveLearningUserStateMetaData.CURRENT_AL_USER_STATE;
+package de.tudarmstadt.ukp.inception.recommendation.sidebar;
 
 import java.util.Set;
 
@@ -32,26 +30,26 @@ import de.agilecoders.wicket.core.markup.html.bootstrap.image.Icon;
 import de.agilecoders.wicket.core.markup.html.bootstrap.image.IconType;
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.icon.FontAwesome5IconType;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
-import de.tudarmstadt.ukp.inception.active.learning.ActiveLearningService;
-import de.tudarmstadt.ukp.inception.active.learning.event.ActiveLearningSessionCompletedEvent;
-import de.tudarmstadt.ukp.inception.active.learning.event.ActiveLearningSessionStartedEvent;
+import de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService;
+import de.tudarmstadt.ukp.inception.recommendation.event.RecommendersResumedEvent;
+import de.tudarmstadt.ukp.inception.recommendation.event.RecommendersSuspendedEvent;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
 
-public class ActiveLearningSidebarIcon
+public class RecommenderSidebarIcon
     extends Panel
 {
     private static final long serialVersionUID = -1870047500327624860L;
 
-    private @SpringBean ActiveLearningService activeLearningService;
+    private @SpringBean RecommendationService recommendationService;
     private @SpringBean UserDao userService;
 
-    public ActiveLearningSidebarIcon(String aId, IModel<AnnotatorState> aState)
+    public RecommenderSidebarIcon(String aId, IModel<AnnotatorState> aState)
     {
         super(aId, aState);
 
         setOutputMarkupId(true);
 
-        queue(new Icon("icon", FontAwesome5IconType.font_s));
+        queue(new Icon("icon", FontAwesome5IconType.robot_s));
         queue(new Icon("badge", LoadableDetachableModel.of(this::getStateIcon))
                 .add(new ClassAttributeModifier()
                 {
@@ -87,8 +85,8 @@ public class ActiveLearningSidebarIcon
 
     private boolean isSessionActive()
     {
-        var alState = getPage().getMetaData(CURRENT_AL_USER_STATE);
-        return alState != null && alState.isSessionActive();
+        return !recommendationService.isSuspended(userService.getCurrentUsername(),
+                getModelObject().getProject());
     }
 
     private IconType getStateIcon()
@@ -101,13 +99,13 @@ public class ActiveLearningSidebarIcon
     }
 
     @OnEvent
-    public void sessionStarted(ActiveLearningSessionStartedEvent aEvent)
+    public void sessionStarted(RecommendersSuspendedEvent aEvent)
     {
         aEvent.getRequestTarget().ifPresent(target -> target.add(this));
     }
 
     @OnEvent
-    public void sessionStarted(ActiveLearningSessionCompletedEvent aEvent)
+    public void sessionStarted(RecommendersResumedEvent aEvent)
     {
         aEvent.getRequestTarget().ifPresent(target -> target.add(this));
     }

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/TrainingTask.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/TrainingTask.java
@@ -245,10 +245,10 @@ public class TrainingTask
         schedulingService.enqueue(predictionTask);
     }
 
-    private void commitContext(User user, Recommender recommender, RecommenderContext ctx)
+    private void commitContext(User aSessionOwner, Recommender recommender, RecommenderContext ctx)
     {
         ctx.close();
-        recommenderService.putContext(user, recommender, ctx);
+        recommenderService.putContext(aSessionOwner, recommender, ctx);
     }
 
     private void logTrainingOverallEnd(long overallStartTime)
@@ -372,9 +372,10 @@ public class TrainingTask
 
     private void logTrainingOverallStart()
     {
-        LOG.debug("[{}][{}]: Starting training for project {} triggered by [{}]...", getId(),
-                getSessionOwner().getUsername(), getProject(), getTrigger());
-        info("Starting training triggered by [%s]...", getTrigger());
+        LOG.debug(
+                "[{}][{}]: Starting training for project {} on data from [{}] triggered by [{}]...",
+                getId(), getSessionOwner().getUsername(), getProject(), dataOwner, getTrigger());
+        info("Starting training on data from [%s] triggered by [%s]...", dataOwner, getTrigger());
     }
 
     private void logTrainingRecommenderStart(LazyCasLoader aLoader, Recommender recommender,

--- a/inception/inception-recommendation/src/main/resources/META-INF/asciidoc/user-guide/projects_recommendation.adoc
+++ b/inception/inception-recommendation/src/main/resources/META-INF/asciidoc/user-guide/projects_recommendation.adoc
@@ -41,6 +41,9 @@ performed some action such as creating an annotation.
 NOTE: Enable this option only if all of your non-trainable recommenders have a fast response time,
       as otherwise your users may complain about a long delay when opening documents.
 
+The option **show suggestions when viewing annotations from another user** configures whether to display annotation
+suggestions when viewing annotations from another user (e.g. as project manager, you can select to view annotations from
+any annotator in the open document dialog).
 
 == Per-recommender settings
 

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/sidebar/SidebarPanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/sidebar/SidebarPanel.java
@@ -101,16 +101,15 @@ public class SidebarPanel
 
     private List<SidebarTab> makeTabs()
     {
-        List<SidebarTab> tabs = new ArrayList<>();
-        for (AnnotationSidebarFactory factory : sidebarRegistry.getSidebarFactories()) {
+        var tabs = new ArrayList<SidebarTab>();
+        for (var factory : sidebarRegistry.getSidebarFactories()) {
 
             if (!factory.applies(stateModel.getObject())) {
                 continue;
             }
 
-            String factoryId = factory.getBeanName();
-            SidebarTab tab = new SidebarTab(Model.of(factory.getDisplayName()),
-                    factory.getBeanName())
+            var factoryId = factory.getBeanName();
+            var tab = new SidebarTab(Model.of(factory.getDisplayName()), factory.getBeanName())
             {
                 private static final long serialVersionUID = 2144644282070158783L;
 

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/sidebar/SidebarTab.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/sidebar/SidebarTab.java
@@ -20,7 +20,6 @@ package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar;
 import org.apache.wicket.Component;
 import org.apache.wicket.extensions.markup.html.tabs.AbstractTab;
 import org.apache.wicket.model.IModel;
-import org.springframework.context.ApplicationContext;
 
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
 import de.tudarmstadt.ukp.inception.support.spring.ApplicationContextProvider;
@@ -49,13 +48,12 @@ public abstract class SidebarTab
             // We need to get the methods and services directly in here so
             // that the lambda doesn't have a dependency on the non-serializable
             // AnnotationSidebarFactory class.
-            ApplicationContext ctx = ApplicationContextProvider.getApplicationContext();
+            var ctx = ApplicationContextProvider.getApplicationContext();
             return ctx.getBean(AnnotationSidebarRegistry.class).getSidebarFactory(factoryId)
                     .createIcon(aId, aState);
         }
         catch (Exception e) {
             throw new RuntimeException(e);
         }
-
     }
 }

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/sidebar/SidebarTabbedPanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/sidebar/SidebarTabbedPanel.java
@@ -37,7 +37,6 @@ import org.apache.wicket.spring.injection.annot.SpringBean;
 
 import de.agilecoders.wicket.core.markup.html.bootstrap.image.Icon;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
-import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.inception.preferences.Key;
 import de.tudarmstadt.ukp.inception.preferences.PreferencesService;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
@@ -69,7 +68,7 @@ public class SidebarTabbedPanel<T extends SidebarTab>
         setOutputMarkupId(true);
         setVisible(!aTabs.isEmpty());
 
-        LambdaAjaxLink showHideLink = new LambdaAjaxLink("showHideLink", this::showHideAction);
+        var showHideLink = new LambdaAjaxLink("showHideLink", this::showHideAction);
 
         showHideLink.add(new Icon("showHideIcon",
                 LoadableDetachableModel.of(() -> isExpanded() ? chevron_left_s : chevron_right_s)));
@@ -121,7 +120,7 @@ public class SidebarTabbedPanel<T extends SidebarTab>
         var sidebarState = new AnnotationSidebarState();
         sidebarState.setSelectedTab(getTabs().get(getSelectedTab()).getFactoryId());
         sidebarState.setExpanded(expanded);
-        User user = userService.getCurrentUser();
+        var user = userService.getCurrentUser();
         prefService.saveTraitsForUserAndProject(KEY_SIDEBAR_STATE, user,
                 state.getObject().getProject(), sidebarState);
     }
@@ -145,8 +144,8 @@ public class SidebarTabbedPanel<T extends SidebarTab>
     @Override
     protected Component newTitle(String aTitleId, IModel<?> aTitleModel, int aIndex)
     {
-        SidebarTab tab = getTabs().get(aIndex);
-        Component icon = tab.getIcon("icon", state);
+        var tab = getTabs().get(aIndex);
+        var icon = tab.getIcon("icon", state);
         icon.add(new AttributeModifier("title", aTitleModel));
         return icon;
     }


### PR DESCRIPTION
**What's in the PR**
- Added options in the project settings to enable/disable displaying suggestions when in curation mode or when looking at annotations from other users
- Added a status badge to the icon of the recommender sidebar
- Switch icons of the recommedner sidebar and active learning sidebar
- Disable recommender and active learning sidebar when recommenders are disabled in curation mode etc.

**How to test manually**
* Use the options in the project settings
* Try their effect on the annotation page

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
