### PR TITLE
#4622 - No helpful error message when recommender is not called due to feature being disabled

### DIFF
--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/TrainingTask.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/TrainingTask.java
@@ -258,6 +258,8 @@ public class TrainingTask
 
     private void logUnsupportedRecommenderType(Recommender aRecommender)
     {
+        warn("Recommender [%s] uses unsupported tool [%s] - skipping", aRecommender.getName(),
+                aRecommender.getTool());
         LOG.warn("[{}][{}]: No factory found - skipping recommender",
                 getSessionOwner().getUsername(), aRecommender.getName());
     }
@@ -270,18 +272,22 @@ public class TrainingTask
 
     private void logRecommenderDisabled(Recommender aRecommender)
     {
-        LOG.debug("[{}][{}][{}]: Recommenderdisabled - skipping", getSessionOwner().getUsername(),
+        LOG.debug("[{}][{}][{}]: Recommender disabled - skipping", getSessionOwner().getUsername(),
                 getId(), aRecommender.getName());
     }
 
     private void logLayerDisabled(Recommender aRecommender)
     {
+        warn("Recommender [%s] uses disabled layer [%s] disabled - skipping recommender.",
+                aRecommender.getName(), aRecommender.getLayer().getUiName());
         LOG.debug("[{}][{}][{}]: Layer disabled - skipping", getSessionOwner().getUsername(),
                 getId(), aRecommender.getLayer().getUiName());
     }
 
     private void logFeatureDisabled(Recommender aRecommender)
     {
+        warn("Recommender [%s] uses disabled feature [%s] - skipping recommender.",
+                aRecommender.getName(), aRecommender.getFeature().getUiName());
         LOG.debug("[{}][{}][{}]: Feature disabled - skipping", getSessionOwner().getUsername(),
                 getId(), aRecommender.getFeature().getUiName());
     }


### PR DESCRIPTION
**What's in the PR**
- Issue warnings in the log in cases where the user may be surprised that the recommender is not running or where the recommender may be misconfigured

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
