### PR TITLE
#4614 - Display suggestions from Named Entity Linker immediately

### DIFF
--- a/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/recommender/NamedEntityLinker.java
+++ b/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/recommender/NamedEntityLinker.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.uima.cas.CAS;
@@ -139,9 +138,9 @@ public class NamedEntityLinker
         Feature predictedFeature = getPredictedFeature(aCas);
         Feature isPredictionFeature = getIsPredictionFeature(aCas);
 
-        for (KBHandle prediction : handles.stream().limit(recommender.getMaxRecommendations())
-                .collect(Collectors.toList())) {
-            AnnotationFS annotation = aCas.createAnnotation(predictedType, aBegin, aEnd);
+        for (var prediction : handles.stream().limit(recommender.getMaxRecommendations())
+                .toList()) {
+            var annotation = aCas.createAnnotation(predictedType, aBegin, aEnd);
             annotation.setStringValue(predictedFeature, prediction.getIdentifier());
             annotation.setBooleanValue(isPredictionFeature, true);
             aCas.addFsToIndexes(annotation);
@@ -164,7 +163,7 @@ public class NamedEntityLinker
     @Override
     public EvaluationResult evaluate(List<CAS> aCasses, DataSplitter aDataSplitter)
     {
-        EvaluationResult result = new EvaluationResult();
+        var result = new EvaluationResult();
         result.setEvaluationSkipped(true);
         result.setErrorMsg("NamedEntityLinker does not support evaluation.");
         return result;

--- a/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/recommender/NamedEntityLinkerFactory.java
+++ b/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/recommender/NamedEntityLinkerFactory.java
@@ -73,6 +73,12 @@ public class NamedEntityLinkerFactory
     }
 
     @Override
+    public boolean isSynchronous()
+    {
+        return true;
+    }
+
+    @Override
     public RecommendationEngine build(Recommender aRecommender)
     {
         NamedEntityLinkerTraits linkerTraits = readTraits(aRecommender);

--- a/inception/inception-imls-ollama/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/ollama/client/OllamaGenerateRequest.java
+++ b/inception/inception-imls-ollama/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/ollama/client/OllamaGenerateRequest.java
@@ -150,41 +150,41 @@ public class OllamaGenerateRequest
 
         public Builder withModel(String aModel)
         {
-            this.model = aModel;
+            model = aModel;
             return this;
         }
 
         public Builder withPrompt(String aPrompt)
         {
-            this.prompt = aPrompt;
+            prompt = aPrompt;
             return this;
         }
 
         public Builder withFormat(OllamaGenerateResponseFormat aFormat)
         {
-            this.format = aFormat;
+            format = aFormat;
             return this;
         }
 
         public Builder withStream(boolean aStream)
         {
-            this.stream = aStream;
+            stream = aStream;
             return this;
         }
 
         public Builder withRaw(boolean aRaw)
         {
-            this.raw = aRaw;
+            raw = aRaw;
             return this;
         }
 
         public <T> Builder withOption(Option<T> aOption, T aValue)
         {
             if (aValue != null) {
-                this.options.put(aOption.getName(), aValue);
+                options.put(aOption.getName(), aValue);
             }
             else {
-                this.options.remove(aOption.getName());
+                options.remove(aOption.getName());
             }
             return this;
         }

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/RecommendationService.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/RecommendationService.java
@@ -138,6 +138,8 @@ public interface RecommendationService
      */
     boolean switchPredictions(String aSessionOwner, Project aProject);
 
+    boolean forceSwitchPredictions(String aSessionOwner, Project aProject);
+
     /**
      * Returns the {@code RecommenderContext} for the given recommender if it exists.
      *

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/event/PredictionsSwitchedEvent.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/event/PredictionsSwitchedEvent.java
@@ -20,7 +20,6 @@ package de.tudarmstadt.ukp.inception.recommendation.api.event;
 import org.springframework.context.ApplicationEvent;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
-import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
 import de.tudarmstadt.ukp.inception.support.wicket.event.HybridApplicationUIEvent;
 
 public class PredictionsSwitchedEvent
@@ -29,25 +28,20 @@ public class PredictionsSwitchedEvent
 {
     private static final long serialVersionUID = 3072280760236986642L;
 
-    private final AnnotatorState state;
     private final String sessionOwner;
+    private final SourceDocument document;
 
-    public PredictionsSwitchedEvent(Object aSource, String aSessionOwner, AnnotatorState aState)
+    public PredictionsSwitchedEvent(Object aSource, String aSessionOwner, SourceDocument aDocument)
     {
         super(aSource);
-        state = aState;
         sessionOwner = aSessionOwner;
-    }
-
-    public AnnotatorState getState()
-    {
-        return state;
+        document = aDocument;
     }
 
     @Override
     public SourceDocument getDocument()
     {
-        return state.getDocument();
+        return document;
     }
 
     @Override

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/recommender/RecommendationEngineFactory.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/recommender/RecommendationEngineFactory.java
@@ -35,6 +35,11 @@ public interface RecommendationEngineFactory<T>
      */
     boolean isDeprecated();
 
+    default boolean isSynchronous()
+    {
+        return false;
+    }
+
     default boolean isEvaluable()
     {
         return true;

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/recommender/RecommendationEngineFactoryImplBase.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/recommender/RecommendationEngineFactoryImplBase.java
@@ -32,7 +32,7 @@ import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
 public abstract class RecommendationEngineFactoryImplBase<T>
     implements RecommendationEngineFactory<T>
 {
-    private Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     @Override
     public AbstractTraitsEditor createTraitsEditor(String aId, IModel<Recommender> aModel)
@@ -65,7 +65,7 @@ public abstract class RecommendationEngineFactoryImplBase<T>
             traits = fromJsonString((Class<T>) createTraits().getClass(), aRecommender.getTraits());
         }
         catch (IOException e) {
-            log.error("Error while reading traits", e);
+            LOG.error("Error while reading traits", e);
         }
 
         if (traits == null) {
@@ -83,7 +83,7 @@ public abstract class RecommendationEngineFactoryImplBase<T>
             aRecommender.setTraits(json);
         }
         catch (IOException e) {
-            log.error("Error while writing traits", e);
+            LOG.error("Error while writing traits", e);
         }
     }
 }

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/RecommendationEditorExtension.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/RecommendationEditorExtension.java
@@ -263,7 +263,7 @@ public class RecommendationEditorExtension
 
         // do not show predictions during curation or when viewing others' work
         var sessionOwner = userService.getCurrentUsername();
-        if (!aState.getMode().equals(ANNOTATION)) {
+        if (aState.getMode() != ANNOTATION) {
             return;
         }
 
@@ -280,8 +280,8 @@ public class RecommendationEditorExtension
 
         // Notify other UI components on the page about the prediction switch such that they can
         // also update their state to remain in sync with the new predictions
-        applicationEventPublisher
-                .publishEvent(new PredictionsSwitchedEvent(this, sessionOwner, aState));
+        applicationEventPublisher.publishEvent(
+                new PredictionsSwitchedEvent(this, sessionOwner, aState.getDocument()));
 
         aTarget.appendJavaScript("document.body.classList.remove('"
                 + RecommenderActionBarPanel.STATE_PREDICTIONS_AVAILABLE + "')");


### PR DESCRIPTION
**What's in the PR**
- Added ability to internally mark recommenders as synchronous. Such recommenders are run immedately after creating an annotation during the very same request such that suggestions appear immediately.

**How to test manually**
* Use the Named Entity Linker recommender

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
