### PR TITLE
#4641 - Ability to assign names to endpoints of relations

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/config/AnnotationAutoConfiguration.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/config/AnnotationAutoConfiguration.java
@@ -34,6 +34,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.rendering.PreRenderer;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.rendering.PreRendererImpl;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.rendering.RenderNotificationRenderStep;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
+import de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationEndpointFeatureSupport;
 import de.tudarmstadt.ukp.inception.documents.api.RepositoryProperties;
 import de.tudarmstadt.ukp.inception.preferences.PreferencesService;
 import de.tudarmstadt.ukp.inception.rendering.coloring.ColoringService;
@@ -95,5 +96,11 @@ public class AnnotationAutoConfiguration
         return new UserPreferencesServiceImpl(aDefaultPreferences, aAnnotationService,
                 aRepositoryProperties, aColoringService, aAnnotationEditorProperties,
                 aPreferencesService, aUserService);
+    }
+
+    @Bean
+    public RelationEndpointFeatureSupport relationEndpointFeatureSupport()
+    {
+        return new RelationEndpointFeatureSupport();
     }
 }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/chain/ChainLayerSupport.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/chain/ChainLayerSupport.java
@@ -188,4 +188,15 @@ public class ChainLayerSupport
 
         return Collections.emptyList();
     }
+
+    @Override
+    public boolean isDeletable(AnnotationFeature aFeature)
+    {
+        if (Set.of(FEATURE_NAME_FIRST, FEATURE_NAME_NEXT, FEATURE_NAME_REFERENCE,
+                FEATURE_NAME_REFERENCE_RELATION).contains(aFeature.getName())) {
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/RelationAdapter.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/RelationAdapter.java
@@ -17,6 +17,8 @@
  */
 package de.tudarmstadt.ukp.inception.annotation.layer.relation;
 
+import static de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationEndpointFeatureSupport.PREFIX_SOURCE;
+import static de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationEndpointFeatureSupport.PREFIX_TARGET;
 import static de.tudarmstadt.ukp.inception.support.uima.ICasUtil.selectByAddr;
 import static java.lang.System.currentTimeMillis;
 import static java.util.Collections.emptyList;
@@ -46,6 +48,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.annotation.layer.TypeAdapter_ImplBase;
 import de.tudarmstadt.ukp.inception.rendering.selection.Selection;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
+import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.AnnotationException;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.FeatureFilter;
 import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureSupportRegistry;
@@ -234,9 +237,9 @@ public class RelationAdapter
     @Override
     public Selection select(VID aVid, AnnotationFS aAnno)
     {
-        Selection selection = new Selection();
-        AnnotationFS src = getSourceAnnotation(aAnno);
-        AnnotationFS tgt = getTargetAnnotation(aAnno);
+        var selection = new Selection();
+        var src = getSourceAnnotation(aAnno);
+        var tgt = getTargetAnnotation(aAnno);
 
         if (getLayer().getAttachFeature() != null) {
             src = FSUtil.getFeature(src, getLayer().getAttachFeature().getName(),
@@ -259,10 +262,10 @@ public class RelationAdapter
         // So if the basic span-oriented comparison returned true, we still must ensure that the
         // relation endpoints are also equivalent. Here, we only consider the endpoint type and
         // position but not any other features.
-        AnnotationFS fs1Source = getSourceAnnotation(aFs1);
-        AnnotationFS fs1Target = getTargetAnnotation(aFs1);
-        AnnotationFS fs2Source = getSourceAnnotation(aFs2);
-        AnnotationFS fs2Target = getTargetAnnotation(aFs2);
+        var fs1Source = getSourceAnnotation(aFs1);
+        var fs1Target = getTargetAnnotation(aFs1);
+        var fs2Source = getSourceAnnotation(aFs2);
+        var fs2Target = getTargetAnnotation(aFs2);
 
         return sameBeginEndAndType(fs1Source, fs2Source)
                 && sameBeginEndAndType(fs1Target, fs2Target);
@@ -273,5 +276,29 @@ public class RelationAdapter
         return aFs1.getBegin() == aFs2.getBegin() && //
                 aFs1.getEnd() == aFs2.getEnd() && //
                 Objects.equals(aFs1.getType().getName(), aFs2.getType().getName());
+    }
+
+    @Override
+    public void initializeLayerConfiguration(AnnotationSchemaService aSchemaService)
+    {
+        var sourceFeature = AnnotationFeature.builder() //
+                .withLayer(getLayer()) //
+                .withType(PREFIX_SOURCE + getAttachTypeName()) //
+                .withName(getSourceFeatureName()) //
+                .withUiName("Source") //
+                .withEnabled(true) //
+                .build();
+
+        aSchemaService.createFeature(sourceFeature);
+
+        var targetFeature = AnnotationFeature.builder() //
+                .withLayer(getLayer()) //
+                .withType(PREFIX_TARGET + getAttachTypeName()) //
+                .withName(getTargetFeatureName()) //
+                .withUiName("Target") //
+                .withEnabled(true) //
+                .build();
+
+        aSchemaService.createFeature(targetFeature);
     }
 }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/RelationEndpointFeatureSupport.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/RelationEndpointFeatureSupport.java
@@ -1,0 +1,232 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.annotation.layer.relation;
+
+import static de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationLayerSupport.FEAT_REL_SOURCE;
+import static de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationLayerSupport.FEAT_REL_TARGET;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.apache.commons.lang3.StringUtils.substringAfter;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.commons.lang3.NotImplementedException;
+import org.apache.uima.cas.CAS;
+import org.apache.uima.cas.FeatureStructure;
+import org.apache.uima.resource.metadata.TypeDescription;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
+import org.apache.wicket.MarkupContainer;
+import org.apache.wicket.markup.html.panel.EmptyPanel;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.model.IModel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.config.AnnotationAutoConfiguration;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.inception.editor.action.AnnotationActionHandler;
+import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
+import de.tudarmstadt.ukp.inception.rendering.editorstate.FeatureState;
+import de.tudarmstadt.ukp.inception.schema.api.adapter.AnnotationException;
+import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureEditor;
+import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureSupport;
+import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureType;
+import de.tudarmstadt.ukp.inception.support.json.JSONUtil;
+
+/**
+ * Extension providing image-related features for annotations.
+ * <p>
+ * This class is exposed as a Spring Component via
+ * {@link AnnotationAutoConfiguration#relationEndpointFeatureSupport}.
+ * </p>
+ */
+public class RelationEndpointFeatureSupport
+    implements FeatureSupport<RelationEndpointFeatureTraits>
+{
+    private final static Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    public static final String PREFIX_SOURCE = "rel-source:";
+    public static final String PREFIX_TARGET = "rel-target:";
+
+    private String featureSupportId;
+
+    @Autowired
+    public RelationEndpointFeatureSupport()
+    {
+        // Nothing to do
+    }
+
+    @Override
+    public String getId()
+    {
+        return featureSupportId;
+    }
+
+    @Override
+    public void setBeanName(String aBeanName)
+    {
+        featureSupportId = aBeanName;
+    }
+
+    @Override
+    public Optional<FeatureType> getFeatureType(AnnotationFeature aFeature)
+    {
+        if (!RelationLayerSupport.TYPE.equals(aFeature.getLayer().getType())) {
+            return Optional.empty();
+        }
+
+        if (FEAT_REL_SOURCE.equals(aFeature.getName())) {
+            return Optional.of(
+                    new FeatureType(aFeature.getType(), "Relation source", featureSupportId, true));
+        }
+
+        if (FEAT_REL_TARGET.equals(aFeature.getName())) {
+            return Optional.of(
+                    new FeatureType(aFeature.getType(), "Relation target", featureSupportId, true));
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    public List<FeatureType> getSupportedFeatureTypes(AnnotationLayer aAnnotationLayer)
+    {
+        if (!RelationLayerSupport.TYPE.equals(aAnnotationLayer.getType())) {
+            return emptyList();
+        }
+
+        var attachType = aAnnotationLayer.getAttachType().getName();
+        return asList( //
+                new FeatureType(PREFIX_SOURCE + attachType, "Relation source", featureSupportId,
+                        true), //
+                new FeatureType(PREFIX_TARGET + attachType, "Relation target", featureSupportId,
+                        true));
+    }
+
+    @Override
+    public boolean accepts(AnnotationFeature aFeature)
+    {
+        return aFeature.getType().startsWith(PREFIX_SOURCE)
+                || aFeature.getType().startsWith(PREFIX_TARGET);
+    }
+
+    @Override
+    public Panel createTraitsEditor(String aId, IModel<AnnotationFeature> aFeatureModel)
+    {
+        return new EmptyPanel(aId);
+    }
+
+    @Override
+    public FeatureEditor createEditor(String aId, MarkupContainer aOwner,
+            AnnotationActionHandler aHandler, IModel<AnnotatorState> aStateModel,
+            IModel<FeatureState> aFeatureStateModel)
+    {
+        return null;
+    }
+
+    @Override
+    public RelationEndpointFeatureTraits readTraits(AnnotationFeature aFeature)
+    {
+        RelationEndpointFeatureTraits traits = null;
+        try {
+            traits = JSONUtil.fromJsonString(RelationEndpointFeatureTraits.class,
+                    aFeature.getTraits());
+        }
+        catch (IOException e) {
+            LOG.error("Unable to read traits", e);
+        }
+
+        if (traits == null) {
+            traits = new RelationEndpointFeatureTraits();
+        }
+
+        return traits;
+    }
+
+    @Override
+    public void writeTraits(AnnotationFeature aFeature, RelationEndpointFeatureTraits aTraits)
+    {
+        try {
+            aFeature.setTraits(JSONUtil.toJsonString(aTraits));
+        }
+        catch (IOException e) {
+            LOG.error("Unable to write traits", e);
+        }
+    }
+
+    @Override
+    public void generateFeature(TypeSystemDescription aTSD, TypeDescription aTD,
+            AnnotationFeature aFeature)
+    {
+        if (aFeature.getType().startsWith(PREFIX_SOURCE)) {
+            aTD.addFeature(aFeature.getName(), "",
+                    substringAfter(aFeature.getType(), PREFIX_SOURCE));
+        }
+        else if (aFeature.getType().startsWith(PREFIX_TARGET)) {
+            aTD.addFeature(aFeature.getName(), "",
+                    substringAfter(aFeature.getType(), PREFIX_TARGET));
+        }
+        else {
+            throw new IllegalStateException(
+                    "Unsupported feature type [" + aFeature.getType() + "]");
+        }
+    }
+
+    @Override
+    public <V> V unwrapFeatureValue(AnnotationFeature aFeature, CAS aCAS, Object aValue)
+    {
+        throw new NotImplementedException("Relation endpoints do not support unwrapFeatureValue");
+    }
+
+    @Override
+    public Serializable wrapFeatureValue(AnnotationFeature aFeature, CAS aCAS, Object aValue)
+    {
+        throw new NotImplementedException("Relation endpoints do not support wrapFeatureValue");
+    }
+
+    @Override
+    public <V> V getFeatureValue(AnnotationFeature aFeature, FeatureStructure aFS)
+    {
+        throw new NotImplementedException("Relation endpoints do not support getFeatureValue");
+    }
+
+    @Override
+    public void setFeatureValue(CAS aCas, AnnotationFeature aFeature, int aAddress, Object aValue)
+        throws AnnotationException
+    {
+        throw new NotImplementedException("Relation endpoints do not support setFeatureValue");
+    }
+
+    @Override
+    public boolean isUsingDefaultOptions(AnnotationFeature aFeature)
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isAccessible(AnnotationFeature aFeature)
+    {
+        return false;
+    }
+}

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/RelationEndpointFeatureTraits.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/RelationEndpointFeatureTraits.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.annotation.layer.relation;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+/**
+ * Traits for image features.
+ */
+// The @JsonSerialize annotation avoid the "InvalidDefinitionException: No serializer found"
+// exception without having to set SerializationFeature.FAIL_ON_EMPTY_BEANS
+@JsonSerialize
+public class RelationEndpointFeatureTraits
+    implements Serializable
+{
+    private static final long serialVersionUID = -5169695344924699148L;
+}

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/RelationLayerSupport.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/RelationLayerSupport.java
@@ -24,9 +24,9 @@ import static org.apache.uima.cas.CAS.TYPE_NAME_ANNOTATION;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Supplier;
 
-import org.apache.uima.resource.metadata.TypeDescription;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
@@ -113,9 +113,8 @@ public class RelationLayerSupport
     public RelationAdapter createAdapter(AnnotationLayer aLayer,
             Supplier<Collection<AnnotationFeature>> aFeatures)
     {
-        RelationAdapter adapter = new RelationAdapter(getLayerSupportRegistry(),
-                featureSupportRegistry, eventPublisher, aLayer, FEAT_REL_TARGET, FEAT_REL_SOURCE,
-                aFeatures,
+        var adapter = new RelationAdapter(getLayerSupportRegistry(), featureSupportRegistry,
+                eventPublisher, aLayer, FEAT_REL_TARGET, FEAT_REL_SOURCE, aFeatures,
                 layerBehaviorsRegistry.getLayerBehaviors(this, RelationLayerBehavior.class));
 
         return adapter;
@@ -125,9 +124,8 @@ public class RelationLayerSupport
     public void generateTypes(TypeSystemDescription aTsd, AnnotationLayer aLayer,
             List<AnnotationFeature> aAllFeaturesInProject)
     {
-        TypeDescription td = aTsd.addType(aLayer.getName(), aLayer.getDescription(),
-                TYPE_NAME_ANNOTATION);
-        AnnotationLayer attachType = aLayer.getAttachType();
+        var td = aTsd.addType(aLayer.getName(), aLayer.getDescription(), TYPE_NAME_ANNOTATION);
+        var attachType = aLayer.getAttachType();
 
         td.addFeature(FEAT_REL_TARGET, "", attachType.getName());
         td.addFeature(FEAT_REL_SOURCE, "", attachType.getName());
@@ -149,7 +147,7 @@ public class RelationLayerSupport
     @Override
     public Panel createTraitsEditor(String aId, IModel<AnnotationLayer> aLayerModel)
     {
-        AnnotationLayer layer = aLayerModel.getObject();
+        var layer = aLayerModel.getObject();
 
         if (!accepts(layer)) {
             throw unsupportedLayerTypeException(layer);
@@ -174,5 +172,15 @@ public class RelationLayerSupport
         }
 
         return Collections.emptyList();
+    }
+
+    @Override
+    public boolean isDeletable(AnnotationFeature aFeature)
+    {
+        if (Set.of(FEAT_REL_SOURCE, FEAT_REL_TARGET).contains(aFeature.getName())) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/lazydetails/LazyDetailsLookupServiceImpl.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/lazydetails/LazyDetailsLookupServiceImpl.java
@@ -120,7 +120,7 @@ public class LazyDetailsLookupServiceImpl
                     .forEach(detailGroups::add);
         }
         else {
-            for (var feature : annotationService.listAnnotationFeature(aLayer)) {
+            for (var feature : annotationService.listSupportedFeatures(aLayer)) {
                 lookupFeatureLevelDetails(aVid, aCas, feature).forEach(detailGroups::add);
             }
         }
@@ -185,6 +185,10 @@ public class LazyDetailsLookupServiceImpl
 
         var fs = selectFsByAddr(aCas, aVid.getId());
         var ext = featureSupportRegistry.findExtension(aFeature).orElseThrow();
+        if (!ext.isAccessible(aFeature)) {
+            return emptyList();
+        }
+
         return ext.lookupLazyDetails(aFeature, ext.getFeatureValue(aFeature, fs));
     }
 

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationDetailPanel.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationDetailPanel.java
@@ -256,6 +256,10 @@ public class DocumentMetadataAnnotationDetailPanel
                 continue;
             }
 
+            if (!featureSupportRegistry.findExtension(feature).get().isAccessible(feature)) {
+                continue;
+            }
+
             Serializable value = null;
             if (fs != null) {
                 value = adapter.getFeatureValue(feature, fs);

--- a/inception/inception-processing/src/main/java/de/tudarmstadt/ukp/inception/processing/recommender/BulkRecommenderPanel.java
+++ b/inception/inception-processing/src/main/java/de/tudarmstadt/ukp/inception/processing/recommender/BulkRecommenderPanel.java
@@ -53,6 +53,7 @@ import de.tudarmstadt.ukp.inception.recommendation.api.recommender.TrainingCapab
 import de.tudarmstadt.ukp.inception.rendering.editorstate.FeatureState;
 import de.tudarmstadt.ukp.inception.scheduling.SchedulingService;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
+import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureSupportRegistry;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxButton;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxFormComponentUpdatingBehavior;
 import de.tudarmstadt.ukp.inception.ui.core.docanno.layer.DocumentMetadataLayerSupport;
@@ -67,6 +68,7 @@ public class BulkRecommenderPanel
     private @SpringBean SchedulingService schedulingService;
     private @SpringBean UserDao userService;
     private @SpringBean AnnotationSchemaService annotationSchemaService;
+    private @SpringBean FeatureSupportRegistry featureSupportRegistry;
 
     private CompoundPropertyModel<FormData> formModel;
     private FeatureEditorPanel processingMetadata;
@@ -175,6 +177,10 @@ public class BulkRecommenderPanel
         var featureStates = new ArrayList<FeatureState>();
         for (var feature : annotationSchemaService.listSupportedFeatures(layer)) {
             if (!feature.isEnabled()) {
+                continue;
+            }
+
+            if (!featureSupportRegistry.findExtension(feature).get().isAccessible(feature)) {
                 continue;
             }
 

--- a/inception/inception-project-initializers-basic/src/main/java/de/tudarmstadt/ukp/inception/project/initializers/basic/BasicRelationLayerInitializer.java
+++ b/inception/inception-project-initializers-basic/src/main/java/de/tudarmstadt/ukp/inception/project/initializers/basic/BasicRelationLayerInitializer.java
@@ -38,7 +38,6 @@ import org.springframework.core.annotation.Order;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
-import de.tudarmstadt.ukp.clarin.webanno.model.TagSet;
 import de.tudarmstadt.ukp.clarin.webanno.project.initializers.LayerInitializer;
 import de.tudarmstadt.ukp.inception.project.api.ProjectInitializer;
 import de.tudarmstadt.ukp.inception.project.initializers.basic.config.InceptionBasicProjectInitializersAutoConfiguration;
@@ -111,16 +110,18 @@ public class BasicRelationLayerInitializer
     @Override
     public void configure(Project aProject) throws IOException
     {
-        AnnotationLayer spanLayer = annotationSchemaService.findLayer(aProject,
-                BASIC_SPAN_LAYER_NAME);
+        var spanLayer = annotationSchemaService.findLayer(aProject, BASIC_SPAN_LAYER_NAME);
 
-        AnnotationLayer relationLayer = new AnnotationLayer(BASIC_RELATION_LAYER_NAME, "Relation",
+        var relationLayer = new AnnotationLayer(BASIC_RELATION_LAYER_NAME, "Relation",
                 RELATION_TYPE, aProject, false, TOKENS, OVERLAP_ONLY);
         relationLayer.setCrossSentence(false);
         relationLayer.setAttachType(spanLayer);
         annotationSchemaService.createOrUpdateLayer(relationLayer);
 
-        TagSet relationTagSet = annotationSchemaService.getTagSet(BASIC_RELATION_TAG_SET_NAME,
+        annotationSchemaService.getAdapter(relationLayer)
+                .initializeLayerConfiguration(annotationSchemaService);
+
+        var relationTagSet = annotationSchemaService.getTagSet(BASIC_RELATION_TAG_SET_NAME,
                 aProject);
 
         annotationSchemaService.createFeature(

--- a/inception/inception-project-initializers/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/initializers/CoreferenceLayerInitializer.java
+++ b/inception/inception-project-initializers/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/initializers/CoreferenceLayerInitializer.java
@@ -35,7 +35,6 @@ import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.OverlapMode;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
-import de.tudarmstadt.ukp.clarin.webanno.model.TagSet;
 import de.tudarmstadt.ukp.clarin.webanno.project.initializers.config.ProjectInitializersAutoConfiguration;
 import de.tudarmstadt.ukp.inception.project.api.ProjectInitializer;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
@@ -100,15 +99,19 @@ public class CoreferenceLayerInitializer
     @Override
     public void configure(Project aProject) throws IOException
     {
-        TagSet corefTypeTagSet = annotationSchemaService
+        var corefTypeTagSet = annotationSchemaService
                 .getTagSet(CoreferenceTypeTagSetInitializer.TAG_SET_NAME, aProject);
-        TagSet corefRelTagSet = annotationSchemaService
+        var corefRelTagSet = annotationSchemaService
                 .getTagSet(CoreferenceRelationTagSetInitializer.TAG_SET_NAME, aProject);
 
-        AnnotationLayer base = new AnnotationLayer(COREFERENCE_LAYER_NAME, "Coreference",
-                CHAIN_TYPE, aProject, true, AnchoringMode.TOKENS, OverlapMode.ANY_OVERLAP);
+        var base = new AnnotationLayer(COREFERENCE_LAYER_NAME, "Coreference", CHAIN_TYPE, aProject,
+                true, AnchoringMode.TOKENS, OverlapMode.ANY_OVERLAP);
         base.setCrossSentence(true);
         annotationSchemaService.createOrUpdateLayer(base);
+
+        // FIXME: should probably be replaced by calling
+        // annotationSchemaService.getAdapter(base)
+        // .initializeLayerConfiguration(annotationSchemaService);
 
         annotationSchemaService.createFeature(new AnnotationFeature(aProject, base, "referenceType",
                 "referenceType", CAS.TYPE_NAME_STRING, "Coreference type", corefTypeTagSet));

--- a/inception/inception-project-initializers/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/initializers/DependencyLayerInitializer.java
+++ b/inception/inception-project-initializers/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/initializers/DependencyLayerInitializer.java
@@ -35,7 +35,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
-import de.tudarmstadt.ukp.clarin.webanno.model.TagSet;
 import de.tudarmstadt.ukp.clarin.webanno.project.initializers.config.ProjectInitializersAutoConfiguration;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
 import de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.Dependency;
@@ -103,14 +102,12 @@ public class DependencyLayerInitializer
     public void configure(Project aProject) throws IOException
     {
         // Dependency Layer
-        AnnotationLayer depLayer = new AnnotationLayer(Dependency.class.getName(), "Dependency",
-                RELATION_TYPE, aProject, true, SINGLE_TOKEN, OVERLAP_ONLY);
-        AnnotationLayer tokenLayer = annotationSchemaService.findLayer(aProject,
-                Token.class.getName());
-        List<AnnotationFeature> tokenFeatures = annotationSchemaService
-                .listAnnotationFeature(tokenLayer);
+        var depLayer = new AnnotationLayer(Dependency.class.getName(), "Dependency", RELATION_TYPE,
+                aProject, true, SINGLE_TOKEN, OVERLAP_ONLY);
+        var tokenLayer = annotationSchemaService.findLayer(aProject, Token.class.getName());
+        var tokenFeatures = annotationSchemaService.listAnnotationFeature(tokenLayer);
         AnnotationFeature tokenPosFeature = null;
-        for (AnnotationFeature feature : tokenFeatures) {
+        for (var feature : tokenFeatures) {
             if (feature.getName().equals("pos")) {
                 tokenPosFeature = feature;
                 break;
@@ -118,16 +115,19 @@ public class DependencyLayerInitializer
         }
         depLayer.setAttachType(tokenLayer);
         depLayer.setAttachFeature(tokenPosFeature);
+        annotationSchemaService.createOrUpdateLayer(depLayer);
 
-        TagSet depTagSet = annotationSchemaService
+        annotationSchemaService.getAdapter(depLayer)
+                .initializeLayerConfiguration(annotationSchemaService);
+
+        var depTagSet = annotationSchemaService
                 .getTagSet(DependencyTypeTagSetInitializer.TAG_SET_NAME, aProject);
 
-        annotationSchemaService.createOrUpdateLayer(depLayer);
         annotationSchemaService
                 .createFeature(new AnnotationFeature(aProject, depLayer, "DependencyType",
                         "Relation", CAS.TYPE_NAME_STRING, "Dependency relation", depTagSet));
 
-        TagSet flavorsTagset = annotationSchemaService
+        var flavorsTagset = annotationSchemaService
                 .getTagSet(DependencyFlavorTagSetInitializer.TAG_SET_NAME, aProject);
 
         annotationSchemaService.createFeature(new AnnotationFeature(aProject, depLayer, "flavor",

--- a/inception/inception-review-editor/src/main/java/de/tudarmstadt/ukp/inception/revieweditor/DocumentAnnotationPanel.java
+++ b/inception/inception-review-editor/src/main/java/de/tudarmstadt/ukp/inception/revieweditor/DocumentAnnotationPanel.java
@@ -151,8 +151,12 @@ public class DocumentAnnotationPanel
 
         // Populate from feature structure
         List<FeatureState> featureStates = new ArrayList<>();
-        for (AnnotationFeature feature : annotationService.listAnnotationFeature(layer)) {
+        for (AnnotationFeature feature : annotationService.listSupportedFeatures(layer)) {
             if (!feature.isEnabled()) {
+                continue;
+            }
+
+            if (!featureSupportRegistry.findExtension(feature).get().isAccessible(feature)) {
                 continue;
             }
 

--- a/inception/inception-review-editor/src/main/java/de/tudarmstadt/ukp/inception/revieweditor/SpanAnnotationPanel.java
+++ b/inception/inception-review-editor/src/main/java/de/tudarmstadt/ukp/inception/revieweditor/SpanAnnotationPanel.java
@@ -140,8 +140,12 @@ public class SpanAnnotationPanel
 
         // Populate from feature structure
         List<FeatureState> featureStates = new ArrayList<>();
-        for (AnnotationFeature feature : annotationService.listAnnotationFeature(aLayer)) {
+        for (AnnotationFeature feature : annotationService.listSupportedFeatures(aLayer)) {
             if (!feature.isEnabled()) {
+                continue;
+            }
+
+            if (!featureSupportRegistry.findExtension(feature).get().isAccessible(feature)) {
                 continue;
             }
 

--- a/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/rendering/Renderer.java
+++ b/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/rendering/Renderer.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.uima.cas.CAS;
@@ -84,10 +83,16 @@ public interface Renderer
                 continue;
             }
 
-            var label = defaultString(fsr.findExtension(feature)
-                    .orElseThrow(() -> new NoSuchElementException(
-                            "No feature support found for feature " + feature))
-                    .renderFeatureValue(feature, aFs));
+            var maybeFeatureSupport = fsr.findExtension(feature);
+            if (maybeFeatureSupport.isEmpty()) {
+                continue;
+            }
+
+            if (!maybeFeatureSupport.get().isAccessible(feature)) {
+                continue;
+            }
+
+            var label = defaultString(maybeFeatureSupport.get().renderFeatureValue(feature, aFs));
 
             features.put(feature.getName(), label);
         }

--- a/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/feature/FeatureSupport.java
+++ b/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/feature/FeatureSupport.java
@@ -400,13 +400,30 @@ public interface FeatureSupport<T>
 
     default FeatureStructure getFS(CAS aCas, AnnotationFeature aFeature, int aAddress)
     {
-        FeatureStructure fs = selectFsByAddr(aCas, aAddress);
-        Feature feature = fs.getType().getFeatureByBaseName(aFeature.getName());
+        var fs = selectFsByAddr(aCas, aAddress);
+        var feature = fs.getType().getFeatureByBaseName(aFeature.getName());
 
         if (feature == null) {
             throw new IllegalArgumentException("On [" + fs.getType().getName() + "] the feature ["
                     + aFeature.getName() + "] does not exist.");
         }
         return fs;
+    }
+
+    default boolean isUsingDefaultOptions(AnnotationFeature aFeature)
+    {
+        return true;
+    }
+
+    /**
+     * @return Whether the given feature is accessible. Non-accessible feature do not need to
+     *         support {@link #getFeatureValue}, {@link #setFeatureValue}, {@link #wrapFeatureValue}
+     *         and {@link #unwrapFeatureValue}.
+     * @param aFeature
+     *            the feature
+     */
+    default boolean isAccessible(AnnotationFeature aFeature)
+    {
+        return true;
     }
 }

--- a/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/layer/LayerSupport.java
+++ b/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/layer/LayerSupport.java
@@ -181,4 +181,9 @@ public interface LayerSupport<A extends TypeAdapter, T>
     {
         return Collections.emptyList();
     }
+
+    default boolean isDeletable(AnnotationFeature aFeature)
+    {
+        return true;
+    }
 }

--- a/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/service/AnnotationSchemaServiceImpl.java
+++ b/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/service/AnnotationSchemaServiceImpl.java
@@ -671,7 +671,9 @@ public class AnnotationSchemaServiceImpl
         return entityManager
                 .createQuery("From AnnotationFeature where name = :name AND layer = :layer",
                         AnnotationFeature.class)
-                .setParameter("name", aName).setParameter("layer", aLayer).getSingleResult();
+                .setParameter("name", aName) //
+                .setParameter("layer", aLayer) //
+                .getSingleResult();
     }
 
     @Override
@@ -749,7 +751,9 @@ public class AnnotationSchemaServiceImpl
     @Transactional
     public List<AnnotationLayer> listAttachedRelationLayers(AnnotationLayer aLayer)
     {
-        String query = String.join("\n",
+        Objects.requireNonNull(aLayer, "Parameter [layer] must be specified");
+
+        var query = String.join("\n",
                 "SELECT l FROM AnnotationLayer l LEFT JOIN l.attachFeature f ", //
                 "WHERE l.type        = :type AND ", //
                 "      l.project     = :project AND ", //

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
@@ -106,6 +106,7 @@ import de.tudarmstadt.ukp.inception.schema.api.AttachedAnnotation;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.AnnotationException;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.TypeAdapter;
 import de.tudarmstadt.ukp.inception.schema.api.config.AnnotationSchemaProperties;
+import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureSupportRegistry;
 import de.tudarmstadt.ukp.inception.schema.api.feature.LinkWithRoleModel;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxLink;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaBehavior;
@@ -126,6 +127,7 @@ public abstract class AnnotationDetailEditorPanel
     private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private @SpringBean AnnotationSchemaService annotationService;
+    private @SpringBean FeatureSupportRegistry featureSupportRegistry;
     private @SpringBean AnnotationSchemaProperties annotationEditorProperties;
 
     // Top-level containers
@@ -1117,10 +1119,14 @@ public abstract class AnnotationDetailEditorPanel
     {
         getModelObject().getFeatureStates().clear();
 
-        AnnotatorState state = AnnotationDetailEditorPanel.this.getModelObject();
+        var state = AnnotationDetailEditorPanel.this.getModelObject();
 
         // Populate from feature structure
-        for (AnnotationFeature feature : annotationService.listSupportedFeatures(aLayer)) {
+        for (var feature : annotationService.listSupportedFeatures(aLayer)) {
+            if (!featureSupportRegistry.findExtension(feature).get().isAccessible(feature)) {
+                continue;
+            }
+
             if (!feature.isEnabled()) {
                 continue;
             }

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationTextPanel.html
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationTextPanel.html
@@ -34,7 +34,7 @@
     
     <div class="row form-row" wicket:enclosure="originText">
       <label class="feature-editor-label col-form-label">
-        <wicket:message key="origin"/> 
+        <wicket:container wicket:id="originName"/>
         <a wicket:id="jumpToOrigin" class="float-end"><i class="fas fa-crosshairs"></i></a>
       </label>
       
@@ -47,7 +47,7 @@
     
     <div class="row form-row" wicket:enclosure="targetText">
       <label class="feature-editor-label col-form-label">
-        <wicket:message key="target"/> 
+        <wicket:container wicket:id="targetName"/>
         <a wicket:id="jumpToTarget" class="float-end"><i class="fas fa-crosshairs"></i></a>
       </label>
       

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationTextPanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationTextPanel.java
@@ -17,14 +17,19 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.detail;
 
+import static de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationLayerSupport.FEAT_REL_SOURCE;
+import static de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationLayerSupport.FEAT_REL_TARGET;
 import static de.tudarmstadt.ukp.inception.support.lambda.LambdaBehavior.visibleWhen;
 
 import java.io.IOException;
+
+import javax.persistence.NoResultException;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.LoadableDetachableModel;
 import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 
@@ -58,7 +63,11 @@ public class AnnotationTextPanel
                 .setAlwaysEnabled(true) // avoid disabling in read-only mode
                 .add(visibleWhen(() -> !isRelationSelected())));
 
+        add(new Label("originName", LoadableDetachableModel.of(this::getOriginName))
+                .add(visibleWhen(() -> isRelationSelected())));
         add(new Label("originText", PropertyModel.of(getModelObject(), "selection.originText"))
+                .add(visibleWhen(() -> isRelationSelected())));
+        add(new Label("targetName", LoadableDetachableModel.of(this::getTargetName))
                 .add(visibleWhen(() -> isRelationSelected())));
         add(new Label("targetText", PropertyModel.of(getModelObject(), "selection.targetText"))
                 .add(visibleWhen(() -> isRelationSelected())));
@@ -68,6 +77,30 @@ public class AnnotationTextPanel
         add(new LambdaAjaxLink("jumpToTarget", this::actionJumpToTarget) //
                 .setAlwaysEnabled(true) // avoid disabling in read-only mode
                 .add(visibleWhen(() -> isRelationSelected())));
+    }
+
+    private String getOriginName()
+    {
+        try {
+            return annotationService
+                    .getFeature(FEAT_REL_SOURCE, getModelObject().getSelectedAnnotationLayer())
+                    .getUiName();
+        }
+        catch (NoResultException e) {
+            return "From";
+        }
+    }
+
+    private String getTargetName()
+    {
+        try {
+            return annotationService
+                    .getFeature(FEAT_REL_TARGET, getModelObject().getSelectedAnnotationLayer())
+                    .getUiName();
+        }
+        catch (NoResultException e) {
+            return "To";
+        }
     }
 
     private boolean isRelationSelected()

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/layers/LayerDetailForm.java
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/layers/LayerDetailForm.java
@@ -65,7 +65,6 @@ import de.tudarmstadt.ukp.inception.bootstrap.BootstrapModalDialog;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.export.LayerImportExportUtils;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
-import de.tudarmstadt.ukp.inception.schema.api.adapter.TypeAdapter;
 import de.tudarmstadt.ukp.inception.schema.api.event.LayerConfigurationChangedEvent;
 import de.tudarmstadt.ukp.inception.schema.api.layer.LayerSupport;
 import de.tudarmstadt.ukp.inception.schema.api.layer.LayerSupportRegistry;
@@ -325,16 +324,16 @@ public class LayerDetailForm
         aTarget.add(getParent());
         aTarget.addChildren(getPage(), IFeedback.class);
 
-        AnnotationLayer layer = aForm.getModelObject();
+        var layer = aForm.getModelObject();
 
-        final Project project = layer.getProject();
+        final var project = layer.getProject();
 
         // Set type name only when the layer is initially created. After that, only the UI
         // name may be updated. Also any validation related to the type name only needs to
         // happen on the initial creation.
-        boolean isNewLayer = isNull(layer.getId());
+        var isNewLayer = isNull(layer.getId());
         if (isNewLayer) {
-            String layerName = StringUtils.capitalize(layer.getUiName());
+            var layerName = StringUtils.capitalize(layer.getUiName());
             layerName = layerName.replaceAll("\\W", "");
 
             if (layerName.isEmpty()) {
@@ -370,7 +369,7 @@ public class LayerDetailForm
         // Initialize default features if necessary but only after the layer has actually been
         // persisted in the database.
         if (isNewLayer) {
-            TypeAdapter adapter = annotationService.getAdapter(layer);
+            var adapter = annotationService.getAdapter(layer);
             adapter.initializeLayerConfiguration(annotationService);
         }
 

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/layers/ProjectLayersPanel.html
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/layers/ProjectLayersPanel.html
@@ -306,59 +306,61 @@
                 <textarea wicket:id="description" rows="4" class="form-control"></textarea>
               </div>
             </div>
-            <div class="row form-row">
-              <label class="col-sm-4 col-form-label">
-                <wicket:message key="options"/>
-              </label>
-              <div class="col-sm-8">
-                <div class="form-check" wicket:enclosure="enabled">
-                  <input wicket:id="enabled" class="form-check-input" type="checkbox">
-                  <label wicket:for="enabled" class="form-check-label">
-                    <wicket:label key="enabled"/>
-                  </label>
-                </div>
-                <div class="form-check" wicket:enclosure="required">
-                  <input wicket:id="required" class="form-check-input" type="checkbox">
-                  <label wicket:for="required" class="form-check-label">
-                    <wicket:label key="required"/>
-                  </label>
-                </div>
-                <div class="form-check" wicket:enclosure="remember">
-                  <input wicket:id="remember" class="form-check-input" type="checkbox">
-                  <label wicket:for="remember" class="form-check-label">
-                    <wicket:label key="remember"/>
-                  </label>
-                </div>
-                <div class="form-check" wicket:enclosure="curatable">
-                  <input wicket:id="curatable" class="form-check-input" type="checkbox">
-                  <label wicket:for="curatable" class="form-check-label">
-                    <wicket:label key="curatable"/>
-                  </label>
+            <div wicket:id="defaultOptionsContainer">
+              <div class="row form-row">
+                <label class="col-sm-4 col-form-label">
+                  <wicket:message key="options"/>
+                </label>
+                <div class="col-sm-8">
+                  <div class="form-check" wicket:enclosure="enabled">
+                    <input wicket:id="enabled" class="form-check-input" type="checkbox">
+                    <label wicket:for="enabled" class="form-check-label">
+                      <wicket:label key="enabled"/>
+                    </label>
+                  </div>
+                  <div class="form-check" wicket:enclosure="required">
+                    <input wicket:id="required" class="form-check-input" type="checkbox">
+                    <label wicket:for="required" class="form-check-label">
+                      <wicket:label key="required"/>
+                    </label>
+                  </div>
+                  <div class="form-check" wicket:enclosure="remember">
+                    <input wicket:id="remember" class="form-check-input" type="checkbox">
+                    <label wicket:for="remember" class="form-check-label">
+                      <wicket:label key="remember"/>
+                    </label>
+                  </div>
+                  <div class="form-check" wicket:enclosure="curatable">
+                    <input wicket:id="curatable" class="form-check-input" type="checkbox">
+                    <label wicket:for="curatable" class="form-check-label">
+                      <wicket:label key="curatable"/>
+                    </label>
+                  </div>
                 </div>
               </div>
-            </div>
-            <div class="row form-row">
-              <label class="col-sm-4 col-form-label">
-                <wicket:message key="visibility"/>
-              </label>
-              <div class="col-sm-8">
-                <div class="form-check" wicket:enclosure="visible">
-                  <input wicket:id="visible" class="form-check-input" type="checkbox">
-                  <label wicket:for="visible" class="form-check-label">
-                    <wicket:label key="visible"/>
-                  </label>
-                </div>
-                <div class="form-check" wicket:enclosure="includeInHover">
-                  <input wicket:id="includeInHover" class="form-check-input" type="checkbox">
-                  <label wicket:for="includeInHover" class="form-check-label">
-                    <wicket:label key="includeInHover"/>
-                  </label>
-                </div>
-                <div class="form-check" wicket:enclosure="hideUnconstraintFeature">
-                  <input wicket:id="hideUnconstraintFeature" class="form-check-input" type="checkbox">
-                  <label wicket:for="hideUnconstraintFeature" class="form-check-label">
-                    <wicket:label key="hideUnconstraintFeature"/>
-                  </label>
+              <div class="row form-row">
+                <label class="col-sm-4 col-form-label">
+                  <wicket:message key="visibility"/>
+                </label>
+                <div class="col-sm-8">
+                  <div class="form-check" wicket:enclosure="visible">
+                    <input wicket:id="visible" class="form-check-input" type="checkbox">
+                    <label wicket:for="visible" class="form-check-label">
+                      <wicket:label key="visible"/>
+                    </label>
+                  </div>
+                  <div class="form-check" wicket:enclosure="includeInHover">
+                    <input wicket:id="includeInHover" class="form-check-input" type="checkbox">
+                    <label wicket:for="includeInHover" class="form-check-label">
+                      <wicket:label key="includeInHover"/>
+                    </label>
+                  </div>
+                  <div class="form-check" wicket:enclosure="hideUnconstraintFeature">
+                    <input wicket:id="hideUnconstraintFeature" class="form-check-input" type="checkbox">
+                    <label wicket:for="hideUnconstraintFeature" class="form-check-label">
+                      <wicket:label key="hideUnconstraintFeature"/>
+                    </label>
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
**What's in the PR**
- Added a new relation endpoint feature support
- Allow editing relation endpoint names (only UI names)
- Create these features when creating new relation layers (existing layers don't get them)

**How to test manually**
* Try working with existing relation layers
* Try creating new projects with new relation layers
* Try changing the names of the relation endpoints and check that the change reflects e.g. in the annotation detail panel

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
