### PR TITLE
#4449 - Adding new document level non-singleton annotations adds them in strange order

### DIFF
--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationSelectionPanel.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationSelectionPanel.java
@@ -24,9 +24,12 @@ import static de.tudarmstadt.ukp.inception.support.lambda.HtmlElementEvents.CLIC
 import static de.tudarmstadt.ukp.inception.support.lambda.LambdaBehavior.enabledWhen;
 import static de.tudarmstadt.ukp.inception.support.lambda.LambdaBehavior.visibleWhen;
 import static de.tudarmstadt.ukp.inception.support.lambda.LambdaBehavior.visibleWhenNot;
+import static de.tudarmstadt.ukp.inception.ui.core.docanno.layer.DocumentMetadataLayerSupport.FEATURE_NAME_ORDER;
 import static java.util.Collections.emptyList;
+import static java.util.Comparator.comparing;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
+import static org.apache.uima.fit.util.FSUtil.getFeature;
 import static org.apache.wicket.event.Broadcast.BREADTH;
 
 import java.io.IOException;
@@ -156,7 +159,7 @@ public class DocumentMetadataAnnotationSelectionPanel
         layer.setChoices(availableLayers);
         layer.setChoiceRenderer(new ChoiceRenderer<>("uiName"));
         layer.add(new LambdaAjaxFormComponentUpdatingBehavior(CHANGE_EVENT));
-        layer.add(visibleWhen(() -> !availableLayers.map(List::isEmpty).orElse(true).getObject()));
+        layer.add(visibleWhenNot(availableLayers.map(List::isEmpty).orElse(true)));
         content.add(layer);
 
         content.add(new LambdaAjaxLink(CID_CREATE, this::actionCreate)
@@ -488,10 +491,18 @@ public class DocumentMetadataAnnotationSelectionPanel
             return;
         }
 
-        for (var fs : cas.select(type)) {
+        var annotations = cas.select(type).asList();
+        var hasOrderFeature = type.getFeatureByBaseName(FEATURE_NAME_ORDER) != null;
+        if (hasOrderFeature) {
+            annotations.sort(comparing(fs -> getFeature(fs, FEATURE_NAME_ORDER, Integer.class)));
+        }
+
+        for (var fs : annotations) {
             var renderedFeatures = renderer.renderLabelFeatureValues(adapter, fs, features);
             var labelText = TypeUtil.getUiLabelText(renderedFeatures);
-            items.add(new AnnotationListItem(VID.of(fs), labelText, aLayer, singleton, 0.0d));
+            var order = hasOrderFeature ? getFeature(fs, FEATURE_NAME_ORDER, Integer.class) : 0;
+            items.add(
+                    new AnnotationListItem(VID.of(fs), labelText, aLayer, singleton, 0.0d, order));
         }
     }
 
@@ -529,7 +540,7 @@ public class DocumentMetadataAnnotationSelectionPanel
                     var annotation = featureSupport.renderFeatureValue(feature,
                             suggestion.getLabel());
                     items.add(new AnnotationListItem(suggestion.getVID(), annotation, aLayer, false,
-                            suggestion.getScore()));
+                            suggestion.getScore(), items.size()));
                 }
             }
         }
@@ -586,7 +597,7 @@ public class DocumentMetadataAnnotationSelectionPanel
     {}
 
     private record AnnotationListItem(VID vid, String label, AnnotationLayer layer,
-            boolean singleton, double score)
+            boolean singleton, double score, int order)
         implements Serializable
     {}
 }

--- a/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/service/AnnotationSchemaServiceImpl.java
+++ b/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/service/AnnotationSchemaServiceImpl.java
@@ -34,9 +34,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Objects.isNull;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.stream.Collectors.toList;
-import static org.apache.commons.lang3.StringUtils.isAlphanumeric;
 import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.apache.commons.lang3.StringUtils.isNumeric;
 import static org.apache.uima.cas.impl.Serialization.deserializeCASComplete;
 import static org.apache.uima.cas.impl.Serialization.serializeCASComplete;
 import static org.apache.uima.cas.impl.Serialization.serializeWithCompression;
@@ -65,6 +63,7 @@ import org.apache.uima.cas.FeatureStructure;
 import org.apache.uima.cas.Type;
 import org.apache.uima.cas.TypeSystem;
 import org.apache.uima.cas.impl.CASImpl;
+import org.apache.uima.cas.impl.TypeSystemUtils;
 import org.apache.uima.cas.text.AnnotationFS;
 import org.apache.uima.fit.factory.CasFactory;
 import org.apache.uima.fit.util.CasUtil;
@@ -1699,10 +1698,9 @@ public class AnnotationSchemaServiceImpl
 
         // Checking if feature name doesn't start with a number or underscore
         // And only uses alphanumeric characters
-        if (isNumeric(name.substring(0, 1)) || name.substring(0, 1).equals("_")
-                || !isAlphanumeric(name.replace("_", ""))) {
-            errors.add(new ValidationError("Feature names must start with a letter and consist "
-                    + "only of letters, digits, or underscores."));
+        if (!TypeSystemUtils.isIdentifier(name)) {
+            errors.add(new ValidationError("Invalid feature name [" + name
+                    + "].  Feature names must start with a letter and consist only of letters, digits, or underscores."));
             return errors;
         }
 


### PR DESCRIPTION
**What's in the PR**
- Introduce "uiOrder" feature on document metadata layer
- Declare "uiOrder" as invalid name on this layer so users cannot create a feature by that name
- Sort annotations according to uiOrder
- Set uiOrder properly when creating a new annotation

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
