### PR TITLE
#4655 - Opening a document in sidebar curation mode does not trigger auto-merge

### DIFF
--- a/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/CasStorageServiceImpl.java
+++ b/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/CasStorageServiceImpl.java
@@ -358,7 +358,7 @@ public class CasStorageServiceImpl
                             mLoaderCas.setReleaseOnClose(false);
 
                             cas = readOrCreateUnmanagedCas(aDocument, aUsername, aSupplier,
-                                    aUpgradeMode);
+                                    aUpgradeMode, aAccessMode);
                         }
 
                         holder.setCas(cas);
@@ -416,10 +416,12 @@ public class CasStorageServiceImpl
                 try (var access = new WithExclusiveAccess(aDocument, aUsername)) {
                     // Since we promise to only read the CAS, we don't have to worry about it being
                     // locked to a particular thread...
-                    casHolder = sharedAccessCache.get(new CasKey(aDocument, aUsername),
-                            (key) -> CasHolder.of(key,
-                                    () -> getRealCas(readOrCreateUnmanagedCas(aDocument, aUsername,
-                                            aSupplier, aUpgradeMode))));
+                    casHolder = sharedAccessCache
+                            .get(new CasKey(aDocument, aUsername),
+                                    (key) -> CasHolder.of(key,
+                                            () -> getRealCas(readOrCreateUnmanagedCas(aDocument,
+                                                    aUsername, aSupplier, aUpgradeMode,
+                                                    aAccessMode))));
                     var size = getSharedAccessCacheSize();
                     var max = casStorageProperties.getSharedCasCacheSize();
                     if (size > (max * 0.9)) {
@@ -434,7 +436,7 @@ public class CasStorageServiceImpl
                 try (var access = new WithExclusiveAccess(aDocument, aUsername)) {
                     casHolder = CasHolder.of(new CasKey(aDocument, aUsername),
                             () -> readOrCreateUnmanagedCas(aDocument, aUsername, aSupplier,
-                                    aUpgradeMode));
+                                    aUpgradeMode, aAccessMode));
                 }
             }
             // else if the special bypass mode is requested, then we fetch directly from disk
@@ -564,7 +566,7 @@ public class CasStorageServiceImpl
      *             if the CAS could not be obtained.
      */
     private CAS readOrCreateUnmanagedCas(SourceDocument aDocument, String aUsername,
-            CasProvider aSupplier, CasUpgradeMode aUpgradeMode)
+            CasProvider aSupplier, CasUpgradeMode aUpgradeMode, CasAccessMode aAccessMode)
         throws IOException
     {
         var start = currentTimeMillis();
@@ -585,30 +587,30 @@ public class CasStorageServiceImpl
 
         // If the CAS exists on disk already, load it from there
         if (driver.existsCas(aDocument, aUsername)) {
+            source = "disk";
             cas = driver.readCas(aDocument, aUsername);
             repairAndUpgradeCasIfRequired(aDocument, aUsername, cas, aUpgradeMode,
                     ISOLATED_SESSION);
-            source = "disk";
+
+            addOrUpdateCasMetadata(aDocument, aUsername, cas);
         }
         // If the CAS does NOT exist on disk, try obtaining it through the given CAS provider
         else if (aSupplier != null) {
+            source = "importer";
             cas = aSupplier.get();
             repairAndUpgradeCasIfRequired(aDocument, aUsername, cas, aUpgradeMode);
-            realWriteCas(aDocument, aUsername, cas);
-            source = "importer";
+
+            if (aAccessMode == EXCLUSIVE_WRITE_ACCESS) {
+                realWriteCas(aDocument, aUsername, cas);
+
+                addOrUpdateCasMetadata(aDocument, aUsername, cas);
+            }
         }
         // If no CAS provider is given, fail
         else {
             throw new FileNotFoundException("CAS file for [" + aDocument.getId() + "," + aUsername
                     + "] does not exist and no initializer is specified.");
         }
-
-        // Add/update the CAS metadata
-        CasMetadataUtils.addOrUpdateCasMetadata(cas, driver.getCasMetadata(aDocument, aUsername)
-                .orElseThrow(() -> new IOException(
-                        "Unable to obtain last modified data for annotation document [" + aDocument
-                                + "] of user [" + aUsername + "]"))
-                .getTimestamp(), aDocument, aUsername);
 
         var duration = currentTimeMillis() - start;
 
@@ -627,6 +629,16 @@ public class CasStorageServiceImpl
         }
 
         return cas;
+    }
+
+    private void addOrUpdateCasMetadata(SourceDocument aDocument, String aUsername, CAS cas)
+        throws IOException
+    {
+        CasMetadataUtils.addOrUpdateCasMetadata(cas, driver.getCasMetadata(aDocument, aUsername)
+                .orElseThrow(() -> new IOException(
+                        "Unable to obtain last modified data for annotation document [" + aDocument
+                                + "] of user [" + aUsername + "]"))
+                .getTimestamp(), aDocument, aUsername);
     }
 
     @Override

--- a/inception/inception-annotation-storage/src/test/java/de/tudarmstadt/ukp/inception/annotation/storage/CasStorageServiceImplTest.java
+++ b/inception/inception-annotation-storage/src/test/java/de/tudarmstadt/ukp/inception/annotation/storage/CasStorageServiceImplTest.java
@@ -39,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Proxy;
 import java.util.ArrayList;
 import java.util.List;
@@ -48,7 +49,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.CASException;
-import org.apache.uima.cas.text.AnnotationFS;
 import org.apache.uima.jcas.JCas;
 import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
@@ -76,7 +76,7 @@ import de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil;
 
 public class CasStorageServiceImplTest
 {
-    private Logger log = LoggerFactory.getLogger(getClass());
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private AtomicBoolean exception = new AtomicBoolean(false);
     private AtomicBoolean rwTasksCompleted = new AtomicBoolean(false);
@@ -122,17 +122,17 @@ public class CasStorageServiceImplTest
     {
         try (CasStorageSession casStorageSession = openNested(true)) {
             // Setup fixture
-            SourceDocument doc = makeSourceDocument(1l, 1l, "test");
-            JCas templateCas = WebAnnoCasUtil.createCas(createTypeSystemDescription()).getJCas();
+            var doc = makeSourceDocument(1l, 1l, "test");
+            var templateCas = WebAnnoCasUtil.createCas(createTypeSystemDescription()).getJCas();
             templateCas.setDocumentText("This is a test");
             casStorageSession.add("cas", EXCLUSIVE_WRITE_ACCESS, templateCas.getCas());
-            String user = "test";
+            var user = "test";
 
             sut.writeCas(doc, templateCas.getCas(), user);
             assertThat(sut.existsCas(doc, user)).isTrue();
 
             // Actual test
-            CAS cas = sut.readCas(doc, user);
+            var cas = sut.readCas(doc, user);
             assertThat(cas.getDocumentText()).isEqualTo(templateCas.getDocumentText());
 
             sut.deleteCas(doc, user);
@@ -149,17 +149,17 @@ public class CasStorageServiceImplTest
             typeSystems.add(createTypeSystemDescription());
             typeSystems.add(CasMetadataUtils.getInternalTypeSystem());
 
-            JCas cas = WebAnnoCasUtil.createCas(mergeTypeSystems(typeSystems)).getJCas();
+            var cas = WebAnnoCasUtil.createCas(mergeTypeSystems(typeSystems)).getJCas();
             casStorageSession.add("cas", EXCLUSIVE_WRITE_ACCESS, cas.getCas());
 
-            SourceDocument doc = makeSourceDocument(2l, 2l, "test");
-            String user = "test";
+            var doc = makeSourceDocument(2l, 2l, "test");
+            var user = "test";
 
             sut.writeCas(doc, cas.getCas(), user);
 
-            JCas cas2 = sut.readCas(doc, user).getJCas();
+            var cas2 = sut.readCas(doc, user).getJCas();
 
-            List<CASMetadata> cmds = new ArrayList<>(select(cas2, CASMetadata.class));
+            var cmds = new ArrayList<>(select(cas2, CASMetadata.class));
             assertThat(cmds).hasSize(1);
             assertThat(cmds.get(0).getProjectId()).isEqualTo(doc.getProject().getId());
             assertThat(cmds.get(0).getSourceDocumentId()).isEqualTo(doc.getId());
@@ -171,15 +171,15 @@ public class CasStorageServiceImplTest
     @Test
     public void testReadOrCreateCas() throws Exception
     {
-        try (CasStorageSession casStorageSession = openNested(true)) {
+        try (var casStorageSession = openNested(true)) {
             // Setup fixture
-            SourceDocument doc = makeSourceDocument(3l, 3l, "test");
+            var doc = makeSourceDocument(3l, 3l, "test");
             String user = "test";
             String text = "This is a test";
             createCasFile(doc, user, text);
 
             // Actual test
-            JCas cas = sut.readCas(doc, user).getJCas();
+            var cas = sut.readCas(doc, user).getJCas();
             assertThat(cas.getDocumentText()).isEqualTo(text);
 
             sut.deleteCas(doc, user);
@@ -191,23 +191,23 @@ public class CasStorageServiceImplTest
     public void testThatLayerChangeEventInvalidatesCachedCas() throws Exception
     {
         // Setup fixture
-        SourceDocument doc = makeSourceDocument(4l, 4l, "test");
-        String user = "test";
-        try (CasStorageSession session = openNested(true)) {
-            String text = "This is a test";
+        var doc = makeSourceDocument(4l, 4l, "test");
+        var user = "test";
+        try (var session = openNested(true)) {
+            var text = "This is a test";
             createCasFile(doc, user, text);
         }
 
         // Actual test
         int casIdentity1;
-        try (CasStorageSession session = openNested(true)) {
-            JCas cas = sut.readCas(doc, user).getJCas();
+        try (var session = openNested(true)) {
+            var cas = sut.readCas(doc, user).getJCas();
             casIdentity1 = System.identityHashCode(cas);
         }
 
         int casIdentity2;
-        try (CasStorageSession session = openNested(true)) {
-            JCas cas = sut.readCas(doc, user).getJCas();
+        try (var session = openNested(true)) {
+            var cas = sut.readCas(doc, user).getJCas();
             casIdentity2 = System.identityHashCode(cas);
         }
 
@@ -215,8 +215,8 @@ public class CasStorageServiceImplTest
                 new LayerConfigurationChangedEvent(this, doc.getProject()));
 
         int casIdentity3;
-        try (CasStorageSession session = openNested(true)) {
-            JCas cas = sut.readCas(doc, user).getJCas();
+        try (var session = openNested(true)) {
+            var cas = sut.readCas(doc, user).getJCas();
             casIdentity3 = System.identityHashCode(cas);
         }
 
@@ -232,21 +232,21 @@ public class CasStorageServiceImplTest
     public void testConcurrentAccess() throws Exception
     {
         // Setup fixture
-        SourceDocument doc = makeSourceDocument(5l, 5l, "test");
-        String user = "test";
+        var doc = makeSourceDocument(5l, 5l, "test");
+        var user = "test";
 
-        try (CasStorageSession session = openNested(true)) {
+        try (var session = openNested(true)) {
             createCasFile(doc, user, "This is a test");
             assertThat(sut.existsCas(doc, user)).isTrue();
         }
 
-        try (CasStorageSession casStorageSession = openNested(true)) {
-            CAS mainCas = sut.readCas(doc, user, EXCLUSIVE_WRITE_ACCESS);
+        try (var casStorageSession = openNested(true)) {
+            var mainCas = sut.readCas(doc, user, EXCLUSIVE_WRITE_ACCESS);
 
-            File casFile = driver.getCasFile(doc, user);
+            var casFile = driver.getCasFile(doc, user);
             casFile.setLastModified(casFile.lastModified() + 10_000);
 
-            long timestamp = sut.getCasTimestamp(doc, user).get();
+            var timestamp = sut.getCasTimestamp(doc, user).get();
 
             assertThatExceptionOfType(IOException.class)
                     .isThrownBy(() -> sut.writeCas(doc, mainCas, user))
@@ -262,24 +262,24 @@ public class CasStorageServiceImplTest
     {
         try (CasStorageSession casStorageSession = openNested(true)) {
             // Setup fixture
-            SourceDocument doc = makeSourceDocument(6l, 6l, "test");
-            String user = "test";
-            File casFile = driver.getCasFile(doc, user);
+            var doc = makeSourceDocument(6l, 6l, "test");
+            var user = "test";
+            var casFile = driver.getCasFile(doc, user);
 
             long casFileSize;
             long casFileLastModified;
 
-            try (CasStorageSession session = openNested(true)) {
+            try (var session = openNested(true)) {
                 createCasFile(doc, user, "This is a test");
                 assertThat(sut.existsCas(doc, user)).isTrue();
                 casFileSize = casFile.length();
                 casFileLastModified = casFile.lastModified();
             }
 
-            CAS mainCas = sut.readCas(doc, user, EXCLUSIVE_WRITE_ACCESS);
+            var mainCas = sut.readCas(doc, user, EXCLUSIVE_WRITE_ACCESS);
 
             // Wrap the CAS in a proxy so that UIMA cannot serialize it
-            CAS guardedCas = (CAS) Proxy.newProxyInstance(getClass().getClassLoader(),
+            var guardedCas = (CAS) Proxy.newProxyInstance(getClass().getClassLoader(),
                     new Class[] { CAS.class },
                     (proxy, method, args) -> method.invoke(mainCas, args));
 
@@ -309,8 +309,8 @@ public class CasStorageServiceImplTest
             }
         };
 
-        SourceDocument doc = makeSourceDocument(7l, 7l, "doc");
-        String user = "annotator";
+        var doc = makeSourceDocument(7l, 7l, "doc");
+        var user = "annotator";
 
         // We interleave all the primary and secondary tasks into the main tasks list
         // Primary tasks run for a certain number of iterations
@@ -343,28 +343,28 @@ public class CasStorageServiceImplTest
             tasks.add(xx);
         }
 
-        log.info("---- Starting all threads ----");
+        LOG.info("---- Starting all threads ----");
         tasks.forEach(Thread::start);
 
-        log.info("---- Waiting for primary threads to complete ----");
-        boolean done = false;
+        LOG.info("---- Waiting for primary threads to complete ----");
+        var done = false;
         while (!done) {
-            long running = primaryTasks.stream().filter(Thread::isAlive).count();
+            var running = primaryTasks.stream().filter(Thread::isAlive).count();
             done = running == 0l;
             sleep(1000);
-            log.info("running {}  complete {}%  rw {}  ro {}  un {}  uni {}  xx {} XX {}", running,
+            LOG.info("running {}  complete {}%  rw {}  ro {}  un {}  uni {}  xx {} XX {}", running,
                     (writeCounter.get() * 100) / (threadGroupCount * iterations), writeCounter,
                     managedReadCounter, unmanagedReadCounter, unmanagedNonInitializingReadCounter,
                     deleteCounter, deleteInitialCounter);
         }
 
-        log.info("---- Waiting for secondary threads to wrap up ----");
+        LOG.info("---- Waiting for secondary threads to wrap up ----");
         rwTasksCompleted.set(true);
-        for (Thread thread : secondaryTasks) {
+        for (var thread : secondaryTasks) {
             thread.join();
         }
 
-        log.info("---- Test is done ----");
+        LOG.info("---- Test is done ----");
 
         assertThat(exception).isFalse();
     }
@@ -388,9 +388,9 @@ public class CasStorageServiceImplTest
             throw new IOException("This initializer should never be called!");
         };
 
-        SourceDocument doc = makeSourceDocument(8l, 8l, "doc");
-        String user = "annotator";
-        try (CasStorageSession session = openNested()) {
+        var doc = makeSourceDocument(8l, 8l, "doc");
+        var user = "annotator";
+        try (var session = openNested()) {
             // Make sure the CAS exists so that the threads should never be forced to call the
             // the initializer
             sut.readOrCreateCas(doc, user, FORCE_CAS_UPGRADE, initializer, EXCLUSIVE_WRITE_ACCESS);
@@ -405,46 +405,45 @@ public class CasStorageServiceImplTest
 
         int threadGroupCount = 4;
         int iterations = 100;
-        for (int n = 0; n < threadGroupCount; n++) {
-            ExclusiveReadWriteTask rw = new ExclusiveReadWriteTask(n, doc, user, badSeed,
-                    iterations);
+        for (var n = 0; n < threadGroupCount; n++) {
+            var rw = new ExclusiveReadWriteTask(n, doc, user, badSeed, iterations);
             primaryTasks.add(rw);
             tasks.add(rw);
 
-            Thread ro = new SharedReadOnlyTask(n, doc, user, badSeed);
+            var ro = new SharedReadOnlyTask(n, doc, user, badSeed);
             secondaryTasks.add(ro);
             tasks.add(ro);
 
-            Thread un = new UnmanagedTask(n, doc, user, badSeed);
+            var un = new UnmanagedTask(n, doc, user, badSeed);
             secondaryTasks.add(un);
             tasks.add(un);
 
-            Thread uni = new UnmanagedNonInitializingTask(n, doc, user);
+            var uni = new UnmanagedNonInitializingTask(n, doc, user);
             secondaryTasks.add(uni);
             tasks.add(uni);
         }
 
-        log.info("---- Starting all threads ----");
+        LOG.info("---- Starting all threads ----");
         tasks.forEach(Thread::start);
 
-        log.info("---- Wait for primary threads to complete ----");
+        LOG.info("---- Wait for primary threads to complete ----");
         boolean done = false;
         while (!done) {
-            long running = primaryTasks.stream().filter(Thread::isAlive).count();
+            var running = primaryTasks.stream().filter(Thread::isAlive).count();
             done = running == 0l;
             sleep(1000);
-            log.info("running {}  complete {}%  rw {}  ro {}  un {}  uni {}", running,
+            LOG.info("running {}  complete {}%  rw {}  ro {}  un {}  uni {}", running,
                     (writeCounter.get() * 100) / (threadGroupCount * iterations), writeCounter,
                     managedReadCounter, unmanagedReadCounter, unmanagedNonInitializingReadCounter);
         }
 
-        log.info("---- Wait for threads secondary threads to wrap up ----");
+        LOG.info("---- Wait for threads secondary threads to wrap up ----");
         rwTasksCompleted.set(true);
-        for (Thread thread : secondaryTasks) {
+        for (var thread : secondaryTasks) {
             thread.join();
         }
 
-        log.info("---- Test is done ----");
+        LOG.info("---- Test is done ----");
 
         assertThat(exception).isFalse();
     }
@@ -477,13 +476,13 @@ public class CasStorageServiceImplTest
                     return;
                 }
 
-                try (CasStorageSession session = openNested()) {
-                    CAS cas = sut.readOrCreateCas(doc, user, FORCE_CAS_UPGRADE, initializer,
+                try (var session = openNested()) {
+                    var cas = sut.readOrCreateCas(doc, user, FORCE_CAS_UPGRADE, initializer,
                             EXCLUSIVE_WRITE_ACCESS);
                     Thread.sleep(50);
-                    AnnotationFS fs = cas.createAnnotation(cas.getAnnotationType(), 0, 10);
+                    var fs = cas.createAnnotation(cas.getAnnotationType(), 0, 10);
                     cas.addFsToIndexes(fs);
-                    log.debug("CAS size: {}", cas.getAnnotationIndex().size());
+                    LOG.debug("CAS size: {}", cas.getAnnotationIndex().size());
                     sut.writeCas(doc, cas, user);
                     writeCounter.incrementAndGet();
                 }
@@ -517,7 +516,7 @@ public class CasStorageServiceImplTest
             MDC.put(Logging.KEY_REPOSITORY_PATH, repositoryProperties.getPath().toString());
 
             while (!(exception.get() || rwTasksCompleted.get())) {
-                try (CasStorageSession session = openNested()) {
+                try (var session = openNested()) {
                     sut.readOrCreateCas(doc, user, AUTO_CAS_UPGRADE, initializer,
                             SHARED_READ_ONLY_ACCESS);
                     managedReadCounter.incrementAndGet();
@@ -552,7 +551,7 @@ public class CasStorageServiceImplTest
             MDC.put(Logging.KEY_REPOSITORY_PATH, repositoryProperties.getPath().toString());
 
             while (!(exception.get() || rwTasksCompleted.get())) {
-                try (CasStorageSession session = openNested()) {
+                try (var session = openNested()) {
                     Thread.sleep(2500 + rnd.nextInt(2500));
                     if (rnd.nextInt(100) >= 75) {
                         sut.deleteCas(doc, INITIAL_CAS_PSEUDO_USER);
@@ -590,7 +589,7 @@ public class CasStorageServiceImplTest
             MDC.put(Logging.KEY_REPOSITORY_PATH, repositoryProperties.getPath().toString());
 
             while (!(exception.get() || rwTasksCompleted.get())) {
-                try (CasStorageSession session = openNested()) {
+                try (var session = openNested()) {
                     sut.readOrCreateCas(doc, user, AUTO_CAS_UPGRADE, initializer, UNMANAGED_ACCESS);
                     unmanagedReadCounter.incrementAndGet();
                     Thread.sleep(50);
@@ -655,7 +654,7 @@ public class CasStorageServiceImplTest
     private JCas createCasFile(SourceDocument doc, String user, String text)
         throws CASException, CasSessionException, IOException
     {
-        JCas casTemplate = sut.readOrCreateCas(doc, user, NO_CAS_UPGRADE, () -> makeCas(text),
+        var casTemplate = sut.readOrCreateCas(doc, user, NO_CAS_UPGRADE, () -> makeCas(text),
                 EXCLUSIVE_WRITE_ACCESS).getJCas();
         assertThat(sut.existsCas(doc, user)).isTrue();
 
@@ -664,10 +663,10 @@ public class CasStorageServiceImplTest
 
     private SourceDocument makeSourceDocument(long aProjectId, long aDocumentId, String aDocName)
     {
-        Project project = new Project();
+        var project = new Project();
         project.setId(aProjectId);
 
-        SourceDocument doc = new SourceDocument();
+        var doc = new SourceDocument();
         doc.setProject(project);
         doc.setId(aDocumentId);
         doc.setName(aDocName);

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/editor/state/AnnotatorStateImpl.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/editor/state/AnnotatorStateImpl.java
@@ -52,6 +52,8 @@ import de.tudarmstadt.ukp.clarin.webanno.model.TagSet;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.inception.annotation.layer.chain.ChainLayerSupport;
 import de.tudarmstadt.ukp.inception.annotation.layer.span.SpanLayerSupport;
+import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
+import de.tudarmstadt.ukp.inception.project.api.ProjectService;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotationPreference;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorStateMetaDataKey;
@@ -302,6 +304,23 @@ public class AnnotatorStateImpl
         else {
             documentIndex = -1;
             numberOfDocuments = -1;
+        }
+    }
+
+    @Override
+    public void refreshDocument(DocumentService aDocumentService)
+    {
+        if (document != null) {
+            document = aDocumentService.getSourceDocument(document.getProject().getId(),
+                    document.getId());
+        }
+    }
+
+    @Override
+    public void refreshProject(ProjectService aProjectService)
+    {
+        if (project != null) {
+            project = aProjectService.getProject(project.getId());
         }
     }
 

--- a/inception/inception-api-render/pom.xml
+++ b/inception/inception-api-render/pom.xml
@@ -50,6 +50,14 @@
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-preferences</artifactId>
     </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-documents-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-project-api</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.uima</groupId>

--- a/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/editorstate/AnnotatorDocumentNavigation.java
+++ b/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/editorstate/AnnotatorDocumentNavigation.java
@@ -20,6 +20,7 @@ package de.tudarmstadt.ukp.inception.rendering.editorstate;
 import java.util.List;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 
 public interface AnnotatorDocumentNavigation
 {
@@ -31,6 +32,8 @@ public interface AnnotatorDocumentNavigation
     SourceDocument getDocument();
 
     void setDocument(SourceDocument aDocument, List<SourceDocument> aDocuments);
+
+    void refreshDocument(DocumentService aDocumentService);
 
     int getDocumentIndex();
 

--- a/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/editorstate/AnnotatorState.java
+++ b/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/editorstate/AnnotatorState.java
@@ -28,6 +28,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.Mode;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
+import de.tudarmstadt.ukp.inception.project.api.ProjectService;
 
 /**
  * Covers information about the state of the annotation editor component that is relevant across
@@ -110,6 +111,8 @@ public interface AnnotatorState
     void clearProject();
 
     void setProject(Project aProject);
+
+    void refreshProject(ProjectService aProjectService);
 
     // ---------------------------------------------------------------------------------------------
     // Constraints

--- a/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/merge/CasMerge.java
+++ b/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/merge/CasMerge.java
@@ -30,6 +30,7 @@ import static de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil.exists;
 import static de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil.isPrimitiveType;
 import static de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil.selectSentences;
 import static de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil.selectTokens;
+import static java.util.Collections.emptyList;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
 import static org.apache.uima.fit.util.CasUtil.getType;
@@ -457,7 +458,11 @@ public class CasMerge
 
     private static boolean existsEquivalentAt(CAS aCas, TypeAdapter aAdapter, AnnotationFS aFs)
     {
-        var targetType = CasUtil.getType(aCas, aFs.getType().getName());
+        var targetType = aCas.getTypeSystem().getType(aFs.getType().getName());
+        if (targetType == null) {
+            return false;
+        }
+
         return selectAt(aCas, targetType, aFs.getBegin(), aFs.getEnd()).stream() //
                 .filter(cand -> aAdapter.equivalents(aFs, cand,
                         (_fs, _f) -> !shouldIgnoreFeatureOnMerge(_f))) //
@@ -469,7 +474,11 @@ public class CasMerge
             AnnotationFS aSourceFs, AnnotationFS aSourceOriginFs, AnnotationFS aSourceTargetFs)
     {
         var type = aSourceFs.getType();
-        var targetType = CasUtil.getType(aTargetCas, aSourceFs.getType().getName());
+        var targetType = aTargetCas.getTypeSystem().getType(aSourceFs.getType().getName());
+        if (targetType == null) {
+            return emptyList();
+        }
+
         var sourceFeat = type.getFeatureByBaseName(FEAT_REL_SOURCE);
         var targetFeat = type.getFeatureByBaseName(FEAT_REL_TARGET);
         return selectCovered(aTargetCas, targetType, aSourceFs.getBegin(), aSourceFs.getEnd())
@@ -520,7 +529,11 @@ public class CasMerge
     private static List<AnnotationFS> getCandidateAnnotations(CAS aTargetCas, TypeAdapter aAdapter,
             AnnotationFS aSource)
     {
-        var targetType = CasUtil.getType(aTargetCas, aSource.getType().getName());
+        var targetType = aTargetCas.getTypeSystem().getType(aSource.getType().getName());
+        if (targetType == null) {
+            return emptyList();
+        }
+
         return selectCovered(aTargetCas, targetType, aSource.getBegin(), aSource.getEnd()).stream()
                 .filter(fs -> aAdapter.equivalents(fs, aSource,
                         (_fs, _f) -> !shouldIgnoreFeatureOnMerge(_f)))
@@ -542,7 +555,7 @@ public class CasMerge
                     "The annotation already exists in the target document.");
         }
 
-        // a) if stacking allowed add this new annotation to the mergeview
+        // a) if stacking allowed add this new annotation to the merge view
         var targetType = CasUtil.getType(aTargetCas, adapter.getAnnotationTypeName());
         var existingAnnos = selectAt(aTargetCas, targetType, aSourceFs.getBegin(),
                 aSourceFs.getEnd());

--- a/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/service/CurationMergeServiceImpl.java
+++ b/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/service/CurationMergeServiceImpl.java
@@ -107,7 +107,7 @@ public class CurationMergeServiceImpl
         }
 
         try (StopWatch watch = new StopWatch(LOG, "CasMerge")) {
-            CasMerge casMerge = new CasMerge(annotationService, applicationEventPublisher);
+            var casMerge = new CasMerge(annotationService, applicationEventPublisher);
             casMerge.setMergeStrategy(aMergeStrategy);
             return casMerge.reMergeCas(diff, aDocument, aTargetCasUserName, aTargetCas,
                     aCassesToMerge);

--- a/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/service/CurationServiceImpl.java
+++ b/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/service/CurationServiceImpl.java
@@ -97,9 +97,7 @@ public class CurationServiceImpl
     @Transactional
     public MergeStrategy getMergeStrategy(CurationWorkflow aCurationWorkflow)
     {
-        MergeStrategyFactory factory = mergeStrategyFactoryExtensionPoint
-                .getExtension(aCurationWorkflow.getMergeStrategy())
-                .orElseGet(mergeStrategyFactoryExtensionPoint::getDefault);
+        MergeStrategyFactory factory = getMergeStrategyFactory(aCurationWorkflow);
         return factory.makeStrategy(factory.readTraits(aCurationWorkflow));
     }
 
@@ -108,7 +106,8 @@ public class CurationServiceImpl
     @Transactional
     public MergeStrategyFactory getMergeStrategyFactory(CurationWorkflow aCurationWorkflow)
     {
-        return mergeStrategyFactoryExtensionPoint.getExtension(aCurationWorkflow.getMergeStrategy())
+        return mergeStrategyFactoryExtensionPoint //
+                .getExtension(aCurationWorkflow.getMergeStrategy())
                 .orElseGet(mergeStrategyFactoryExtensionPoint::getDefault);
     }
 }

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
@@ -24,6 +24,8 @@ import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasUpgradeMode.NO
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState.IGNORE;
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentStateChangeFlag.EXPLICIT_ANNOTATOR_USER_ACTION;
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.ANNOTATOR;
+import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.CURATION_FINISHED;
+import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.CURATION_IN_PROGRESS;
 import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentStateTransition.ANNOTATION_IN_PROGRESS_TO_CURATION_IN_PROGRESS;
 import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentStateTransition.NEW_TO_ANNOTATION_IN_PROGRESS;
 import static de.tudarmstadt.ukp.clarin.webanno.ui.core.page.ProjectPageBase.NS_PROJECT;
@@ -36,8 +38,6 @@ import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Objects;
 
 import org.apache.uima.cas.CAS;
@@ -431,19 +431,23 @@ public class AnnotationPage
     protected void actionLoadDocument(AjaxRequestTarget aTarget, int aFocus)
     {
         try {
-            var sessionOwner = userRepository.getCurrentUser().getUsername();
+            var sessionOwner = userRepository.getCurrentUser();
+            var sessionOwnerName = sessionOwner.getUsername();
 
             var state = getModelObject();
             if (state.getUser() == null) {
-                state.setUser(userRepository.getCurrentUser());
+                state.setUser(sessionOwner);
             }
+
+            state.refreshProject(projectService);
+            state.refreshDocument(documentService);
 
             LOG.trace("Preparing to open document {}@{} {}", state.getUser(), state.getDocument(),
                     aFocus);
             state.reset();
             applicationEventPublisherHolder.get().publishEvent(
                     new PreparingToOpenDocumentEvent(this, getModelObject().getDocument(),
-                            getModelObject().getUser().getUsername(), sessionOwner));
+                            getModelObject().getUser().getUsername(), sessionOwnerName));
 
             // INFO BOUNDARY ---------------------------------------------------------------
             // PreparingToOpenDocumentEvent has the option to change the annotator state.
@@ -465,10 +469,11 @@ public class AnnotationPage
             var editorCas = documentService.readAnnotationCas(annotationDocument,
                     editable ? FORCE_CAS_UPGRADE : NO_CAS_UPGRADE);
 
+            var dataOwnerName = getModelObject().getUser().getUsername();
             applicationEventPublisherHolder.get()
                     .publishEvent(new BeforeDocumentOpenedEvent(this, editorCas,
-                            getModelObject().getDocument(),
-                            getModelObject().getUser().getUsername(), sessionOwner, editable));
+                            getModelObject().getDocument(), dataOwnerName, sessionOwnerName,
+                            editable));
 
             if (editable) {
                 // After creating an new CAS or upgrading the CAS, we need to save it. If the
@@ -510,21 +515,23 @@ public class AnnotationPage
 
             // Update document state
             if (isEditable()) {
-                if (SourceDocumentState.NEW.equals(state.getDocument().getState())) {
+                if (SourceDocumentState.NEW == state.getDocument().getState()) {
                     documentService.transitionSourceDocumentState(state.getDocument(),
                             NEW_TO_ANNOTATION_IN_PROGRESS);
                 }
 
-                if (AnnotationDocumentState.NEW.equals(annotationDocument.getState())) {
+                // We maintain an AnnotationDocument for the `CURATION_USER` now
+                if (AnnotationDocumentState.NEW == annotationDocument.getState()) {
                     documentService.setAnnotationDocumentState(annotationDocument,
                             AnnotationDocumentState.IN_PROGRESS, EXPLICIT_ANNOTATOR_USER_ACTION);
                 }
 
+                // We also use the SourceDocumentState to indicate the curation status
                 if (state.getUser().getUsername().equals(CURATION_USER)) {
-                    SourceDocument sourceDoc = state.getDocument();
-                    SourceDocumentState sourceDocState = sourceDoc.getState();
-                    if (!sourceDocState.equals(SourceDocumentState.CURATION_IN_PROGRESS)
-                            && !sourceDocState.equals(SourceDocumentState.CURATION_FINISHED)) {
+                    var sourceDoc = state.getDocument();
+                    var sourceDocState = sourceDoc.getState();
+                    if (sourceDocState != CURATION_IN_PROGRESS
+                            && sourceDocState != CURATION_FINISHED) {
                         documentService.transitionSourceDocumentState(sourceDoc,
                                 ANNOTATION_IN_PROGRESS_TO_CURATION_IN_PROGRESS);
                     }
@@ -546,7 +553,7 @@ public class AnnotationPage
             applicationEventPublisherHolder.get()
                     .publishEvent(new DocumentOpenedEvent(this, editorCas,
                             getModelObject().getDocument(), stateBeforeOpening,
-                            getModelObject().getUser().getUsername(), sessionOwner));
+                            getModelObject().getUser().getUsername(), sessionOwnerName));
         }
         catch (Exception e) {
             handleException(aTarget, e);
@@ -706,7 +713,7 @@ public class AnnotationPage
         AnnotatorState state = getModelObject();
 
         if (state.isUserViewingOthersWork(userRepository.getCurrentUsername())
-                || state.getUser().getUsername().equals(CURATION_USER)) {
+                || CURATION_USER.equals(state.getUser().getUsername())) {
             userPreferenceService.loadPreferences(state,
                     userRepository.getCurrentUser().getUsername());
         }
@@ -717,23 +724,22 @@ public class AnnotationPage
 
     public List<AnnotationDocument> listAccessibleDocuments(Project aProject, User aUser)
     {
-        final List<AnnotationDocument> allDocuments = new ArrayList<>();
-        Map<SourceDocument, AnnotationDocument> docs = documentService.listAllDocuments(aProject,
-                aUser.getUsername());
+        var allDocuments = new ArrayList<AnnotationDocument>();
+        var docs = documentService.listAllDocuments(aProject, aUser.getUsername());
 
-        User user = userRepository.getCurrentUser();
-        for (Entry<SourceDocument, AnnotationDocument> e : docs.entrySet()) {
-            SourceDocument sd = e.getKey();
-            AnnotationDocument ad = e.getValue();
+        var sessionOwner = userRepository.getCurrentUser();
+        for (var e : docs.entrySet()) {
+            var sd = e.getKey();
+            var ad = e.getValue();
             if (ad != null) {
                 // if current user is opening her own docs, don't let her see locked ones
-                boolean userIsSelected = aUser.equals(user);
+                var userIsSelected = aUser.equals(sessionOwner);
                 if (userIsSelected && ad.getState() == IGNORE) {
                     continue;
                 }
             }
             else {
-                ad = new AnnotationDocument(user.getUsername(), sd);
+                ad = new AnnotationDocument(sessionOwner.getUsername(), sd);
             }
 
             allDocuments.add(ad);

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/CurationPage.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/CurationPage.java
@@ -496,6 +496,10 @@ public class CurationPage
 
         try {
             var state = getModelObject();
+            state.refreshProject(projectService);
+            state.refreshDocument(documentService);
+
+            var project = state.getProject();
             state.setUser(userRepository.getCurationUser());
             state.reset();
 
@@ -506,19 +510,19 @@ public class CurationPage
             }
 
             // Load constraints
-            state.setConstraints(constraintsService.loadConstraints(state.getProject()));
+            state.setConstraints(constraintsService.loadConstraints(project));
 
             // Load user preferences
             loadPreferences();
 
             // if project is changed, reset some project specific settings
-            if (currentprojectId != state.getProject().getId()) {
+            if (currentprojectId != project.getId()) {
                 state.clearRememberedFeatures();
-                currentprojectId = state.getProject().getId();
+                currentprojectId = project.getId();
             }
 
-            var mergeCas = readOrCreateCurationCas(
-                    curationService.getDefaultMergeStrategy(getProject()), false);
+            var mergeCas = readOrCreateCurationCas(curationService.getDefaultMergeStrategy(project),
+                    false);
 
             // Initialize timestamp in state
             curationDocumentService.getCurationCasTimestamp(state.getDocument())
@@ -526,8 +530,6 @@ public class CurationPage
 
             // Initialize the visible content
             state.moveToUnit(mergeCas, aFocus + 1, TOP);
-
-            currentprojectId = state.getProject().getId();
 
             curationUnits.setObject(buildUnitOverview(state));
             detailEditor.reset(aTarget);

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebarBehavior.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebarBehavior.java
@@ -17,9 +17,11 @@
  */
 package de.tudarmstadt.ukp.inception.ui.curation.sidebar;
 
+import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasUpgradeMode.FORCE_CAS_UPGRADE;
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.CURATOR;
 import static de.tudarmstadt.ukp.clarin.webanno.ui.core.page.ProjectPageBase.setProjectPageParameter;
 import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.CURATION_USER;
+import static de.tudarmstadt.ukp.inception.support.wicket.WicketExceptionUtil.handleException;
 import static java.lang.invoke.MethodHandles.lookup;
 import static java.util.Arrays.asList;
 import static org.slf4j.LoggerFactory.getLogger;
@@ -28,6 +30,7 @@ import org.apache.wicket.Component;
 import org.apache.wicket.RestartResponseException;
 import org.apache.wicket.behavior.Behavior;
 import org.apache.wicket.event.IEvent;
+import org.apache.wicket.feedback.IFeedback;
 import org.apache.wicket.request.mapper.parameter.PageParameters;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.slf4j.Logger;
@@ -38,6 +41,8 @@ import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.AnnotationPage;
 import de.tudarmstadt.ukp.inception.annotation.events.PreparingToOpenDocumentEvent;
+import de.tudarmstadt.ukp.inception.curation.service.CurationDocumentService;
+import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.project.api.ProjectService;
 
 public class CurationSidebarBehavior
@@ -54,6 +59,8 @@ public class CurationSidebarBehavior
     private static final String PARAM_CURATION_SESSION = "curationSession";
     private static final String PARAM_CURATION_TARGET_OWN = "curationTargetOwn";
 
+    private @SpringBean DocumentService documentService;
+    private @SpringBean CurationDocumentService curationDocumentService;
     private @SpringBean CurationSidebarService curationSidebarService;
     private @SpringBean UserDao userService;
     private @SpringBean ProjectService projectService;
@@ -73,23 +80,28 @@ public class CurationSidebarBehavior
         }
 
         var event = (PreparingToOpenDocumentEvent) aEvent.getPayload();
+        onPreparingToOpenDocumentEvent(event);
 
-        var page = event.getSource();
+    }
+
+    private void onPreparingToOpenDocumentEvent(PreparingToOpenDocumentEvent aEvent)
+    {
+        var page = aEvent.getSource();
 
         if (!(page instanceof AnnotationPage)) {
             // Only applies to the AnnotationPage - not to the CurationPage!
             LOG.trace(
                     "Curation sidebar is not deployed on AnnotationPage but rather [{}] - ignoring event [{}]",
-                    page.getClass(), event.getClass());
+                    page.getClass(), aEvent.getClass());
             return;
         }
 
         var params = page.getPageParameters();
 
         var sessionOwner = userService.getCurrentUsername();
-        var doc = event.getDocument();
+        var doc = aEvent.getDocument();
         var project = doc.getProject();
-        var dataOwner = event.getDocumentOwner();
+        var dataOwner = aEvent.getDocumentOwner();
 
         if (!projectService.hasRole(sessionOwner, project, CURATOR)) {
             LOG.trace(
@@ -101,9 +113,43 @@ public class CurationSidebarBehavior
         LOG.trace("Curation sidebar reacting to [{}]@{} being opened by [{}]", dataOwner, doc,
                 sessionOwner);
 
-        handleSessionActivation(page, params, doc, sessionOwner);
+        handleSessionActivationPageParameters(page, params, doc, sessionOwner);
 
         ensureDataOwnerMatchesCurationTarget(page, project, sessionOwner, dataOwner);
+
+        if (userService.getCurationUser().getUsername().equals(aEvent.getDocumentOwner())) {
+            autoMerge(aEvent, page);
+        }
+    }
+
+    private void autoMerge(PreparingToOpenDocumentEvent aEvent, AnnotationPageBase page)
+    {
+        var sessionOwner = userService.getCurrentUsername();
+        var doc = aEvent.getDocument();
+        var project = doc.getProject();
+
+        try {
+            var editable = page.isEditable();
+            if (!curationDocumentService.existsCurationCas(doc) && editable) {
+                var state = page.getModelObject();
+                // We need to force upgrade the editor CAS here already so the merge can succeed
+                // The annotation page will do this again in the actionLoadDocument, but I don't
+                // currently see a good way to avoid this duplication. At least we only do it twice
+                // if an initial merge is required.
+                documentService.readAnnotationCas(state.getDocument(),
+                        state.getUser().getUsername(), FORCE_CAS_UPGRADE);
+                var selectedUsers = curationSidebarService.getSelectedUsers(sessionOwner,
+                        project.getId());
+                var mergeStrategyFactory = curationSidebarService.merge(state,
+                        state.getUser().getUsername(), selectedUsers);
+                page.success(
+                        "Performed initial merge using [" + mergeStrategyFactory.getLabel() + "].");
+                aEvent.getRequestTarget().ifPresent($ -> $.addChildren(page, IFeedback.class));
+            }
+        }
+        catch (Exception e) {
+            handleException(LOG, page, e);
+        }
     }
 
     private void ensureDataOwnerMatchesCurationTarget(AnnotationPageBase aPage, Project aProject,
@@ -135,8 +181,8 @@ public class CurationSidebarBehavior
         }
     }
 
-    private void handleSessionActivation(AnnotationPageBase aPage, PageParameters aParams,
-            SourceDocument aDoc, String aSessionOwner)
+    private void handleSessionActivationPageParameters(AnnotationPageBase aPage,
+            PageParameters aParams, SourceDocument aDoc, String aSessionOwner)
     {
         var project = aDoc.getProject();
 

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebarService.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebarService.java
@@ -26,11 +26,13 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.uima.UIMAException;
 import org.apache.uima.cas.CAS;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
+import de.tudarmstadt.ukp.inception.curation.merge.MergeStrategyFactory;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
 
 public interface CurationSidebarService
@@ -128,4 +130,7 @@ public interface CurationSidebarService
     boolean isShowAll(String aUsername, Long aProjectId);
 
     void setDefaultSelectedUsersForDocument(String aSessionOwner, SourceDocument aDocument);
+
+    MergeStrategyFactory<?> merge(AnnotatorState aState, String aCurator, Collection<User> aUsers)
+        throws IOException, UIMAException;
 }

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/config/CurationSidebarAutoConfiguration.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/config/CurationSidebarAutoConfiguration.java
@@ -29,6 +29,8 @@ import org.springframework.security.core.session.SessionRegistry;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasStorageService;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
+import de.tudarmstadt.ukp.inception.curation.service.CurationMergeService;
+import de.tudarmstadt.ukp.inception.curation.service.CurationService;
 import de.tudarmstadt.ukp.inception.diam.editor.lazydetails.LazyDetailsLookupService;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.project.api.ProjectService;
@@ -53,10 +55,12 @@ public class CurationSidebarAutoConfiguration
     public CurationSidebarService curationSidebarService(EntityManager aEntityManager,
             DocumentService aDocumentService, SessionRegistry aSessionRegistry,
             ProjectService aProjectService, UserDao aUserRegistry,
-            CasStorageService aCasStorageService)
+            CasStorageService aCasStorageService, CurationService aCurationService,
+            CurationMergeService aCurationMergeService)
     {
         return new CurationSidebarServiceImpl(aEntityManager, aDocumentService, aSessionRegistry,
-                aProjectService, aUserRegistry, aCasStorageService);
+                aProjectService, aUserRegistry, aCasStorageService, aCurationService,
+                aCurationMergeService);
     }
 
     @Bean(CurationEditorExtension.EXTENSION_ID)

--- a/inception/inception-ui-curation/src/test/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebarServiceTest.java
+++ b/inception/inception-ui-curation/src/test/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebarServiceTest.java
@@ -68,7 +68,7 @@ public class CurationSidebarServiceTest
     public void setUp() throws Exception
     {
         sut = new CurationSidebarServiceImpl(testEntityManager.getEntityManager(), null, null, null,
-                null, null);
+                null, null, null, null);
 
         // create users
         User current = new User("current", Role.ROLE_USER);

--- a/inception/pom.xml
+++ b/inception/pom.xml
@@ -28,6 +28,7 @@
 
   <properties>
     <maven.surefire.heap>6g</maven.surefire.heap>
+    <maven.surefire.argLine>-XX:+EnableDynamicAgentLoading</maven.surefire.argLine>
     <maven.compiler.release>17</maven.compiler.release>
     <maven.compiler.target>${maven.compiler.release}</maven.compiler.target>
     <maven.compiler.source>${maven.compiler.release}</maven.compiler.source>


### PR DESCRIPTION
**What's in the PR**
- Auto-merge when accessing a document in curation sidebar mode if the document has not been curated yet - however - for the moment only when curating to the curation user
- When reading annotations in another mode than exclusive-write-access, do not persist the annotations to disk e.g. after loading them from the initial CAS and upgrading

**How to test manually**
* Try using the curation sidebar, switching between documents, enabling/disabling curation mode and check if the initial merges happen as expected
* Use the monitoring page to reset the curation from time to time

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
