### PR TITLE
#4664 - Implicitly created DocumentAnnotation can trigger UnreachableAnnotationsCheck

### DIFF
--- a/inception/inception-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/CasDoctorException.java
+++ b/inception/inception-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/CasDoctorException.java
@@ -63,4 +63,16 @@ public class CasDoctorException
     {
         return details;
     }
+
+    @Override
+    public String getMessage()
+    {
+        var buffer = new StringBuffer();
+        buffer.append("CasDoctor found " + details.size() + " issues:\n");
+        for (var msg : details) {
+            buffer.append(msg.getMessage());
+            buffer.append("\n");
+        }
+        return buffer.toString();
+    }
 }

--- a/inception/inception-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/UnreachableAnnotationsCheck.java
+++ b/inception/inception-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/UnreachableAnnotationsCheck.java
@@ -47,6 +47,7 @@ public class UnreachableAnnotationsCheck
         var casImpl = (CASImpl) getRealCas(aCas);
 
         var annotationCountsBefore = countFeatureStructures(casImpl);
+        annotationCountsBefore.remove(CAS.TYPE_NAME_DOCUMENT_ANNOTATION);
 
         // Disable forced retaining of all assigned annotations so that during serialization,
         // any temporary annotations that got potentially stuck in the CAS can be released.
@@ -58,6 +59,7 @@ public class UnreachableAnnotationsCheck
         }
 
         var annotationCountsAfter = countFeatureStructures(dummy);
+        annotationCountsAfter.remove(CAS.TYPE_NAME_DOCUMENT_ANNOTATION);
 
         var diffTypes = 0;
         var totalDiff = 0;


### PR DESCRIPTION
**What's in the PR**
- Ignore DocumentAnnotation in the UnreachableAnnotationsCheck
- Return CAS doctor results in exception message.

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
