### PR TITLE
#4683 - Improve speed of DB queries to find annotation documents for a project and user

### DIFF
--- a/inception/inception-model/src/main/resources/de/tudarmstadt/ukp/clarin/webanno/model/db-changelog.xml
+++ b/inception/inception-model/src/main/resources/de/tudarmstadt/ukp/clarin/webanno/model/db-changelog.xml
@@ -1438,4 +1438,16 @@
       </column>
     </addColumn>
   </changeSet>
+  
+  <changeSet author="INCEpTION Team" id="20240404-01">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <indexExists tableName="annotation_document" indexName="idx_user_project"/>
+      </not>
+    </preConditions>
+    <createIndex indexName="idx_user_project" tableName="annotation_document">
+      <column name="user"/>
+      <column name="project"/>
+    </createIndex>
+  </changeSet>
 </databaseChangeLog>

--- a/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/exporters/AnnotationDocumentExporter.java
+++ b/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/exporters/AnnotationDocumentExporter.java
@@ -147,8 +147,7 @@ public class AnnotationDocumentExporter
     {
         List<ExportedAnnotationDocument> annotationDocuments = new ArrayList<>();
 
-        for (AnnotationDocument annotationDocument : documentService
-                .listAnnotationDocuments(aProject)) {
+        for (var annotationDocument : documentService.listAnnotationDocuments(aProject)) {
             ExportedAnnotationDocument exAnnotationDocument = new ExportedAnnotationDocument();
             exAnnotationDocument.setName(annotationDocument.getName());
             exAnnotationDocument.setState(annotationDocument.getState());


### PR DESCRIPTION
**What's in the PR**
- Added a new index to the annotation_document table

**How to test manually**
* You'd need a **very** large project to feel the difference

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
