### PR TITLE
#2412 - Possibility to reopen all curated documents at once

### DIFF
--- a/inception/inception-documents-api/src/main/java/de/tudarmstadt/ukp/inception/documents/api/DocumentService.java
+++ b/inception/inception-documents-api/src/main/java/de/tudarmstadt/ukp/inception/documents/api/DocumentService.java
@@ -173,6 +173,20 @@ public interface DocumentService
     SourceDocumentState setSourceDocumentState(SourceDocument aDocument,
             SourceDocumentState aState);
 
+    /**
+     * Sets the state of multiple source documents at once. This method does not generate
+     * {@code DocumentStateChangeEvent} events. This means in particular that webhooks for
+     * annotation document changes will not fire and that workload managers will not know that they
+     * need to recalculate the document and project states.
+     * 
+     * @param aDocuments
+     *            the documents to update
+     * @param aState
+     *            the state to update the documents to
+     */
+    void bulkSetSourceDocumentState(Iterable<SourceDocument> aDocuments,
+            SourceDocumentState aState);
+
     // --------------------------------------------------------------------------------------------
     // Methods related to AnnotationDocuments
     // --------------------------------------------------------------------------------------------

--- a/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/DocumentServiceImpl.java
+++ b/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/DocumentServiceImpl.java
@@ -464,14 +464,7 @@ public class DocumentServiceImpl
     public SourceDocumentState setSourceDocumentState(SourceDocument aDocument,
             SourceDocumentState aState)
     {
-        Validate.notNull(aDocument, "Source document must be specified");
-        Validate.notNull(aState, "State must be specified");
-
-        var oldState = aDocument.getState();
-
-        aDocument.setState(aState);
-
-        createSourceDocument(aDocument);
+        var oldState = setSourceDocumentStateNoEvent(aDocument, aState);
 
         // Notify about change in document state
         if (!Objects.equals(oldState, aDocument.getState())) {
@@ -480,6 +473,30 @@ public class DocumentServiceImpl
         }
 
         return oldState;
+    }
+
+    private SourceDocumentState setSourceDocumentStateNoEvent(SourceDocument aDocument,
+            SourceDocumentState aState)
+    {
+        Validate.notNull(aDocument, "Source document must be specified");
+        Validate.notNull(aState, "State must be specified");
+
+        var oldState = aDocument.getState();
+
+        aDocument.setState(aState);
+
+        createSourceDocument(aDocument);
+        return oldState;
+    }
+
+    @Override
+    @Transactional
+    public void bulkSetSourceDocumentState(Iterable<SourceDocument> aDocuments,
+            SourceDocumentState aState)
+    {
+        for (var doc : aDocuments) {
+            setSourceDocumentStateNoEvent(doc, aState);
+        }
     }
 
     @Override
@@ -1383,8 +1400,7 @@ public class DocumentServiceImpl
     public AnnotationDocumentState setAnnotationDocumentState(AnnotationDocument aDocument,
             AnnotationDocumentState aState, AnnotationDocumentStateChangeFlag... aFlags)
     {
-        AnnotationDocumentState oldState = setAnnotationDocumentStateNoEvent(aDocument, aState,
-                aFlags);
+        var oldState = setAnnotationDocumentStateNoEvent(aDocument, aState, aFlags);
 
         if (!Objects.equals(oldState, aDocument.getState())) {
             applicationEventPublisher
@@ -1397,7 +1413,7 @@ public class DocumentServiceImpl
     private AnnotationDocumentState setAnnotationDocumentStateNoEvent(AnnotationDocument aDocument,
             AnnotationDocumentState aState, AnnotationDocumentStateChangeFlag... aFlags)
     {
-        AnnotationDocumentState oldState = aDocument.getState();
+        var oldState = aDocument.getState();
 
         aDocument.setState(aState);
 
@@ -1424,7 +1440,7 @@ public class DocumentServiceImpl
     public void bulkSetAnnotationDocumentState(Iterable<AnnotationDocument> aDocuments,
             AnnotationDocumentState aState)
     {
-        for (AnnotationDocument doc : aDocuments) {
+        for (var doc : aDocuments) {
             setAnnotationDocumentStateNoEvent(doc, aState);
         }
     }

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/MatrixWorkloadManagementPage.html
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/MatrixWorkloadManagementPage.html
@@ -141,52 +141,58 @@
                     </button>
                     <button wicket:id="bulkActionDropdownButton" class="btn btn-primary btn-action dropdown-toggle flex-content border-start" type="button" data-bs-toggle="dropdown"></button>
                     <div wicket:id="bulkActionDropdown" class="dropdown-menu shadow-lg" role="menu" style="min-width: 20em;">
-                      <a wicket:id="bulkClose" class="dropdown-item">
-                        Close selected
-                        <span class="float-end text-muted">
-                          <i class="far fa-play-circle"></i>&nbsp;<i class="fas fa-long-arrow-alt-right"></i>&nbsp;<i class="far fa-check-circle"></i>
-                          &nbsp;&nbsp;
-                          <i class="far fa-circle"></i>&nbsp;<i class="fas fa-long-arrow-alt-right"></i>&nbsp;<i class="fas fa-lock"></i>
-                        </span>
-                      </a>
                       <a wicket:id="bulkOpen" class="dropdown-item">
-                        Open selected
+                        Open annotation
                         <span class="float-end text-muted">
                           <i class="far fa-check-circle"></i>&nbsp;<i class="fas fa-long-arrow-alt-right"></i>&nbsp;<i class="far fa-play-circle"></i>
                           &nbsp;&nbsp;
                           <i class="fas fa-lock"></i>&nbsp;<i class="fas fa-long-arrow-alt-right"></i>&nbsp;<i class="far fa-circle"></i>
                         </span>
                       </a>
+                      <a wicket:id="bulkClose" class="dropdown-item">
+                        Close annotation
+                        <span class="float-end text-muted">
+                          <i class="far fa-play-circle"></i>&nbsp;<i class="fas fa-long-arrow-alt-right"></i>&nbsp;<i class="far fa-check-circle"></i>
+                          &nbsp;&nbsp;
+                          <i class="far fa-circle"></i>&nbsp;<i class="fas fa-long-arrow-alt-right"></i>&nbsp;<i class="fas fa-lock"></i>
+                        </span>
+                      </a>
                       <hr class="dropdown-divider"/>
                       <a wicket:id="bulkStartProgress" class="dropdown-item">
-                        Start progress (dev-only) 
+                        Start annotation (dev-only) 
                         <span class="float-end text-muted">
                           <i class="far fa-circle"></i>&nbsp;<i class="fas fa-long-arrow-alt-right"></i>&nbsp;<i class="far fa-play-circle"></i>
                         </span>
                       </a>
                       <a wicket:id="bulkLock" class="dropdown-item">
-                        Lock selected 
+                        Lock annotation 
                         <span class="float-end text-muted">
                           <i class="far fa-circle"></i>&nbsp;<i class="fas fa-long-arrow-alt-right"></i>&nbsp;<i class="fas fa-lock"></i>
                         </span>
                       </a>
                       <a wicket:id="bulkUnlock" class="dropdown-item">
-                        Unlock selected
+                        Unlock annotation
                         <span class="float-end text-muted">
                           <i class="fas fa-lock"></i>&nbsp;<i class="fas fa-long-arrow-alt-right"></i>&nbsp;<i class="far fa-circle"></i>
                         </span>
                       </a>
                       <hr class="dropdown-divider"/>
                       <a wicket:id="bulkFinish" class="dropdown-item">
-                        Finish selected
+                        Finish annotation
                         <span class="float-end text-muted">
                           <i class="far fa-play-circle"></i>&nbsp;<i class="fas fa-long-arrow-alt-right"></i>&nbsp;<i class="far fa-check-circle"></i>
                         </span>
                       </a>
                       <a wicket:id="bulkResume" class="dropdown-item">
-                        Resume selected
+                        Resume annotation
                         <span class="float-end text-muted">
                           <i class="far fa-check-circle"></i>&nbsp;<i class="fas fa-long-arrow-alt-right"></i>&nbsp;<i class="far fa-play-circle"></i>
+                        </span>
+                      </a>
+                      <a wicket:id="bulkResumeCuration" class="dropdown-item">
+                        Resume curation
+                        <span class="float-end text-muted">
+                          <i class="fas fa-clipboard-check"></i>&nbsp;<i class="fas fa-long-arrow-alt-right"></i>&nbsp;<i class="fas fa-clipboard"></i>
                         </span>
                       </a>
                       <hr class="dropdown-divider"/>


### PR DESCRIPTION
**What's in the PR**
- Added option to move multiple documents into active curation
- Use bulk state update for reseting curation documents instead of updating the state for each document individually

**How to test manually**
* Enable bulk actions
* Select one or more documents or the curator column
* Select "Resume curation"

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
