### PR TITLE
#4700 - Ability to generate tagset from pre-annotated data

### DIFF
--- a/inception/inception-processing/src/main/java/de/tudarmstadt/ukp/inception/processing/BulkProcessingPage.html
+++ b/inception/inception-processing/src/main/java/de/tudarmstadt/ukp/inception/processing/BulkProcessingPage.html
@@ -31,7 +31,8 @@
   <wicket:extend>
     <div class="d-flex flex-row flex-grow-1 overflow-hidden">
       <div class="d-flex flex-grow-1 flex-column scrolling">
-        <div wicket:id="processingPanel" class="d-flex flex-column flex-grow-1"/>
+        <div wicket:id="bulkRecommenderPanel" class="d-flex flex-column"/>
+        <div wicket:id="tagSetExtractionPanel" class="d-flex flex-column"/>
       </div>
 
       <div class="d-flex flex-sidebar flex-column border-start scrolling" style="min-width: 30rem;">

--- a/inception/inception-processing/src/main/java/de/tudarmstadt/ukp/inception/processing/BulkProcessingPage.java
+++ b/inception/inception-processing/src/main/java/de/tudarmstadt/ukp/inception/processing/BulkProcessingPage.java
@@ -28,6 +28,7 @@ import org.wicketstuff.annotation.mount.MountPath;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.ui.core.page.ProjectPageBase;
 import de.tudarmstadt.ukp.inception.processing.recommender.BulkRecommenderPanel;
+import de.tudarmstadt.ukp.inception.processing.tagset.TagSetExtractionPanel;
 import de.tudarmstadt.ukp.inception.ui.scheduling.TaskMonitorPanel;
 
 @MountPath(NS_PROJECT + "/${" + PAGE_PARAM_PROJECT + "}/process")
@@ -46,7 +47,9 @@ public class BulkProcessingPage
 
         requireProjectRole(user, MANAGER);
 
-        queue(new BulkRecommenderPanel("processingPanel", getProjectModel()));
+        queue(new BulkRecommenderPanel("bulkRecommenderPanel", getProjectModel()));
+
+        queue(new TagSetExtractionPanel("tagSetExtractionPanel", getProjectModel()));
 
         queue(new TaskMonitorPanel("runningProcesses", getProject()) //
                 .setPopupMode(false) //

--- a/inception/inception-processing/src/main/java/de/tudarmstadt/ukp/inception/processing/tagset/TagSetExtractionPanel.html
+++ b/inception/inception-processing/src/main/java/de/tudarmstadt/ukp/inception/processing/tagset/TagSetExtractionPanel.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<!--
+  Licensed to the Technische Universität Darmstadt under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The Technische Universität Darmstadt 
+  licenses this file to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.
+   
+  http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<html xmlns:wicket="http://wicket.apache.org">
+<wicket:panel>
+  <form wicket:id="form" class="card m-3">
+    <div class="card-header">
+      <wicket:message key="extractTagSet"/>
+    </div>
+    <div class="card-body">
+      <p>
+        <wicket:message key="extractTagSetDescription"/>
+      </p>
+      <div class="container">
+        <div class="row form-row form-floating" wicket:enclosure="layer">
+          <select wicket:id="layer" class="form-select" wicket:message="placeholder:layer"/>
+          <label wicket:for="layer">
+            <wicket:label key="layer"/>
+          </label>
+        </div>
+        <div class="row form-row form-floating" wicket:enclosure="feature">
+          <select wicket:id="feature" class="form-select" wicket:message="placeholder:feature"/>
+          <label wicket:for="feature">
+            <wicket:label key="feature"/>
+          </label>
+        </div>
+        <div class="row form-row form-floating" wicket:enclosure="tagSet">
+          <select wicket:id="tagSet" class="form-select" wicket:message="placeholder:tagset"/>
+          <label wicket:for="tagSet">
+            <wicket:label key="tagset"/>
+          </label>
+        </div>
+      </div>
+    
+      <div class="text-end">
+        <button wicket:id="startProcessing" type="button" class="btn btn-primary text-nowrap">
+          <i class="fas fa-play"></i>&nbsp;
+          <wicket:message key="startProcessing"/>
+        </button>
+      </div>
+    </div>
+  </form>
+</wicket:panel>
+</html>

--- a/inception/inception-processing/src/main/java/de/tudarmstadt/ukp/inception/processing/tagset/TagSetExtractionPanel.java
+++ b/inception/inception-processing/src/main/java/de/tudarmstadt/ukp/inception/processing/tagset/TagSetExtractionPanel.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.processing.tagset;
+
+import static de.tudarmstadt.ukp.inception.support.lambda.HtmlElementEvents.CHANGE_EVENT;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.markup.html.form.ChoiceRenderer;
+import org.apache.wicket.markup.html.form.DropDownChoice;
+import org.apache.wicket.markup.html.form.Form;
+import org.apache.wicket.markup.html.panel.GenericPanel;
+import org.apache.wicket.model.CompoundPropertyModel;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.LoadableDetachableModel;
+import org.apache.wicket.spring.injection.annot.SpringBean;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature_;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer_;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.model.TagSet;
+import de.tudarmstadt.ukp.clarin.webanno.model.TagSet_;
+import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
+import de.tudarmstadt.ukp.inception.project.api.ProjectService;
+import de.tudarmstadt.ukp.inception.scheduling.SchedulingService;
+import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
+import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxButton;
+import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxFormComponentUpdatingBehavior;
+
+public class TagSetExtractionPanel
+    extends GenericPanel<Project>
+{
+    private static final long serialVersionUID = 3568501821432165745L;
+
+    private @SpringBean ProjectService projectService;
+    private @SpringBean SchedulingService schedulingService;
+    private @SpringBean UserDao userService;
+    private @SpringBean AnnotationSchemaService schemaService;
+
+    private CompoundPropertyModel<FormData> formModel;
+
+    public TagSetExtractionPanel(String aId, IModel<Project> aModel)
+    {
+        super(aId, aModel);
+
+        formModel = new CompoundPropertyModel<>(new FormData());
+        queue(new Form<FormData>("form", formModel));
+
+        queue(new DropDownChoice<>("tagSet") //
+                .setChoices(LoadableDetachableModel.of(this::listTagSets)) //
+                .setChoiceRenderer(new ChoiceRenderer<>(TagSet_.NAME)) //
+                .setRequired(true));
+
+        var featureChoice = new DropDownChoice<>("feature") //
+                .setChoices(LoadableDetachableModel.of(this::listFeatures)) //
+                .setChoiceRenderer(new ChoiceRenderer<>(AnnotationFeature_.UI_NAME)) //
+                .setRequired(true);
+        queue(featureChoice);
+
+        queue(new DropDownChoice<>("layer") //
+                .setChoices(LoadableDetachableModel.of(this::listLayers)) //
+                .setChoiceRenderer(new ChoiceRenderer<>(AnnotationLayer_.UI_NAME)) //
+                .setRequired(true) //
+                .add(new LambdaAjaxFormComponentUpdatingBehavior(CHANGE_EVENT,
+                        $ -> $.add(featureChoice))));
+
+        queue(new LambdaAjaxButton<>("startProcessing", this::actionStartProcessing));
+    }
+
+    private void actionStartProcessing(AjaxRequestTarget aTarget, Form<FormData> aForm)
+    {
+        var formData = aForm.getModelObject();
+        schedulingService.enqueue(TagSetExtractionTask.builder() //
+                .withSessionOwner(userService.getCurrentUser()) //
+                .withProject(getModelObject()) //
+                .withAnnotationFeature(formData.feature) //
+                .withTagSet(formData.tagSet) //
+                .withTrigger("User request") //
+                .build());
+    }
+
+    private List<TagSet> listTagSets()
+    {
+        return schemaService.listTagSets(getModelObject());
+    }
+
+    private List<AnnotationLayer> listLayers()
+    {
+        return schemaService.listAnnotationLayer(getModelObject());
+    }
+
+    private List<AnnotationFeature> listFeatures()
+    {
+        var layer = formModel.getObject().layer;
+        if (layer == null) {
+            return Collections.emptyList();
+        }
+        return schemaService.listAnnotationFeature(layer);
+    }
+
+    private static class FormData
+        implements Serializable
+    {
+        private static final long serialVersionUID = -9011757425705942346L;
+
+        private TagSet tagSet;
+        private AnnotationLayer layer;
+        private AnnotationFeature feature;
+    }
+}

--- a/inception/inception-processing/src/main/java/de/tudarmstadt/ukp/inception/processing/tagset/TagSetExtractionPanel.properties
+++ b/inception/inception-processing/src/main/java/de/tudarmstadt/ukp/inception/processing/tagset/TagSetExtractionPanel.properties
@@ -1,0 +1,18 @@
+# Licensed to the Technische Universität Darmstadt under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The Technische Universität Darmstadt 
+# licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.
+#  
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+extractTagSet=Extract Tag Set
+startProcessing=Start processing...
+extractTagSetDescription=Populate a tag set based on the labels of existing annotations.

--- a/inception/inception-processing/src/main/java/de/tudarmstadt/ukp/inception/processing/tagset/TagSetExtractionTask.java
+++ b/inception/inception-processing/src/main/java/de/tudarmstadt/ukp/inception/processing/tagset/TagSetExtractionTask.java
@@ -1,0 +1,219 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.processing.tagset;
+
+import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode.SHARED_READ_ONLY_ACCESS;
+import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasUpgradeMode.AUTO_CAS_UPGRADE;
+import static de.tudarmstadt.ukp.inception.scheduling.TaskScope.PROJECT;
+import static de.tudarmstadt.ukp.inception.scheduling.TaskState.RUNNING;
+import static java.util.Arrays.asList;
+import static org.apache.uima.cas.CAS.TYPE_NAME_STRING_ARRAY;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.lang3.Validate;
+import org.apache.uima.cas.CAS;
+import org.apache.uima.fit.util.FSUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.clarin.webanno.model.Tag;
+import de.tudarmstadt.ukp.clarin.webanno.model.TagSet;
+import de.tudarmstadt.ukp.inception.annotation.storage.CasStorageSession;
+import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
+import de.tudarmstadt.ukp.inception.recommendation.tasks.RecommendationTask_ImplBase;
+import de.tudarmstadt.ukp.inception.scheduling.ProjectTask;
+import de.tudarmstadt.ukp.inception.scheduling.Task;
+import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
+import de.tudarmstadt.ukp.inception.support.logging.LogMessage;
+
+public class TagSetExtractionTask
+    extends Task
+    implements ProjectTask
+{
+    public static final String TYPE = "TagsetExtractionTask";
+
+    private static final List<String> supportedTypes = asList(CAS.TYPE_NAME_STRING,
+            CAS.TYPE_NAME_STRING_ARRAY);
+
+    private @Autowired DocumentService documentService;
+    private @Autowired AnnotationSchemaService schemaService;
+
+    private final AnnotationFeature feature;
+    private final TagSet tagSet;
+
+    public TagSetExtractionTask(Builder<? extends Builder<?>> aBuilder)
+    {
+        super(aBuilder.withType(TYPE).withCancellable(true).withScope(PROJECT));
+
+        feature = aBuilder.feature;
+        tagSet = aBuilder.tagSet;
+    }
+
+    @Override
+    public String getTitle()
+    {
+        return "Extracting tagset...";
+    }
+
+    @Override
+    public void execute()
+    {
+        var extractedTags = extractTags();
+
+        updateTagset(extractedTags);
+    }
+
+    private void updateTagset(Set<String> discoveredTags)
+    {
+        var existingTags = schemaService.listTags(tagSet);
+        int nextRank = 0;
+        for (var tag : existingTags) {
+            discoveredTags.remove(tag.getName());
+            nextRank = Math.max(nextRank, tag.getRank());
+        }
+
+        var newTags = new ArrayList<Tag>();
+        for (var tag : discoveredTags.stream().sorted().toList()) {
+            var newTag = new Tag(tagSet, tag);
+            newTag.setRank(nextRank);
+            newTags.add(newTag);
+            nextRank++;
+        }
+
+        schemaService.createTags(newTags.toArray(Tag[]::new));
+    }
+
+    private Set<String> extractTags()
+    {
+        var monitor = getMonitor();
+
+        var tags = new HashSet<String>();
+
+        var documents = documentService.listSourceDocuments(getProject());
+        var processedDocumentsCount = 0;
+        var totalDocumentsCount = documents.size();
+
+        for (var srcDoc : documents) {
+            monitor.setStateAndProgress(RUNNING, processedDocumentsCount, totalDocumentsCount);
+
+            extractTagsFromDocument(tags, srcDoc);
+
+            processedDocumentsCount++;
+        }
+
+        monitor.setStateAndProgress(RUNNING, processedDocumentsCount, totalDocumentsCount);
+
+        return tags;
+    }
+
+    private void extractTagsFromDocument(HashSet<String> tags, SourceDocument srcDoc)
+    {
+        var annDocs = documentService.listAnnotationDocuments(srcDoc);
+
+        try (var session = CasStorageSession.openNested()) {
+            if (annDocs.isEmpty()) {
+                var cas = documentService.createOrReadInitialCas(srcDoc, AUTO_CAS_UPGRADE,
+                        SHARED_READ_ONLY_ACCESS);
+
+                extractTagsFromCas(cas, tags);
+            }
+            else {
+                for (var annDoc : annDocs) {
+                    var cas = documentService.readAnnotationCas(annDoc.getDocument(),
+                            annDoc.getUser(), AUTO_CAS_UPGRADE, SHARED_READ_ONLY_ACCESS);
+
+                    extractTagsFromCas(cas, tags);
+                }
+            }
+        }
+        catch (IOException e) {
+            getMonitor().addMessage(
+                    LogMessage.error(this, "Unable to process document [%s].", srcDoc.getName()));
+        }
+    }
+
+    private void extractTagsFromCas(CAS aCas, HashSet<String> aTags)
+    {
+        var adapter = schemaService.getAdapter(feature.getLayer());
+
+        var uimaType = aCas.getTypeSystem().getType(adapter.getAnnotationTypeName());
+        if (uimaType == null) {
+            return;
+        }
+
+        var uimaFeature = uimaType.getFeatureByBaseName(feature.getName());
+        if (!supportedTypes.contains(uimaFeature.getRange().getName())) {
+            return;
+        }
+
+        var isMultiValue = TYPE_NAME_STRING_ARRAY.equals(uimaFeature.getRange().getName());
+        for (var ann : aCas.select(uimaType)) {
+            if (isMultiValue) {
+                var labels = FSUtil.getFeature(ann, uimaFeature, String[].class);
+                if (labels != null) {
+                    aTags.addAll(asList(labels));
+                }
+            }
+            else {
+                aTags.add(ann.getFeatureValueAsString(uimaFeature));
+            }
+        }
+    }
+
+    public static Builder<Builder<?>> builder()
+    {
+        return new Builder<>();
+    }
+
+    public static class Builder<T extends Builder<?>>
+        extends RecommendationTask_ImplBase.Builder<T>
+    {
+        private TagSet tagSet;
+        private AnnotationFeature feature;
+
+        @SuppressWarnings("unchecked")
+        public T withAnnotationFeature(AnnotationFeature aFeature)
+        {
+            feature = aFeature;
+            return (T) this;
+        }
+
+        @SuppressWarnings("unchecked")
+        public T withTagSet(TagSet aTagSet)
+        {
+            tagSet = aTagSet;
+            return (T) this;
+        }
+
+        public TagSetExtractionTask build()
+        {
+            Validate.notNull(sessionOwner, "TagsetExtractionTask requires a session owner");
+            Validate.notNull(project, "TagsetExtractionTask requires a project");
+            Validate.notNull(feature, "TagsetExtractionTask requires a feature");
+            Validate.notNull(feature, "TagsetExtractionTask requires a tagSet");
+
+            return new TagSetExtractionTask(this);
+        }
+    }
+}

--- a/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/service/AnnotationSchemaServiceImpl.java
+++ b/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/service/AnnotationSchemaServiceImpl.java
@@ -195,13 +195,13 @@ public class AnnotationSchemaServiceImpl
             return;
         }
 
-        TagSet tagset = aTags[0].getTagSet();
-        Project project = tagset.getProject();
+        var tagset = aTags[0].getTagSet();
+        var project = tagset.getProject();
 
-        int createdCount = 0;
-        int updatedCount = 0;
-        for (Tag tag : aTags) {
-            boolean created = createTagNoLog(tag);
+        var createdCount = 0;
+        var updatedCount = 0;
+        for (var tag : aTags) {
+            var created = createTagNoLog(tag);
             if (created) {
                 createdCount++;
             }
@@ -214,6 +214,8 @@ public class AnnotationSchemaServiceImpl
             log.info("Created {} tags and updated {} tags in tagset {} in project {}", createdCount,
                     updatedCount, tagset, project);
         }
+
+        flushImmutableTagCache(tagset);
     }
 
     private boolean createTagNoLog(Tag aTag)


### PR DESCRIPTION
**What's in the PR**
- Added tagset extraction task to the processing page

**How to test manually**
* Enable the processing page experimental feature
* Import some pre-annotated data
* Create a target tagset in the project settings 
* Go to the processing page, select the layer / feature / tagset to populate
* Run process
* Go back to the tagset panel in the project settings and review that the tags have been created

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
