### PR TITLE
#4702 - Improve TEI styling for scientific publications processed with grobid

### DIFF
--- a/inception/inception-html-apache-annotator-editor/pom.xml
+++ b/inception/inception-html-apache-annotator-editor/pom.xml
@@ -71,6 +71,10 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-io-tei</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-io-xml</artifactId>
     </dependency>
     <dependency>
@@ -127,6 +131,7 @@
               <!-- Inlined constants are required for building but cannot be detected afterwards  -->
               <ignoredDependency>de.tudarmstadt.ukp.inception.app:inception-io-html</ignoredDependency>
               <ignoredDependency>de.tudarmstadt.ukp.inception.app:inception-io-xml</ignoredDependency>
+              <ignoredDependency>de.tudarmstadt.ukp.inception.app:inception-io-tei</ignoredDependency>
             </ignoredDependencies>
           </configuration>
         </plugin>

--- a/inception/inception-html-apache-annotator-editor/src/main/java/de/tudarmstadt/ukp/inception/apacheannotatoreditor/ApacheAnnotatorHtmlAnnotationEditorFactory.java
+++ b/inception/inception-html-apache-annotator-editor/src/main/java/de/tudarmstadt/ukp/inception/apacheannotatoreditor/ApacheAnnotatorHtmlAnnotationEditorFactory.java
@@ -34,6 +34,7 @@ import de.tudarmstadt.ukp.inception.editor.AnnotationEditorFactoryImplBase;
 import de.tudarmstadt.ukp.inception.editor.action.AnnotationActionHandler;
 import de.tudarmstadt.ukp.inception.io.html.HtmlFormatSupport;
 import de.tudarmstadt.ukp.inception.io.html.MHtmlFormatSupport;
+import de.tudarmstadt.ukp.inception.io.tei.TeiXmlDocumentFormatSupport;
 import de.tudarmstadt.ukp.inception.io.xml.CustomXmlFormatLoader;
 import de.tudarmstadt.ukp.inception.io.xml.XmlFormatSupport;
 import de.tudarmstadt.ukp.inception.preferences.ClientSidePreferencesKey;
@@ -79,14 +80,12 @@ public class ApacheAnnotatorHtmlAnnotationEditorFactory
             return PREFERRED;
         }
 
-        switch (aFormat) {
-        case HtmlFormatSupport.ID: // fall-through
-        case MHtmlFormatSupport.ID: // fall-through
-        case XmlFormatSupport.ID:
-            return PREFERRED;
+        return switch (aFormat) {
+        case HtmlFormatSupport.ID, MHtmlFormatSupport.ID, XmlFormatSupport.ID, TeiXmlDocumentFormatSupport.ID:
+            yield PREFERRED;
         default:
-            return DEFAULT;
-        }
+            yield DEFAULT;
+        };
     }
 
     @Override

--- a/inception/inception-io-tei/src/main/java/de/tudarmstadt/ukp/inception/io/tei/TeiXmlDocumentFormatSupport.java
+++ b/inception/inception-io-tei/src/main/java/de/tudarmstadt/ukp/inception/io/tei/TeiXmlDocumentFormatSupport.java
@@ -68,7 +68,7 @@ public class TeiXmlDocumentFormatSupport
     @Override
     public List<String> getSectionElements()
     {
-        return asList("p", "lg");
+        return asList("p", "lg", "biblStruct");
     }
 
     @Override

--- a/inception/inception-io-tei/src/main/java/de/tudarmstadt/ukp/inception/io/tei/TeiXmlDocumentPolicy.yaml
+++ b/inception/inception-io-tei/src/main/java/de/tudarmstadt/ukp/inception/io/tei/TeiXmlDocumentPolicy.yaml
@@ -84,7 +84,30 @@ policies:
       "add",
       "del",
       "metamark",
-      "unclear"
+      "unclear",
+      "addrLine",
+      "address",
+      "analytic",
+      "author",
+      "biblScope",
+      "biblStruct",
+      "date",
+      "figDesc",
+      "forename",
+      "graphic",
+      "idno",
+      "imprint",
+      "label",
+      "listBibl",
+      "listOrg",
+      "meeting",
+      "monogr",
+      "org",
+      "orgName",
+      "persName",
+      "rs",
+      "surname",
+      "title"
     ]
     action: PASS
   - { attributes: ["class", "type"], action: "PASS" }

--- a/inception/inception-io-tei/src/main/ts/src/TeiXmlDocument.scss
+++ b/inception/inception-io-tei/src/main/ts/src/TeiXmlDocument.scss
@@ -16,9 +16,11 @@
  * limitations under the License.
  */
 @import 'typography';
+@import 'bibliography';
 @import 'layout';
 @import 'tables';
 @import 'notes';
+@import 'figures';
 
 :root {
   --section-padding: 8px;
@@ -175,5 +177,13 @@ TEI {
     background-color: #ddd;
     font-style: normal;
     border-radius: 16px;
+  }
+
+  rs {
+    font-style: italic;
+  }
+
+  ref {
+    font-style: italic;
   }
 }

--- a/inception/inception-io-tei/src/main/ts/src/bibliography.scss
+++ b/inception/inception-io-tei/src/main/ts/src/bibliography.scss
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@mixin m-join-children($separator, $margin: 0px) {
+  & > * {
+    &:not(:last-child) {
+      &:after {
+        display: inline-block;
+        content: $separator;
+        margin-right: $margin;
+      }
+    }
+  }
+}
+
+TEI {
+  listBibl {
+    display: block;
+
+    biblStruct {
+      display: list-item;
+      list-style-type: disc; // Remove default list bullet
+    }
+  }
+
+  biblStruct {
+    display: block;
+    @include m-join-children("; ");
+
+    title {
+      display: inline;
+      font-weight: bold;
+    }
+
+    analytic {
+      @include m-join-children(", ");
+    }
+
+
+    persName {
+      @include m-join-children(" ", 0.25em);
+    }
+  }
+
+  monogr {
+    @include m-join-children(", ");
+
+    title {
+      font-style: italic;
+      font-weight: inherit;
+    }
+  }
+
+  idno {
+    font-style: italic;
+  }
+}

--- a/inception/inception-io-tei/src/main/ts/src/figures.scss
+++ b/inception/inception-io-tei/src/main/ts/src/figures.scss
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ TEI {
+  figure {
+    display: block;
+    border: 1px solid black;
+    margin-bottom: 0.5em;
+    padding: 0.5em;
+
+    head {
+      font-size: inherit;
+    }
+
+    label {
+
+    }
+
+    figDesc {
+
+    }
+  }
+ }


### PR DESCRIPTION
**What's in the PR**
- Add more styling for stuff produced by grobid
- Make Apache Annotator the default editor for TEI XML files

**How to test manually**
* Process a PDF to TEI using grobid, e.g. https://grobid.readthedocs.io/en/latest/Grobid-service/
* Import the TEI file as TEI XML (experimental)
* Open it in the annotation editor

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
