### PR TITLE
#4709 - Rely on layer type instead of feature presence for relation repair action

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/RelationAdapter.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/RelationAdapter.java
@@ -192,12 +192,18 @@ public class RelationAdapter
     public AnnotationFS getSourceAnnotation(AnnotationFS aTargetFs)
     {
         var sourceFeature = aTargetFs.getType().getFeatureByBaseName(sourceFeatureName);
+        if (sourceFeature == null) {
+            return null;
+        }
         return (AnnotationFS) aTargetFs.getFeatureValue(sourceFeature);
     }
 
     public AnnotationFS getTargetAnnotation(AnnotationFS aTargetFs)
     {
         var targetFeature = aTargetFs.getType().getFeatureByBaseName(targetFeatureName);
+        if (targetFeature == null) {
+            return null;
+        }
         return (AnnotationFS) aTargetFs.getFeatureValue(targetFeature);
     }
 

--- a/inception/inception-diag/src/test/java/de/tudarmstadt/ukp/clarin/webanno/diag/repairs/RemoveDanglingRelationsRepairTest.java
+++ b/inception/inception-diag/src/test/java/de/tudarmstadt/ukp/clarin/webanno/diag/repairs/RemoveDanglingRelationsRepairTest.java
@@ -17,15 +17,20 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.diag.repairs;
 
+import static de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationLayerSupport.FEAT_REL_SOURCE;
+import static de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationLayerSupport.FEAT_REL_TARGET;
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.uima.fit.factory.JCasFactory;
-import org.apache.uima.jcas.JCas;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import de.tudarmstadt.ukp.clarin.webanno.diag.CasDoctor;
 import de.tudarmstadt.ukp.clarin.webanno.diag.ChecksRegistryImpl;
@@ -33,42 +38,50 @@ import de.tudarmstadt.ukp.clarin.webanno.diag.RepairsRegistryImpl;
 import de.tudarmstadt.ukp.clarin.webanno.diag.checks.AllFeatureStructuresIndexedCheck;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
 import de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.Dependency;
+import de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationAdapter;
+import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.support.logging.LogMessage;
 
+@ExtendWith(MockitoExtension.class)
 public class RemoveDanglingRelationsRepairTest
 {
+    private @Mock AnnotationSchemaService schemaService;
+
     @Test
     public void test() throws Exception
     {
+        when(schemaService.findAdapter(any(), any())).thenReturn(new RelationAdapter(null, null,
+                null, null, FEAT_REL_SOURCE, FEAT_REL_TARGET, () -> asList(), asList()));
+
         var checksRegistry = new ChecksRegistryImpl(asList(new AllFeatureStructuresIndexedCheck()));
         checksRegistry.init();
         var repairsRegistry = new RepairsRegistryImpl(
-                asList(new RemoveDanglingRelationsRepair(null)));
+                asList(new RemoveDanglingRelationsRepair(schemaService)));
         repairsRegistry.init();
 
-        JCas jcas = JCasFactory.createJCas();
+        var jcas = JCasFactory.createJCas();
 
         jcas.setDocumentText("This is a test.");
 
-        Token span1 = new Token(jcas, 0, 4);
+        var span1 = new Token(jcas, 0, 4);
         span1.addToIndexes();
 
-        Token span2 = new Token(jcas, 6, 8);
+        var span2 = new Token(jcas, 6, 8);
 
-        Dependency dep = new Dependency(jcas, 0, 8);
+        var dep = new Dependency(jcas, 0, 8);
         dep.setGovernor(span1);
         dep.setDependent(span2);
         dep.addToIndexes();
 
-        List<LogMessage> messages = new ArrayList<>();
-        CasDoctor cd = new CasDoctor(checksRegistry, repairsRegistry);
+        var messages = new ArrayList<LogMessage>();
+        var cd = new CasDoctor(checksRegistry, repairsRegistry);
         cd.setActiveChecks(
                 checksRegistry.getExtensions().stream().map(c -> c.getId()).toArray(String[]::new));
         cd.setActiveRepairs(repairsRegistry.getExtensions().stream().map(c -> c.getId())
                 .toArray(String[]::new));
 
         // A project is not required for this check
-        boolean result = cd.analyze(null, jcas.getCas(), messages);
+        var result = cd.analyze(null, jcas.getCas(), messages);
 
         // A project is not required for this repair
         cd.repair(null, jcas.getCas(), messages);


### PR DESCRIPTION
**What's in the PR**
- Detect relation layers using the adapter mechanism

**How to test manually**
* No specific test procedure

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
