### PR TITLE
#4704 - Per-document agreement across all annotators

### DIFF
--- a/inception/inception-agreement/pom.xml
+++ b/inception/inception-agreement/pom.xml
@@ -33,6 +33,10 @@
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
+      <artifactId>commons-collections4</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
       <artifactId>commons-math3</artifactId>
     </dependency>
 

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/config/AgreementAutoConfiguration.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/config/AgreementAutoConfiguration.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.agreement.config;
+
+import org.springframework.context.annotation.Bean;
+
+import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.cohenkappa.CohenKappaAgreementMeasureSupport;
+import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.fleisskappa.FleissKappaAgreementMeasureSupport;
+import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.krippendorffalpha.KrippendorffAlphaAgreementMeasureSupport;
+import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.krippendorffalphaunitizing.KrippendorffAlphaUnitizingAgreementMeasureSupport;
+import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
+
+public class AgreementAutoConfiguration
+{
+    @Bean
+    public CohenKappaAgreementMeasureSupport cohenKappaAgreementMeasureSupport(
+            AnnotationSchemaService aAnnotationService)
+    {
+        return new CohenKappaAgreementMeasureSupport(aAnnotationService);
+    }
+
+    @Bean
+    public FleissKappaAgreementMeasureSupport fleissKappaAgreementMeasureSupport(
+            AnnotationSchemaService aAnnotationService)
+    {
+        return new FleissKappaAgreementMeasureSupport(aAnnotationService);
+    }
+
+    @Bean
+    public KrippendorffAlphaAgreementMeasureSupport KrippendorffAlphaAgreementMeasureSupport(
+            AnnotationSchemaService aAnnotationService)
+    {
+        return new KrippendorffAlphaAgreementMeasureSupport(aAnnotationService);
+    }
+
+    @Bean
+    public KrippendorffAlphaUnitizingAgreementMeasureSupport krippendorffAlphaUnitizingAgreementMeasureSupport()
+    {
+        return new KrippendorffAlphaUnitizingAgreementMeasureSupport();
+    }
+}

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/AgreementMeasureSupport.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/AgreementMeasureSupport.java
@@ -21,7 +21,6 @@ import org.apache.wicket.markup.html.panel.EmptyPanel;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
 import org.dkpro.statistics.agreement.IAnnotationStudy;
-import org.springframework.beans.factory.BeanNameAware;
 
 import de.tudarmstadt.ukp.clarin.webanno.agreement.AgreementResult_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.FullAgreementResult_ImplBase;
@@ -31,7 +30,6 @@ public interface AgreementMeasureSupport<//
         T extends DefaultAgreementTraits, //
         R extends FullAgreementResult_ImplBase<S>, //
         S extends IAnnotationStudy>
-    extends BeanNameAware
 {
     String getId();
 

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/AgreementMeasureSupport_ImplBase.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/AgreementMeasureSupport_ImplBase.java
@@ -30,20 +30,6 @@ public abstract class AgreementMeasureSupport_ImplBase<//
         S extends IAnnotationStudy>
     implements AgreementMeasureSupport<T, R, S>
 {
-    private String id;
-
-    @Override
-    public void setBeanName(String aName)
-    {
-        id = aName;
-    }
-
-    @Override
-    public String getId()
-    {
-        return id;
-    }
-
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
     public Panel createTraitsEditor(String aId, IModel<AnnotationFeature> aFeature,

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/cohenkappa/CohenKappaAgreementMeasureSupport.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/cohenkappa/CohenKappaAgreementMeasureSupport.java
@@ -17,8 +17,6 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.agreement.measures.cohenkappa;
 
-import org.springframework.stereotype.Component;
-
 import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.AgreementMeasure;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.DefaultAgreementTraits;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.results.coding.AbstractCodingAgreementMeasureSupport;
@@ -26,15 +24,22 @@ import de.tudarmstadt.ukp.clarin.webanno.agreement.results.coding.FullCodingAgre
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 
-@Component
 public class CohenKappaAgreementMeasureSupport
     extends AbstractCodingAgreementMeasureSupport<DefaultAgreementTraits>
 {
+    public static final String ID = "CohenKappa";
+
     private final AnnotationSchemaService annotationService;
 
     public CohenKappaAgreementMeasureSupport(AnnotationSchemaService aAnnotationService)
     {
         annotationService = aAnnotationService;
+    }
+
+    @Override
+    public String getId()
+    {
+        return ID;
     }
 
     @Override

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/fleisskappa/FleissKappaAgreementMeasureSupport.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/fleisskappa/FleissKappaAgreementMeasureSupport.java
@@ -17,8 +17,6 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.agreement.measures.fleisskappa;
 
-import org.springframework.stereotype.Component;
-
 import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.AgreementMeasure;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.DefaultAgreementTraits;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.results.coding.AbstractCodingAgreementMeasureSupport;
@@ -26,16 +24,22 @@ import de.tudarmstadt.ukp.clarin.webanno.agreement.results.coding.FullCodingAgre
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 
-@Component
 public class FleissKappaAgreementMeasureSupport
     extends AbstractCodingAgreementMeasureSupport<DefaultAgreementTraits>
 {
+    public static final String ID = "FleissKappa";
+
     private final AnnotationSchemaService annotationService;
 
     public FleissKappaAgreementMeasureSupport(AnnotationSchemaService aAnnotationService)
     {
-        super();
         annotationService = aAnnotationService;
+    }
+
+    @Override
+    public String getId()
+    {
+        return ID;
     }
 
     @Override

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/krippendorffalpha/KrippendorffAlphaAgreementMeasureSupport.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/krippendorffalpha/KrippendorffAlphaAgreementMeasureSupport.java
@@ -19,7 +19,6 @@ package de.tudarmstadt.ukp.clarin.webanno.agreement.measures.krippendorffalpha;
 
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
-import org.springframework.stereotype.Component;
 
 import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.AgreementMeasure;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.DefaultAgreementTraits;
@@ -28,16 +27,22 @@ import de.tudarmstadt.ukp.clarin.webanno.agreement.results.coding.FullCodingAgre
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 
-@Component
 public class KrippendorffAlphaAgreementMeasureSupport
     extends AbstractCodingAgreementMeasureSupport<DefaultAgreementTraits>
 {
+    public static final String ID = "KrippendorffAlpha";
+
     private final AnnotationSchemaService annotationService;
 
     public KrippendorffAlphaAgreementMeasureSupport(AnnotationSchemaService aAnnotationService)
     {
-        super();
         annotationService = aAnnotationService;
+    }
+
+    @Override
+    public String getId()
+    {
+        return ID;
     }
 
     @Override

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/krippendorffalphaunitizing/KrippendorffAlphaUnitizingAgreementMeasureSupport.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/krippendorffalphaunitizing/KrippendorffAlphaUnitizingAgreementMeasureSupport.java
@@ -21,7 +21,6 @@ import org.apache.wicket.markup.html.panel.EmptyPanel;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
 import org.dkpro.statistics.agreement.unitizing.IUnitizingAnnotationStudy;
-import org.springframework.stereotype.Component;
 
 import de.tudarmstadt.ukp.clarin.webanno.agreement.AgreementResult_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.PairwiseAgreementResult;
@@ -34,19 +33,19 @@ import de.tudarmstadt.ukp.clarin.webanno.agreement.results.unitizing.FullUnitizi
 import de.tudarmstadt.ukp.clarin.webanno.agreement.results.unitizing.PairwiseUnitizingAgreementTable;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.inception.annotation.layer.span.SpanLayerSupport;
-import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 
-@Component
 public class KrippendorffAlphaUnitizingAgreementMeasureSupport
     extends AgreementMeasureSupport_ImplBase<//
             DefaultAgreementTraits, //
             FullUnitizingAgreementResult, //
             IUnitizingAnnotationStudy>
 {
-    public KrippendorffAlphaUnitizingAgreementMeasureSupport(
-            AnnotationSchemaService aAnnotationService)
+    public static final String ID = "KrippendorffAlphaUnitizing";
+
+    @Override
+    public String getId()
     {
-        super();
+        return ID;
     }
 
     @Override

--- a/inception/inception-agreement/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/inception/inception-agreement/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+de.tudarmstadt.ukp.clarin.webanno.agreement.config.AgreementAutoConfiguration

--- a/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/AgreementMeasureTestSuite_ImplBase.java
+++ b/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/AgreementMeasureTestSuite_ImplBase.java
@@ -248,12 +248,12 @@ public class AgreementMeasureTestSuite_ImplBase
         layer.setId(1l);
         layers.add(layer);
 
-        AnnotationFeature feature = new AnnotationFeature(project, layer, "PosValue", "PosValue",
-                CAS.TYPE_NAME_STRING);
+        var feature = new AnnotationFeature(project, layer, "PosValue", "PosValue",
+                TYPE_NAME_STRING);
         feature.setId(1l);
         features.add(feature);
 
-        JCas user1 = JCasFactory.createText("test");
+        var user1 = JCasFactory.createText("test");
 
         new POS(user1, 0, 1).addToIndexes();
         new POS(user1, 1, 2).addToIndexes();
@@ -261,11 +261,11 @@ public class AgreementMeasureTestSuite_ImplBase
         p1.setPosValue("A");
         p1.addToIndexes();
 
-        JCas user2 = JCasFactory.createText("test");
+        var user2 = JCasFactory.createText("test");
 
         new POS(user2, 0, 1).addToIndexes();
         new POS(user2, 2, 3).addToIndexes();
-        POS p2 = new POS(user2, 3, 4);
+        var p2 = new POS(user2, 3, 4);
         p2.setPosValue("B");
         p2.addToIndexes();
 
@@ -273,7 +273,7 @@ public class AgreementMeasureTestSuite_ImplBase
         casByUser.put("user1", user1.getCas());
         casByUser.put("user2", user2.getCas());
 
-        AgreementMeasure<R> measure = aSupport.createMeasure(feature, aTraits);
+        var measure = aSupport.createMeasure(feature, aTraits);
 
         return measure.getAgreement(casByUser);
     }
@@ -289,8 +289,8 @@ public class AgreementMeasureTestSuite_ImplBase
         layer.setId(1l);
         layers.add(layer);
 
-        AnnotationFeature feature = new AnnotationFeature(project, layer, "PosValue", "PosValue",
-                CAS.TYPE_NAME_STRING);
+        var feature = new AnnotationFeature(project, layer, "PosValue", "PosValue",
+                TYPE_NAME_STRING);
         feature.setId(1l);
         feature.setTagset(tagset);
         features.add(feature);

--- a/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/FleissKappaAgreementMeasureTest.java
+++ b/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/FleissKappaAgreementMeasureTest.java
@@ -17,18 +17,28 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.agreement.measures;
 
+import static de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.Tag.COMPLETE;
+import static de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.Tag.DIFFERENCE;
+import static de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.Tag.INCOMPLETE_POSITION;
 import static java.lang.Double.NaN;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-import org.dkpro.statistics.agreement.coding.ICodingAnnotationItem;
+import java.util.Set;
+import java.util.stream.StreamSupport;
+
+import org.dkpro.statistics.agreement.IAnnotationUnit;
 import org.dkpro.statistics.agreement.coding.ICodingAnnotationStudy;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.fleisskappa.FleissKappaAgreementMeasureSupport;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.results.coding.FullCodingAgreementResult;
+import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.ConfigurationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 
 public class FleissKappaAgreementMeasureTest
@@ -108,18 +118,34 @@ public class FleissKappaAgreementMeasureTest
     {
         var result = twoWithoutLabelTest(sut, traits);
 
-        ICodingAnnotationItem item1 = result.getStudy().getItem(0);
-        ICodingAnnotationItem item2 = result.getStudy().getItem(1);
-        assertEquals("", item1.getUnit(0).getCategory());
-        assertEquals("", item1.getUnit(1).getCategory());
-        assertEquals("A", item2.getUnit(0).getCategory());
+        assertThat(result.getStudy().getItems())
+                .extracting(item -> StreamSupport.stream(item.getUnits().spliterator(), false)
+                        .map(IAnnotationUnit::getCategory).toList())
+                .containsExactly( //
+                        asList("", ""), //
+                        asList("A", "B"));
 
         assertEquals(4, result.getTotalSetCount());
-        assertEquals(0, result.getIrrelevantSets().size());
-        assertEquals(2, result.getIncompleteSetsByPosition().size());
-        assertEquals(0, result.getIncompleteSetsByLabel().size());
-        assertEquals(1, result.getSetsWithDifferences().size());
+        assertThat(result.getIrrelevantSets()).isEmpty();
+        assertThat(result.getIncompleteSetsByPosition()) //
+                .extracting(ConfigurationSet::getCasGroupIds, ConfigurationSet::getTags) //
+                .containsExactly( //
+                        tuple(Set.of("user1"), Set.of(INCOMPLETE_POSITION)), //
+                        tuple(Set.of("user2"), Set.of(INCOMPLETE_POSITION)));
+        assertThat(result.getIncompleteSetsByLabel()).isEmpty();
+        assertThat(result.getSetsWithDifferences()) //
+                .extracting(ConfigurationSet::getCasGroupIds, ConfigurationSet::getTags) //
+                .containsExactly( //
+                        tuple(Set.of("user1", "user2"), Set.of(DIFFERENCE, COMPLETE)));
+        assertThat(result.getRelevantSets()) //
+                .extracting(ConfigurationSet::getCasGroupIds, ConfigurationSet::getTags) //
+                .containsExactly( //
+                        tuple(Set.of("user1", "user2"), Set.of(COMPLETE)), //
+                        tuple(Set.of("user1"), Set.of(INCOMPLETE_POSITION)), //
+                        tuple(Set.of("user2"), Set.of(INCOMPLETE_POSITION)), //
+                        tuple(Set.of("user1", "user2"), Set.of(DIFFERENCE, COMPLETE)));
         assertEquals(4, result.getRelevantSetCount());
+
         assertEquals(0.2, result.getAgreement(), 0.01);
     }
 
@@ -128,7 +154,7 @@ public class FleissKappaAgreementMeasureTest
     {
         var result = fullSingleCategoryAgreementWithTagset(sut, traits);
 
-        ICodingAnnotationItem item1 = result.getStudy().getItem(0);
+        var item1 = result.getStudy().getItem(0);
         assertEquals("+", item1.getUnit(0).getCategory());
 
         assertEquals(1, result.getTotalSetCount());

--- a/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/KrippendorffAlphaUnitizingAgreementMeasureTest.java
+++ b/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/KrippendorffAlphaUnitizingAgreementMeasureTest.java
@@ -40,7 +40,7 @@ public class KrippendorffAlphaUnitizingAgreementMeasureTest
     {
         super.setup();
 
-        sut = new KrippendorffAlphaUnitizingAgreementMeasureSupport(annotationService);
+        sut = new KrippendorffAlphaUnitizingAgreementMeasureSupport();
         traits = sut.createTraits();
     }
 

--- a/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/ConfigurationSet.java
+++ b/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/ConfigurationSet.java
@@ -22,8 +22,11 @@ import static java.util.Arrays.asList;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -44,7 +47,9 @@ public class ConfigurationSet
 
     private List<Configuration> configurations = new ArrayList<>();
     private Set<String> casGroupIds = new LinkedHashSet<>();
+
     private EnumSet<Tag> tags = EnumSet.noneOf(Tag.class);
+    private Map<String, Set<Object>> values = new HashMap<>();
 
     public ConfigurationSet(Position aPosition)
     {
@@ -60,6 +65,9 @@ public class ConfigurationSet
         return this;
     }
 
+    /**
+     * @return tags added during agreement calculation (not by {@link CasDiff}!)
+     */
     public EnumSet<Tag> getTags()
     {
         return tags;
@@ -68,6 +76,19 @@ public class ConfigurationSet
     public boolean hasTag(Tag aTag)
     {
         return tags.contains(aTag);
+    }
+
+    public void addValue(String aDataOwner, Object aValue)
+    {
+        values.computeIfAbsent(aDataOwner, $ -> new HashSet<>()).add(aValue);
+    }
+
+    /**
+     * @return values added during agreement calculation (not by {@link CasDiff}!)
+     */
+    public Set<Object> getValues(String aDataOwner)
+    {
+        return values.get(aDataOwner);
     }
 
     /**

--- a/inception/inception-ui-agreement/src/main/java/de/tudarmstadt/ukp/inception/ui/agreement/page/AgreementService.java
+++ b/inception/inception-ui-agreement/src/main/java/de/tudarmstadt/ukp/inception/ui/agreement/page/AgreementService.java
@@ -37,7 +37,6 @@ public interface AgreementService
     Map<SourceDocument, List<AnnotationDocument>> getDocumentsToEvaluate(Project aProject,
             List<SourceDocument> aDocuments, DefaultAgreementTraits aTraits);
 
-    void exportDiff(OutputStream aOut, AnnotationFeature aFeature, String aMeasure,
-            DefaultAgreementTraits aTraits, User aCurrentUser, List<SourceDocument> aDocuments,
-            List<String> aAnnotators);
+    void exportDiff(OutputStream aOut, AnnotationFeature aFeature, DefaultAgreementTraits aTraits,
+            User aCurrentUser, List<SourceDocument> aDocuments, List<String> aAnnotators);
 }


### PR DESCRIPTION
**What's in the PR**
- Include incomplete / stacked positions and include annotator's values on these as well in the diff export
- Fix a bug where a configuration set might not be marked as "difference" when there are more than two annotators

**How to test manually**
* Export diff from the agreement page and inspect the result

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
