### PR TITLE
#4735 - Some events that should not be filtered out are logged

### DIFF
--- a/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/log/ActiveLearningRecommendationEventAdapter.java
+++ b/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/log/ActiveLearningRecommendationEventAdapter.java
@@ -38,9 +38,9 @@ public class ActiveLearningRecommendationEventAdapter
     implements EventLoggingAdapter<ActiveLearningRecommendationEvent>
 {
     @Override
-    public boolean accepts(Object aEvent)
+    public boolean accepts(Class<?> aEvent)
     {
-        return aEvent instanceof ActiveLearningRecommendationEvent;
+        return ActiveLearningRecommendationEvent.class.isAssignableFrom(aEvent);
     }
 
     @Override

--- a/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/log/ActiveLearningSuggestionOfferedAdapter.java
+++ b/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/log/ActiveLearningSuggestionOfferedAdapter.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import de.tudarmstadt.ukp.inception.active.learning.config.ActiveLearningAutoConfiguration;
-import de.tudarmstadt.ukp.inception.active.learning.event.ActiveLearningRecommendationEvent;
 import de.tudarmstadt.ukp.inception.active.learning.event.ActiveLearningSuggestionOfferedEvent;
 import de.tudarmstadt.ukp.inception.log.adapter.EventLoggingAdapter;
 import de.tudarmstadt.ukp.inception.log.model.AnnotationDetails;
@@ -39,9 +38,9 @@ public class ActiveLearningSuggestionOfferedAdapter
     implements EventLoggingAdapter<ActiveLearningSuggestionOfferedEvent>
 {
     @Override
-    public boolean accepts(Object aEvent)
+    public boolean accepts(Class<?> aEvent)
     {
-        return aEvent instanceof ActiveLearningRecommendationEvent;
+        return ActiveLearningSuggestionOfferedEvent.class.isAssignableFrom(aEvent);
     }
 
     @Override

--- a/inception/inception-external-search-core/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/log/ExternalSearchQueryEventAdapter.java
+++ b/inception/inception-external-search-core/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/log/ExternalSearchQueryEventAdapter.java
@@ -30,9 +30,9 @@ public class ExternalSearchQueryEventAdapter
     implements EventLoggingAdapter<ExternalSearchQueryEvent>
 {
     @Override
-    public boolean accepts(Object aEvent)
+    public boolean accepts(Class<?> aEvent)
     {
-        return aEvent instanceof ExternalSearchQueryEvent;
+        return ExternalSearchQueryEvent.class.isAssignableFrom(aEvent);
     }
 
     @Override

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/log/DocumentMetadataEventAdapter.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/log/DocumentMetadataEventAdapter.java
@@ -31,9 +31,9 @@ public class DocumentMetadataEventAdapter
     implements EventLoggingAdapter<DocumentMetadataEvent>
 {
     @Override
-    public boolean accepts(Object aEvent)
+    public boolean accepts(Class<?> aEvent)
     {
-        return aEvent instanceof DocumentMetadataEvent;
+        return DocumentMetadataEvent.class.isAssignableFrom(aEvent);
     }
 
     @Override

--- a/inception/inception-log-ui/src/main/java/de/tudarmstadt/ukp/inception/websocket/controller/LoggedEventsWebsocketControllerImpl.java
+++ b/inception/inception-log-ui/src/main/java/de/tudarmstadt/ukp/inception/websocket/controller/LoggedEventsWebsocketControllerImpl.java
@@ -74,7 +74,7 @@ public class LoggedEventsWebsocketControllerImpl
     @Override
     public void onApplicationEvent(ApplicationEvent aEvent)
     {
-        adapterRegistry.getAdapter(aEvent)
+        adapterRegistry.getAdapter(aEvent).filter(a -> a.isLoggable(aEvent)) //
                 .map(a -> createLoggedEventMessage(a.getUser(aEvent), a.getProject(aEvent),
                         a.getCreated(aEvent), a.getEvent(aEvent), a.getDocument(aEvent)))
                 .ifPresent(eventMsg -> msgTemplate.convertAndSend(LOGGED_EVENTS_TOPIC, eventMsg));
@@ -102,7 +102,8 @@ public class LoggedEventsWebsocketControllerImpl
         return eventRepo.listRecentActivity(aUsername, aMaxEvents).stream()
                 .map(event -> createLoggedEventMessage(event.getUser(), event.getProject(),
                         event.getCreated(), event.getEvent(), event.getDocument()))
-                .filter(Objects::nonNull).collect(toList());
+                .filter(Objects::nonNull) //
+                .collect(toList());
     }
 
     private LoggedEventMessage createLoggedEventMessage(String aUsername, long aProjectId,

--- a/inception/inception-log-ui/src/test/java/de/tudarmstadt/ukp/inception/websocket/WebSocketIntegrationTest.java
+++ b/inception/inception-log-ui/src/test/java/de/tudarmstadt/ukp/inception/websocket/WebSocketIntegrationTest.java
@@ -63,6 +63,8 @@ import org.springframework.messaging.simp.stomp.StompFrameHandler;
 import org.springframework.messaging.simp.stomp.StompHeaders;
 import org.springframework.messaging.simp.stomp.StompSession;
 import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
+import org.springframework.security.authentication.AuthenticationEventPublisher;
+import org.springframework.security.authentication.DefaultAuthenticationEventPublisher;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -281,11 +283,17 @@ public class WebSocketIntegrationTest
             return new ApplicationContextProvider();
         }
 
+        @Bean
+        AuthenticationEventPublisher authenticationEventPublisher()
+        {
+            return new DefaultAuthenticationEventPublisher();
+        }
+
         @Bean(name = "authenticationProvider")
         public DaoAuthenticationProvider internalAuthenticationProvider(PasswordEncoder aEncoder,
                 @Lazy UserDetailsManager aUserDetailsManager)
         {
-            DaoAuthenticationProvider authProvider = new InceptionDaoAuthenticationProvider();
+            var authProvider = new InceptionDaoAuthenticationProvider();
             authProvider.setUserDetailsService(aUserDetailsManager);
             authProvider.setPasswordEncoder(aEncoder);
             return authProvider;

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/EventLoggingListener.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/EventLoggingListener.java
@@ -117,6 +117,9 @@ public class EventLoggingListener
         }
 
         var adapter = maybeAdapter.get();
+        if (!adapter.isLoggable(aEvent)) {
+            return;
+        }
 
         if (!shouldLogEvent(adapter.getEvent(aEvent))) {
             return;

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/AfterCasWrittenEventAdapter.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/AfterCasWrittenEventAdapter.java
@@ -30,9 +30,9 @@ public class AfterCasWrittenEventAdapter
     implements EventLoggingAdapter<AfterCasWrittenEvent>
 {
     @Override
-    public boolean accepts(Object aEvent)
+    public boolean accepts(Class<?> aEvent)
     {
-        return aEvent instanceof AfterCasWrittenEvent;
+        return AfterCasWrittenEvent.class.isAssignableFrom(aEvent);
     }
 
     @Override

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/AfterDocumentCreatedEventAdapter.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/AfterDocumentCreatedEventAdapter.java
@@ -30,9 +30,9 @@ public class AfterDocumentCreatedEventAdapter
     implements EventLoggingAdapter<AfterDocumentCreatedEvent>
 {
     @Override
-    public boolean accepts(Object aEvent)
+    public boolean accepts(Class<?> aEvent)
     {
-        return aEvent instanceof AfterDocumentCreatedEvent;
+        return AfterDocumentCreatedEvent.class.isAssignableFrom(aEvent);
     }
 
     @Override

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/AfterProjectCreatedEventAdapter.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/AfterProjectCreatedEventAdapter.java
@@ -29,9 +29,9 @@ public class AfterProjectCreatedEventAdapter
     implements EventLoggingAdapter<AfterProjectCreatedEvent>
 {
     @Override
-    public boolean accepts(Object aEvent)
+    public boolean accepts(Class<?> aEvent)
     {
-        return aEvent instanceof AfterProjectCreatedEvent;
+        return AfterProjectCreatedEvent.class.isAssignableFrom(aEvent);
     }
 
     @Override

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/AfterProjectRemovedEventAdapter.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/AfterProjectRemovedEventAdapter.java
@@ -26,9 +26,9 @@ public class AfterProjectRemovedEventAdapter
     implements EventLoggingAdapter<AfterProjectRemovedEvent>
 {
     @Override
-    public boolean accepts(Object aEvent)
+    public boolean accepts(Class<?> aEvent)
     {
-        return aEvent instanceof AfterProjectRemovedEvent;
+        return AfterProjectRemovedEvent.class.isAssignableFrom(aEvent);
     }
 
     @Override

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/AnnotationStateChangedEventAdapter.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/AnnotationStateChangedEventAdapter.java
@@ -34,9 +34,9 @@ public class AnnotationStateChangedEventAdapter
     implements EventLoggingAdapter<AnnotationStateChangeEvent>
 {
     @Override
-    public boolean accepts(Object aEvent)
+    public boolean accepts(Class<?> aEvent)
     {
-        return aEvent instanceof AnnotationStateChangeEvent;
+        return AnnotationStateChangeEvent.class.isAssignableFrom(aEvent);
     }
 
     @Override

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/AuthenticationFailedEventAdapter.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/AuthenticationFailedEventAdapter.java
@@ -17,23 +17,28 @@
  */
 package de.tudarmstadt.ukp.inception.log.adapter;
 
+import org.springframework.security.authentication.event.AbstractAuthenticationFailureEvent;
 import org.springframework.stereotype.Component;
 
-import de.tudarmstadt.ukp.inception.project.api.event.BeforeProjectRemovedEvent;
-
 @Component
-public class BeforeProjectRemovedEventAdapter
-    implements EventLoggingAdapter<BeforeProjectRemovedEvent>
+public class AuthenticationFailedEventAdapter
+    implements EventLoggingAdapter<AbstractAuthenticationFailureEvent>
 {
     @Override
     public boolean accepts(Class<?> aEvent)
     {
-        return BeforeProjectRemovedEvent.class.isAssignableFrom(aEvent);
+        return AbstractAuthenticationFailureEvent.class.isAssignableFrom(aEvent);
     }
 
     @Override
-    public long getProject(BeforeProjectRemovedEvent aEvent)
+    public String getEvent(AbstractAuthenticationFailureEvent aEvent)
     {
-        return aEvent.getProject().getId();
+        return aEvent.getClass().getSimpleName();
+    }
+
+    @Override
+    public String getUser(AbstractAuthenticationFailureEvent aEvent)
+    {
+        return aEvent.getAuthentication().getName();
     }
 }

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/AuthenticationSuccessEventAdapter.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/AuthenticationSuccessEventAdapter.java
@@ -31,9 +31,9 @@ public class AuthenticationSuccessEventAdapter
     implements EventLoggingAdapter<AuthenticationSuccessEvent>
 {
     @Override
-    public boolean accepts(Object aEvent)
+    public boolean accepts(Class<?> aEvent)
     {
-        return aEvent instanceof AuthenticationSuccessEvent;
+        return AuthenticationSuccessEvent.class.isAssignableFrom(aEvent);
     }
 
     @Override

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/BeforeDocumentRemovedEventAdapter.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/BeforeDocumentRemovedEventAdapter.java
@@ -26,9 +26,9 @@ public class BeforeDocumentRemovedEventAdapter
     implements EventLoggingAdapter<BeforeDocumentRemovedEvent>
 {
     @Override
-    public boolean accepts(Object aEvent)
+    public boolean accepts(Class<?> aEvent)
     {
-        return aEvent instanceof BeforeDocumentRemovedEvent;
+        return BeforeDocumentRemovedEvent.class.isAssignableFrom(aEvent);
     }
 
     @Override

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/BulkAnnotationEventAdapter.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/BulkAnnotationEventAdapter.java
@@ -26,9 +26,9 @@ public class BulkAnnotationEventAdapter
     implements EventLoggingAdapter<BulkAnnotationEvent>
 {
     @Override
-    public boolean accepts(Object aEvent)
+    public boolean accepts(Class<?> aEvent)
     {
-        return aEvent instanceof BulkAnnotationEvent;
+        return BulkAnnotationEvent.class.isAssignableFrom(aEvent);
     }
 
     @Override

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/ChainLinkEventAdapter.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/ChainLinkEventAdapter.java
@@ -31,9 +31,9 @@ public class ChainLinkEventAdapter
     implements EventLoggingAdapter<ChainLinkEvent>
 {
     @Override
-    public boolean accepts(Object aEvent)
+    public boolean accepts(Class<?> aEvent)
     {
-        return aEvent instanceof ChainLinkEvent;
+        return ChainLinkEvent.class.isAssignableFrom(aEvent);
     }
 
     @Override

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/ChainSpanEventAdapter.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/ChainSpanEventAdapter.java
@@ -30,9 +30,9 @@ public class ChainSpanEventAdapter
     implements EventLoggingAdapter<ChainSpanEvent>
 {
     @Override
-    public boolean accepts(Object aEvent)
+    public boolean accepts(Class<?> aEvent)
     {
-        return aEvent instanceof ChainSpanEvent;
+        return ChainSpanEvent.class.isAssignableFrom(aEvent);
     }
 
     @Override

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/DocumentOpenedEventAdapter.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/DocumentOpenedEventAdapter.java
@@ -25,11 +25,10 @@ import de.tudarmstadt.ukp.inception.annotation.events.DocumentOpenedEvent;
 public class DocumentOpenedEventAdapter
     implements EventLoggingAdapter<DocumentOpenedEvent>
 {
-
     @Override
-    public boolean accepts(Object aEvent)
+    public boolean accepts(Class<?> aEvent)
     {
-        return aEvent instanceof DocumentOpenedEvent;
+        return DocumentOpenedEvent.class.isAssignableFrom(aEvent);
     }
 
     @Override

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/DocumentStateChangedEventAdapter.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/DocumentStateChangedEventAdapter.java
@@ -31,9 +31,9 @@ public class DocumentStateChangedEventAdapter
     implements EventLoggingAdapter<DocumentStateChangedEvent>
 {
     @Override
-    public boolean accepts(Object aEvent)
+    public boolean accepts(Class<?> aEvent)
     {
-        return aEvent instanceof DocumentStateChangedEvent;
+        return DocumentStateChangedEvent.class.isAssignableFrom(aEvent);
     }
 
     @Override

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/EventLoggingAdapter.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/EventLoggingAdapter.java
@@ -30,7 +30,12 @@ public interface EventLoggingAdapter<T>
     public static final String SYSTEM_USER = "<SYSTEM>";
     public static final String ANONYMOUS_USER = "anonymousUser";
 
-    boolean accepts(Object aEvent);
+    boolean accepts(Class<?> aEvent);
+
+    default boolean isLoggable(T aEvent)
+    {
+        return true;
+    }
 
     default String getDetails(T aEvent) throws Exception
     {

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/EventLoggingAdapterRegistryImpl.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/EventLoggingAdapterRegistryImpl.java
@@ -82,22 +82,30 @@ public class EventLoggingAdapterRegistryImpl
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public <T> Optional<EventLoggingAdapter<T>> getAdapter(T aEvent)
     {
+        if (aEvent == null) {
+            return Optional.empty();
+        }
+
+        var eventClass = aEvent.getClass();
+
         // Try to obtain the adapter from the cache
-        EventLoggingAdapter<T> adapter = (EventLoggingAdapter) adapterCache.get(aEvent.getClass());
+        var adapter = (EventLoggingAdapter) adapterCache.get(eventClass);
 
         // This happens for events generated during applications startup.
-        if (adapter == null && adapters != null) {
-            for (EventLoggingAdapter a : adapters) {
-                if (a.accepts(aEvent)) {
-                    adapter = a;
-                    adapterCache.put(aEvent.getClass(), adapter);
-                    break;
+        if (adapter == null) {
+            if (adapters != null) {
+                for (var a : adapters) {
+                    if (a.accepts(eventClass)) {
+                        adapter = a;
+                        adapterCache.put(eventClass, adapter);
+                        break;
+                    }
                 }
             }
         }
 
         // If no adapter could be found, check if the generic adapter applies
-        if (adapter == null && GenericEventAdapter.INSTANCE.accepts(aEvent)) {
+        if (adapter == null && GenericEventAdapter.INSTANCE.accepts(eventClass)) {
             adapter = (EventLoggingAdapter<T>) GenericEventAdapter.INSTANCE;
         }
 

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/FeatureValueUpdatedEventAdapter.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/FeatureValueUpdatedEventAdapter.java
@@ -30,9 +30,9 @@ public class FeatureValueUpdatedEventAdapter
     implements EventLoggingAdapter<FeatureValueUpdatedEvent>
 {
     @Override
-    public boolean accepts(Object aEvent)
+    public boolean accepts(Class<?> aEvent)
     {
-        return aEvent instanceof FeatureValueUpdatedEvent;
+        return FeatureValueUpdatedEvent.class.isAssignableFrom(aEvent);
     }
 
     @Override

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/GenericEventAdapter.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/GenericEventAdapter.java
@@ -17,11 +17,14 @@
  */
 package de.tudarmstadt.ukp.inception.log.adapter;
 
+import java.util.Set;
+
 import org.springframework.boot.web.context.WebServerInitializedEvent;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.event.ApplicationContextEvent;
 import org.springframework.security.access.event.AbstractAuthorizationEvent;
 import org.springframework.security.authentication.event.AbstractAuthenticationEvent;
+import org.springframework.security.authorization.event.AuthorizationEvent;
 import org.springframework.security.core.session.SessionCreationEvent;
 import org.springframework.security.core.session.SessionDestroyedEvent;
 import org.springframework.web.context.support.ServletRequestHandledEvent;
@@ -36,22 +39,26 @@ public class GenericEventAdapter
 {
     public static final GenericEventAdapter INSTANCE = new GenericEventAdapter();
 
+    private static final Set<Class<?>> UNLOGGED_EVENTS = Set.of( //
+            ApplicationContextEvent.class, //
+            ServletRequestHandledEvent.class, //
+            SessionCreationEvent.class, //
+            SessionDestroyedEvent.class, //
+            AuthorizationEvent.class, //
+            AbstractAuthorizationEvent.class, //
+            AbstractAuthenticationEvent.class, //
+            WebServerInitializedEvent.class, //
+            // Websocket events
+            SessionConnectedEvent.class, //
+            SessionConnectEvent.class, //
+            SessionDisconnectEvent.class, //
+            SessionSubscribeEvent.class, //
+            SessionUnsubscribeEvent.class);
+
     @Override
-    public boolean accepts(Object aEvent)
+    public boolean accepts(Class<?> aEvent)
     {
-        return aEvent instanceof ApplicationEvent && //
-                !(aEvent instanceof ApplicationContextEvent //
-                        || aEvent instanceof ServletRequestHandledEvent //
-                        || aEvent instanceof SessionCreationEvent //
-                        || aEvent instanceof SessionDestroyedEvent //
-                        || aEvent instanceof AbstractAuthorizationEvent //
-                        || aEvent instanceof AbstractAuthenticationEvent //
-                        || aEvent instanceof WebServerInitializedEvent //
-                        // Websocket events
-                        || aEvent instanceof SessionConnectedEvent //
-                        || aEvent instanceof SessionConnectEvent //
-                        || aEvent instanceof SessionDisconnectEvent //
-                        || aEvent instanceof SessionSubscribeEvent //
-                        || aEvent instanceof SessionUnsubscribeEvent);
+        return ApplicationEvent.class.isAssignableFrom(aEvent)
+                && UNLOGGED_EVENTS.stream().noneMatch($ -> $.isAssignableFrom(aEvent));
     }
 }

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/HttpSessionDestroyedEventAdapter.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/HttpSessionDestroyedEventAdapter.java
@@ -33,12 +33,14 @@ public class HttpSessionDestroyedEventAdapter
     private static final Set<String> IGNORE_USERS = Set.of(ANONYMOUS_USER, SYSTEM_USER);
 
     @Override
-    public boolean accepts(Object aEvent)
+    public boolean accepts(Class<?> aEvent)
     {
-        if (!(aEvent instanceof HttpSessionDestroyedEvent)) {
-            return false;
-        }
+        return HttpSessionDestroyedEvent.class.isAssignableFrom(aEvent);
+    }
 
+    @Override
+    public boolean isLoggable(HttpSessionDestroyedEvent aEvent)
+    {
         var user = getUser((HttpSessionDestroyedEvent) aEvent);
         if (IGNORE_USERS.contains(user)) {
             return false;

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/LayerConfigurationChangedEventAdapter.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/LayerConfigurationChangedEventAdapter.java
@@ -26,9 +26,9 @@ public class LayerConfigurationChangedEventAdapter
     implements EventLoggingAdapter<LayerConfigurationChangedEvent>
 {
     @Override
-    public boolean accepts(Object aEvent)
+    public boolean accepts(Class<?> aEvent)
     {
-        return aEvent instanceof LayerConfigurationChangedEvent;
+        return LayerConfigurationChangedEvent.class.isAssignableFrom(aEvent);
     }
 
     @Override

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/ProjectImportEventAdapter.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/ProjectImportEventAdapter.java
@@ -27,9 +27,9 @@ public class ProjectImportEventAdapter
     implements EventLoggingAdapter<ProjectImportEvent>
 {
     @Override
-    public boolean accepts(Object aEvent)
+    public boolean accepts(Class<?> aEvent)
     {
-        return aEvent instanceof ProjectImportEvent;
+        return ProjectImportEvent.class.isAssignableFrom(aEvent);
     }
 
     @Override

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/ProjectPermissionsChangedEventAdapter.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/ProjectPermissionsChangedEventAdapter.java
@@ -33,9 +33,9 @@ public class ProjectPermissionsChangedEventAdapter
     implements EventLoggingAdapter<ProjectPermissionsChangedEvent>
 {
     @Override
-    public boolean accepts(Object aEvent)
+    public boolean accepts(Class<?> aEvent)
     {
-        return aEvent instanceof ProjectPermissionsChangedEvent;
+        return ProjectPermissionsChangedEvent.class.isAssignableFrom(aEvent);
     }
 
     @Override

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/ProjectStateChangedEventAdapter.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/ProjectStateChangedEventAdapter.java
@@ -31,9 +31,9 @@ public class ProjectStateChangedEventAdapter
     implements EventLoggingAdapter<ProjectStateChangedEvent>
 {
     @Override
-    public boolean accepts(Object aEvent)
+    public boolean accepts(Class<?> aEvent)
     {
-        return aEvent instanceof ProjectStateChangedEvent;
+        return ProjectStateChangedEvent.class.isAssignableFrom(aEvent);
     }
 
     @Override

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/RelationEventAdapter.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/RelationEventAdapter.java
@@ -31,9 +31,9 @@ public class RelationEventAdapter
     implements EventLoggingAdapter<RelationEvent>
 {
     @Override
-    public boolean accepts(Object aEvent)
+    public boolean accepts(Class<?> aEvent)
     {
-        return aEvent instanceof RelationEvent;
+        return RelationEvent.class.isAssignableFrom(aEvent);
     }
 
     @Override

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/SpanEventAdapter.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/SpanEventAdapter.java
@@ -30,9 +30,9 @@ public class SpanEventAdapter
     implements EventLoggingAdapter<SpanEvent>
 {
     @Override
-    public boolean accepts(Object aEvent)
+    public boolean accepts(Class<?> aEvent)
     {
-        return aEvent instanceof SpanEvent;
+        return SpanEvent.class.isAssignableFrom(aEvent);
     }
 
     @Override

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/TagEventAdapter.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/adapter/TagEventAdapter.java
@@ -34,9 +34,9 @@ public class TagEventAdapter
     private final Logger log = LoggerFactory.getLogger(getClass());
 
     @Override
-    public boolean accepts(Object aEvent)
+    public boolean accepts(Class<?> aEvent)
     {
-        return aEvent instanceof TagEvent;
+        return TagEvent.class.isAssignableFrom(aEvent);
     }
 
     @Override

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/log/RecommendationAcceptedEventAdapter.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/log/RecommendationAcceptedEventAdapter.java
@@ -36,9 +36,9 @@ public class RecommendationAcceptedEventAdapter
     implements EventLoggingAdapter<RecommendationAcceptedEvent>
 {
     @Override
-    public boolean accepts(Object aEvent)
+    public boolean accepts(Class<?> aEvent)
     {
-        return aEvent instanceof RecommendationAcceptedEvent;
+        return RecommendationAcceptedEvent.class.isAssignableFrom(aEvent);
     }
 
     @Override

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/log/RecommendationRejectedEventAdapter.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/log/RecommendationRejectedEventAdapter.java
@@ -36,9 +36,9 @@ public class RecommendationRejectedEventAdapter
     implements EventLoggingAdapter<RecommendationRejectedEvent>
 {
     @Override
-    public boolean accepts(Object aEvent)
+    public boolean accepts(Class<?> aEvent)
     {
-        return aEvent instanceof RecommendationRejectedEvent;
+        return RecommendationRejectedEvent.class.isAssignableFrom(aEvent);
     }
 
     @Override

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/log/RecommenderDeletedEventAdapter.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/log/RecommenderDeletedEventAdapter.java
@@ -32,8 +32,8 @@ public class RecommenderDeletedEventAdapter
     implements EventLoggingAdapter<RecommenderDeletedEvent>
 {
     @Override
-    public boolean accepts(Object aEvent)
+    public boolean accepts(Class<?> aEvent)
     {
-        return aEvent instanceof RecommenderDeletedEvent;
+        return RecommenderDeletedEvent.class.isAssignableFrom(aEvent);
     }
 }

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/log/RecommenderEvaluationResultEventAdapter.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/log/RecommenderEvaluationResultEventAdapter.java
@@ -37,9 +37,9 @@ public class RecommenderEvaluationResultEventAdapter
     implements EventLoggingAdapter<RecommenderEvaluationResultEvent>
 {
     @Override
-    public boolean accepts(Object aEvent)
+    public boolean accepts(Class<?> aEvent)
     {
-        return aEvent instanceof RecommenderEvaluationResultEvent;
+        return RecommenderEvaluationResultEvent.class.isAssignableFrom(aEvent);
     }
 
     @Override

--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/log/SearchQueryEventAdapter.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/log/SearchQueryEventAdapter.java
@@ -35,9 +35,9 @@ public class SearchQueryEventAdapter
     implements EventLoggingAdapter<SearchQueryEvent>
 {
     @Override
-    public boolean accepts(Object aEvent)
+    public boolean accepts(Class<?> aEvent)
     {
-        return aEvent instanceof SearchQueryEvent;
+        return SearchQueryEvent.class.isAssignableFrom(aEvent);
     }
 
     @Override

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/SpringAuthenticatedWebSession.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/SpringAuthenticatedWebSession.java
@@ -109,16 +109,16 @@ public class SpringAuthenticatedWebSession
                 containerRequest.getSession().invalidate();
             }
 
-            Authentication authentication = authenticationConfigurationHolder
-                    .getAuthenticationConfiguration().getAuthenticationManager()
+            var authentication = authenticationConfigurationHolder.getAuthenticationConfiguration()
+                    .getAuthenticationManager()
                     .authenticate(new UsernamePasswordAuthenticationToken(username, password));
 
             springSecuritySignIn(authentication);
 
-            // If this is called, the authentication object has been created artificially and not
-            // via the authenticationManager, so we need to send the login even manually
-            applicationEventPublisherHolder.get()
-                    .publishEvent(new AuthenticationSuccessEvent(authentication));
+            // // If this is called, the authentication object has been created artificially and not
+            // // via the authenticationManager, so we need to send the login even manually
+            // applicationEventPublisherHolder.get()
+            // .publishEvent(new AuthenticationSuccessEvent(authentication));
 
             return true;
         }

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/config/InceptionSecurityAutoConfiguration.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/config/InceptionSecurityAutoConfiguration.java
@@ -24,8 +24,8 @@ import javax.sql.DataSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.context.annotation.Profile;
+import org.springframework.security.authentication.AuthenticationEventPublisher;
 import org.springframework.security.authentication.AuthenticationProvider;
-import org.springframework.security.authentication.DefaultAuthenticationEventPublisher;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
@@ -56,7 +56,8 @@ public class InceptionSecurityAutoConfiguration
 
     @Bean
     public GlobalAuthenticationConfigurerAdapter globalAuthenticationConfigurerAdapter(
-            AuthenticationProvider authenticationProvider)
+            AuthenticationProvider authenticationProvider,
+            AuthenticationEventPublisher aAuthenticationEventPublisher)
     {
         return new GlobalAuthenticationConfigurerAdapter()
         {
@@ -64,7 +65,7 @@ public class InceptionSecurityAutoConfiguration
             public void configure(AuthenticationManagerBuilder aAuth) throws Exception
             {
                 aAuth.authenticationProvider(authenticationProvider);
-                aAuth.authenticationEventPublisher(new DefaultAuthenticationEventPublisher());
+                aAuth.authenticationEventPublisher(aAuthenticationEventPublisher);
             }
         };
     }

--- a/inception/inception-security/src/test/java/de/tudarmstadt/ukp/clarin/webanno/security/preauth/ShibbolethRequestHeaderAuthenticationFilterTest.java
+++ b/inception/inception-security/src/test/java/de/tudarmstadt/ukp/clarin/webanno/security/preauth/ShibbolethRequestHeaderAuthenticationFilterTest.java
@@ -32,7 +32,9 @@ import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Bean;
+import org.springframework.security.authentication.AuthenticationEventPublisher;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.DefaultAuthenticationEventPublisher;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
@@ -179,6 +181,12 @@ class ShibbolethRequestHeaderAuthenticationFilterTest
             sut.setUserRepository(aUserService);
             sut.setAuthenticationManager(aAuthenticationConfiguration.getAuthenticationManager());
             return sut;
+        }
+
+        @Bean
+        AuthenticationEventPublisher authenticationEventPublisher()
+        {
+            return new DefaultAuthenticationEventPublisher();
         }
     }
 }

--- a/inception/inception-security/src/test/java/de/tudarmstadt/ukp/inception/security/oauth/OAuth2AdapterImplTest.java
+++ b/inception/inception-security/src/test/java/de/tudarmstadt/ukp/inception/security/oauth/OAuth2AdapterImplTest.java
@@ -37,7 +37,9 @@ import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Bean;
+import org.springframework.security.authentication.AuthenticationEventPublisher;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.DefaultAuthenticationEventPublisher;
 import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
@@ -189,6 +191,12 @@ class OAuth2AdapterImplTest
         ApplicationContextProvider applicationContextProvider()
         {
             return new ApplicationContextProvider();
+        }
+
+        @Bean
+        AuthenticationEventPublisher authenticationEventPublisher()
+        {
+            return new DefaultAuthenticationEventPublisher();
         }
     }
 

--- a/inception/inception-security/src/test/java/de/tudarmstadt/ukp/inception/security/saml/Saml2AdapterImplTest.java
+++ b/inception/inception-security/src/test/java/de/tudarmstadt/ukp/inception/security/saml/Saml2AdapterImplTest.java
@@ -33,7 +33,9 @@ import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Bean;
+import org.springframework.security.authentication.AuthenticationEventPublisher;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.DefaultAuthenticationEventPublisher;
 import org.springframework.security.authentication.DisabledException;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
@@ -164,6 +166,12 @@ class Saml2AdapterImplTest
         ApplicationContextProvider applicationContextProvider()
         {
             return new ApplicationContextProvider();
+        }
+
+        @Bean
+        AuthenticationEventPublisher authenticationEventPublisher()
+        {
+            return new DefaultAuthenticationEventPublisher();
         }
     }
 }


### PR DESCRIPTION
**What's in the PR**
- Fix issue that some events are logged through a cached log adapter even though the adapter would have rejected the particular event
- Fix issue that authenication success event is logged twice
- Add logger for authentication failure events

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
