### PR TITLE
#4752 - Suggest entities for linking only if there an empty feature in a target annotation to be linked

### DIFF
--- a/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/model/Range.java
+++ b/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/model/Range.java
@@ -23,7 +23,6 @@ import static java.lang.String.format;
 
 import java.io.Serializable;
 import java.lang.invoke.MethodHandles;
-import java.util.Iterator;
 import java.util.Objects;
 
 import org.apache.uima.cas.CAS;
@@ -76,16 +75,16 @@ public class Range
      * @deprecated Use {@link #rangeCoveringAnnotations(Iterable)} instead.
      */
     @Deprecated
-    public Range(Iterable<AnnotationFS> aAnnotations)
+    public Range(Iterable<? extends AnnotationFS> aAnnotations)
     {
-        Iterator<AnnotationFS> i = aAnnotations.iterator();
+        var i = aAnnotations.iterator();
         if (!i.hasNext()) {
             begin = -1;
             end = -1;
             return;
         }
 
-        AnnotationFS current = i.next();
+        var current = i.next();
         int b = current.getBegin();
         int e = current.getEnd();
 
@@ -136,7 +135,7 @@ public class Range
         return new Range(aCas);
     }
 
-    public static Range rangeCoveringAnnotations(Iterable<AnnotationFS> aAnnotations)
+    public static Range rangeCoveringAnnotations(Iterable<? extends AnnotationFS> aAnnotations)
     {
         return new Range(aAnnotations);
     }

--- a/inception/inception-concept-linking/pom.xml
+++ b/inception/inception-concept-linking/pom.xml
@@ -136,6 +136,10 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework</groupId>
@@ -221,20 +225,10 @@
       <artifactId>inception-testing</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.dkpro.core</groupId>
-      <artifactId>dkpro-core-api-datasets-asl</artifactId>
-      <scope>test</scope>
-    </dependency>
 
     <dependency>
       <groupId>org.dkpro.core</groupId>
       <artifactId>dkpro-core-api-ner-asl</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.dkpro.core</groupId>
-      <artifactId>dkpro-core-io-conll-asl</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/recommender/NamedEntityLinker.java
+++ b/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/recommender/NamedEntityLinker.java
@@ -17,23 +17,18 @@
  */
 package de.tudarmstadt.ukp.inception.conceptlinking.recommender;
 
-import static de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil.selectOverlapping;
-import static org.apache.uima.fit.util.CasUtil.getType;
+import static de.tudarmstadt.ukp.inception.rendering.model.Range.rangeCoveringAnnotations;
+import static org.apache.uima.cas.text.AnnotationPredicates.colocated;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.uima.cas.CAS;
-import org.apache.uima.cas.Feature;
-import org.apache.uima.cas.Type;
 import org.apache.uima.cas.text.AnnotationFS;
 import org.apache.uima.jcas.tcas.Annotation;
 
-import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
-import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
 import de.tudarmstadt.ukp.inception.conceptlinking.service.ConceptLinkingService;
 import de.tudarmstadt.ukp.inception.kb.ConceptFeatureTraits;
 import de.tudarmstadt.ukp.inception.kb.KnowledgeBaseService;
@@ -54,12 +49,11 @@ import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureSupportRegistry;
 public class NamedEntityLinker
     extends RecommendationEngine
 {
-    private NamedEntityLinkerTraits traits;
-
-    private KnowledgeBaseService kbService;
-    private ConceptLinkingService clService;
-    private FeatureSupportRegistry fsRegistry;
-    private ConceptFeatureTraits featureTraits;
+    private final NamedEntityLinkerTraits traits;
+    private final KnowledgeBaseService kbService;
+    private final ConceptLinkingService clService;
+    private final FeatureSupportRegistry fsRegistry;
+    private final ConceptFeatureTraits featureTraits;
 
     public static final Key<Collection<ImmutablePair<String, Collection<AnnotationFS>>>> KEY_MODEL = new Key<>(
             "model");
@@ -93,50 +87,62 @@ public class NamedEntityLinker
     public Range predict(PredictionContext aContext, CAS aCas, int aBegin, int aEnd)
         throws RecommendationException
     {
-        Type predictedType = getPredictedType(aCas);
+        var stackingAllowed = getRecommender().getLayer().isAllowStacking();
+        var predictedType = getPredictedType(aCas);
+        var predictedFeature = getPredictedFeature(aCas);
 
-        var sentences = selectOverlapping(aCas, getType(aCas, Sentence.class), aBegin, aEnd);
-
-        for (AnnotationFS sentence : sentences) {
-
-            for (Annotation annotation : aCas.<Annotation> select(predictedType)
-                    .coveredBy(sentence)) {
-                int begin = annotation.getBegin();
-                int end = annotation.getEnd();
-                predictSingle(annotation.getCoveredText(), begin, end, aCas);
+        var candidates = aCas.<Annotation> select(predictedType).coveredBy(aBegin, aEnd).asList();
+        Annotation prevCandidate = null;
+        for (var candidate : candidates) {
+            if (prevCandidate != null && colocated(candidate, prevCandidate)) {
+                // If we did already do a KB lookup at this position, no need to do one again. Mind
+                // that UIMA provides annotations with the same offsets as a block in iteration
+                // order
+                continue;
             }
+
+            if (candidate.getFeatureValueAsString(predictedFeature) != null
+                    && (!stackingAllowed || traits.isEmptyCandidateFeatureRequired())) {
+                // If the candidate feature is already filled, we can skip prediction if stacking is
+                // not allowed or if an empty candidate feature is required
+                continue;
+            }
+
+            predictSingle(candidate.getCoveredText(), candidate.getBegin(), candidate.getEnd(),
+                    aCas);
+
+            prevCandidate = candidate;
         }
 
-        return new Range(sentences);
+        return rangeCoveringAnnotations(candidates);
     }
 
     private void predictSingle(String aCoveredText, int aBegin, int aEnd, CAS aCas)
     {
-        List<KBHandle> handles = new ArrayList<>();
+        var handles = new ArrayList<KBHandle>();
 
-        AnnotationFeature feat = recommender.getFeature();
-        ConceptFeatureTraits conceptFeatureTraits = fsRegistry.readTraits(feat,
-                ConceptFeatureTraits::new);
+        var feat = recommender.getFeature();
+        var conceptFeatureTraits = fsRegistry.readTraits(feat, ConceptFeatureTraits::new);
 
         if (conceptFeatureTraits.getRepositoryId() != null) {
-            Optional<KnowledgeBase> kb = kbService.getKnowledgeBaseById(recommender.getProject(),
+            var kb = kbService.getKnowledgeBaseById(recommender.getProject(),
                     conceptFeatureTraits.getRepositoryId());
             if (kb.isPresent() && kb.get().isEnabled() && kb.get().isSupportConceptLinking()) {
                 handles.addAll(readCandidates(kb.get(), aCoveredText, aBegin, aCas));
             }
         }
         else {
-            for (KnowledgeBase kb : kbService.getEnabledKnowledgeBases(recommender.getProject())) {
+            for (var kb : kbService.getEnabledKnowledgeBases(recommender.getProject())) {
                 if (kb.isSupportConceptLinking()) {
                     handles.addAll(readCandidates(kb, aCoveredText, aBegin, aCas));
                 }
             }
         }
 
-        Type predictedType = getPredictedType(aCas);
+        var predictedType = getPredictedType(aCas);
         // Feature scoreFeature = getScoreFeature(aCas);
-        Feature predictedFeature = getPredictedFeature(aCas);
-        Feature isPredictionFeature = getIsPredictionFeature(aCas);
+        var predictedFeature = getPredictedFeature(aCas);
+        var isPredictionFeature = getIsPredictionFeature(aCas);
 
         for (var prediction : handles.stream().limit(recommender.getMaxRecommendations())
                 .toList()) {

--- a/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/recommender/NamedEntityLinkerFactory.java
+++ b/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/recommender/NamedEntityLinkerFactory.java
@@ -18,6 +18,7 @@
 
 package de.tudarmstadt.ukp.inception.conceptlinking.recommender;
 
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.CHARACTERS;
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.SINGLE_TOKEN;
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.TOKENS;
 import static java.util.Arrays.asList;
@@ -73,16 +74,16 @@ public class NamedEntityLinkerFactory
     }
 
     @Override
-    public boolean isSynchronous()
+    public boolean isSynchronous(Recommender aRecommender)
     {
-        return true;
+        return readTraits(aRecommender).isSynchronous();
     }
 
     @Override
     public RecommendationEngine build(Recommender aRecommender)
     {
-        NamedEntityLinkerTraits linkerTraits = readTraits(aRecommender);
-        ConceptFeatureTraits featureTraits = fsRegistry.readTraits(aRecommender.getFeature(),
+        var linkerTraits = readTraits(aRecommender);
+        var featureTraits = fsRegistry.readTraits(aRecommender.getFeature(),
                 ConceptFeatureTraits::new);
 
         return new NamedEntityLinker(aRecommender, linkerTraits, kbService, clService, fsRegistry,
@@ -101,8 +102,8 @@ public class NamedEntityLinkerFactory
         if (aLayer == null || aFeature == null) {
             return false;
         }
-        return asList(SINGLE_TOKEN, TOKENS).contains(aLayer.getAnchoringMode())
-                && !aLayer.isCrossSentence() && SpanLayerSupport.TYPE.equals(aLayer.getType())
+        return asList(SINGLE_TOKEN, TOKENS, CHARACTERS).contains(aLayer.getAnchoringMode())
+                && SpanLayerSupport.TYPE.equals(aLayer.getType())
                 && aFeature.getType().startsWith(PREFIX);
     }
 

--- a/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/recommender/NamedEntityLinkerTraits.java
+++ b/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/recommender/NamedEntityLinkerTraits.java
@@ -19,11 +19,36 @@ package de.tudarmstadt.ukp.inception.conceptlinking.recommender;
 
 import java.io.Serializable;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 @JsonSerialize
 public class NamedEntityLinkerTraits
     implements Serializable
 {
     private static final long serialVersionUID = 4379021097577126023L;
+
+    private boolean emptyCandidateFeatureRequired = true;
+    private boolean synchronous = true;
+
+    public boolean isEmptyCandidateFeatureRequired()
+    {
+        return emptyCandidateFeatureRequired;
+    }
+
+    public void setEmptyCandidateFeatureRequired(boolean aEmptyCandidateFeatureRequired)
+    {
+        emptyCandidateFeatureRequired = aEmptyCandidateFeatureRequired;
+    }
+
+    public boolean isSynchronous()
+    {
+        return synchronous;
+    }
+
+    public void setSynchronous(boolean aSynchronous)
+    {
+        synchronous = aSynchronous;
+    }
 }

--- a/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/recommender/NamedEntityLinkerTraitsEditor.html
+++ b/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/recommender/NamedEntityLinkerTraitsEditor.html
@@ -19,6 +19,26 @@
   xmlns:wicket="http://wicket.apache.org/dtds.data/wicket-xhtml1.4-strict.dtd">
 <wicket:panel>
   <form wicket:id="form">
+    <div class="row form-row" wicket:enclosure="emptyCandidateFeatureRequired">
+      <div class="offset-sm-3 col-sm-9">
+        <div class="form-check form-switch">
+          <input wicket:id="emptyCandidateFeatureRequired" class="form-check-input" type="checkbox"/>
+          <label wicket:for="emptyCandidateFeatureRequired" class="form-check-label">
+            <wicket:label key="emptyCandidateFeatureRequired"/>
+          </label>
+        </div>
+      </div>  
+    </div>
+    <div class="row form-row" wicket:enclosure="synchronous">
+      <div class="offset-sm-3 col-sm-9">
+        <div class="form-check form-switch">
+          <input wicket:id="synchronous" class="form-check-input" type="checkbox"/>
+          <label wicket:for="synchronous" class="form-check-label">
+            <wicket:label key="synchronous"/>
+          </label>
+        </div>
+      </div>  
+    </div>
   </form>
 </wicket:panel>
 </html>

--- a/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/recommender/NamedEntityLinkerTraitsEditor.java
+++ b/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/recommender/NamedEntityLinkerTraitsEditor.java
@@ -17,12 +17,16 @@
  */
 package de.tudarmstadt.ukp.inception.conceptlinking.recommender;
 
+import static de.tudarmstadt.ukp.inception.support.lambda.LambdaBehavior.visibleWhen;
+
+import org.apache.wicket.markup.html.form.CheckBox;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
 import de.tudarmstadt.ukp.inception.recommendation.api.recommender.AbstractTraitsEditor;
 import de.tudarmstadt.ukp.inception.recommendation.api.recommender.RecommendationEngineFactory;
@@ -44,8 +48,7 @@ public class NamedEntityLinkerTraitsEditor
 
         traits = toolFactory.readTraits(aRecommender.getObject());
 
-        Form<NamedEntityLinkerTraits> form = new Form<NamedEntityLinkerTraits>(MID_FORM,
-                CompoundPropertyModel.of(Model.of(traits)))
+        var form = new Form<>(MID_FORM, CompoundPropertyModel.of(Model.of(traits)))
         {
             private static final long serialVersionUID = -3109239605742291123L;
 
@@ -56,6 +59,14 @@ public class NamedEntityLinkerTraitsEditor
                 toolFactory.writeTraits(aRecommender.getObject(), traits);
             }
         };
+
+        form.add(new CheckBox("emptyCandidateFeatureRequired") //
+                .add(visibleWhen(aRecommender.map(Recommender::getLayer)
+                        .map(AnnotationLayer::isAllowStacking))) //
+                .setOutputMarkupPlaceholderTag(true));
+
+        form.add(new CheckBox("synchronous") //
+                .setOutputMarkupPlaceholderTag(true));
 
         add(form);
     }

--- a/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/recommender/NamedEntityLinkerTraitsEditor.properties
+++ b/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/recommender/NamedEntityLinkerTraitsEditor.properties
@@ -13,4 +13,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+emptyCandidateFeatureRequired=Empty candidate feature required
+synchronous=Synchronous prediction

--- a/inception/inception-documents-api/src/main/java/de/tudarmstadt/ukp/inception/documents/api/DocumentService.java
+++ b/inception/inception-documents-api/src/main/java/de/tudarmstadt/ukp/inception/documents/api/DocumentService.java
@@ -224,6 +224,23 @@ public interface DocumentService
      *
      * @param aCas
      *            the CAS.
+     * @param aAnnotationDocument
+     *            the annotation document.
+     * @param aExplicitAnnotatorUserAction
+     *            indicate that the CAS is written as the result of an explicit annotator user
+     *            action (i.e. not as a result of a third person or implicitly by the system).
+     * @throws IOException
+     *             if an I/O error occurs.
+     */
+    void writeAnnotationCasSilently(CAS aCas, AnnotationDocument aAnnotationDocument,
+            boolean aExplicitAnnotatorUserAction)
+        throws IOException;
+
+    /**
+     * Saves the annotations from the CAS to the storage.
+     *
+     * @param aCas
+     *            the CAS.
      * @param aDocument
      *            the source document.
      * @param aUser

--- a/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/DocumentServiceImpl.java
+++ b/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/DocumentServiceImpl.java
@@ -1022,6 +1022,18 @@ public class DocumentServiceImpl
             boolean aExplicitAnnotatorUserAction)
         throws IOException
     {
+        writeAnnotationCasSilently(aCas, aAnnotationDocument, aExplicitAnnotatorUserAction);
+
+        applicationEventPublisher
+                .publishEvent(new AfterCasWrittenEvent(this, aAnnotationDocument, aCas));
+    }
+
+    @Override
+    @Transactional
+    public void writeAnnotationCasSilently(CAS aCas, AnnotationDocument aAnnotationDocument,
+            boolean aExplicitAnnotatorUserAction)
+        throws IOException
+    {
         casStorageService.writeCas(aAnnotationDocument.getDocument(), aCas,
                 aAnnotationDocument.getUser());
 
@@ -1030,9 +1042,6 @@ public class DocumentServiceImpl
             setAnnotationDocumentState(aAnnotationDocument, AnnotationDocumentState.IN_PROGRESS,
                     EXPLICIT_ANNOTATOR_USER_ACTION);
         }
-
-        applicationEventPublisher
-                .publishEvent(new AfterCasWrittenEvent(this, aAnnotationDocument, aCas));
     }
 
     // NO TRANSACTION REQUIRED - This does not do any should not do a database access, so we do not

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/recommender/RecommendationEngineFactory.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/recommender/RecommendationEngineFactory.java
@@ -35,7 +35,7 @@ public interface RecommendationEngineFactory<T>
      */
     boolean isDeprecated();
 
-    default boolean isSynchronous()
+    default boolean isSynchronous(Recommender aRecommender)
     {
         return false;
     }

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
@@ -491,6 +491,11 @@ public class RecommendationServiceImpl
     {
         var project = aEvent.getDocument().getProject();
         var sessionOwnerName = aEvent.getSessionOwner();
+
+        if (isSuspended(sessionOwnerName, project)) {
+            return;
+        }
+
         var dataOwner = aEvent.getDocumentOwner();
         var doc = aEvent.getDocument();
         var predictions = getState(sessionOwnerName, project).getActivePredictions();
@@ -525,6 +530,13 @@ public class RecommendationServiceImpl
                     .build());
         }
 
+        // Check if there are any synchronous recommenders we need to run
+        var recommenders = listEnabledRecommenders(aEvent.getDocument().getProject());
+        if (!recommenders.isEmpty()) {
+            runSynchronousRecommenders(aEvent.getDocument(), aEvent.getDocumentOwner(),
+                    recommenders, "onDocumentOpened");
+        }
+
         // Check if we need to wait for the initial recommender run before displaying the document
         // to the user
         var predictionTriggered = nonTrainableRecommenderRunSync(doc, predictions, sessionOwner,
@@ -554,7 +566,13 @@ public class RecommendationServiceImpl
         // start the predictions so that the user gets recommendations as quickly as possible
         // without any interaction needed
         if (!predictionTriggered) {
-            triggerPrediction(sessionOwnerName, trigger, doc, dataOwner);
+            schedulingService.enqueue(PredictionTask.builder() //
+                    .withSessionOwner(sessionOwner) //
+                    .withTrigger("onDocumentOpened") //
+                    .withCurrentDocument(doc) //
+                    .withDataOwner(dataOwner) //
+                    .withSynchronousRecommenders(false) //
+                    .build());
         }
     }
 
@@ -585,6 +603,7 @@ public class RecommendationServiceImpl
                 .withTrigger(trigger) //
                 .withCurrentDocument(doc) //
                 .withDataOwner(aDataOwner) //
+                .withSynchronousRecommenders(false) //
                 .build());
         switchPredictions(aSessionOwner.getUsername(), doc.getProject());
 
@@ -729,7 +748,8 @@ public class RecommendationServiceImpl
             return;
         }
 
-        runSynchronousRecommenders(aEvent, recommenders);
+        runSynchronousRecommenders(aEvent.getDocument().getDocument(),
+                aEvent.getDocument().getUser(), recommenders, "onAfterCasWritten");
 
         var committed = requestCycle.getMetaData(COMMITTED);
         if (committed == null) {
@@ -772,33 +792,39 @@ public class RecommendationServiceImpl
         }
     }
 
-    private void runSynchronousRecommenders(AfterCasWrittenEvent aEvent,
-            List<Recommender> recommenders)
+    private void runSynchronousRecommenders(SourceDocument aDocument, String aDataOwner,
+            List<Recommender> recommenders, String aTrigger)
     {
         var sessionOwner = userRepository.getCurrentUser();
+
+        if (isSuspended(sessionOwner.getUsername(), aDocument.getProject())) {
+            return;
+        }
+
         var anySyncRan = false;
         for (var recommender : recommenders) {
             var factory = getRecommenderFactory(recommender);
-            if (factory.map(RecommendationEngineFactory::isSynchronous).orElse(false)) {
-                var predictionTask = PredictionTask.builder() //
+            if (factory.map($ -> $.isSynchronous(recommender)).orElse(false)) {
+                schedulingService.executeSync(PredictionTask.builder() //
                         .withSessionOwner(sessionOwner) //
-                        .withTrigger("Synchronous prediction") //
-                        .withCurrentDocument(aEvent.getDocument().getDocument()) //
-                        .withDataOwner(aEvent.getDocument().getUser()) //
+                        .withTrigger(aTrigger) //
+                        .withCurrentDocument(aDocument) //
+                        .withDataOwner(aDataOwner) //
                         .withRecommender(recommender) //
-                        .build();
-                schedulingService.executeSync(predictionTask);
+                        .build());
+
                 anySyncRan = true;
             }
         }
+
         if (anySyncRan) {
             var switched = forceSwitchPredictions(sessionOwner.getUsername(),
-                    aEvent.getDocument().getProject());
+                    aDocument.getProject());
             if (switched) {
                 // Notify other UI components on the page about the prediction switch such that they
                 // can also update their state to remain in sync with the new predictions
-                applicationEventPublisher.publishEvent(new PredictionsSwitchedEvent(this,
-                        sessionOwner.getUsername(), aEvent.getDocument().getDocument()));
+                applicationEventPublisher.publishEvent(
+                        new PredictionsSwitchedEvent(this, sessionOwner.getUsername(), aDocument));
             }
         }
     }

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/TrainingTask.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/TrainingTask.java
@@ -238,6 +238,7 @@ public class TrainingTask
                 .withTrigger(String.format("TrainingTask %s complete", getId())) //
                 .withCurrentDocument(currentDocument) //
                 .withDataOwner(dataOwner) //
+                .withSynchronousRecommenders(false) // ;
                 .build();
 
         predictionTask.inheritLog(this);

--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchServiceImpl.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchServiceImpl.java
@@ -405,27 +405,27 @@ public class SearchServiceImpl
 
     @TransactionalEventListener(fallbackExecution = true)
     @Transactional
-    public void afterDocumentCreate(AfterDocumentCreatedEvent aEvent)
+    public void onAfterDocumentCreated(AfterDocumentCreatedEvent aEvent)
     {
         log.trace("Starting afterDocumentCreate");
 
         // Schedule new document index process
-        enqueueIndexDocument(aEvent.getDocument(), "afterDocumentCreate");
+        enqueueIndexDocument(aEvent.getDocument(), "onAfterDocumentCreated");
     }
 
     @TransactionalEventListener(fallbackExecution = true)
     @Transactional
-    public void afterAnnotationUpdate(AfterCasWrittenEvent aEvent)
+    public void onAfterCasWritten(AfterCasWrittenEvent aEvent)
     {
         log.trace("Starting afterAnnotationUpdate");
 
         // Schedule new document index process
-        enqueueIndexDocument(aEvent.getDocument(), "afterAnnotationUpdate");
+        enqueueIndexDocument(aEvent.getDocument(), "onAfterCasWritten");
     }
 
     @TransactionalEventListener(fallbackExecution = true)
     @Transactional
-    public void beforeLayerConfigurationChanged(LayerConfigurationChangedEvent aEvent)
+    public void onLayerConfigurationChanged(LayerConfigurationChangedEvent aEvent)
     {
         log.trace("Starting beforeLayerConfigurationChanged");
 
@@ -439,7 +439,7 @@ public class SearchServiceImpl
         }
 
         // Schedule re-indexing of the physical index
-        enqueueReindexTask(aEvent.getProject(), "beforeLayerConfigurationChanged");
+        enqueueReindexTask(aEvent.getProject(), "onLayerConfigurationChanged");
     }
 
     @Override

--- a/inception/inception-testing/pom.xml
+++ b/inception/inception-testing/pom.xml
@@ -27,10 +27,6 @@
   <dependencies>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
-      <artifactId>inception-schema-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-recommendation-api</artifactId>
     </dependency>
     <dependency>

--- a/inception/inception-testing/src/main/java/de/tudarmstadt/ukp/inception/support/test/recommendation/RecommenderTestHelper.java
+++ b/inception/inception-testing/src/main/java/de/tudarmstadt/ukp/inception/support/test/recommendation/RecommenderTestHelper.java
@@ -31,36 +31,29 @@ import java.util.stream.Collectors;
 
 import org.apache.uima.UIMAException;
 import org.apache.uima.cas.CAS;
-import org.apache.uima.cas.Feature;
 import org.apache.uima.cas.FeatureStructure;
-import org.apache.uima.cas.Type;
 import org.apache.uima.cas.text.AnnotationFS;
 import org.apache.uima.fit.util.CasUtil;
-import org.apache.uima.fit.util.JCasUtil;
 import org.apache.uima.jcas.tcas.Annotation;
-import org.apache.uima.resource.metadata.TypeDescription;
-import org.apache.uima.resource.metadata.TypeSystemDescription;
 
-import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.service.AnnotationSchemaServiceImpl;
 
 public class RecommenderTestHelper
 {
-
     public static void addPredictionFeatures(CAS aCas, String aTypeName, String aFeatureName)
         throws IOException, UIMAException
     {
-        String scoreFeatureName = aFeatureName + FEATURE_NAME_SCORE_SUFFIX;
-        String scoreExplanationFeatureName = aFeatureName + FEATURE_NAME_SCORE_EXPLANATION_SUFFIX;
+        var scoreFeatureName = aFeatureName + FEATURE_NAME_SCORE_SUFFIX;
+        var scoreExplanationFeatureName = aFeatureName + FEATURE_NAME_SCORE_EXPLANATION_SUFFIX;
 
-        TypeSystemDescription tsd = typeSystem2TypeSystemDescription(aCas.getTypeSystem());
-        TypeDescription typeDescription = tsd.getType(aTypeName);
+        var tsd = typeSystem2TypeSystemDescription(aCas.getTypeSystem());
+        var typeDescription = tsd.getType(aTypeName);
         typeDescription.addFeature(scoreFeatureName, "Score feature", TYPE_NAME_DOUBLE);
         typeDescription.addFeature(scoreExplanationFeatureName, "Score explanation feature",
                 TYPE_NAME_STRING);
         typeDescription.addFeature(FEATURE_NAME_IS_PREDICTION, "Is prediction", TYPE_NAME_BOOLEAN);
 
-        AnnotationSchemaService schemaService = new AnnotationSchemaServiceImpl();
+        var schemaService = new AnnotationSchemaServiceImpl();
         schemaService.upgradeCas(aCas, tsd);
     }
 
@@ -73,14 +66,14 @@ public class RecommenderTestHelper
 
     public static double getScore(AnnotationFS aAnnotationFS, String aFeatureName)
     {
-        Feature feature = aAnnotationFS.getType()
+        var feature = aAnnotationFS.getType()
                 .getFeatureByBaseName(aFeatureName + FEATURE_NAME_SCORE_SUFFIX);
         return aAnnotationFS.getDoubleValue(feature);
     }
 
     public static String getScoreExplanation(AnnotationFS aAnnotationFS, String aFeatureName)
     {
-        Feature feature = aAnnotationFS.getType()
+        var feature = aAnnotationFS.getType()
                 .getFeatureByBaseName(aFeatureName + FEATURE_NAME_SCORE_EXPLANATION_SUFFIX);
         return aAnnotationFS.getStringValue(feature);
     }
@@ -88,29 +81,32 @@ public class RecommenderTestHelper
     public static <T extends Annotation> List<T> getPredictions(CAS aCas, Class<T> aClass)
         throws Exception
     {
-        Type type = CasUtil.getType(aCas, aClass);
-        Feature feature = type.getFeatureByBaseName(FEATURE_NAME_IS_PREDICTION);
+        var type = CasUtil.getType(aCas, aClass);
+        var feature = type.getFeatureByBaseName(FEATURE_NAME_IS_PREDICTION);
 
-        return JCasUtil.select(aCas.getJCas(), aClass).stream()
-                .filter(fs -> fs.getBooleanValue(feature)).collect(Collectors.toList());
+        return aCas.select(aClass) //
+                .filter(fs -> fs.getBooleanValue(feature)) //
+                .collect(Collectors.toList());
     }
 
     public static List<AnnotationFS> getPredictions(CAS aCas, String aTypeName) throws Exception
     {
-        Type type = CasUtil.getType(aCas, aTypeName);
-        Feature feature = type.getFeatureByBaseName(FEATURE_NAME_IS_PREDICTION);
+        var type = CasUtil.getType(aCas, aTypeName);
+        var feature = type.getFeatureByBaseName(FEATURE_NAME_IS_PREDICTION);
 
-        return CasUtil.select(aCas, type).stream().filter(fs -> fs.getBooleanValue(feature))
+        return aCas.<Annotation> select(type) //
+                .filter(fs -> fs.getBooleanValue(feature)) //
                 .collect(Collectors.toList());
     }
 
     public static List<FeatureStructure> getPredictionFSes(CAS aCas, String aTypeName)
         throws Exception
     {
-        Type type = CasUtil.getType(aCas, aTypeName);
-        Feature feature = type.getFeatureByBaseName(FEATURE_NAME_IS_PREDICTION);
+        var type = CasUtil.getType(aCas, aTypeName);
+        var feature = type.getFeatureByBaseName(FEATURE_NAME_IS_PREDICTION);
 
-        return aCas.select(type).filter(fs -> fs.getBooleanValue(feature))
+        return aCas.select(type) //
+                .filter(fs -> fs.getBooleanValue(feature)) //
                 .collect(Collectors.toList());
     }
 }

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
@@ -485,8 +485,10 @@ public class AnnotationPage
                 // IN_PROGRESS, then we use this opportunity also to set the timestamp of the
                 // annotation document - this ensures that e.g. the dynamic workflow considers the
                 // document to be "active" for the given user so that it won't be considered as
-                // abandoned immediately after having been opened for the first time
-                documentService.writeAnnotationCas(editorCas, annotationDocument,
+                // abandoned immediately after having been opened for the first time.
+                // We suppress the AfterCasWrittenEvent here - handlers should react to
+                // DocumentOpenedEvent instead.
+                documentService.writeAnnotationCasSilently(editorCas, annotationDocument,
                         AnnotationDocumentState.NEW.equals(annotationDocument.getState()));
 
                 bumpAnnotationCasTimestamp(state);


### PR DESCRIPTION
**What's in the PR**
- Added option to suggest entites only if there is a free target feature
- Added option to disable synchronous behavior of entity linker
- Expand entity linker to additional layer configurations
- No longer require sentences for entity linker to work
- Added new tests
- Properly inherit suggestions if a recommender is skipped because a particular run does not include (a)sync recommenders
- Avoid running synchronous recommenders twice when opening a document

**How to test manually**
* Try using the entity linker recommender, e.g. in a wikidata linking project

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
