### PR TITLE
#4762 - Re-merging via the curation sidebar always uses the project settings instead of the dialog settings

### DIFF
--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebar.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebar.java
@@ -177,15 +177,16 @@ public class CurationSidebar
     {
         var state = getModelObject();
         var dataOwner = state.getUser();
+        var curationWorkflow = curationWorkflowModel.getObject();
 
         if (aForm.getModelObject().isSaveSettingsAsDefault()) {
-            curationService.createOrUpdateCurationWorkflow(curationWorkflowModel.getObject());
+            curationService.createOrUpdateCurationWorkflow(curationWorkflow);
             success("Updated project merge strategy settings");
         }
 
         try {
-            var mergeStrategyFactory = curationSidebarService.merge(state, dataOwner.getUsername(),
-                    selectedUsers.getModelObject());
+            var mergeStrategyFactory = curationSidebarService.merge(state, curationWorkflow,
+                    dataOwner.getUsername(), selectedUsers.getModelObject());
             success("Re-merge using [" + mergeStrategyFactory.getLabel() + "] finished!");
             aTarget.addChildren(getPage(), IFeedback.class);
         }

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebarService.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebarService.java
@@ -33,6 +33,8 @@ import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.inception.curation.merge.MergeStrategyFactory;
+import de.tudarmstadt.ukp.inception.curation.merge.strategy.MergeStrategy;
+import de.tudarmstadt.ukp.inception.curation.model.CurationWorkflow;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
 
 public interface CurationSidebarService
@@ -132,5 +134,13 @@ public interface CurationSidebarService
     void setDefaultSelectedUsersForDocument(String aSessionOwner, SourceDocument aDocument);
 
     MergeStrategyFactory<?> merge(AnnotatorState aState, String aCurator, Collection<User> aUsers)
+        throws IOException, UIMAException;
+
+    void merge(AnnotatorState aState, MergeStrategy aStrategy, String aCurator,
+            Collection<User> aUsers)
+        throws IOException, UIMAException;
+
+    MergeStrategyFactory<?> merge(AnnotatorState aState, CurationWorkflow aWorkflow,
+            String aCurator, Collection<User> aUsers)
         throws IOException, UIMAException;
 }


### PR DESCRIPTION
**What's in the PR**
- Pass the dialog settings on to the merge operation

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
