### PR TITLE
#4764 - No longer force-enable server-side timings when dev mode is disabled

### DIFF
--- a/inception/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/INCEpTION.java
+++ b/inception/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/INCEpTION.java
@@ -92,7 +92,6 @@ public class INCEpTION
         if (Boolean.getBoolean("inception.dev")) {
             System.setProperty("wicket.core.settings.debug.enabled", "true");
             System.setProperty("wicket.core.settings.general.configuration-type", "development");
-            System.setProperty("debug.sendServerSideTimings", "true");
             System.setProperty("webanno.debug.enforce_cas_thread_lock", "true");
             aBuilder.profiles(DeploymentModeService.PROFILE_DEVELOPMENT_MODE);
         }

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.java
@@ -160,8 +160,7 @@ public abstract class WicketApplicationBase
     private void installTimingListener()
     {
         var settings = SettingsUtil.getSettings();
-        if (!DEVELOPMENT.equals(getConfigurationType())
-                && !"true".equalsIgnoreCase(settings.getProperty("debug.sendServerSideTimings"))) {
+        if (!"true".equalsIgnoreCase(settings.getProperty("debug.sendServerSideTimings"))) {
             return;
         }
 
@@ -395,8 +394,7 @@ public abstract class WicketApplicationBase
     protected void initServerTimeReporting()
     {
         Properties settings = SettingsUtil.getSettings();
-        if (DEVELOPMENT != getConfigurationType()
-                && !"true".equalsIgnoreCase(settings.getProperty("debug.sendServerSideTimings"))) {
+        if (!"true".equalsIgnoreCase(settings.getProperty("debug.sendServerSideTimings"))) {
             return;
         }
 


### PR DESCRIPTION
**What's in the PR**
- Do not force-enable server-side timings in dev mode

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
