### PR TITLE
#4774 - Ability to not reset curation when performing a manual merge (sidebar curation)

### DIFF
--- a/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/service/CurationMergeService.java
+++ b/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/service/CurationMergeService.java
@@ -52,7 +52,7 @@ public interface CurationMergeService
      */
     Set<LogMessage> mergeCasses(SourceDocument aDocument, String aTargetCasUserName, CAS aTargetCas,
             Map<String, CAS> aCassesToMerge, MergeStrategy aMergeStrategy,
-            List<AnnotationLayer> aLayers)
+            List<AnnotationLayer> aLayers, boolean aClearTargetCas)
         throws UIMAException;
 
     /**

--- a/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/service/CurationMergeServiceImpl.java
+++ b/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/service/CurationMergeServiceImpl.java
@@ -35,7 +35,6 @@ import org.slf4j.Logger;
 import org.springframework.context.ApplicationEventPublisher;
 
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.DiffResult;
-import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.api.DiffAdapter;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
@@ -79,16 +78,16 @@ public class CurationMergeServiceImpl
                 .collect(toList());
 
         return mergeCasses(aDocument, aTargetCasUserName, aTargetCas, aCassesToMerge,
-                aMergeStrategy, layers);
+                aMergeStrategy, layers, true);
     }
 
     @Override
     public Set<LogMessage> mergeCasses(SourceDocument aDocument, String aTargetCasUserName,
             CAS aTargetCas, Map<String, CAS> aCassesToMerge, MergeStrategy aMergeStrategy,
-            List<AnnotationLayer> aLayers)
+            List<AnnotationLayer> aLayers, boolean aClearTargetCas)
         throws UIMAException
     {
-        List<DiffAdapter> adapters = getDiffAdapters(annotationService, aLayers);
+        var adapters = getDiffAdapters(annotationService, aLayers);
 
         // If the token/sentence layer is not editable, we do not offer curation of the tokens.
         // Instead the tokens are obtained from a random template CAS when initializing the CAS - we
@@ -109,8 +108,14 @@ public class CurationMergeServiceImpl
         try (StopWatch watch = new StopWatch(LOG, "CasMerge")) {
             var casMerge = new CasMerge(annotationService, applicationEventPublisher);
             casMerge.setMergeStrategy(aMergeStrategy);
-            return casMerge.reMergeCas(diff, aDocument, aTargetCasUserName, aTargetCas,
-                    aCassesToMerge);
+            if (aClearTargetCas) {
+                return casMerge.clearAndMergeCas(diff, aDocument, aTargetCasUserName, aTargetCas,
+                        aCassesToMerge);
+            }
+            else {
+                return casMerge.mergeCas(diff, aDocument, aTargetCasUserName, aTargetCas,
+                        aCassesToMerge);
+            }
         }
     }
 }

--- a/inception/inception-curation/src/test/java/de/tudarmstadt/ukp/inception/curation/merge/CasMergeRemergeTest.java
+++ b/inception/inception-curation/src/test/java/de/tudarmstadt/ukp/inception/curation/merge/CasMergeRemergeTest.java
@@ -88,7 +88,7 @@ public class CasMergeRemergeTest
 
         DiffResult result = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser).toResult();
 
-        sut.reMergeCas(result, document, DUMMY_USER, curatorCas.getCas(), casByUser);
+        sut.clearAndMergeCas(result, document, DUMMY_USER, curatorCas.getCas(), casByUser);
 
         assertThat(result.getDifferingConfigurationSets()).isEmpty();
         assertThat(result.getIncompleteConfigurationSets().values())
@@ -126,7 +126,7 @@ public class CasMergeRemergeTest
         DiffResult result = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser).toResult();
 
         sut.setMergeStrategy(new MergeIncompleteStrategy());
-        sut.reMergeCas(result, document, DUMMY_USER, curatorCas.getCas(), casByUser);
+        sut.clearAndMergeCas(result, document, DUMMY_USER, curatorCas.getCas(), casByUser);
 
         assertThat(result.getDifferingConfigurationSets()).isEmpty();
         assertThat(result.getIncompleteConfigurationSets().values())
@@ -162,7 +162,7 @@ public class CasMergeRemergeTest
 
         // result.print(System.out);
 
-        sut.reMergeCas(result, document, DUMMY_USER, curatorCas.getCas(), casByUser);
+        sut.clearAndMergeCas(result, document, DUMMY_USER, curatorCas.getCas(), casByUser);
 
         casByUser = new HashMap<String, CAS>();
         casByUser.put("actual", jcasA.getCas());
@@ -195,7 +195,7 @@ public class CasMergeRemergeTest
 
         // result.print(System.out);
 
-        sut.reMergeCas(result, document, DUMMY_USER, curatorCas.getCas(), casByUser);
+        sut.clearAndMergeCas(result, document, DUMMY_USER, curatorCas.getCas(), casByUser);
 
         Type hostType = curatorCas.getCas().getTypeSystem().getType(HOST_TYPE);
         FeatureSupport<?> slotSupport = featureSupportRegistry.findExtension(slotFeature)
@@ -229,7 +229,7 @@ public class CasMergeRemergeTest
 
         // result.print(System.out);
 
-        sut.reMergeCas(result, document, DUMMY_USER, curatorCas.getCas(), casByUser);
+        sut.clearAndMergeCas(result, document, DUMMY_USER, curatorCas.getCas(), casByUser);
 
         var hostType = curatorCas.getCas().getTypeSystem().getType(HOST_TYPE);
         FeatureSupport<?> slotSupport = featureSupportRegistry.findExtension(slotFeature)
@@ -268,7 +268,7 @@ public class CasMergeRemergeTest
 
         // result.print(System.out);
 
-        sut.reMergeCas(result, document, DUMMY_USER, curatorCas, casByUser);
+        sut.clearAndMergeCas(result, document, DUMMY_USER, curatorCas, casByUser);
 
         assertThat(select(curatorCas, getType(curatorCas, HOST_TYPE))).isEmpty();
         assertThat(calculateState(result)).isEqualTo(AGREE);
@@ -297,7 +297,7 @@ public class CasMergeRemergeTest
 
         // result.print(System.out);
 
-        sut.reMergeCas(result, document, DUMMY_USER, curatorCas.getCas(), casByUser);
+        sut.clearAndMergeCas(result, document, DUMMY_USER, curatorCas.getCas(), casByUser);
 
         Type hostType = curatorCas.getTypeSystem().getType(HOST_TYPE);
 

--- a/inception/inception-curation/src/test/java/de/tudarmstadt/ukp/inception/curation/merge/CasMergeSuiteTest.java
+++ b/inception/inception-curation/src/test/java/de/tudarmstadt/ukp/inception/curation/merge/CasMergeSuiteTest.java
@@ -69,7 +69,7 @@ public class CasMergeSuiteTest
 
         var result = doDiff(diffAdapters, LINK_TARGET_AS_LABEL, casByUser).toResult();
 
-        sut.reMergeCas(result, document, "dummyTargetUser", curatorCas, casByUser);
+        sut.clearAndMergeCas(result, document, "dummyTargetUser", curatorCas, casByUser);
 
         writeAndAssertEquals(curatorCas, aReferenceFolder);
     }

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/CurationPage.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/CurationPage.java
@@ -761,7 +761,7 @@ public class CurationPage
             mergeCas = documentService.readAnnotationCas(aTemplate.getDocument(),
                     aTemplate.getUser(), FORCE_CAS_UPGRADE, UNMANAGED_ACCESS);
             curationMergeService.mergeCasses(aState.getDocument(), aState.getUser().getUsername(),
-                    mergeCas, aCasses, aMergeStrategy, aState.getAnnotationLayers());
+                    mergeCas, aCasses, aMergeStrategy, aState.getAnnotationLayers(), true);
             curationDocumentService.writeCurationCas(mergeCas, aTemplate.getDocument(), false);
         }
         else {

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/MergeDialog$ContentPanel.html
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/MergeDialog$ContentPanel.html
@@ -53,6 +53,16 @@
             </div>
           </div>
         </div>
+        <div class="row form-row" wicket:enclosure="clearTargetCas">
+          <div class="col-sm-12">
+            <div class="form-check">
+              <input wicket:id="clearTargetCas" class="form-check-input" type="checkbox" />
+              <label wicket:for="clearTargetCas" class="form-check-label">
+                Discard already curated annotations
+              </label>
+            </div>
+          </div>
+        </div>
         <div class="row form-row">
           <div class="col-sm-12">
             <p>

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/MergeDialog.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/MergeDialog.java
@@ -17,6 +17,8 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.ui.curation.page;
 
+import static de.tudarmstadt.ukp.inception.support.lambda.LambdaBehavior.visibleWhen;
+
 import java.io.Serializable;
 import java.util.Objects;
 
@@ -32,6 +34,7 @@ import org.apache.wicket.model.ResourceModel;
 import org.apache.wicket.request.RequestHandlerExecutor.ReplaceHandlerException;
 import org.slf4j.LoggerFactory;
 
+import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.AnnotationPage;
 import de.tudarmstadt.ukp.inception.bootstrap.BootstrapModalDialog;
 import de.tudarmstadt.ukp.inception.curation.model.CurationWorkflow;
 import de.tudarmstadt.ukp.inception.curation.settings.MergeStrategyPanel;
@@ -181,10 +184,16 @@ public class MergeDialog
         String response;
         String feedback;
         boolean saveSettingsAsDefault;
+        boolean clearTargetCas = true;
 
         public boolean isSaveSettingsAsDefault()
         {
             return saveSettingsAsDefault;
+        }
+
+        public boolean isClearTargetCas()
+        {
+            return clearTargetCas;
         }
     }
 
@@ -210,6 +219,9 @@ public class MergeDialog
             queue(new TextField<>("response"));
             queue(new MergeStrategyPanel("mergeStrategySettings", curationWorkflowModel));
             queue(new CheckBox("saveSettingsAsDefault").setOutputMarkupId(true));
+            // On the curation page, the option to (not) clear the target CAS is not (yet) supported
+            queue(new CheckBox("clearTargetCas").setOutputMarkupId(true)
+                    .add(visibleWhen(() -> getPage() instanceof AnnotationPage)));
             queue(new LambdaAjaxButton<>("confirm", MergeDialog.this::onConfirmInternal)
                     .triggerAfterSubmit());
             queue(new LambdaAjaxLink("closeDialog", MergeDialog.this::onCancelInternal));

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebar.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebar.java
@@ -186,7 +186,8 @@ public class CurationSidebar
 
         try {
             var mergeStrategyFactory = curationSidebarService.merge(state, curationWorkflow,
-                    dataOwner.getUsername(), selectedUsers.getModelObject());
+                    dataOwner.getUsername(), selectedUsers.getModelObject(),
+                    aForm.getModelObject().isClearTargetCas());
             success("Re-merge using [" + mergeStrategyFactory.getLabel() + "] finished!");
             aTarget.addChildren(getPage(), IFeedback.class);
         }

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebarBehavior.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebarBehavior.java
@@ -148,7 +148,7 @@ public class CurationSidebarBehavior
                 var selectedUsers = curationSidebarService.getSelectedUsers(sessionOwner,
                         project.getId());
                 var mergeStrategyFactory = curationSidebarService.merge(state,
-                        state.getUser().getUsername(), selectedUsers);
+                        state.getUser().getUsername(), selectedUsers, true);
                 page.success(
                         "Performed initial merge using [" + mergeStrategyFactory.getLabel() + "].");
                 aEvent.getRequestTarget().ifPresent($ -> $.addChildren(page, IFeedback.class));

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebarService.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebarService.java
@@ -133,14 +133,15 @@ public interface CurationSidebarService
 
     void setDefaultSelectedUsersForDocument(String aSessionOwner, SourceDocument aDocument);
 
-    MergeStrategyFactory<?> merge(AnnotatorState aState, String aCurator, Collection<User> aUsers)
+    MergeStrategyFactory<?> merge(AnnotatorState aState, String aCurator, Collection<User> aUsers,
+            boolean aClearTargetCas)
         throws IOException, UIMAException;
 
     void merge(AnnotatorState aState, MergeStrategy aStrategy, String aCurator,
-            Collection<User> aUsers)
+            Collection<User> aUsers, boolean aClearTargetCas)
         throws IOException, UIMAException;
 
     MergeStrategyFactory<?> merge(AnnotatorState aState, CurationWorkflow aWorkflow,
-            String aCurator, Collection<User> aUsers)
+            String aCurator, Collection<User> aUsers, boolean aClearTargetCas)
         throws IOException, UIMAException;
 }

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebarServiceImpl.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebarServiceImpl.java
@@ -543,32 +543,31 @@ public class CurationSidebarServiceImpl
                         && sourceDoc.getState().equals(CURATION_FINISHED));
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
     public MergeStrategyFactory<?> merge(AnnotatorState aState, String aCurator,
-            Collection<User> aUsers)
+            Collection<User> aUsers, boolean aClearTargetCas)
         throws IOException, UIMAException
     {
         var workflow = curationService.readOrCreateCurationWorkflow(aState.getProject());
-        return merge(aState, workflow, aCurator, aUsers);
+        return merge(aState, workflow, aCurator, aUsers, aClearTargetCas);
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Override
     public MergeStrategyFactory<?> merge(AnnotatorState aState, CurationWorkflow aWorkflow,
-            String aCurator, Collection<User> aUsers)
+            String aCurator, Collection<User> aUsers, boolean aClearTargetCas)
         throws IOException, UIMAException
     {
         MergeStrategyFactory factory = curationService.getMergeStrategyFactory(aWorkflow);
         var traits = factory.readTraits(aWorkflow);
         var mergeStrategy = factory.makeStrategy(traits);
-        merge(aState, mergeStrategy, aCurator, aUsers);
+        merge(aState, mergeStrategy, aCurator, aUsers, aClearTargetCas);
         return factory;
     }
 
     @Override
     public void merge(AnnotatorState aState, MergeStrategy aStrategy, String aCurator,
-            Collection<User> aUsers)
+            Collection<User> aUsers, boolean aClearTargetCas)
         throws IOException, UIMAException
     {
         var doc = aState.getDocument();
@@ -581,7 +580,7 @@ public class CurationSidebarServiceImpl
         // deleting the users annotations!!!), currently fixed by warn message to user
         // prepare merged CAS
         curationMergeService.mergeCasses(doc, aState.getUser().getUsername(), aTargetCas, userCases,
-                aStrategy, aState.getAnnotationLayers());
+                aStrategy, aState.getAnnotationLayers(), aClearTargetCas);
 
         // write back and update timestamp
         writeCurationCas(aTargetCas, aState, doc.getProject().getId());


### PR DESCRIPTION
**What's in the PR**
- Added the switch

**How to test manually**
* In curation sidebar mode, partially curate manually, then use the merge dialog to merge the rest, disabling the "discard curated annotations" option

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
