### PR TITLE
#4739 - Auto-merge on open document in curation mode

### DIFF
--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebarBehavior.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebarBehavior.java
@@ -19,6 +19,8 @@ package de.tudarmstadt.ukp.inception.ui.curation.sidebar;
 
 import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasUpgradeMode.FORCE_CAS_UPGRADE;
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.CURATOR;
+import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.CURATION_FINISHED;
+import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.CURATION_IN_PROGRESS;
 import static de.tudarmstadt.ukp.clarin.webanno.ui.core.page.ProjectPageBase.setProjectPageParameter;
 import static de.tudarmstadt.ukp.inception.curation.sidebar.CurationSidebarManagerPrefs.KEY_CURATION_SIDEBAR_MANAGER_PREFS;
 import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.CURATION_USER;
@@ -123,7 +125,7 @@ public class CurationSidebarBehavior
         var prefs = preferencesService
                 .loadDefaultTraitsForProject(KEY_CURATION_SIDEBAR_MANAGER_PREFS, project);
         if (prefs.isAutoMergeCurationSidebar()) {
-            if (userService.getCurationUser().getUsername().equals(aEvent.getDocumentOwner())) {
+            if (userService.getCurationUser().equals(page.getModelObject().getUser())) {
                 autoMerge(aEvent, page);
             }
         }
@@ -137,7 +139,8 @@ public class CurationSidebarBehavior
 
         try {
             var editable = page.isEditable();
-            if (!curationDocumentService.existsCurationCas(doc) && editable) {
+            if (!asList(CURATION_IN_PROGRESS, CURATION_FINISHED).contains(doc.getState())
+                    && editable) {
                 var state = page.getModelObject();
                 // We need to force upgrade the editor CAS here already so the merge can succeed
                 // The annotation page will do this again in the actionLoadDocument, but I don't

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/MatrixWorkloadManagementPage.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/MatrixWorkloadManagementPage.java
@@ -441,6 +441,10 @@ public class MatrixWorkloadManagementPage
 
             documentService.bulkSetSourceDocumentState(documentsToReset, ANNOTATION_IN_PROGRESS);
 
+            for (var doc : documentsToReset) {
+                curationService.deleteCurationCas(doc);
+            }
+
             success(format("The curation state of %s document(s) has been set reset.",
                     documentsToReset.size()));
             _target.addChildren(getPage(), IFeedback.class);
@@ -483,8 +487,9 @@ public class MatrixWorkloadManagementPage
 
         dialogContent.setExpectedResponseModel(Model.of(aDocument.getName()));
         dialogContent.setConfirmAction(_target -> {
-            curationService.deleteCurationCas(aDocument);
             documentService.setSourceDocumentState(aDocument, ANNOTATION_IN_PROGRESS);
+
+            curationService.deleteCurationCas(aDocument);
 
             success(format("The curation of document [%s] has been set reset.",
                     aDocument.getName()));


### PR DESCRIPTION
**What's in the PR**
- Trigger merge based on source document state and not based on whether the curation CAS exists
- Delete curation CAS as part of bulk reset

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
