### PR TITLE
#4778 - Links and other active elements in PDFs interfere with annotation and should be disabled

### DIFF
--- a/inception/inception-pdf-editor2/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor2/view/pdfjs/PdfJsViewerPage.java
+++ b/inception/inception-pdf-editor2/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor2/view/pdfjs/PdfJsViewerPage.java
@@ -59,6 +59,7 @@ public class PdfJsViewerPage
         aResponse.render(JavaScriptHeaderItem.forReference(PdfJsViewerJavaScriptReference.get()));
         var script = String.join("\n", //
                 "window.addEventListener('DOMContentLoaded', function() {", //
+                "  PDFViewerApplicationOptions.set('annotationMode', 0);", //
                 "  PDFViewerApplicationOptions.set('defaultUrl', null);", //
                 "  PDFViewerApplicationOptions.set('disablePreferences', true);", //
                 "  PDFViewerApplicationOptions.set('workerSrc', 'pdf.worker.min.js');", //


### PR DESCRIPTION
**What's in the PR**
- Disable annotations in the PDF viewer

**How to test manually**
- Print a Wikipedia page to PDF using the print-to-PDF functionality on macOS and then import the resulting PDF into INCEpTION

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
