### PR TITLE
#4782 - Avoid duplicate key error when importing documents very rapidly

### DIFF
--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/model/Index.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/model/Index.java
@@ -54,7 +54,7 @@ public class Index
     @JoinColumn(name = "project")
     private Project project;
 
-    private Boolean invalid;
+    private boolean invalid;
 
     @Temporal(TemporalType.TIMESTAMP)
     @Column(nullable = true)
@@ -85,14 +85,14 @@ public class Index
         this.project = project;
     }
 
-    public Boolean getInvalid()
+    public boolean isInvalid()
     {
         return invalid;
     }
 
-    public void setInvalid(Boolean state)
+    public void setInvalid(Boolean aState)
     {
-        this.invalid = state;
+        invalid = aState;
     }
 
     public Date getCreationDate()

--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/scheduling/tasks/IndexSourceDocumentTask.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/scheduling/tasks/IndexSourceDocumentTask.java
@@ -75,7 +75,7 @@ public class IndexSourceDocumentTask
     @Override
     public void execute()
     {
-        try (CasStorageSession session = CasStorageSession.open()) {
+        try (var session = CasStorageSession.open()) {
             var cas = documentService.createOrReadInitialCas(getSourceDocument(), AUTO_CAS_UPGRADE,
                     SHARED_READ_ONLY_ACCESS);
             searchService.indexDocument(getSourceDocument(), WebAnnoCasUtil.casToByteArray(cas));

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/documents/ImportDocumentsPanel.java
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/documents/ImportDocumentsPanel.java
@@ -24,7 +24,6 @@ import static org.apache.commons.collections4.CollectionUtils.isEmpty;
 import static org.apache.commons.lang3.exception.ExceptionUtils.getRootCauseMessage;
 import static org.apache.wicket.event.Broadcast.BUBBLE;
 
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -168,13 +167,13 @@ public class ImportDocumentsPanel
             }
 
             try {
-                SourceDocument document = new SourceDocument();
+                var document = new SourceDocument();
                 document.setName(fileName);
                 document.setProject(project);
                 document.setFormat(
                         importExportService.getFormatByName(format.getObject()).get().getId());
 
-                try (InputStream is = documentToUpload.getInputStream()) {
+                try (var is = documentToUpload.getInputStream()) {
                     documentService.uploadSourceDocument(is, document, fullProjectTypeSystem);
                 }
 


### PR DESCRIPTION
**What's in the PR**
- Fix the issue by only persisting the DB record if we actually change the "invalid" flag
- Bit of cleaning up

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
