### PR TITLE
#4791 - BOM not removed when importing plain text files

### DIFF
--- a/inception/inception-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/DocumentTextStartsWithBomCheck.java
+++ b/inception/inception-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/DocumentTextStartsWithBomCheck.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.diag.checks;
+
+import java.util.List;
+
+import org.apache.uima.cas.CAS;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.inception.support.logging.LogMessage;
+
+public class DocumentTextStartsWithBomCheck
+    implements Check
+{
+    @Override
+    public boolean check(Project aProject, CAS aCas, List<LogMessage> aMessages)
+    {
+        // BOM for UTF-16BE: FE FF
+        // BOM for UTF-16LE: FF FE
+
+        var text = aCas.getDocumentText();
+
+        if (text.charAt(0) == '\uFEFF' || text.charAt(0) == '\uFFFE') {
+            aMessages.add(
+                    LogMessage.info(this, "Document text starts with a Byte Order Mark (BOM)"));
+        }
+
+        return true;
+    }
+}

--- a/inception/inception-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/config/CasDoctorAutoConfiguration.java
+++ b/inception/inception-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/config/CasDoctorAutoConfiguration.java
@@ -36,6 +36,7 @@ import de.tudarmstadt.ukp.clarin.webanno.diag.checks.AllFeatureStructuresIndexed
 import de.tudarmstadt.ukp.clarin.webanno.diag.checks.CASMetadataTypeIsPresentCheck;
 import de.tudarmstadt.ukp.clarin.webanno.diag.checks.Check;
 import de.tudarmstadt.ukp.clarin.webanno.diag.checks.DanglingRelationsCheck;
+import de.tudarmstadt.ukp.clarin.webanno.diag.checks.DocumentTextStartsWithBomCheck;
 import de.tudarmstadt.ukp.clarin.webanno.diag.checks.FeatureAttachedSpanAnnotationsTrulyAttachedCheck;
 import de.tudarmstadt.ukp.clarin.webanno.diag.checks.LinksReachableThroughChainsCheck;
 import de.tudarmstadt.ukp.clarin.webanno.diag.checks.NegativeSizeAnnotationsCheck;
@@ -50,6 +51,7 @@ import de.tudarmstadt.ukp.clarin.webanno.diag.repairs.ReattachFeatureAttachedSpa
 import de.tudarmstadt.ukp.clarin.webanno.diag.repairs.ReattachFeatureAttachedSpanAnnotationsRepair;
 import de.tudarmstadt.ukp.clarin.webanno.diag.repairs.ReindexFeatureAttachedSpanAnnotationsRepair;
 import de.tudarmstadt.ukp.clarin.webanno.diag.repairs.RelationOffsetsRepair;
+import de.tudarmstadt.ukp.clarin.webanno.diag.repairs.RemoveBomRepair;
 import de.tudarmstadt.ukp.clarin.webanno.diag.repairs.RemoveDanglingChainLinksRepair;
 import de.tudarmstadt.ukp.clarin.webanno.diag.repairs.RemoveDanglingFeatureAttachedSpanAnnotationsRepair;
 import de.tudarmstadt.ukp.clarin.webanno.diag.repairs.RemoveDanglingRelationsRepair;
@@ -250,5 +252,17 @@ public class CasDoctorAutoConfiguration
     public TrimAnnotationsRepair trimAnnotationsRepair(AnnotationSchemaService aAnnotationService)
     {
         return new TrimAnnotationsRepair(aAnnotationService);
+    }
+
+    @Bean
+    public DocumentTextStartsWithBomCheck documentTextStartsWithBomCheck()
+    {
+        return new DocumentTextStartsWithBomCheck();
+    }
+
+    @Bean
+    public RemoveBomRepair removeBomRepair()
+    {
+        return new RemoveBomRepair();
     }
 }

--- a/inception/inception-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/repairs/RemoveBomRepair.java
+++ b/inception/inception-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/repairs/RemoveBomRepair.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.diag.repairs;
+
+import static de.tudarmstadt.ukp.clarin.webanno.diag.checks.UnreachableAnnotationsCheck.findAllFeatureStructures;
+import static de.tudarmstadt.ukp.inception.support.uima.ICasUtil.forceOverwriteSofa;
+import static de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil.getRealCas;
+
+import java.util.List;
+
+import org.apache.uima.cas.CAS;
+import org.apache.uima.jcas.tcas.Annotation;
+
+import de.tudarmstadt.ukp.clarin.webanno.diag.repairs.Repair.Safe;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.inception.support.logging.LogMessage;
+
+@Safe(false)
+public class RemoveBomRepair
+    implements Repair
+{
+    @Override
+    public void repair(Project aProject, CAS aCas, List<LogMessage> aMessages)
+    {
+        var cas = getRealCas(aCas);
+        var text = cas.getDocumentText();
+        if (text.length() < 1) {
+            return;
+        }
+
+        if (text.charAt(0) != '\uFEFF' && text.charAt(0) != '\uFFFE') {
+            return;
+        }
+
+        forceOverwriteSofa(cas, text.substring(1));
+
+        cas.protectIndexes(() -> {
+            findAllFeatureStructures(getRealCas(cas)).stream() //
+                    .filter(fs -> fs instanceof Annotation) //
+                    .map(fs -> (Annotation) fs) //
+                    .forEach(ann -> {
+                        var begin = ann.getBegin();
+                        var end = ann.getEnd();
+
+                        if (begin > 0) {
+                            ann.setBegin(begin - 1);
+                        }
+
+                        if (end > 0) {
+                            ann.setEnd(end - 1);
+                        }
+                    });
+        });
+
+        aMessages.add(LogMessage.info(this, "BOM removed and annotation offsets adjusted."));
+    }
+}

--- a/inception/inception-diag/src/main/resources/META-INF/asciidoc/user-guide/casdoctor.adoc
+++ b/inception/inception-diag/src/main/resources/META-INF/asciidoc/user-guide/casdoctor.adoc
@@ -231,6 +231,14 @@ Checks if all annotations start and end with a character (i.e. not a whitespace)
 whitespace character can cause problems during rendering. Trimming whitespace at the begin and end is typically as 
 harmless procedure.
 
+[[check_DocumentTextStartsWithBomCheck]]
+=== Document text starts with Byte Order Mark
+[horizontal]
+ID:: `check_DocumentTextStartsWithBomCheck`
+Related repairs:: <<repair_RemoveBomRepair>>
+
+Checks if the document text starts with a Byte Order Mark (BOM).
+
 
 [[sect_repairs]]
 == Repairs
@@ -388,3 +396,11 @@ ID:: `TrimAnnotationsRepair`
 
 This repair adjusts annotation boundaries such that they do not include any whitespace at the beginning or end of the 
 annotation.
+
+[[repair_RemoveBomRepair]]
+=== Remove Byte Order Mark
+
+[horizontal]
+ID:: `RemoveBomRepair`
+
+This repair removes the Byte Order Mark at the start of the document and adjusts all annotation offsets accordingly.

--- a/inception/inception-diag/src/test/java/de/tudarmstadt/ukp/clarin/webanno/diag/repairs/RemoveBomRepairTest.java
+++ b/inception/inception-diag/src/test/java/de/tudarmstadt/ukp/clarin/webanno/diag/repairs/RemoveBomRepairTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.diag.repairs;
+
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.random.RandomGenerator;
+
+import org.apache.uima.cas.text.AnnotationFS;
+import org.apache.uima.fit.factory.CasFactory;
+import org.apache.uima.jcas.tcas.Annotation;
+import org.junit.jupiter.api.Test;
+
+import de.tudarmstadt.ukp.inception.support.logging.LogMessage;
+
+class RemoveBomRepairTest
+{
+    private RandomGenerator rng = RandomGenerator.getDefault();
+
+    private RemoveBomRepair sut = new RemoveBomRepair();
+
+    @Test
+    void test() throws Exception
+    {
+        var annotationCount = 100;
+        var cas = CasFactory.createText("\uFEFF" + generateRandomString(100));
+
+        for (int n = 0; n < annotationCount; n++) {
+            var begin = rng.nextInt(0, cas.getDocumentText().length());
+            var end = rng.nextInt(0, cas.getDocumentText().length());
+            var ann = cas.createAnnotation(cas.getAnnotationType(), min(begin, end),
+                    max(begin, end));
+            cas.addFsToIndexes(ann);
+        }
+
+        var coveredTextsBefore = new HashMap<AnnotationFS, String>();
+        var annotations = cas.select(Annotation.class).asList();
+        for (var ann : annotations) {
+            coveredTextsBefore.put(ann, ann.getCoveredText());
+        }
+
+        var messages = new ArrayList<LogMessage>();
+        sut.repair(null, cas, messages);
+
+        assertThat(annotations).hasSizeGreaterThan(annotationCount);
+
+        for (var ann : annotations) {
+            var oldText = coveredTextsBefore.get(ann);
+            if (oldText.length() > 0
+                    && (oldText.charAt(0) == '\uFEFF' || oldText.charAt(0) == '\uFFFE')) {
+                oldText = oldText.substring(1);
+            }
+            assertThat(ann.getCoveredText()).isEqualTo(oldText);
+        }
+    }
+
+    private String generateRandomString(int len)
+    {
+        var chars = new char[len];
+        for (int i = 0; i < chars.length; i++) {
+            chars[i] = (char) rng.nextInt('0', 'z');
+        }
+        return String.valueOf(chars);
+    }
+}

--- a/inception/inception-io-brat/src/main/java/de/tudarmstadt/ukp/inception/io/brat/dkprocore/internal/mapping/TypeMappings.java
+++ b/inception/inception-io-brat/src/main/java/de/tudarmstadt/ukp/inception/io/brat/dkprocore/internal/mapping/TypeMappings.java
@@ -83,8 +83,8 @@ public class TypeMappings
     public TypeMapping getMappingByBratType(String aBratType)
     {
         return parsedMappings.stream() //
-        		.filter(mapping -> mapping.matches(aBratType)) //
-        		.findFirst() //
+                .filter(mapping -> mapping.matches(aBratType)) //
+                .findFirst() //
                 .orElse(null);
     }
 

--- a/inception/inception-io-text/pom.xml
+++ b/inception/inception-io-text/pom.xml
@@ -15,7 +15,9 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>de.tudarmstadt.ukp.inception.app</groupId>
@@ -57,6 +59,10 @@
       <artifactId>uimafit-core</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.dkpro.core</groupId>
+      <artifactId>dkpro-core-api-resources-asl</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.dkpro.core</groupId>
       <artifactId>dkpro-core-io-text-asl</artifactId>

--- a/inception/inception-io-text/src/main/java/de/tudarmstadt/ukp/clarin/webanno/text/PretokenizedLineOrientedTextReader.java
+++ b/inception/inception-io-text/src/main/java/de/tudarmstadt/ukp/clarin/webanno/text/PretokenizedLineOrientedTextReader.java
@@ -17,14 +17,15 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.text;
 
-import java.io.BufferedInputStream;
+import static org.dkpro.core.api.resources.CompressionUtils.getInputStream;
+
 import java.io.IOException;
-import java.io.InputStream;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.input.BOMInputStream;
 import org.apache.uima.collection.CollectionException;
+import org.apache.uima.fit.descriptor.ConfigurationParameter;
 import org.apache.uima.fit.descriptor.TypeCapability;
 import org.apache.uima.jcas.JCas;
 import org.dkpro.core.api.io.JCasResourceCollectionReader_ImplBase;
@@ -39,21 +40,31 @@ import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
 public class PretokenizedLineOrientedTextReader
     extends JCasResourceCollectionReader_ImplBase
 {
-    private static final Pattern whitespace = Pattern.compile("\\s+");
+    private static final Pattern WHITESPACE = Pattern.compile("\\s+");
+
+    /**
+     * Whether to remove a byte-order mark from the start of the text.
+     */
+    public static final String PARAM_INCLUDE_BOM = "includeBom";
+    @ConfigurationParameter(name = PARAM_INCLUDE_BOM, mandatory = true, defaultValue = "false")
+    private boolean includeBom;
 
     @Override
     public void getNext(JCas aJCas) throws IOException, CollectionException
     {
-        Resource res = nextFile();
+        var res = nextFile();
         initCas(aJCas, res);
 
-        try (InputStream is = new BufferedInputStream(res.getInputStream())) {
+        try (var is = BOMInputStream.builder() //
+                .setInclude(includeBom) //
+                .setInputStream(getInputStream(res.getLocation(), res.getInputStream())) //
+                .get()) {
             aJCas.setDocumentText(IOUtils.toString(is, "UTF-8"));
         }
 
-        String t = aJCas.getDocumentText();
-        int start = 0;
-        int end = t.indexOf('\n');
+        var t = aJCas.getDocumentText();
+        var start = 0;
+        var end = t.indexOf('\n');
         while (end >= 0) {
             createSentence(aJCas, start, end);
             start = end + 1;
@@ -72,13 +83,13 @@ public class PretokenizedLineOrientedTextReader
 
     protected Sentence createSentence(final JCas aJCas, final int aBegin, final int aEnd)
     {
-        int[] span = new int[] { aBegin, aEnd };
+        var span = new int[] { aBegin, aEnd };
         trim(aJCas.getDocumentText(), span);
         if (!isEmpty(span[0], span[1])) {
             Sentence seg = new Sentence(aJCas, span[0], span[1]);
             seg.addToIndexes(aJCas);
 
-            Matcher whitespaceMatcher = whitespace.matcher(seg.getCoveredText());
+            var whitespaceMatcher = WHITESPACE.matcher(seg.getCoveredText());
             int prevBegin = 0;
             while (whitespaceMatcher.find()) {
                 int end = whitespaceMatcher.start();
@@ -99,10 +110,10 @@ public class PretokenizedLineOrientedTextReader
 
     protected Token createToken(final JCas aJCas, final int aBegin, final int aEnd)
     {
-        int[] span = new int[] { aBegin, aEnd };
+        var span = new int[] { aBegin, aEnd };
         trim(aJCas.getDocumentText(), span);
         if (!isEmpty(span[0], span[1])) {
-            Token seg = new Token(aJCas, span[0], span[1]);
+            var seg = new Token(aJCas, span[0], span[1]);
             seg.addToIndexes(aJCas);
             return seg;
         }
@@ -121,12 +132,13 @@ public class PretokenizedLineOrientedTextReader
      */
     public void trim(String aText, int[] aSpan)
     {
-        int begin = aSpan[0];
-        int end = aSpan[1] - 1;
+        var begin = aSpan[0];
+        var end = aSpan[1] - 1;
 
         while ((begin < (aText.length() - 1)) && trimChar(aText.charAt(begin))) {
             begin++;
         }
+
         while ((end > 0) && trimChar(aText.charAt(end))) {
             end--;
         }

--- a/inception/inception-io-text/src/main/java/de/tudarmstadt/ukp/clarin/webanno/text/TextFormatSupport.java
+++ b/inception/inception-io-text/src/main/java/de/tudarmstadt/ukp/clarin/webanno/text/TextFormatSupport.java
@@ -25,7 +25,6 @@ import org.apache.uima.cas.CAS;
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
-import org.dkpro.core.io.text.TextReader;
 import org.dkpro.core.io.text.TextWriter;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;

--- a/inception/inception-io-text/src/main/java/de/tudarmstadt/ukp/clarin/webanno/text/TextReader.java
+++ b/inception/inception-io-text/src/main/java/de/tudarmstadt/ukp/clarin/webanno/text/TextReader.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.text;
+
+import static org.dkpro.core.api.resources.CompressionUtils.getInputStream;
+
+import java.io.IOException;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.input.BOMInputStream;
+import org.apache.uima.cas.CAS;
+import org.apache.uima.collection.CollectionException;
+import org.apache.uima.fit.descriptor.ConfigurationParameter;
+import org.apache.uima.fit.descriptor.MimeTypeCapability;
+import org.apache.uima.fit.descriptor.TypeCapability;
+import org.dkpro.core.api.io.ResourceCollectionReaderBase;
+import org.dkpro.core.api.parameter.ComponentParameters;
+import org.dkpro.core.api.parameter.MimeTypes;
+
+import com.ibm.icu.text.CharsetDetector;
+
+/**
+ * UIMA collection reader for plain text files.
+ */
+@MimeTypeCapability(MimeTypes.TEXT_PLAIN)
+@TypeCapability(outputs = { "de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData" })
+public class TextReader
+    extends ResourceCollectionReaderBase
+{
+    /**
+     * Automatically detect encoding.
+     *
+     * @see CharsetDetector
+     */
+    public static final String ENCODING_AUTO = "auto";
+
+    /**
+     * Name of configuration parameter that contains the character encoding used by the input files.
+     */
+    public static final String PARAM_SOURCE_ENCODING = ComponentParameters.PARAM_SOURCE_ENCODING;
+    @ConfigurationParameter(name = PARAM_SOURCE_ENCODING, mandatory = true, //
+            defaultValue = ComponentParameters.DEFAULT_ENCODING)
+    private String sourceEncoding;
+
+    /**
+     * Whether to remove a byte-order mark from the start of the text.
+     */
+    public static final String PARAM_INCLUDE_BOM = "includeBom";
+    @ConfigurationParameter(name = PARAM_INCLUDE_BOM, mandatory = true, defaultValue = "false")
+    private boolean includeBom;
+
+    @Override
+    public void getNext(CAS aJCas) throws IOException, CollectionException
+    {
+        var res = nextFile();
+        initCas(aJCas, res);
+
+        try (var is = BOMInputStream.builder() //
+                .setInclude(includeBom) //
+                .setInputStream(getInputStream(res.getLocation(), res.getInputStream())) //
+                .get()) {
+            String text;
+
+            if (ENCODING_AUTO.equals(sourceEncoding)) {
+                var detector = new CharsetDetector();
+                text = IOUtils.toString(detector.getReader(is, null));
+            }
+            else {
+                text = IOUtils.toString(is, sourceEncoding);
+            }
+
+            aJCas.setDocumentText(text);
+        }
+    }
+}

--- a/inception/inception-io-text/src/main/java/de/tudarmstadt/ukp/clarin/webanno/text/TextReader.java
+++ b/inception/inception-io-text/src/main/java/de/tudarmstadt/ukp/clarin/webanno/text/TextReader.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.text;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.dkpro.core.api.resources.CompressionUtils.getInputStream;
 
 import java.io.IOException;
@@ -29,10 +30,7 @@ import org.apache.uima.fit.descriptor.ConfigurationParameter;
 import org.apache.uima.fit.descriptor.MimeTypeCapability;
 import org.apache.uima.fit.descriptor.TypeCapability;
 import org.dkpro.core.api.io.ResourceCollectionReaderBase;
-import org.dkpro.core.api.parameter.ComponentParameters;
 import org.dkpro.core.api.parameter.MimeTypes;
-
-import com.ibm.icu.text.CharsetDetector;
 
 /**
  * UIMA collection reader for plain text files.
@@ -42,21 +40,6 @@ import com.ibm.icu.text.CharsetDetector;
 public class TextReader
     extends ResourceCollectionReaderBase
 {
-    /**
-     * Automatically detect encoding.
-     *
-     * @see CharsetDetector
-     */
-    public static final String ENCODING_AUTO = "auto";
-
-    /**
-     * Name of configuration parameter that contains the character encoding used by the input files.
-     */
-    public static final String PARAM_SOURCE_ENCODING = ComponentParameters.PARAM_SOURCE_ENCODING;
-    @ConfigurationParameter(name = PARAM_SOURCE_ENCODING, mandatory = true, //
-            defaultValue = ComponentParameters.DEFAULT_ENCODING)
-    private String sourceEncoding;
-
     /**
      * Whether to remove a byte-order mark from the start of the text.
      */
@@ -74,16 +57,7 @@ public class TextReader
                 .setInclude(includeBom) //
                 .setInputStream(getInputStream(res.getLocation(), res.getInputStream())) //
                 .get()) {
-            String text;
-
-            if (ENCODING_AUTO.equals(sourceEncoding)) {
-                var detector = new CharsetDetector();
-                text = IOUtils.toString(detector.getReader(is, null));
-            }
-            else {
-                text = IOUtils.toString(is, sourceEncoding);
-            }
-
+            var text = IOUtils.toString(is, UTF_8);
             aJCas.setDocumentText(text);
         }
     }

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController.java
@@ -22,6 +22,7 @@ import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.CURATOR;
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.MANAGER;
 import static de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.aero.model.RMessageLevel.ERROR;
 import static de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.aero.model.RMessageLevel.INFO;
+import static de.tudarmstadt.ukp.inception.support.uima.ICasUtil.forceOverwriteSofa;
 import static de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil.selectSentences;
 import static de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil.selectTokens;
 import static java.io.File.createTempFile;
@@ -43,8 +44,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.lang.invoke.MethodHandle;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -61,12 +60,9 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.reflect.FieldUtils;
-import org.apache.commons.lang3.reflect.MethodUtils;
 import org.apache.uima.UIMAException;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.text.AnnotationFS;
-import org.apache.uima.jcas.cas.Sofa;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -994,7 +990,7 @@ public class AeroRemoteApiController
         var document = getDocument(project, aDocumentId);
 
         // Check if the format is supported
-        String format = aFormatId.orElse(FORMAT_DEFAULT);
+        var format = aFormatId.orElse(FORMAT_DEFAULT);
         if (!importExportService.getReadableFormatById(format).isPresent()) {
             throw new UnsupportedFormatException(
                     "Format [%s] not supported. Acceptable formats are %s.", format,
@@ -1002,7 +998,7 @@ public class AeroRemoteApiController
                             .sorted().collect(toList()));
         }
 
-        String originalFilename = isNotBlank(aFile.getOriginalFilename())
+        var originalFilename = isNotBlank(aFile.getOriginalFilename()) //
                 ? aFile.getOriginalFilename()
                 : document.getName();
         if (!documentService.isValidDocumentName(originalFilename)) {
@@ -1100,29 +1096,6 @@ public class AeroRemoteApiController
                         as.getBegin(), as.getEnd());
             }
             unitIndex++;
-        }
-    }
-
-    private static void forceOverwriteSofa(CAS aCas, String aValue)
-    {
-        try {
-            Sofa sofa = (Sofa) aCas.getSofa();
-            MethodHandle _FH_sofaString = (MethodHandle) FieldUtils.readField(sofa,
-                    "_FH_sofaString", true);
-            Method method = MethodUtils.getMatchingMethod(Sofa.class, "wrapGetIntCatchException",
-                    MethodHandle.class);
-            int adjOffset;
-            try {
-                method.setAccessible(true);
-                adjOffset = (int) method.invoke(null, _FH_sofaString);
-            }
-            finally {
-                method.setAccessible(false);
-            }
-            sofa._setStringValueNcWj(adjOffset, aValue);
-        }
-        catch (Exception e) {
-            throw new IllegalStateException("Cannot force-update SofA string", e);
         }
     }
 

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/uima/ICasUtil.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/uima/ICasUtil.java
@@ -20,6 +20,11 @@ package de.tudarmstadt.ukp.inception.support.uima;
 import static org.apache.uima.fit.util.FSCollectionFactory.createStringArrayFS;
 import static org.apache.uima.fit.util.FSCollectionFactory.createStringList;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.reflect.Method;
+
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.commons.lang3.reflect.MethodUtils;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.Feature;
 import org.apache.uima.cas.FeatureStructure;
@@ -27,6 +32,7 @@ import org.apache.uima.cas.impl.CASImpl;
 import org.apache.uima.cas.text.AnnotationFS;
 import org.apache.uima.fit.util.CasUtil;
 import org.apache.uima.fit.util.FSUtil;
+import org.apache.uima.jcas.cas.Sofa;
 import org.apache.uima.jcas.cas.TOP;
 
 public class ICasUtil
@@ -188,5 +194,37 @@ public class ICasUtil
             typeName = CAS.TYPE_NAME_ANNOTATION;
         }
         return typeName;
+    }
+
+    /**
+     * NOT AT HOME THIS YOU SHOULD TRY<br>
+     * SETTING THE SOFA STRING FORCEFULLY FOLLOWING THE DARK SIDE IS!
+     * 
+     * @param aCas
+     *            the CAS to change
+     * @param aValue
+     *            the new sofa string
+     */
+    public static void forceOverwriteSofa(CAS aCas, String aValue)
+    {
+        try {
+            Sofa sofa = (Sofa) aCas.getSofa();
+            MethodHandle _FH_sofaString = (MethodHandle) FieldUtils.readField(sofa,
+                    "_FH_sofaString", true);
+            Method method = MethodUtils.getMatchingMethod(Sofa.class, "wrapGetIntCatchException",
+                    MethodHandle.class);
+            int adjOffset;
+            try {
+                method.setAccessible(true);
+                adjOffset = (int) method.invoke(null, _FH_sofaString);
+            }
+            finally {
+                method.setAccessible(false);
+            }
+            sofa._setStringValueNcWj(adjOffset, aValue);
+        }
+        catch (Exception e) {
+            throw new IllegalStateException("Cannot force-update SofA string", e);
+        }
     }
 }


### PR DESCRIPTION
**What's in the PR**
- Use BOMInputStream to strip BOM in the plain-text readers

**How to test manually**
* Import a file with a BOM

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
