### PR TITLE
#4796 - Annotation popover is not destroyed when switching between documents

### DIFF
--- a/inception/inception-brat-editor/src/main/ts/src/BratEditor.ts
+++ b/inception/inception-brat-editor/src/main/ts/src/BratEditor.ts
@@ -78,7 +78,8 @@ export class BratEditor implements AnnotationEditor {
   }
 
   destroy (): void {
-    // Nothing to do
-    console.log('destroy: not implemented')
+    if (this.popover?.$destroy) {
+      this.popover.$destroy()
+    }
   }
 }

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorEditor.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorEditor.ts
@@ -289,6 +289,9 @@ export class ApacheAnnotatorEditor implements AnnotationEditor {
   }
 
   destroy (): void {
+    if (this.popover?.$destroy) {
+      this.popover.$destroy()
+    }
     this.vis?.destroy()
     this.selector?.destroy()
   }

--- a/inception/inception-html-recogito-editor/src/main/ts/src/recogito/RecogitoEditor.ts
+++ b/inception/inception-html-recogito-editor/src/main/ts/src/recogito/RecogitoEditor.ts
@@ -479,6 +479,9 @@ export class RecogitoEditor implements AnnotationEditor {
   }
 
   public destroy (): void {
+    if (this.popover?.$destroy) {
+      this.popover.$destroy()
+    }
     this.connections.destroy()
     this.recogito.destroy()
   }

--- a/inception/inception-js-api/src/main/ts/src/widget/AnnotationDetailPopOver.svelte
+++ b/inception/inception-js-api/src/main/ts/src/widget/AnnotationDetailPopOver.svelte
@@ -81,11 +81,6 @@
     function onMouseMove(e: MouseEvent) {
         if (!annotation) return;
 
-        // if (!popoverTimeoutId && annotation) {
-        //     annotation = undefined
-        //     return
-        // }
-
         movePopover(e);
     }
 
@@ -146,6 +141,8 @@
     }
 
     function movePopover(e: MouseEvent) {
+        if (!popover) return
+
         const rect = popover.getBoundingClientRect();
 
         const x = e.clientX;

--- a/inception/inception-pdf-editor2/src/main/ts/src/PdfAnnotationEditor.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/PdfAnnotationEditor.ts
@@ -17,7 +17,7 @@
  */
 import type { AnnotationEditor, DiamAjax, Offsets } from '@inception-project/inception-js-api'
 import './PdfAnnotationEditor.css'
-import { initPdfAnno, getAnnotations as doLoadAnnotations, scrollTo } from './pdfanno/pdfanno'
+import { initPdfAnno, getAnnotations as doLoadAnnotations, scrollTo, destroy as destroyPdfAnno } from './pdfanno/pdfanno'
 import AbstractAnnotation from './pdfanno/core/src/model/AbstractAnnotation'
 
 export class PdfAnnotationEditor implements AnnotationEditor {
@@ -107,6 +107,6 @@ export class PdfAnnotationEditor implements AnnotationEditor {
   }
 
   destroy (): void {
-    console.log('Destroy not implemented yet')
+    destroyPdfAnno()
   }
 }

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/pdfanno.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/pdfanno.ts
@@ -30,6 +30,7 @@ let currentFocusPage: number
 let pagechangeEventCounter: number
 
 let data: AnnotatedText | undefined
+let popover: AnnotationDetailPopOver
 
 export async function initPdfAnno (ajax: DiamAjax): Promise<void> {
   globalThis.globalEvent = new EventEmitter()
@@ -82,7 +83,7 @@ export async function initPdfAnno (ajax: DiamAjax): Promise<void> {
   installSpanSelection()
   installRelationSelection()
 
-  new AnnotationDetailPopOver({
+  popover = new AnnotationDetailPopOver({
     target: document.body,
     props: {
       root: document.body,
@@ -94,6 +95,12 @@ export async function initPdfAnno (ajax: DiamAjax): Promise<void> {
   displayViewer()
 
   return initPromise
+}
+
+export function destroy() {
+  if (popover?.$destroy) {
+    popover.$destroy()
+  }
 }
 
 function onPageRendered (ev) {

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/svelte/SvelteBehavior.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/svelte/SvelteBehavior.java
@@ -172,7 +172,8 @@ public class SvelteBehavior
                 "if (element.$destroy) {", //
                 "  element.$destroy();", //
                 "  delete element.$destroy;", //
-                "  console.log('Svelte component on element [" + id + "] was destroyed');", //
+                "  console.log('Svelte component with class [" + host.getClass().getName()
+                        + "] on element [" + id + "] was destroyed');", //
                 "}"));
     }
 }


### PR DESCRIPTION
**What's in the PR**
- Destroy the popover in brat, apache annotator, pdf and recogito editors
- Fix an exception in the popover when a rendering/moving is triggered while the element the component is attached to is already gone

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
