### PR TITLE
#4796 - Annotation popover is not destroyed when switching between documents

### DIFF
--- a/inception/inception-diam-editor/src/main/ts/src/DiamAnnotationBrowser.svelte
+++ b/inception/inception-diam-editor/src/main/ts/src/DiamAnnotationBrowser.svelte
@@ -40,6 +40,7 @@
     export let pinnedGroups: string[];
     export let userPreferencesKey: string;
 
+    let popover : AnnotationDetailPopOver = null;
     let connected = false;
     let element = null;
     let self = get_current_component();
@@ -131,7 +132,7 @@
 
     onMount(async () => { 
         connect()
-        new AnnotationDetailPopOver({
+        popover = new AnnotationDetailPopOver({
             target: element,
             props: {
                 root: element,
@@ -140,7 +141,10 @@
         })
     });
 
-    onDestroy(async () => disconnect());
+    onDestroy(async () => { 
+        popover?.$destroy()
+        disconnect() 
+    });
 
     function cancelRightClick (e: Event): void {
     if (e instanceof MouseEvent) {

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/EditorAjaxRequestHandlerBase.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/EditorAjaxRequestHandlerBase.java
@@ -86,11 +86,11 @@ public abstract class EditorAjaxRequestHandlerBase
 
     protected DefaultAjaxResponse handleError(String aMessage, Exception e)
     {
-        AjaxRequestTarget target = getAjaxRequestTarget();
+        var target = getAjaxRequestTarget();
 
         target.addChildren(target.getPage(), IFeedback.class);
 
-        String fullMessage = aMessage + ": " + e.getMessage();
+        var fullMessage = aMessage + ": " + e.getMessage();
 
         if (e instanceof AnnotationException) {
             // These are common exceptions happening as part of the user interaction. We do

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/LazyDetailsHandler.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/LazyDetailsHandler.java
@@ -19,8 +19,13 @@ package de.tudarmstadt.ukp.inception.diam.editor.actions;
 
 import static de.tudarmstadt.ukp.inception.support.json.JSONUtil.toInterpretableJsonString;
 
+import java.lang.invoke.MethodHandles;
+
+import org.apache.uima.cas.impl.LowLevelException;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.request.Request;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.annotation.Order;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
@@ -39,6 +44,8 @@ import de.tudarmstadt.ukp.inception.diam.model.ajax.DefaultAjaxResponse;
 public class LazyDetailsHandler
     extends EditorAjaxRequestHandlerBase
 {
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
     public static final String COMMAND = "normData";
 
     private final LazyDetailsLookupService lazyDetailsLookupService;
@@ -70,6 +77,17 @@ public class LazyDetailsHandler
                     state.getUser(), state.getWindowBeginOffset(), state.getWindowEndOffset());
             attachResponse(aTarget, aRequest, toInterpretableJsonString(details));
 
+            return new DefaultAjaxResponse(COMMAND);
+        }
+        catch (LowLevelException e) {
+            // This can happen when the lazy details are loading while switching between documents.
+            // In this case, it is possible that the details for an annotation with an ID from the
+            // old document are still being loaded while the backend editor state has already been
+            // configured for the new document. If no suitable annotation with the given ID exists
+            // in the new document, this exception will be thrown. As part of switching the
+            // document, the popover will be destroyed and re-created anyway, so in any case, the
+            // user should never see this data.
+            // So, we ignore this exception.
             return new DefaultAjaxResponse(COMMAND);
         }
         catch (Exception e) {


### PR DESCRIPTION
**What's in the PR**
- Destroy the popover in diam sidebar
- Ignore the LowLevelException in the LazyDetailsHandler with a suitable explanation

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
