### PR TITLE
#1319 - Cross-Layer Relations

### DIFF
--- a/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/annotation/BratAnnotationEditor.java
+++ b/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/annotation/BratAnnotationEditor.java
@@ -114,7 +114,7 @@ public class BratAnnotationEditor
     @Override
     protected AnnotationEditorProperties getProperties()
     {
-        AnnotationEditorProperties props = new AnnotationEditorProperties();
+        var props = new AnnotationEditorProperties();
         // The factory is the JS call. Cf. the "globalName" in build.js and the factory method
         // defined in main.ts
         props.setEditorFactory("Brat.factory()");
@@ -216,7 +216,8 @@ public class BratAnnotationEditor
         }
 
         @Override
-        public AjaxResponse handle(AjaxRequestTarget aTarget, Request aRequest)
+        public AjaxResponse handle(DiamAjaxBehavior aBehavior, AjaxRequestTarget aTarget,
+                Request aRequest)
         {
             try {
                 var cas = getCasProvider().get();

--- a/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/annotation/GetCollectionInformationHandler.java
+++ b/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/annotation/GetCollectionInformationHandler.java
@@ -26,6 +26,7 @@ import org.apache.wicket.request.Request;
 import de.tudarmstadt.ukp.clarin.webanno.brat.message.GetCollectionInformationResponse;
 import de.tudarmstadt.ukp.clarin.webanno.brat.message.VisualOptions;
 import de.tudarmstadt.ukp.clarin.webanno.brat.schema.BratSchemaGenerator;
+import de.tudarmstadt.ukp.inception.diam.editor.DiamAjaxBehavior;
 import de.tudarmstadt.ukp.inception.diam.editor.actions.EditorAjaxRequestHandlerBase;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.AjaxResponse;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.DefaultAjaxResponse;
@@ -53,7 +54,8 @@ class GetCollectionInformationHandler
     }
 
     @Override
-    public AjaxResponse handle(AjaxRequestTarget aTarget, Request aRequest)
+    public AjaxResponse handle(DiamAjaxBehavior aBehavior, AjaxRequestTarget aTarget,
+            Request aRequest)
     {
         try {
             var result = getCollectionInformation(getAnnotatorState());
@@ -67,7 +69,7 @@ class GetCollectionInformationHandler
 
     public GetCollectionInformationResponse getCollectionInformation(AnnotatorState aState)
     {
-        GetCollectionInformationResponse info = new GetCollectionInformationResponse();
+        var info = new GetCollectionInformationResponse();
         if (aState.getProject() != null) {
             info.setEntityTypes(bratSchemaGenerator.buildEntityTypes(aState.getProject(),
                     aState.getAnnotationLayers()));

--- a/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/annotation/LoadConfHandler.java
+++ b/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/annotation/LoadConfHandler.java
@@ -25,6 +25,7 @@ import org.apache.wicket.request.Request;
 
 import de.tudarmstadt.ukp.clarin.webanno.brat.config.BratAnnotationEditorProperties;
 import de.tudarmstadt.ukp.clarin.webanno.brat.message.LoadConfResponse;
+import de.tudarmstadt.ukp.inception.diam.editor.DiamAjaxBehavior;
 import de.tudarmstadt.ukp.inception.diam.editor.actions.EditorAjaxRequestHandlerBase;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.AjaxResponse;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.DefaultAjaxResponse;
@@ -51,7 +52,7 @@ class LoadConfHandler
     }
 
     @Override
-    public AjaxResponse handle(AjaxRequestTarget aTarget, Request aRequest)
+    public AjaxResponse handle(DiamAjaxBehavior aBehavior, AjaxRequestTarget aTarget, Request aRequest)
     {
         try {
             var result = new LoadConfResponse(bratProperties);

--- a/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/schema/BratSchemaGeneratorImpl.java
+++ b/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/schema/BratSchemaGeneratorImpl.java
@@ -17,14 +17,15 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.brat.schema;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.groupingBy;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import javax.persistence.NoResultException;
@@ -39,6 +40,8 @@ import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.POS;
 import de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.Dependency;
 import de.tudarmstadt.ukp.inception.annotation.layer.chain.ChainLayerSupport;
+import de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationLayerSupport;
+import de.tudarmstadt.ukp.inception.annotation.layer.span.SpanLayerSupport;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 
 /**
@@ -71,25 +74,29 @@ public class BratSchemaGeneratorImpl
             List<AnnotationLayer> aAnnotationLayers)
     {
         // Sort layers
-        List<AnnotationLayer> layers = new ArrayList<>(aAnnotationLayers);
+        var layers = new ArrayList<AnnotationLayer>(aAnnotationLayers);
         layers.sort(comparing(AnnotationLayer::getName));
 
         // Look up all the features once to avoid hammering the database in the loop below
-        Map<AnnotationLayer, List<AnnotationFeature>> layerToFeatures = annotationService
-                .listSupportedFeatures(aProject).stream()
+        var layerToFeatures = annotationService.listSupportedFeatures(aProject).stream()
                 .collect(groupingBy(AnnotationFeature::getLayer));
 
         // Now build the actual configuration
-        Set<EntityType> entityTypes = new LinkedHashSet<>();
-        for (AnnotationLayer layer : layers) {
-            EntityType entityType = configureEntityType(layer);
+        var entityTypes = new LinkedHashMap<AnnotationLayer, EntityType>();
+        var relationTypes = new LinkedHashMap<AnnotationLayer, RelationType>();
+        for (var layer : layers) {
+            if (RelationLayerSupport.TYPE.equals(layer.getType())) {
+                continue;
+            }
 
-            List<RelationType> arcs = new ArrayList<>();
+            var entityType = configureEntityType(layer);
+
+            var arcs = new LinkedHashSet<RelationType>();
 
             // For link features, we also need to configure the arcs, even though there is no arc
             // layer here.
             boolean hasLinkFeatures = false;
-            for (AnnotationFeature f : layerToFeatures.computeIfAbsent(layer, k -> emptyList())) {
+            for (var f : layerToFeatures.computeIfAbsent(layer, k -> emptyList())) {
                 if (!LinkMode.NONE.equals(f.getLinkMode())) {
                     hasLinkFeatures = true;
                     break;
@@ -97,20 +104,23 @@ public class BratSchemaGeneratorImpl
             }
 
             if (hasLinkFeatures) {
-                arcs.add(new RelationType(layer.getName(), layer.getUiName(),
-                        getBratTypeName(layer), getBratTypeName(layer), null, "triangle,5", "3,3"));
+                arcs.add(new RelationType(layer.getUiName(), getBratTypeName(layer),
+                        getBratTypeName(layer), null, "triangle,5", "3,3"));
             }
 
             // Styles for the remaining relation and chain layers
-            for (AnnotationLayer attachingLayer : getAttachingLayers(layer, layers)) {
-                arcs.add(configureRelationType(layer, attachingLayer));
+            for (var attachingLayer : getAttachingLayers(layer, layers)) {
+                var relationLayer = relationTypes.computeIfAbsent(attachingLayer,
+                        $ -> buildRelationType(layer, attachingLayer));
+                relationLayer.addTarget(getBratTypeName(layer));
+                arcs.add(relationLayer);
             }
 
-            entityType.setArcs(arcs);
-            entityTypes.add(entityType);
+            entityType.setArcs(new ArrayList<>(arcs));
+            entityTypes.put(layer, entityType);
         }
 
-        return entityTypes;
+        return new LinkedHashSet<>(entityTypes.values());
     }
 
     /**
@@ -119,12 +129,12 @@ public class BratSchemaGeneratorImpl
     private List<AnnotationLayer> getAttachingLayers(AnnotationLayer aTarget,
             List<AnnotationLayer> aLayers)
     {
-        List<AnnotationLayer> attachingLayers = new ArrayList<>();
-
         // Chains always attach to themselves
         if (ChainLayerSupport.TYPE.equals(aTarget.getType())) {
-            attachingLayers.add(aTarget);
+            return asList(aTarget);
         }
+
+        var attachingLayers = new ArrayList<AnnotationLayer>();
 
         // FIXME This is a hack! Actually we should check the type of the attachFeature when
         // determine which layers attach to with other layers. Currently we only use attachType,
@@ -140,9 +150,16 @@ public class BratSchemaGeneratorImpl
         }
 
         // Custom layers
-        for (AnnotationLayer l : aLayers) {
-            if (aTarget.equals(l.getAttachType())) {
-                attachingLayers.add(l);
+        for (var layer : aLayers) {
+            // Layer attaches explicitly to other layer
+            if (aTarget.equals(layer.getAttachType())) {
+                attachingLayers.add(layer);
+            }
+            // Relation layer that attaches to "any" other span layer
+            else if (SpanLayerSupport.TYPE.equals(aTarget.getType())
+                    && RelationLayerSupport.TYPE.equals(layer.getType())
+                    && layer.getAttachType() == null) {
+                attachingLayers.add(layer);
             }
         }
 
@@ -151,12 +168,11 @@ public class BratSchemaGeneratorImpl
 
     private EntityType configureEntityType(AnnotationLayer aLayer)
     {
-        String bratTypeName = getBratTypeName(aLayer);
+        var bratTypeName = getBratTypeName(aLayer);
         return new EntityType(aLayer.getName(), aLayer.getUiName(), bratTypeName);
     }
 
-    private RelationType configureRelationType(AnnotationLayer aLayer,
-            AnnotationLayer aAttachingLayer)
+    private RelationType buildRelationType(AnnotationLayer aLayer, AnnotationLayer aAttachingLayer)
     {
         String attachingLayerBratTypeName = getBratTypeName(aAttachingLayer);
 
@@ -187,9 +203,9 @@ public class BratSchemaGeneratorImpl
             break;
         }
 
-        String bratTypeName = getBratTypeName(aLayer);
-        return new RelationType(aAttachingLayer.getName(), aAttachingLayer.getUiName(),
-                attachingLayerBratTypeName, bratTypeName, null, arrowHead, dashArray);
+        var bratTypeName = getBratTypeName(aLayer);
+        return new RelationType(aAttachingLayer.getUiName(), attachingLayerBratTypeName,
+                bratTypeName, null, arrowHead, dashArray);
     }
 
     public static String getBratTypeName(AnnotationLayer aLayer)

--- a/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/schema/model/RelationType.java
+++ b/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/schema/model/RelationType.java
@@ -20,7 +20,14 @@ package de.tudarmstadt.ukp.clarin.webanno.brat.schema.model;
 import static de.tudarmstadt.ukp.clarin.webanno.brat.render.BratSerializerImpl.abbreviate;
 import static java.util.Arrays.asList;
 
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import de.tudarmstadt.ukp.clarin.webanno.brat.render.model.Entity;
 
@@ -30,7 +37,10 @@ import de.tudarmstadt.ukp.clarin.webanno.brat.render.model.Entity;
  * "targets":["nam"],"dashArray":""}]....
  */
 public class RelationType
+    implements Serializable
 {
+    private static final long serialVersionUID = 4523870233669399336L;
+
     /**
      * The type of the arc annotation
      */
@@ -38,19 +48,21 @@ public class RelationType
 
     private String color;
     private String arrowHead;
+
     /**
      * Possible List of labels to be used on the arc
      */
     private List<String> labels;
+
     /**
      * List of Target Labels, which are a span annotation ({@link Entity}
      */
-    private List<String> targets;
+    private Set<String> targets = new HashSet<>();
     private String dashArray;
 
     public RelationType()
     {
-        // Nothing to do
+        // For serialization
     }
 
     // allow similar colors per layer
@@ -67,7 +79,7 @@ public class RelationType
     // this(aName, aType, aTarget, aColor, "triangle,5");
     // }
 
-    public RelationType(String aName, String aLabel, String aType, String aTarget, String aColor,
+    public RelationType(String aLabel, String aType, String aTarget, String aColor,
             String aArrowHead, String aDashArray)
     {
         this(aColor, aArrowHead, asList(aLabel, abbreviate(aLabel)), aType, asList(aTarget),
@@ -77,13 +89,15 @@ public class RelationType
     private RelationType(String aColor, String aArrowHead, List<String> aLabels, String aType,
             List<String> aTargets, String aDashArray)
     {
-        super();
         color = aColor;
         arrowHead = aArrowHead;
         labels = aLabels;
         type = aType;
-        targets = aTargets;
         dashArray = aDashArray;
+
+        if (aTargets != null) {
+            targets.addAll(aTargets);
+        }
     }
 
     public String getColor()
@@ -126,14 +140,20 @@ public class RelationType
         type = aType;
     }
 
-    public List<String> getTargets()
+    public Set<String> getTargets()
     {
         return targets;
     }
 
-    public void setTargets(List<String> aTargets)
+    public void addTarget(String aTarget)
     {
-        targets = aTargets;
+        targets.add(aTarget);
+    }
+
+    public void setTargets(Collection<String> aTargets)
+    {
+        targets.clear();
+        targets.addAll(aTargets);
     }
 
     public String getDashArray()
@@ -144,5 +164,21 @@ public class RelationType
     public void setDashArray(String aDashArray)
     {
         dashArray = aDashArray;
+    }
+
+    @Override
+    public boolean equals(final Object other)
+    {
+        if (!(other instanceof RelationType)) {
+            return false;
+        }
+        RelationType castOther = (RelationType) other;
+        return new EqualsBuilder().append(type, castOther.type).isEquals();
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return new HashCodeBuilder().append(type).toHashCode();
     }
 }

--- a/inception/inception-brat-editor/src/main/ts/src/annotator_ui/AnnotatorUI.ts
+++ b/inception/inception-brat-editor/src/main/ts/src/annotator_ui/AnnotatorUI.ts
@@ -678,7 +678,7 @@ export class AnnotatorUI {
             target: targetSpan.id
           }
 
-          this.ajax.createRelationAnnotation(originSpan.id, targetSpan.id)
+          this.ajax.createRelationAnnotation(originSpan.id, targetSpan.id, evt)
         }
       }
     } finally {

--- a/inception/inception-diam-editor/src/main/java/de/tudarmstadt/ukp/inception/diam/sidebar/DiamAnnotationBrowser.java
+++ b/inception/inception-diam-editor/src/main/java/de/tudarmstadt/ukp/inception/diam/sidebar/DiamAnnotationBrowser.java
@@ -74,7 +74,7 @@ public class DiamAnnotationBrowser
         var page = findParent(AnnotationPage.class);
 
         add(diamBehavior = createDiamBehavior());
-        diamBehavior.addPriorityHandler(new ShowContextMenuHandler(extensionRegistry, contextMenu,
+        diamBehavior.addPriorityHandler(new ShowContextMenuHandler(extensionRegistry,
                 page.getModel(), page.getAnnotationActionHandler(), page::getEditorCas));
         add(new SvelteBehavior());
     }
@@ -118,8 +118,7 @@ public class DiamAnnotationBrowser
 
     protected DiamAjaxBehavior createDiamBehavior()
     {
-        var diam = new DiamAjaxBehavior();
-        return diam;
+        return new DiamAjaxBehavior(contextMenu);
     }
 
     @Override

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/DiamAjaxBehavior.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/DiamAjaxBehavior.java
@@ -21,17 +21,21 @@ import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.wicket.Component;
+import org.apache.wicket.MarkupContainer;
 import org.apache.wicket.ajax.AbstractDefaultAjaxBehavior;
 import org.apache.wicket.ajax.AjaxRequestTarget;
-import org.apache.wicket.request.Request;
 import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.spring.injection.annot.SpringBean;
+import org.apache.wicket.util.visit.IVisit;
+import org.apache.wicket.util.visit.IVisitor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import de.tudarmstadt.ukp.inception.diam.editor.actions.EditorAjaxRequestHandler;
 import de.tudarmstadt.ukp.inception.diam.editor.actions.EditorAjaxRequestHandlerExtensionPoint;
 import de.tudarmstadt.ukp.inception.support.http.ServerTimingWatch;
+import de.tudarmstadt.ukp.inception.support.wicket.ContextMenu;
 
 public class DiamAjaxBehavior
     extends AbstractDefaultAjaxBehavior
@@ -45,6 +49,18 @@ public class DiamAjaxBehavior
     private List<EditorAjaxRequestHandler> priorityHandlers = new ArrayList<>();
 
     private boolean globalHandlersEnabled = true;
+
+    private final ContextMenu contextMenu;
+
+    public DiamAjaxBehavior()
+    {
+        this(null);
+    }
+
+    public DiamAjaxBehavior(ContextMenu aContextMenu)
+    {
+        contextMenu = aContextMenu;
+    }
 
     public DiamAjaxBehavior addPriorityHandler(EditorAjaxRequestHandler aHandler)
     {
@@ -69,7 +85,7 @@ public class DiamAjaxBehavior
     {
         LOG.trace("AJAX request received");
 
-        Request request = RequestCycle.get().getRequest();
+        var request = RequestCycle.get().getRequest();
 
         var priorityHandler = priorityHandlers.stream() //
                 .filter(handler -> handler.accepts(request)) //
@@ -88,10 +104,34 @@ public class DiamAjaxBehavior
 
     private void call(AjaxRequestTarget aTarget, EditorAjaxRequestHandler aHandler)
     {
-        Request request = RequestCycle.get().getRequest();
+        var request = RequestCycle.get().getRequest();
         try (var watch = new ServerTimingWatch("diam", "diam (" + aHandler.getCommand() + ")")) {
-            aHandler.handle(aTarget, request);
+            aHandler.handle(this, aTarget, request);
             return;
         }
+    }
+
+    public ContextMenu findContextMenu()
+    {
+        var component = getComponent();
+        if (component instanceof MarkupContainer container) {
+            final Component[] result = new Component[1]; // Array to hold the result
+            container.visitChildren(ContextMenu.class, new IVisitor<Component, Void>()
+            {
+                @Override
+                public void component(Component aComponent, IVisit<Void> visit)
+                {
+                    result[0] = aComponent;
+                    visit.stop();
+                }
+            });
+            return (ContextMenu) result[0];
+        }
+        return null;
+    }
+
+    public ContextMenu getContextMenu()
+    {
+        return contextMenu;
     }
 }

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/CreateRelationAnnotationHandler.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/CreateRelationAnnotationHandler.java
@@ -27,10 +27,22 @@ import org.apache.wicket.request.IRequestParameters;
 import org.apache.wicket.request.Request;
 import org.springframework.core.annotation.Order;
 
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.IllegalPlacementException;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.inception.annotation.layer.chain.ChainAdapter;
+import de.tudarmstadt.ukp.inception.annotation.layer.relation.CreateRelationAnnotationRequest;
+import de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationAdapter;
+import de.tudarmstadt.ukp.inception.diam.editor.DiamAjaxBehavior;
 import de.tudarmstadt.ukp.inception.diam.editor.config.DiamAutoConfig;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.DefaultAjaxResponse;
+import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
+import de.tudarmstadt.ukp.inception.rendering.selection.Selection;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
+import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.AnnotationException;
+import de.tudarmstadt.ukp.inception.schema.api.config.AnnotationSchemaProperties;
+import de.tudarmstadt.ukp.inception.support.lambda.LambdaMenuItem;
 
 /**
  * <p>
@@ -44,6 +56,16 @@ public class CreateRelationAnnotationHandler
 {
     public static final String COMMAND = "arcOpenDialog";
 
+    private final AnnotationSchemaService schemaService;
+    private final AnnotationSchemaProperties schemaProperties;
+
+    public CreateRelationAnnotationHandler(AnnotationSchemaService aSchemaService,
+            AnnotationSchemaProperties aSchemaProperties)
+    {
+        schemaService = aSchemaService;
+        schemaProperties = aSchemaProperties;
+    }
+
     @Override
     public String getCommand()
     {
@@ -51,10 +73,11 @@ public class CreateRelationAnnotationHandler
     }
 
     @Override
-    public DefaultAjaxResponse handle(AjaxRequestTarget aTarget, Request aRequest)
+    public DefaultAjaxResponse handle(DiamAjaxBehavior aBehavior, AjaxRequestTarget aTarget,
+            Request aRequest)
     {
         try {
-            actionArc(aTarget, aRequest.getRequestParameters());
+            actionArc(aBehavior, aTarget, aRequest.getRequestParameters());
             return new DefaultAjaxResponse(getAction(aRequest));
         }
         catch (Exception e) {
@@ -62,30 +85,121 @@ public class CreateRelationAnnotationHandler
         }
     }
 
-    private void actionArc(AjaxRequestTarget aTarget, IRequestParameters aParams)
+    private void actionArc(DiamAjaxBehavior aBehavior, AjaxRequestTarget aTarget,
+            IRequestParameters aParams)
         throws IOException, AnnotationException
     {
         var page = getPage();
 
         page.ensureIsEditable();
 
-        var origin = VID.parse(aParams.getParameterValue(PARAM_ORIGIN_SPAN_ID).toString());
-        var target = VID.parse(aParams.getParameterValue(PARAM_TARGET_SPAN_ID).toString());
+        var originSpan = VID.parse(aParams.getParameterValue(PARAM_ORIGIN_SPAN_ID).toString());
+        var targetSpan = VID.parse(aParams.getParameterValue(PARAM_TARGET_SPAN_ID).toString());
 
-        if (origin.isSynthetic() || target.isSynthetic()) {
+        if (originSpan.isSynthetic() || targetSpan.isSynthetic()) {
             page.error("Relations cannot be created from/to synthetic annotations");
             aTarget.addChildren(page, IFeedback.class);
             return;
         }
 
         var cas = page.getEditorCas();
+        var state = getAnnotatorState();
+        var originFs = selectAnnotationByAddr(cas, originSpan.getId());
+        var originLayer = schemaService.findLayer(state.getProject(), originFs);
+        var originAdapter = schemaService.getAdapter(originLayer);
+
+        if (originAdapter instanceof ChainAdapter chainAdapter) {
+            createChainLink(chainAdapter, aTarget, originSpan, targetSpan);
+        }
+        else {
+            createRelationAnnotation(aBehavior, aTarget, originLayer, originSpan, targetSpan);
+        }
+    }
+
+    private void createChainLink(ChainAdapter chainAdapter, AjaxRequestTarget aTarget,
+            VID aOriginSpan, VID aTargetSpan)
+        throws IOException, AnnotationException
+    {
+        var page = getPage();
+        var cas = page.getEditorCas();
+        var originFs = selectAnnotationByAddr(cas, aOriginSpan.getId());
+        var targetFs = selectAnnotationByAddr(cas, aTargetSpan.getId());
+
+        if (!originFs.getType().equals(targetFs.getType())) {
+            throw new IllegalPlacementException(
+                    "Cannot create links between chain elements on different layers");
+        }
+
+        var state = getAnnotatorState();
+        var request = new CreateRelationAnnotationRequest(state.getDocument(),
+                state.getUser().getUsername(), cas, originFs, targetFs);
+
+        var ann = chainAdapter.handle(request);
+        var selection = chainAdapter.selectLink(ann);
+
+        commitAnnotation(aTarget, page, state, selection);
+
+    }
+
+    private void createRelationAnnotation(DiamAjaxBehavior aBehavior, AjaxRequestTarget aTarget,
+            AnnotationLayer originLayer, VID aOriginSpan, VID aTargetSpan)
+        throws AnnotationException, IllegalPlacementException, IOException
+    {
+        var candidateLayers = schemaService.getRelationLayersFor(originLayer);
+        if (candidateLayers.isEmpty()) {
+            throw new IllegalPlacementException(
+                    "There are no relation layers that can be created between these endpoints");
+        }
+
+        if (candidateLayers.size() == 1) {
+            var relationLayer = candidateLayers.get(0);
+            createRelationAnnotation(aTarget, relationLayer, aOriginSpan, aTargetSpan);
+        }
+
+        var cm = aBehavior.getContextMenu();
+        var items = cm.getItemList();
+        items.clear();
+
+        for (var layer : candidateLayers) {
+            items.add(new LambdaMenuItem(layer.getUiName(),
+                    $ -> createRelationAnnotation($, layer, aOriginSpan, aTargetSpan)));
+        }
+
+        cm.onOpen(aTarget);
+    }
+
+    private void createRelationAnnotation(AjaxRequestTarget aTarget, AnnotationLayer relationLayer,
+            VID origin, VID target)
+        throws AnnotationException, IOException
+    {
+        var state = getAnnotatorState();
+
+        var page = getPage();
+        var cas = page.getEditorCas();
         var originFs = selectAnnotationByAddr(cas, origin.getId());
         var targetFs = selectAnnotationByAddr(cas, target.getId());
 
-        var state = page.getModelObject();
-        var selection = state.getSelection();
-        selection.selectArc(originFs, targetFs);
+        if (!schemaProperties.isCrossLayerRelationsEnabled()
+                && !originFs.getType().equals(targetFs.getType())) {
+            throw new IllegalPlacementException(
+                    "Cannot create relation between spans on different layers");
+        }
 
-        page.getAnnotationActionHandler().actionCreateOrUpdate(aTarget, cas);
+        var request = new CreateRelationAnnotationRequest(state.getDocument(),
+                state.getUser().getUsername(), cas, originFs, targetFs);
+        var relationAdapter = (RelationAdapter) schemaService.getAdapter(relationLayer);
+        var ann = relationAdapter.handle(request);
+        var selection = relationAdapter.select(VID.of(ann), ann);
+
+        commitAnnotation(aTarget, page, state, selection);
+    }
+
+    private void commitAnnotation(AjaxRequestTarget aTarget, AnnotationPageBase page,
+            AnnotatorState state, Selection selection)
+        throws IOException, AnnotationException
+    {
+        state.getSelection().set(selection);
+        page.getAnnotationActionHandler().actionSelect(aTarget);
+        page.getAnnotationActionHandler().writeEditorCas();
     }
 }

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/CreateRelationAnnotationHandler.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/CreateRelationAnnotationHandler.java
@@ -43,6 +43,8 @@ import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.AnnotationException;
 import de.tudarmstadt.ukp.inception.schema.api.config.AnnotationSchemaProperties;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaMenuItem;
+import de.tudarmstadt.ukp.inception.support.lambda.MenuCategoryHeader;
+import de.tudarmstadt.ukp.inception.support.spring.ApplicationContextProvider;
 
 /**
  * <p>
@@ -160,9 +162,15 @@ public class CreateRelationAnnotationHandler
         var items = cm.getItemList();
         items.clear();
 
+        items.add(new MenuCategoryHeader("Select layer..."));
         for (var layer : candidateLayers) {
-            items.add(new LambdaMenuItem(layer.getUiName(),
-                    $ -> createRelationAnnotation($, layer, aOriginSpan, aTargetSpan)));
+            items.add(new LambdaMenuItem(layer.getUiName(), $ -> {
+                // We need to fetch the bean here again because it is not serializable and
+                // the AJAX callback here needs to be serializable
+                var handler = ApplicationContextProvider.getApplicationContext()
+                        .getBean(CreateRelationAnnotationHandler.class);
+                handler.createRelationAnnotation($, layer, aOriginSpan, aTargetSpan);
+            }));
         }
 
         cm.onOpen(aTarget);

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/CreateSpanAnnotationHandler.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/CreateSpanAnnotationHandler.java
@@ -27,6 +27,7 @@ import org.apache.wicket.request.IRequestParameters;
 import org.apache.wicket.request.Request;
 import org.springframework.core.annotation.Order;
 
+import de.tudarmstadt.ukp.inception.diam.editor.DiamAjaxBehavior;
 import de.tudarmstadt.ukp.inception.diam.editor.config.DiamAutoConfig;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.DefaultAjaxResponse;
 import de.tudarmstadt.ukp.inception.diam.model.compact.CompactRangeList;
@@ -53,7 +54,7 @@ public class CreateSpanAnnotationHandler
     }
 
     @Override
-    public DefaultAjaxResponse handle(AjaxRequestTarget aTarget, Request aRequest)
+    public DefaultAjaxResponse handle(DiamAjaxBehavior aBehavior, AjaxRequestTarget aTarget, Request aRequest)
     {
         try {
             var page = getPage();

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/DeleteAnnotationHandler.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/DeleteAnnotationHandler.java
@@ -21,6 +21,7 @@ import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.request.Request;
 import org.springframework.core.annotation.Order;
 
+import de.tudarmstadt.ukp.inception.diam.editor.DiamAjaxBehavior;
 import de.tudarmstadt.ukp.inception.diam.editor.config.DiamAutoConfig;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.DefaultAjaxResponse;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
@@ -58,7 +59,7 @@ public class DeleteAnnotationHandler
     }
 
     @Override
-    public DefaultAjaxResponse handle(AjaxRequestTarget aTarget, Request aRequest)
+    public DefaultAjaxResponse handle(DiamAjaxBehavior aBehavior, AjaxRequestTarget aTarget, Request aRequest)
     {
         try {
             var page = getPage();

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/EditorAjaxRequestHandler.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/EditorAjaxRequestHandler.java
@@ -22,6 +22,7 @@ import javax.servlet.http.HttpServletRequest;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.request.Request;
 
+import de.tudarmstadt.ukp.inception.diam.editor.DiamAjaxBehavior;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.AjaxResponse;
 import de.tudarmstadt.ukp.inception.support.extensionpoint.Extension;
 
@@ -51,7 +52,7 @@ public interface EditorAjaxRequestHandler
             throw new IllegalArgumentException("Request is not a HttpServletRequest");
         }
 
-        HttpServletRequest request = (HttpServletRequest) aRequest.getContainerRequest();
+        var request = (HttpServletRequest) aRequest.getContainerRequest();
 
         return request.getMethod();
     }
@@ -65,5 +66,5 @@ public interface EditorAjaxRequestHandler
                 aRequest.getRequestParameters().getParameterValue(PARAM_ACTION).toOptionalString());
     }
 
-    AjaxResponse handle(AjaxRequestTarget aTarget, Request aRequest);
+    AjaxResponse handle(DiamAjaxBehavior aBehavior, AjaxRequestTarget aTarget, Request aRequest);
 }

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/EditorAjaxRequestHandlerBase.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/EditorAjaxRequestHandlerBase.java
@@ -23,7 +23,6 @@ import java.lang.invoke.MethodHandles;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.feedback.IFeedback;
-import org.apache.wicket.request.IRequestParameters;
 import org.apache.wicket.request.Request;
 import org.apache.wicket.request.cycle.RequestCycle;
 import org.slf4j.Logger;
@@ -72,14 +71,14 @@ public abstract class EditorAjaxRequestHandlerBase
 
     public VID getVid(Request aRequest)
     {
-        IRequestParameters requestParameters = aRequest.getRequestParameters();
+        var requestParameters = aRequest.getRequestParameters();
 
         return VID.parseOptional(requestParameters.getParameterValue(PARAM_ID).toString());
     }
 
     protected void attachResponse(AjaxRequestTarget aTarget, Request aRequest, String json)
     {
-        String token = aRequest.getRequestParameters().getParameterValue(PARAM_TOKEN).toString();
+        var token = aRequest.getRequestParameters().getParameterValue(PARAM_TOKEN).toString();
         aTarget.prependJavaScript(
                 "document['DIAM_TRANSPORT_BUFFER']['" + token + "'] = " + json + ";");
     }

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/ExtensionActionHandler.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/ExtensionActionHandler.java
@@ -21,6 +21,7 @@ import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.request.Request;
 import org.springframework.core.annotation.Order;
 
+import de.tudarmstadt.ukp.inception.diam.editor.DiamAjaxBehavior;
 import de.tudarmstadt.ukp.inception.diam.editor.config.DiamAutoConfig;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.DefaultAjaxResponse;
 import de.tudarmstadt.ukp.inception.editor.AnnotationEditorExtensionRegistry;
@@ -56,7 +57,7 @@ public class ExtensionActionHandler
     }
 
     @Override
-    public DefaultAjaxResponse handle(AjaxRequestTarget aTarget, Request aRequest)
+    public DefaultAjaxResponse handle(DiamAjaxBehavior aBehavior, AjaxRequestTarget aTarget, Request aRequest)
     {
         try {
             var page = getPage();

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/FillSlotWithExistingAnnotationHandler.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/FillSlotWithExistingAnnotationHandler.java
@@ -21,6 +21,7 @@ import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.request.Request;
 import org.springframework.core.annotation.Order;
 
+import de.tudarmstadt.ukp.inception.diam.editor.DiamAjaxBehavior;
 import de.tudarmstadt.ukp.inception.diam.editor.config.DiamAutoConfig;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.DefaultAjaxResponse;
 
@@ -43,7 +44,7 @@ public class FillSlotWithExistingAnnotationHandler
     }
 
     @Override
-    public DefaultAjaxResponse handle(AjaxRequestTarget aTarget, Request aRequest)
+    public DefaultAjaxResponse handle(DiamAjaxBehavior aBehavior, AjaxRequestTarget aTarget, Request aRequest)
     {
         try {
             var page = getPage();

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/FillSlotWithNewAnnotationHandler.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/FillSlotWithNewAnnotationHandler.java
@@ -25,6 +25,7 @@ import org.apache.wicket.request.IRequestParameters;
 import org.apache.wicket.request.Request;
 import org.springframework.core.annotation.Order;
 
+import de.tudarmstadt.ukp.inception.diam.editor.DiamAjaxBehavior;
 import de.tudarmstadt.ukp.inception.diam.editor.config.DiamAutoConfig;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.DefaultAjaxResponse;
 import de.tudarmstadt.ukp.inception.diam.model.compact.CompactRange;
@@ -51,7 +52,7 @@ public class FillSlotWithNewAnnotationHandler
     }
 
     @Override
-    public DefaultAjaxResponse handle(AjaxRequestTarget aTarget, Request aRequest)
+    public DefaultAjaxResponse handle(DiamAjaxBehavior aBehavior, AjaxRequestTarget aTarget, Request aRequest)
     {
         try {
             var page = getPage();

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/ImplicitUnarmSlotHandler.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/ImplicitUnarmSlotHandler.java
@@ -21,6 +21,7 @@ import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.request.Request;
 import org.springframework.core.annotation.Order;
 
+import de.tudarmstadt.ukp.inception.diam.editor.DiamAjaxBehavior;
 import de.tudarmstadt.ukp.inception.diam.editor.config.DiamAutoConfig;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.AjaxResponse;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
@@ -55,7 +56,7 @@ public class ImplicitUnarmSlotHandler
     }
 
     @Override
-    public AjaxResponse handle(AjaxRequestTarget aTarget, Request aRequest)
+    public AjaxResponse handle(DiamAjaxBehavior aBehavior, AjaxRequestTarget aTarget, Request aRequest)
     {
         throw new IllegalStateException("This handler should never handle a request!");
     }

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/LazyDetailsHandler.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/LazyDetailsHandler.java
@@ -30,6 +30,7 @@ import org.springframework.core.annotation.Order;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasProvider;
+import de.tudarmstadt.ukp.inception.diam.editor.DiamAjaxBehavior;
 import de.tudarmstadt.ukp.inception.diam.editor.config.DiamAutoConfig;
 import de.tudarmstadt.ukp.inception.diam.editor.lazydetails.LazyDetailsLookupService;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.AjaxResponse;
@@ -62,7 +63,7 @@ public class LazyDetailsHandler
     }
 
     @Override
-    public AjaxResponse handle(AjaxRequestTarget aTarget, Request aRequest)
+    public AjaxResponse handle(DiamAjaxBehavior aBehavior, AjaxRequestTarget aTarget, Request aRequest)
     {
         try {
             var page = (AnnotationPageBase) aTarget.getPage();

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/LoadAnnotationsHandler.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/LoadAnnotationsHandler.java
@@ -26,6 +26,7 @@ import org.apache.wicket.request.Request;
 import org.springframework.core.annotation.Order;
 
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
+import de.tudarmstadt.ukp.inception.diam.editor.DiamAjaxBehavior;
 import de.tudarmstadt.ukp.inception.diam.editor.config.DiamAutoConfig;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.AjaxResponse;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.DefaultAjaxResponse;
@@ -74,7 +75,7 @@ public class LoadAnnotationsHandler
     }
 
     @Override
-    public AjaxResponse handle(AjaxRequestTarget aTarget, Request aRequest)
+    public AjaxResponse handle(DiamAjaxBehavior aBehavior, AjaxRequestTarget aTarget, Request aRequest)
     {
         try {
             var request = prepareRenderRequest(aRequest);

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/LoadPreferences.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/LoadPreferences.java
@@ -24,6 +24,7 @@ import org.apache.wicket.request.Request;
 import org.springframework.core.annotation.Order;
 
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
+import de.tudarmstadt.ukp.inception.diam.editor.DiamAjaxBehavior;
 import de.tudarmstadt.ukp.inception.diam.editor.config.DiamAutoConfig;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.AjaxResponse;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.DefaultAjaxResponse;
@@ -60,7 +61,7 @@ public class LoadPreferences
     }
 
     @Override
-    public AjaxResponse handle(AjaxRequestTarget aTarget, Request aRequest)
+    public AjaxResponse handle(DiamAjaxBehavior aBehavior, AjaxRequestTarget aTarget, Request aRequest)
     {
         try {
             var key = new ClientSidePreferencesKey<Map>(Map.class,

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/MoveSpanAnnotationHandler.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/MoveSpanAnnotationHandler.java
@@ -27,6 +27,7 @@ import org.apache.wicket.request.Request;
 import org.springframework.core.annotation.Order;
 
 import de.tudarmstadt.ukp.inception.annotation.layer.span.SpanAdapter;
+import de.tudarmstadt.ukp.inception.diam.editor.DiamAjaxBehavior;
 import de.tudarmstadt.ukp.inception.diam.editor.config.DiamAutoConfig;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.DefaultAjaxResponse;
 import de.tudarmstadt.ukp.inception.rendering.model.Range;
@@ -60,7 +61,7 @@ public class MoveSpanAnnotationHandler
     }
 
     @Override
-    public DefaultAjaxResponse handle(AjaxRequestTarget aTarget, Request aRequest)
+    public DefaultAjaxResponse handle(DiamAjaxBehavior aBehavior, AjaxRequestTarget aTarget, Request aRequest)
     {
         try {
             var page = getPage();

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/SavePreferences.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/SavePreferences.java
@@ -27,6 +27,7 @@ import org.apache.wicket.request.Request;
 import org.springframework.core.annotation.Order;
 
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
+import de.tudarmstadt.ukp.inception.diam.editor.DiamAjaxBehavior;
 import de.tudarmstadt.ukp.inception.diam.editor.config.DiamAutoConfig;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.AjaxResponse;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.DefaultAjaxResponse;
@@ -66,7 +67,7 @@ public class SavePreferences
     }
 
     @Override
-    public AjaxResponse handle(AjaxRequestTarget aTarget, Request aRequest)
+    public AjaxResponse handle(DiamAjaxBehavior aBehavior, AjaxRequestTarget aTarget, Request aRequest)
     {
         try {
             var keyParameter = aRequest.getRequestParameters().getParameterValue(PARAM_KEY)

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/ScrollToHandler.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/ScrollToHandler.java
@@ -26,6 +26,7 @@ import org.apache.wicket.request.Request;
 import org.springframework.core.annotation.Order;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
+import de.tudarmstadt.ukp.inception.diam.editor.DiamAjaxBehavior;
 import de.tudarmstadt.ukp.inception.diam.editor.config.DiamAutoConfig;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.DefaultAjaxResponse;
 import de.tudarmstadt.ukp.inception.rendering.model.Range;
@@ -49,7 +50,7 @@ public class ScrollToHandler
     }
 
     @Override
-    public DefaultAjaxResponse handle(AjaxRequestTarget aTarget, Request aRequest)
+    public DefaultAjaxResponse handle(DiamAjaxBehavior aBehavior, AjaxRequestTarget aTarget, Request aRequest)
     {
         try {
             AnnotationPageBase page = getPage();

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/SelectAnnotationHandler.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/SelectAnnotationHandler.java
@@ -21,6 +21,7 @@ import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.request.Request;
 import org.springframework.core.annotation.Order;
 
+import de.tudarmstadt.ukp.inception.diam.editor.DiamAjaxBehavior;
 import de.tudarmstadt.ukp.inception.diam.editor.config.DiamAutoConfig;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.DefaultAjaxResponse;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
@@ -58,7 +59,7 @@ public class SelectAnnotationHandler
     }
 
     @Override
-    public DefaultAjaxResponse handle(AjaxRequestTarget aTarget, Request aRequest)
+    public DefaultAjaxResponse handle(DiamAjaxBehavior aBehavior, AjaxRequestTarget aTarget, Request aRequest)
     {
         try {
             var page = getPage();

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/ShowContextMenuHandler.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/ShowContextMenuHandler.java
@@ -28,6 +28,7 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.request.Request;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasProvider;
+import de.tudarmstadt.ukp.inception.diam.editor.DiamAjaxBehavior;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.AjaxResponse;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.DefaultAjaxResponse;
 import de.tudarmstadt.ukp.inception.editor.AnnotationEditorExtensionRegistry;
@@ -36,7 +37,6 @@ import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.AnnotationException;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaMenuItem;
-import de.tudarmstadt.ukp.inception.support.wicket.ContextMenu;
 
 public class ShowContextMenuHandler
     extends EditorAjaxRequestHandlerBase
@@ -45,18 +45,16 @@ public class ShowContextMenuHandler
     private static final long serialVersionUID = 2566256640285857435L;
 
     private final AnnotationEditorExtensionRegistry extensionRegistry;
-    private final ContextMenu contextMenu;
     private final IModel<AnnotatorState> model;
     private final AnnotationActionHandler actionHandler;
     private final CasProvider casProvider;
 
     public ShowContextMenuHandler(
             AnnotationEditorExtensionRegistry aAnnotationEditorExtensionRegistry,
-            ContextMenu aContextMenu, IModel<AnnotatorState> aState,
-            AnnotationActionHandler aActionHandler, CasProvider aCasProvider)
+            IModel<AnnotatorState> aState, AnnotationActionHandler aActionHandler,
+            CasProvider aCasProvider)
     {
         extensionRegistry = aAnnotationEditorExtensionRegistry;
-        contextMenu = aContextMenu;
         model = aState;
         actionHandler = aActionHandler;
         casProvider = aCasProvider;
@@ -77,10 +75,17 @@ public class ShowContextMenuHandler
     }
 
     @Override
-    public AjaxResponse handle(AjaxRequestTarget aTarget, Request aRequest)
+    public AjaxResponse handle(DiamAjaxBehavior aBehavior, AjaxRequestTarget aTarget,
+            Request aRequest)
     {
+        var cm = aBehavior.getContextMenu();
+        if (cm == null) {
+            return new DefaultAjaxResponse(getAction(aRequest));
+        }
+
         try {
-            var items = contextMenu.getItemList();
+
+            var items = cm.getItemList();
             items.clear();
 
             if (model.getObject().getSelection().isSpan()) {
@@ -91,7 +96,7 @@ public class ShowContextMenuHandler
             extensionRegistry.generateContextMenuItems(items);
 
             if (!items.isEmpty()) {
-                contextMenu.onOpen(aTarget);
+                cm.onOpen(aTarget);
             }
         }
         catch (Exception e) {

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/config/DiamAutoConfig.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/config/DiamAutoConfig.java
@@ -99,9 +99,11 @@ public class DiamAutoConfig
     }
 
     @Bean
-    public CreateRelationAnnotationHandler createRelationAnnotationHandler()
+    public CreateRelationAnnotationHandler createRelationAnnotationHandler(
+            AnnotationSchemaService aSchemaService,
+            AnnotationSchemaProperties aAnnotationSchemaProperties)
     {
-        return new CreateRelationAnnotationHandler();
+        return new CreateRelationAnnotationHandler(aSchemaService, aAnnotationSchemaProperties);
     }
 
     @Bean

--- a/inception/inception-diam/src/main/ts/src/diam/DiamAjaxImpl.ts
+++ b/inception/inception-diam/src/main/ts/src/diam/DiamAjaxImpl.ts
@@ -118,17 +118,29 @@ export class DiamAjaxImpl implements DiamAjax {
     })
   }
 
-  createRelationAnnotation (originSpanId: VID, targetSpanId: VID): void {
+  createRelationAnnotation (originSpanId: VID, targetSpanId: VID, evt: MouseEvent): void {
+    let { clientX, clientY, overlay } = this.calculateClientPosition(evt)
+
     DiamAjaxImpl.performAjaxCall(() => {
-      Wicket.Ajax.ajax({
-        m: 'POST',
-        u: this.ajaxEndpoint,
-        ep: {
-          action: 'arcOpenDialog',
-          originSpanId,
-          targetSpanId
-        }
-      })
+      new Promise<void>((resolve, reject) => {
+        Wicket.Ajax.ajax({
+          m: 'POST',
+          u: this.ajaxEndpoint,
+          ep: {
+            action: 'arcOpenDialog',
+            originSpanId,
+            targetSpanId,
+            clientX,
+            clientY
+          },
+          sh: [() => {
+            resolve()
+          }],
+          eh: [() => {
+            reject(new Error('Error while trying to create relation'))
+          }]
+        })
+      }).then(() => this.closeOverlayWhenContextMenuIsHidden(overlay))
     })
   }
 
@@ -351,10 +363,39 @@ export class DiamAjaxImpl implements DiamAjax {
   }
 
   openContextMenu (id: VID, evt: MouseEvent): void {
+    let { clientX, clientY, overlay } = this.calculateClientPosition(evt)
+
+    DiamAjaxImpl.performAjaxCall(() => {
+      new Promise<void>((resolve, reject) => {
+        Wicket.Ajax.ajax({
+          m: 'POST',
+          u: this.ajaxEndpoint,
+          ep: {
+            action: 'contextMenu',
+            id,
+            clientX,
+            clientY
+          },
+          sh: [() => {
+            resolve()
+          }],
+          eh: [() => {
+            reject(new Error('Unable to open context menu'))
+          }]
+        })
+      }).then(() => this.closeOverlayWhenContextMenuIsHidden(overlay))
+    })
+  }
+
+  private calculateClientPosition(evt: MouseEvent) : { clientX: number; clientY: number; overlay?: HTMLElement } {
+    if (!evt) {
+      return { clientX: window.innerWidth / 2, clientY: window.innerHeight / 2, overlay: undefined };
+    }
+
     let clientX = evt.clientX
     let clientY = evt.clientY
 
-    let overlay: HTMLElement
+    let overlay: HTMLElement | undefined = undefined
 
     // If the editor is in an IFrame, we need to adjust the coordinates.
     // We also need to ensure that clicks outside the context menu are not
@@ -384,26 +425,7 @@ export class DiamAjaxImpl implements DiamAjax {
     clientX = Math.round(clientX)
     clientY = Math.round(clientY)
 
-    DiamAjaxImpl.performAjaxCall(() => {
-      new Promise<void>((resolve, reject) => {
-        Wicket.Ajax.ajax({
-          m: 'POST',
-          u: this.ajaxEndpoint,
-          ep: {
-            action: 'contextMenu',
-            id,
-            clientX,
-            clientY
-          },
-          sh: [() => {
-            resolve()
-          }],
-          eh: [() => {
-            reject(new Error('Unable to open context menu'))
-          }]
-        })
-      }).then(() => this.closeOverlayWhenContextMenuIsHidden(overlay))
-    })
+    return { clientX, clientY, overlay }
   }
 
   private createOverlay (frame: HTMLElement): HTMLElement {
@@ -418,7 +440,7 @@ export class DiamAjaxImpl implements DiamAjax {
     return overlay
   }
 
-  private closeOverlayWhenContextMenuIsHidden (overlay: HTMLElement): void {
+  private closeOverlayWhenContextMenuIsHidden (overlay?: HTMLElement): void {
     if (!overlay) {
       return
     }

--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/ExternalAnnotationEditorBase.java
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/ExternalAnnotationEditorBase.java
@@ -123,9 +123,9 @@ public abstract class ExternalAnnotationEditorBase
 
     protected DiamAjaxBehavior createDiamBehavior()
     {
-        var diam = new DiamAjaxBehavior();
-        diam.addPriorityHandler(new ShowContextMenuHandler(extensionRegistry, contextMenu,
-                getModel(), getActionHandler(), getCasProvider()));
+        var diam = new DiamAjaxBehavior(contextMenu);
+        diam.addPriorityHandler(new ShowContextMenuHandler(extensionRegistry, getModel(),
+                getActionHandler(), getCasProvider()));
         return diam;
     }
 

--- a/inception/inception-js-api/src/main/ts/src/diam/DiamAjax.ts
+++ b/inception/inception-js-api/src/main/ts/src/diam/DiamAjax.ts
@@ -81,8 +81,10 @@ export interface DiamAjax {
    *
    * @param originSpanId the ID of the origin span
    * @param targetSpanId the ID of the target span
+   * @param evt the mouse event that triggered the relation creation. The mouse position from the
+   * event is used by the server to determine where to display the context menu if necessary.
    */
-  createRelationAnnotation(originSpanId: VID, targetSpanId: VID): void;
+  createRelationAnnotation(originSpanId: VID, targetSpanId: VID, evt: MouseEvent): void;
 
   /**
    * Load annotations from the server. In the options, you can specify the format of the annotations.

--- a/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/AnnotationSchemaService.java
+++ b/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/AnnotationSchemaService.java
@@ -678,4 +678,6 @@ public interface AnnotationSchemaService
     List<AnnotationFeature> listEnabledFeatures(Project aProject);
 
     List<AnnotationLayer> listEnabledLayers(Project aProject);
+
+    List<AnnotationLayer> getRelationLayersFor(AnnotationLayer aSpanLayer);
 }

--- a/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/config/AnnotationSchemaProperties.java
+++ b/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/config/AnnotationSchemaProperties.java
@@ -27,7 +27,7 @@ public interface AnnotationSchemaProperties
 
     boolean isSentenceLayerEditable();
 
-    boolean isCrossLayerRelationEnabled();
+    boolean isCrossLayerRelationsEnabled();
 
     default boolean isLayerBlocked(AnnotationLayer aLayer)
     {

--- a/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/config/AnnotationSchemaPropertiesImpl.java
+++ b/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/config/AnnotationSchemaPropertiesImpl.java
@@ -35,7 +35,7 @@ public class AnnotationSchemaPropertiesImpl
 {
     private boolean tokenLayerEditable;
     private boolean sentenceLayerEditable;
-    private boolean crossLayerRelationEnabled;
+    private boolean crossLayerRelationsEnabled;
 
     @ManagedAttribute
     @Override
@@ -65,14 +65,14 @@ public class AnnotationSchemaPropertiesImpl
 
     @ManagedAttribute
     @Override
-    public boolean isCrossLayerRelationEnabled()
+    public boolean isCrossLayerRelationsEnabled()
     {
-        return crossLayerRelationEnabled;
+        return crossLayerRelationsEnabled;
     }
 
     @ManagedAttribute
-    public void setCrossLayerRelationEnabled(boolean aCrossLayerRelationEnabled)
+    public void setCrossLayerRelationsEnabled(boolean aCrossLayerRelationEnabled)
     {
-        crossLayerRelationEnabled = aCrossLayerRelationEnabled;
+        crossLayerRelationsEnabled = aCrossLayerRelationEnabled;
     }
 }

--- a/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/service/AnnotationSchemaServiceImpl.java
+++ b/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/service/AnnotationSchemaServiceImpl.java
@@ -1747,7 +1747,7 @@ public class AnnotationSchemaServiceImpl
     public List<AnnotationLayer> getRelationLayersFor(AnnotationLayer aSpanLayer)
     {
         var candidates = new ArrayList<AnnotationLayer>();
-        for (var layer : listAnnotationLayer(aSpanLayer.getProject())) {
+        for (var layer : listEnabledLayers(aSpanLayer.getProject())) {
             if (!RelationLayerSupport.TYPE.equals(layer.getType())) {
                 continue;
             }

--- a/inception/inception-support-bootstrap/src/main/ts/bootstrap/inception-custom.scss
+++ b/inception/inception-support-bootstrap/src/main/ts/bootstrap/inception-custom.scss
@@ -244,6 +244,7 @@ a.disabled {
       color: $component-active-color;
       background-color: $component-active-bg;
       background-image: none;
+      font-weight: normal;
     }
   }
 }

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/lambda/MenuCategoryHeader.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/lambda/MenuCategoryHeader.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.support.lambda;
+
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
+
+import com.googlecode.wicket.jquery.ui.JQueryIcon;
+import com.googlecode.wicket.jquery.ui.widget.menu.AbstractMenuItem;
+
+public class MenuCategoryHeader
+    extends AbstractMenuItem
+{
+    private static final long serialVersionUID = 4051171004089469088L;
+
+    public MenuCategoryHeader(String title)
+    {
+        this(Model.of(title), JQueryIcon.NONE);
+    }
+
+    public MenuCategoryHeader(IModel<String> aTitle, String aIcon)
+    {
+        super(aTitle, aIcon);
+        setEnabled(false);
+    }
+
+    @Override
+    final public void onClick(AjaxRequestTarget aTarget)
+    {
+        // Nothing to do
+    }
+}

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
@@ -532,7 +532,7 @@ public abstract class AnnotationDetailEditorPanel
         var originFS = selectAnnotationByAddr(aCas, state.getSelection().getOrigin());
         var targetFS = selectAnnotationByAddr(aCas, state.getSelection().getTarget());
 
-        if (!schemaProperties.isCrossLayerRelationEnabled()
+        if (!schemaProperties.isCrossLayerRelationsEnabled()
                 && !originFS.getType().equals(targetFS.getType())) {
             reset(aTarget);
             throw new IllegalPlacementException(
@@ -559,7 +559,7 @@ public abstract class AnnotationDetailEditorPanel
         }
         // Otherwise, look up the possible relation layer(s) in the database.
         else {
-            var viableRelationLayers = getRelationLayersFor(originLayer);
+            var viableRelationLayers = annotationService.getRelationLayersFor(originLayer);
             if (viableRelationLayers.isEmpty()) {
                 throw new IllegalPlacementException(
                         "There are no relation layers that can be created between these endpoints");
@@ -578,28 +578,6 @@ public abstract class AnnotationDetailEditorPanel
                     state.getSelectedAnnotationLayer());
             loadFeatureEditorModels(aTarget);
         }
-    }
-
-    private List<AnnotationLayer> getRelationLayersFor(AnnotationLayer aSpanLayer)
-    {
-        var candidates = new ArrayList<AnnotationLayer>();
-        for (var layer : annotationService.listAnnotationLayer(aSpanLayer.getProject())) {
-            if (!RelationLayerSupport.TYPE.equals(layer.getType())) {
-                continue;
-            }
-
-            if (aSpanLayer.equals(layer.getAttachType())) {
-                candidates.add(layer);
-            }
-
-            // Special case for built-in layers such as the Dependency layer
-            if (layer.getAttachFeature() != null
-                    && layer.getAttachFeature().getType().equals(aSpanLayer.getName())) {
-                candidates.add(layer);
-            }
-        }
-
-        return candidates;
     }
 
     /**

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/BratSuggestionVisualizer.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/BratSuggestionVisualizer.java
@@ -176,8 +176,9 @@ public abstract class BratSuggestionVisualizer
                 AjaxEventBehavior.onEvent("click", _t -> actionShowAnnotatorComment(_t, annDoc)));
         queue(commentSymbol);
 
-        controller = new DiamAjaxBehavior().setGlobalHandlersEnabled(false)
-                .addPriorityHandler(new CurationLazyDetailsHandler())
+        controller = new DiamAjaxBehavior() //
+                .setGlobalHandlersEnabled(false) //
+                .addPriorityHandler(new CurationLazyDetailsHandler()) //
                 .addPriorityHandler(new CurationActionAjaxRequestHandler());
         add(controller);
     }
@@ -374,7 +375,8 @@ public abstract class BratSuggestionVisualizer
         }
 
         @Override
-        public AjaxResponse handle(AjaxRequestTarget aTarget, Request aRequest)
+        public AjaxResponse handle(DiamAjaxBehavior aBehavior, AjaxRequestTarget aTarget,
+                Request aRequest)
         {
             try {
                 final IRequestParameters request = getRequest().getPostParameters();
@@ -404,7 +406,8 @@ public abstract class BratSuggestionVisualizer
         private static final long serialVersionUID = 8053988681869772378L;
 
         @Override
-        public AjaxResponse handle(AjaxRequestTarget aTarget, Request aRequest)
+        public AjaxResponse handle(DiamAjaxBehavior aBehavior, AjaxRequestTarget aTarget,
+                Request aRequest)
         {
             try {
                 onClientEvent(aTarget);

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/layers/LayerDetailForm.java
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/layers/LayerDetailForm.java
@@ -216,6 +216,10 @@ public class LayerDetailForm
         var layer = LayerDetailForm.this.getModelObject();
 
         if (layer.getAttachType() == null) {
+            if (RelationLayerSupport.TYPE.equals(layer.getType())) {
+                return "Any span";
+            }
+
             return null;
         }
 

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/layers/LayerDetailForm.java
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/layers/LayerDetailForm.java
@@ -61,6 +61,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.ui.project.layers.ProjectLayersPanel.FeatureSelectionForm;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
+import de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationLayerSupport;
 import de.tudarmstadt.ukp.inception.bootstrap.BootstrapModalDialog;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.export.LayerImportExportUtils;
@@ -358,8 +359,9 @@ public class LayerDetailForm
             layer.setName(layerName);
         }
 
-        if (annotationSchemaProperties.isCrossLayerRelationEnabled()) {
-            if (layer.getType().equals(RELATION_TYPE) && layer.getAttachType() == null) {
+        if (!annotationSchemaProperties.isCrossLayerRelationsEnabled()) {
+            if (RelationLayerSupport.TYPE.equals(layer.getType())
+                    && layer.getAttachType() == null) {
                 error("A relation layer needs to attach to a span layer.");
                 return;
             }
@@ -375,7 +377,6 @@ public class LayerDetailForm
         }
 
         success("Settings for layer [" + layer.getUiName() + "] saved.");
-        aTarget.addChildren(getPage(), IFeedback.class);
         aTarget.add(findParent(ProjectLayersPanel.class));
         aTarget.add(featureDetailForm);
         aTarget.add(featureSelectionForm);

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/layers/ProjectLayersPanel.properties
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/layers/ProjectLayersPanel.properties
@@ -28,7 +28,7 @@ layerDetailForm.cancel.label=Cancel
 layerDetailForm.uiName.Required=Layer name is required
 layerDetailForm.type.Required=Layer type is required
 
-attachType.nullValid=Any
+attachType.nullValid=Any span
 
 featureDetailForm.save.label=Save feature
 featureDetailForm.cancel.label=Cancel


### PR DESCRIPTION
**What's in the PR**
- Handle relation creation fully in the CreateRelationAnnotationHandle and to not go through the AnnotationDetailEditorPanel
- Open context menu if there are multiple relation annotations that could be created between two span layers
- Make context menu accessible by other handlers than the ShowContextMenuHandler
- Move getRelationLayersFor to the AnnotationSchemaService

**How to test manually**
* Enable experimental cross-layer creation
* Create two relation layers that attach to *Any* span layer
* Try using them

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
