### PR TITLE
#4826 - Option to show relation arcs only when span is selected

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/rendering/NopRenderer.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/rendering/NopRenderer.java
@@ -61,8 +61,9 @@ public class NopRenderer
     }
 
     @Override
-    public List<VObject> render(VDocument aVDocument, AnnotationFS aFS,
-            List<AnnotationFeature> aFeatures, int aWindowBegin, int aWindowEnd)
+    public List<VObject> render(RenderRequest aRequest, List<AnnotationFeature> aFeatures,
+            VDocument aResponse, int windowBeginOffset, int windowEndOffset, AnnotationFS aFS)
+
     {
         return Collections.emptyList();
     }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/rendering/PreRendererImpl.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/rendering/PreRendererImpl.java
@@ -19,9 +19,9 @@ package de.tudarmstadt.ukp.clarin.webanno.api.annotation.rendering;
 
 import static java.lang.System.currentTimeMillis;
 import static java.util.concurrent.TimeUnit.MINUTES;
-import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
+import java.lang.invoke.MethodHandles;
 import java.util.List;
 import java.util.Objects;
 
@@ -57,7 +57,7 @@ public class PreRendererImpl
 {
     public static final String ID = "PreRenderer";
 
-    private final Logger log = LoggerFactory.getLogger(getClass());
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private final AnnotationSchemaService annotationService;
     private final LayerSupportRegistry layerSupportRegistry;
@@ -91,7 +91,7 @@ public class PreRendererImpl
     @Override
     public void render(VDocument aResponse, RenderRequest aRequest)
     {
-        log.trace("Prerenderer.render()");
+        LOG.trace("Prerenderer.render()");
 
         var cas = aRequest.getCas();
         var documentText = cas.getDocumentText();
@@ -120,10 +120,10 @@ public class PreRendererImpl
         for (var layer : aRequest.getVisibleLayers()) {
             var layerSupportedFeatures = supportedFeatures.stream() //
                     .filter(feature -> feature.getLayer().equals(layer)) //
-                    .collect(toList());
+                    .toList();
             var layerAllFeatures = allFeatures.stream() //
                     .filter(feature -> feature.getLayer().equals(layer)) //
-                    .collect(toList());
+                    .toList();
             // We need to pass in *all* the annotation features here because we also to that in
             // other places where we create renderers - and the set of features must always be
             // the same because otherwise the IDs of armed slots would be inconsistent
@@ -132,9 +132,9 @@ public class PreRendererImpl
             renderer.render(aRequest, layerSupportedFeatures, aResponse, renderBegin, renderEnd);
         }
 
-        if (log.isTraceEnabled()) {
+        if (LOG.isTraceEnabled()) {
             long duration = currentTimeMillis() - start;
-            log.trace(
+            LOG.trace(
                     "Prerenderer.render() took {}ms to render {} layers [{}-{}] with {} spans and {} arcs",
                     duration, aRequest.getVisibleLayers().size(), renderBegin, renderEnd,
                     aResponse.spans().size(), aResponse.arcs().size());

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/chain/ChainRenderer.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/chain/ChainRenderer.java
@@ -207,8 +207,8 @@ public class ChainRenderer
     }
 
     @Override
-    public List<VObject> render(VDocument aVDocument, AnnotationFS aFS,
-            List<AnnotationFeature> aFeatures, int aWindowBegin, int aWindowEnd)
+    public List<VObject> render(RenderRequest aRequest, List<AnnotationFeature> aFeatures,
+            VDocument aResponse, int windowBeginOffset, int windowEndOffset, AnnotationFS aFS)
     {
         return Collections.emptyList();
     }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/RelationLayerTraits.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/RelationLayerTraits.java
@@ -17,6 +17,9 @@
  */
 package de.tudarmstadt.ukp.inception.annotation.layer.relation;
 
+import static de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationRenderMode.ALWAYS;
+import static de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationRenderMode.NEVER;
+
 import java.io.Serializable;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -32,6 +35,7 @@ public class RelationLayerTraits
 
     private ColoringRules coloringRules = new ColoringRules();
     private boolean renderArcs = true;
+    private RelationRenderMode renderMode;
 
     public RelationLayerTraits()
     {
@@ -50,13 +54,29 @@ public class RelationLayerTraits
         coloringRules = aColoringRules;
     }
 
+    @Deprecated
     public boolean isRenderArcs()
     {
         return renderArcs;
     }
 
+    @Deprecated
     public void setRenderArcs(boolean aRenderArcs)
     {
         renderArcs = aRenderArcs;
+    }
+
+    public RelationRenderMode getRenderMode()
+    {
+        if (renderMode == null) {
+            return renderArcs ? ALWAYS : NEVER;
+        }
+
+        return renderMode;
+    }
+
+    public void setRenderMode(RelationRenderMode aRenderMode)
+    {
+        renderMode = aRenderMode;
     }
 }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/RelationLayerTraitsEditor.html
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/RelationLayerTraitsEditor.html
@@ -18,13 +18,11 @@
 -->
 <html xmlns:wicket="http://wicket.apache.org">
 <wicket:extend>
-  <div class="form-row" wicket:enclosure="renderArcs">
-    <div class="form-check form-switch">
-      <input wicket:id="renderArcs" class="form-check-input" type="checkbox" />
-      <label wicket:for="renderArcs" class="form-check-label">
-        <wicket:label key="renderArcs" />
-      </label>
-    </div>
+  <div class="form-row form-floating" wicket:enclosure="renderMode">
+    <select wicket:id="renderMode" class="form-select" wicket:message="placeholder:renderMode"/>
+    <label wicket:for="renderMode">
+      <wicket:label key="renderMode" />
+    </label>
   </div>
   <div class="form-row form-floating" wicket:enclosure="validationMode">
     <select wicket:id="validationMode" class="form-select" wicket:message="placeholder:validationMode"/>

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/RelationLayerTraitsEditor.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/RelationLayerTraitsEditor.java
@@ -48,9 +48,7 @@ public class RelationLayerTraitsEditor
     @Override
     protected void initializeForm(Form<RelationLayerTraits> aForm)
     {
-        var renderArcs = new CheckBox("renderArcs", getTraitsModel().bind("renderArcs"));
-        renderArcs.setOutputMarkupPlaceholderTag(true);
-        aForm.add(renderArcs);
+        aForm.add(new RelationRenderModeSelect("renderMode"));
 
         aForm.add(new ValidationModeSelect("validationMode", getLayerModel()));
 

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/RelationRenderMode.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/RelationRenderMode.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.annotation.layer.relation;
+
+public enum RelationRenderMode
+{
+    NEVER, //
+    WHEN_SELECTED, //
+    ALWAYS;
+}

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/RelationRenderModeSelect.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/RelationRenderModeSelect.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.annotation.layer.relation;
+
+import static java.util.Arrays.asList;
+
+import org.apache.wicket.markup.html.form.DropDownChoice;
+import org.apache.wicket.markup.html.form.EnumChoiceRenderer;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.PropertyModel;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+
+public class RelationRenderModeSelect
+    extends DropDownChoice<RelationRenderMode>
+{
+    private static final long serialVersionUID = 7947988674895121258L;
+
+    public RelationRenderModeSelect(String aId)
+    {
+        super(aId);
+    }
+
+    public RelationRenderModeSelect(String aId, IModel<AnnotationLayer> aLayerModel)
+    {
+        super(aId);
+
+        setModel(PropertyModel.of(aLayerModel, "renderMode"));
+    }
+
+    @Override
+    protected void onInitialize()
+    {
+        super.onInitialize();
+
+        setChoiceRenderer(new EnumChoiceRenderer<>(this));
+        setChoices(asList(RelationRenderMode.values()));
+    }
+}

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanRenderer.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanRenderer.java
@@ -136,7 +136,7 @@ public class SpanRenderer
 
         // List<AnnotationFS> annotations = selectCovered(aCas, type, aWindowBegin, aWindowEnd);
         for (var fs : annotations) {
-            for (var vobj : render(aResponse, fs, aFeatures, aWindowBegin, aWindowEnd)) {
+            for (var vobj : render(aRequest, aFeatures, aResponse, aWindowBegin, aWindowEnd, fs)) {
                 aResponse.add(vobj);
 
                 if (vobj instanceof VSpan vspan) {
@@ -153,14 +153,14 @@ public class SpanRenderer
     }
 
     @Override
-    public List<VObject> render(VDocument aVDocument, AnnotationFS aFS,
-            List<AnnotationFeature> aFeatures, int aWindowBegin, int aWindowEnd)
+    public List<VObject> render(RenderRequest aRequest, List<AnnotationFeature> aFeatures,
+            VDocument aResponse, int windowBeginOffset, int windowEndOffset, AnnotationFS aFS)
     {
         if (!checkTypeSystem(aFS.getCAS())) {
             return emptyList();
         }
 
-        var range = VRange.clippedRange(aVDocument, aFS);
+        var range = VRange.clippedRange(aResponse, aFS);
 
         if (!range.isPresent()) {
             return emptyList();

--- a/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/rendering/Renderer.java
+++ b/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/rendering/Renderer.java
@@ -58,18 +58,32 @@ public interface Renderer
      *            The render request.
      * @param aFeatures
      *            the features.
-     * @param aBuffer
-     *            The rendering buffer.
+     * @param aResponse
+     *            The rendering response.
      * @param windowBeginOffset
      *            The start position of the window offset.
      * @param windowEndOffset
      *            The end position of the window offset.
      */
-    void render(RenderRequest aRequest, List<AnnotationFeature> aFeatures, VDocument aBuffer,
+    void render(RenderRequest aRequest, List<AnnotationFeature> aFeatures, VDocument aResponse,
             int windowBeginOffset, int windowEndOffset);
 
-    List<VObject> render(VDocument aVDocument, AnnotationFS aFS, List<AnnotationFeature> aFeatures,
-            int aWindowBegin, int aWindowEnd);
+    /**
+     * Render a single annotation .
+     *
+     * @param aRequest
+     *            The render request.
+     * @param aFeatures
+     *            the features.
+     * @param aResponse
+     *            The rendering response.
+     * @param windowBeginOffset
+     *            The start position of the window offset.
+     * @param windowEndOffset
+     *            The end position of the window offset.
+     */
+    List<VObject> render(RenderRequest aRequest, List<AnnotationFeature> aFeatures,
+            VDocument aResponse, int windowBeginOffset, int windowEndOffset, AnnotationFS aFS);
 
     FeatureSupportRegistry getFeatureSupportRegistry();
 

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.properties
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.properties
@@ -96,12 +96,16 @@ curatable=Curatable
 includeInHover=Show on hover
 remember=Remember
 hideUnconstraintFeature=Show only when constraints apply
+renderMode=Render mode
+
+RelationRenderMode.NEVER=Never
+RelationRenderMode.WHEN_SELECTED=When selected
+RelationRenderMode.ALWAYS=Always
 
 lockToTokenOffset=Lock to token
 allowMultipleTokens=Allow multiple tokens
 allowStacking=Allow stacking
 allowCrossSentence=Allow crossing sentence boundaries
-renderArcs=Show arcs
 showTextInHover=Show text on hover
 linkedListBehavior=Behave like a linked list
 onClickJavascriptAction=Run Javascript action on click

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/render/CurationSidebarRenderer.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/render/CurationSidebarRenderer.java
@@ -176,8 +176,9 @@ public class CurationSidebarRenderer
                 var layerSupport = layerSupportRegistry.getLayerSupport(layer);
                 var renderer = layerSupport.createRenderer(layer, () -> layerAllFeatures);
 
-                var objects = renderer.render(aVdoc, (AnnotationFS) fs, layerSupportedFeatures,
-                        aRequest.getWindowBeginOffset(), aRequest.getWindowEndOffset());
+                var objects = renderer.render(aRequest, layerSupportedFeatures, aVdoc,
+                        aRequest.getWindowBeginOffset(), aRequest.getWindowEndOffset(),
+                        (AnnotationFS) fs);
 
                 for (var object : objects) {
                     if (cfg.getPosition() instanceof SpanPosition spanPosition) {

--- a/inception/inception-ui-project/src/main/resources/META-INF/asciidoc/user-guide/projects_layers.adoc
+++ b/inception/inception-ui-project/src/main/resources/META-INF/asciidoc/user-guide/projects_layers.adoc
@@ -193,8 +193,11 @@ NOTE: It is currently not possible to create relations between spans in differen
 | Show text on hover
 | Whether the text covered by the annotation is shown in the popup panel that appears when hovering with the mouse over an annotation label. Note that this popup may not be supported by all annotation editors.
 
+| Render mode (relation)
+| Determines when to render relations as arcs. Possible settings are **Always** (always render arcs), **Never** (never render arcs), and **When selected** (render arcs only when one of the relation endpoints or the relation itself is selected). Note that this setting is only available for relation layers.
+
 | Validation
-| When pre-annotated data is imported or when the  behaviors settings are changed, it is possible that annotations exist which are not conforming to the current behavior settings. This setting controls when a validation of annotations is performed. Possible settings are **Never** (no validation when a user marks a document as finished) and **Always** (validation is performed when a user marks a document as finished). Mind that changing the document state via the Monitoring page does not trigger a validation. Also, problematic annotations are highlighted using an error marker in the annotation interface. **NOTE:** the default setting for new projects/layers is **Always**, but for any existing projects or for projects imported from versions of {product-name} where this setting did not exist yet, the setting is initialized with **Never**.
+| When pre-annotated data is imported or when the  behaviors settings are changed, it is possible that annotations exist which are not conforming to the current behavior settings. This setting controls when a validation of annotations is performed. Possible settings are **Never** (no validation when a user marks a document as finished) and **Always** (validation is performed when a user marks a document as finished). Mind that changing the document state via the Monitoring page does not trigger a validation. Also, problematic annotations are highlighted using an error marker in the annotation interface. **NOTE:** the default setting for new projects/layers is **Always**, but for any existing projects or for projects imported from versions of {product-name} where this setting did not exist yet, the setting is initialized with **Never**.
 
 | Granularity
 _(span, chain)_
@@ -233,19 +236,19 @@ The following feature types are supported.
 |====
 | Type | Description
 
-| uima.cas.String
+| `uima.cas.String`
 | Textual feature that can optionally be controlled by a tagset. It is rendered as a text field or as a combobox if a tagset is defined.
 
-| uima.cas.Boolean
+| `uima.cas.Boolean`
 | Boolean feature that can be true or false and is rendered as a checkbox.
 
-| uima.cas.Integer
+| `uima.cas.Integer`
 | Numeric feature for integer numbers.
 
-| uima.cas.Float
+| `uima.cas.Float`
 | Numeric feature for decimal numbers.
 
-| uima.tcas.Annotation
+| `uima.tcas.Annotation`
 _(Span layers)_
 | Link feature that can point to any arbitrary span annotation
 


### PR DESCRIPTION
**What's in the PR**
- Added option to render the arc of a relation only when the relation or one of its endpoints is selected

**How to test manually**
* Change the render mode for a relation layer to "when selected"

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
