### PR TITLE
#4830 - Cannot enable logging for JUL-based libraries

### DIFF
--- a/inception/inception-app-webapp/pom.xml
+++ b/inception/inception-app-webapp/pom.xml
@@ -529,6 +529,10 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
+      <artifactId>jul-to-slf4j</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
     </dependency>
     <dependency>

--- a/inception/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/INCEpTION.java
+++ b/inception/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/INCEpTION.java
@@ -27,8 +27,11 @@ import static org.springframework.boot.WebApplicationType.SERVLET;
 
 import java.io.IOException;
 import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
 
 import org.dkpro.core.api.resources.ResourceObjectProviderBase;
+import org.slf4j.bridge.SLF4JBridgeHandler;
 import org.springframework.boot.Banner;
 import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -94,6 +97,12 @@ public class INCEpTION
             System.setProperty("wicket.core.settings.general.configuration-type", "development");
             System.setProperty("webanno.debug.enforce_cas_thread_lock", "true");
             aBuilder.profiles(DeploymentModeService.PROFILE_DEVELOPMENT_MODE);
+
+            // Route JUL through log4j
+            java.util.logging.LogManager.getLogManager().reset();
+            SLF4JBridgeHandler.removeHandlersForRootLogger();
+            SLF4JBridgeHandler.install();
+            LogManager.getLogManager().getLogger("").setLevel(Level.ALL);
         }
         else {
             aBuilder.profiles(DeploymentModeService.PROFILE_PRODUCTION_MODE);

--- a/inception/inception-dependencies/pom.xml
+++ b/inception/inception-dependencies/pom.xml
@@ -563,38 +563,10 @@
       <!-- SLF4J -->
       <dependency>
         <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
+        <artifactId>slf4j-bom</artifactId>
         <version>${slf4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>jcl-over-slf4j</artifactId>
-        <version>${slf4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>log4j-over-slf4j</artifactId>
-        <version>${slf4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-simple</artifactId>
-        <version>${slf4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-jdk14</artifactId>
-        <version>${slf4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>jul-to-slf4j</artifactId>
-        <version>${slf4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-reload4j</artifactId>
-        <version>${slf4j.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
 
       <dependency>

--- a/inception/pom.xml
+++ b/inception/pom.xml
@@ -90,6 +90,12 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
+      <!-- Route Java Util Logging over SLF4J -->
+      <groupId>org.slf4j</groupId>
+      <artifactId>jul-to-slf4j</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <!-- Add json logger for Logstash -->
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-layout-template-json</artifactId>
@@ -417,6 +423,7 @@
             <dependency>org.apache.logging.log4j:log4j-core</dependency>
             <dependency>org.slf4j:log4j-over-slf4j</dependency>
             <dependency>org.slf4j:jcl-over-slf4j</dependency>
+            <dependency>org.slf4j:jul-to-slf4j</dependency>
             <dependency>commons-logging:commons-logging</dependency>
             <!--
               - JAXB is used via reflection and cannot be detected by Maven


### PR DESCRIPTION
**What's in the PR**
- Added JUL-to-SLF4J bridge
- Enable the bridge only in dev mode for performance reasons

**How to test manually**
* Enable dev mode (`-Dinception.dev=true`)
* Configure Tomcat logging in `settings.properties` using `logging.level.org.apache.catalina=TRACE`

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
