### PR TITLE
#4745 - Upgrade dependencies

### DIFF
--- a/inception/inception-dependencies/pom.xml
+++ b/inception/inception-dependencies/pom.xml
@@ -179,7 +179,7 @@
       <dependency>
         <groupId>com.nimbusds</groupId>
         <artifactId>nimbus-jose-jwt</artifactId>
-        <version>9.37.3</version>
+        <version>9.39.3</version>
       </dependency>
       <dependency>
         <groupId>org.awaitility</groupId>
@@ -453,7 +453,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-csv</artifactId>
-        <version>1.10.0</version>
+        <version>1.11.0</version>
       </dependency>
       <dependency>
         <groupId>commons-fileupload</groupId>
@@ -506,7 +506,7 @@
       <dependency>
         <groupId>commons-logging</groupId>
         <artifactId>commons-logging</artifactId>
-        <version>1.3.1</version>
+        <version>1.3.2</version>
       </dependency>
       
       <!-- Jena -->
@@ -658,12 +658,12 @@
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy</artifactId>
-        <version>1.14.15</version>
+        <version>1.14.17</version>
       </dependency>
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy-agent</artifactId>
-        <version>1.14.15</version>
+        <version>1.14.17</version>
       </dependency>
       <dependency>
         <groupId>org.wicketstuff</groupId>
@@ -810,7 +810,7 @@
       <dependency>
         <groupId>org.hsqldb</groupId>
         <artifactId>hsqldb</artifactId>
-        <version>2.7.2</version>
+        <version>2.7.3</version>
       </dependency>
 
       <dependency>
@@ -961,7 +961,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-text</artifactId>
-        <version>1.11.0</version>
+        <version>1.12.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -971,7 +971,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-compress</artifactId>
-        <version>1.26.1</version>
+        <version>1.26.2</version>
       </dependency>
       <dependency>
         <groupId>commons-codec</groupId>
@@ -981,7 +981,7 @@
       <dependency>
         <groupId>commons-validator</groupId>
         <artifactId>commons-validator</artifactId>
-        <version>1.8.0</version>
+        <version>1.9.0</version>
       </dependency>
       <dependency>
         <groupId>com.github.ben-manes.caffeine</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -86,12 +86,12 @@
 
     <pdfbox.version>2.0.30</pdfbox.version>
 
-    <spring.version>5.3.34</spring.version>
+    <spring.version>5.3.36</spring.version>
     <spring.boot.version>2.7.18</spring.boot.version>
     <spring.data.version>2.7.18</spring.data.version>
     <spring.security.version>5.8.12</spring.security.version>
     <springdoc.version>1.8.0</springdoc.version>
-    <swagger.version>2.2.21</swagger.version>
+    <swagger.version>2.2.22</swagger.version>
     <jjwt.version>0.12.5</jjwt.version>
 
     <slf4j.version>2.0.13</slf4j.version>
@@ -107,7 +107,7 @@
     <hibernate.version>5.6.15.Final</hibernate.version>
     <hibernate.validator.version>6.2.5.Final</hibernate.validator.version>
 
-    <wicket.version>9.17.0</wicket.version>
+    <wicket.version>9.18.0</wicket.version>
     <wicketstuff.version>9.17.0</wicketstuff.version>
     <wicket-jquery-ui.version>9.12.0</wicket-jquery-ui.version>
     <wicket-bootstrap.version>6.0.5</wicket-bootstrap.version>
@@ -177,7 +177,7 @@
     <jsdom.version>^20.0.0</jsdom.version>
     <jsdom-global.version>^3.0.2</jsdom-global.version>
     <jquery.version>3.7.1</jquery.version>
-    <jquery-ui.version>1.13.2</jquery-ui.version>
+    <jquery-ui.version>1.13.3</jquery-ui.version>
     <pdfjs.version>2.14.305</pdfjs.version>
     <popperjs.version>2.11.8</popperjs.version>
     <recogitojs.version>1.8.2</recogitojs.version>
@@ -255,11 +255,11 @@
       </snapshots>
     </repository>
     -->
-    <!-- For Apache UIMA release candidates -->
+    <!-- For release candidates -->
     <!--
     <repository>
       <id>ext-staging</id>
-      <url>https://repository.apache.org/content/repositories/orgapacheuima-1261</url>
+      <url>https://repository.apache.org/content/repositories/orgapachewicket-1203</url>
       <releases>
         <enabled>true</enabled>
       </releases>


### PR DESCRIPTION
**What's in the PR**
- Wicket 9.17.0 -> 9.18.0
- Spring 5.3.34 -> 5.3.36
- Swagger 2.2.21 -> 2.2.22
- JQuery UI 1.13.2 -> 1.13.3
- nimbus-jose-jwt 9.37.3 -> 9.39.3
- commons-csv 1.10.0 -> 1.11.0
- commons-logging 1.3.1 -> 1.3.2
- byte-buddy 1.14.15 -> 1.14.17
- hsqldb 2.7.2 -> 2.7.3
- commons-compress 1.26.1 -> 1.26.2
- commons-text 1.11.0 -> 1.12.0
- commons-validator 1.8.0 -> 1.9.0

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
