### PR TITLE
#4839 - Scrolling to selection does sometimes not work in Apache Annotator Editor

### DIFF
--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorVisualizer.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorVisualizer.ts
@@ -420,6 +420,7 @@ export class ApacheAnnotatorVisualizer {
 
     window.clearTimeout(this.removeTransientMarkersTimeout)
     this.removeTransientMarkers.forEach(remove => remove())
+    this.root.normalize() // https://github.com/apache/incubator-annotator/issues/120
 
     const removeScrollMarker = highlightText(range, 'mark', { id: 'iaa-scroll-marker' })
     this.removeTransientMarkers = [removeScrollMarker]
@@ -469,6 +470,7 @@ export class ApacheAnnotatorVisualizer {
     this.removeTransientMarkersTimeout = window.setTimeout(() => {
       this.removeTransientMarkers.forEach(remove => remove())
       this.removeTransientMarkers = []
+      this.root.normalize() // https://github.com/apache/incubator-annotator/issues/120
     }, 2000)
   }
 


### PR DESCRIPTION
**What's in the PR**
- Normalize DOM after removing markers because Apache Annotator can fail to create marker annotations in a fragemented DOM

**How to test manually**
* Requires an affected document

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
