### PR TITLE
#4745 - Upgrade dependencies

### DIFF
--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/installation_docker.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/installation_docker.adoc
@@ -146,6 +146,7 @@ If it becomes necessary to pass command line arguments to {product-name} running
 `APP_ARGS` environment variable. Note, this is specifically for application parameters, not for parameters for the Java
 Virtual Machine.
 
+[[sect_docker_compose]]
 == Docker Compose
 
 Using Docker Compose, you can manage multiple related containers. This section illustrates how to use
@@ -222,3 +223,11 @@ NOTE: Mind that you cannot arbitrarily switch between volume-managed and host-st
 
 There is a lot more that you can do using Docker and Docker Compose. Please see the link:https://docs.docker.com/compose/[docker-compose reference] for details.
 
+=== Upgrading with Docker Compose
+
+When new versions of {product-name} are released, they may at times include an updated Docker Compose example file.
+
+Starting with {product-name} 33.0, the MariaDB container that is configured in the example file will set the environment
+variable `MARIADB_AUTO_UPGRADE` to `1` to have MariaDB automatically upgrade its internal tables when encountering a database
+produced with an earlier version of MariaDB (see link:https://hub.docker.com/_/mariadb[MariaDB Environment Variables].
+If you do not want this behavior, be sure to remove this settings from the compose file.

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/scripts/docker-compose.yml
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/scripts/docker-compose.yml
@@ -9,18 +9,18 @@ networks:
 
 services:
   db:
-    image: "mariadb:10.11"
+    image: "mariadb:11.4"
     environment:
-      - MYSQL_RANDOM_ROOT_PASSWORD=yes
-      - MYSQL_DATABASE=inception
-      - MYSQL_USER=${DBUSER:-inception}
-      - MYSQL_PORT=3306
-      - MYSQL_PASSWORD=${DBPASSWORD:-inception}
+      - MARIADB_RANDOM_ROOT_PASSWORD=yes
+      - MARIADB_DATABASE=inception
+      - MARIADB_USER=${DBUSER:-inception}
+      - MARIADB_PASSWORD=${DBPASSWORD:-inception}
+      - MARIADB_AUTO_UPGRADE=1
     volumes:
       - ${INCEPTION_DB_HOME:-db-data}:/var/lib/mysql
     command: ["--character-set-server=utf8mb4", "--collation-server=utf8mb4_bin"]
     healthcheck:
-      test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost", "-p${DBPASSWORD:-inception}", "-u${DBUSER:-inception}"]
+      test: ["CMD", "mariadb-admin" ,"ping", "-h", "localhost", "-p${DBPASSWORD:-inception}", "-u${DBUSER:-inception}"]
       interval: 20s
       timeout: 10s
       retries: 10
@@ -32,8 +32,7 @@ services:
     ports:
       - "${INCEPTION_PORT:-8080}:8080"
     environment:
-      - INCEPTION_DB_DIALECT=org.hibernate.dialect.MariaDB103Dialect 
-      - INCEPTION_DB_DRIVER=org.mariadb.jdbc.Driver
+      - INCEPTION_DB_DIALECT=org.hibernate.dialect.MariaDB106Dialect
       - INCEPTION_DB_URL=jdbc:mariadb://db:3306/inception?useSSL=false&useUnicode=true&characterEncoding=UTF-8
       - INCEPTION_DB_USERNAME=${DBUSER:-inception}
       - INCEPTION_DB_PASSWORD=${DBPASSWORD:-inception}

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/upgrade.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/upgrade.adoc
@@ -67,3 +67,9 @@ disk.
 Also, for certain versions there might be special considerations to be aware of when performing the
 upgrade. Always be sure to check the section below **as well as the release notes** of every version
 between the version you are upgrading from up to and including the version you are upgrading to.
+
+=== Database upgrades
+
+If - as recommeded - you are using a dedicated database (e.g. MariaDB), you should also occasinally upgrade that. 
+If you are obtaining a new <<sect_docker_compose,Docker Compose>>, it may well include a new database version.
+Please refer to the upgrade documentation of your database (e.g. link:https://mariadb.com/kb/en/upgrading/[MariaDB upgrade]) or to the <<sect_docker_compose,Docker Compose section>> in this manual for more information.

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/upgrade_notes.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/upgrade_notes.adoc
@@ -16,11 +16,23 @@
 
 = Upgrade notes
 
-This section summarizes important upgrade notes from the release history of INCEpTION. If you upgrade from any version `X`, carefully read all the upgrade notes for versions later than `X`. In particular, if any of the upgrade notes mentions that an intermediate upgrade to that version must be made before going to a higher version, then first perform all required intermediate upgrades in order. 
+This section summarizes important upgrade notes from the release history of {product-name}. If you upgrade from any version `X`, carefully read all the upgrade notes for versions later than `X`. In particular, if any of the upgrade notes mentions that an intermediate upgrade to that version must be made before going to a higher version, then first perform all required intermediate upgrades in order. 
 
 NOTE: It is a good idea to back up your installation and data before an upgrade. Also make sure that
       you can actually re-create a working installation by restoring your backup. A backup which cannot be
       successfully restored is worthless.
+
+== INCEpTION 33.0
+
+=== MariaDB upgrade in the Docker Compose file
+
+The MariaDB container that is configured in the example file will now set the environment
+variable `MARIADB_AUTO_UPGRADE` to `1` to have MariaDB automatically upgrade its internal tables when encountering a database
+produced with an earlier version of MariaDB (see link:https://hub.docker.com/_/mariadb[MariaDB Environment Variables].
+If you do not want this behavior, be sure to remove this settings from the compose file.
+
+The MariaDB container is also upgraded to the current LTS version 11.4 in the compose file. If you are not using the
+auto-upgrade behavior mentioned above, you need to manually perform the link:https://mariadb.com/kb/en/upgrading/[MariaDB upgrade] procedure.
 
 == INCEpTION 32.0
 


### PR DESCRIPTION
**What's in the PR**
- MariaDB 10.11 -> 11.4 (Docker Compose)
- Enable auto-upgrade for schema (Docker Compose)

**How to test manually**
* Try upgrading an existing Docker Compose setup to the new version

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
