### PR TITLE
#4064 - Support for agreement calculation on document-level annotations

### DIFF
--- a/inception/inception-agreement/pom.xml
+++ b/inception/inception-agreement/pom.xml
@@ -97,6 +97,10 @@
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-annotation-storage-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-layer-docmetadata</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.dkpro.statistics</groupId>

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/coding/AbstractCodingAgreementMeasureSupport.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/coding/AbstractCodingAgreementMeasureSupport.java
@@ -39,6 +39,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.MultiValueMode;
 import de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationLayerSupport;
 import de.tudarmstadt.ukp.inception.annotation.layer.span.SpanLayerSupport;
+import de.tudarmstadt.ukp.inception.ui.core.docanno.layer.DocumentMetadataLayerSupport;
 
 public abstract class AbstractCodingAgreementMeasureSupport<T extends DefaultAgreementTraits>
     extends AgreementMeasureSupport_ImplBase<T, FullCodingAgreementResult, ICodingAnnotationStudy>
@@ -48,7 +49,8 @@ public abstract class AbstractCodingAgreementMeasureSupport<T extends DefaultAgr
     {
         AnnotationLayer layer = aFeature.getLayer();
 
-        return asList(SpanLayerSupport.TYPE, RelationLayerSupport.TYPE).contains(layer.getType())
+        return asList(SpanLayerSupport.TYPE, RelationLayerSupport.TYPE,
+                DocumentMetadataLayerSupport.TYPE).contains(layer.getType())
                 && asList(SINGLE_TOKEN, TOKENS, SENTENCES).contains(layer.getAnchoringMode())
                 // Link features are supported (because the links generate sub-positions in the diff
                 // but multi-value primitives (e.g. multi-value strings) are not supported

--- a/inception/inception-curation-legacy/pom.xml
+++ b/inception/inception-curation-legacy/pom.xml
@@ -64,6 +64,10 @@
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-model-vdoc</artifactId>
     </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-layer-docmetadata</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.dkpro.core</groupId>
@@ -115,6 +119,7 @@
             <ignoredDependencies combine.children="append">
               <!-- Directly used only in tests but we need it for a transitive base class -->
               <ignoredDependency>de.tudarmstadt.ukp.inception.app:inception-support</ignoredDependency>
+              <ignoredDependency>de.tudarmstadt.ukp.inception.app:inception-layer-docmetadata</ignoredDependency>
             </ignoredDependencies>
           </configuration>
         </plugin>

--- a/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/CasDiff.java
+++ b/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/CasDiff.java
@@ -45,6 +45,7 @@ import org.apache.uima.cas.Type;
 import org.apache.uima.cas.TypeSystem;
 import org.apache.uima.cas.text.AnnotationFS;
 import org.apache.uima.fit.util.FSUtil;
+import org.apache.uima.jcas.cas.AnnotationBase;
 import org.apache.uima.jcas.tcas.Annotation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,6 +53,7 @@ import org.slf4j.LoggerFactory;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.api.DiffAdapter;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.api.DiffAdapter_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.api.Position;
+import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.docmeta.DocumentMetadataDiffAdapter;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.internal.AID;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.relation.RelationDiffAdapter;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.span.SpanDiffAdapter;
@@ -65,6 +67,7 @@ import de.tudarmstadt.ukp.inception.annotation.layer.span.SpanLayerSupport;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.support.uima.ICasUtil;
 import de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil;
+import de.tudarmstadt.ukp.inception.ui.core.docanno.layer.DocumentMetadataLayerSupport;
 
 public class CasDiff
 {
@@ -229,7 +232,7 @@ public class CasDiff
 
         var adapter = getAdapter(aType);
 
-        Collection<Annotation> annotations;
+        Collection<? extends AnnotationBase> annotations;
         if (begin == -1 && end == -1) {
             annotations = aCas.<Annotation> select(type).asList();
         }
@@ -680,6 +683,10 @@ public class CasDiff
                 var typeAdpt = (RelationAdapter) schemaService.getAdapter(layer);
                 adapter = new RelationDiffAdapter(layer.getName(), typeAdpt.getSourceFeatureName(),
                         typeAdpt.getTargetFeatureName(), labelFeatures);
+                break;
+            }
+            case DocumentMetadataLayerSupport.TYPE: {
+                adapter = new DocumentMetadataDiffAdapter(layer.getName(), labelFeatures);
                 break;
             }
             default:

--- a/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/api/DiffAdapter.java
+++ b/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/api/DiffAdapter.java
@@ -23,8 +23,7 @@ import java.util.Set;
 
 import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.FeatureStructure;
-import org.apache.uima.cas.text.AnnotationFS;
-import org.apache.uima.jcas.tcas.Annotation;
+import org.apache.uima.jcas.cas.AnnotationBase;
 
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.LinkCompareBehavior;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.LinkFeatureDecl;
@@ -36,7 +35,7 @@ public interface DiffAdapter
      */
     String getType();
 
-    Collection<? extends Position> generateSubPositions(AnnotationFS aFs,
+    Collection<? extends Position> generateSubPositions(AnnotationBase aFs,
             LinkCompareBehavior aLinkCompareBehavior);
 
     LinkFeatureDecl getLinkFeature(String aFeature);
@@ -48,5 +47,6 @@ public interface DiffAdapter
     Position getPosition(FeatureStructure aFS, String aFeature, String aRole, int aLinkTargetBegin,
             int aLinkTargetEnd, LinkCompareBehavior aLinkCompareBehavior);
 
-    List<Annotation> selectAnnotationsInWindow(CAS aCas, int aWindowBegin, int aWindowEnd);
+    List<? extends AnnotationBase> selectAnnotationsInWindow(CAS aCas, int aWindowBegin,
+            int aWindowEnd);
 }

--- a/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/api/DiffAdapter_ImplBase.java
+++ b/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/api/DiffAdapter_ImplBase.java
@@ -27,6 +27,7 @@ import org.apache.uima.cas.ArrayFS;
 import org.apache.uima.cas.FeatureStructure;
 import org.apache.uima.cas.text.AnnotationFS;
 import org.apache.uima.fit.util.FSUtil;
+import org.apache.uima.jcas.cas.AnnotationBase;
 
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.LinkCompareBehavior;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.LinkFeatureDecl;
@@ -81,7 +82,7 @@ public abstract class DiffAdapter_ImplBase
     }
 
     @Override
-    public List<? extends Position> generateSubPositions(AnnotationFS aFs,
+    public List<? extends Position> generateSubPositions(AnnotationBase aFs,
             LinkCompareBehavior aLinkCompareBehavior)
     {
         var subPositions = new ArrayList<Position>();

--- a/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/docmeta/DocumentMetadataDiffAdapter.java
+++ b/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/docmeta/DocumentMetadataDiffAdapter.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.docmeta;
+
+import static java.util.Arrays.asList;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.uima.cas.CAS;
+import org.apache.uima.cas.FeatureStructure;
+import org.apache.uima.fit.util.FSUtil;
+import org.apache.uima.jcas.cas.AnnotationBase;
+
+import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.LinkCompareBehavior;
+import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.api.DiffAdapter_ImplBase;
+import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.api.Position;
+import de.tudarmstadt.ukp.inception.annotation.layer.span.SpanRenderer;
+import de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil;
+
+public class DocumentMetadataDiffAdapter
+    extends DiffAdapter_ImplBase
+{
+    public DocumentMetadataDiffAdapter(String aType, String... aLabelFeatures)
+    {
+        this(aType, new HashSet<>(asList(aLabelFeatures)));
+    }
+
+    public DocumentMetadataDiffAdapter(String aType, Set<String> aLabelFeatures)
+    {
+        super(aType, aLabelFeatures);
+    }
+
+    /**
+     * @see SpanRenderer#selectAnnotationsInWindow
+     */
+    @Override
+    public List<AnnotationBase> selectAnnotationsInWindow(CAS aCas, int aWindowBegin,
+            int aWindowEnd)
+    {
+        return aCas.<AnnotationBase> select(getType()).asList();
+    }
+
+    @Override
+    public Position getPosition(FeatureStructure aFS, String aFeature, String aRole,
+            int aLinkTargetBegin, int aLinkTargetEnd, LinkCompareBehavior aLinkCompareBehavior)
+    {
+        String collectionId = null;
+        String documentId = null;
+        try {
+            var dmd = WebAnnoCasUtil.getDocumentMetadata(aFS.getCAS());
+            collectionId = FSUtil.getFeature(dmd, "collectionId", String.class);
+            documentId = FSUtil.getFeature(dmd, "documentId", String.class);
+        }
+        catch (IllegalArgumentException e) {
+            // We use this information only for debugging - so we can ignore if the information
+            // is missing.
+        }
+
+        String linkTargetText = null;
+        if (aLinkTargetBegin != -1 && aFS.getCAS().getDocumentText() != null) {
+            linkTargetText = aFS.getCAS().getDocumentText().substring(aLinkTargetBegin,
+                    aLinkTargetEnd);
+        }
+
+        return new DocumentPosition(collectionId, documentId, getType(), aFeature, aRole,
+                aLinkTargetBegin, aLinkTargetEnd, linkTargetText, aLinkCompareBehavior);
+    }
+}

--- a/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/docmeta/DocumentPosition.java
+++ b/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/docmeta/DocumentPosition.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.docmeta;
+
+import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.LinkCompareBehavior;
+import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.api.Position_ImplBase;
+
+/**
+ * Represents a document position.
+ */
+public class DocumentPosition
+    extends Position_ImplBase
+{
+    private static final long serialVersionUID = -1020728944030217843L;
+
+    public DocumentPosition(String aCollectionId, String aDocumentId, String aType, String aFeature,
+            String aRole, int aLinkTargetBegin, int aLinkTargetEnd, String aLinkTargetText,
+            LinkCompareBehavior aLinkCompareBehavior)
+    {
+        super(aCollectionId, aDocumentId, aType, aFeature, aRole, aLinkTargetBegin, aLinkTargetEnd,
+                aLinkTargetText, aLinkCompareBehavior);
+    }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder builder = new StringBuilder();
+        builder.append("Document [");
+        toStringFragment(builder);
+        builder.append(']');
+        return builder.toString();
+    }
+
+    @Override
+    public String toMinimalString()
+    {
+        return "Document";
+    }
+}


### PR DESCRIPTION
**What's in the PR**
- Added a diff adapter for document-level annotations
- Allow document-level layers in coding agreements

**How to test manually**
* Create a document-level annotation layer with a string feature
* Annotate it using two annotators
* Calculate agreement

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
