### PR TITLE
#4858 - Option to not finish bulk-processed documents if no annotations were accepted

### DIFF
--- a/inception/inception-processing/src/main/java/de/tudarmstadt/ukp/inception/processing/recommender/BulkRecommenderPanel.html
+++ b/inception/inception-processing/src/main/java/de/tudarmstadt/ukp/inception/processing/recommender/BulkRecommenderPanel.html
@@ -33,12 +33,23 @@
             <wicket:label key="user"/>
           </label>
         </div>
+                
         <div class="row form-row form-floating" wicket:enclosure="recommender">
           <select wicket:id="recommender" class="form-select" wicket:message="placeholder:recommender"/>
           <label wicket:for="recommender">
             <wicket:label key="recommender"/>
           </label>
         </div>
+
+        <div class="row form-row" wicket:enclosure="finishDocumentsWithoutRecommendations">
+          <div class="form-check form-switch">
+            <input wicket:id="finishDocumentsWithoutRecommendations" class="form-check-input" type="checkbox"> 
+            <label wicket:for="finishDocumentsWithoutRecommendations" class="form-check-label" >
+              <wicket:label key="finishDocumentsWithoutRecommendations"/>
+            </label>
+          </div>
+        </div>
+        
         <div class="row form-row form-floating" wicket:enclosure="processingMetadataLayer">
           <select wicket:id="processingMetadataLayer" class="form-select" wicket:message="placeholder:processingMetadataLayer"/>
           <label wicket:for="processingMetadataLayer">

--- a/inception/inception-processing/src/main/java/de/tudarmstadt/ukp/inception/processing/recommender/BulkRecommenderPanel.java
+++ b/inception/inception-processing/src/main/java/de/tudarmstadt/ukp/inception/processing/recommender/BulkRecommenderPanel.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.markup.html.form.CheckBox;
 import org.apache.wicket.markup.html.form.ChoiceRenderer;
 import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.markup.html.form.Form;
@@ -105,6 +106,9 @@ public class BulkRecommenderPanel
                 })) //
                 .add(visibleWhenNot(docMetaLayers.map(List::isEmpty))));
 
+        queue(new CheckBox("finishDocumentsWithoutRecommendations") //
+                .setOutputMarkupId(true));
+
         queue(new LambdaAjaxButton<>("startProcessing", this::actionStartProcessing));
     }
 
@@ -122,6 +126,8 @@ public class BulkRecommenderPanel
                 .withTrigger("User request") //
                 .withDataOwner(formData.user.getUsername()) //
                 .withProcessingMetadata(metadata) //
+                .withFinishDocumentsWithoutRecommendations(
+                        formData.finishDocumentsWithoutRecommendations) //
                 .build());
     }
 
@@ -132,8 +138,8 @@ public class BulkRecommenderPanel
 
     private List<AnnotationLayer> listDocumentMetadataLayers()
     {
-        return annotationSchemaService.listAnnotationLayer(getModelObject()) //
-                .stream().filter(l -> DocumentMetadataLayerSupport.TYPE.equals(l.getType())) //
+        return annotationSchemaService.listAnnotationLayer(getModelObject()).stream() //
+                .filter(l -> DocumentMetadataLayerSupport.TYPE.equals(l.getType())) //
                 .toList();
     }
 
@@ -197,5 +203,6 @@ public class BulkRecommenderPanel
         private User user;
         private Recommender recommender;
         private AnnotationLayer processingMetadataLayer;
+        private boolean finishDocumentsWithoutRecommendations;
     }
 }

--- a/inception/inception-processing/src/main/java/de/tudarmstadt/ukp/inception/processing/recommender/BulkRecommenderPanel.properties
+++ b/inception/inception-processing/src/main/java/de/tudarmstadt/ukp/inception/processing/recommender/BulkRecommenderPanel.properties
@@ -19,4 +19,5 @@ applyRecommenderDescription=Apply a recommender to all documents the chosen anno
   on yet. Once the recommender has been applied, the documents are marked as <i>finished</i>. Only recommenders that \
   do not require training can be used here.
 processingMetadataLayer=Processing metadata layer
-  
+finishDocumentsWithoutRecommendations=Mark a document as finished even if no annotations were generated in it
+processingMetadataLayer.nullValid=- None -


### PR DESCRIPTION
**What's in the PR**
- Added the option

**How to test manually**
* Set up a string-matching recommender and a document without any annotations
* Run the recommender using the bulk processing without enabling the option - the document should be "in progress" afterwards
* Run the recommender with the option enabled - the document should be "finished" afterwards

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
