### PR TITLE
#4860 - Knowledge base items should be matched even if query contains terms out of order

### DIFF
--- a/inception/inception-build/src/main/resources/inception/checkstyle.xml
+++ b/inception/inception-build/src/main/resources/inception/checkstyle.xml
@@ -107,7 +107,7 @@
       <property name="ordered" value="true"/>
       <property name="separated" value="true"/>
       <property name="option" value="top"/>
-      <property name="sortStaticImportsAlphabetically" value="true"/>
+      <!-- property name="sortStaticImportsAlphabetically" value="true"/ -->
     </module>
     
     <module name="EqualsHashCode"/>

--- a/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/config/EntityLinkingServiceAutoConfiguration.java
+++ b/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/config/EntityLinkingServiceAutoConfiguration.java
@@ -33,6 +33,7 @@ import de.tudarmstadt.ukp.inception.conceptlinking.feature.EntityRankingFeatureG
 import de.tudarmstadt.ukp.inception.conceptlinking.feature.FrequencyFeatureGenerator;
 import de.tudarmstadt.ukp.inception.conceptlinking.feature.FtsScoreFeatureGenerator;
 import de.tudarmstadt.ukp.inception.conceptlinking.feature.LevenshteinFeatureGenerator;
+import de.tudarmstadt.ukp.inception.conceptlinking.feature.MatchingTokenOverlapFeatureGenerator;
 import de.tudarmstadt.ukp.inception.conceptlinking.feature.SemanticSignatureFeatureGenerator;
 import de.tudarmstadt.ukp.inception.conceptlinking.feature.WikidataIdRankFeatureGenerator;
 import de.tudarmstadt.ukp.inception.conceptlinking.recommender.NamedEntityLinkerFactory;
@@ -79,6 +80,12 @@ public class EntityLinkingServiceAutoConfiguration
     public LevenshteinFeatureGenerator levenshteinFeatureGenerator()
     {
         return new LevenshteinFeatureGenerator();
+    }
+
+    @Bean
+    public MatchingTokenOverlapFeatureGenerator matchingTokenOverlapFeatureGenerator()
+    {
+        return new MatchingTokenOverlapFeatureGenerator();
     }
 
     @Bean

--- a/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/feature/LevenshteinFeatureGenerator.java
+++ b/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/feature/LevenshteinFeatureGenerator.java
@@ -44,26 +44,26 @@ import de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity;
 public class LevenshteinFeatureGenerator
     implements EntityRankingFeatureGenerator
 {
-    private final LevenshteinDistance lev = LevenshteinDistance.getDefaultInstance();
+    private final static LevenshteinDistance MEASURE = LevenshteinDistance.getDefaultInstance();
 
     @Override
     public void apply(CandidateEntity aCandidate)
     {
-        String label = aCandidate.getLabel();
+        var label = aCandidate.getLabel();
         update(aCandidate, label);
         aCandidate.getHandle().getMatchTerms().forEach(p -> update(aCandidate, p.getKey()));
     }
 
     private void update(CandidateEntity aCandidate, String aTerm)
     {
-        String termNC = aTerm.toLowerCase(aCandidate.getLocale());
+        var termNC = aTerm.toLowerCase(aCandidate.getLocale());
 
         aCandidate.get(KEY_MENTION_NC) //
-                .map(mention -> lev.apply(termNC, mention)) //
+                .map(mention -> MEASURE.apply(termNC, mention)) //
                 .ifPresent(score -> aCandidate.mergeMin(KEY_LEVENSHTEIN_MENTION_NC, score));
 
         aCandidate.get(KEY_QUERY_NC) //
-                .map(query -> lev.apply(termNC, query)) //
+                .map(query -> MEASURE.apply(termNC, query)) //
                 .ifPresent(score -> {
                     if (aCandidate.mergeMin(KEY_LEVENSHTEIN_QUERY_NC, score)) {
                         aCandidate.put(KEY_QUERY_BEST_MATCH_TERM_NC, aTerm);
@@ -71,15 +71,15 @@ public class LevenshteinFeatureGenerator
                 });
 
         aCandidate.get(KEY_MENTION) //
-                .map(mention -> lev.apply(aTerm, mention)) //
+                .map(mention -> MEASURE.apply(aTerm, mention)) //
                 .ifPresent(score -> aCandidate.mergeMin(KEY_LEVENSHTEIN_MENTION, score));
 
         aCandidate.get(KEY_QUERY) //
-                .map(query -> lev.apply(aTerm, query)) //
+                .map(query -> MEASURE.apply(aTerm, query)) //
                 .ifPresent(score -> aCandidate.mergeMin(KEY_LEVENSHTEIN_QUERY, score));
 
         aCandidate.get(KEY_MENTION_CONTEXT) //
-                .map(context -> lev.apply(aTerm, join(context, ' '))) //
+                .map(context -> MEASURE.apply(aTerm, join(context, ' '))) //
                 .ifPresent(score -> aCandidate.mergeMin(KEY_LEVENSHTEIN_MENTION_CONTEXT, score));
     }
 }

--- a/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/feature/MatchingTokenOverlapFeatureGenerator.java
+++ b/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/feature/MatchingTokenOverlapFeatureGenerator.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.conceptlinking.feature;
+
+import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_MENTION_BOW;
+import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_MENTION_BOW_NC;
+import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_MENTION_CONTEXT;
+import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_QUERY_BEST_MATCH_TERM_NC;
+import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_QUERY_BOW;
+import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_QUERY_BOW_NC;
+import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_TOKEN_OVERLAP_MENTION;
+import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_TOKEN_OVERLAP_MENTION_CONTEXT;
+import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_TOKEN_OVERLAP_MENTION_NC;
+import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_TOKEN_OVERLAP_QUERY;
+import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_TOKEN_OVERLAP_QUERY_NC;
+import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.sortedBagOfWords;
+import static java.util.Arrays.copyOf;
+
+import de.tudarmstadt.ukp.inception.conceptlinking.config.EntityLinkingServiceAutoConfiguration;
+import de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity;
+
+/**
+ * <p>
+ * This class is exposed as a Spring Component via
+ * {@link EntityLinkingServiceAutoConfiguration#matchingTokenOverlapFeatureGenerator}.
+ * </p>
+ */
+public class MatchingTokenOverlapFeatureGenerator
+    implements EntityRankingFeatureGenerator
+{
+
+    @Override
+    public void apply(CandidateEntity aCandidate)
+    {
+        var label = aCandidate.getLabel();
+        update(aCandidate, label);
+        aCandidate.getHandle().getMatchTerms().forEach(p -> update(aCandidate, p.getKey()));
+    }
+
+    private void update(CandidateEntity aCandidate, String aTerm)
+    {
+        var tokens = sortedBagOfWords(aTerm);
+        var tokensNC = sortedBagOfWords(aTerm.toLowerCase(aCandidate.getLocale()));
+
+        aCandidate.get(KEY_MENTION_BOW_NC) //
+                .map(mention -> distance(tokensNC, mention)) //
+                .filter(score -> score >= 0) //
+                .ifPresent(score -> aCandidate.mergeMin(KEY_TOKEN_OVERLAP_MENTION_NC, score));
+
+        aCandidate.get(KEY_QUERY_BOW_NC) //
+                .map(query -> distance(tokensNC, query)) //
+                .filter(score -> score >= 0) //
+                .ifPresent(score -> {
+                    if (aCandidate.mergeMin(KEY_TOKEN_OVERLAP_QUERY_NC, score)) {
+                        aCandidate.put(KEY_QUERY_BEST_MATCH_TERM_NC, aTerm);
+                    }
+                });
+
+        aCandidate.get(KEY_MENTION_BOW) //
+                .map(mention -> distance(tokens, mention)) //
+                .filter(score -> score >= 0) //
+                .ifPresent(score -> aCandidate.mergeMin(KEY_TOKEN_OVERLAP_MENTION, score));
+
+        aCandidate.get(KEY_QUERY_BOW) //
+                .map(query -> distance(tokens, query)) //
+                .filter(score -> score >= 0) //
+                .ifPresent(score -> aCandidate.mergeMin(KEY_TOKEN_OVERLAP_QUERY, score));
+
+        aCandidate.get(KEY_MENTION_CONTEXT) //
+                .map(context -> distance(tokens, context.toArray(String[]::new))) //
+                .filter(score -> score >= 0) //
+                .ifPresent(score -> aCandidate.mergeMin(KEY_TOKEN_OVERLAP_MENTION_CONTEXT, score));
+    }
+
+    private int distance(String[] aSortedBowCandidate, String[] aSortedBowUser)
+    {
+        if (aSortedBowCandidate == null || aSortedBowUser == null) {
+            return -1;
+        }
+
+        var sortedBowCandidate = copyOf(aSortedBowCandidate, aSortedBowCandidate.length);
+
+        var userTermsMatched = 0;
+        var distance = 0;
+
+        // First go over the terms provided by the user
+        for (var userIndex = 0; userIndex < aSortedBowUser.length; userIndex++) {
+            var userTerm = aSortedBowUser[userIndex];
+
+            if (userTerm.length() == 0) {
+                continue;
+            }
+
+            var userTermMatched = false;
+
+            for (var candIndex = 0; candIndex < sortedBowCandidate.length; candIndex++) {
+                var candTerm = sortedBowCandidate[candIndex];
+
+                if (candTerm == null || candTerm.length() == 0) {
+                    continue;
+                }
+
+                if (candTerm.startsWith(userTerm)) {
+                    distance += candTerm.length() - userTerm.length();
+                    // Since the terms are sorted by length and are unique, there won't be another
+                    // term that is a longer prefix of the current candidate. Thus, we can remove
+                    // the candidate.
+                    sortedBowCandidate[candIndex] = null;
+                    userTermMatched = true;
+                }
+            }
+
+            if (userTermMatched) {
+                userTermsMatched++;
+            }
+        }
+
+        // Any candidate terms that were not matched by a user term contribute to the distance
+        for (var candIndex = 0; candIndex < sortedBowCandidate.length; candIndex++) {
+            var candTerm = sortedBowCandidate[candIndex];
+            if (candTerm != null) {
+                distance += candTerm.length();
+            }
+        }
+
+        if (userTermsMatched == aSortedBowUser.length) {
+            return distance;
+        }
+
+        return -1;
+    }
+}

--- a/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/model/CandidateEntity.java
+++ b/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/model/CandidateEntity.java
@@ -20,6 +20,8 @@ package de.tudarmstadt.ukp.inception.conceptlinking.model;
 import static java.lang.Integer.MAX_VALUE;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.unmodifiableMap;
+import static java.util.Comparator.comparing;
+import static java.util.function.Function.identity;
 
 import java.util.IllformedLocaleException;
 import java.util.List;
@@ -28,6 +30,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
@@ -38,11 +42,23 @@ import de.tudarmstadt.ukp.inception.kb.graph.KBHandle;
  */
 public class CandidateEntity
 {
+    public static final Pattern TOKENKIZER_PATTERN = Pattern.compile("\\s+");
+
+    public static String[] sortedBagOfWords(String aString)
+    {
+        return Stream.of(TOKENKIZER_PATTERN.split(aString))
+                .sorted(comparing(String::length).reversed().thenComparing(identity())) //
+                .distinct() //
+                .toArray(String[]::new);
+    }
+
     /**
      * The query entered by the user.
      */
     public static final Key<String> KEY_QUERY = new Key<>("query");
     public static final Key<String> KEY_QUERY_NC = new Key<>("queryNC");
+    public static final Key<String[]> KEY_QUERY_BOW = new Key<>("queryBow");
+    public static final Key<String[]> KEY_QUERY_BOW_NC = new Key<>("queryBowNc");
 
     /**
      * The term which had the best match with query or mention. This should be displayed to the user
@@ -60,7 +76,9 @@ public class CandidateEntity
      * The mention in the text which is to be linked.
      */
     public static final Key<String> KEY_MENTION = new Key<>("mention");
-    public static final Key<String> KEY_MENTION_NC = new Key<>("mentionNC");
+    public static final Key<String> KEY_MENTION_NC = new Key<>("mentionNc");
+    public static final Key<String[]> KEY_MENTION_BOW = new Key<>("mentionBow");
+    public static final Key<String[]> KEY_MENTION_BOW_NC = new Key<>("mentionBowNc");
 
     public static final Key<String> KEY_LABEL_NC = new Key<>("labelNC");
 
@@ -78,8 +96,14 @@ public class CandidateEntity
      */
     public static final Key<Integer> KEY_LEVENSHTEIN_MENTION = new Key<>("levMention", MAX_VALUE);
 
-    public static final Key<Integer> KEY_LEVENSHTEIN_MENTION_NC = new Key<>("levMentionNC",
+    public static final Key<Integer> KEY_LEVENSHTEIN_MENTION_NC = new Key<>("levMentionNc",
             MAX_VALUE);
+
+    public static final Key<Integer> KEY_TOKEN_OVERLAP_MENTION = new Key<>("tokenOverlapMention",
+            MAX_VALUE);
+
+    public static final Key<Integer> KEY_TOKEN_OVERLAP_MENTION_NC = new Key<>(
+            "tokenOverlapMentionNc", MAX_VALUE);
 
     /**
      * Edit distance between mention + context and candidate entity label
@@ -91,6 +115,9 @@ public class CandidateEntity
     public static final Key<Integer> KEY_LEVENSHTEIN_MENTION_CONTEXT = new Key<>("levContext",
             MAX_VALUE);
 
+    public static final Key<Integer> KEY_TOKEN_OVERLAP_MENTION_CONTEXT = new Key<>(
+            "tokenOverlapContext", MAX_VALUE);
+
     /**
      * Edit distance between typed string and candidate entity label
      * <p>
@@ -100,7 +127,13 @@ public class CandidateEntity
      */
     public static final Key<Integer> KEY_LEVENSHTEIN_QUERY = new Key<>("levQuery", MAX_VALUE);
 
-    public static final Key<Integer> KEY_LEVENSHTEIN_QUERY_NC = new Key<>("levQueryNC", MAX_VALUE);
+    public static final Key<Integer> KEY_LEVENSHTEIN_QUERY_NC = new Key<>("levQueryNc", MAX_VALUE);
+
+    public static final Key<Integer> KEY_TOKEN_OVERLAP_QUERY = new Key<>("tokenOverlapQuery",
+            MAX_VALUE);
+
+    public static final Key<Integer> KEY_TOKEN_OVERLAP_QUERY_NC = new Key<>("tokenOverlapQueryNc",
+            MAX_VALUE);
 
     /**
      * set of directly related entities as IRI Strings
@@ -154,6 +187,8 @@ public class CandidateEntity
                 locale = Locale.ENGLISH;
             }
         }
+
+        put(KEY_LABEL_NC, getLabel().toLowerCase(getLocale()));
     }
 
     public KBHandle getHandle()
@@ -198,6 +233,30 @@ public class CandidateEntity
     public boolean isDeprecated()
     {
         return handle.isDeprecated();
+    }
+
+    public CandidateEntity withQuery(String aQuery)
+    {
+        if (aQuery != null) {
+            put(KEY_QUERY, aQuery);
+            put(KEY_QUERY_BOW, sortedBagOfWords(aQuery));
+            var lowerCaseQuery = aQuery.toLowerCase(getLocale());
+            put(KEY_QUERY_NC, lowerCaseQuery);
+            put(KEY_QUERY_BOW_NC, sortedBagOfWords(lowerCaseQuery));
+        }
+        return this;
+    }
+
+    public CandidateEntity withMention(String aMention)
+    {
+        if (aMention != null) {
+            put(KEY_MENTION, aMention);
+            put(KEY_MENTION_BOW, sortedBagOfWords(aMention));
+            var lowerCaseMention = aMention.toLowerCase(getLocale());
+            put(KEY_MENTION_NC, lowerCaseMention);
+            put(KEY_MENTION_BOW_NC, sortedBagOfWords(lowerCaseMention));
+        }
+        return this;
     }
 
     @SuppressWarnings("unchecked")
@@ -245,6 +304,28 @@ public class CandidateEntity
     public Map<String, Object> getFeatures()
     {
         return unmodifiableMap(features);
+    }
+
+    public String getFeaturesAsString()
+    {
+        var sb = new StringBuilder();
+
+        for (var key : features.keySet().stream().sorted().toList()) {
+            var value = features.get(key);
+            if (value == null || value.getClass().isArray()) {
+                continue;
+            }
+
+            if (sb.length() > 0) {
+                sb.append(", ");
+            }
+
+            sb.append(key);
+            sb.append(":");
+            sb.append(value);
+        }
+
+        return sb.toString();
     }
 
     public static class Key<T>

--- a/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/ranking/BaselineRankingStrategy.java
+++ b/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/ranking/BaselineRankingStrategy.java
@@ -29,6 +29,7 @@ import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.
 import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_QUERY_IS_LOWER_CASE;
 import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_QUERY_NC;
 import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_SIGNATURE_OVERLAP_SCORE;
+import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_TOKEN_OVERLAP_QUERY_NC;
 
 import java.util.Comparator;
 
@@ -44,6 +45,11 @@ public class BaselineRankingStrategy
             // a 0 while a mismatch is represented using 1. The typical case is that neither
             // candidate matches the query which causes the next ranking criteria to be evaluated
             .append(queryMatchesIri(e1), queryMatchesIri(e2))
+            // Use FTS score if available
+            // .append(e2.get(KEY_FTS_SCORE).get(), e1.get(KEY_FTS_SCORE).get())
+            // Require token overlap
+            .append(e1.get(KEY_TOKEN_OVERLAP_QUERY_NC).get(),
+                    e2.get(KEY_TOKEN_OVERLAP_QUERY_NC).get())
             // Prefer matches where the query appears in the label
             .append(labelMatchesQueryNC(e1), labelMatchesQueryNC(e2))
             // Compare geometric mean of the Levenshtein distance to query and mention

--- a/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/service/ConceptLinkingServiceImpl.java
+++ b/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/service/ConceptLinkingServiceImpl.java
@@ -17,15 +17,12 @@
  */
 package de.tudarmstadt.ukp.inception.conceptlinking.service;
 
-import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_LABEL_NC;
-import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_MENTION;
 import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_MENTION_CONTEXT;
-import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_MENTION_NC;
-import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_QUERY;
 import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_QUERY_BEST_MATCH_TERM_NC;
-import static de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity.KEY_QUERY_NC;
+import static de.tudarmstadt.ukp.inception.kb.RepositoryType.LOCAL;
 import static java.lang.System.currentTimeMillis;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Comparator.comparingInt;
@@ -74,7 +71,6 @@ import de.tudarmstadt.ukp.inception.conceptlinking.util.FileUtils;
 import de.tudarmstadt.ukp.inception.documents.api.RepositoryProperties;
 import de.tudarmstadt.ukp.inception.kb.ConceptFeatureValueType;
 import de.tudarmstadt.ukp.inception.kb.KnowledgeBaseService;
-import de.tudarmstadt.ukp.inception.kb.RepositoryType;
 import de.tudarmstadt.ukp.inception.kb.graph.KBHandle;
 import de.tudarmstadt.ukp.inception.kb.model.KnowledgeBase;
 import de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilder;
@@ -175,7 +171,7 @@ public class ConceptLinkingServiceImpl
         // where we want to avoid long reaction times when there is large number of candidates
         // (which is very likely when e.g. searching for all items starting with or containing a
         // specific letter.
-        final var threshold = RepositoryType.LOCAL.equals(aKB.getType()) ? 0 : 3;
+        final var threshold = aKB.getType() == LOCAL ? 0 : 3;
 
         var results = new LinkedHashSet<KBHandle>();
 
@@ -277,7 +273,7 @@ public class ConceptLinkingServiceImpl
         if (longLabels.length == 0) {
             LOG.debug(
                     "Not searching for candidates containing query/mention because they are too short");
-            return Collections.emptyList();
+            return emptyList();
         }
 
         var startTime = currentTimeMillis();
@@ -407,16 +403,8 @@ public class ConceptLinkingServiceImpl
     private CandidateEntity initCandidate(CandidateEntity candidate, String aQuery, String aMention,
             CAS aCas, int aBegin)
     {
-        if (aMention != null) {
-            candidate.put(KEY_MENTION, aMention);
-            candidate.put(KEY_MENTION_NC, aMention.toLowerCase(candidate.getLocale()));
-        }
-        if (aQuery != null) {
-            candidate.put(KEY_QUERY, aQuery);
-            candidate.put(KEY_QUERY_NC, aQuery.toLowerCase(candidate.getLocale()));
-        }
-
-        candidate.put(KEY_LABEL_NC, candidate.getLabel().toLowerCase(candidate.getLocale()));
+        candidate.withMention(aMention);
+        candidate.withQuery(aQuery);
 
         if (aCas != null && aMention != null) {
             var sentence = selectSentenceCovering(aCas, aBegin);
@@ -471,7 +459,7 @@ public class ConceptLinkingServiceImpl
         var results = candidates.stream() //
                 .map(candidate -> {
                     var handle = candidate.getHandle();
-                    handle.setDebugInfo(String.valueOf(candidate.getFeatures()));
+                    handle.setDebugInfo(candidate.getFeaturesAsString());
                     candidate.get(KEY_QUERY_BEST_MATCH_TERM_NC)
                             .filter(t -> !t.equalsIgnoreCase(handle.getUiLabel()))
                             .ifPresent(handle::setQueryBestMatchTerm);

--- a/inception/inception-concept-linking/src/test/java/de/tudarmstadt/ukp/inception/conceptlinking/feature/MatchingTokenOverlapFeatureGeneratorTest.java
+++ b/inception/inception-concept-linking/src/test/java/de/tudarmstadt/ukp/inception/conceptlinking/feature/MatchingTokenOverlapFeatureGeneratorTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.conceptlinking.feature;
+
+import static java.lang.Integer.MAX_VALUE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import de.tudarmstadt.ukp.inception.conceptlinking.model.CandidateEntity;
+import de.tudarmstadt.ukp.inception.kb.graph.KBHandle;
+
+class MatchingTokenOverlapFeatureGeneratorTest
+{
+    private MatchingTokenOverlapFeatureGenerator sut;
+
+    @BeforeEach
+    void setup()
+    {
+        sut = new MatchingTokenOverlapFeatureGenerator();
+    }
+
+    // Method to provide test cases
+    static Stream<Arguments> data()
+    {
+        return Stream.of( //
+                arguments("archery domain", "archery domain", 0), //
+                arguments("domain archery", "archery domain", 0), //
+                arguments("arch dom", "archery domain", 6), //
+                arguments("dom arch", "archery domain", 6), //
+                arguments("dom dom arch", "archery domain", 6), //
+                arguments("dom dom", "archery domain", 10), //
+                arguments("arch dom doma", "archery domain dominance", 11), //
+                arguments("arch dom dom", "archery domain dominance", 12), //
+                arguments("doma dom arch", "archery domain", MAX_VALUE), //
+                arguments("", "archery domain", MAX_VALUE), //
+                arguments("archery domain", "", MAX_VALUE), //
+                arguments("bull dia", "bulla", MAX_VALUE));
+    }
+
+    @ParameterizedTest
+    @MethodSource("data")
+    void test(String s1, String s2, int expected)
+    {
+        assertDistance(s1, s2, expected);
+    }
+
+    private void assertDistance(String query, String label, int distance)
+    {
+        var kbHandle = new KBHandle("id", label, "desc", "en");
+        var candidateEntity = new CandidateEntity(kbHandle) //
+                .withMention(null) //
+                .withQuery(query);
+
+        sut.apply(candidateEntity);
+
+        assertThat(candidateEntity.get(CandidateEntity.KEY_TOKEN_OVERLAP_QUERY)) //
+                .get().isEqualTo(distance);
+    }
+}

--- a/inception/inception-concept-linking/src/test/java/de/tudarmstadt/ukp/inception/conceptlinking/ranking/BaselineRankingStrategyTest.java
+++ b/inception/inception-concept-linking/src/test/java/de/tudarmstadt/ukp/inception/conceptlinking/ranking/BaselineRankingStrategyTest.java
@@ -49,8 +49,8 @@ public class BaselineRankingStrategyTest
     @Test
     public void thatIriExactlyMatchingQueryIsRankedFirst()
     {
-        String query = "123";
-        String mention = "456";
+        var query = "123";
+        var mention = "456";
 
         var exactIriMatch = new KBHandle(query, "1");
         var labelMatchLev0 = new KBHandle("1", "123");
@@ -86,8 +86,8 @@ public class BaselineRankingStrategyTest
     @Test
     public void thatCasedEditDistanceWinsIfUncasedEditDistanceIsEqual()
     {
-        String query = "this";
-        String mention = "Chicago";
+        var query = "this";
+        var mention = "Chicago";
 
         var labelMatch0 = new KBHandle("1", "This");
         var labelMatch2 = new KBHandle("3", "tHIS");
@@ -137,9 +137,9 @@ public class BaselineRankingStrategyTest
 
     private List<CandidateEntity> build(String aQuery, String aMention, KBHandle... aCandidates)
     {
-        List<CandidateEntity> results = new ArrayList<>();
-        for (KBHandle candidate : aCandidates) {
-            CandidateEntity cand = new CandidateEntity(candidate) //
+        var results = new ArrayList<CandidateEntity>();
+        for (var candidate : aCandidates) {
+            var cand = new CandidateEntity(candidate) //
                     .with(KEY_LABEL_NC, candidate.getUiLabel().toLowerCase(Locale.ROOT))
                     .with(KEY_QUERY, aQuery) //
                     .with(KEY_QUERY_NC, aQuery.toLowerCase(Locale.ROOT)) //

--- a/inception/inception-concept-linking/src/test/java/de/tudarmstadt/ukp/inception/conceptlinking/service/ConceptLinkingServiceImplTest.java
+++ b/inception/inception-concept-linking/src/test/java/de/tudarmstadt/ukp/inception/conceptlinking/service/ConceptLinkingServiceImplTest.java
@@ -23,10 +23,6 @@ import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
-import java.io.InputStream;
-import java.util.List;
-
-import javax.persistence.EntityManager;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,14 +36,11 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.transaction.annotation.Transactional;
 
-import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.inception.conceptlinking.config.EntityLinkingPropertiesImpl;
 import de.tudarmstadt.ukp.inception.conceptlinking.util.TestFixtures;
-import de.tudarmstadt.ukp.inception.documents.api.RepositoryProperties;
 import de.tudarmstadt.ukp.inception.documents.api.RepositoryPropertiesImpl;
 import de.tudarmstadt.ukp.inception.kb.KnowledgeBaseService;
 import de.tudarmstadt.ukp.inception.kb.KnowledgeBaseServiceImpl;
-import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBaseProperties;
 import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBasePropertiesImpl;
 import de.tudarmstadt.ukp.inception.kb.graph.KBConcept;
 import de.tudarmstadt.ukp.inception.kb.graph.KBHandle;
@@ -80,17 +73,20 @@ public class ConceptLinkingServiceImplTest
     @BeforeEach
     public void setUp() throws Exception
     {
-        RepositoryProperties repoProps = new RepositoryPropertiesImpl();
-        KnowledgeBaseProperties kbProperties = new KnowledgeBasePropertiesImpl();
+        var repoProps = new RepositoryPropertiesImpl();
+        var kbProperties = new KnowledgeBasePropertiesImpl();
         repoProps.setPath(temporaryFolder);
-        EntityManager entityManager = testEntityManager.getEntityManager();
-        TestFixtures testFixtures = new TestFixtures(testEntityManager);
+
+        var entityManager = testEntityManager.getEntityManager();
+        var testFixtures = new TestFixtures(testEntityManager);
         kbService = new KnowledgeBaseServiceImpl(repoProps, kbProperties, entityManager);
+
         sut = new ConceptLinkingServiceImpl(kbService, new EntityLinkingPropertiesImpl(), repoProps,
                 emptyList());
         sut.afterPropertiesSet();
         sut.init();
-        Project project = testFixtures.createProject(PROJECT_NAME);
+
+        var project = testFixtures.createProject(PROJECT_NAME);
         kb = testFixtures.buildKnowledgeBase(project, KB_NAME, Reification.NONE);
     }
 
@@ -100,7 +96,7 @@ public class ConceptLinkingServiceImplTest
         kbService.registerKnowledgeBase(kb, kbService.getNativeConfig());
         importKnowledgeBase("data/pets.ttl");
 
-        List<KBHandle> handles = sut.disambiguate(kb, null, ANY_OBJECT, "soc", null, 0, null);
+        var handles = sut.disambiguate(kb, null, ANY_OBJECT, "soc", null, 0, null);
 
         assertThat(handles.stream().map(KBHandle::getName))
                 .as("Check whether \"Socke\" has been retrieved.") //
@@ -115,10 +111,11 @@ public class ConceptLinkingServiceImplTest
         kbService.registerKnowledgeBase(kb, kbService.getNativeConfig());
         importKnowledgeBase("data/pets.ttl");
 
-        KBConcept concept = new KBConcept();
+        var concept = new KBConcept();
         concept.setName("manatee");
         kbService.createConcept(kb, concept);
-        List<KBHandle> handles = sut.disambiguate(kb, null, ANY_OBJECT, "man", null, 0, null);
+
+        var handles = sut.disambiguate(kb, null, ANY_OBJECT, "man", null, 0, null);
 
         assertThat(handles.stream().map(KBHandle::getName))
                 .as("Check whether \"manatee\" has been retrieved.") //
@@ -129,9 +126,9 @@ public class ConceptLinkingServiceImplTest
 
     private void importKnowledgeBase(String resourceName) throws Exception
     {
-        ClassLoader classLoader = getClass().getClassLoader();
-        String fileName = classLoader.getResource(resourceName).getFile();
-        try (InputStream is = classLoader.getResourceAsStream(resourceName)) {
+        var classLoader = getClass().getClassLoader();
+        var fileName = classLoader.getResource(resourceName).getFile();
+        try (var is = classLoader.getResourceAsStream(resourceName)) {
             kbService.importData(kb, fileName, is);
         }
     }

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
@@ -23,6 +23,9 @@ import static de.tudarmstadt.ukp.inception.kb.http.PerThreadSslCheckingHttpClien
 import static de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilder.DEFAULT_LIMIT;
 import static de.tudarmstadt.ukp.inception.project.api.ProjectService.withProjectLogger;
 import static de.tudarmstadt.ukp.inception.support.logging.BaseLoggers.BOOT_LOG;
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+import static java.lang.Math.round;
 import static java.nio.file.Files.createDirectories;
 import static java.nio.file.Files.move;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
@@ -1486,7 +1489,7 @@ public class KnowledgeBaseServiceImpl
 
                 // Apply the FTS results limit to the KB
                 luceneSailCfg.setParameter(LuceneSail.MAX_DOCUMENTS_KEY,
-                        Integer.toString(aKB.getMaxResults()));
+                        Long.toString(getFtsInternalMaxResultsFactor(aKB)));
 
                 // Improve fuzzy search speed
                 luceneSailCfg.setParameter(LuceneSail.FUZZY_PREFIX_LENGTH_KEY,
@@ -1503,7 +1506,7 @@ public class KnowledgeBaseServiceImpl
                 if (sailConnection instanceof LuceneSailConnection luceneSailConnection) {
                     var luceneIndex = (LuceneIndex) readField(luceneSailConnection, "luceneIndex",
                             true);
-                    writeField(luceneIndex, "maxDocs", kb.getMaxResults(), true);
+                    writeField(luceneIndex, "maxDocs", getFtsInternalMaxResultsFactor(kb), true);
                     writeField(luceneIndex, "fuzzyPrefixLength", LOCAL_FUZZY_PREFIX_LENGTH, true);
                 }
             }
@@ -1512,6 +1515,12 @@ public class KnowledgeBaseServiceImpl
             throw new RuntimeException("Unable to sync query parameters into live index - "
                     + "maybe the RDF4J Lucene index implementation has changed.", e);
         }
+    }
+
+    private int getFtsInternalMaxResultsFactor(KnowledgeBase aKB)
+    {
+        return (int) round(aKB.getMaxResults()
+                * min(10.0, max(1.0, properties.getFtsInternalMaxResultsFactor())));
     }
 
     private void syncSparqlUrlLiveParameters(KnowledgeBase kb,

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/config/KnowledgeBaseProperties.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/config/KnowledgeBaseProperties.java
@@ -21,6 +21,8 @@ import java.time.Duration;
 
 public interface KnowledgeBaseProperties
 {
+    double getFtsInternalMaxResultsFactor();
+
     int getDefaultMaxResults();
 
     int getHardMaxResults();

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/config/KnowledgeBasePropertiesImpl.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/config/KnowledgeBasePropertiesImpl.java
@@ -36,6 +36,8 @@ public class KnowledgeBasePropertiesImpl
 {
     public static final int HARD_MIN_RESULTS = 10;
 
+    private double ftsInternalMaxResultsFactor = 2.5;
+
     private int defaultMaxResults = 1_000;
     private int hardMaxResults = 10_000;
 
@@ -48,6 +50,17 @@ public class KnowledgeBasePropertiesImpl
     private long renderCacheSize = 10_000;
     private @DurationUnit(MINUTES) Duration renderCacheExpireDelay = ofMinutes(10);
     private @DurationUnit(MINUTES) Duration renderCacheRefreshDelay = ofMinutes(1);
+
+    public void setInternalFtsMaxResultsFactor(double aFtsMaxResultsFactor)
+    {
+        ftsInternalMaxResultsFactor = aFtsMaxResultsFactor;
+    }
+
+    @Override
+    public double getFtsInternalMaxResultsFactor()
+    {
+        return ftsInternalMaxResultsFactor;
+    }
 
     @Override
     public int getDefaultMaxResults()

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterBlazegraph.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterBlazegraph.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.inception.kb.querybuilder;
 
 import static de.tudarmstadt.ukp.inception.kb.IriConstants.PREFIX_BLAZEGRAPH;
+import static de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilder.convertToRequiredTokenPrefixMatchingQuery;
 import static de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilder.Priority.PRIMARY;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.prefix;
@@ -33,6 +34,8 @@ import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPattern;
 public class FtsAdapterBlazegraph
     implements FtsAdapter
 {
+    private static final String MULTI_CHAR_WILDCARD = "*";
+
     private static final Prefix PREFIX_BLAZEGRAPH_SEARCH = prefix("bds", iri(PREFIX_BLAZEGRAPH));
 
     private final SPARQLQueryBuilder builder;
@@ -44,20 +47,13 @@ public class FtsAdapterBlazegraph
     }
 
     @Override
-    public void withLabelMatchingExactlyAnyOf(String[] aValues)
+    public void withLabelMatchingExactlyAnyOf(String... aValues)
     {
         var kb = builder.getKnowledgeBase();
 
         var valuePatterns = new ArrayList<GraphPattern>();
         for (var value : aValues) {
-            var sanitizedValue = SPARQLQueryBuilder.sanitizeQueryString_FTS(value);
-
-            // We assume that the FTS is case insensitive and found that some FTSes (i.e.
-            // Fuseki) can have trouble matching if they get upper-case query when they
-            // internally lower-case#
-            if (builder.isCaseInsensitive()) {
-                sanitizedValue = SPARQLQueryBuilder.toLowerCase(kb, sanitizedValue);
-            }
+            var sanitizedValue = builder.sanitizeQueryString_FTS(value);
 
             if (isBlank(sanitizedValue)) {
                 continue;
@@ -73,6 +69,10 @@ public class FtsAdapterBlazegraph
                                     kb)));
         }
 
+        if (valuePatterns.isEmpty()) {
+            builder.noResult();
+        }
+
         builder.addPattern(PRIMARY, and( //
                 builder.bindMatchTermProperties(SPARQLQueryBuilder.VAR_MATCH_TERM_PROPERTY), //
                 union(valuePatterns.toArray(GraphPattern[]::new))));
@@ -81,18 +81,9 @@ public class FtsAdapterBlazegraph
     @Override
     public void withLabelContainingAnyOf(String... aValues)
     {
-        var kb = builder.getKnowledgeBase();
-
         var valuePatterns = new ArrayList<GraphPattern>();
         for (var value : aValues) {
-            var sanitizedValue = SPARQLQueryBuilder.sanitizeQueryString_FTS(value);
-
-            // We assume that the FTS is case insensitive and found that some FTSes (i.e.
-            // Fuseki) can have trouble matching if they get upper-case query when they
-            // internally lower-case#
-            if (builder.isCaseInsensitive()) {
-                sanitizedValue = SPARQLQueryBuilder.toLowerCase(kb, sanitizedValue);
-            }
+            var sanitizedValue = builder.sanitizeQueryString_FTS(value);
 
             if (isBlank(sanitizedValue)) {
                 continue;
@@ -108,6 +99,10 @@ public class FtsAdapterBlazegraph
                                     value)));
         }
 
+        if (valuePatterns.isEmpty()) {
+            builder.noResult();
+        }
+
         builder.addPattern(PRIMARY,
                 and(builder.bindMatchTermProperties(SPARQLQueryBuilder.VAR_MATCH_TERM_PROPERTY),
                         union(valuePatterns.toArray(GraphPattern[]::new))));
@@ -116,26 +111,18 @@ public class FtsAdapterBlazegraph
     @Override
     public void withLabelStartingWith(String aPrefixQuery)
     {
-        var kb = builder.getKnowledgeBase();
+        // Strip single quotes and asterisks because they have special semantics
+        var queryString = builder.sanitizeQueryString_FTS(aPrefixQuery);
 
-        var queryString = aPrefixQuery.trim();
-
-        // We assume that the FTS is case insensitive and found that some FTSes (i.e.
-        // Fuseki) can have trouble matching if they get upper-case query when they
-        // internally lower-case#
-        if (builder.isCaseInsensitive()) {
-            queryString = SPARQLQueryBuilder.toLowerCase(kb, queryString);
-        }
-
-        if (queryString.isEmpty()) {
-            builder.setReturnEmptyResult(true);
+        if (isBlank(queryString)) {
+            builder.noResult();
         }
 
         // If the query string entered by the user does not end with a space character, then
         // we assume that the user may not yet have finished writing the word and add a
         // wildcard
         if (!aPrefixQuery.endsWith(" ")) {
-            queryString += "*";
+            queryString += MULTI_CHAR_WILDCARD;
         }
 
         builder.addProjection(SPARQLQueryBuilder.VAR_SCORE);
@@ -155,24 +142,16 @@ public class FtsAdapterBlazegraph
     @Override
     public void withLabelMatchingAnyOf(String... aValues)
     {
-        var kb = builder.getKnowledgeBase();
-
         var valuePatterns = new ArrayList<GraphPattern>();
         for (var value : aValues) {
-            var sanitizedValue = SPARQLQueryBuilder.sanitizeQueryString_FTS(value);
+            var sanitizedValue = builder.sanitizeQueryString_FTS(value);
 
             if (isBlank(sanitizedValue)) {
                 continue;
             }
 
-            // We assume that the FTS is case insensitive and found that some FTSes (i.e.
-            // Fuseki) can have trouble matching if they get upper-case query when they
-            // internally lower-case#
-            if (builder.isCaseInsensitive()) {
-                sanitizedValue = SPARQLQueryBuilder.toLowerCase(kb, sanitizedValue);
-            }
-
-            var fuzzyQuery = SPARQLQueryBuilder.convertToFuzzyMatchingQuery(sanitizedValue, "*");
+            var fuzzyQuery = convertToRequiredTokenPrefixMatchingQuery(sanitizedValue, "",
+                    MULTI_CHAR_WILDCARD);
 
             if (isBlank(fuzzyQuery)) {
                 continue;
@@ -184,6 +163,10 @@ public class FtsAdapterBlazegraph
                     SPARQLQueryBuilder.VAR_SCORE, SPARQLQueryBuilder.VAR_MATCH_TERM,
                     SPARQLQueryBuilder.VAR_MATCH_TERM_PROPERTY, fuzzyQuery)
                             .withLimit(builder.getLimit()));
+        }
+
+        if (valuePatterns.isEmpty()) {
+            builder.noResult();
         }
 
         builder.addPattern(PRIMARY,

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterNoFts.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterNoFts.java
@@ -60,6 +60,10 @@ public class FtsAdapterNoFts
             values.add(literalOf(sanitizedValue));
         }
 
+        if (values.isEmpty()) {
+            builder.noResult();
+        }
+
         builder.addPattern(PRIMARY,
                 and(builder.bindMatchTermProperties(VAR_MATCH_TERM_PROPERTY),
                         new ValuesPattern(VAR_MATCH_TERM, values),
@@ -80,6 +84,10 @@ public class FtsAdapterNoFts
                     .filter(builder.containsPattern(VAR_MATCH_TERM, value)));
         }
 
+        if (valuePatterns.isEmpty()) {
+            builder.noResult();
+        }
+
         // The WikiData search service does not support properties. So we disable the use of the
         // WikiData search service when looking for properties. But then, searching first by
         // the label becomes very slow because withLabelMatchingAnyOf falls back to "containing"
@@ -94,7 +102,7 @@ public class FtsAdapterNoFts
     public void withLabelStartingWith(String aPrefixQuery)
     {
         if (aPrefixQuery.isEmpty()) {
-            builder.setReturnEmptyResult(true);
+            builder.noResult();
         }
 
         // Label matching without FTS is slow, so we add this with low prio and hope that some

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterRdf4J.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterRdf4J.java
@@ -18,6 +18,8 @@
 package de.tudarmstadt.ukp.inception.kb.querybuilder;
 
 import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_RDF4J_LUCENE;
+import static de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilder.convertToFuzzyMatchingQuery;
+import static de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilder.convertToRequiredTokenPrefixMatchingQuery;
 import static de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilder.Priority.PRIMARY;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions.and;
@@ -38,6 +40,7 @@ import java.util.ArrayList;
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expression;
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions;
 import org.eclipse.rdf4j.sparqlbuilder.core.Prefix;
+import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPattern;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
 
@@ -46,12 +49,21 @@ import de.tudarmstadt.ukp.inception.kb.IriConstants;
 public class FtsAdapterRdf4J
     implements FtsAdapter
 {
+    private static final String REQUIRED_PREFIX = "+";
+    private static final String VAR_LABEL_NAME = "label";
+    private static final Variable VAR_LABEL = var(VAR_LABEL_NAME);
+    private static final String VAR_SNIPPET_NAME = "snippet";
+    private static final Variable VAR_SNIPPET = var(VAR_SNIPPET_NAME);
+
     private static final Prefix PREFIX_RDF4J_LUCENE_SEARCH = prefix("search",
             iri(IriConstants.PREFIX_RDF4J_LUCENE_SEARCH));
     private static final Iri LUCENE_QUERY = PREFIX_RDF4J_LUCENE_SEARCH.iri("query");
     private static final Iri LUCENE_PROPERTY = PREFIX_RDF4J_LUCENE_SEARCH.iri("property");
     private static final Iri LUCENE_SCORE = PREFIX_RDF4J_LUCENE_SEARCH.iri("score");
-    private static final Iri LUCENE_SNIPPET = PREFIX_RDF4J_LUCENE_SEARCH.iri("snippet");
+    private static final Iri LUCENE_SNIPPET = PREFIX_RDF4J_LUCENE_SEARCH.iri(VAR_SNIPPET_NAME);
+
+    private static final String MULTI_CHAR_WILDCARD = "*";
+    private static final String FUZZY_SUFFIX = "~";
 
     private final SPARQLQueryBuilder builder;
 
@@ -68,7 +80,7 @@ public class FtsAdapterRdf4J
         var valuePatterns = new ArrayList<GraphPattern>();
         for (var value : aValues) {
             // Strip single quotes and asterisks because they have special semantics
-            var sanitizedValue = SPARQLQueryBuilder.sanitizeQueryString_FTS(value);
+            var sanitizedValue = builder.sanitizeQueryString_FTS(value);
 
             if (isBlank(sanitizedValue)) {
                 continue;
@@ -84,6 +96,10 @@ public class FtsAdapterRdf4J
                             .equalsPattern(VAR_MATCH_TERM, value, builder.getKnowledgeBase())));
         }
 
+        if (valuePatterns.isEmpty()) {
+            builder.noResult();
+        }
+
         builder.addPattern(PRIMARY, and( //
                 builder.bindMatchTermProperties(VAR_MATCH_TERM_PROPERTY), //
                 union(valuePatterns.toArray(GraphPattern[]::new))));
@@ -96,25 +112,49 @@ public class FtsAdapterRdf4J
 
         var valuePatterns = new ArrayList<GraphPattern>();
         for (var value : aValues) {
-            var sanitizedValue = SPARQLQueryBuilder.sanitizeQueryString_FTS(value);
+            // Strip single quotes and asterisks because they have special semantics
+            var sanitizedValue = builder.sanitizeQueryString_FTS(value);
 
-            if (isBlank(sanitizedValue)) {
+            var query = convertToRequiredTokenPrefixMatchingQuery(sanitizedValue, REQUIRED_PREFIX,
+                    MULTI_CHAR_WILDCARD);
+
+            if (isBlank(query)) {
                 continue;
             }
 
+            var labelFilterExpressions = new ArrayList<Expression<?>>();
+            labelFilterExpressions.add(Expressions.equals(str(VAR_LABEL), str(VAR_MATCH_TERM)));
+            labelFilterExpressions.add(builder.matchKbLanguage(VAR_MATCH_TERM));
+
             builder.addProjection(VAR_SCORE);
 
-            valuePatterns
-                    .add(VAR_SUBJECT
-                            .has(FTS_RDF4J_LUCENE,
-                                    bNode(LUCENE_QUERY, literalOf(sanitizedValue + "*")) //
-                                            .andHas(LUCENE_PROPERTY, VAR_MATCH_TERM_PROPERTY) //
-                                            .andHas(LUCENE_SCORE, VAR_SCORE))
-                            .andHas(VAR_MATCH_TERM_PROPERTY, VAR_MATCH_TERM)
-                            .filter(builder.containsPattern(VAR_MATCH_TERM, value)));
+            // If a KB item has multiple labels, we want to return only the ones which actually
+            // match the query term such that the user is not confused that the results contain
+            // items that don't match the query (even though they do through a label that is not
+            // returned). RDF4J only provides access to the matched term in a "highlighted" form
+            // where "<B>" and "</B>" match the search term. So we have to strip these markers
+            // out as part of the query.
+            valuePatterns.add(VAR_SUBJECT //
+                    .has(FTS_RDF4J_LUCENE, bNode(LUCENE_QUERY, literalOf(query)) //
+                            .andHas(LUCENE_PROPERTY, VAR_MATCH_TERM_PROPERTY) //
+                            .andHas(LUCENE_SCORE, VAR_SCORE) //
+                            .andHas(LUCENE_SNIPPET, VAR_SNIPPET))
+                    .and(bind(
+                            function(REPLACE,
+                                    function(REPLACE, VAR_SNIPPET, literalOf("</B>"),
+                                            literalOf("")),
+                                    literalOf("<B>"), literalOf("")),
+                            VAR_LABEL))
+                    .and(VAR_SUBJECT.has(VAR_MATCH_TERM_PROPERTY, VAR_MATCH_TERM))
+                    .filter(and(labelFilterExpressions.toArray(Expression[]::new))));
         }
 
-        builder.addPattern(PRIMARY, and(builder.bindMatchTermProperties(VAR_MATCH_TERM_PROPERTY),
+        if (valuePatterns.isEmpty()) {
+            builder.noResult();
+        }
+
+        builder.addPattern(PRIMARY, and( //
+                builder.bindMatchTermProperties(VAR_MATCH_TERM_PROPERTY),
                 union(valuePatterns.toArray(GraphPattern[]::new))));
     }
 
@@ -124,19 +164,17 @@ public class FtsAdapterRdf4J
         builder.addPrefix(PREFIX_RDF4J_LUCENE_SEARCH);
 
         // Strip single quotes and asterisks because they have special semantics
-        var sanitizedValue = SPARQLQueryBuilder.sanitizeQueryString_FTS(aPrefixQuery);
+        var queryString = builder.sanitizeQueryString_FTS(aPrefixQuery);
 
-        if (isBlank(sanitizedValue)) {
-            builder.setReturnEmptyResult(true);
+        if (isBlank(queryString)) {
+            builder.noResult();
         }
-
-        var queryString = sanitizedValue.trim();
 
         // If the query string entered by the user does not end with a space character, then
         // we assume that the user may not yet have finished writing the word and add a
         // wildcard
         if (!aPrefixQuery.endsWith(" ")) {
-            queryString += "*";
+            queryString += MULTI_CHAR_WILDCARD;
         }
 
         builder.addProjection(VAR_SCORE);
@@ -160,16 +198,16 @@ public class FtsAdapterRdf4J
         var valuePatterns = new ArrayList<GraphPattern>();
         for (var value : aValues) {
             // Strip single quotes and asterisks because they have special semantics
-            var sanitizedValue = SPARQLQueryBuilder.sanitizeQueryString_FTS(value);
+            var sanitizedValue = builder.sanitizeQueryString_FTS(value);
 
-            var fuzzyQuery = SPARQLQueryBuilder.convertToFuzzyMatchingQuery(sanitizedValue, "~");
+            var queryString = convertToFuzzyMatchingQuery(sanitizedValue, FUZZY_SUFFIX);
 
-            if (isBlank(sanitizedValue) || isBlank(fuzzyQuery)) {
+            if (isBlank(queryString)) {
                 continue;
             }
 
             var labelFilterExpressions = new ArrayList<Expression<?>>();
-            labelFilterExpressions.add(Expressions.equals(str(var("label")), str(VAR_MATCH_TERM)));
+            labelFilterExpressions.add(Expressions.equals(str(VAR_LABEL), str(VAR_MATCH_TERM)));
             labelFilterExpressions.add(builder.matchKbLanguage(VAR_MATCH_TERM));
 
             builder.addProjection(VAR_SCORE);
@@ -177,22 +215,26 @@ public class FtsAdapterRdf4J
             // If a KB item has multiple labels, we want to return only the ones which actually
             // match the query term such that the user is not confused that the results contain
             // items that don't match the query (even though they do through a label that is not
-            // returned). RDF4J only provides access to the matched term in a "highlighed" form
+            // returned). RDF4J only provides access to the matched term in a "highlighted" form
             // where "<B>" and "</B>" match the search term. So we have to strip these markers
             // out as part of the query.
             valuePatterns.add(VAR_SUBJECT //
-                    .has(FTS_RDF4J_LUCENE, bNode(LUCENE_QUERY, literalOf(fuzzyQuery)) //
+                    .has(FTS_RDF4J_LUCENE, bNode(LUCENE_QUERY, literalOf(queryString)) //
                             .andHas(LUCENE_PROPERTY, VAR_MATCH_TERM_PROPERTY) //
                             .andHas(LUCENE_SCORE, VAR_SCORE) //
-                            .andHas(LUCENE_SNIPPET, var("snippet")))
+                            .andHas(LUCENE_SNIPPET, VAR_SNIPPET))
                     .and(bind(
                             function(REPLACE,
-                                    function(REPLACE, var("snippet"), literalOf("</B>"),
+                                    function(REPLACE, VAR_SNIPPET, literalOf("</B>"),
                                             literalOf("")),
                                     literalOf("<B>"), literalOf("")),
-                            var("label")))
+                            VAR_LABEL))
                     .and(VAR_SUBJECT.has(VAR_MATCH_TERM_PROPERTY, VAR_MATCH_TERM))
                     .filter(and(labelFilterExpressions.toArray(Expression[]::new))));
+        }
+
+        if (valuePatterns.isEmpty()) {
+            builder.noResult();
         }
 
         builder.addPattern(PRIMARY, and( //

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterVirtuoso.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterVirtuoso.java
@@ -44,7 +44,7 @@ public class FtsAdapterVirtuoso
 
         var valuePatterns = new ArrayList<GraphPattern>();
         for (var value : aValues) {
-            var sanitizedValue = SPARQLQueryBuilder.sanitizeQueryString_FTS(value);
+            var sanitizedValue = builder.sanitizeQueryString_FTS(value);
 
             if (isBlank(sanitizedValue)) {
                 continue;
@@ -55,6 +55,10 @@ public class FtsAdapterVirtuoso
                             literalOf("\"" + sanitizedValue + "\"")))
                     .filter(builder.equalsPattern(VAR_MATCH_TERM, value,
                             builder.getKnowledgeBase())));
+        }
+
+        if (valuePatterns.isEmpty()) {
+            builder.noResult();
         }
 
         builder.addPattern(PRIMARY, and( //
@@ -69,7 +73,7 @@ public class FtsAdapterVirtuoso
 
         var valuePatterns = new ArrayList<GraphPattern>();
         for (var value : aValues) {
-            var sanitizedValue = SPARQLQueryBuilder.sanitizeQueryString_FTS(value);
+            var sanitizedValue = builder.sanitizeQueryString_FTS(value);
 
             if (isBlank(sanitizedValue)) {
                 continue;
@@ -79,6 +83,10 @@ public class FtsAdapterVirtuoso
                     .and(VAR_MATCH_TERM.has(VIRTUOSO_QUERY,
                             literalOf("\"" + sanitizedValue + "\"")))
                     .filter(builder.containsPattern(VAR_MATCH_TERM, value)));
+        }
+
+        if (valuePatterns.isEmpty()) {
+            builder.noResult();
         }
 
         builder.addPattern(PRIMARY, and( //
@@ -92,20 +100,20 @@ public class FtsAdapterVirtuoso
         // addPrefix(PREFIX_VIRTUOSO_SEARCH);
 
         // Strip single quotes and asterisks because they have special semantics
-        String sanitizedQuery = SPARQLQueryBuilder.sanitizeQueryString_FTS(aPrefixQuery);
+        var queryString = builder.sanitizeQueryString_FTS(aPrefixQuery);
 
         // If the query string entered by the user does not end with a space character, then
         // we assume that the user may not yet have finished writing the word and add a
         // wildcard
         if (!aPrefixQuery.endsWith(" ")) {
-            sanitizedQuery = virtuosoStartsWithQuery(sanitizedQuery);
+            queryString = virtuosoStartsWithQuery(queryString);
         }
 
         // If the query string was reduced to nothing, then the query should always return an
         // empty
         // result.
-        if (sanitizedQuery.length() == 2) {
-            builder.setReturnEmptyResult(true);
+        if (queryString.length() == 2) {
+            builder.noResult();
         }
 
         // Locate all entries where the label contains the prefix (using the FTS) and then
@@ -114,7 +122,7 @@ public class FtsAdapterVirtuoso
                 builder.bindMatchTermProperties(VAR_MATCH_TERM_PROPERTY),
                 VAR_SUBJECT.has(VAR_MATCH_TERM_PROPERTY, VAR_MATCH_TERM)
                         .and(VAR_MATCH_TERM.has(VIRTUOSO_QUERY,
-                                literalOf("\"" + sanitizedQuery + "\"")))
+                                literalOf("\"" + queryString + "\"")))
                         .filter(builder.startsWithPattern(VAR_MATCH_TERM, aPrefixQuery))));
     }
 
@@ -153,7 +161,7 @@ public class FtsAdapterVirtuoso
 
         var valuePatterns = new ArrayList<GraphPattern>();
         for (var value : aValues) {
-            var sanitizedValue = SPARQLQueryBuilder.sanitizeQueryString_FTS(value);
+            var sanitizedValue = builder.sanitizeQueryString_FTS(value);
 
             if (isBlank(sanitizedValue)) {
                 continue;
@@ -168,6 +176,10 @@ public class FtsAdapterVirtuoso
 
             valuePatterns.add(VAR_SUBJECT.has(VAR_MATCH_TERM_PROPERTY, VAR_MATCH_TERM).and(
                     VAR_MATCH_TERM.has(VIRTUOSO_QUERY, literalOf("\"" + sanitizedValue + "\""))));
+        }
+
+        if (valuePatterns.isEmpty()) {
+            builder.noResult();
         }
 
         builder.addPattern(PRIMARY, and( //

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterWikidata.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterWikidata.java
@@ -47,15 +47,19 @@ public class FtsAdapterWikidata
 
         var valuePatterns = new ArrayList<GraphPattern>();
         for (var value : aValues) {
-            var sanitizedValue = SPARQLQueryBuilder.sanitizeQueryString_FTS(value);
+            var query = builder.sanitizeQueryString_FTS(value);
 
-            if (isBlank(sanitizedValue)) {
+            if (isBlank(query)) {
                 continue;
             }
 
-            valuePatterns.add(new WikidataEntitySearchService(VAR_SUBJECT, sanitizedValue, language)
+            valuePatterns.add(new WikidataEntitySearchService(VAR_SUBJECT, query, language)
                     .and(VAR_SUBJECT.has(VAR_MATCH_TERM_PROPERTY, VAR_MATCH_TERM)
                             .filter(builder.equalsPattern(VAR_MATCH_TERM, value, kb))));
+        }
+
+        if (valuePatterns.isEmpty()) {
+            builder.noResult();
         }
 
         builder.addPattern(PRIMARY, and( //
@@ -74,15 +78,19 @@ public class FtsAdapterWikidata
 
         var valuePatterns = new ArrayList<GraphPattern>();
         for (var value : aValues) {
-            var sanitizedValue = SPARQLQueryBuilder.sanitizeQueryString_FTS(value);
+            var query = builder.sanitizeQueryString_FTS(value);
 
-            if (isBlank(sanitizedValue)) {
+            if (isBlank(query)) {
                 continue;
             }
 
-            valuePatterns.add(new WikidataEntitySearchService(VAR_SUBJECT, sanitizedValue, language)
+            valuePatterns.add(new WikidataEntitySearchService(VAR_SUBJECT, query, language)
                     .and(VAR_SUBJECT.has(VAR_MATCH_TERM_PROPERTY, VAR_MATCH_TERM)
                             .filter(builder.containsPattern(VAR_MATCH_TERM, value))));
+        }
+
+        if (valuePatterns.isEmpty()) {
+            builder.noResult();
         }
 
         builder.addPattern(PRIMARY, and( //
@@ -100,10 +108,10 @@ public class FtsAdapterWikidata
         var language = kb.getDefaultLanguage() != null ? kb.getDefaultLanguage() : "en";
 
         if (aPrefixQuery.isEmpty()) {
-            builder.setReturnEmptyResult(true);
+            builder.noResult();
         }
 
-        var sanitizedValue = SPARQLQueryBuilder.sanitizeQueryString_FTS(aPrefixQuery);
+        var sanitizedValue = builder.sanitizeQueryString_FTS(aPrefixQuery);
 
         builder.addPattern(PRIMARY, and( //
                 builder.bindMatchTermProperties(VAR_MATCH_TERM_PROPERTY),
@@ -123,7 +131,7 @@ public class FtsAdapterWikidata
 
         var valuePatterns = new ArrayList<GraphPattern>();
         for (var value : aValues) {
-            var sanitizedValue = SPARQLQueryBuilder.sanitizeQueryString_FTS(value);
+            var sanitizedValue = builder.sanitizeQueryString_FTS(value);
 
             if (isBlank(sanitizedValue)) {
                 continue;
@@ -131,6 +139,10 @@ public class FtsAdapterWikidata
 
             valuePatterns.add(new WikidataEntitySearchService(VAR_SUBJECT, sanitizedValue, language)
                     .and(VAR_SUBJECT.has(VAR_MATCH_TERM_PROPERTY, VAR_MATCH_TERM)));
+        }
+
+        if (valuePatterns.isEmpty()) {
+            builder.noResult();
         }
 
         builder.addPattern(PRIMARY, and( //

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderRemoteServicesTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderRemoteServicesTest.java
@@ -23,7 +23,6 @@ import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_WIKIDATA;
 import static de.tudarmstadt.ukp.inception.kb.RepositoryType.REMOTE;
 import static de.tudarmstadt.ukp.inception.kb.http.PerThreadSslCheckingHttpClientUtils.restoreSslVerification;
 import static de.tudarmstadt.ukp.inception.kb.http.PerThreadSslCheckingHttpClientUtils.suspendSslVerification;
-import static de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilder.sanitizeQueryString_FTS;
 import static de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilderAsserts.asHandles;
 import static de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilderAsserts.assertThatChildrenOfExplicitRootCanBeRetrieved;
 import static de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilderLocalTestScenarios.assertIsReachable;
@@ -640,11 +639,5 @@ public class SPARQLQueryBuilderRemoteServicesTest
         assertThat(results) //
                 .extracting(KBHandle::getName) //
                 .contains("agent", "Thing");
-    }
-
-    @Test
-    public void thatLineBreaksAreSanitized() throws Exception
-    {
-        assertThat(sanitizeQueryString_FTS("Green\n\rGoblin")).isEqualTo("Green Goblin");
     }
 }

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderTest.java
@@ -17,16 +17,23 @@
  */
 package de.tudarmstadt.ukp.inception.kb.querybuilder;
 
-import static de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilder.sanitizeQueryString_FTS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
+
+import de.tudarmstadt.ukp.inception.kb.model.KnowledgeBase;
+import de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilder.Mode;
 
 public class SPARQLQueryBuilderTest
 {
     @Test
     public void thatLineBreaksAreSanitized() throws Exception
     {
-        assertThat(sanitizeQueryString_FTS("Green\n\rGoblin")).isEqualTo("Green Goblin");
+        var kb = new KnowledgeBase();
+        var sut = new SPARQLQueryBuilder(kb, Mode.CLASS);
+        sut.caseSensitive(true);
+
+        assertThat(sut.sanitizeQueryString_FTS("Green\n\rGoblin")) //
+                .isEqualTo("Green Goblin");
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
     <!-- * 1.3.5    depends on Lucene 8.10.1 -->
     <!--   2.x      depends on Lucene 9.x -->
 
-    <rdf4j.version>4.3.11</rdf4j.version> 
+    <rdf4j.version>4.3.12</rdf4j.version> 
     <!-- * 4.3.x depends on Lucene 8.9.x -->
     <!-- * 5.x.x depends on Lucene 9.x.x -->
 


### PR DESCRIPTION
**What's in the PR**
- Decompose the query into terms and match them independently of their order
- Internally retrieve more items from the FTS before filtering them down
- Additional testing
- Cleaning up

**How to test manually**
* E.g if a KB contains an entry "long beach", try searching for "beach long"

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
