### PR TITLE
#4867 - Cannot re-open document for curation if it contains an invalid feature value

### DIFF
--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/actionbar/CuratorWorkflowActionBarItemGroup.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/actionbar/CuratorWorkflowActionBarItemGroup.java
@@ -133,21 +133,21 @@ public class CuratorWorkflowActionBarItemGroup
     protected void actionToggleCurationState(AjaxRequestTarget aTarget)
         throws IOException, AnnotationException
     {
-        try {
-            page.actionValidateDocument(aTarget, page.getEditorCas());
-        }
-        catch (ValidationException e) {
-            page.error("Document cannot be marked as finished: " + e.getMessage());
-            aTarget.addChildren(page, IFeedback.class);
-            return;
-        }
-
-        AnnotatorState state = page.getModelObject();
-        SourceDocument sourceDocument = state.getDocument();
+        var state = page.getModelObject();
+        var sourceDocument = state.getDocument();
         var docState = sourceDocument.getState();
 
         switch (docState) {
         case CURATION_IN_PROGRESS:
+            try {
+                page.actionValidateDocument(aTarget, page.getEditorCas());
+            }
+            catch (ValidationException e) {
+                page.error("Document cannot be marked as finished: " + e.getMessage());
+                aTarget.addChildren(page, IFeedback.class);
+                return;
+            }
+
             documentService.setSourceDocumentState(sourceDocument, CURATION_FINISHED);
             aTarget.add(page);
             break;


### PR DESCRIPTION
**What's in the PR**
- Validate only when marking document as finished, but not when putting back into progress

**How to test manually**
* Close a curated document with some string feature that has an empty value
* Make the string feature mandatory in the project settings
* Try re-opening the curated document from the action bar in the curation page

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
