### PR TITLE
#4889 - Document sometimes not rendered in by line brat render modes

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/paging/SentenceOrientedPagingStrategy.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/paging/SentenceOrientedPagingStrategy.java
@@ -86,8 +86,8 @@ public class SentenceOrientedPagingStrategy
     @Override
     public Component createPositionLabel(String aId, IModel<AnnotatorState> aModel)
     {
-        Label label = new Label(aId, () -> {
-            AnnotatorState state = aModel.getObject();
+        var label = new Label(aId, () -> {
+            var state = aModel.getObject();
             return String.format("%d-%d / %d sentences [doc %d / %d]",
                     state.getFirstVisibleUnitIndex(), state.getLastVisibleUnitIndex(),
                     state.getUnitCount(), state.getDocumentIndex() + 1,

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/paging/TokenWrappingPagingStrategy.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/paging/TokenWrappingPagingStrategy.java
@@ -52,7 +52,7 @@ public class TokenWrappingPagingStrategy
     {
         Iterator<AnnotationFS> tokenIterator = WebAnnoCasUtil.selectTokens(aCas).iterator();
 
-        List<Unit> units = new ArrayList<>();
+        var units = new ArrayList<Unit>();
 
         int currentUnitStart = 0;
         int currentUnitEnd = 0;
@@ -65,7 +65,7 @@ public class TokenWrappingPagingStrategy
                         currentToken.getBegin(), currentToken.getEnd(), currentUnitEnd));
             }
 
-            String gap = aCas.getDocumentText().substring(currentUnitEnd, currentToken.getBegin());
+            var gap = aCas.getDocumentText().substring(currentUnitEnd, currentToken.getBegin());
             int gapStart = currentUnitEnd;
             int lineBreakIndex = gap.indexOf("\n");
             while (lineBreakIndex > -1) {
@@ -75,8 +75,8 @@ public class TokenWrappingPagingStrategy
                 lineBreakIndex = gap.indexOf("\n", lineBreakIndex + 1);
             }
 
-            boolean unitNonEmpty = (currentUnitEnd - currentUnitStart) > 0;
-            boolean unitFull = unitNonEmpty
+            var unitNonEmpty = (currentUnitEnd - currentUnitStart) > 0;
+            var unitFull = unitNonEmpty
                     && ((currentToken.getEnd() - currentUnitStart) > maxLineLength);
 
             // If the unit is full, finish the unit and start a new one

--- a/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/render/BratSerializerImpl.java
+++ b/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/render/BratSerializerImpl.java
@@ -21,6 +21,7 @@ import static de.tudarmstadt.ukp.clarin.webanno.brat.schema.BratSchemaGeneratorI
 import static de.tudarmstadt.ukp.clarin.webanno.model.ScriptDirection.RTL;
 import static java.util.Arrays.asList;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.apache.uima.cas.text.AnnotationPredicates.covering;
 import static org.apache.uima.fit.util.CasUtil.getType;
 import static org.apache.uima.fit.util.CasUtil.select;
 
@@ -338,12 +339,11 @@ public class BratSerializerImpl
         }
 
         // If the annotation extends across the row boundaries, create multiple ranges for the
-        // annotation, one for every row. Note that in UIMA annotations are
-        // half-open intervals [begin,end) so that a begin offset must always be
-        // smaller than the end of a covering annotation to be considered properly
-        // covered.
-        Offsets beginRow = aRows.stream()
-                .filter(span -> span.getBegin() <= aBegin && aBegin < span.getEnd()) //
+        // annotation, one for every row. Note that in UIMA annotations are half-open intervals
+        // [begin,end) so that a begin offset must always be smaller than the end of a covering
+        // annotation to be considered properly covered.
+        var beginRow = aRows.stream() //
+                .filter(row -> covering(row.getBegin(), row.getEnd(), aBegin, aBegin)) //
                 .findFirst() //
                 .orElseThrow(() -> new IllegalArgumentException(
                         "Start position of range [" + (aWindowBegin + aBegin) + "-"
@@ -351,12 +351,11 @@ public class BratSerializerImpl
                                 + "sentence-based editor, this is most likely caused by "
                                 + "annotations outside sentences."));
 
-        // Zero-width annotations that are on the boundary of two directly
-        // adjacent sentences (i.e. without whitespace between them) are considered
-        // to be at the end of the first sentence rather than at the beginning of the
-        // second sentence.
-        Offsets endRow = aRows.stream()
-                .filter(span -> span.getBegin() <= aEnd && aEnd <= span.getEnd()) //
+        // Zero-width annotations that are on the boundary of two directly adjacent sentences (i.e.
+        // without whitespace between them) are considered to be at the end of the first sentence
+        // rather than at the beginning of the second sentence.
+        var endRow = aRows.stream() //
+                .filter(row -> covering(row.getBegin(), row.getEnd(), aEnd, aEnd)) //
                 .findFirst() //
                 .orElseThrow(() -> new IllegalArgumentException(
                         "End position of range [" + (aWindowBegin + aBegin) + "-"
@@ -369,11 +368,10 @@ public class BratSerializerImpl
             return asList(new Offsets(aBegin, aEnd));
         }
 
-        List<Offsets> coveredRows = aRows.subList(aRows.indexOf(beginRow),
-                aRows.indexOf(endRow) + 1);
+        var coveredRows = aRows.subList(aRows.indexOf(beginRow), aRows.indexOf(endRow) + 1);
 
-        List<Offsets> ranges = new ArrayList<>();
-        for (Offsets row : coveredRows) {
+        var ranges = new ArrayList<Offsets>();
+        for (var row : coveredRows) {
             Offsets range;
 
             if (row.getBegin() <= aBegin && aBegin < row.getEnd()) {
@@ -388,7 +386,9 @@ public class BratSerializerImpl
 
             trim(aText, range);
 
-            ranges.add(range);
+            if (!range.isEmpty()) {
+                ranges.add(range);
+            }
         }
 
         return ranges;
@@ -442,17 +442,22 @@ public class BratSerializerImpl
      */
     static private void trim(CharSequence aText, Offsets aOffsets)
     {
-        int begin = aOffsets.getBegin();
-        int end = aOffsets.getEnd() - 1;
+        if (aOffsets.getBegin() == aOffsets.getEnd()) {
+            // Nothing to do on empty spans
+            return;
+        }
 
-        // Remove whitespace at end
-        while ((end > 0) && trimChar(aText.charAt(end))) {
+        int begin = aOffsets.getBegin();
+        int end = aOffsets.getEnd();
+
+        // First we trim at the end. If a trimmed span is empty, we want to return the original
+        // begin as the begin/end of the trimmed span
+        while ((end > 0) && end > begin && trimChar(aText.charAt(end - 1))) {
             end--;
         }
-        end++;
 
-        // Remove whitespace at start
-        while ((begin < end) && trimChar(aText.charAt(begin))) {
+        // Then, trim at the start
+        while ((begin < (aText.length() - 1)) && begin < end && trimChar(aText.charAt(begin))) {
             begin++;
         }
 

--- a/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/render/model/Offsets.java
+++ b/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/render/model/Offsets.java
@@ -77,6 +77,11 @@ public class Offsets
         end = aEnd;
     }
 
+    public boolean isEmpty()
+    {
+        return end == begin;
+    }
+
     @Override
     public String toString()
     {

--- a/inception/inception-brat-editor/src/main/ts/src/BratEditor.ts
+++ b/inception/inception-brat-editor/src/main/ts/src/BratEditor.ts
@@ -29,6 +29,7 @@ export class BratEditor implements AnnotationEditor {
   dispatcher: Dispatcher
   visualizer: Visualizer
   resizer: ResizeManager
+  resizeObserver: ResizeObserver
   popover: AnnotationDetailPopOver
 
   public constructor (element: Element, ajax: DiamAjax, props: AnnotationEditorProperties) {
@@ -46,10 +47,11 @@ export class BratEditor implements AnnotationEditor {
     // Ensure that the visualizer is resized when the container element size changes, e.g. when
     // the sidebars are opened or closed.
     if (element.parentElement) {
-      new ResizeObserver(() => {
+      this.resizeObserver = new ResizeObserver(() => {
         // console.log(`resize: ${element.id} ${element.clientWidth} ${element.clientHeight}`)
         this.dispatcher.post('resize')
-      }).observe(element.parentElement)
+      })
+      this.resizeObserver.observe(element.parentElement)
     }
 
     this.resizer = new ResizeManager(this.dispatcher, this.visualizer, ajax)
@@ -78,8 +80,12 @@ export class BratEditor implements AnnotationEditor {
   }
 
   destroy (): void {
+    console.log("Destroying BratEditor")
     if (this.popover?.$destroy) {
       this.popover.$destroy()
+    }
+    if (this.resizeObserver) { 
+      this.resizeObserver.disconnect()
     }
   }
 }

--- a/inception/inception-brat-editor/src/main/ts/src/annotator_ui/ResizeManager.ts
+++ b/inception/inception-brat-editor/src/main/ts/src/annotator_ui/ResizeManager.ts
@@ -60,7 +60,19 @@ export class ResizeManager {
     this.hide()
 
     // Event handlers for the resizer component
-    this.visualizer.svgContainer.addEventListener('mouseover', e => this.showResizer(e))
+    this.showResizer = this.showResizer.bind(this)
+    this.visualizer.svgContainer.addEventListener('mouseover', this.showResizer)
+  }
+
+  public destroy() {
+    this.hide()
+    this.visualizer.svgContainer.removeEventListener('mouseover', this.showResizer)
+    if (this.beginHandle?.$destroy) {
+      this.beginHandle.$destroy()
+    }
+    if (this.endHandle?.$destroy) {
+      this.endHandle.$destroy()
+    }
   }
 
   private showResizer (event: Event): void {

--- a/inception/inception-brat-editor/src/main/ts/src/visualizer/Chunk.ts
+++ b/inception/inception-brat-editor/src/main/ts/src/visualizer/Chunk.ts
@@ -62,6 +62,7 @@ export class Chunk {
   lastSpace: string
   nextSpace: string
   sentence: number
+  virtual: boolean
   group: SVGTypeMapping<SVGGElement>
   highlightGroup: SVGTypeMapping<SVGGElement>
   markedTextStart: MarkerStart[] = []

--- a/inception/inception-brat-editor/src/main/ts/src/visualizer/Row.ts
+++ b/inception/inception-brat-editor/src/main/ts/src/visualizer/Row.ts
@@ -64,7 +64,12 @@ export class Row {
     // Object.seal(this)
   }
 
-  updateFragmentHeight () {
+  updateFragmentHeight (defaultHeight: number) {
+    if (this.chunks.length === 0) {
+      this.maxSpanHeight = defaultHeight
+      return
+    }
+
     for (const chunk of this.chunks) {
       for (const fragment of chunk.fragments) {
         if (this.maxSpanHeight < fragment.height) {

--- a/inception/inception-brat-editor/src/main/ts/src/visualizer/Visualizer.ts
+++ b/inception/inception-brat-editor/src/main/ts/src/visualizer/Visualizer.ts
@@ -281,7 +281,7 @@ export class Visualizer {
   }
 
   scrollTo (args: { offset: number, position?: string, pingRanges?: Offsets[] }): void {
-    const chunk = this.getChunkAtOffset(args.offset - (this.sourceData?.windowBegin || 0))
+    const chunk = this.findChunkClosestToOffset(args.offset - (this.sourceData?.windowBegin || 0))
 
     if (!chunk) {
       console.warn('Could not find chunk at offset', args.offset)
@@ -820,6 +820,17 @@ export class Visualizer {
     let chunk: Chunk
     const chunks : Chunk[] = []
 
+    for (const fragment of sortedFragments) {
+      if (fragment.span.id === 'rel:0-before') {
+        chunk = new Chunk(chunkNo++, '', fragment.from, fragment.to, '')
+        chunk.virtual = true
+        fragment.chunk = chunk
+        chunk.fragments.push(fragment)
+        chunks.push(chunk)
+        break;
+      }
+    }
+
     tokenOffsets.forEach(offset => {
       const from = offset[0]
       const to = offset[1]
@@ -827,7 +838,7 @@ export class Visualizer {
         firstFrom = from
       }
 
-      // Is the token end inside a span?
+      // Is the token end inside a span annotation / fragment?
       if (startFragmentId && to > sortedFragments[startFragmentId - 1].to) {
         while (startFragmentId < numFragments && to > sortedFragments[startFragmentId].from) {
           startFragmentId++
@@ -848,6 +859,7 @@ export class Visualizer {
       if (chunk) {
         chunk.nextSpace = space
       }
+
       //               (index,     text, from,      to, space) {
       chunk = new Chunk(chunkNo++, text, firstFrom, to, space)
       chunk.lastSpace = space
@@ -855,6 +867,17 @@ export class Visualizer {
       lastTo = to
       firstFrom = null
     })
+
+    for (const fragment of sortedFragments) {
+      if (fragment.span.id === 'rel:1-after') {
+        chunk = new Chunk(chunkNo++, '', fragment.from, fragment.to, '')
+        chunk.virtual = true
+        fragment.chunk = chunk
+        chunk.fragments.push(fragment)
+        chunks.push(chunk)
+        break;
+      }
+    }
 
     return chunks
   }
@@ -868,13 +891,10 @@ export class Visualizer {
     let chunkNo = 0
     let sentenceNo = firstSentence
 
-    for (const offset of sentenceOffsets) {
-      const from = offset[0]
-      const to = offset[1]
-
+    for (const [sentFrom, sentTo] of sentenceOffsets) {
       // Skip all chunks that belonged to the previous sentence
       let chunk : Chunk | undefined
-      while (chunkNo < numChunks && (chunk = chunks[chunkNo]).from < from) {
+      while (chunkNo < numChunks && (chunk = chunks[chunkNo]).from < sentFrom) {
         chunkNo++
       }
 
@@ -884,7 +904,7 @@ export class Visualizer {
       }
 
       // If the current chunk is not within the current sentence, then it was an empty sentence
-      if (chunks[chunkNo].from >= to) {
+      if (!covering(sentFrom, sentTo, chunks[chunkNo].from, chunks[chunkNo].to)) {
         sentenceNo++
         continue
       }
@@ -902,22 +922,19 @@ export class Visualizer {
       return
     }
 
-    let currentChunkId = 0
-    let chunk: Chunk
-    for (const fragment of sortedFragments) {
-      const span = fragment.span
+    // Avoid assigining fragments to virtual chunks link those created for rel:0-before and rel:1-after
+    chunks = chunks.filter(chunk => !chunk.virtual)
 
-      chunk = chunks[currentChunkId]
-      while (fragment.to > chunk.to) {
-        currentChunkId++
-        chunk = chunks[currentChunkId]
-        if (!chunk) {
-          // If the fragment is outside of the last chunk, create a new chunk because otherwise
-          // we won't be able to render relations towards the end of the viewport
-          chunk = new Chunk(currentChunkId, '', fragment.from, fragment.to, '')
-          chunks.push(chunk)
-          break
-        }
+    for (const fragment of sortedFragments) {
+      // The before and after fragments have already been assigned to their own chunks in 
+      // buildChunksFromTokenOffsets
+      if (fragment.span.id === 'rel:0-before' || fragment.span.id === 'rel:1-after') continue
+
+      let chunk = chunks.find(c => overlapping(c.from, c.to, fragment.from, fragment.to));
+
+      if (!chunk) {
+        console.warn('Could not find chunk for fragment', fragment);
+        continue
       }
 
       chunk.fragments.push(fragment)
@@ -999,7 +1016,7 @@ export class Visualizer {
     const triggerHash = this.buildSpansFromTriggers(this.sourceData.triggers)
     this.buildEventDescsFromTriggers(this.data, this.sourceData, triggerHash)
 
-    // split spans into span fragments (for discontinuous spans)
+    // split span annotations into span fragments (for discontinuous spans)
     this.splitSpansIntoFragments(Object.values(this.data.spans))
     this.buildEventDescsFromEquivs(this.sourceData.equivs, this.data.spans, this.data.eventDescs)
     this.buildEventDescsFromRelations(this.sourceData.relations, this.data.eventDescs)
@@ -1256,6 +1273,9 @@ export class Visualizer {
       }
     }
 
+    // Add dummy element used only to get the text height even if we have no chunks
+    this.svg.plain("TEXT").addTo(textMeasureGroup)
+
     const bbox = textMeasureGroup.bbox()
     textMeasureGroup.remove()
 
@@ -1489,16 +1509,22 @@ export class Visualizer {
   }
 
   private calculateSubstringWidthFast (text: SVGTextContentElement, firstChar: number, lastChar: number) {
-    let startPos: number
-    if (firstChar < text.getNumberOfChars()) {
-      startPos = text.getStartPositionOfChar(firstChar).x
-    } else {
-      startPos = text.getComputedTextLength()
+    try {
+{      let startPos: number
+      if (firstChar < text.getNumberOfChars()) {
+        startPos = text.getStartPositionOfChar(firstChar).x
+      } else {
+        startPos = text.getComputedTextLength()
+      }
+      const endPos = (lastChar < firstChar)
+        ? startPos
+        : text.getEndPositionOfChar(lastChar).x
+      return [startPos, endPos]
+}    }
+    catch (e) {
+      console.error(`Unable to calculate width of range ${firstChar}-${lastChar} on [${text}]`, e)
+      return [0, 0]
     }
-    const endPos = (lastChar < firstChar)
-      ? startPos
-      : text.getEndPositionOfChar(lastChar).x
-    return [startPos, endPos]
   }
 
   /**
@@ -1809,9 +1835,10 @@ export class Visualizer {
       let chunkTo = 0
       let chunkHeight = 0
       let spacing = 0
-      let spacingChunkId: number
+      let spacingChunkId: number | undefined = undefined
       let spacingRowBreak = 0
 
+      // Render the fragments for the current chunk
       chunk.fragments.forEach(fragment => {
         const span = fragment.span
 
@@ -2007,7 +2034,7 @@ export class Visualizer {
       // If chunkFrom becomes negative (LTR) or chunkTo becomes positive (RTL), then boxX becomes positive
       const boxX = this.rtlmode ? chunkTo : -Math.min(chunkFrom, 0)
 
-      let boxWidth
+      let boxWidth : number
       if (this.rtlmode) {
         boxWidth = Math.max(textWidth, -chunkFrom) - Math.min(0, -chunkTo)
       } else {
@@ -2042,7 +2069,7 @@ export class Visualizer {
         // row is added
       }
 
-      let chunkDoesNotFit
+      let chunkDoesNotFit : boolean
       if (this.rtlmode) {
         chunkDoesNotFit = currentX - boxWidth - leftBorderForArcs <=
           2 * Configuration.visual.margin.x
@@ -2051,13 +2078,14 @@ export class Visualizer {
           this.canvasWidth - 2 * Configuration.visual.margin.x
       }
 
+      // Check if a new row needs to be started and if so start it
       if (chunk.sentence > sourceData.sentence_number_offset || chunkDoesNotFit) {
         // the chunk does not fit
         row.arcs = this.svg.group().addTo(row.group).addClass('arcs')
         let indent = 0
         if (chunk.lastSpace) {
           const spaceLen = chunk.lastSpace.length || 0
-          let spacePos
+          let spacePos : number
           if (chunk.sentence) {
             // If this is line-initial spacing, fetch the sentence to which the chunk belongs
             // so we can determine where it begins
@@ -2095,23 +2123,24 @@ export class Visualizer {
           spacing = 0 // do not center intervening elements
         }
 
-        // new row
+        // Finish up current row
         rows.push(row)
-
         chunk.group.remove()
+
+        // Start new row
         row = new Row(this.svg)
-        // Change row background color if a new sentence is starting
         if (chunk.sentence) {
+          // Change row background color if a new sentence is starting
           sentenceToggle = 1 - sentenceToggle
         }
         row.backgroundIndex = sentenceToggle
         row.index = ++rowIndex
         chunk.group.addTo(row.group)
         chunk.group = SVG(row.group.node.lastElementChild as SVGGElement)
-        $(chunk.group).children("g[class='span']").each((index, element) => {
+        chunk.group.node.querySelectorAll("g.span").forEach((element, index) => {
           chunk.fragments[index].group = SVG(element as SVGGElement)
         })
-        $(chunk.group).find('rect[data-span-id]').each((index, element) => {
+        chunk.group.node.querySelectorAll('rect[data-span-id]').forEach((element, index) => {
           chunk.fragments[index].rect = SVG(element as SVGElement)
         })
       }
@@ -2155,8 +2184,8 @@ export class Visualizer {
         row.sentence = ++sentenceNumber
       }
 
-      if (spacing > 0) {
-        // if we added a gap, center the intervening elements
+      // if we added a gap, center the intervening elements
+      if (spacing > 0 && spacingChunkId !== undefined) {
         spacing /= 2
         const firstChunkInRow = row.chunks[row.chunks.length - 1]
         if (firstChunkInRow === undefined) {
@@ -2173,6 +2202,7 @@ export class Visualizer {
         }
       }
 
+      // Assign chunk to row
       row.chunks.push(chunk)
       chunk.row = row
 
@@ -2359,7 +2389,7 @@ export class Visualizer {
 
         for (let i = 0; i < chunk.fragments.length; i++) {
           const fragment = chunk.fragments[orderedIdx[i]]
-          if (fragment.span.hidden) {
+          if (fragment.span.hidden || fragment.span.id === "rel:0-before" || fragment.span.id === "rel:1-after") {
             continue
           }
 
@@ -3097,7 +3127,7 @@ export class Visualizer {
     let currentSent = 0
     for (const row of rows) {
       // find the maximum fragment height
-      row.updateFragmentHeight()
+      row.updateFragmentHeight(docData.sizes.texts.height)
       row.updateRowBoxHeight(this.rowSpacing, this.rowPadding)
 
       if (row.sentence) {
@@ -4142,8 +4172,28 @@ export class Visualizer {
       .addTo(fragment.group)
   }
 
-  getChunkAtOffset (offset: number) : Chunk | null {
-    return this.data?.chunks?.find(chunk => chunk.from <= offset && offset < chunk.to) || null
+  findChunkClosestToOffset (offset: number) : Chunk | null {
+    let closestChunk : Chunk | null = null
+    let closestNonVirtualChunk : Chunk | null = null
+    let minDiff = Infinity
+    let nonVirtualMinDiff = Infinity
+    for (const chunk of this.data?.chunks || []) {
+      const diff = Math.min(Math.abs(chunk.from - offset), Math.abs(chunk.to - offset))
+
+      if (!chunk.virtual && diff < nonVirtualMinDiff) {
+        closestNonVirtualChunk = chunk
+        nonVirtualMinDiff = diff
+      }
+
+      if (diff < minDiff) {
+        closestChunk = chunk
+        minDiff = diff
+      }
+    }
+
+    // Try to return a non-virtual chunk because we can highlight that with a ping.
+    // Only if no non-virtual chunk is found, return the closest chunk.
+    return closestNonVirtualChunk || closestChunk;
   }
 
   getChunkElementWithId (id: VID): Element | null {
@@ -4399,4 +4449,12 @@ function sentenceSplit (text: string): Array<Offsets> {
   }
 
   return sentenceOffsets
+}
+
+function overlapping(aXBegin: number, aXEnd: number, aYBegin: number, aYEnd: number): boolean {
+  return aYBegin === aXBegin || aYEnd === aXEnd || (aXBegin < aYEnd && aYBegin < aXEnd);
+} 
+
+function covering(aXBegin: number, aXEnd: number, aYBegin: number, aYEnd: number): boolean {
+  return aXBegin <= aYBegin && aYEnd <= aXEnd;
 }

--- a/inception/inception-model-vdoc/src/main/java/de/tudarmstadt/ukp/inception/rendering/vmodel/VRange.java
+++ b/inception/inception-model-vdoc/src/main/java/de/tudarmstadt/ukp/inception/rendering/vmodel/VRange.java
@@ -21,6 +21,7 @@ import java.io.Serializable;
 import java.util.Optional;
 
 import org.apache.uima.cas.text.AnnotationFS;
+import org.apache.uima.cas.text.AnnotationPredicates;
 
 import de.tudarmstadt.ukp.inception.support.annotation.OffsetSpan;
 
@@ -131,7 +132,7 @@ public class VRange
             int aEnd)
     {
         // Range is fully outside the viewport.
-        if (aEnd < aViewportBegin || aBegin > aViewPortEnd) {
+        if (!AnnotationPredicates.overlapping(aViewportBegin, aViewPortEnd, aBegin, aEnd)) {
             return Optional.empty();
         }
 


### PR DESCRIPTION
**What's in the PR**
- Create a virtual chunk at the end of the viewport if necessary to avoid the brat rendering process crashing later because the end-of-page fragment `rel:1-after` cannot be assigned to a chunk
- Fix span clipping in the backend

**How to test manually**
* See issue description
* In general, view documents with (long) spans and relations in brat mode

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
