### PR TITLE
#4727 - Switching between editors can cause the old and the new editors to be loaded and initialized

### DIFF
--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPage.java
@@ -450,7 +450,20 @@ public class AnnotationPage
 
             LOG.trace("Preparing to open document {}@{} {}", state.getUser(), state.getDocument(),
                     aFocus);
+
+            // Load constraints
+            state.setConstraints(constraintsService.getMergedConstraints(state.getProject()));
+
+            // Load user preferences
+            loadPreferences();
+
+            // Set the actual editor component. This has to happen *before* any AJAX refreshes are
+            // scheduled and *after* the preferences have been loaded (because the current editor
+            // type is set in the preferences.
+            createAnnotationEditor();
+
             state.reset();
+
             applicationEventPublisherHolder.get().publishEvent(
                     new PreparingToOpenDocumentEvent(this, getModelObject().getDocument(),
                             getModelObject().getUser().getUsername(), sessionOwnerName));
@@ -498,22 +511,12 @@ public class AnnotationPage
                 bumpAnnotationCasTimestamp(state);
             }
 
-            // Load constraints
-            state.setConstraints(constraintsService.getMergedConstraints(state.getProject()));
-
-            // Load user preferences
-            loadPreferences();
-
             // if project is changed, reset some project specific settings
             if (currentProjectId != state.getProject().getId()) {
                 state.clearRememberedFeatures();
                 currentProjectId = state.getProject().getId();
             }
 
-            // Set the actual editor component. This has to happen *before* any AJAX refreshes are
-            // scheduled and *after* the preferences have been loaded (because the current editor
-            // type is set in the preferences.
-            createAnnotationEditor();
             actionBar.refresh();
 
             // update paging, only do it during document load so we load the CAS after it has been


### PR DESCRIPTION
**What's in the PR**
- Ensure that the proper editor has been created before clearing the state which then triggers a selection-change event that the editor reacts to

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
