### PR TITLE
#4892 - Curation sidebar state not cleared when logging out

### DIFF
--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
@@ -1045,8 +1045,9 @@ public class RecommendationServiceImpl
         }
     }
 
-    @EventListener
+    // Set order so this is handled before session info is removed from sessionRegistry
     @Order(Ordered.HIGHEST_PRECEDENCE)
+    @EventListener
     public void onSessionDestroyed(SessionDestroyedEvent event)
     {
         var info = sessionRegistry.getSessionInformation(event.getId());

--- a/inception/inception-scheduling/src/main/java/de/tudarmstadt/ukp/inception/scheduling/SchedulingServiceImpl.java
+++ b/inception/inception-scheduling/src/main/java/de/tudarmstadt/ukp/inception/scheduling/SchedulingServiceImpl.java
@@ -442,8 +442,9 @@ public class SchedulingServiceImpl
         deletionPending.remove(aEvent.getProject());
     }
 
-    @EventListener
+    // Set order so this is handled before session info is removed from sessionRegistry
     @Order(Ordered.HIGHEST_PRECEDENCE)
+    @EventListener
     public void onSessionDestroyed(SessionDestroyedEvent event)
     {
         LOG.debug("Cleaning up tasks on session destroyed");


### PR DESCRIPTION
**What's in the PR**
- Ensure the curation sidebar service reacts to the logout before the session information is cleared from the registry

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
