### PR TITLE
#4896 - Ability to search for additional languages in knowledge-base

### DIFF
--- a/inception/inception-kb/pom.xml
+++ b/inception/inception-kb/pom.xml
@@ -200,6 +200,10 @@
 
     <dependency>
       <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
     </dependency>
     <dependency>
@@ -332,11 +336,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
       <scope>test</scope>
@@ -354,6 +353,10 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
           <configuration>
+            <ignoredDependencies>
+              <!-- Maven does not recognize it -->
+              <usedDependency>org.springframework:spring-core</usedDependency>
+            </ignoredDependencies>
             <usedDependencies>
               <!-- OWLAPI plugins - used via reflection -->
               <usedDependency>net.sourceforge.owlapi:owlapi-impl</usedDependency>

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/config/KnowledgeBaseProperties.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/config/KnowledgeBaseProperties.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.inception.kb.config;
 
 import java.time.Duration;
+import java.util.List;
 
 public interface KnowledgeBaseProperties
 {
@@ -54,4 +55,6 @@ public interface KnowledgeBaseProperties
     Duration getRenderCacheExpireDelay();
 
     long getRenderCacheSize();
+
+    List<String> getDefaultFallbackLanguages();
 }

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/config/KnowledgeBasePropertiesImpl.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/config/KnowledgeBasePropertiesImpl.java
@@ -19,8 +19,10 @@ package de.tudarmstadt.ukp.inception.kb.config;
 
 import static java.time.Duration.ofMinutes;
 import static java.time.temporal.ChronoUnit.MINUTES;
+import static java.util.Collections.emptyList;
 
 import java.time.Duration;
+import java.util.List;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.convert.DurationUnit;
@@ -51,7 +53,9 @@ public class KnowledgeBasePropertiesImpl
     private @DurationUnit(MINUTES) Duration renderCacheExpireDelay = ofMinutes(10);
     private @DurationUnit(MINUTES) Duration renderCacheRefreshDelay = ofMinutes(1);
 
-    public void setInternalFtsMaxResultsFactor(double aFtsMaxResultsFactor)
+    private List<String> defaultFallbackLanguages = emptyList();
+
+    public void setFtsInternalMaxResultsFactor(double aFtsMaxResultsFactor)
     {
         ftsInternalMaxResultsFactor = aFtsMaxResultsFactor;
     }
@@ -159,5 +163,16 @@ public class KnowledgeBasePropertiesImpl
     public void setRenderCacheRefreshDelay(Duration aRenderCacheRefreshDelay)
     {
         renderCacheRefreshDelay = aRenderCacheRefreshDelay;
+    }
+
+    @Override
+    public List<String> getDefaultFallbackLanguages()
+    {
+        return defaultFallbackLanguages;
+    }
+
+    public void setDefaultFallbackLanguages(List<String> aDefaultFallbackLanguages)
+    {
+        defaultFallbackLanguages = aDefaultFallbackLanguages;
     }
 }

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterAllegroGraph.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterAllegroGraph.java
@@ -21,6 +21,7 @@ import static de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilder.co
 import static de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilder.convertToRequiredTokenPrefixMatchingQuery;
 import static de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilder.Priority.PRIMARY;
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions.and;
 import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.prefix;
 import static org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns.and;
 import static org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns.union;
@@ -28,6 +29,7 @@ import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
 
 import java.util.ArrayList;
 
+import org.eclipse.rdf4j.sparqlbuilder.constraint.Expression;
 import org.eclipse.rdf4j.sparqlbuilder.core.Prefix;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPattern;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
@@ -101,8 +103,12 @@ public class FtsAdapterAllegroGraph
 
             builder.addProjection(VAR_SCORE);
 
+            var labelFilterExpressions = new ArrayList<Expression<?>>();
+            labelFilterExpressions.add(builder.matchKbLanguage(VAR_MATCH_TERM));
+
             valuePatterns.add(new AllegroGraphFtsQuery(VAR_SUBJECT, VAR_SCORE, VAR_MATCH_TERM,
-                    VAR_MATCH_TERM_PROPERTY, query));
+                    VAR_MATCH_TERM_PROPERTY, query)
+                            .filter(and(labelFilterExpressions.toArray(Expression[]::new))));
         }
 
         if (valuePatterns.isEmpty()) {
@@ -134,13 +140,17 @@ public class FtsAdapterAllegroGraph
 
         builder.addProjection(VAR_SCORE);
 
+        var labelFilterExpressions = new ArrayList<Expression<?>>();
+        labelFilterExpressions.add(builder.startsWithPattern(VAR_MATCH_TERM, aPrefixQuery));
+        labelFilterExpressions.add(builder.matchKbLanguage(VAR_MATCH_TERM));
+
         // Locate all entries where the label contains the prefix (using the FTS) and then
         // filter them by those which actually start with the prefix.
         builder.addPattern(PRIMARY, and( //
                 builder.bindMatchTermProperties(VAR_MATCH_TERM_PROPERTY), //
                 new AllegroGraphFtsQuery(VAR_SUBJECT, VAR_SCORE, VAR_MATCH_TERM,
                         VAR_MATCH_TERM_PROPERTY, queryString) //
-                                .filter(builder.startsWithPattern(VAR_MATCH_TERM, aPrefixQuery))));
+                                .filter(and(labelFilterExpressions.toArray(Expression[]::new)))));
     }
 
     @Override
@@ -164,8 +174,12 @@ public class FtsAdapterAllegroGraph
 
             builder.addProjection(VAR_SCORE);
 
+            var labelFilterExpressions = new ArrayList<Expression<?>>();
+            labelFilterExpressions.add(builder.matchKbLanguage(VAR_MATCH_TERM));
+
             valuePatterns.add(new AllegroGraphFtsQuery(VAR_SUBJECT, VAR_SCORE, VAR_MATCH_TERM,
-                    VAR_MATCH_TERM_PROPERTY, query));
+                    VAR_MATCH_TERM_PROPERTY, query) //
+                            .filter(and(labelFilterExpressions.toArray(Expression[]::new))));
         }
 
         if (valuePatterns.isEmpty()) {

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterBlazegraph.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterBlazegraph.java
@@ -21,6 +21,7 @@ import static de.tudarmstadt.ukp.inception.kb.IriConstants.PREFIX_BLAZEGRAPH;
 import static de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilder.convertToRequiredTokenPrefixMatchingQuery;
 import static de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilder.Priority.PRIMARY;
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions.and;
 import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.prefix;
 import static org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns.and;
 import static org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns.union;
@@ -28,6 +29,7 @@ import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
 
 import java.util.ArrayList;
 
+import org.eclipse.rdf4j.sparqlbuilder.constraint.Expression;
 import org.eclipse.rdf4j.sparqlbuilder.core.Prefix;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPattern;
 
@@ -159,10 +161,14 @@ public class FtsAdapterBlazegraph
 
             builder.addProjection(SPARQLQueryBuilder.VAR_SCORE);
 
+            var labelFilterExpressions = new ArrayList<Expression<?>>();
+            labelFilterExpressions.add(builder.matchKbLanguage(VAR_MATCH_TERM));
+
             valuePatterns.add(new BlazegraphFtsQuery(SPARQLQueryBuilder.VAR_SUBJECT,
                     SPARQLQueryBuilder.VAR_SCORE, SPARQLQueryBuilder.VAR_MATCH_TERM,
-                    SPARQLQueryBuilder.VAR_MATCH_TERM_PROPERTY, fuzzyQuery)
-                            .withLimit(builder.getLimit()));
+                    SPARQLQueryBuilder.VAR_MATCH_TERM_PROPERTY, fuzzyQuery) //
+                            .withLimit(builder.getLimit()) //
+                            .filter(and(labelFilterExpressions.toArray(Expression[]::new))));
         }
 
         if (valuePatterns.isEmpty()) {

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterFuseki.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterFuseki.java
@@ -20,6 +20,7 @@ package de.tudarmstadt.ukp.inception.kb.querybuilder;
 import static de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilder.convertToRequiredTokenPrefixMatchingQuery;
 import static de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilder.Priority.PRIMARY;
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions.and;
 import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.prefix;
 import static org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns.and;
 import static org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns.union;
@@ -27,6 +28,7 @@ import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
 
 import java.util.ArrayList;
 
+import org.eclipse.rdf4j.sparqlbuilder.constraint.Expression;
 import org.eclipse.rdf4j.sparqlbuilder.core.Prefix;
 import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPattern;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
@@ -160,15 +162,21 @@ public class FtsAdapterFuseki
 
             builder.addProjection(VAR_SCORE);
 
+            var labelFilterExpressions = new ArrayList<Expression<?>>();
+            labelFilterExpressions.add(builder.matchKbLanguage(VAR_MATCH_TERM));
+
             valuePatterns.add(new FusekiFtsQuery(VAR_SUBJECT, VAR_SCORE, VAR_MATCH_TERM,
-                    VAR_MATCH_TERM_PROPERTY, fuzzyQuery).withLimit(builder.getLimit()));
+                    VAR_MATCH_TERM_PROPERTY, fuzzyQuery) //
+                            .withLimit(builder.getLimit()) //
+                            .filter(and(labelFilterExpressions.toArray(Expression[]::new))));
         }
 
         if (valuePatterns.isEmpty()) {
             builder.noResult();
         }
 
-        builder.addPattern(PRIMARY, and(builder.bindMatchTermProperties(VAR_MATCH_TERM_PROPERTY),
+        builder.addPattern(PRIMARY, and( //
+                builder.bindMatchTermProperties(VAR_MATCH_TERM_PROPERTY),
                 union(valuePatterns.toArray(GraphPattern[]::new))));
     }
 }

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterRdf4J.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterRdf4J.java
@@ -79,7 +79,6 @@ public class FtsAdapterRdf4J
 
         var valuePatterns = new ArrayList<GraphPattern>();
         for (var value : aValues) {
-            // Strip single quotes and asterisks because they have special semantics
             var sanitizedValue = builder.sanitizeQueryString_FTS(value);
 
             if (isBlank(sanitizedValue)) {

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterWikidata.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterWikidata.java
@@ -29,6 +29,7 @@ import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPattern;
 public class FtsAdapterWikidata
     implements FtsAdapter
 {
+    private static final String FALLBACK_LANGUAGE = "en";
     private final SPARQLQueryBuilder builder;
 
     public FtsAdapterWikidata(SPARQLQueryBuilder aBuilder)
@@ -43,7 +44,8 @@ public class FtsAdapterWikidata
 
         // In our KB settings, the language can be unset, but the Wikidata entity search
         // requires a preferred language. So we use English as the default.
-        var language = kb.getDefaultLanguage() != null ? kb.getDefaultLanguage() : "en";
+        var language = kb.getDefaultLanguage() != null ? kb.getDefaultLanguage()
+                : FALLBACK_LANGUAGE;
 
         var valuePatterns = new ArrayList<GraphPattern>();
         for (var value : aValues) {
@@ -74,7 +76,8 @@ public class FtsAdapterWikidata
 
         // In our KB settings, the language can be unset, but the Wikidata entity search
         // requires a preferred language. So we use English as the default.
-        var language = kb.getDefaultLanguage() != null ? kb.getDefaultLanguage() : "en";
+        var language = kb.getDefaultLanguage() != null ? kb.getDefaultLanguage()
+                : FALLBACK_LANGUAGE;
 
         var valuePatterns = new ArrayList<GraphPattern>();
         for (var value : aValues) {
@@ -105,7 +108,8 @@ public class FtsAdapterWikidata
 
         // In our KB settings, the language can be unset, but the Wikidata entity search
         // requires a preferred language. So we use English as the default.
-        var language = kb.getDefaultLanguage() != null ? kb.getDefaultLanguage() : "en";
+        var language = kb.getDefaultLanguage() != null ? kb.getDefaultLanguage()
+                : FALLBACK_LANGUAGE;
 
         if (aPrefixQuery.isEmpty()) {
             builder.noResult();
@@ -127,7 +131,8 @@ public class FtsAdapterWikidata
 
         // In our KB settings, the language can be unset, but the Wikidata entity search
         // requires a preferred language. So we use English as the default.
-        var language = kb.getDefaultLanguage() != null ? kb.getDefaultLanguage() : "en";
+        var language = kb.getDefaultLanguage() != null ? kb.getDefaultLanguage()
+                : FALLBACK_LANGUAGE;
 
         var valuePatterns = new ArrayList<GraphPattern>();
         for (var value : aValues) {

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryPrimaryConditions.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryPrimaryConditions.java
@@ -17,6 +17,8 @@
  */
 package de.tudarmstadt.ukp.inception.kb.querybuilder;
 
+import java.util.Collection;
+
 public interface SPARQLQueryPrimaryConditions
     extends SPARQLQuery, SPARQLQueryOptionalElements
 {
@@ -158,4 +160,7 @@ public interface SPARQLQueryPrimaryConditions
      */
     SPARQLQueryPrimaryConditions matchingDomain(String aItemIri);
 
+    SPARQLQueryPrimaryConditions withFallbackLanguages(String... aLanguages);
+
+    SPARQLQueryPrimaryConditions withFallbackLanguages(Collection<String> aString);
 }

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplIntegrationTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplIntegrationTest.java
@@ -1610,7 +1610,6 @@ public class KnowledgeBaseServiceImplIntegrationTest
     public void getConceptRoots_WithWildlifeOntologyAndExplicityDefinedConcepts_ShouldReturnRootConcepts(
             Reification reification)
         throws Exception
-
     {
         setUp(reification);
 
@@ -1623,8 +1622,7 @@ public class KnowledgeBaseServiceImplIntegrationTest
         importKnowledgeBase("data/wildlife_ontology.ttl");
         setSchema(kb, OWL.CLASS, RDFS.SUBCLASSOF, RDF.TYPE, RDFS.COMMENT, RDFS.LABEL, RDF.PROPERTY);
 
-        Stream<String> rootConcepts = sut.listRootConcepts(kb, false).stream()
-                .map(KBHandle::getName);
+        var rootConcepts = sut.listRootConcepts(kb, false).stream().map(KBHandle::getName);
 
         String[] expectedLabels = { "Animal Intelligence", "Ecozone" };
         assertThat(rootConcepts).as("Check that all root concepts have been found")
@@ -1824,8 +1822,8 @@ public class KnowledgeBaseServiceImplIntegrationTest
     {
         setUp(reification);
 
-        KBInstance germanInstance = buildInstanceWithLanguage("de");
-        KBInstance englishInstance = buildInstanceWithLanguage("en");
+        var germanInstance = buildInstanceWithLanguage("de");
+        var englishInstance = buildInstanceWithLanguage("en");
 
         kb.setDefaultLanguage("en");
         sut.registerKnowledgeBase(kb, sut.getNativeConfig());
@@ -1837,8 +1835,9 @@ public class KnowledgeBaseServiceImplIntegrationTest
             englishInstance.write(conn, kb);
         });
 
-        KBInstance firstInstance = sut.readInstance(kb, germanInstance.getIdentifier()).get();
-        assertThat(firstInstance.getLanguage()).as("Check that the English instance is retrieved.")
+        var firstInstance = sut.readInstance(kb, germanInstance.getIdentifier()).get();
+        assertThat(firstInstance.getLanguage()) //
+                .as("Check that the English instance is retrieved.") //
                 .isEqualTo("en");
     }
 

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FusekiRepositoryTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FusekiRepositoryTest.java
@@ -33,11 +33,9 @@ import org.apache.jena.fuseki.main.FusekiServer;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.query.text.EntityDefinition;
 import org.apache.jena.query.text.TextDatasetFactory;
-import org.apache.jena.query.text.TextIndex;
 import org.apache.jena.query.text.TextIndexConfig;
 import org.apache.jena.query.text.TextIndexLucene;
 import org.apache.jena.tdb.TDBFactory;
-import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.MMapDirectory;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
@@ -130,15 +128,15 @@ public class FusekiRepositoryTest
      */
     Dataset createFusekiFTSDataset() throws IOException
     {
-        Dataset ds1 = TDBFactory.createDataset();
-        Directory dir = new MMapDirectory(temp);
-        EntityDefinition eDef = new EntityDefinition("iri", "text");
+        var ds1 = TDBFactory.createDataset();
+        var dir = new MMapDirectory(temp);
+        var eDef = new EntityDefinition("iri", "text");
         eDef.setPrimaryPredicate(org.apache.jena.vocabulary.RDFS.label);
-        TextIndexConfig tidxCfg = new TextIndexConfig(eDef);
+        var tidxCfg = new TextIndexConfig(eDef);
         tidxCfg.setValueStored(true);
         tidxCfg.setMultilingualSupport(true);
-        TextIndex tidx = new TextIndexLucene(dir, tidxCfg);
-        Dataset ds = TextDatasetFactory.create(ds1, tidx);
+        var tidx = new TextIndexLucene(dir, tidxCfg);
+        var ds = TextDatasetFactory.create(ds1, tidx);
         return ds;
     }
 }

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/RepositoryTestSuite.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/RepositoryTestSuite.java
@@ -22,6 +22,7 @@ import org.junit.platform.suite.api.Suite;
 
 @Suite
 @SelectClasses({ //
+        AllegroGraphRepositoryTest.class, //
         BlazegraphRepositoryTest.class, //
         FusekiRepositoryTest.class, //
         Rdf4JRepositoryTest.class, //

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderLocalTestScenarios.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderLocalTestScenarios.java
@@ -174,35 +174,35 @@ public class SPARQLQueryBuilderLocalTestScenarios
             "    <#implicit-property-1> 'value1' .");
 
     static final String DATA_DEPRECATED = """
-            <#class-1>
-                rdf:type rdfs:Class ;
-                rdfs:label 'Class 1' ;
-                owl:deprecated true .
-            <#class-2>
-                rdf:type rdfs:Class ;
-                rdfs:label 'Class 2' ;
-                owl:deprecated false .
-            <#class-3>
-                rdf:type rdfs:Class ;
-                rdfs:label 'Class 3' ;
-                owl:deprecated 'lala' .
-            <#class-4>
-                rdf:type rdfs:Class ;
-                rdfs:label 'Class 4' ;
-                owl:deprecated 0 .
-            <#class-5>
-                rdf:type rdfs:Class ;
-                rdfs:label 'Class 5' ;
-                owl:deprecated 1 .
-            <#instance-1>
-                rdf:type <#class-1> ;
-                rdfs:label 'Instance 1' ;
-                owl:deprecated true .
-            <#property-1>
-                rdf:type rdf:Property ;
-                rdfs:label 'Property 1' ;
-                owl:deprecated true .
-            """;
+                                          <#class-1>
+                                              rdf:type rdfs:Class ;
+                                              rdfs:label 'Class 1' ;
+                                              owl:deprecated true .
+                                          <#class-2>
+                                              rdf:type rdfs:Class ;
+                                              rdfs:label 'Class 2' ;
+                                              owl:deprecated false .
+                                          <#class-3>
+                                              rdf:type rdfs:Class ;
+                                              rdfs:label 'Class 3' ;
+                                              owl:deprecated 'lala' .
+                                          <#class-4>
+                                              rdf:type rdfs:Class ;
+                                              rdfs:label 'Class 4' ;
+                                              owl:deprecated 0 .
+                                          <#class-5>
+                                              rdf:type rdfs:Class ;
+                                              rdfs:label 'Class 5' ;
+                                              owl:deprecated 1 .
+                                          <#instance-1>
+                                              rdf:type <#class-1> ;
+                                              rdfs:label 'Instance 1' ;
+                                              owl:deprecated true .
+                                          <#property-1>
+                                              rdf:type rdf:Property ;
+                                              rdfs:label 'Property 1' ;
+                                              owl:deprecated true .
+                                          """;
 
     private KnowledgeBase kb;
 
@@ -255,6 +255,8 @@ public class SPARQLQueryBuilderLocalTestScenarios
                         SPARQLQueryBuilderLocalTestScenarios::thatRootsCanBeRetrieved_ontolex),
                 new Scenario("testWithLabelContainingAnyOf_withLanguage_noFTS",
                         SPARQLQueryBuilderLocalTestScenarios::testWithLabelContainingAnyOf_withLanguage_noFTS),
+                new Scenario("testWithLabelMatchingAnyOf_withFallbackLanguages",
+                        SPARQLQueryBuilderLocalTestScenarios::testWithLabelMatchingAnyOf_withFallbackLanguages),
                 new Scenario("testWithLabelContainingAnyOf_withLanguage",
                         SPARQLQueryBuilderLocalTestScenarios::testWithLabelContainingAnyOf_withLanguage),
                 new Scenario("testWithLabelMatchingAnyOf_withLanguage",
@@ -384,7 +386,7 @@ public class SPARQLQueryBuilderLocalTestScenarios
     {
         importDataFromString(aRepository, aKB, TURTLE, TURTLE_PREFIX, DATA_CLASS_RDFS_HIERARCHY);
 
-        boolean result = exists(aRepository, SPARQLQueryBuilder.forClasses(aKB));
+        var result = exists(aRepository, SPARQLQueryBuilder.forClasses(aKB));
 
         assertThat(result).isTrue();
     }
@@ -458,7 +460,7 @@ public class SPARQLQueryBuilderLocalTestScenarios
     {
         importDataFromString(aRepository, aKB, TURTLE, TURTLE_PREFIX, DATA_MULTIPLE_LABELS);
 
-        for (String term : asList("specimen", "sample", "instance", "case")) {
+        for (var term : asList("specimen", "sample", "instance", "case")) {
             var results = asHandles(aRepository, SPARQLQueryBuilder //
                     .forItems(aKB) //
                     .withLabelMatchingAnyOf(term) //
@@ -545,7 +547,7 @@ public class SPARQLQueryBuilderLocalTestScenarios
     {
         importDataFromString(aRepository, aKB, TURTLE, TURTLE_PREFIX, DATA_CLASS_RDFS_HIERARCHY);
 
-        boolean result = exists(aRepository,
+        var result = exists(aRepository,
                 SPARQLQueryBuilder.forClasses(aKB).parentsOf("http://example.org/#explicitRoot"));
 
         assertThat(result).isFalse();
@@ -563,7 +565,7 @@ public class SPARQLQueryBuilderLocalTestScenarios
     {
         importDataFromString(aRepository, aKB, TURTLE, TURTLE_PREFIX, DATA_CLASS_RDFS_HIERARCHY);
 
-        boolean result = exists(aRepository, SPARQLQueryBuilder.forClasses(aKB)
+        var result = exists(aRepository, SPARQLQueryBuilder.forClasses(aKB)
                 .withIdentifier("http://example.org/#explicitRoot"));
 
         assertThat(result).isTrue();
@@ -581,7 +583,7 @@ public class SPARQLQueryBuilderLocalTestScenarios
     {
         importDataFromString(aRepository, aKB, TURTLE, TURTLE_PREFIX, DATA_CLASS_RDFS_HIERARCHY);
 
-        boolean result = exists(aRepository, SPARQLQueryBuilder.forClasses(aKB)
+        var result = exists(aRepository, SPARQLQueryBuilder.forClasses(aKB)
                 .withIdentifier("http://example.org/#implicitRoot"));
 
         assertThat(result).isTrue();
@@ -600,7 +602,7 @@ public class SPARQLQueryBuilderLocalTestScenarios
     {
         importDataFromString(aRepository, aKB, TURTLE, TURTLE_PREFIX, DATA_CLASS_RDFS_HIERARCHY);
 
-        boolean result = exists(aRepository, SPARQLQueryBuilder.forClasses(aKB)
+        var result = exists(aRepository, SPARQLQueryBuilder.forClasses(aKB)
                 .withIdentifier("http://example.org/#DoesNotExist"));
 
         assertThat(result).isFalse();
@@ -1011,10 +1013,13 @@ public class SPARQLQueryBuilderLocalTestScenarios
         assertThat(results).extracting(KBHandle::getUiLabel)
                 .allMatch(label -> label.contains("Goblin"));
         assertThat(results).extracting(KBHandle::getIdentifier).doesNotHaveDuplicates();
-        assertThat(results).usingRecursiveFieldByFieldElementComparatorOnFields("identifier",
-                "name", "language").containsExactlyInAnyOrder(
-                        new KBHandle("http://example.org/#red-goblin", "Red Goblin"), new KBHandle(
-                                "http://example.org/#green-goblin", "Green Goblin", null, "en"));
+        assertThat(results) //
+                .usingRecursiveFieldByFieldElementComparatorOnFields( //
+                        "identifier", "name", "language") //
+                .containsExactlyInAnyOrder(
+                        new KBHandle("http://example.org/#red-goblin", "Red Goblin"), //
+                        new KBHandle("http://example.org/#green-goblin", "Green Goblin", null,
+                                "en"));
     }
 
     static void testWithLabelContainingAnyOf_withLanguage_noFTS(Repository aRepository,
@@ -1024,6 +1029,28 @@ public class SPARQLQueryBuilderLocalTestScenarios
         aKB.setFullTextSearchIri(null);
 
         testWithLabelContainingAnyOf_withLanguage(aRepository, aKB);
+    }
+
+    static void testWithLabelMatchingAnyOf_withFallbackLanguages(Repository aRepository,
+            KnowledgeBase aKB)
+        throws Exception
+    {
+        importDataFromString(aRepository, aKB, TURTLE, TURTLE_PREFIX,
+                DATA_LABELS_AND_DESCRIPTIONS_WITH_LANGUAGE);
+
+        var results = asHandles(aRepository, SPARQLQueryBuilder //
+                .forItems(aKB) //
+                .withFallbackLanguages("it", "fr") //
+                .withLabelMatchingAnyOf("Blue"));
+
+        assertThat(results).extracting(KBHandle::getUiLabel)
+                .allMatch(label -> label.contains("Blu"));
+        assertThat(results).extracting(KBHandle::getIdentifier).doesNotHaveDuplicates();
+        assertThat(results) //
+                .usingRecursiveFieldByFieldElementComparatorOnFields( //
+                        "identifier", "name", "language") //
+                .containsExactlyInAnyOrder(new KBHandle("http://example.org/#blue-goblin",
+                        "Folletto Blue", null, "it"));
     }
 
     static void testWithLabelContainingAnyOf_withLanguage(Repository aRepository, KnowledgeBase aKB)
@@ -1331,7 +1358,7 @@ public class SPARQLQueryBuilderLocalTestScenarios
             // If the RDF file contains relative URLs, then they probably start with a hash.
             // To avoid having two hashes here, we drop the hash from the base prefix configured
             // by the user.
-            String prefix = StringUtils.removeEnd(aKB.getBasePrefix(), "#");
+            var prefix = StringUtils.removeEnd(aKB.getBasePrefix(), "#");
             if (aKB.getDefaultDatasetIri() != null) {
                 var ctx = SimpleValueFactory.getInstance().createIRI(aKB.getDefaultDatasetIri());
                 conn.add(aIS, prefix, aFormat, ctx);
@@ -1389,13 +1416,9 @@ public class SPARQLQueryBuilderLocalTestScenarios
 
     public static void assertIsReachable(Repository aRepository)
     {
-        if (!(aRepository instanceof SPARQLRepository)) {
-            return;
+        if (aRepository instanceof SPARQLRepository sparqlRepository) {
+            assumeTrue(isReachable(sparqlRepository.toString()),
+                    "Remote repository at [" + sparqlRepository + "] is not reachable");
         }
-
-        SPARQLRepository sparqlRepository = (SPARQLRepository) aRepository;
-
-        assumeTrue(isReachable(sparqlRepository.toString()),
-                "Remote repository at [" + sparqlRepository + "] is not reachable");
     }
 }

--- a/inception/inception-kb/src/test/resources/turtle/data_labels_and_descriptions_with_language.ttl
+++ b/inception/inception-kb/src/test/resources/turtle/data_labels_and_descriptions_with_language.ttl
@@ -16,3 +16,9 @@
 <#red-goblin>
     rdfs:label 'Red Goblin' ;
     rdfs:comment 'Little red monster' .
+
+<#blue-goblin>
+    rdfs:label 'Gobelin Blue'@fr ;
+    rdfs:label 'Folletto Blue'@it ;
+    rdfs:label 'Super Blue' ;
+    rdfs:comment 'Piccolo mostro blu'@it .

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/PredictionTask.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/PredictionTask.java
@@ -102,7 +102,7 @@ public class PredictionTask
 
     public PredictionTask(Builder<? extends Builder<?>> aBuilder)
     {
-        super(aBuilder.withType(TYPE));
+        super(aBuilder.withType(TYPE).withCancellable(true));
 
         currentDocument = aBuilder.currentDocument;
         dataOwner = aBuilder.dataOwner;
@@ -223,6 +223,10 @@ public class PredictionTask
 
         try (var casHolder = new PredictionCasHolder()) {
             for (var document : aDocuments) {
+                if (monitor.isCancelled()) {
+                    break;
+                }
+
                 monitor.setProgressWithMessage(progress, maxProgress,
                         LogMessage.info(this, "%s", document.getName()));
                 applyAllRecommendersToDocument(activePredictions, incomingPredictions,


### PR DESCRIPTION
**What's in the PR**
- Added ability to globally configure fallback languages via settings.properties file (to be changed for 34.x)
- Added simpel test

**How to test manually**
* Add e.g. `knowledge-base.default-fallback-languages[0]=es` to the `settings.properties` file

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
