### PR TITLE
#4898 - Unable to import project with knowledge-based exported by INCEpTION 33.0

### DIFF
--- a/inception/inception-export-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/export/ProjectExporter.java
+++ b/inception/inception-export-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/export/ProjectExporter.java
@@ -17,6 +17,9 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.api.export;
 
+import static org.apache.commons.io.FilenameUtils.normalize;
+import static org.apache.commons.lang3.StringUtils.removeStart;
+
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Collections;
@@ -62,12 +65,22 @@ public interface ProjectExporter
         return entryName;
     }
 
+    static ZipEntry getEntry(ZipFile aFile, String aEntryName)
+    {
+        var entryName = new ZipEntry(removeStart(normalize(aEntryName, true), "/"));
+        var entry = aFile.getEntry(aEntryName);
+        if (entry != null) {
+            return entry;
+        }
+        return aFile.getEntry("/" + entryName);
+    }
+
     static void writeEntry(ZipOutputStream aStage, String aEntryName,
             FailableConsumer<OutputStream, IOException> aWriter)
         throws IOException
     {
-        var entry = new ZipEntry(aEntryName);
-        aStage.putNextEntry(entry);
+        var entryName = new ZipEntry(removeStart(normalize(aEntryName, true), "/"));
+        aStage.putNextEntry(entryName);
         try {
             aWriter.accept(CloseShieldOutputStream.wrap(aStage));
         }

--- a/inception/inception-imls-weblicht/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/weblicht/exporter/ChainExporter.java
+++ b/inception/inception-imls-weblicht/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/weblicht/exporter/ChainExporter.java
@@ -128,7 +128,8 @@ public class ChainExporter
             chain.setRecommender(recommender);
             chainService.createOrUpdateChain(chain);
 
-            var entry = aZip.getEntry(CHAINS_FOLDER + "/" + exportedChain.getId() + ".xml");
+            var entry = ProjectExporter.getEntry(aZip,
+                    CHAINS_FOLDER + "/" + exportedChain.getId() + ".xml");
             try (var is = aZip.getInputStream(entry)) {
                 chainService.importChainFile(chain, is);
             }

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/exporter/KnowledgeBaseExporter.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/exporter/KnowledgeBaseExporter.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.kb.exporter;
 
+import static de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExporter.getEntry;
 import static java.util.Arrays.asList;
 
 import java.io.IOException;
@@ -326,12 +327,9 @@ public class KnowledgeBaseExporter
      */
     private void importKnowledgeBaseFiles(ZipFile aZip, KnowledgeBase kb) throws IOException
     {
-        var sourceFileName = getSourceFileName(kb);
-        // remove leading "/"
-        var entry = aZip.getEntry(sourceFileName.substring(1));
-
+        var entry = getEntry(aZip, getSourceFileName(kb));
         try (var is = aZip.getInputStream(entry)) {
-            kbService.importData(kb, sourceFileName, is);
+            kbService.importData(kb, entry.getName(), is);
         }
     }
 

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseExporterTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseExporterTest.java
@@ -33,6 +33,7 @@ import static org.mockito.Mockito.when;
 import java.io.File;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
 
@@ -119,6 +120,8 @@ public class KnowledgeBaseExporterTest
 
         var importRequest = new ProjectImportRequest(true);
         var zipFile = mock(ZipFile.class);
+        var zipFileEntry = mock(ZipEntry.class);
+        when(zipFile.getEntry(any())).thenReturn(zipFileEntry);
 
         sut.importData(importRequest, targetProject, exportedProject, zipFile);
 
@@ -165,6 +168,8 @@ public class KnowledgeBaseExporterTest
         // Import the project again
         var importRequest = new ProjectImportRequest(true);
         var zipFile = mock(ZipFile.class);
+        var zipFileEntry = mock(ZipEntry.class);
+        when(zipFile.getEntry(any())).thenReturn(zipFileEntry);
         sut.importData(importRequest, targetProject, exportedProject, zipFile);
 
         // Verify that features were actually processed

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/exporter/LoggedEventExporter.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/exporter/LoggedEventExporter.java
@@ -157,7 +157,7 @@ public class LoggedEventExporter
     {
         int eventCount = 0;
 
-        var entry = aZip.getEntry(EVENT_LOG);
+        var entry = ProjectExporter.getEntry(aZip, EVENT_LOG);
 
         if (entry == null) {
             LOG.info("No event log available for import in project [{}]", aProject.getName());


### PR DESCRIPTION
**What's in the PR**
- Standardize entry paths when writing ZIP to remove the problem with ZIP entries starting with a slash that seems to have been introduced in 33.0
- Be more robust when loading entries from the export ZIP to allow loading ZIPs exported using 33.0

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
