### PR TITLE
#4901 - Consider document structure when splitting sentences in custom XML formats

### DIFF
--- a/inception/inception-io-xml/pom.xml
+++ b/inception/inception-io-xml/pom.xml
@@ -77,6 +77,10 @@
       <groupId>org.dkpro.core</groupId>
       <artifactId>dkpro-core-api-resources-asl</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.dkpro.core</groupId>
+      <artifactId>dkpro-core-api-segmentation-asl</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.wicket</groupId>
@@ -91,6 +95,11 @@
       <artifactId>jackson-annotations</artifactId>
     </dependency>
     
+    <dependency>
+      <groupId>it.unimi.dsi</groupId>
+      <artifactId>fastutil</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>

--- a/inception/inception-io-xml/src/main/java/de/tudarmstadt/ukp/inception/io/xml/CustomXmlFormatFactory.java
+++ b/inception/inception-io-xml/src/main/java/de/tudarmstadt/ukp/inception/io/xml/CustomXmlFormatFactory.java
@@ -120,7 +120,10 @@ public class CustomXmlFormatFactory
             TypeSystemDescription aTSD)
         throws ResourceInitializationException
     {
-        return createReaderDescription(XmlDocumentReader.class, aTSD);
+        return createReaderDescription(XmlDocumentReader.class, aTSD, //
+                XmlDocumentReader.PARAM_BLOCK_ELEMENTS, description.getBlockElements(), //
+                XmlDocumentReader.PARAM_SPLIT_SENTENCES_IN_BLOCK_ELEMENTS,
+                description.isSplitSentencesInBlockElements());
     }
 
     @Override

--- a/inception/inception-io-xml/src/main/java/de/tudarmstadt/ukp/inception/io/xml/CustomXmlFormatPluginDescripion.java
+++ b/inception/inception-io-xml/src/main/java/de/tudarmstadt/ukp/inception/io/xml/CustomXmlFormatPluginDescripion.java
@@ -34,6 +34,8 @@ public class CustomXmlFormatPluginDescripion
 
     private List<String> stylesheets = Collections.emptyList();
     private List<String> sectionElements;
+    private List<String> blockElements;
+    private boolean splitSentencesInBlockElements;
 
     private @JsonIgnore Path basePath;
 
@@ -85,5 +87,25 @@ public class CustomXmlFormatPluginDescripion
     public void setSectionElements(List<String> aSectionElements)
     {
         sectionElements = aSectionElements;
+    }
+
+    public void setBlockElements(List<String> aBlockElements)
+    {
+        blockElements = aBlockElements;
+    }
+
+    public List<String> getBlockElements()
+    {
+        return blockElements;
+    }
+
+    public void setSplitSentencesInBlockElements(boolean aSplitSentencesInBlockElements)
+    {
+        splitSentencesInBlockElements = aSplitSentencesInBlockElements;
+    }
+
+    public boolean isSplitSentencesInBlockElements()
+    {
+        return splitSentencesInBlockElements;
     }
 }

--- a/inception/inception-io-xml/src/main/resources/META-INF/asciidoc/user-guide/formats-xml-custom.adoc
+++ b/inception/inception-io-xml/src/main/resources/META-INF/asciidoc/user-guide/formats-xml-custom.adoc
@@ -34,7 +34,11 @@ Custom XML formats are based on the <<sect_formats_xml>> format support. They ar
   "name": "TTML format (external)",
   "stylesheets": [ 
     "styles.css"
-  ]
+  ],
+  "blockElements": [
+    "div", "p"
+  ],
+  "splitSentencesInBlockElements": true
 }
 ----
 

--- a/inception/inception-io-xml/src/main/resources/xml/block-elements.xml
+++ b/inception/inception-io-xml/src/main/resources/xml/block-elements.xml
@@ -1,0 +1,8 @@
+<body>
+  Sentence 1.
+  <p>
+    Sentence 2.
+    Sentence 3.
+  </p>
+  Sentence 4.
+</body>

--- a/inception/inception-io-xml/src/test/java/de/tudarmstadt/ukp/inception/io/xml/dkprocore/CasXmlHandlerTest.java
+++ b/inception/inception-io-xml/src/test/java/de/tudarmstadt/ukp/inception/io/xml/dkprocore/CasXmlHandlerTest.java
@@ -25,8 +25,6 @@ import static org.apache.commons.io.IOUtils.toInputStream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
-import javax.xml.parsers.SAXParser;
-
 import org.apache.uima.fit.factory.JCasFactory;
 import org.apache.uima.jcas.JCas;
 import org.dkpro.core.api.xml.type.XmlAttribute;
@@ -52,9 +50,9 @@ public class CasXmlHandlerTest
     @Test
     void testWithDefaultNamespace() throws Exception
     {
-        String xml = "<root xmlns='http://namespace.org'/>";
+        var xml = "<root xmlns='http://namespace.org'/>";
 
-        SAXParser parser = XmlParserUtils.newSaxParser();
+        var parser = XmlParserUtils.newSaxParser();
         parser.parse(toInputStream(xml, UTF_8), sut);
 
         assertThat(jcas.select(XmlElement.class).asList()) //
@@ -69,9 +67,9 @@ public class CasXmlHandlerTest
     @Test
     void testWithPrefixedNamespace() throws Exception
     {
-        String xml = "<ns:root xmlns:ns='http://namespace.org'/>";
+        var xml = "<ns:root xmlns:ns='http://namespace.org'/>";
 
-        SAXParser parser = XmlParserUtils.newSaxParser();
+        var parser = XmlParserUtils.newSaxParser();
         parser.parse(toInputStream(xml, UTF_8), sut);
 
         assertThat(jcas.select(XmlElement.class).asList()) //
@@ -87,9 +85,9 @@ public class CasXmlHandlerTest
     @Test
     void testWithPrefixedNamespace_NS_enabled() throws Exception
     {
-        String xml = "<ns:root xmlns:ns='http://namespace.org' x='true'/>";
+        var xml = "<ns:root xmlns:ns='http://namespace.org' x='true'/>";
 
-        SAXParser parser = newSaxParser(enableNamespaceSupport(newSaxParserFactory()));
+        var parser = newSaxParser(enableNamespaceSupport(newSaxParserFactory()));
         parser.parse(toInputStream(xml, UTF_8), sut);
 
         assertThat(jcas.select(XmlElement.class).asList()) //

--- a/inception/inception-io-xml/src/test/java/de/tudarmstadt/ukp/inception/io/xml/dkprocore/XmlDocumentReaderTest.java
+++ b/inception/inception-io-xml/src/test/java/de/tudarmstadt/ukp/inception/io/xml/dkprocore/XmlDocumentReaderTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.io.xml.dkprocore;
+
+import static org.apache.uima.fit.factory.CollectionReaderFactory.createReader;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.uima.fit.factory.JCasFactory;
+import org.junit.jupiter.api.Test;
+
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
+
+class XmlDocumentReaderTest
+{
+    @Test
+    void testBlockElementsAsSentences() throws Exception
+    {
+        var reader = createReader( //
+                XmlDocumentReader.class, //
+                XmlDocumentReader.PARAM_SOURCE_LOCATION, "classpath:/xml/block-elements.xml", //
+                XmlDocumentReader.PARAM_BLOCK_ELEMENTS, "p", //
+                XmlDocumentReader.PARAM_SPLIT_SENTENCES_IN_BLOCK_ELEMENTS, false);
+
+        var jcas = JCasFactory.createJCas();
+        reader.getNext(jcas.getCas());
+
+        assertThat(jcas.select(Sentence.class).asList()) //
+                .extracting(Sentence::getCoveredText) //
+                .containsExactly("Sentence 1.", "Sentence 2.\n    Sentence 3.", "Sentence 4.");
+    }
+
+    @Test
+    void testSentencesRespectingBlockElements() throws Exception
+    {
+        var reader = createReader( //
+                XmlDocumentReader.class, //
+                XmlDocumentReader.PARAM_SOURCE_LOCATION, "classpath:/xml/block-elements.xml", //
+                XmlDocumentReader.PARAM_BLOCK_ELEMENTS, "p", //
+                XmlDocumentReader.PARAM_SPLIT_SENTENCES_IN_BLOCK_ELEMENTS, true);
+
+        var jcas = JCasFactory.createJCas();
+        reader.getNext(jcas.getCas());
+
+        assertThat(jcas.select(Sentence.class).asList()) //
+                .extracting(Sentence::getCoveredText) //
+                .containsExactly("Sentence 1.", "Sentence 2.", "Sentence 3.", "Sentence 4.");
+    }
+}


### PR DESCRIPTION
**What's in the PR**
- Added options to define block elements in XML files which are considered when doing sentence splitting

**How to test manually**
* Add new configuration options to custom XML format JSON, e.g.
```
{
  "name": "TMX (external)",
  "stylesheets": [ 
    "styles.css"
  ],
  "blockElements": [
    "seg"
  ],
  "splitSentencesInBlockElements": false
}
```

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [x] PR updates documentation
