### PR TITLE
#4909 - Upgrade dependencies

### DIFF
--- a/inception/inception-app-webapp/pom.xml
+++ b/inception/inception-app-webapp/pom.xml
@@ -533,10 +533,6 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>jcl-over-slf4j</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
       <artifactId>log4j-over-slf4j</artifactId>
     </dependency>
 
@@ -569,6 +565,11 @@
     <dependency>
       <groupId>org.liquibase</groupId>
       <artifactId>liquibase-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.mattbertolini</groupId>
+      <artifactId>liquibase-slf4j</artifactId>
+      <version>5.0.0</version>
     </dependency>
 
     <dependency>
@@ -997,6 +998,7 @@
               <usedDependency>org.postgresql:postgresql</usedDependency>
               <usedDependency>org.hsqldb:hsqldb</usedDependency>
               <!-- Logging - used via reflection / optional -->
+              <usedDependency>com.mattbertolini:liquibase-slf4j</usedDependency>
               <usedDependency>org.slf4j:log4j-over-slf4j</usedDependency>
               <usedDependency>org.apache.logging.log4j:log4j-slf4j2-impl</usedDependency>
               <usedDependency>org.apache.logging.log4j:log4j-core</usedDependency>

--- a/inception/inception-dependencies/pom.xml
+++ b/inception/inception-dependencies/pom.xml
@@ -576,6 +576,10 @@
             <groupId>org.glassfish</groupId>
             <artifactId>jakarta.json</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -969,11 +973,23 @@
         <groupId>org.apache.solr</groupId>
         <artifactId>solr-solrj</artifactId>
         <version>${solr.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.solr</groupId>
         <artifactId>solr-core</artifactId>
         <version>${solr.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.solr</groupId>
@@ -1024,6 +1040,12 @@
         <groupId>commons-validator</groupId>
         <artifactId>commons-validator</artifactId>
         <version>1.9.0</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.github.ben-manes.caffeine</groupId>
@@ -1053,6 +1075,17 @@
       </dependency>
       <dependency>
         <groupId>org.dkpro.core</groupId>
+        <artifactId>dkpro-core-api-datasets-asl</artifactId>
+        <version>${dkpro.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging-api</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.dkpro.core</groupId>
         <artifactId>dkpro-core-io-xml-asl</artifactId>
         <version>${dkpro.version}</version>
         <exclusions>
@@ -1073,6 +1106,28 @@
           </exclusion>
         </exclusions>
       </dependency>
+      <dependency>
+        <groupId>org.dkpro.core</groupId>
+        <artifactId>dkpro-core-api-resources-asl</artifactId>
+        <version>${dkpro.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging-api</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.dkpro.core</groupId>
+        <artifactId>dkpro-core-io-pdf-asl</artifactId>
+        <version>${dkpro.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging-api</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
 
       <dependency>
         <groupId>org.eclipse.rdf4j</groupId>
@@ -1089,6 +1144,39 @@
           <exclusion>
             <groupId>org.locationtech.spatial4j</groupId>
             <artifactId>spatial4j</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.rdf4j</groupId>
+        <artifactId>rdf4j-rio-jsonld</artifactId>
+        <version>${rdf4j.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.rdf4j</groupId>
+        <artifactId>rdf4j-http-client</artifactId>
+        <version>${rdf4j.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.rdf4j</groupId>
+        <artifactId>rdf4j-rio-api</artifactId>
+        <version>${rdf4j.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -1165,6 +1253,12 @@
         <groupId>org.elasticsearch.client</groupId>
         <artifactId>elasticsearch-rest-client</artifactId>
         <version>${elasticsearch.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.elasticsearch.client</groupId>
@@ -1186,6 +1280,12 @@
         <groupId>org.opensearch.client</groupId>
         <artifactId>opensearch-rest-client</artifactId>
         <version>${opensearch.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.opensearch.client</groupId>
@@ -1362,31 +1462,6 @@
         <version>${dkpro.version}</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.dkpro.core</groupId>
-        <artifactId>dkpro-core-api-resources-asl</artifactId>
-        <version>${dkpro.version}</version>
-        <exclusions>
-          <!-- We do not use DKPro Core model-downloading -->
-          <!--  
-          <exclusion>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-model</artifactId>
-          </exclusion>
-          -->
-          <!--  
-          Cannot exclude until https://github.com/dkpro/dkpro-core/issues/1511 is fixed
-          <exclusion>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-utils</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.ivy</groupId>
-            <artifactId>ivy</artifactId>
-          </exclusion>
-          -->
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.ivy</groupId>

--- a/inception/inception-plugin-parent/pom.xml
+++ b/inception/inception-plugin-parent/pom.xml
@@ -65,9 +65,8 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <!-- Avoid Commons Logging -->
-      <groupId>commons-logging</groupId>
-      <artifactId>commons-logging</artifactId>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-jcl</artifactId>
       <scope>provided</scope>
     </dependency>
 

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/wicket/ServletContextUtils.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/wicket/ServletContextUtils.java
@@ -29,8 +29,7 @@ public class ServletContextUtils
     public static String referenceToUrl(ServletContext aServletContext,
             ResourceReference aResourceReference)
     {
-        ResourceReferenceRequestHandler handler = new ResourceReferenceRequestHandler(
-                aResourceReference, new PageParameters());
+        var handler = new ResourceReferenceRequestHandler(aResourceReference, new PageParameters());
 
         var contextPath = aServletContext.getContextPath();
         if (!contextPath.startsWith("/")) {

--- a/inception/inception-ui-core/pom.xml
+++ b/inception/inception-ui-core/pom.xml
@@ -199,10 +199,6 @@
       <artifactId>wicket-bootstrap-extensions</artifactId>
     </dependency>
     <dependency>
-      <groupId>de.agilecoders.wicket.webjars</groupId>
-      <artifactId>wicket-webjars</artifactId>
-    </dependency>
-    <dependency>
       <groupId>jakarta.persistence</groupId>
       <artifactId>jakarta.persistence-api</artifactId>
     </dependency>

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.java
@@ -79,7 +79,6 @@ import com.giffing.wicket.spring.boot.starter.app.WicketBootSecuredWebApplicatio
 
 import de.agilecoders.wicket.core.Bootstrap;
 import de.agilecoders.wicket.core.settings.IBootstrapSettings;
-import de.agilecoders.wicket.webjars.WicketWebjars;
 import de.tudarmstadt.ukp.clarin.webanno.security.SpringAuthenticatedWebSession;
 import de.tudarmstadt.ukp.clarin.webanno.ui.config.FontAwesomeResourceBehavior;
 import de.tudarmstadt.ukp.clarin.webanno.ui.core.page.ApplicationPageBase;
@@ -116,7 +115,7 @@ public abstract class WicketApplicationBase
     {
         super.init();
 
-        CompoundAuthorizationStrategy authorizationStrategy = new CompoundAuthorizationStrategy();
+        var authorizationStrategy = new CompoundAuthorizationStrategy();
         authorizationStrategy.add(new RoleAuthorizationStrategy(this));
         getSecuritySettings().setAuthorizationStrategy(authorizationStrategy);
 
@@ -247,14 +246,6 @@ public abstract class WicketApplicationBase
     private void initPageRequestTracker()
     {
         getRequestCycleListeners().add(new PageRequestHandlerTracker());
-    }
-
-    @Override
-    protected void internalInit()
-    {
-        super.internalInit();
-
-        WicketWebjars.install(this);
     }
 
     protected void initWebFrameworks()

--- a/inception/pom.xml
+++ b/inception/pom.xml
@@ -86,12 +86,6 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
-      <!-- Avoid Commons Logging (we use the spring-jcl bridge -->
-      <groupId>org.slf4j</groupId>
-      <artifactId>jcl-over-slf4j</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <!-- Route Java Util Logging over SLF4J -->
       <groupId>org.slf4j</groupId>
       <artifactId>jul-to-slf4j</artifactId>
@@ -106,13 +100,6 @@
       <!-- Route Java Commons Logging over SLF4J -->
       <groupId>org.springframework</groupId>
       <artifactId>spring-jcl</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <!-- Avoid Commons Logging (we use the spring-jcl bridge -->
-      <groupId>commons-logging</groupId>
-      <artifactId>commons-logging</artifactId>
-      <scope>provided</scope>
     </dependency>
     
     <!-- Dev aids -->
@@ -440,7 +427,6 @@
             <dependency>org.apache.logging.log4j:log4j-layout-template-json</dependency>
             <dependency>org.apache.logging.log4j:log4j-core</dependency>
             <dependency>org.slf4j:log4j-over-slf4j</dependency>
-            <dependency>org.slf4j:jcl-over-slf4j</dependency>
             <dependency>org.slf4j:jul-to-slf4j</dependency>
             <dependency>commons-logging:commons-logging</dependency>
             <dependency>org.springframework:spring-jcl</dependency>
@@ -515,6 +501,13 @@
                 <requireJavaVersion>
                   <version>[${maven.compiler.release},)</version>
                 </requireJavaVersion>
+                <bannedDependencies>
+                  <excludes>
+                    <exclude>commons-logging:commons-logging</exclude>
+                    <exclude>commons-logging:commons-logging-api</exclude>
+                    <exclude>org.slf4j:jcl-over-slf4j</exclude>
+                  </excludes>
+                </bannedDependencies>
               </rules>
             </configuration>
           </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
     <hibernate.validator.version>8.0.1.Final</hibernate.validator.version>
 
     <wicket.version>10.1.0</wicket.version>
-    <wicketstuff.version>10.1.0</wicketstuff.version>
+    <wicketstuff.version>10.1.1</wicketstuff.version>
     <wicket-bootstrap.version>7.0.5</wicket-bootstrap.version>
     <wicket-jquery-selectors.version>4.0.5</wicket-jquery-selectors.version>
     <wicket-webjars.version>4.0.4</wicket-webjars.version>


### PR DESCRIPTION
**What's in the PR**
- WicketStuff Core 10.1.0 -> 10.1.1
- Exclude jcl-over-log4j, commons-logging and commons-logging-api in favor of spring-jcl
- liquibase-slf4j -> 5.0.0
- Remove Wicket Webjars workaround for bug in WicketStuff 10.1.0
- Remove/exclude dependencies on all commons-logging stuff except spring-jcl
- Route liquibase logging through SLF4J

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
