### PR TITLE
#3407 - Remove old database migrations that seem to get always executed

### DIFF
--- a/inception/inception-external-search-core/src/main/resources/de/tudarmstadt/ukp/inception/externalsearch/model/db-changelog.xml
+++ b/inception/inception-external-search-core/src/main/resources/de/tudarmstadt/ukp/inception/externalsearch/model/db-changelog.xml
@@ -3,7 +3,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="
     http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd 
-    http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+    http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.27.xsd">
 
   <changeSet author="INCEpTION Team" id="20180629-external-search-01">
     <preConditions onFail="MARK_RAN">

--- a/inception/inception-imls-elg/src/main/resources/de/tudarmstadt/ukp/inception/recommendation/imls/elg/model/db-changelog.xml
+++ b/inception/inception-imls-elg/src/main/resources/de/tudarmstadt/ukp/inception/recommendation/imls/elg/model/db-changelog.xml
@@ -3,7 +3,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="
     http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd 
-    http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+    http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.27.xsd">
 
   <changeSet author="INCEpTION Team" id="20220115-01">
     <createTable tableName="elg_session">

--- a/inception/inception-imls-stringmatch/src/main/resources/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/model/db-changelog.xml
+++ b/inception/inception-imls-stringmatch/src/main/resources/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/model/db-changelog.xml
@@ -3,7 +3,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="
     http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd 
-    http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+    http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.27.xsd">
 
   <changeSet author="INCEpTION Team" id="20190203-01">
     <createTable tableName="gazeteer">

--- a/inception/inception-imls-weblicht/src/main/resources/de/tudarmstadt/ukp/inception/recommendation/imls/weblicht/model/db-changelog.xml
+++ b/inception/inception-imls-weblicht/src/main/resources/de/tudarmstadt/ukp/inception/recommendation/imls/weblicht/model/db-changelog.xml
@@ -3,7 +3,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="
     http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd 
-    http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+    http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.27.xsd">
 
   <changeSet author="INCEpTION Team" id="20190927-01">
     <createTable tableName="weblicht_chain">

--- a/inception/inception-kb/src/main/resources/de/tudarmstadt/ukp/inception/kb/model/db-changelog.xml
+++ b/inception/inception-kb/src/main/resources/de/tudarmstadt/ukp/inception/kb/model/db-changelog.xml
@@ -3,7 +3,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="
     http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd 
-    http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+    http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.27.xsd">
 
   <changeSet author="INCEpTION Team" id="1512303750846-7">
     <preConditions onFail="MARK_RAN">

--- a/inception/inception-log/src/main/resources/de/tudarmstadt/ukp/inception/log/model/db-changelog.xml
+++ b/inception/inception-log/src/main/resources/de/tudarmstadt/ukp/inception/log/model/db-changelog.xml
@@ -5,7 +5,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="
     http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd 
-    http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+    http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.27.xsd">
   <changeSet author="INCEpTION Team" id="20180117-log-1">
     <preConditions onFail="MARK_RAN">
       <not>

--- a/inception/inception-model/src/main/resources/de/tudarmstadt/ukp/clarin/webanno/model/db-changelog.xml
+++ b/inception/inception-model/src/main/resources/de/tudarmstadt/ukp/clarin/webanno/model/db-changelog.xml
@@ -22,7 +22,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="
     http://www.liquibase.org/xml/ns/dbchangelog-ext https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd 
-    http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+    http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.27.xsd">
   
   <changeSet author="WebAnno Team" id="1512223050574-1">
     <preConditions onFail="MARK_RAN">
@@ -48,19 +48,6 @@
       <column name="document" type="BIGINT" />
       <column name="project" type="BIGINT" />
     </createTable>
-  </changeSet>
-  
-  <!--
-    Clean up legacy unique constraint (name, project, user) on (annotation_document)
-    
-    NOTE: This change set ignores failures since there is no precondition to check if
-          unique constraints exist or not. So we simply have to try it.
-   -->
-  <changeSet author="WebAnno Team" id="1512223050574-1.1" failOnError="false">
-    <dropUniqueConstraint 
-      tableName="annotation_document" 
-      constraintName="UK_lq2x3u95l76hxx8ei9hydk824"
-      uniqueColumns="name, project, user" />
   </changeSet>
 
   <!-- 
@@ -147,19 +134,6 @@
     </createTable>
   </changeSet>
 
-  <!--
-    Clean up legacy unique constraint (annotation_type, name, project) on (annotation_feature)
-    
-    NOTE: This change set ignores failures since there is no precondition to check if
-          unique constraints exist or not. So we simply have to try it.
-   -->
-  <changeSet author="WebAnno Team" id="1512223050574-2.1" failOnError="false">
-    <dropUniqueConstraint 
-      tableName="annotation_feature"
-      constraintName="UK_pgq9palohljgv9qympj7nbcp2" 
-      uniqueColumns="annotation_type, name, project" />
-  </changeSet>
-
   <!-- 
     Add unique constraint (annotation_type, name, project) on (annotation_feature)
     
@@ -226,19 +200,6 @@
       <column name="project" type="BIGINT" />
     </createTable>
   </changeSet>
-  
-  <!--
-    Clean up legacy unique constraint (annotation_type, name, project) on (annotation_feature)
-    
-    NOTE: This change set ignores failures since there is no precondition to check if
-          unique constraints exist or not. So we simply have to try it.
-   -->
-  <changeSet author="WebAnno Team" id="1512223050574-3.1" failOnError="false">
-    <dropUniqueConstraint 
-      tableName="annotation_type" 
-      constraintName="UK_m2jvqyu4akybpmyv7e6xli166"
-      uniqueColumns="name, project" />
-  </changeSet>
 
   <!-- 
     Add unique constraint (annotation_type, name, project) on (annotation_feature)
@@ -282,19 +243,6 @@
       </column>
       <column name="project" type="BIGINT" />
     </createTable>
-  </changeSet>
-  
-  <!--
-    Clean up legacy unique constraint (name, project) on (constraint_set)
-    
-    NOTE: This change set ignores failures since there is no precondition to check if
-          unique constraints exist or not. So we simply have to try it.
-   -->
-  <changeSet author="WebAnno Team" id="1512223050574-6.1" failOnError="false">
-    <dropUniqueConstraint
-      tableName="constraint_set" 
-      constraintName="UK_m2jvqyu4akybpmyv7e6xli166"
-      uniqueColumns="name, project" />
   </changeSet>
 
   <!-- 
@@ -350,19 +298,6 @@
       </column>
     </createTable>
   </changeSet>
-  
-  <!--
-    Clean up legacy unique constraint (name) on (project)
-    
-    NOTE: This change set ignores failures since there is no precondition to check if
-          unique constraints exist or not. So we simply have to try it.
-   -->
-  <changeSet author="WebAnno Team" id="1512223050574-9.1" failOnError="false">
-    <dropUniqueConstraint
-      tableName="project"
-      constraintName="UK_3k75vvu7mevyvvb5may5lj8k7" 
-      uniqueColumns="name" />
-  </changeSet>
 
   <!-- 
     Add unique constraint (name) on (project)
@@ -391,19 +326,6 @@
       <column name="user" type="VARCHAR(255)" />
       <column name="project" type="BIGINT" />
     </createTable>
-  </changeSet>
-  
-  <!--
-    Clean up legacy unique constraint (user, level, project) on (project_permissions)
-    
-    NOTE: This change set ignores failures since there is no precondition to check if
-          unique constraints exist or not. So we simply have to try it.
-   -->
-  <changeSet author="WebAnno Team" id="1512223050574-10.1" failOnError="false">
-    <dropUniqueConstraint
-      tableName="project_permissions" 
-      constraintName="UK_gh78wc2j1lxhhmk1hu5b9u8vb"
-      uniqueColumns="user, level, project" />
   </changeSet>
 
   <!-- 
@@ -464,19 +386,6 @@
       <column name="updated" type="datetime(6)" />
       <column name="project" type="BIGINT" />
     </createTable>
-  </changeSet>
-  
-  <!--
-    Clean up legacy unique constraint (name, project) on (source_document)
-    
-    NOTE: This change set ignores failures since there is no precondition to check if
-          unique constraints exist or not. So we simply have to try it.
-   -->
-  <changeSet author="WebAnno Team" id="1512223050574-11.1" failOnError="false">
-    <dropUniqueConstraint
-      tableName="source_document"
-      constraintName="UK_3ma3d81kn5x2sjpv7e99rnt2h"
-      uniqueColumns="name, project" />
   </changeSet>
 
   <!-- 
@@ -559,19 +468,6 @@
       <column name="project" type="BIGINT" />
     </createTable>
   </changeSet>
-  
-  <!--
-    Clean up legacy unique constraint (name, project) on (tag_set)
-    
-    NOTE: This change set ignores failures since there is no precondition to check if
-          unique constraints exist or not. So we simply have to try it.
-   -->
-  <changeSet author="WebAnno Team" id="1512223050574-13.1" failOnError="false">
-    <dropUniqueConstraint
-      tableName="tag_set" 
-      constraintName="UK_n1pf8qa78xwkkq5890mp5u5rw"
-      uniqueColumns="name, project" />
-  </changeSet>
 
   <!-- 
     Add unique constraint (name, project) on (tag_set)
@@ -599,77 +495,7 @@
       <column name="project" />
     </createIndex>
   </changeSet>  
-  
-  <changeSet author="WebAnno Team" id="1512223050574-14">
-    <preConditions onFail="MARK_RAN">
-      <not>
-        <tableExists tableName="train_document" />
-      </not>
-    </preConditions>
-    <createTable tableName="train_document">
-      <column autoIncrement="true" name="id" type="BIGINT">
-        <constraints primaryKey="true" />
-      </column>
-      <column name="format" type="VARCHAR(255)" />
-      <column name="name" type="VARCHAR(255)">
-        <constraints nullable="false" />
-      </column>
-      <column name="processed" type="BIT(1)">
-        <constraints nullable="false" />
-      </column>
-      <column name="sentenceAccessed" type="INT">
-        <constraints nullable="false" />
-      </column>
-      <column name="state" type="VARCHAR(255)">
-        <constraints nullable="false" />
-      </column>
-      <column name="timestamp" type="datetime(6)" />
-      <column name="feature_id" type="BIGINT" />
-      <column name="project" type="BIGINT" />
-    </createTable>
-  </changeSet>
-  
-  <!--
-    Clean up legacy unique constraint (name, project) on (train_document)
-    
-    NOTE: This change set ignores failures since there is no precondition to check if
-          unique constraints exist or not. So we simply have to try it.
-   -->
-  <changeSet author="WebAnno Team" id="1512223050574-14.1" failOnError="false">
-    <dropUniqueConstraint
-      tableName="train_document" 
-      constraintName="UK_jf8bhw2u6xwp9goc2yqv2qfhc"
-      uniqueColumns="name, project" />
-  </changeSet>
 
-  <!-- 
-    Add unique constraint (name, project) on (train_document)
-    
-    NOTE: This change set ignores failures since there is no precondition to check if
-          unique constraints exist or not. So we simply have to try it.
-   -->
-  <changeSet author="WebAnno Team" id="1512223050574-14.2" failOnError="false">
-    <addUniqueConstraint 
-      tableName="train_document" 
-      constraintName="UKjf8bhw2u6xwp9goc2yqv2qfhc"
-      columnNames="name, project" />
-  </changeSet>  
-
-  <!--
-    Add index (project) on (train_document)
-   -->
-  <changeSet author="WebAnno Team" id="1512223050574-14.4">
-    <preConditions onFail="MARK_RAN">
-      <not>
-        <indexExists tableName="train_document" indexName="FKrthd11flannrdgc0hvvjcagy5"/>
-      </not>
-    </preConditions>
-    <createIndex indexName="FKrthd11flannrdgc0hvvjcagy5" tableName="train_document">
-      <column name="project" />
-    </createIndex>
-  </changeSet>  
-  
-  
   <changeSet author="WebAnno Team" id="1512223050574-41.1">
     <preConditions onFail="MARK_RAN">
       <foreignKeyConstraintExists foreignKeyTableName="constraint_set" foreignKeyName="FK7D6BCB001EBB5F0A" />
@@ -903,25 +729,6 @@
       onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="tag_set" />
   </changeSet>
 
-
-  <changeSet author="WebAnno Team" id="1512223050574-54.1">
-    <preConditions onFail="MARK_RAN">
-      <foreignKeyConstraintExists foreignKeyTableName="train_document" foreignKeyName="FK_ijpb9cuo73wabicxjvnpf8gb6" />
-    </preConditions>
-    <dropForeignKeyConstraint baseTableName="train_document" constraintName="FK_ijpb9cuo73wabicxjvnpf8gb6" />
-  </changeSet>
-
-  <changeSet author="WebAnno Team" id="1512223050574-54.3">
-    <preConditions onFail="MARK_RAN">
-      <not>
-        <foreignKeyConstraintExists foreignKeyTableName="train_document" foreignKeyName="FKrthd11flannrdgc0hvvjcagy5" />
-      </not>
-    </preConditions>
-    <addForeignKeyConstraint baseColumnNames="project" baseTableName="train_document"
-      constraintName="FKrthd11flannrdgc0hvvjcagy5" deferrable="false" initiallyDeferred="false"
-      onDelete="NO ACTION" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="project" />
-  </changeSet>
-
   <!--
     Clean up legacy index (project) on (annotation_document)
    -->
@@ -1030,18 +837,6 @@
       indexName="FK_o4j88awilp74dl39y4kh6p1h0" />
   </changeSet>
 
-  <!--
-    Clean up legacy index (project) on (train_document)
-   -->
-  <changeSet author="WebAnno Team" id="1512223050574-14.3">
-    <preConditions onFail="MARK_RAN">
-      <indexExists tableName="train_document" indexName="FK_ijpb9cuo73wabicxjvnpf8gb6"/>
-    </preConditions>
-    <dropIndex 
-      tableName="train_document"
-      indexName="FK_ijpb9cuo73wabicxjvnpf8gb6" />
-  </changeSet>
-  
   <changeSet author="WebAnno Team" id="20180204-1">
     <preConditions onFail="MARK_RAN">
       <not>
@@ -1226,7 +1021,7 @@
       <where>"allowSTacking" = b'0'</where>
     </update>
   </changeSet>
-  
+
   <changeSet author="WebAnno Team" id="20190125-1c" failOnError="false">
     <preConditions onFail="MARK_RAN">
       <changeSetExecuted author="WebAnno Team" id="20190125-1b"/>
@@ -1236,7 +1031,7 @@
       columnName="overlap_mode"
       columnDataType="VARCHAR(255)" />
   </changeSet>
-  
+
   <changeSet author="WebAnno Team" id="20100129-1">
     <preConditions onFail="MARK_RAN">
       <not>
@@ -1261,8 +1056,8 @@
         <constraints nullable="false" />
       </column>
     </addColumn>
-  </changeSet>  
-
+  </changeSet>
+  
   <changeSet author="WebAnno Team" id="20190711-1">
     <preConditions onFail="MARK_RAN">
       <not>
@@ -1321,7 +1116,7 @@
   </changeSet>
 
   <changeSet author="INCEpTION Team" id="20210218-2">
-    <preConditions onFail="WARN">
+    <preConditions onFail="MARK_RAN">
       <changeSetExecuted author="WebAnno Team" id="1512223050574-14"/>
     </preConditions>
     <dropTable tableName="train_document" cascadeConstraints="true"/>

--- a/inception/inception-search-core/src/main/resources/de/tudarmstadt/ukp/inception/search/model/db-changelog.xml
+++ b/inception/inception-search-core/src/main/resources/de/tudarmstadt/ukp/inception/search/model/db-changelog.xml
@@ -3,7 +3,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="
     http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd 
-    http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+    http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.27.xsd">
 
   <changeSet author="INCEpTION Team" id="20180406-search-01">
     <preConditions onFail="MARK_RAN">

--- a/inception/inception-security/src/main/resources/de/tudarmstadt/ukp/clarin/webanno/security/model/db-changelog.xml
+++ b/inception/inception-security/src/main/resources/de/tudarmstadt/ukp/clarin/webanno/security/model/db-changelog.xml
@@ -21,7 +21,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="
     http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd 
-    http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+    http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.27.xsd">
 
   <changeSet author="WebAnno Team" id="1512223050574-4">
     <preConditions onFail="MARK_RAN">
@@ -40,19 +40,6 @@
         <constraints nullable="false" />
       </column>
     </createTable>
-  </changeSet>
-  
-  <!--
-    Clean up legacy unique constraint (authority, username) on (authorities)
-    
-    NOTE: This change set ignores failures since there is no precondition to check if
-          unique constraints exist or not. So we simply have to try it.
-   -->
-  <changeSet author="WebAnno Team" id="1512223050574-4.1" failOnError="false">
-    <dropUniqueConstraint
-      tableName="authorities" 
-      constraintName="UK_2uf74smucdwf9qal2n67m2343"
-      uniqueColumns="authority, username" />
   </changeSet>
 
   <!-- 
@@ -81,7 +68,7 @@
       <column name="username" />
     </createIndex>
   </changeSet>  
-  
+
   <changeSet author="WebAnno Team" id="1512223050574-15">
     <preConditions onFail="MARK_RAN">
       <not>
@@ -103,8 +90,7 @@
     </createTable>
     <addPrimaryKey columnNames="username" tableName="users" />
   </changeSet>
-  
-  
+
   <changeSet author="WebAnno Team" id="1512223050574-48.1">
     <preConditions onFail="MARK_RAN">
       <foreignKeyConstraintExists foreignKeyTableName="authorities" foreignKeyName="FK2B0F1321292E1AC9" />
@@ -118,7 +104,7 @@
     </preConditions>
     <dropForeignKeyConstraint baseTableName="authorities" constraintName="FK_baahryprcge2u172egph1qwur" />
   </changeSet>
-  
+
   <changeSet author="WebAnno Team" id="1512223050574-48.3">
     <preConditions onFail="MARK_RAN">
       <not>
@@ -156,14 +142,14 @@
       </column>
     </addColumn>
   </changeSet>
-  
+
   <changeSet author="INCEpTION Team" id="20210410-01" failOnError="false">
     <addUniqueConstraint 
       tableName="users" 
       constraintName="UK_realm_uiName"
       columnNames="realm, uiName" />
   </changeSet>
-  
+
   <changeSet author="INCEpTION Team" id="20210410-02">
     <preConditions onFail="MARK_RAN">
       <foreignKeyConstraintExists 
@@ -188,7 +174,7 @@
       onDelete="CASCADE" onUpdate="CASCADE" referencedColumnNames="username"
       referencedTableName="users" />
   </changeSet>
-  
+
   <changeSet author="INCEpTION Team" id="20220930-2" dbms="!postgresql">
     <modifyDataType tableName="users" columnName="enabled" newDataType="BOOLEAN"/>
     <addNotNullConstraint tableName="users" columnName="enabled" columnDataType="BOOLEAN"/>

--- a/inception/inception-telemetry/src/main/resources/de/tudarmstadt/ukp/clarin/webanno/telemetry/model/db-changelog.xml
+++ b/inception/inception-telemetry/src/main/resources/de/tudarmstadt/ukp/clarin/webanno/telemetry/model/db-changelog.xml
@@ -22,7 +22,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="
     http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd 
-    http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+    http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.27.xsd">
   
   <changeSet author="WebAnno Team" id="20190712-1">
     <preConditions onFail="MARK_RAN">


### PR DESCRIPTION
**What's in the PR**
- Removed the migrations from the WebAnno era that delete indexes that were created before Liquibase was introduced

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
