### PR TITLE
#4925 - Retain ability to select users in curation sidebar in finished documents

### DIFF
--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebar.html
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebar.html
@@ -77,7 +77,6 @@
         </form>
         
         <span class="flex-content no-data-notice" wicket:id="noDocumentsLabel"></span>
-        <span class="flex-content no-data-notice" wicket:id="finishedLabel"></span>
       </div>
     </div>
   </div>

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebar.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebar.java
@@ -48,7 +48,6 @@ import org.apache.wicket.model.LoadableDetachableModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.model.ResourceModel;
-import org.apache.wicket.model.StringResourceModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -105,9 +104,9 @@ public class CurationSidebar
     private final Form<Void> usersForm;
     private CheckBox showMerged;
     private final IModel<CurationWorkflow> curationWorkflowModel;
+    private final IModel<Boolean> isTargetFinished;
 
     private final Label noDocsLabel;
-    private final Label finishedLabel;
 
     private final MergeDialog mergeConfirm;
 
@@ -121,14 +120,8 @@ public class CurationSidebar
 
         queue(createSessionControlForm(CID_SESSION_CONTROL_FORM));
 
-        var isTargetFinished = LambdaModel.of(() -> curationSidebarService.isCurationFinished(state,
+        isTargetFinished = LambdaModel.of(() -> curationSidebarService.isCurationFinished(state,
                 userRepository.getCurrentUsername()));
-
-        finishedLabel = new Label("finishedLabel", new StringResourceModel("finished", this,
-                LoadableDetachableModel.of(state::getUser)));
-        finishedLabel.setOutputMarkupPlaceholderTag(true);
-        finishedLabel.add(visibleWhen(() -> isSessionActive() && isTargetFinished.getObject()));
-        queue(finishedLabel);
 
         noDocsLabel = new Label("noDocumentsLabel", new ResourceModel("noDocuments"));
         noDocsLabel.add(visibleWhen(() -> isSessionActive() && !isTargetFinished.getObject()
@@ -284,11 +277,10 @@ public class CurationSidebar
 
         var form = new Form<Void>(aId);
         form.setOutputMarkupPlaceholderTag(true);
-        form.add(visibleWhen(() -> isSessionActive()
-                && !curationSidebarService.isCurationFinished(getModelObject(), sessionOwner)
-                && !users.getModelObject().isEmpty()));
+        form.add(visibleWhen(() -> isSessionActive() && !users.getModelObject().isEmpty()));
 
-        form.add(new LambdaAjaxButton<>("merge", this::actionOpenMergeDialog));
+        form.add(new LambdaAjaxButton<>("merge", this::actionOpenMergeDialog)
+                .add(visibleWhenNot(isTargetFinished)));
 
         users = new ListView<User>("users", LoadableDetachableModel.of(this::listCuratableUsers))
         {

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebar.properties
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebar.properties
@@ -21,7 +21,6 @@ merge=Re-Merge annotations of selected users into curation document
 curationHeader=Curation
 curationTarget=Curation target
 noDocuments=Other users need to have this document marked as finished to start curating!
-finished = User ${username} marked this document as finished, you can no longer curate it.
 mergeConfirmText=Automatically merging other users' annotations into your own document might delete your previous annotations. To complete the action, please enter the document name into the input field below.
 mergeConfirmTitle=Automatic Merge
 showMerged=Show merged annotations


### PR DESCRIPTION
**What's in the PR**
- Do not hide the users list when document is finished
- Hide the remerge button though

**How to test manually**
* Enable curation sidebar
* Mark document as finished
* Toggle users

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
