### PR TITLE
#4929 - Unmergable annotations should be hidden in integrated curation mode

### DIFF
--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/render/CurationSidebarRenderer.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/render/CurationSidebarRenderer.java
@@ -21,6 +21,8 @@ import static de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.doDiff;
 import static de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.getDiffAdapters;
 import static de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.LinkCompareBehavior.LINK_ROLE_AS_LABEL;
 import static de.tudarmstadt.ukp.clarin.webanno.model.Mode.ANNOTATION;
+import static de.tudarmstadt.ukp.clarin.webanno.model.OverlapMode.NO_OVERLAP;
+import static de.tudarmstadt.ukp.clarin.webanno.model.OverlapMode.STACKING_ONLY;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toMap;
@@ -167,6 +169,9 @@ public class CurationSidebarRenderer
                     .filter(feature -> feature.getLayer().equals(layer)) //
                     .toList();
 
+            var noOverlap = layer.getOverlapMode() == NO_OVERLAP
+                    || layer.getOverlapMode() == STACKING_ONLY;
+
             for (var cfg : cfgSet.getConfigurations()) {
                 var fs = cfg.getRepresentative(casDiff.getCasMap());
                 if (!(fs instanceof Annotation)) {
@@ -194,11 +199,24 @@ public class CurationSidebarRenderer
                     }
 
                     if (!showAll && object instanceof VSpan) {
+                        // Check if the target already contains an annotation from this
+                        // configuration
                         var sourceConfiguration = diff.findConfiguration(
                                 cfg.getRepresentativeCasGroupId(), new AID(object.getVid()));
                         if (sourceConfiguration.map($ -> $.getAID(targetUser) != null)
                                 .orElse(false)) {
                             continue;
+                        }
+
+                        // Check if the position could be merged at all or if the merge is blocked
+                        // by an overlapping annotation (which may not be contained in the
+                        // configuration)
+                        if (noOverlap && fs instanceof Annotation ann) {
+                            var cas = aRequest.getCas();
+                            if (cas.<Annotation> select(ann.getType().getName())
+                                    .anyMatch(f -> ann.overlapping(f))) {
+                                continue;
+                            }
                         }
                     }
 


### PR DESCRIPTION
**What's in the PR**
- Hide overlapping curation suggestions if the layer does not support overlapping annotations

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
