### PR TITLE
#4909 - Upgrade dependencies (34.0)

### DIFF
--- a/inception/inception-app-webapp/pom.xml
+++ b/inception/inception-app-webapp/pom.xml
@@ -561,7 +561,7 @@
     <!-- SENTRY DEPENDENCIES -->
     <dependency>
       <groupId>io.sentry</groupId>
-      <artifactId>sentry-spring-boot-starter</artifactId>
+      <artifactId>sentry-spring-boot-starter-jakarta</artifactId>
     </dependency>
     <dependency>
       <groupId>io.sentry</groupId>
@@ -725,8 +725,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
+      <groupId>com.mysql</groupId>
+      <artifactId>mysql-connector-j</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -1044,8 +1044,8 @@
               <usedDependency>org.hsqldb:hsqldb</usedDependency>
               <usedDependency>org.mariadb.jdbc:mariadb-java-client</usedDependency>
               <usedDependency>com.microsoft.sqlserver:mssql-jdbc</usedDependency>
-              <usedDependency>mysql:mysql-connector-java</usedDependency>
               <usedDependency>org.postgresql:postgresql</usedDependency>
+              <usedDependency>com.mysql:mysql-connector-j</usedDependency>
               <!-- Logging - used via reflection / optional -->
               <usedDependency>com.mattbertolini:liquibase-slf4j</usedDependency>
               <usedDependency>org.slf4j:log4j-over-slf4j</usedDependency>
@@ -1053,7 +1053,7 @@
               <usedDependency>org.apache.logging.log4j:log4j-core</usedDependency>
               <usedDependency>org.apache.logging.log4j:log4j-layout-template-json</usedDependency>
               <!-- Monitoring - used via reflection / optional -->
-              <usedDependency>io.sentry:sentry-spring-boot-starter</usedDependency>
+              <usedDependency>io.sentry:sentry-spring-boot-starter-jakarta</usedDependency>
               <usedDependency>io.sentry:sentry-log4j2</usedDependency>
               <!-- Themes -->
               <usedDependency>org.wicketstuff:wicketstuff-kendo-ui-theme-bootstrap</usedDependency>

--- a/inception/inception-build/src/main/resources/inception/rules.xml
+++ b/inception/inception-build/src/main/resources/inception/rules.xml
@@ -23,6 +23,7 @@
     <ignoreVersion type="regex">(?i).*[-_\.]b[0-9\.]*</ignoreVersion>
     <ignoreVersion type="regex">(?i).*[-_\.]M[0-9\.]*</ignoreVersion>
     <ignoreVersion type="regex">(?i).*[-_\.]rc[0-9\.-]*</ignoreVersion>
+    <ignoreVersion type="regex">(?i).*[-_\.]Dev[0-9\.-]*</ignoreVersion>
     <ignoreVersion type="regex">(?i).*[-_\.]alpha[0-9\.-]*</ignoreVersion>
     <ignoreVersion type="regex">(?i).*[-_\.]beta[0-9\.-]*</ignoreVersion>
     <!-- e.g. commons-collections:commons-collections ... 3.2.1.redhat-7 -> 20040117.000000 -->

--- a/inception/inception-dependencies/pom.xml
+++ b/inception/inception-dependencies/pom.xml
@@ -202,7 +202,7 @@
       <dependency>
         <groupId>com.nimbusds</groupId>
         <artifactId>nimbus-jose-jwt</artifactId>
-        <version>9.39.3</version>
+        <version>${nimbus-jose-jwt.version}</version>
       </dependency>
       <dependency>
         <groupId>org.awaitility</groupId>
@@ -507,7 +507,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-dbcp2</artifactId>
-        <version>2.11.0</version>
+        <version>${commons-dbcp2.version}</version>
       </dependency>
       <dependency>
         <groupId>org.dom4j</groupId>
@@ -632,7 +632,7 @@
       <dependency>
         <groupId>com.fasterxml.woodstox</groupId>
         <artifactId>woodstox-core</artifactId>
-        <version>6.6.2</version>
+        <version>${woodstox-core.version}</version>
       </dependency>
       <dependency>
         <groupId>org.codehaus.woodstox</groupId>
@@ -649,7 +649,7 @@
       <dependency>
         <groupId>it.unimi.dsi</groupId>
         <artifactId>fastutil</artifactId>
-        <version>8.5.13</version>
+        <version>${fastutil.version}</version>
       </dependency>
 
       <dependency>
@@ -696,12 +696,12 @@
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy</artifactId>
-        <version>1.14.17</version>
+        <version>${byte-buddy.version}</version>
       </dependency>
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy-agent</artifactId>
-        <version>1.14.17</version>
+        <version>${byte-buddy.version}</version>
       </dependency>
       <dependency>
         <groupId>org.wicketstuff</groupId>
@@ -747,7 +747,7 @@
       <dependency>
         <groupId>com.networknt</groupId>
         <artifactId>json-schema-validator</artifactId>
-        <version>1.4.0</version>
+        <version>${json-schema-validator.version}</version>
       </dependency>
 
       <!-- SPRING SECURITY -->
@@ -789,12 +789,12 @@
       <!-- Springdoc -->
       <dependency>
         <groupId>org.springdoc</groupId>
-        <artifactId>springdoc-openapi-ui</artifactId>
+        <artifactId>springdoc-openapi-starter-common</artifactId>
         <version>${springdoc.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springdoc</groupId>
-        <artifactId>springdoc-openapi-common</artifactId>
+        <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
         <version>${springdoc.version}</version>
       </dependency>
       <dependency>
@@ -1040,7 +1040,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.14.0</version>
+        <version>${commons-lang3.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -1050,7 +1050,7 @@
       <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
-        <version>1.17.0</version>
+        <version>${commons-codec.version}</version>
       </dependency>
       <dependency>
         <groupId>commons-validator</groupId>
@@ -1328,7 +1328,7 @@
       <dependency>
         <groupId>org.eclipse.jgit</groupId>
         <artifactId>org.eclipse.jgit</artifactId>
-        <version>6.9.0.202403050737-r</version>
+        <version>${jgit.version}</version>
       </dependency>
 
       <dependency>
@@ -1417,12 +1417,12 @@
       <dependency>
         <groupId>info.picocli</groupId>
         <artifactId>picocli</artifactId>
-        <version>4.7.6</version>
+        <version>${picocli.version}</version>
       </dependency>
       <dependency>
         <groupId>info.picocli</groupId>
         <artifactId>picocli-spring-boot-starter</artifactId>
-        <version>4.7.5</version>
+        <version>${picocli.version}</version>
       </dependency>
 
       <dependency>

--- a/inception/inception-dependencies/pom.xml
+++ b/inception/inception-dependencies/pom.xml
@@ -61,7 +61,7 @@
       <dependency>
         <groupId>org.glassfish.jaxb</groupId>
         <artifactId>jaxb-bom</artifactId>
-        <version>2.3.9</version>
+        <version>${jaxb.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -88,7 +88,7 @@
       <dependency>
         <groupId>org.glassfish.jaxb</groupId>
         <artifactId>jaxb-runtime</artifactId>
-        <version>2.3.9</version>
+        <version>${jaxb.version}</version>
       </dependency>
       <dependency>
         <groupId>javax.activation</groupId>
@@ -400,7 +400,7 @@
       <dependency>
         <groupId>org.webjars</groupId>
         <artifactId>font-awesome</artifactId>
-        <version>5.15.4</version>
+        <version>${font-awesome.version}</version>
       </dependency>
       <dependency>
         <groupId>org.webjars.npm</groupId>
@@ -464,7 +464,7 @@
       <dependency>
         <groupId>com.hubspot.jinjava</groupId>
         <artifactId>jinjava</artifactId>
-        <version>2.7.2</version>
+        <version>${jinjava.version}</version>
       </dependency>
 
       <dependency>
@@ -476,7 +476,7 @@
       <dependency>
         <groupId>commons-beanutils</groupId>
         <artifactId>commons-beanutils</artifactId>
-        <version>1.9.4</version>
+        <version>${commons-beanutils.version}</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -487,22 +487,22 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-collections4</artifactId>
-        <version>4.4</version>
+        <version>${commons-collections4.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-csv</artifactId>
-        <version>1.11.0</version>
+        <version>${commons-csv.version}</version>
       </dependency>
       <dependency>
         <groupId>commons-fileupload</groupId>
         <artifactId>commons-fileupload</artifactId>
-        <version>1.5</version>
+        <version>${commons-fileupload.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-pool2</artifactId>
-        <version>2.12.0</version>
+        <version>${commons-pool2.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -528,7 +528,7 @@
       <dependency>
         <groupId>org.pf4j</groupId>
         <artifactId>pf4j-spring</artifactId>
-        <version>0.5.0</version>
+        <version>${pf4j-spring.version}</version>
         <exclusions>
           <exclusion>
             <groupId>org.slf4j</groupId>
@@ -540,12 +540,12 @@
       <dependency>
         <groupId>commons-logging</groupId>
         <artifactId>commons-logging-api</artifactId>
-        <version>1.1</version>
+        <version>${commons-logging-api.version}</version>
       </dependency>
       <dependency>
         <groupId>commons-logging</groupId>
         <artifactId>commons-logging</artifactId>
-        <version>1.3.2</version>
+        <version>${commons-logging.version}</version>
       </dependency>
 
       <!-- Jena -->
@@ -643,7 +643,7 @@
       <dependency>
         <groupId>com.github.openjson</groupId>
         <artifactId>openjson</artifactId>
-        <version>1.0.13</version>
+        <version>${openjson.version}</version>
       </dependency>
 
       <dependency>
@@ -691,7 +691,7 @@
       <dependency>
         <groupId>org.javassist</groupId>
         <artifactId>javassist</artifactId>
-        <version>3.30.2-GA</version>
+        <version>${javassist.version}</version>
       </dependency>
       <dependency>
         <groupId>net.bytebuddy</groupId>
@@ -761,7 +761,7 @@
       <dependency>
         <groupId>com.nimbusds</groupId>
         <artifactId>oauth2-oidc-sdk</artifactId>
-        <version>9.43.4</version>
+        <version>${oauth2-oidc-sdk.version}</version>
       </dependency>
       <dependency>
         <groupId>io.jsonwebtoken</groupId>
@@ -781,7 +781,7 @@
       <dependency>
         <groupId>org.opensaml</groupId>
         <artifactId>opensaml-bom</artifactId>
-        <version>4.3.2</version>
+        <version>${opensaml.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -799,12 +799,12 @@
       </dependency>
       <dependency>
         <groupId>io.swagger.core.v3</groupId>
-        <artifactId>swagger-annotations</artifactId>
+        <artifactId>swagger-annotations-jakarta</artifactId>
         <version>${swagger.version}</version>
       </dependency>
       <dependency>
         <groupId>io.swagger.core.v3</groupId>
-        <artifactId>swagger-models</artifactId>
+        <artifactId>swagger-models-jakarta</artifactId>
         <version>${swagger.version}</version>
       </dependency>
 
@@ -857,7 +857,7 @@
       <dependency>
         <groupId>org.hsqldb</groupId>
         <artifactId>hsqldb</artifactId>
-        <version>2.7.3</version>
+        <version>${hsqldb.version}</version>
       </dependency>
 
       <dependency>
@@ -897,7 +897,7 @@
       <dependency>
         <groupId>org.jsoup</groupId>
         <artifactId>jsoup</artifactId>
-        <version>1.16.1</version>
+        <version>${jsoup.version}</version>
       </dependency>
 
       <!-- MIME4J -->
@@ -905,12 +905,12 @@
       <dependency>
         <groupId>org.apache.james</groupId>
         <artifactId>apache-mime4j-core</artifactId>
-        <version>0.8.10</version>
+        <version>${mime4j.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.james</groupId>
         <artifactId>apache-mime4j-dom</artifactId>
-        <version>0.8.10</version>
+        <version>${mime4j.version}</version>
       </dependency>
 
       <!-- LUCENE MTAS -->
@@ -1013,29 +1013,16 @@
         <version>${solr.version}</version>
         <scope>test</scope>
       </dependency>
-      <dependency>
-        <groupId>org.textexploration.mtas</groupId>
-        <artifactId>mtas</artifactId>
-        <version>${mtas.version}</version>
-        <exclusions>
-          <!-- We do not use MTAS with Solr -->
-          <!-- Solr depends on jdk.tools via Hadoop which is not available on recent JDKs -->
-          <exclusion>
-            <groupId>org.apache.solr</groupId>
-            <artifactId>solr-core</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
 
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.16.1</version>
+        <version>${commons-io.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-text</artifactId>
-        <version>1.12.0</version>
+        <version>${commons-text.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -1045,7 +1032,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-compress</artifactId>
-        <version>1.26.2</version>
+        <version>${commons-compress.version}</version>
       </dependency>
       <dependency>
         <groupId>commons-codec</groupId>
@@ -1055,7 +1042,7 @@
       <dependency>
         <groupId>commons-validator</groupId>
         <artifactId>commons-validator</artifactId>
-        <version>1.9.0</version>
+        <version>${commons-validator.version}</version>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -1066,12 +1053,12 @@
       <dependency>
         <groupId>com.github.ben-manes.caffeine</groupId>
         <artifactId>caffeine</artifactId>
-        <version>3.1.8</version>
+        <version>${caffeine.version}</version>
       </dependency>
       <dependency>
         <groupId>org.xerial.snappy</groupId>
         <artifactId>snappy-java</artifactId>
-        <version>1.1.10.5</version>
+        <version>${snappy.version}</version>
       </dependency>
 
       <dependency>
@@ -1242,7 +1229,7 @@
       <dependency>
         <groupId>com.github.jsonld-java</groupId>
         <artifactId>jsonld-java</artifactId>
-        <version>0.13.6</version>
+        <version>${jsonld-java.version}</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.httpcomponents</groupId>
@@ -1322,7 +1309,7 @@
       <dependency>
         <groupId>net.java.dev.jna</groupId>
         <artifactId>jna</artifactId>
-        <version>5.13.0</version>
+        <version>${jna.version}</version>
       </dependency>
 
       <dependency>
@@ -1360,6 +1347,12 @@
         <groupId>org.mariadb.jdbc</groupId>
         <artifactId>mariadb-java-client</artifactId>
         <version>${mariadb.driver.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.postgresql</groupId>
@@ -1372,8 +1365,8 @@
         <version>${mssql.driver.version}</version>
       </dependency>
       <dependency>
-        <groupId>mysql</groupId>
-        <artifactId>mysql-connector-java</artifactId>
+        <groupId>com.mysql</groupId>
+        <artifactId>mysql-connector-j</artifactId>
         <version>${mysql.driver.version}</version>
       </dependency>
 

--- a/inception/inception-project-export/pom.xml
+++ b/inception/inception-project-export/pom.xml
@@ -169,7 +169,7 @@
 
     <dependency>
       <groupId>io.swagger.core.v3</groupId>
-      <artifactId>swagger-annotations</artifactId>
+      <artifactId>swagger-annotations-jakarta</artifactId>
     </dependency>
 
     <dependency>

--- a/inception/inception-remote/pom.xml
+++ b/inception/inception-remote/pom.xml
@@ -194,11 +194,11 @@
     </dependency>
     <dependency>
       <groupId>io.swagger.core.v3</groupId>
-      <artifactId>swagger-annotations</artifactId>
+      <artifactId>swagger-models-jakarta</artifactId>
     </dependency>
     <dependency>
       <groupId>io.swagger.core.v3</groupId>
-      <artifactId>swagger-models</artifactId>
+      <artifactId>swagger-annotations-jakarta</artifactId>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/inception/inception-remote/pom.xml
+++ b/inception/inception-remote/pom.xml
@@ -186,11 +186,11 @@
     <!-- Swagger / Springdoc -->
     <dependency>
       <groupId>org.springdoc</groupId>
-      <artifactId>springdoc-openapi-ui</artifactId>
+      <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springdoc</groupId>
-      <artifactId>springdoc-openapi-common</artifactId>
+      <artifactId>springdoc-openapi-starter-common</artifactId>
     </dependency>
     <dependency>
       <groupId>io.swagger.core.v3</groupId>
@@ -361,7 +361,7 @@
               <!--
                - Need this for auto-configuration 
                -->
-              <ignoredDependency>org.springdoc:springdoc-openapi-ui</ignoredDependency>
+              <ignoredDependency>org.springdoc:springdoc-openapi-starter-webmvc-ui</ignoredDependency>
               <!--
                - Test dependencies used via auto-configuration and reflection
                -->

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/config/RemoteApiAutoConfiguration.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/config/RemoteApiAutoConfiguration.java
@@ -23,7 +23,7 @@ import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 
-import org.springdoc.core.GroupedOpenApi;
+import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -67,7 +67,7 @@ public class RemoteApiAutoConfiguration
     {
         return GroupedOpenApi.builder().group("disabled") //
                 .pathsToExclude("/**") //
-                .addOpenApiCustomiser(openApi -> { //
+                .addOpenApiCustomizer(openApi -> { //
                     openApi.info(new Info() //
                             .title("Remote API disabled") //
                             .description("The remote API is not enabled."));
@@ -81,7 +81,7 @@ public class RemoteApiAutoConfiguration
     {
         return GroupedOpenApi.builder().group("legacy-v1")
                 .pathsToMatch(LegacyRemoteApiController.API_BASE + "/**") //
-                .addOpenApiCustomiser(openApi -> { //
+                .addOpenApiCustomizer(openApi -> { //
                     openApi.info(new Info() //
                             .title("Legacy API") //
                             .version("1"));
@@ -95,7 +95,7 @@ public class RemoteApiAutoConfiguration
     {
         return GroupedOpenApi.builder().group("aero-v1")
                 .pathsToMatch(AeroRemoteApiController.API_BASE + "/**")
-                .addOpenApiCustomiser(openApi -> { //
+                .addOpenApiCustomizer(openApi -> { //
                     openApi.info(new Info() //
                             .title("AERO") //
                             .version("1.0.0")

--- a/inception/pom.xml
+++ b/inception/pom.xml
@@ -868,7 +868,7 @@
                 <dependency>
                   <groupId>com.puppycrawl.tools</groupId>
                   <artifactId>checkstyle</artifactId>
-                  <version>10.14.2</version>
+                  <version>10.17.0</version>
                 </dependency>
               </dependencies>
               <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
 
   <properties>
     <build-ant-version>1.10.14</build-ant-version>
-    <build-groovy-version>4.0.21</build-groovy-version>
+    <build-groovy-version>4.0.22</build-groovy-version>
 
     <junit-jupiter.version>5.10.3</junit-jupiter.version>
     <junit-platform.version>1.10.3</junit-platform.version>
@@ -97,15 +97,15 @@
     <slf4j.version>2.0.13</slf4j.version>
     <log4j2.version>2.23.1</log4j2.version>
     <jboss.logging.version>3.6.0.Final</jboss.logging.version>
-    <sentry.version>6.34.0</sentry.version>
+    <sentry.version>7.12.1</sentry.version>
 
     <tomcat.version>10.1.26</tomcat.version>
     <jetty.version>12.0.12</jetty.version>
     <servlet-api.version>6.0.0</servlet-api.version>
 
-    <mariadb.driver.version>2.7.12</mariadb.driver.version>
+    <mariadb.driver.version>3.4.1</mariadb.driver.version>
     <mssql.driver.version>12.6.3.jre11</mssql.driver.version>
-    <mysql.driver.version>8.0.33</mysql.driver.version>
+    <mysql.driver.version>9.0.0</mysql.driver.version>
     <postgres.driver.version>42.7.3</postgres.driver.version>
     <hibernate.version>6.5.2.Final</hibernate.version>
     <hibernate.validator.version>8.0.1.Final</hibernate.validator.version>
@@ -120,7 +120,7 @@
     <!--
       - These are all interconnected - because they share the dependency on Lucene.
       -->
-    <lucene.version>9.11.1</lucene.version>
+    <lucene.version>9.10.0</lucene.version>
     <solr.version>9.6.1</solr.version>
     <opensearch.version>2.15.0</opensearch.version>
     <jena.version>5.1.0</jena.version>
@@ -134,20 +134,45 @@
 
     <json.version>20230227</json.version>
     <pf4j.version>2.6.0</pf4j.version>
+    <pf4j-spring.version>0.5.0</pf4j-spring.version>
     <jackson.version>2.17.2</jackson.version>
     <snakeyaml.version>2.2</snakeyaml.version>
     <okhttp.version>4.12.0</okhttp.version>
     <okio.version>3.9.0</okio.version>
     <byte-buddy.version>1.14.18</byte-buddy.version>
+    <caffeine.version>3.1.8</caffeine.version>
+    <commons-beanutils.version>1.9.4</commons-beanutils.version>
+    <commons-collections4.version>4.4</commons-collections4.version>
+    <commons-csv.version>1.11.0</commons-csv.version>
+    <commons-fileupload.version>1.5</commons-fileupload.version>
+    <commons-pool2.version>2.12.0</commons-pool2.version>
     <commons-lang3.version>3.15.0</commons-lang3.version>
     <commons-dbcp2.version>2.12.0</commons-dbcp2.version>
     <commons-codec.version>1.17.1</commons-codec.version>
+    <commons-compress.version>1.26.2</commons-compress.version>
+    <commons-text.version>1.12.0</commons-text.version>
+    <commons-validator.version>1.9.0</commons-validator.version>
+    <commons-io.version>2.16.1</commons-io.version>
+    <commons-logging.version>1.3.3</commons-logging.version>
+    <commons-logging-api.version>1.1</commons-logging-api.version>
+    <jinjava.version>2.7.2</jinjava.version>
     <fastutil.version>8.5.14</fastutil.version>
     <picocli.version>4.7.6</picocli.version>
     <woodstox-core.version>6.7.0</woodstox-core.version>
     <nimbus-jose-jwt.version>9.40</nimbus-jose-jwt.version>
     <json-schema-validator.version>1.5.1</json-schema-validator.version>
     <jgit.version>6.10.0.202406032230-r</jgit.version>
+    <jaxb.version>4.0.5</jaxb.version>
+    <snappy.version>1.1.10.5</snappy.version>
+    <jsonld-java.version>0.13.6</jsonld-java.version>
+    <jna.version>5.14.0</jna.version>
+    <jsoup.version>1.16.1</jsoup.version>
+    <mime4j.version>0.8.10</mime4j.version>
+    <hsqldb.version>2.7.3</hsqldb.version>
+    <opensaml.version>4.3.2</opensaml.version>
+    <oauth2-oidc-sdk.version>9.43.4</oauth2-oidc-sdk.version>
+    <javassist.version>3.30.2-GA</javassist.version>
+    <openjson.version>1.0.13</openjson.version>
 
     <node.version>20.12.2</node.version>
     <apache-annotator.version>0.2.0</apache-annotator.version>
@@ -166,6 +191,7 @@
     <eslint-plugin-svelte.version>^2.37.0</eslint-plugin-svelte.version>
     <events.version>^3.3.0</events.version>
     <fast-json-patch.version>^3.1.1</fast-json-patch.version>
+    <font-awesome.version>6.5.2</font-awesome.version>
     <fs-extra.version>^11.2.0</fs-extra.version>
     <jsdom.version>^20.0.0</jsdom.version>
     <jsdom-global.version>^3.0.2</jsdom-global.version>

--- a/pom.xml
+++ b/pom.xml
@@ -70,12 +70,12 @@
     <build-ant-version>1.10.14</build-ant-version>
     <build-groovy-version>4.0.21</build-groovy-version>
 
-    <junit-jupiter.version>5.10.2</junit-jupiter.version>
-    <junit-platform.version>1.10.2</junit-platform.version>
+    <junit-jupiter.version>5.10.3</junit-jupiter.version>
+    <junit-platform.version>1.10.3</junit-platform.version>
     <mockito.version>5.12.0</mockito.version>
-    <assertj.version>3.26.0</assertj.version>
+    <assertj.version>3.26.3</assertj.version>
     <xmlunit.version>2.10.0</xmlunit.version>
-    <testcontainers.version>1.19.8</testcontainers.version>
+    <testcontainers.version>1.20.0</testcontainers.version>
 
     <awaitility.version>4.2.1</awaitility.version>
 
@@ -86,26 +86,26 @@
 
     <pdfbox.version>2.0.30</pdfbox.version>
 
-    <spring.version>6.1.8</spring.version>
-    <spring.boot.version>3.3.0</spring.boot.version>
-    <spring.data.version>3.2.4</spring.data.version>
-    <spring.security.version>6.3.0</spring.security.version>
-    <springdoc.version>1.8.0</springdoc.version>
+    <spring.version>6.1.11</spring.version>
+    <spring.boot.version>3.3.2</spring.boot.version>
+    <spring.data.version>3.3.2</spring.data.version>
+    <spring.security.version>6.3.1</spring.security.version>
+    <springdoc.version>2.6.0</springdoc.version>
     <swagger.version>2.2.22</swagger.version>
-    <jjwt.version>0.12.5</jjwt.version>
+    <jjwt.version>0.12.6</jjwt.version>
 
     <slf4j.version>2.0.13</slf4j.version>
     <log4j2.version>2.23.1</log4j2.version>
-    <jboss.logging.version>3.5.3.Final</jboss.logging.version>
+    <jboss.logging.version>3.6.0.Final</jboss.logging.version>
     <sentry.version>6.34.0</sentry.version>
 
-    <tomcat.version>10.1.24</tomcat.version>
-    <jetty.version>12.0.11</jetty.version>
+    <tomcat.version>10.1.26</tomcat.version>
+    <jetty.version>12.0.12</jetty.version>
     <servlet-api.version>6.0.0</servlet-api.version>
 
     <mariadb.driver.version>2.7.12</mariadb.driver.version>
     <mssql.driver.version>12.6.3.jre11</mssql.driver.version>
-    <mysql.driver.version>8.0.27</mysql.driver.version>
+    <mysql.driver.version>8.0.33</mysql.driver.version>
     <postgres.driver.version>42.7.3</postgres.driver.version>
     <hibernate.version>6.5.2.Final</hibernate.version>
     <hibernate.validator.version>8.0.1.Final</hibernate.validator.version>
@@ -120,24 +120,34 @@
     <!--
       - These are all interconnected - because they share the dependency on Lucene.
       -->
-    <lucene.version>9.10.0</lucene.version>
+    <lucene.version>9.11.1</lucene.version>
     <solr.version>9.6.1</solr.version>
-    <opensearch.version>2.14.0</opensearch.version>
+    <opensearch.version>2.15.0</opensearch.version>
     <jena.version>5.1.0</jena.version>
     <rdf4j.version>4.3.13</rdf4j.version> 
     <owlapi-version>5.5.0</owlapi-version>
 
     <asciidoctor.plugin.version>2.2.3</asciidoctor.plugin.version>
-    <asciidoctor.version>2.5.12</asciidoctor.version>
-    <asciidoctor-diagram.version>2.3.0</asciidoctor-diagram.version>
-    <build-asciidoctorj-pdf-version>2.3.15</build-asciidoctorj-pdf-version>
+    <asciidoctor.version>2.5.13</asciidoctor.version>
+    <asciidoctor-diagram.version>2.3.1</asciidoctor-diagram.version>
+    <build-asciidoctorj-pdf-version>2.3.17</build-asciidoctorj-pdf-version>
 
     <json.version>20230227</json.version>
     <pf4j.version>2.6.0</pf4j.version>
-    <jackson.version>2.17.1</jackson.version>
+    <jackson.version>2.17.2</jackson.version>
     <snakeyaml.version>2.2</snakeyaml.version>
     <okhttp.version>4.12.0</okhttp.version>
     <okio.version>3.9.0</okio.version>
+    <byte-buddy.version>1.14.18</byte-buddy.version>
+    <commons-lang3.version>3.15.0</commons-lang3.version>
+    <commons-dbcp2.version>2.12.0</commons-dbcp2.version>
+    <commons-codec.version>1.17.1</commons-codec.version>
+    <fastutil.version>8.5.14</fastutil.version>
+    <picocli.version>4.7.6</picocli.version>
+    <woodstox-core.version>6.7.0</woodstox-core.version>
+    <nimbus-jose-jwt.version>9.40</nimbus-jose-jwt.version>
+    <json-schema-validator.version>1.5.1</json-schema-validator.version>
+    <jgit.version>6.10.0.202406032230-r</jgit.version>
 
     <node.version>20.12.2</node.version>
     <apache-annotator.version>0.2.0</apache-annotator.version>


### PR DESCRIPTION
**What's in the PR**
- junit 5.10.2 -> 5.10.3
- junit-platform 1.10.2 -> 1.10.3
- spring 6.1.8 -> 6.1.11
- spring-boot 3.3.0 -> 3.3.2
- spring-data 3.2.4 -> 3.3.2
- spring-security 6.3.0 -> 6.3.1
- springdoc 1.8.0 -> 2.6.0
- jjwt 0.12.5 -> 0.12.6
- jboss-logging 3.5.3 -> 3.6.0
- assertj 3.26.0 -> 3.26.3
- testcontainers 1.19.8 -> 1.20.0
- tomcat 10.1.24 -> 10.1.26
- jetty 12.0.11 -> 12.0.12
- mysql-driver 8.0.27 -> 8.0.33
- hibernate-validator
- opensearch 2.14.0 -> 2.15.0
- asciidoctor 2.5.12 -> 2.5.13
- asciidoctor-diagram 2.3.0 -> 2.3.1
- asciidoctor-pdf 2.3.15 -> 2.3.17
- jackson 2.17.1 -> 2.17.2
- byte-buddy 1.14.17 -> 1.14.8
- commons-lang3 3.14.0 -> 3.15.0
- commons-codec 1.17.0 -> 1.17.1
- commons-dbcp2 2.11.0 -> 2.12.0
- jgit 6.9.0.202403050737-r -> 6.10.0.202406032230-r
- json-schema-validator 1.4.0 -> 1.5.1
- fastutil 8.5.13 -> 8.5.14
- woodstox-core 6.6.2 -> 6.7.0
- nimbus-jose-jwt 9.39.3 -> 9.40
- groovy 4.0.21 -> 4.0.22
- sentry 6.34.0 -> 7.12.1
- mariadb-driver 2.7.12 -> 3.4.1
- mysql-driver 8.0.33 -> 9.0.0
- font-awesome 5.15.4 -> 6.5.2
- jaxb 2.3.9 -> 4.0.5
- jna 5.13.0 -> 5.14.0

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
