### PR TITLE
#4975 - Cancelling background jobs no longer works

### DIFF
--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/WicketSecurityUtils.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/WicketSecurityUtils.java
@@ -19,6 +19,7 @@ package de.tudarmstadt.ukp.clarin.webanno.security;
 
 import org.apache.wicket.protocol.http.servlet.ServletWebRequest;
 import org.apache.wicket.request.cycle.RequestCycle;
+import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.security.web.csrf.HttpSessionCsrfTokenRepository;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -30,6 +31,12 @@ public class WicketSecurityUtils
     {
         var httpRequest = (HttpServletRequest) RequestCycle.get().getRequest()
                 .getContainerRequest();
+
+        var token = (CsrfToken) httpRequest.getAttribute("_csrf");
+        if (token != null) {
+            return token.getToken();
+        }
+
         var httpResponse = (HttpServletResponse) RequestCycle.get().getResponse()
                 .getContainerResponse();
 

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/config/InceptionSecurityWebUIApiAutoConfiguration.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/config/InceptionSecurityWebUIApiAutoConfiguration.java
@@ -71,14 +71,21 @@ public class InceptionSecurityWebUIApiAutoConfiguration
 
     private void commonConfiguration(HttpSecurity aHttp) throws Exception
     {
-        aHttp.authorizeHttpRequests() //
-                .requestMatchers("/**").hasAnyRole("USER") //
-                .anyRequest().denyAll();
-        aHttp.sessionManagement().sessionCreationPolicy(NEVER);
-        aHttp.exceptionHandling() //
-                .defaultAuthenticationEntryPointFor( //
-                        new Http403ForbiddenEntryPoint(), //
-                        new AntPathRequestMatcher("/**"));
+        aHttp.authorizeHttpRequests(authorizeHttpRequests -> {
+            authorizeHttpRequests //
+                    .requestMatchers("/**").hasAnyRole("USER") //
+                    .anyRequest().denyAll();
+        });
+
+        aHttp.sessionManagement(sessionManagement -> {
+            sessionManagement.sessionCreationPolicy(NEVER);
+        });
+
+        aHttp.exceptionHandling(exceptionHandling -> {
+            exceptionHandling.defaultAuthenticationEntryPointFor( //
+                    new Http403ForbiddenEntryPoint(), //
+                    new AntPathRequestMatcher("/**"));
+        });
 
     }
 }


### PR DESCRIPTION
**What's in the PR**
- Change the way that CSRF is not applied to Wicket UI calls but still register Spring CSRF token in the request
- Update some of the Spring Security configuration to non-deprecated calls

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
