### PR TITLE
#4990 - Non-trainable recommender may be invoked even though inheritable predictions exist

### DIFF
--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/PredictionTask.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/PredictionTask.java
@@ -213,8 +213,7 @@ public class PredictionTask
         var monitor = getMonitor();
         var sessionOwner = getSessionOwner();
         var project = getProject();
-        var activePredictions = isolated ? null
-                : recommendationService.getPredictions(sessionOwner, project);
+        var activePredictions = getPredecessorPredictions(sessionOwner, project);
         var incomingPredictions = activePredictions != null ? new Predictions(activePredictions)
                 : new Predictions(sessionOwner, dataOwner, project);
 
@@ -260,14 +259,14 @@ public class PredictionTask
     {
         var sessionOwner = getSessionOwner();
         var project = getProject();
-        var activePredictions = isolated ? null
-                : recommendationService.getPredictions(sessionOwner, project);
-        var incomingPredictions = activePredictions != null ? new Predictions(activePredictions)
+        var predecessorPredictions = getPredecessorPredictions(sessionOwner, project);
+        var incomingPredictions = predecessorPredictions != null
+                ? new Predictions(predecessorPredictions)
                 : new Predictions(sessionOwner, dataOwner, project);
 
         aMonitor.setMaxProgress(1);
 
-        if (activePredictions != null) {
+        if (predecessorPredictions != null) {
             // Limit prediction to a single document and inherit the rest
             var documentsToInheritSuggestionsFor = aDocuments.stream() //
                     .filter(d -> !d.equals(currentDocument)) //
@@ -276,7 +275,7 @@ public class PredictionTask
             logPredictionStartedForOneDocumentWithInheritance(documentsToInheritSuggestionsFor);
 
             for (var document : documentsToInheritSuggestionsFor) {
-                inheritSuggestionsAtDocumentLevel(project, document, activePredictions,
+                inheritSuggestionsAtDocumentLevel(project, document, predecessorPredictions,
                         incomingPredictions);
             }
         }
@@ -287,8 +286,8 @@ public class PredictionTask
         try (var casHolder = new PredictionCasHolder()) {
 
             final CAS predictionCas = casHolder.cas;
-            applyAllRecommendersToDocument(activePredictions, incomingPredictions, predictionCas,
-                    aCurrentDocument, predictionBegin, predictionEnd);
+            applyAllRecommendersToDocument(predecessorPredictions, incomingPredictions,
+                    predictionCas, aCurrentDocument, predictionBegin, predictionEnd);
         }
         catch (ResourceInitializationException e) {
             logErrorCreationPredictionCas(incomingPredictions);
@@ -297,6 +296,21 @@ public class PredictionTask
         aMonitor.setProgress(1);
 
         return incomingPredictions;
+    }
+
+    private Predictions getPredecessorPredictions(User sessionOwner, Project project)
+    {
+        if (isolated) {
+            return null;
+        }
+
+        var incomingPredictions = recommendationService.getIncomingPredictions(sessionOwner,
+                project);
+        if (incomingPredictions != null) {
+            return incomingPredictions;
+        }
+
+        return recommendationService.getPredictions(sessionOwner, project);
     }
 
     /**


### PR DESCRIPTION
**What's in the PR**
- The inheritable annotations may be in the incoming predictions and not in the active predictions, so look at incoming first, if none are there, then look in active.

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
