### PR TITLE
#4994 - Annotation browser sometimes does not load in sidebar curation mode

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/rendering/LabelRenderer.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/rendering/LabelRenderer.java
@@ -22,11 +22,9 @@ import static de.tudarmstadt.ukp.inception.schema.api.feature.TypeUtil.getUiLabe
 import org.springframework.core.annotation.Order;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.config.AnnotationAutoConfiguration;
-import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.inception.rendering.pipeline.RenderStep;
 import de.tudarmstadt.ukp.inception.rendering.request.RenderRequest;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VDocument;
-import de.tudarmstadt.ukp.inception.rendering.vmodel.VObject;
 
 /**
  * <p>
@@ -49,8 +47,8 @@ public class LabelRenderer
     @Override
     public void render(VDocument aVDoc, RenderRequest aRequest)
     {
-        for (AnnotationLayer layer : aVDoc.getAnnotationLayers()) {
-            for (VObject vobj : aVDoc.objects(layer.getId())) {
+        for (var layer : aVDoc.getAnnotationLayers()) {
+            for (var vobj : aVDoc.objects(layer.getId())) {
                 if (vobj.getLabelHint() != null) {
                     // Label hint was already set earlier - do not overwrite it!
                     continue;

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanRenderer.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanRenderer.java
@@ -19,6 +19,7 @@ package de.tudarmstadt.ukp.inception.annotation.layer.span;
 
 import static de.tudarmstadt.ukp.clarin.webanno.model.LinkMode.WITH_ROLE;
 import static de.tudarmstadt.ukp.clarin.webanno.model.MultiValueMode.ARRAY;
+import static de.tudarmstadt.ukp.inception.support.uima.ICasUtil.selectAnnotationByAddr;
 import static de.tudarmstadt.ukp.inception.support.uima.ICasUtil.selectByAddr;
 import static java.util.Collections.emptyList;
 import static org.apache.commons.lang3.StringUtils.abbreviate;
@@ -122,6 +123,16 @@ public class SpanRenderer
         var group = new VLazyDetailGroup();
         group.addDetail(
                 new VLazyDetail("Text", abbreviate(fs.getCoveredText(), MAX_HOVER_TEXT_LENGTH)));
+
+        if (aVid.getAttribute() != VID.NONE) {
+            var adapter = getTypeAdapter();
+            var feature = adapter.listFeatures().stream().sequential().skip(aVid.getAttribute())
+                    .findFirst().get();
+            List<LinkWithRoleModel> sourceLinks = adapter.getFeatureValue(feature, fs);
+            var target = selectAnnotationByAddr(aCas, sourceLinks.get(aVid.getSlot()).targetAddr);
+            group.addDetail(new VLazyDetail("Target",
+                    abbreviate(target.getCoveredText(), MAX_HOVER_TEXT_LENGTH)));
+        }
 
         var details = super.lookupLazyDetails(aCas, aVid);
         if (!group.getDetails().isEmpty()) {

--- a/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/CasDiff.java
+++ b/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/CasDiff.java
@@ -21,11 +21,11 @@ import static de.tudarmstadt.ukp.clarin.webanno.model.LinkMode.NONE;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toCollection;
+import static java.util.stream.Stream.concat;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.uima.cas.ArrayFS;
@@ -42,7 +41,6 @@ import org.apache.uima.cas.Feature;
 import org.apache.uima.cas.FeatureStructure;
 import org.apache.uima.cas.SofaFS;
 import org.apache.uima.cas.Type;
-import org.apache.uima.cas.TypeSystem;
 import org.apache.uima.cas.text.AnnotationFS;
 import org.apache.uima.fit.util.FSUtil;
 import org.apache.uima.jcas.cas.AnnotationBase;
@@ -445,8 +443,8 @@ public class CasDiff
             return true;
         }
 
-        Type type1 = aFS1.getType();
-        Type type2 = aFS2.getType();
+        var type1 = aFS1.getType();
+        var type2 = aFS2.getType();
 
         // Types must be the same
         if (!type1.getName().equals(type2.getName())) {
@@ -464,14 +462,13 @@ public class CasDiff
         // such as begin, end, etc. Mind that the types may come from different CASes at different
         // levels of upgrading, so it could be that the types actually have slightly different
         // features.
-        Set<String> labelFeatures = adapter.getLabelFeatures();
-        List<String> sortedFeatures = Stream
-                .concat(type1.getFeatures().stream().map(Feature::getShortName),
-                        type2.getFeatures().stream().map(Feature::getShortName)) //
-                .filter(labelFeatures::contains) //
-                .sorted() //
-                .distinct() //
-                .collect(toList());
+        var labelFeatures = adapter.getLabelFeatures();
+        var sortedFeatures = concat(type1.getFeatures().stream().map(Feature::getShortName),
+                type2.getFeatures().stream().map(Feature::getShortName)) //
+                        .filter(labelFeatures::contains) //
+                        .sorted() //
+                        .distinct() //
+                        .collect(toCollection(ArrayList::new));
 
         if (!recurseIntoLinkFeatures) {
             // #1795 Chili REC: We can/should change CasDiff2 such that it does not recurse into
@@ -502,13 +499,13 @@ public class CasDiff
 
             switch (range.getName()) {
             case CAS.TYPE_NAME_STRING_ARRAY: {
-                var value1 = FSUtil.getFeature(aFS1, f1, Set.class);
+                var value1 = f1 != null ? FSUtil.getFeature(aFS1, f1, Set.class) : null;
                 if (value1 == null) {
-                    value1 = Collections.emptySet();
+                    value1 = emptySet();
                 }
-                var value2 = FSUtil.getFeature(aFS2, f2, Set.class);
+                var value2 = f2 != null ? FSUtil.getFeature(aFS2, f2, Set.class) : null;
                 if (value2 == null) {
-                    value2 = Collections.emptySet();
+                    value2 = emptySet();
                 }
                 if (!value1.equals(value2)) {
                     return false;
@@ -589,8 +586,8 @@ public class CasDiff
             }
             default: {
                 // Must be some kind of feature structure then
-                FeatureStructure valueFS1 = f1 != null ? aFS1.getFeatureValue(f1) : null;
-                FeatureStructure valueFS2 = f2 != null ? aFS2.getFeatureValue(f2) : null;
+                var valueFS1 = f1 != null ? aFS1.getFeatureValue(f1) : null;
+                var valueFS2 = f2 != null ? aFS2.getFeatureValue(f2) : null;
 
                 // Ignore the SofaFS - we already checked that the CAS is the same.
                 if (valueFS1 instanceof SofaFS) {
@@ -607,7 +604,7 @@ public class CasDiff
                 // Q: Why do we not check recursively?
                 // A: Because e.g. for chains, this would mean we consider the whole chain as a
                 // single annotation, but we want to consider each link as an annotation
-                TypeSystem ts1 = aFS1.getCAS().getTypeSystem();
+                var ts1 = aFS1.getCAS().getTypeSystem();
                 if (ts1.subsumes(ts1.getType(CAS.TYPE_NAME_ANNOTATION), type1)) {
                     if (!equalsAnnotationFS((AnnotationFS) aFS1, (AnnotationFS) aFS2)) {
                         return false;

--- a/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/api/DiffAdapter_ImplBase.java
+++ b/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/api/DiffAdapter_ImplBase.java
@@ -17,8 +17,9 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.api;
 
+import static java.util.Collections.unmodifiableSet;
+
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -44,7 +45,7 @@ public abstract class DiffAdapter_ImplBase
     public DiffAdapter_ImplBase(String aType, Set<String> aLabelFeatures)
     {
         type = aType;
-        labelFeatures = Collections.unmodifiableSet(new HashSet<>(aLabelFeatures));
+        labelFeatures = unmodifiableSet(new HashSet<>(aLabelFeatures));
     }
 
     public void addLinkFeature(String aName, String aRoleFeature, String aTargetFeature)

--- a/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/api/Position.java
+++ b/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/api/Position.java
@@ -55,4 +55,6 @@ public interface Position
     String getDocumentId();
 
     String toMinimalString();
+
+    boolean isLinkFeaturePosition();
 }

--- a/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/relation/RelationPosition.java
+++ b/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/relation/RelationPosition.java
@@ -17,6 +17,8 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.relation;
 
+import java.util.Objects;
+
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.LinkCompareBehavior;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.api.Position;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.api.Position_ImplBase;
@@ -108,6 +110,28 @@ public class RelationPosition
                 return otherSpan.targetEnd - targetEnd;
             }
         }
+    }
+
+    @Override
+    public boolean equals(final Object other)
+    {
+        if (!(other instanceof RelationPosition)) {
+            return false;
+        }
+        if (!super.equals(other)) {
+            return false;
+        }
+        RelationPosition castOther = (RelationPosition) other;
+        return Objects.equals(sourceBegin, castOther.sourceBegin)
+                && Objects.equals(sourceEnd, castOther.sourceEnd)
+                && Objects.equals(targetBegin, castOther.targetBegin)
+                && Objects.equals(targetEnd, castOther.targetEnd);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(super.hashCode(), sourceBegin, sourceEnd, targetBegin, targetEnd);
     }
 
     @Override

--- a/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/span/SpanPosition.java
+++ b/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/span/SpanPosition.java
@@ -17,6 +17,8 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.span;
 
+import java.util.Objects;
+
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.LinkCompareBehavior;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.api.Position;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.api.Position_ImplBase;
@@ -34,6 +36,15 @@ public class SpanPosition
     private final String text;
 
     public SpanPosition(String aCollectionId, String aDocumentId, String aType, int aBegin,
+            int aEnd, String aText)
+    {
+        super(aCollectionId, aDocumentId, aType, null, null, 0, 0, null, null);
+        begin = aBegin;
+        end = aEnd;
+        text = aText;
+    }
+
+    public SpanPosition(String aCollectionId, String aDocumentId, String aType, int aBegin,
             int aEnd, String aText, String aFeature, String aRole, int aLinkTargetBegin,
             int aLinkTargetEnd, String aLinkTargetText, LinkCompareBehavior aLinkCompareBehavior)
     {
@@ -42,6 +53,14 @@ public class SpanPosition
         begin = aBegin;
         end = aEnd;
         text = aText;
+    }
+
+    /**
+     * @return the span position that owns the link feature (if this is a link feature position).
+     */
+    public SpanPosition getBasePosition()
+    {
+        return new SpanPosition(getCollectionId(), getDocumentId(), getType(), begin, end, text);
     }
 
     /**
@@ -82,9 +101,28 @@ public class SpanPosition
     }
 
     @Override
+    public boolean equals(final Object other)
+    {
+        if (!(other instanceof SpanPosition)) {
+            return false;
+        }
+        if (!super.equals(other)) {
+            return false;
+        }
+        SpanPosition castOther = (SpanPosition) other;
+        return Objects.equals(begin, castOther.begin) && Objects.equals(end, castOther.end);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(super.hashCode(), begin, end);
+    }
+
+    @Override
     public String toString()
     {
-        StringBuilder builder = new StringBuilder();
+        var builder = new StringBuilder();
         builder.append("Span [");
         toStringFragment(builder);
         builder.append(", span=(").append(begin).append('-').append(end).append(')');
@@ -96,9 +134,10 @@ public class SpanPosition
     @Override
     public String toMinimalString()
     {
-        StringBuilder builder = new StringBuilder();
+        var builder = new StringBuilder();
         builder.append(begin).append('-').append(end).append(" [").append(text).append(']');
-        LinkCompareBehavior linkCompareBehavior = getLinkCompareBehavior();
+        var linkCompareBehavior = getLinkCompareBehavior();
+
         if (linkCompareBehavior != null) {
             switch (linkCompareBehavior) {
             case LINK_TARGET_AS_LABEL:
@@ -114,6 +153,7 @@ public class SpanPosition
                         "Unknown link target comparison mode [" + linkCompareBehavior + "]");
             }
         }
+
         return builder.toString();
     }
 }

--- a/inception/inception-diam-editor/src/main/ts/src/AnnotationsByLabelList.svelte
+++ b/inception/inception-diam-editor/src/main/ts/src/AnnotationsByLabelList.svelte
@@ -76,20 +76,21 @@
                     if ($sortByScore && aIsRec && bIsRec) {
                         return b.score - a.score;
                     }
+
                     return (
                         compareSpanText(data, a, b) ||
                         compareOffsets(a.offsets[0], b.offsets[0])
-                    );
+                    )
                 }
 
                 if (a instanceof Relation && b instanceof Relation) {
                     if ($sortByScore && aIsRec && bIsRec) {
                         return b.score - a.score;
                     }
-                    return compareOffsets(
-                        (a.arguments[0].target as Span).offsets[0],
-                        (b.arguments[0].target as Span).offsets[0]
-                    );
+
+                    const targetA = a.arguments[0].target as Span
+                    const targetB = b.arguments[0].target as Span
+                    return compareOffsets(targetA.offsets[0], targetB.offsets[0]);
                 }
 
                 console.error("Unexpected annotation type combination", a, b);

--- a/inception/inception-diam-editor/src/main/ts/src/AnnotationsByLayerList.svelte
+++ b/inception/inception-diam-editor/src/main/ts/src/AnnotationsByLayerList.svelte
@@ -76,20 +76,21 @@
                     if ($sortByScore && aIsRec && bIsRec) {
                         return b.score - a.score;
                     }
+
                     return (
                         compareSpanText(data, a, b) ||
                         compareOffsets(a.offsets[0], b.offsets[0])
-                    );
+                    )
                 }
 
                 if (a instanceof Relation && b instanceof Relation) {
                     if ($sortByScore && aIsRec && bIsRec) {
                         return b.score - a.score;
                     }
-                    return compareOffsets(
-                        (a.arguments[0].target as Span).offsets[0],
-                        (b.arguments[0].target as Span).offsets[0]
-                    );
+
+                    const targetA = a.arguments[0].target as Span
+                    const targetB = b.arguments[0].target as Span
+                    return compareOffsets(targetA.offsets[0], targetB.offsets[0]);
                 }
 
                 console.error("Unexpected annotation type combination", a, b);

--- a/inception/inception-js-api/src/main/ts/src/model/compact_v2/CompactAnnotatedText.ts
+++ b/inception/inception-js-api/src/main/ts/src/model/compact_v2/CompactAnnotatedText.ts
@@ -41,12 +41,16 @@ export function unpackCompactAnnotatedText (raw: CompactAnnotatedText): Annotate
 
   for (const span of raw.spans || []) {
     const cookedSpan = unpackCompactSpan(cooked, span)
-    cooked.spans.set(cookedSpan.vid, cookedSpan)
+    if (cookedSpan) {
+      cooked.spans.set(cookedSpan.vid, cookedSpan)
+    }
   }
 
   for (const rel of raw.relations || []) {
     const cookedRel = unpackCompactRelation(cooked, rel)
-    cooked.relations.set(cookedRel.vid, cookedRel)
+    if (cookedRel) {
+      cooked.relations.set(cookedRel.vid, cookedRel)
+    }
   }
 
   const annotationMarkers = raw.annotationMarkers?.map(unpackCompactAnnotationMarker)

--- a/inception/inception-js-api/src/main/ts/src/model/compact_v2/CompactArgument.ts
+++ b/inception/inception-js-api/src/main/ts/src/model/compact_v2/CompactArgument.ts
@@ -25,13 +25,14 @@ export type CompactArgument = [
   label?: string
 ]
 
-export function unpackCompactArgument (doc: AnnotatedText, raw: CompactArgument): Argument {
+export function unpackCompactArgument (doc: AnnotatedText, raw: CompactArgument): Argument | undefined {
   const cooked = new Argument()
   cooked.targetId = raw[0]
+  cooked.label = raw[1]
   cooked.target = doc.spans.get(cooked.targetId)
   if (!cooked.target) {
     console.warn(`Target ${cooked.targetId} not found`)
+    return undefined
   }
-  cooked.label = raw[1]
   return cooked
 }

--- a/inception/inception-js-api/src/main/ts/src/model/compact_v2/CompactRelation.ts
+++ b/inception/inception-js-api/src/main/ts/src/model/compact_v2/CompactRelation.ts
@@ -27,7 +27,7 @@ export type CompactRelation = [
   attributes?: CompactRelationAttributes
 ]
 
-export function unpackCompactRelation (doc: AnnotatedText, raw: CompactRelation): Relation {
+export function unpackCompactRelation (doc: AnnotatedText, raw: CompactRelation): Relation | undefined {
   const cooked = new Relation()
   cooked.document = doc
   cooked.layer = doc.__getOrCreateLayer(raw[0])
@@ -38,5 +38,12 @@ export function unpackCompactRelation (doc: AnnotatedText, raw: CompactRelation)
   cooked.score = raw[3]?.s
   cooked.hideScore = raw[3]?.hs ? true : false
   cooked.comments = unpackCompactComments(doc, cooked, raw[3]?.cm)
+
+  // Check if all arguments are defined
+  if (cooked.arguments.some(arg => arg === undefined)) {
+    console.warn(`Not decoding invalid relation relation ${cooked.vid}: undefined arguments`, cooked)
+    return undefined
+  }
+
   return cooked
 }

--- a/inception/inception-model-vdoc/src/main/java/de/tudarmstadt/ukp/inception/rendering/vmodel/VArc.java
+++ b/inception/inception-model-vdoc/src/main/java/de/tudarmstadt/ukp/inception/rendering/vmodel/VArc.java
@@ -40,8 +40,8 @@ public class VArc
         super(builder.layer, builder.vid, builder.equivalenceSet, builder.features);
         setPlaceholder(builder.placeholder);
         setLabelHint(builder.label);
-        this.source = builder.source;
-        this.target = builder.target;
+        source = builder.source;
+        target = builder.target;
     }
 
     /**
@@ -142,6 +142,12 @@ public class VArc
     public VID getTarget()
     {
         return target;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "VArc [" + getVid() + "]";
     }
 
     public static Builder builder()

--- a/inception/inception-model-vdoc/src/main/java/de/tudarmstadt/ukp/inception/rendering/vmodel/VSpan.java
+++ b/inception/inception-model-vdoc/src/main/java/de/tudarmstadt/ukp/inception/rendering/vmodel/VSpan.java
@@ -128,6 +128,12 @@ public class VSpan
         return new Builder();
     }
 
+    @Override
+    public String toString()
+    {
+        return "VSpan [" + getVid() + "]";
+    }
+
     public static final class Builder
     {
         private AnnotationLayer layer;


### PR DESCRIPTION
**What's in the PR**
- Make browser component more robust to even render if arc targets are missing (ignoring those arcs)
- Improve curation sidebar renderer to handle cases where a link source is hidden due to an already merged annotation
- Add hashCode and equals to Positions because it also implements compareTo

**How to test manually**
* Try sidebar curation mode

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
