### PR TITLE
#5031 - ChatGPT recommender fails because format is not a supported parameter

### DIFF
--- a/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/chatgpt/ChatGptRecommenderTraits.java
+++ b/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/chatgpt/ChatGptRecommenderTraits.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
-import de.tudarmstadt.ukp.inception.recommendation.imls.chatgpt.client.GenerateResponseFormat;
+import de.tudarmstadt.ukp.inception.recommendation.imls.chatgpt.client.ResponseFormatType;
 import de.tudarmstadt.ukp.inception.recommendation.imls.support.llm.prompt.PromptingMode;
 import de.tudarmstadt.ukp.inception.recommendation.imls.support.llm.response.ExtractionMode;
 import de.tudarmstadt.ukp.inception.security.client.auth.AuthenticationTraits;
@@ -48,7 +48,7 @@ public class ChatGptRecommenderTraits
 
     private String model = "gpt-3.5-turbo";
 
-    private GenerateResponseFormat format;
+    private ResponseFormatType format;
 
     private PromptingMode promptingMode = PromptingMode.PER_ANNOTATION;
 
@@ -106,12 +106,12 @@ public class ChatGptRecommenderTraits
         promptingMode = aPromptingMode;
     }
 
-    public GenerateResponseFormat getFormat()
+    public ResponseFormatType getFormat()
     {
         return format;
     }
 
-    public void setFormat(GenerateResponseFormat aFormat)
+    public void setFormat(ResponseFormatType aFormat)
     {
         format = aFormat;
     }

--- a/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/chatgpt/ChatGptRecommenderTraitsEditor.html
+++ b/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/chatgpt/ChatGptRecommenderTraitsEditor.html
@@ -31,7 +31,7 @@
         <wicket:message key="url"/>
       </label>
       <div class="col-sm-9">
-        <input wicket:id="url" type="text" class="form-control"/>
+        <input wicket:id="url"/>
       </div>
     </div>
     <div class="row form-row" wicket:enclosure="authentication">

--- a/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/chatgpt/ChatGptRecommenderTraitsEditor.java
+++ b/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/chatgpt/ChatGptRecommenderTraitsEditor.java
@@ -17,9 +17,11 @@
  */
 package de.tudarmstadt.ukp.inception.recommendation.imls.chatgpt;
 
+import static de.tudarmstadt.ukp.inception.recommendation.imls.chatgpt.ChatGptRecommenderTraits.DEFAULT_CHATGPT_URL;
 import static de.tudarmstadt.ukp.inception.support.lambda.HtmlElementEvents.CHANGE_EVENT;
 import static de.tudarmstadt.ukp.inception.support.wicket.WicketUtil.wrapInTryCatch;
 import static java.lang.String.format;
+import static java.util.Arrays.asList;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import java.io.IOException;
@@ -31,7 +33,6 @@ import org.apache.wicket.markup.html.form.ChoiceRenderer;
 import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.form.TextArea;
-import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.LoadableDetachableModel;
@@ -123,7 +124,12 @@ public class ChatGptRecommenderTraitsEditor
             traits.getObject().setAuthentication(new ApiKeyAuthenticationTraits());
         }
 
-        form.add(new TextField<String>("url"));
+        var comboBox = new ComboBox<String>("url", asList(DEFAULT_CHATGPT_URL,
+                "https://api.cerebras.ai/v1", "https://api.groq.com/openai/v1"));
+        comboBox.setOutputMarkupId(true);
+        comboBox.setRequired(true);
+        form.add(comboBox);
+
         authenticationTraitsEditor = new ApiKeyAuthenticationTraitsEditor("authentication",
                 Model.of((ApiKeyAuthenticationTraits) traits.getObject().getAuthentication()));
         form.add(authenticationTraitsEditor);

--- a/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/chatgpt/ChatGptRecommenderTraitsEditor.properties
+++ b/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/chatgpt/ChatGptRecommenderTraitsEditor.properties
@@ -28,7 +28,7 @@ PromptingMode.PER_DOCUMENT=Per document
 
 format=Response format
 format.nullValid=Default
-GenerateResponseFormat.JSON=JSON
+ResponseFormatType.JSON_OBJECT=JSON object
 
 extractionMode=Extraction mode
 ExtractionMode.RESPONSE_AS_LABEL=Response as label

--- a/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/chatgpt/ChatGptResponseFormatSelect.java
+++ b/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/chatgpt/ChatGptResponseFormatSelect.java
@@ -23,10 +23,10 @@ import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.markup.html.form.EnumChoiceRenderer;
 import org.apache.wicket.model.IModel;
 
-import de.tudarmstadt.ukp.inception.recommendation.imls.chatgpt.client.GenerateResponseFormat;
+import de.tudarmstadt.ukp.inception.recommendation.imls.chatgpt.client.ResponseFormatType;
 
 public class ChatGptResponseFormatSelect
-    extends DropDownChoice<GenerateResponseFormat>
+    extends DropDownChoice<ResponseFormatType>
 {
     private static final long serialVersionUID = 3115872987735239823L;
 
@@ -35,7 +35,7 @@ public class ChatGptResponseFormatSelect
         super(aId);
     }
 
-    public ChatGptResponseFormatSelect(String aId, IModel<GenerateResponseFormat> aModel)
+    public ChatGptResponseFormatSelect(String aId, IModel<ResponseFormatType> aModel)
     {
         super(aId);
         setModel(aModel);
@@ -47,7 +47,7 @@ public class ChatGptResponseFormatSelect
         super.onInitialize();
 
         setChoiceRenderer(new EnumChoiceRenderer<>(this));
-        setChoices(asList(GenerateResponseFormat.values()));
+        setChoices(asList(ResponseFormatType.JSON_OBJECT));
         setNullValid(true);
     }
 }

--- a/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/chatgpt/Preset.java
+++ b/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/chatgpt/Preset.java
@@ -21,7 +21,7 @@ import java.io.Serializable;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
-import de.tudarmstadt.ukp.inception.recommendation.imls.chatgpt.client.GenerateResponseFormat;
+import de.tudarmstadt.ukp.inception.recommendation.imls.chatgpt.client.ResponseFormatType;
 import de.tudarmstadt.ukp.inception.recommendation.imls.support.llm.prompt.PromptingMode;
 import de.tudarmstadt.ukp.inception.recommendation.imls.support.llm.response.ExtractionMode;
 
@@ -39,7 +39,7 @@ public class Preset
 
     private boolean raw;
 
-    private GenerateResponseFormat format;
+    private ResponseFormatType format;
 
     private PromptingMode promptingMode = PromptingMode.PER_ANNOTATION;
 
@@ -95,12 +95,12 @@ public class Preset
         raw = aRaw;
     }
 
-    public GenerateResponseFormat getFormat()
+    public ResponseFormatType getFormat()
     {
         return format;
     }
 
-    public void setFormat(GenerateResponseFormat aFormat)
+    public void setFormat(ResponseFormatType aFormat)
     {
         format = aFormat;
     }

--- a/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/chatgpt/client/ChatCompletionRequest.java
+++ b/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/chatgpt/client/ChatCompletionRequest.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import de.tudarmstadt.ukp.inception.recommendation.imls.support.llm.option.Option;
 
@@ -44,7 +45,7 @@ public class ChatCompletionRequest
     private final @JsonIgnore String apiKey;
     private final String model;
     private final List<ChatCompletionMessage> messages;
-    private final @JsonInclude(NON_NULL) GenerateResponseFormat format;
+    private final @JsonProperty("response_format") @JsonInclude(NON_NULL) ResponseFormat format;
 
     private ChatCompletionRequest(Builder builder)
     {
@@ -64,7 +65,7 @@ public class ChatCompletionRequest
         return model;
     }
 
-    public GenerateResponseFormat getFormat()
+    public ResponseFormat getFormat()
     {
         return format;
     }
@@ -84,7 +85,7 @@ public class ChatCompletionRequest
         private String model;
         private String apiKey;
         private String prompt;
-        private GenerateResponseFormat format;
+        private ResponseFormat format;
         private Map<String, Object> options = new HashMap<>();
 
         private Builder()
@@ -109,7 +110,7 @@ public class ChatCompletionRequest
             return this;
         }
 
-        public Builder withFormat(GenerateResponseFormat aFormat)
+        public Builder withResponseFormat(ResponseFormat aFormat)
         {
             this.format = aFormat;
             return this;

--- a/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/chatgpt/client/ResponseFormat.java
+++ b/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/chatgpt/client/ResponseFormat.java
@@ -17,10 +17,47 @@
  */
 package de.tudarmstadt.ukp.inception.recommendation.imls.chatgpt.client;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
-public enum GenerateResponseFormat
+public class ResponseFormat
 {
-    @JsonProperty("json")
-    JSON
+    private ResponseFormatType type;
+
+    private ResponseFormat(Builder builder)
+    {
+        type = builder.type;
+    }
+
+    public ResponseFormatType getType()
+    {
+        return type;
+    }
+
+    public void setType(ResponseFormatType aType)
+    {
+        type = aType;
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static final class Builder
+    {
+        private ResponseFormatType type;
+
+        private Builder()
+        {
+        }
+
+        public Builder withType(ResponseFormatType aType)
+        {
+            type = aType;
+            return this;
+        }
+
+        public ResponseFormat build()
+        {
+            return new ResponseFormat(this);
+        }
+    }
 }

--- a/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/chatgpt/client/ResponseFormatType.java
+++ b/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/chatgpt/client/ResponseFormatType.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.imls.chatgpt.client;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum ResponseFormatType
+{
+    @JsonProperty("json_schema")
+    JSON_SCHEMA,
+
+    @JsonProperty("json_object")
+    @JsonAlias({ "json" })
+    JSON_OBJECT;
+}

--- a/inception/inception-imls-chatgpt/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/azureaiopenai/client/OpenAiClientTest.java
+++ b/inception/inception-imls-chatgpt/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/azureaiopenai/client/OpenAiClientTest.java
@@ -18,7 +18,7 @@
 package de.tudarmstadt.ukp.inception.recommendation.imls.azureaiopenai.client;
 
 import static de.tudarmstadt.ukp.inception.recommendation.imls.chatgpt.ChatGptRecommenderTraits.DEFAULT_CHATGPT_URL;
-import static de.tudarmstadt.ukp.inception.recommendation.imls.chatgpt.client.GenerateResponseFormat.JSON;
+import static de.tudarmstadt.ukp.inception.recommendation.imls.chatgpt.client.ResponseFormatType.JSON_OBJECT;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.lang.invoke.MethodHandles;
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import de.tudarmstadt.ukp.inception.recommendation.imls.chatgpt.client.ChatCompletionRequest;
 import de.tudarmstadt.ukp.inception.recommendation.imls.chatgpt.client.ChatGptClientImpl;
 import de.tudarmstadt.ukp.inception.recommendation.imls.chatgpt.client.ListModelsRequest;
+import de.tudarmstadt.ukp.inception.recommendation.imls.chatgpt.client.ResponseFormat;
 
 class OpenAiClientTest
 {
@@ -65,7 +66,7 @@ class OpenAiClientTest
         var response = sut.generate(CHATGPT_BASE_URL, ChatCompletionRequest.builder() //
                 .withApiKey(CHATGPT_API_KEY) //
                 .withPrompt("Generate a JSON map with the key/value pairs `a = 1` and `b = 2`") //
-                .withFormat(JSON) //
+                .withResponseFormat(ResponseFormat.builder().withType(JSON_OBJECT).build()) //
                 .build());
         LOG.info("Response: [{}]", response.trim());
     }


### PR DESCRIPTION
**What's in the PR**
- Switch to using `reponse_format` parameter
- Add several default URLs for the recommender including OpenAI, Groq and Cerebras

**How to test manually**
* Try using one of the endpoints with JSON response format

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
