### PR TITLE
#5035 - NBSPs should not be treated as tokens

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanAnchoringModeBehavior.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanAnchoringModeBehavior.java
@@ -21,11 +21,8 @@ import static de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil.selectOve
 import static org.apache.uima.fit.util.CasUtil.getType;
 
 import java.util.Arrays;
-import java.util.List;
 
 import org.apache.uima.cas.CAS;
-import org.apache.uima.cas.Type;
-import org.apache.uima.cas.text.AnnotationFS;
 import org.springframework.core.annotation.Order;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.IllegalPlacementException;
@@ -61,6 +58,7 @@ public class SpanAnchoringModeBehavior
         return onRequest(aAdapter, aRequest);
     }
 
+    @Override
     public MoveSpanAnnotationRequest onMove(TypeAdapter aAdapter,
             MoveSpanAnnotationRequest aRequest)
         throws AnnotationException
@@ -102,8 +100,8 @@ public class SpanAnchoringModeBehavior
             return aRange;
         }
         case SINGLE_TOKEN: {
-            Type tokenType = getType(aCas, Token.class);
-            List<AnnotationFS> tokens = selectOverlapping(aCas, tokenType, aRange[0], aRange[1]);
+            var tokenType = getType(aCas, Token.class);
+            var tokens = selectOverlapping(aCas, tokenType, aRange[0], aRange[1]);
 
             if (tokens.isEmpty()) {
                 throw new IllegalPlacementException(
@@ -113,8 +111,8 @@ public class SpanAnchoringModeBehavior
             return new int[] { tokens.get(0).getBegin(), tokens.get(0).getEnd() };
         }
         case TOKENS: {
-            Type tokenType = getType(aCas, Token.class);
-            List<AnnotationFS> tokens = selectOverlapping(aCas, tokenType, aRange[0], aRange[1]);
+            var tokenType = getType(aCas, Token.class);
+            var tokens = selectOverlapping(aCas, tokenType, aRange[0], aRange[1]);
 
             if (tokens.isEmpty()) {
                 throw new IllegalPlacementException(
@@ -128,9 +126,8 @@ public class SpanAnchoringModeBehavior
             return new int[] { begin, end };
         }
         case SENTENCES: {
-            Type sentenceType = getType(aCas, Sentence.class);
-            List<AnnotationFS> sentences = selectOverlapping(aCas, sentenceType, aRange[0],
-                    aRange[1]);
+            var sentenceType = getType(aCas, Sentence.class);
+            var sentences = selectOverlapping(aCas, sentenceType, aRange[0], aRange[1]);
 
             if (sentences.isEmpty()) {
                 throw new IllegalPlacementException(
@@ -138,8 +135,8 @@ public class SpanAnchoringModeBehavior
             }
 
             // update the begin and ends (no sub token selection)
-            int begin = sentences.get(0).getBegin();
-            int end = sentences.get(sentences.size() - 1).getEnd();
+            var begin = sentences.get(0).getBegin();
+            var end = sentences.get(sentences.size() - 1).getEnd();
 
             return new int[] { begin, end };
         }

--- a/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/render/BratSerializerImpl.java
+++ b/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/render/BratSerializerImpl.java
@@ -54,7 +54,6 @@ import de.tudarmstadt.ukp.clarin.webanno.brat.render.model.Relation;
 import de.tudarmstadt.ukp.clarin.webanno.brat.render.model.SentenceComment;
 import de.tudarmstadt.ukp.clarin.webanno.brat.render.model.SentenceMarker;
 import de.tudarmstadt.ukp.clarin.webanno.brat.render.model.TextMarker;
-import de.tudarmstadt.ukp.dkpro.core.api.segmentation.TrimUtils;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
 import de.tudarmstadt.ukp.inception.rendering.paging.Unit;
 import de.tudarmstadt.ukp.inception.rendering.request.RenderRequest;
@@ -66,6 +65,7 @@ import de.tudarmstadt.ukp.inception.rendering.vmodel.VMarker;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VSentenceMarker;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VTextMarker;
 import de.tudarmstadt.ukp.inception.support.text.TextUtils;
+import de.tudarmstadt.ukp.inception.support.text.TrimUtils;
 import de.tudarmstadt.ukp.inception.support.uima.ICasUtil;
 
 /**

--- a/inception/inception-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/AllAnnotationsStartAndEndWithCharactersCheck.java
+++ b/inception/inception-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/AllAnnotationsStartAndEndWithCharactersCheck.java
@@ -31,9 +31,9 @@ import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.Type;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
-import de.tudarmstadt.ukp.dkpro.core.api.segmentation.TrimUtils;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.support.logging.LogMessage;
+import de.tudarmstadt.ukp.inception.support.text.TrimUtils;
 
 public class AllAnnotationsStartAndEndWithCharactersCheck
     implements Check
@@ -79,8 +79,8 @@ public class AllAnnotationsStartAndEndWithCharactersCheck
                 var offsets = new int[] { ann.getBegin(), ann.getEnd() };
                 TrimUtils.trim(docText, offsets);
 
-                boolean startsWithWhitespace = offsets[0] != ann.getBegin();
-                boolean endsWithWhitespace = offsets[1] != ann.getEnd();
+                var startsWithWhitespace = offsets[0] != ann.getBegin();
+                var endsWithWhitespace = offsets[1] != ann.getEnd();
                 if (!startsWithWhitespace && !endsWithWhitespace) {
                     continue;
                 }

--- a/inception/inception-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/repairs/TrimAnnotationsRepair.java
+++ b/inception/inception-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/repairs/TrimAnnotationsRepair.java
@@ -32,9 +32,9 @@ import org.apache.uima.cas.Type;
 import org.apache.uima.jcas.tcas.Annotation;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
-import de.tudarmstadt.ukp.dkpro.core.api.segmentation.TrimUtils;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.support.logging.LogMessage;
+import de.tudarmstadt.ukp.inception.support.text.TrimUtils;
 
 public class TrimAnnotationsRepair
     implements Repair

--- a/inception/inception-diag/src/main/resources/META-INF/asciidoc/user-guide/casdoctor.adoc
+++ b/inception/inception-diag/src/main/resources/META-INF/asciidoc/user-guide/casdoctor.adoc
@@ -397,6 +397,10 @@ ID:: `TrimAnnotationsRepair`
 This repair adjusts annotation boundaries such that they do not include any whitespace at the beginning or end of the 
 annotation.
 
+NOTE: Run the checks again after applying this repair as certain annotations can become invalid if they get trimmed down
+      to a length of zero. It may be necessary to apply another repair such as <<repair_RemoveZeroSizeTokensAndSentencesRepair>>
+      to remove these annotations.
+
 [[repair_RemoveBomRepair]]
 === Remove Byte Order Mark
 

--- a/inception/inception-diag/src/test/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/AllAnnotationsStartAndEndWithCharactersCheckTest.java
+++ b/inception/inception-diag/src/test/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/AllAnnotationsStartAndEndWithCharactersCheckTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.diag.checks;
+
+import static java.lang.String.join;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.uima.fit.factory.JCasFactory;
+import org.apache.uima.jcas.JCas;
+import org.apache.uima.jcas.tcas.Annotation;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity;
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
+import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
+import de.tudarmstadt.ukp.inception.support.logging.LogMessage;
+
+@ExtendWith(SpringExtension.class)
+class AllAnnotationsStartAndEndWithCharactersCheckTest
+{
+    @Configuration
+    @Import({ AnnotationSchemaService.class, AllAnnotationsStartAndEndWithCharactersCheck.class })
+    static class Config
+    {
+    }
+
+    @MockBean
+    AnnotationSchemaService annotationService;
+
+    @Autowired
+    AllAnnotationsStartAndEndWithCharactersCheck sut;
+
+    Project project;
+    JCas jCas;
+    List<AnnotationLayer> layers;
+
+    @BeforeEach
+    void setup() throws Exception
+    {
+        project = new Project();
+        jCas = JCasFactory.createJCas();
+
+        var namedEntityLayer = new AnnotationLayer();
+        namedEntityLayer.setName(NamedEntity._TypeName);
+        layers = asList(namedEntityLayer);
+    }
+
+    @Test
+    void test()
+    {
+        when(annotationService.listAnnotationLayer(project)).thenReturn(layers);
+
+        jCas.setDocumentText(join("a", "\u00A0", "b", " ", "c", " ", "d"));
+
+        var annotations = asList( //
+                new Sentence(jCas, 0, 10), //
+                new NamedEntity(jCas, 0, 2));
+        annotations.forEach(Annotation::addToIndexes);
+
+        var messages = new ArrayList<LogMessage>();
+
+        var result = sut.check(project, jCas.getCas(), messages);
+
+        assertThat(result).isFalse();
+        assertThat(messages).hasSize(1);
+        assertThat(messages.get(0).getMessage()).contains(
+                "[de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity] [\\u00A0a]@[0-2] starts with whitespace");
+
+    }
+}

--- a/inception/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/span/StringMatchingRecommender.java
+++ b/inception/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/span/StringMatchingRecommender.java
@@ -17,7 +17,9 @@
  */
 package de.tudarmstadt.ukp.inception.recommendation.imls.stringmatch.span;
 
-import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.CHARACTERS;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.SENTENCES;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.SINGLE_TOKEN;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.TOKENS;
 import static de.tudarmstadt.ukp.inception.recommendation.api.evaluation.EvaluationResult.toEvaluationResult;
 import static de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil.selectOverlapping;
 import static java.util.Arrays.asList;
@@ -37,6 +39,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -236,8 +239,8 @@ public class StringMatchingRecommender
 
     private List<Sample> predict(CAS aCas, List<AnnotationFS> units, Trie<DictEntry> aDict)
     {
-        var requireEndAtTokenBoundary = !CHARACTERS
-                .equals(getRecommender().getLayer().getAnchoringMode());
+        var requireEndAtTokenBoundary = Set.of(SINGLE_TOKEN, TOKENS, SENTENCES)
+                .contains(getRecommender().getLayer().getAnchoringMode());
 
         var requireSingleSentence = !getRecommender().getLayer().isCrossSentence();
 

--- a/inception/inception-io-html/src/main/java/de/tudarmstadt/ukp/inception/io/html/dkprocore/CasXmlNodeVisitor.java
+++ b/inception/inception-io-html/src/main/java/de/tudarmstadt/ukp/inception/io/html/dkprocore/CasXmlNodeVisitor.java
@@ -17,9 +17,9 @@
  */
 package de.tudarmstadt.ukp.inception.io.html.dkprocore;
 
-import static de.tudarmstadt.ukp.dkpro.core.api.segmentation.TrimUtils.trim;
 import static de.tudarmstadt.ukp.inception.io.html.dkprocore.internal.JSoupUtil.appendNormalisedText;
 import static de.tudarmstadt.ukp.inception.io.html.dkprocore.internal.JSoupUtil.lastCharIsWhitespace;
+import static de.tudarmstadt.ukp.inception.support.text.TrimUtils.trim;
 
 import java.util.Map;
 

--- a/inception/inception-io-tei/src/main/java/de/tudarmstadt/ukp/inception/io/tei/dkprobackport/TeiReader.java
+++ b/inception/inception-io-tei/src/main/java/de/tudarmstadt/ukp/inception/io/tei/dkprobackport/TeiReader.java
@@ -86,13 +86,13 @@ import org.xml.sax.helpers.DefaultHandler;
 import de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.POS;
 import de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData;
 import de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity;
-import de.tudarmstadt.ukp.dkpro.core.api.segmentation.TrimUtils;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Lemma;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Paragraph;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
 import de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.Constituent;
 import de.tudarmstadt.ukp.dkpro.core.api.syntax.type.constituent.ROOT;
+import de.tudarmstadt.ukp.inception.support.text.TrimUtils;
 import eu.openminted.share.annotations.api.DocumentationResource;
 
 /**

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/span/SpanSuggestionSupport.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/span/SpanSuggestionSupport.java
@@ -56,7 +56,6 @@ import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.MultiValueMode;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
-import de.tudarmstadt.ukp.dkpro.core.api.segmentation.TrimUtils;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
 import de.tudarmstadt.ukp.inception.annotation.layer.span.SpanAdapter;
@@ -82,6 +81,7 @@ import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.AnnotationException;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.TypeAdapter;
 import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureSupportRegistry;
+import de.tudarmstadt.ukp.inception.support.text.TrimUtils;
 
 public class SpanSuggestionSupport
     extends SuggestionSupport_ImplBase

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/text/TrimUtils.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/text/TrimUtils.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.support.text;
+
+import org.apache.uima.jcas.tcas.Annotation;
+
+public class TrimUtils
+{
+    /**
+     * Trim the offsets of the given annotation to remove leading/trailing whitespace.
+     * <p>
+     * <b>Note:</b> use this method if the document text of the CAS has not been set yet but you
+     * have it available in a buffer.
+     * <p>
+     * <b>Note:</b> best use this method before adding the annotation to the indexes.
+     * 
+     * @param aText
+     *            the document text (available so far).
+     * @param aAnnotation
+     *            the annotation to trim. Offsets are updated.
+     */
+    public static void trim(CharSequence aText, Annotation aAnnotation)
+    {
+        int[] offsets = { aAnnotation.getBegin(), aAnnotation.getEnd() };
+        trim(aText, offsets);
+        aAnnotation.setBegin(offsets[0]);
+        aAnnotation.setEnd(offsets[1]);
+    }
+
+    /**
+     * Remove trailing or leading whitespace from the annotation.
+     * 
+     * @param aText
+     *            the text.
+     * @param aSpan
+     *            the offsets.
+     */
+    public static void trim(CharSequence aText, int[] aSpan)
+    {
+        if (aSpan[0] == aSpan[1]) {
+            // Nothing to do on empty spans
+            return;
+        }
+
+        int begin = aSpan[0];
+        int end = aSpan[1];
+
+        // First we trim at the end. If a trimmed span is empty, we want to return the original
+        // begin as the begin/end of the trimmed span
+        while ((end > 0) && end > begin && trimChar(aText.charAt(end - 1))) {
+            end--;
+        }
+
+        // Then, trim at the start
+        while ((begin < (aText.length() - 1)) && begin < end && trimChar(aText.charAt(begin))) {
+            begin++;
+        }
+
+        aSpan[0] = begin;
+        aSpan[1] = end;
+    }
+
+    private static boolean trimChar(final char aChar)
+    {
+        switch (aChar) {
+        case '\n': // Line break
+        case '\r': // Carriage return
+        case '\t': // Tab
+        case '\u00A0': // NBSP
+        case '\u2000': // EN QUAD
+        case '\u2001': // EM QUAD
+        case '\u2002': // EN SPACE
+        case '\u2003': // EM SPACE
+        case '\u2004': // THREE-PER-EM SPACE
+        case '\u2005': // FOUR-PER-EM SPACE
+        case '\u2006': // SIX-PER-EM SPACE
+        case '\u2007': // FIGURE SPACE
+        case '\u2008': // PUNCTUATION SPACE
+        case '\u2009': // THIN SPACE
+        case '\u200A': // HAIR SPACE
+        case '\u200B': // ZERO WIDTH SPACE
+        case '\u200C': // ZERO WIDTH NON-JOINER
+        case '\u200D': // ZERO WIDTH JOINER
+        case '\u200E': // LEFT-TO-RIGHT MARK
+        case '\u200F': // RIGHT-TO-LEFT MARK
+        case '\u2028': // LINE SEPARATOR
+        case '\u2029': // PARAGRAPH SEPARATOR
+        case '\u202A': // LEFT-TO-RIGHT EMBEDDING
+        case '\u202B': // RIGHT-TO-LEFT EMBEDDING
+        case '\u202C': // POP DIRECTIONAL FORMATTING
+        case '\u202D': // LEFT-TO-RIGHT OVERRIDE
+        case '\u202E': // RIGHT-TO-LEFT OVERRIDE
+        case '\u202F': // NARROW NO-BREAK SPACE
+        case '\u2060': // WORD JOINER
+        case '\u2061': // FUNCTION APPLICATION
+        case '\u2062': // INVISIBLE TIMES
+        case '\u2063': // INVISIBLE SEPARATOR
+        case '\u2064': // INVISIBLE PLUS
+        case '\u2065': // <unassigned>
+        case '\u2066': // LEFT-TO-RIGHT ISOLATE
+        case '\u2067': // RIGHT-TO-LEFT ISOLATE
+        case '\u2068': // FIRST STRONG ISOLATE
+        case '\u2069': // POP DIRECTIONAL ISOLATE
+        case '\u206A': // INHIBIT SYMMETRIC SWAPPING
+        case '\u206B': // ACTIVATE SYMMETRIC SWAPPING
+        case '\u206C': // INHIBIT ARABIC FORM SHAPING
+        case '\u206D': // ACTIVATE ARABIC FORM SHAPING
+        case '\u206E': // NATIONAL DIGIT SHAPES
+        case '\u206F': // NOMINAL DIGIT SHAPES
+            return true;
+        default:
+            return Character.isWhitespace(aChar);
+        }
+    }
+}

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/uima/SegmentationUtils.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/uima/SegmentationUtils.java
@@ -29,6 +29,7 @@ import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.text.AnnotationFS;
 
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
+import de.tudarmstadt.ukp.inception.support.text.TrimUtils;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 
 public abstract class SegmentationUtils
@@ -98,7 +99,7 @@ public abstract class SegmentationUtils
             var cur = bi.next();
             while (cur != BreakIterator.DONE) {
                 var span = new int[] { last + begin, cur + begin };
-                trim(aCas.getDocumentText(), span);
+                TrimUtils.trim(aCas.getDocumentText(), span);
                 if (!isEmpty(span[0], span[1])) {
                     aCas.addFsToIndexes(createSentence(aCas, span[0], span[1]));
                 }
@@ -121,7 +122,7 @@ public abstract class SegmentationUtils
             int cur = bi.next();
             while (cur != BreakIterator.DONE) {
                 int[] span = new int[] { last, cur };
-                trim(s.getCoveredText(), span);
+                TrimUtils.trim(s.getCoveredText(), span);
                 if (!isEmpty(span[0], span[1])) {
                     aCas.addFsToIndexes(
                             createToken(aCas, span[0] + s.getBegin(), span[1] + s.getBegin()));
@@ -132,61 +133,8 @@ public abstract class SegmentationUtils
         }
     }
 
-    /**
-     * Remove trailing or leading whitespace from the annotation.
-     * 
-     * @param aText
-     *            the text.
-     * @param aSpan
-     *            the offsets.
-     */
-    public static void trim(String aText, int[] aSpan)
-    {
-        String data = aText;
-
-        int begin = aSpan[0];
-        int end = aSpan[1] - 1;
-
-        // Remove whitespace at end
-        while ((end > 0) && trimChar(data.charAt(end))) {
-            end--;
-        }
-        end++;
-
-        // Remove whitespace at start
-        while ((begin < end) && trimChar(data.charAt(begin))) {
-            begin++;
-        }
-
-        aSpan[0] = begin;
-        aSpan[1] = end;
-    }
-
     public static boolean isEmpty(int aBegin, int aEnd)
     {
         return aBegin >= aEnd;
     }
-
-    public static boolean trimChar(final char aChar)
-    {
-        switch (aChar) {
-        case '\n':
-            return true; // Line break
-        case '\r':
-            return true; // Carriage return
-        case '\t':
-            return true; // Tab
-        case '\u200E':
-            return true; // LEFT-TO-RIGHT MARK
-        case '\u200F':
-            return true; // RIGHT-TO-LEFT MARK
-        case '\u2028':
-            return true; // LINE SEPARATOR
-        case '\u2029':
-            return true; // PARAGRAPH SEPARATOR
-        default:
-            return Character.isWhitespace(aChar);
-        }
-    }
-
 }

--- a/inception/inception-support/src/test/java/de/tudarmstadt/ukp/inception/support/text/TrimUtilsTest.java
+++ b/inception/inception-support/src/test/java/de/tudarmstadt/ukp/inception/support/text/TrimUtilsTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.support.text;
+
+import static de.tudarmstadt.ukp.inception.support.text.TrimUtils.trim;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class TrimUtilsTest
+{
+    @Test
+    public void thatEmptySpanIsTrimmedToEmptySpan()
+    {
+        int[] span = new int[] { 2, 2 };
+        trim("    ", span);
+        assertThat(span).containsExactly(2, 2);
+    }
+
+    @Test
+    public void thatSpanIsTrimmedToEmptySpanStartingAtOriginalStart()
+    {
+        int[] span = new int[] { 2, 3 };
+        trim("    ", span);
+        assertThat(span).containsExactly(2, 2);
+    }
+
+    @Test
+    public void thatLeadingAndTrailingWhitespaceIsRemoved()
+    {
+        int[] span = new int[] { 0, 4 };
+        trim(" ab ", span);
+        assertThat(span).containsExactly(1, 3);
+    }
+
+    @Test
+    public void thatInnerWhitespaceIsRemoved1()
+    {
+        int[] span = new int[] { 0, 2 };
+        trim(" a b ", span);
+        assertThat(span).containsExactly(1, 2);
+    }
+
+    @Test
+    public void thatInnerWhitespaceIsRemoved2()
+    {
+        int[] span = new int[] { 2, 5 };
+        trim(" a b ", span);
+        assertThat(span).containsExactly(3, 4);
+    }
+
+    @Test
+    public void testSingleCharacter()
+    {
+        int[] span = { 0, 1 };
+        trim(".", span);
+        assertThat(span).containsExactly(0, 1);
+    }
+
+    @Test
+    public void testLeadingWhitespace()
+    {
+        int[] span = { 0, 5 };
+        trim(" \t\n\r.", span);
+        assertThat(span).containsExactly(4, 5);
+    }
+
+    @Test
+    public void testTrailingWhitespace()
+    {
+        int[] span = { 0, 5 };
+        trim(". \n\r\t", span);
+        assertThat(span).containsExactly(0, 1);
+    }
+
+    @Test
+    public void testLeadingTrailingWhitespace()
+    {
+        int[] span = { 0, 9 };
+        trim(" \t\n\r. \n\r\t", span);
+        assertThat(span).containsExactly(4, 5);
+    }
+
+    @Test
+    public void testBlankString()
+    {
+        int[] span = { 1, 2 };
+        trim("   ", span);
+        assertThat(span).containsExactly(1, 1);
+    }
+
+    @Test
+    public void testNbsp()
+    {
+        int[] span = { 0, 2 };
+        trim("\u00A0a", span);
+        assertThat(span).containsExactly(1, 2);
+    }
+}


### PR DESCRIPTION
**What's in the PR**
- Change the central trimming functions to consider NBSP and various other invisible Unicode characters as trimmable space
- Added unit test

**How to test manually**
* See issue description

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [x] PR updates documentation
