### PR TITLE
#5037 - Show fraction of annotators that chose a certain label in curation sidebar mode

### DIFF
--- a/inception/inception-brat-editor/pom.xml
+++ b/inception/inception-brat-editor/pom.xml
@@ -30,6 +30,10 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-math3</artifactId>
+    </dependency>
+    <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-project-api</artifactId>
     </dependency>

--- a/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/render/BratSerializerImpl.java
+++ b/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/render/BratSerializerImpl.java
@@ -59,10 +59,8 @@ import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
 import de.tudarmstadt.ukp.inception.rendering.paging.Unit;
 import de.tudarmstadt.ukp.inception.rendering.request.RenderRequest;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VAnnotationMarker;
-import de.tudarmstadt.ukp.inception.rendering.vmodel.VComment;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VDocument;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
-import de.tudarmstadt.ukp.inception.rendering.vmodel.VMarker;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VSentenceMarker;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VTextMarker;
 import de.tudarmstadt.ukp.inception.support.text.TextUtils;
@@ -154,6 +152,7 @@ public class BratSerializerImpl
                         .setClippedAtStart(vspan.getRanges().get(0).isClippedAtBegin());
                 entity.getAttributes().setClippedAtEnd(
                         vspan.getRanges().get(vspan.getRanges().size() - 1).isClippedAtEnd());
+                entity.getAttributes().setScore(vspan.getScore());
 
                 aResponse.addEntity(entity);
             }
@@ -183,7 +182,7 @@ public class BratSerializerImpl
         }
 
         Map<AnnotationFS, Integer> sentenceIndexes = null;
-        for (VComment vcomment : aVDoc.comments()) {
+        for (var vcomment : aVDoc.comments()) {
             String type;
             switch (vcomment.getCommentType()) {
             case ERROR:
@@ -205,7 +204,7 @@ public class BratSerializerImpl
                 if (sentenceIndexes == null) {
                     sentenceIndexes = new HashMap<>();
                     int i = 1;
-                    for (AnnotationFS s : select(cas, getType(cas, Sentence.class))) {
+                    for (var s : select(cas, getType(cas, Sentence.class))) {
                         sentenceIndexes.put(s, i);
                         i++;
                     }
@@ -224,18 +223,14 @@ public class BratSerializerImpl
 
     private void renderMarkers(GetDocumentResponse aResponse, VDocument aVDoc)
     {
-        // Render markers
-        for (VMarker vmarker : aVDoc.getMarkers()) {
-            if (vmarker instanceof VAnnotationMarker) {
-                VAnnotationMarker marker = (VAnnotationMarker) vmarker;
+        for (var vmarker : aVDoc.getMarkers()) {
+            if (vmarker instanceof VAnnotationMarker marker) {
                 aResponse.addMarker(new AnnotationMarker(vmarker.getType(), marker.getVid()));
             }
-            else if (vmarker instanceof VSentenceMarker) {
-                VSentenceMarker marker = (VSentenceMarker) vmarker;
+            else if (vmarker instanceof VSentenceMarker marker) {
                 aResponse.addMarker(new SentenceMarker(vmarker.getType(), marker.getIndex()));
             }
-            else if (vmarker instanceof VTextMarker) {
-                var marker = (VTextMarker) vmarker;
+            else if (vmarker instanceof VTextMarker marker) {
                 var range = marker.getRange();
                 aResponse.addMarker(
                         new TextMarker(marker.getType(), range.getBegin(), range.getEnd()));

--- a/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/render/model/EntityAttributes.java
+++ b/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/render/model/EntityAttributes.java
@@ -41,6 +41,7 @@ public class EntityAttributes
     public static final String ATTR_HOVER_TEXT = "h";
     public static final String ATTR_ACTION_BUTTONS = "a";
     public static final String ATTR_CLIPPED = "cl";
+    public static final String ATTR_SCORE = "s";
 
     private @JsonProperty(ATTR_LABEL) String labelText;
     private @JsonProperty(ATTR_COLOR) String color;
@@ -48,6 +49,10 @@ public class EntityAttributes
     @JsonSerialize(using = NumericBooleanSerializer.class)
     private @JsonProperty(ATTR_ACTION_BUTTONS) boolean actionButtons;
     private @JsonProperty(ATTR_CLIPPED) String clipped;
+
+    @JsonInclude(Include.NON_DEFAULT)
+    @JsonSerialize(using = ScoreSerializer.class)
+    private @JsonProperty(ATTR_SCORE) double score;
 
     public void setLabelText(String aLabelText)
     {
@@ -151,5 +156,15 @@ public class EntityAttributes
     public void setClipped(String aClipped)
     {
         clipped = aClipped;
+    }
+
+    public void setScore(double aScore)
+    {
+        score = aScore;
+    }
+
+    public double getScore()
+    {
+        return score;
     }
 }

--- a/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/render/model/ScoreSerializer.java
+++ b/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/render/model/ScoreSerializer.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.brat.render.model;
+
+import java.io.IOException;
+
+import org.apache.commons.math3.util.Precision;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.NumberSerializers.Base;
+
+public class ScoreSerializer
+    extends Base<Object>
+{
+    private static final long serialVersionUID = -1140076942834412161L;
+
+    final static ScoreSerializer instance = new ScoreSerializer();
+
+    public ScoreSerializer()
+    {
+        super(Double.class, JsonParser.NumberType.DOUBLE, "number");
+    }
+
+    @Override
+    public void serialize(Object value, JsonGenerator gen, SerializerProvider provider)
+        throws IOException
+    {
+        gen.writeNumber(Precision.round((Double) value, 2));
+    }
+}

--- a/inception/inception-brat-editor/src/main/ts/src/protocol/Protocol.ts
+++ b/inception/inception-brat-editor/src/main/ts/src/protocol/Protocol.ts
@@ -37,6 +37,7 @@ export type EntityAttributesDto = {
   c: ColorCode;
   h: string;
   a: boolean;
+  s: number;
   cl: ClippedState;
 }
 

--- a/inception/inception-brat-editor/src/main/ts/src/visualizer/Entity.ts
+++ b/inception/inception-brat-editor/src/main/ts/src/visualizer/Entity.ts
@@ -79,6 +79,7 @@ export class Entity {
   comment: Comment
   drawCurly = false
   labelText: string
+  score: number | undefined
   refedIndexSum: number
   color: string
   shadowClass: string

--- a/inception/inception-brat-editor/src/main/ts/src/visualizer/Visualizer.ts
+++ b/inception/inception-brat-editor/src/main/ts/src/visualizer/Visualizer.ts
@@ -548,6 +548,9 @@ export class Visualizer {
         if (Object.prototype.hasOwnProperty.call(attributes, 'a')) {
           span.actionButtons = !!(attributes.a)
         }
+        if (Object.prototype.hasOwnProperty.call(attributes, 's')) {
+          span.score = attributes.s
+        }
         if (Object.prototype.hasOwnProperty.call(attributes, 'cl') && attributes.cl) {
           span.clippedAtStart = attributes.cl.startsWith('s')
           span.clippedAtEnd = attributes.cl.endsWith('e')
@@ -1140,6 +1143,7 @@ export class Visualizer {
   private updateFragmentLabelText (fragment: Fragment) {
     const spanLabels = Util.getSpanLabels(this.entityTypes, fragment.span.type)
     fragment.labelText = Util.spanDisplayForm(this.entityTypes, fragment.span.type)
+
     // Find the most appropriate label according to text width
     if (Configuration.abbrevsOn && spanLabels) {
       let labelIdx = 1 // first abbrev
@@ -1151,9 +1155,15 @@ export class Visualizer {
       }
     }
 
-    fragment.labelText = '(' + fragment.labelText + ')'
     if (fragment.span.labelText) {
       fragment.labelText = fragment.span.labelText
+    }
+    else {
+      fragment.labelText = '(' + fragment.labelText + ')'
+    }
+
+    if (fragment.span.score) {
+      fragment.labelText += ' [' + fragment.span.score.toFixed(2) + ']'
     }
   }
 

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebar.html
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebar.html
@@ -42,12 +42,21 @@
           </div>
         </form>
       
-        <div class="row form-row" wicket:enclosure="showMerged">
-          <div class="col-sm-12">
-            <div class="form-check">
+        <div class="row form-row" >
+          <div class="col-sm-12" wicket:enclosure="showMerged">
+            <div class="form-check form-switch">
               <input class="form-check-input" type="checkbox" wicket:id="showMerged">
               <label class="form-check-label" wicket:for="showMerged">
                 <wicket:label key="showMerged"/>
+              </label>
+            </div>
+          </div>
+
+          <div class="col-sm-12" wicket:enclosure="showScore">
+            <div class="form-check form-switch">
+              <input class="form-check-input" type="checkbox" wicket:id="showScore">
+              <label class="form-check-label" wicket:for="showScore">
+                <wicket:label key="showScore"/>
               </label>
             </div>
           </div>

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebar.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebar.java
@@ -103,6 +103,7 @@ public class CurationSidebar
     private ListView<User> users;
     private final Form<Void> usersForm;
     private CheckBox showMerged;
+    private CheckBox showScore;
     private final IModel<CurationWorkflow> curationWorkflowModel;
     private final IModel<Boolean> isTargetFinished;
 
@@ -120,8 +121,10 @@ public class CurationSidebar
 
         queue(createSessionControlForm(CID_SESSION_CONTROL_FORM));
 
-        isTargetFinished = LambdaModel.of(() -> curationSidebarService.isCurationFinished(state,
-                userRepository.getCurrentUsername()));
+        isTargetFinished = LambdaModel.of(() -> {
+            var sessionOwner = userRepository.getCurrentUsername();
+            return curationSidebarService.isCurationFinished(state, sessionOwner);
+        });
 
         noDocsLabel = new Label("noDocumentsLabel", new ResourceModel("noDocuments"));
         noDocsLabel.add(visibleWhen(() -> isSessionActive() && !isTargetFinished.getObject()
@@ -136,9 +139,19 @@ public class CurationSidebar
                 this::actionToggleShowMerged));
         queue(showMerged);
 
+        showScore = new CheckBox("showScore", Model.of());
+        showScore.add(visibleWhen(this::isSessionActive));
+        showScore.add(new LambdaAjaxFormComponentUpdatingBehavior(CHANGE_EVENT,
+                this::actionToggleShowScore));
+        queue(showScore);
+
         if (isSessionActive()) {
-            showMerged.setModelObject(curationSidebarService
-                    .isShowAll(userRepository.getCurrentUsername(), state.getProject().getId()));
+            var sessionOwner = userRepository.getCurrentUsername();
+            var project = state.getProject();
+            showMerged.setModelObject(
+                    curationSidebarService.isShowAll(sessionOwner, project.getId()));
+            showScore.setModelObject(
+                    curationSidebarService.isShowScore(sessionOwner, project.getId()));
         }
 
         curationWorkflowModel = Model
@@ -157,6 +170,14 @@ public class CurationSidebar
         var sessionOwner = userRepository.getCurrentUsername();
         curationSidebarService.setShowAll(sessionOwner, getModelObject().getProject().getId(),
                 showMerged.getModelObject());
+        getAnnotationPage().actionRefreshDocument(aTarget);
+    }
+
+    private void actionToggleShowScore(AjaxRequestTarget aTarget)
+    {
+        var sessionOwner = userRepository.getCurrentUsername();
+        curationSidebarService.setShowScore(sessionOwner, getModelObject().getProject().getId(),
+                showScore.getModelObject());
         getAnnotationPage().actionRefreshDocument(aTarget);
     }
 

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebar.properties
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebar.properties
@@ -24,3 +24,4 @@ noDocuments=Other users need to have this document marked as finished to start c
 mergeConfirmText=Automatically merging other users' annotations into your own document might delete your previous annotations. To complete the action, please enter the document name into the input field below.
 mergeConfirmTitle=Automatic Merge
 showMerged=Show all curatable annotations
+showScore=Show percentage of annotators

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebarService.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebarService.java
@@ -125,6 +125,10 @@ public interface CurationSidebarService
 
     boolean isShowAll(String aUsername, Long aProjectId);
 
+    void setShowScore(String aUsername, Long aProjectId, boolean aValue);
+
+    boolean isShowScore(String aUsername, Long aProjectId);
+
     void setDefaultSelectedUsersForDocument(String aSessionOwner, SourceDocument aDocument);
 
     MergeStrategyFactory<?> merge(AnnotatorState aState, String aCurator, Collection<User> aUsers,

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebarServiceImpl.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebarServiceImpl.java
@@ -477,6 +477,24 @@ public class CurationSidebarServiceImpl
 
     @Transactional
     @Override
+    public boolean isShowScore(String aSessionOwner, Long aProjectId)
+    {
+        synchronized (sessions) {
+            return getSession(aSessionOwner, aProjectId).isShowScore();
+        }
+    }
+
+    @Transactional
+    @Override
+    public void setShowScore(String aSessionOwner, Long aProjectId, boolean aValue)
+    {
+        synchronized (sessions) {
+            getSession(aSessionOwner, aProjectId).setShowScore(aValue);
+        }
+    }
+
+    @Transactional
+    @Override
     public String getCurationTarget(String aSessionOwner, long aProjectId)
     {
         String curationUser;
@@ -576,6 +594,7 @@ public class CurationSidebarServiceImpl
         // the curationdoc can be retrieved from user (CURATION or current) and projectId
         private String curationTarget;
         private boolean showAll;
+        private boolean showScore;
 
         public CurationSession(String aUser)
         {
@@ -616,6 +635,16 @@ public class CurationSidebarServiceImpl
         public void setShowAll(boolean aShowAll)
         {
             showAll = aShowAll;
+        }
+
+        public boolean isShowScore()
+        {
+            return showScore;
+        }
+
+        public void setShowScore(boolean aShowScore)
+        {
+            showScore = aShowScore;
         }
     }
 }

--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/DynamicWorkloadExtensionImpl.java
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/DynamicWorkloadExtensionImpl.java
@@ -55,7 +55,6 @@ import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.inception.annotation.storage.CasStorageSession;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
-import de.tudarmstadt.ukp.inception.documents.api.SourceDocumentStateStats;
 import de.tudarmstadt.ukp.inception.project.api.ProjectService;
 import de.tudarmstadt.ukp.inception.support.json.JSONUtil;
 import de.tudarmstadt.ukp.inception.workload.dynamic.config.DynamicWorkloadManagerAutoConfiguration;
@@ -216,17 +215,17 @@ public class DynamicWorkloadExtensionImpl
     @Transactional
     public ProjectState recalculate(Project aProject)
     {
-        WorkloadManager currentWorkload = workloadManagementService
+        var currentWorkload = workloadManagementService
                 .loadOrCreateWorkloadManagerConfiguration(aProject);
-        DynamicWorkloadTraits traits = readTraits(currentWorkload);
+        var traits = readTraits(currentWorkload);
 
-        for (SourceDocument doc : documentService.listSourceDocuments(aProject)) {
+        for (var doc : documentService.listSourceDocuments(aProject)) {
             updateDocumentState(doc, traits.getDefaultNumberOfAnnotations());
         }
 
         // Refresh the project stats and recalculate them
-        Project project = projectService.getProject(aProject.getId());
-        SourceDocumentStateStats stats = documentService.getSourceDocumentStats(project);
+        var project = projectService.getProject(aProject.getId());
+        var stats = documentService.getSourceDocumentStats(project);
         projectService.setProjectState(aProject, stats.getProjectState());
 
         return project.getState();
@@ -236,9 +235,9 @@ public class DynamicWorkloadExtensionImpl
     @Transactional
     public ProjectState freshenStatus(Project aProject)
     {
-        WorkloadManager currentWorkload = workloadManagementService
+        var currentWorkload = workloadManagementService
                 .loadOrCreateWorkloadManagerConfiguration(aProject);
-        DynamicWorkloadTraits traits = readTraits(currentWorkload);
+        var traits = readTraits(currentWorkload);
 
         // If the duration is not positive, then we can already stop here
         if (traits.getAbandonationTimeout().isZero()
@@ -246,14 +245,14 @@ public class DynamicWorkloadExtensionImpl
             return projectService.getProject(aProject.getId()).getState();
         }
 
-        List<AnnotationDocument> inProgressDocuments = documentService
-                .listAnnotationDocumentsInState(aProject, IN_PROGRESS);
+        var inProgressDocuments = documentService.listAnnotationDocumentsInState(aProject,
+                IN_PROGRESS);
 
         // Find abandoned annotation documents
         Map<SourceDocument, Set<AnnotationDocument>> abandonedDocuments = new LinkedHashMap<>();
-        Instant now = Instant.now();
-        Duration abandonationTimeout = traits.getAbandonationTimeout();
-        for (AnnotationDocument doc : inProgressDocuments) {
+        var now = Instant.now();
+        var abandonationTimeout = traits.getAbandonationTimeout();
+        for (var doc : inProgressDocuments) {
             // If the SOURCE document is already in curation, we do not touch the state anymore
             if (doc.getDocument().getState() == CURATION_FINISHED
                     || doc.getDocument().getState() == CURATION_IN_PROGRESS) {
@@ -289,7 +288,7 @@ public class DynamicWorkloadExtensionImpl
         for (Entry<SourceDocument, Set<AnnotationDocument>> docSet : abandonedDocuments
                 .entrySet()) {
             if (AnnotationDocumentState.NEW == traits.getAbandonationState()) {
-                for (AnnotationDocument adoc : docSet.getValue()) {
+                for (var adoc : docSet.getValue()) {
                     User user = userCache.computeIfAbsent(adoc.getUser(),
                             username -> userRepository.get(username));
                     try (var session = CasStorageSession.openNested()) {
@@ -309,8 +308,8 @@ public class DynamicWorkloadExtensionImpl
         }
 
         // Refresh the project stats and recalculate them
-        Project project = projectService.getProject(aProject.getId());
-        SourceDocumentStateStats stats = documentService.getSourceDocumentStats(project);
+        var project = projectService.getProject(aProject.getId());
+        var stats = documentService.getSourceDocumentStats(project);
         projectService.setProjectState(aProject, stats.getProjectState());
 
         return project.getState();
@@ -326,10 +325,9 @@ public class DynamicWorkloadExtensionImpl
             return;
         }
 
-        Map<AnnotationDocumentState, Long> stats = documentService
-                .getAnnotationDocumentStats(aDocument);
-        long finishedCount = stats.get(AnnotationDocumentState.FINISHED);
-        long inProgressCount = stats.get(AnnotationDocumentState.IN_PROGRESS);
+        var stats = documentService.getAnnotationDocumentStats(aDocument);
+        var finishedCount = stats.get(AnnotationDocumentState.FINISHED);
+        var inProgressCount = stats.get(AnnotationDocumentState.IN_PROGRESS);
 
         // If enough documents are finished, mark as finished
         if (finishedCount >= aRequiredAnnotatorCount) {


### PR DESCRIPTION
**What's in the PR**
- Added option to show the fraction as a score
- Added rendering of annotation scores to brat spans (not relations atm though!)
- Minor cleanup
- Curation scores will also be shown in the annotation overview
- Recommender scores now will also show up on span suggestions in the brat view

**How to test manually**
* Open a document in curation sidebar mode and enable the **Show percentage of annotators** option

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
