### PR TITLE
#4949 - Showing the start and end points of relations in left side bar

### DIFF
--- a/inception/inception-diam-compactv2/src/main/java/de/tudarmstadt/ukp/inception/diam/model/compactv2/CompactLayer.java
+++ b/inception/inception-diam-compactv2/src/main/java/de/tudarmstadt/ukp/inception/diam/model/compactv2/CompactLayer.java
@@ -21,11 +21,13 @@ public class CompactLayer
 {
     private final long id;
     private final String name;
+    private final String type;
 
-    public CompactLayer(long aId, String aName)
+    public CompactLayer(long aId, String aName, String aType)
     {
         id = aId;
         name = aName;
+        type = aType;
     }
 
     public long getId()
@@ -36,5 +38,10 @@ public class CompactLayer
     public String getName()
     {
         return name;
+    }
+
+    public String getType()
+    {
+        return type;
     }
 }

--- a/inception/inception-diam-compactv2/src/main/java/de/tudarmstadt/ukp/inception/diam/model/compactv2/CompactSerializerV2Impl.java
+++ b/inception/inception-diam-compactv2/src/main/java/de/tudarmstadt/ukp/inception/diam/model/compactv2/CompactSerializerV2Impl.java
@@ -99,7 +99,7 @@ public class CompactSerializerV2Impl
                 continue;
             }
 
-            layers.add(new CompactLayer(layer.getId(), layer.getUiName()));
+            layers.add(new CompactLayer(layer.getId(), layer.getUiName(), layer.getType()));
 
             for (VSpan vspan : aVDoc.spans(layer.getId())) {
                 var cspan = renderSpan(aRequest, vspan);

--- a/inception/inception-diam-compactv2/src/test/resources/compactv2/reference.json
+++ b/inception/inception-diam-compactv2/src/test/resources/compactv2/reference.json
@@ -2,10 +2,12 @@
   "action" : "getAnnotatedDocument",
   "layers" : [ {
     "id" : 1,
-    "name" : "Span"
+    "name" : "Span",
+    "type" : "span"
   }, {
     "id" : 2,
-    "name" : "Relation"
+    "name" : "Relation",
+    "type" : "relation"
   } ],
   "text" : "This is a test.",
   "window" : [ 0, 15 ],

--- a/inception/inception-diam-editor/src/main/ts/src/AnnotationsByLabelList.svelte
+++ b/inception/inception-diam-editor/src/main/ts/src/AnnotationsByLabelList.svelte
@@ -88,7 +88,9 @@
                         return b.score - a.score;
                     }
 
-                    return compareOffsets(targetA.offsets[0], targetB.offsets[0])
+                    const targetA = a.arguments[0].target as Span
+                    const targetB = b.arguments[0].target as Span
+                    return compareOffsets(targetA.offsets[0], targetB.offsets[0]);
                 }
 
                 console.error("Unexpected annotation type combination", a, b);

--- a/inception/inception-diam-editor/src/main/ts/src/AnnotationsByLayerList.svelte
+++ b/inception/inception-diam-editor/src/main/ts/src/AnnotationsByLayerList.svelte
@@ -30,12 +30,13 @@
     import { compareOffsets } from "@inception-project/inception-js-api/src/model/Offsets";
     import LabelBadge from "./LabelBadge.svelte";
     import SpanText from "./SpanText.svelte";
-    import { compareSpanText, debounce, filterAnnotations, getCoveredText, groupBy, uniqueLayers } from "./Utils";
+    import { compareSpanText, debounce, filterAnnotations, groupRelationsBySource, groupBy, uniqueLayers } from "./Utils";
     import { sortByScore, recommendationsFirst } from "./AnnotationBrowserState"
 
     export let ajaxClient: DiamAjax;
     export let data: AnnotatedText;
 
+    let groupedRelations: Record<string, Relation[]>;
     let groupedAnnotations: Record<string, Annotation[]>;
     let groups: { layer: Layer, collapsed: boolean }[]
     let collapsedGroups = new Set<number>()
@@ -54,6 +55,8 @@
             [...spans, ...relations],
             (s) => s.layer.name
         )
+
+        groupedRelations = groupRelationsBySource(data);
 
         for (let [key, items] of Object.entries(groupedAnnotations)) {
             items = filterAnnotations(data, items, filter)
@@ -193,6 +196,7 @@
                 {#each groups as group}
                     <li class="list-group-item py-0 px-0 border-0">
                         <!-- svelte-ignore a11y-click-events-have-key-events -->
+                        <!-- svelte-ignore a11y-no-static-element-interactions -->
                         <div
                             class="px-2 py-1 bg-light-subtle fw-bold sticky-top border-top border-bottom"
                             on:click={() => toggleCollapsed(group)}
@@ -200,49 +204,104 @@
                             <button class="btn btn-link p-0" style="color: var(--bs-body-color)">
                                 <i class="fas fa-caret-down d-inline-block" class:group-collapsed={group.collapsed}/>
                             </button>
-                            <span>{group.layer.name}</span>
+                            <span>{group.layer.name} {group.layer.type}</span>
                         </div>
                         <ul class="px-0 list-group list-group-flush" class:d-none={group.collapsed}>
                             {#if groupedAnnotations[group.layer.name]}
                             {#each groupedAnnotations[group.layer.name] as ann}
                                 <!-- svelte-ignore a11y-mouse-events-have-key-events -->
-                                <li
-                                    class="list-group-item list-group-item-action p-0 d-flex"
-                                    on:mouseover={ev => mouseOverAnnotation(ev, ann)}
-                                    on:mouseout={ev => mouseOutAnnotation(ev, ann)}
-                                >
-                                    <div
-                                        class="text-secondary bg-light-subtle border-end px-2 d-flex align-items-center"
+                                {#if ann instanceof Span}
+                                    <li
+                                        class="list-group-item list-group-item-action p-0 d-flex"
+                                        on:mouseover={ev => mouseOverAnnotation(ev, ann)}
+                                        on:mouseout={ev => mouseOutAnnotation(ev, ann)}
                                     >
-                                        {#if ann instanceof Span}
-                                            <div class="annotation-type-marker i7n-icon-span"/>
-                                        {:else if ann instanceof Relation}
-                                            <div class="annotation-type-marker i7n-icon-relation"/>
-                                        {/if}
-                                    </div>
-                                    <!-- svelte-ignore a11y-click-events-have-key-events -->
-                                    <div
-                                        class="flex-grow-1 my-1 mx-2 position-relative overflow-hidden"
-                                        on:click={() => scrollTo(ann)}
-                                    >
-                                        <div class="float-end labels">
-                                            <LabelBadge
-                                                annotation={ann}
-                                                {ajaxClient}
-                                                showText={true}
-                                            />
-                                        </div>
-
-                                        {#if ann instanceof Span}
+                                        <!-- svelte-ignore a11y-click-events-have-key-events -->
+                                        <!-- svelte-ignore a11y-no-static-element-interactions -->
+                                        <div class="flex-grow-1 my-1 mx-2 position-relative overflow-hidden"  on:click={() => scrollTo(ann)}>
+                                            <div class="float-end labels me-1">
+                                                <LabelBadge
+                                                    annotation={ann}
+                                                    {ajaxClient}
+                                                    showText={true}
+                                                />
+                                            </div>
                                             <SpanText {data} span={ann} />
-                                        {:else if ann instanceof Relation}
-                                            <SpanText
-                                                {data}
-                                                span={ann.arguments[0].target}
-                                            />
-                                        {/if}
-                                    </div>
-                                </li>
+                                        </div>
+                                    </li>
+
+                                    {@const relations = groupedRelations[`${ann.vid}`]}
+                                    {#if relations}
+                                        {#each relations as relation}
+                                            {@const target = relation.arguments[1].target}
+                                            <!-- svelte-ignore a11y-mouse-events-have-key-events -->
+                                            <li
+                                                class="list-group-item list-group-item-action p-0 d-flex"
+                                                on:mouseover={(ev) =>
+                                                    mouseOverAnnotation(ev, relation)}
+                                                on:mouseout={(ev) =>
+                                                    mouseOutAnnotation(ev, relation)}
+                                            >
+                                                <div
+                                                    class="text-secondary bg-light-subtle border-end px-2 d-flex align-items-center"
+                                                >
+                                                    <span>↳</span>
+                                                </div>
+                                                <!-- svelte-ignore a11y-click-events-have-key-events -->
+                                                <!-- svelte-ignore a11y-no-static-element-interactions -->
+                                                <div
+                                                    class="flex-grow-1 my-1 mx-2 overflow-hidden"
+                                                    on:click={() => scrollTo(target)}
+                                                >
+                                                    <div class="float-end labels me-1">
+                                                        <LabelBadge
+                                                            annotation={relation}
+                                                            {ajaxClient}
+                                                        />
+                                                    </div>
+                
+                                                    <SpanText {data} span={target} />
+                                                </div>
+                                            </li>
+                                        {/each}
+                                    {/if}                                       
+                                {:else if ann instanceof Relation && group.layer.type === "relation"}
+                                    <li
+                                        class="list-group-item p-0 d-flex"
+                                        on:mouseover={ev => mouseOverAnnotation(ev, ann)}
+                                        on:mouseout={ev => mouseOutAnnotation(ev, ann)}
+                                >
+                                        <!-- svelte-ignore a11y-click-events-have-key-events -->
+                                        <!-- svelte-ignore a11y-no-static-element-interactions -->
+                                        <div class="flex-grow-1 my-1 mx-0 position-relative overflow-hidden">
+                                            <div class="me-2">
+                                                <LabelBadge
+                                                    annotation={ann}
+                                                    {ajaxClient}
+                                                    showText={true}
+                                                />
+                                            </div>
+                                            <div class="d-flex flex-row list-group-item-action" on:click={() => scrollTo(ann.arguments[0].target)}>
+                                                <div class="text-secondary bg-light-subtle border-end px-2 d-flex align-items-center">
+                                                    <span style="transform: rotate(90deg);">↳</span>
+                                                </div>
+                                                <SpanText
+                                                    {data}
+                                                    span={ann.arguments[0].target}
+                                                />
+                                            </div>
+                                            <div class="d-flex flex-row list-group-item-action" on:click={() => scrollTo(ann.arguments[1].target)}>
+                                                <div class="text-secondary bg-light-subtle border-end px-2 d-flex align-items-center">
+                                                    <span>↳</span>
+                                                </div>
+                                                <SpanText
+                                                    {data}
+                                                    span={ann.arguments[1].target}
+                                                />
+                                            </div>
+                                        </div>
+                                    </li>
+                                {/if}
                             {/each}
                             {:else}
                             <li class="list-group-item list-group-item-action p-2 text-center text-secondary bg-light">

--- a/inception/inception-diam-editor/src/main/ts/src/AnnotationsByPositionList.svelte
+++ b/inception/inception-diam-editor/src/main/ts/src/AnnotationsByPositionList.svelte
@@ -29,7 +29,7 @@
     import LabelBadge from "./LabelBadge.svelte";
     import SpanText from "./SpanText.svelte";
     import {
-    debounce,
+        debounce,
         groupRelationsByPosition,
         groupSpansByPosition,
         uniqueOffsets,
@@ -103,7 +103,7 @@
                             class="flex-grow-1 my-1 mx-2 overflow-hidden"
                             on:click={() => scrollToSpan(firstSpan)}
                         >
-                            <div class="float-end labels">
+                            <div class="float-end labels me-1">
                                 {#each spans as span}
                                     <span
                                         on:mouseover={(ev) =>
@@ -144,7 +144,7 @@
                                     class="flex-grow-1 my-1 mx-2 overflow-hidden"
                                     on:click={() => scrollToRelation(relation)}
                                 >
-                                    <div class="float-end labels">
+                                    <div class="float-end labels me-1">
                                         <LabelBadge
                                             annotation={relation}
                                             {ajaxClient}

--- a/inception/inception-diam-editor/src/main/ts/src/LabelBadge.svelte
+++ b/inception/inception-diam-editor/src/main/ts/src/LabelBadge.svelte
@@ -60,7 +60,7 @@
 
 <!-- svelte-ignore a11y-click-events-have-key-events -->
 {#if annotation.vid.toString().startsWith("rec:")}
-    <div class="btn-group mb-0 ms-0 btn-group-recommendation bg-body" role="group">
+    <div class="btn-group mb-1 ms-0 btn-group-recommendation bg-body" role="group">
         <button
             type="button"
             class="btn-accept btn btn-outline-success btn-sm py-0 px-1"
@@ -90,7 +90,7 @@
 {:else if annotation.vid.toString().startsWith("cur:")}
     <button
         type="button"
-        class="btn-merge btn btn-colored btn-sm py-0 px-1 border-dark"
+        class="btn-merge btn btn-colored btn-sm pt-0 mb-1 px-1 border-dark mb-1"
         style="color: {textColor}; background-color: {backgroundColor}"
         on:click={handleMerge}
         title="Merge"
@@ -107,7 +107,7 @@
         {/if}
     </button>
 {:else}
-    <div class="input-group mb-0 ms-1 bg-body" role="group">
+    <div class="input-group mb-1 ms-1 bg-body flex-nowrap text-break" role="group">
         {#if hasError || hasInfo}
             <span class="input-group-text py-0 px-1">
                 {#if hasError}<i class="fas fa-exclamation-circle" style="color: var(--i7n-error-color)"></i>{/if}

--- a/inception/inception-diam-editor/src/main/ts/src/SpanText.svelte
+++ b/inception/inception-diam-editor/src/main/ts/src/SpanText.svelte
@@ -40,7 +40,7 @@
     <span>{text.substring(0, 50)}</span>
     <span class="text-muted trailing-text">…</span>
 {:else}
-    {text}
+    <span style="overflow-wrap: normal;">{text}</span>
     {#if textAfter.length > 0}
         <span class="text-muted trailing-text">{textAfter}</span>
     {/if}

--- a/inception/inception-diam-editor/src/main/ts/src/Utils.ts
+++ b/inception/inception-diam-editor/src/main/ts/src/Utils.ts
@@ -171,6 +171,10 @@ export function groupRelationsByPosition (data: AnnotatedText): Record<string, R
   return groupBy(data?.relations.values(), (r) => `${(r.arguments[0].target as Span).offsets}`)
 }
 
+export function groupRelationsBySource (data: AnnotatedText): Record<string, Relation[]> {
+  return groupBy(data?.relations.values(), (r) => `${r.arguments[0].target?.vid}`)
+}
+
 export function highlightClasses (vid: VID, data: AnnotatedText): string {
   const classes: string[] = []
   for (const marker of data.annotationMarkers.get(vid) || []) {

--- a/inception/inception-js-api/src/main/ts/src/model/Layer.ts
+++ b/inception/inception-js-api/src/main/ts/src/model/Layer.ts
@@ -18,4 +18,5 @@
 export class Layer {
   id: number
   name: string
+  type: string
 }

--- a/inception/inception-js-api/src/main/ts/src/model/compact_v2/CompactLayer.ts
+++ b/inception/inception-js-api/src/main/ts/src/model/compact_v2/CompactLayer.ts
@@ -21,11 +21,13 @@ import { Layer } from '../Layer'
 export type CompactLayer = {
   id: number,
   name: string
+  type: string
 }
 
 export function unpackCompactLayer (raw: CompactLayer): Layer {
   const cooked = new Layer()
   cooked.id = raw.id
   cooked.name = raw.name
+  cooked.type = raw.type
   return cooked
 }


### PR DESCRIPTION
**What's in the PR**
- Display start and end of a relation in layer-grouping mode
- Sort link targets under link sources in layer-grouping mode
- Generally try to impove the visuals a bit

**How to test manually**
* Try using the annotation sidebar in different modes

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
