### PR TITLE
#5052 - No lazy details when viewing annotation suggestions for another user

### DIFF
--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/CreateSpanAnnotationHandler.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/CreateSpanAnnotationHandler.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 
 import org.apache.uima.cas.CAS;
 import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.feedback.IFeedback;
 import org.apache.wicket.request.IRequestParameters;
 import org.apache.wicket.request.Request;
 import org.springframework.core.annotation.Order;
@@ -76,11 +77,19 @@ public class CreateSpanAnnotationHandler
             var page = getPage();
             page.ensureIsEditable();
 
-            var cas = page.getEditorCas();
             var state = getAnnotatorState();
+            var layer = state.getDefaultAnnotationLayer();
+            if (layer == null) {
+                page.info(
+                        "Cannot create annotation: this project does not define any span annotation layers.");
+                aTarget.addChildren(page, IFeedback.class);
+                return new DefaultAjaxResponse(getAction(aRequest));
+            }
+
+            var cas = page.getEditorCas();
             var range = getRangeFromRequest(state, aRequest.getRequestParameters(), cas);
 
-            var adapter = schemaService.getAdapter(state.getDefaultAnnotationLayer());
+            var adapter = schemaService.getAdapter(layer);
 
             var request = new CreateSpanAnnotationRequest(state.getDocument(),
                     state.getUser().getUsername(), cas, range.getBegin(), range.getEnd());

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/LazyDetailsHandler.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/LazyDetailsHandler.java
@@ -87,7 +87,7 @@ public class LazyDetailsHandler
             // old document are still being loaded while the backend editor state has already been
             // configured for the new document. If no suitable annotation with the given ID exists
             // in the new document, this exception will be thrown. As part of switching the
-            // document, the popover will be destroyed and re-created anyway, so in any case, the
+            // document, the pop-over will be destroyed and re-created anyway, so in any case, the
             // user should never see this data.
             // So, we ignore this exception.
             return new DefaultAjaxResponse(COMMAND);

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/lazydetails/LazyDetailsLookupService.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/lazydetails/LazyDetailsLookupService.java
@@ -35,12 +35,12 @@ import de.tudarmstadt.ukp.inception.schema.api.adapter.AnnotationException;
 public interface LazyDetailsLookupService
 {
     List<LazyDetailGroup> lookupLazyDetails(IRequestParameters request, VID paramId,
-            CasProvider aCas, SourceDocument aSourceDocument, User aUser, int windowBeginOffset,
-            int windowEndOffset)
+            CasProvider aCas, SourceDocument aSourceDocument, User aDataOwner,
+            int windowBeginOffset, int windowEndOffset)
         throws AnnotationException, IOException;
 
     List<VLazyDetailGroup> lookupAnnotationLevelDetails(VID aVid, SourceDocument aDocument,
-            User aUser, AnnotationLayer aLayer, CAS aCas)
+            User aDataOwner, AnnotationLayer aLayer, CAS aCas)
         throws AnnotationException, IOException;
 
     List<VLazyDetailGroup> lookupFeatureLevelDetails(VID aVid, CAS aCas,

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/RecommenderGeneralSettings.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/RecommenderGeneralSettings.java
@@ -31,7 +31,7 @@ public class RecommenderGeneralSettings
 
     private boolean waitForRecommendersOnOpenDocument = false;
 
-    private boolean showRecommendationsWhenViewingOtherUser = true;
+    private boolean showRecommendationsWhenViewingOtherUser = false;
 
     private boolean showRecommendationsWhenViewingCurationUser = true;
 


### PR DESCRIPTION
**What's in the PR**
- Use the session owner when loading lazy details for annotation suggestions instead of the data owner
- By default, disable displaying annotation suggestions when viewing annotations of another user

**How to test manually**
* See issue

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
