### PR TITLE
#5078 - Upgrade dependencies

### DIFF
--- a/inception/inception-dependencies/pom.xml
+++ b/inception/inception-dependencies/pom.xml
@@ -390,7 +390,7 @@
       <dependency>
         <groupId>org.mozilla</groupId>
         <artifactId>rhino-runtime</artifactId>
-        <version>1.7.14</version>
+        <version>1.7.15</version>
       </dependency>
 
       <dependency>
@@ -1372,7 +1372,7 @@
       <dependency>
         <groupId>org.apache.ant</groupId>
         <artifactId>ant</artifactId>
-        <version>1.10.14</version>
+        <version>${ant-version}</version>
       </dependency>
 
       <dependency>
@@ -1424,6 +1424,28 @@
         <version>${spring.boot.version}</version>
         <type>pom</type>
         <scope>import</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.infinispan</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -67,15 +67,15 @@
   </distributionManagement>
 
   <properties>
-    <build-ant-version>1.10.14</build-ant-version>
-    <build-groovy-version>4.0.22</build-groovy-version>
+    <build-ant-version>1.10.15</build-ant-version>
+    <build-groovy-version>4.0.23</build-groovy-version>
 
-    <junit-jupiter.version>5.11.0</junit-jupiter.version>
-    <junit-platform.version>1.11.0</junit-platform.version>
-    <mockito.version>5.12.0</mockito.version>
+    <junit-jupiter.version>5.11.1</junit-jupiter.version>
+    <junit-platform.version>1.11.1</junit-platform.version>
+    <mockito.version>5.14.1</mockito.version>
     <assertj.version>3.26.3</assertj.version>
     <xmlunit.version>2.10.0</xmlunit.version>
-    <testcontainers.version>1.20.1</testcontainers.version>
+    <testcontainers.version>1.20.2</testcontainers.version>
 
     <awaitility.version>4.2.2</awaitility.version>
 
@@ -86,35 +86,35 @@
 
     <pdfbox.version>3.0.3</pdfbox.version>
 
-    <spring.version>6.1.12</spring.version>
-    <spring.boot.version>3.3.2</spring.boot.version>
+    <spring.version>6.1.13</spring.version>
+    <spring.boot.version>3.3.4</spring.boot.version>
     <spring.data.version>3.3.2</spring.data.version>
-    <spring.security.version>6.3.1</spring.security.version>
+    <spring.security.version>6.3.3</spring.security.version>
     <springdoc.version>2.6.0</springdoc.version>
-    <swagger.version>2.2.22</swagger.version>
+    <swagger.version>2.2.24</swagger.version>
     <jjwt.version>0.12.6</jjwt.version>
 
     <slf4j.version>2.0.16</slf4j.version>
-    <log4j2.version>2.23.1</log4j2.version>
+    <log4j2.version>2.24.1</log4j2.version>
     <jboss.logging.version>3.6.0.Final</jboss.logging.version>
     <sentry.version>7.14.0</sentry.version>
 
-    <tomcat.version>10.1.28</tomcat.version>
-    <jetty.version>12.0.12</jetty.version>
+    <tomcat.version>10.1.30</tomcat.version>
+    <jetty.version>12.0.14</jetty.version>
     <servlet-api.version>6.0.0</servlet-api.version>
 
     <mariadb.driver.version>3.4.1</mariadb.driver.version>
     <mssql.driver.version>12.6.3.jre11</mssql.driver.version>
     <mysql.driver.version>9.0.0</mysql.driver.version>
-    <postgres.driver.version>42.7.3</postgres.driver.version>
+    <postgres.driver.version>42.7.4</postgres.driver.version>
     <hibernate.version>6.5.2.Final</hibernate.version>
     <hibernate.validator.version>8.0.1.Final</hibernate.validator.version>
 
-    <wicket.version>10.1.0</wicket.version>
-    <wicketstuff.version>10.1.1</wicketstuff.version>
-    <wicket-bootstrap.version>7.0.5</wicket-bootstrap.version>
-    <wicket-jquery-selectors.version>4.0.5</wicket-jquery-selectors.version>
-    <wicket-webjars.version>4.0.4</wicket-webjars.version>
+    <wicket.version>10.2.0</wicket.version>
+    <wicketstuff.version>10.2.0</wicketstuff.version>
+    <wicket-bootstrap.version>7.0.8</wicket-bootstrap.version>
+    <wicket-jquery-selectors.version>4.0.6</wicket-jquery-selectors.version>
+    <wicket-webjars.version>4.0.5</wicket-webjars.version>
     <wicket-spring-boot.version>4.0.0</wicket-spring-boot.version>
 
     <!--
@@ -122,7 +122,7 @@
       -->
     <lucene.version>9.11.1</lucene.version>
     <solr.version>9.6.1</solr.version>
-    <opensearch.version>2.16.0</opensearch.version>
+    <opensearch.version>2.17.0</opensearch.version>
     <jena.version>5.1.0</jena.version>
     <rdf4j.version>5.0.2</rdf4j.version> 
     <owlapi-version>5.5.1</owlapi-version>
@@ -132,39 +132,40 @@
     <asciidoctor-diagram.version>2.3.1</asciidoctor-diagram.version>
     <build-asciidoctorj-pdf-version>2.3.18</build-asciidoctorj-pdf-version>
 
+    <ant-version>1.10.15</ant-version>
     <json.version>20230227</json.version>
     <pf4j.version>2.6.0</pf4j.version>
     <pf4j-spring.version>0.5.0</pf4j-spring.version>
-    <jackson.version>2.17.2</jackson.version>
-    <snakeyaml.version>2.2</snakeyaml.version>
+    <jackson.version>2.18.0</jackson.version>
+    <snakeyaml.version>2.3</snakeyaml.version>
     <okhttp.version>4.12.0</okhttp.version>
-    <okio.version>3.9.0</okio.version>
-    <byte-buddy.version>1.14.19</byte-buddy.version>
+    <okio.version>3.9.1</okio.version>
+    <byte-buddy.version>1.15.3</byte-buddy.version>
     <caffeine.version>3.1.8</caffeine.version>
     <commons-beanutils.version>1.9.4</commons-beanutils.version>
     <commons-collections4.version>4.4</commons-collections4.version>
-    <commons-csv.version>1.11.0</commons-csv.version>
+    <commons-csv.version>1.12.0</commons-csv.version>
     <commons-fileupload.version>1.5</commons-fileupload.version>
     <commons-pool2.version>2.12.0</commons-pool2.version>
-    <commons-lang3.version>3.16.0</commons-lang3.version>
+    <commons-lang3.version>3.17.0</commons-lang3.version>
     <commons-dbcp2.version>2.12.0</commons-dbcp2.version>
     <commons-codec.version>1.17.1</commons-codec.version>
-    <commons-compress.version>1.27.0</commons-compress.version>
+    <commons-compress.version>1.27.1</commons-compress.version>
     <commons-math3.version>3.6.1</commons-math3.version>
     <commons-text.version>1.12.0</commons-text.version>
     <commons-validator.version>1.9.0</commons-validator.version>
-    <commons-io.version>2.16.1</commons-io.version>
+    <commons-io.version>2.17.0</commons-io.version>
     <commons-logging.version>1.3.3</commons-logging.version>
     <commons-logging-api.version>1.1</commons-logging-api.version>
-    <jinjava.version>2.7.2</jinjava.version>
+    <jinjava.version>2.7.3</jinjava.version>
     <fastutil.version>8.5.14</fastutil.version>
     <picocli.version>4.7.6</picocli.version>
     <woodstox-core.version>6.7.0</woodstox-core.version>
-    <nimbus-jose-jwt.version>9.40</nimbus-jose-jwt.version>
-    <json-schema-validator.version>1.5.1</json-schema-validator.version>
+    <nimbus-jose-jwt.version>9.41.2</nimbus-jose-jwt.version>
+    <json-schema-validator.version>1.5.2</json-schema-validator.version>
     <jgit.version>6.10.0.202406032230-r</jgit.version>
     <jaxb.version>4.0.5</jaxb.version>
-    <snappy.version>1.1.10.6</snappy.version>
+    <snappy.version>1.1.10.7</snappy.version>
     <jsonld-java.version>0.13.6</jsonld-java.version>
     <jna.version>5.14.0</jna.version>
     <jsoup.version>1.18.1</jsoup.version>
@@ -197,7 +198,7 @@
     <jsdom.version>^20.0.0</jsdom.version>
     <jsdom-global.version>^3.0.2</jsdom-global.version>
     <jquery.version>3.7.1</jquery.version>
-    <jquery-ui.version>1.13.3</jquery-ui.version>
+    <jquery-ui.version>1.14.0</jquery-ui.version>
     <pdfjs.version>2.14.305</pdfjs.version>
     <popperjs.version>2.11.8</popperjs.version>
     <recogitojs.version>1.8.2</recogitojs.version>


### PR DESCRIPTION
**What's in the PR**
- rhino 1.7.14 -> 1.7.15
- ant 1.10.14 -> 1.10.15
- junit 5.11.0 -> 5.11.1
- junit-platform 1.11.0 -> 1.11.1
- mockito 5.12.0 -> 5.14.1
- testcontainers 1.20.1 -> 1.20.2
- spring 6.1.12 -> 6.1.13
- spring-boot 3.3.2 -> 3.3.4
- spring-security 6.3.1 -> 6.3.3
- swagger 2.2.22 -> 2.2.24
- log4j 2.23.1 -> 2.24.1
- tomcat 10.1.28 -> 10.1.30
- jetty 12.0.12 -> 12.0.14
- postgres-driver 42.7.3 -> 43.7.4
- wicket 10.1.0 -> 10.2.0
- wicketstuff 10.1.1 -> 10.2.0
- wicket-bootstrap 7.0.5 -> 7.0.8
- wicket-jquery-selectors 4.0.5 -> 4.0.6
- wicket-webjars 4.0.4 -> 4.0.5
- opensearch 2.16.0 -> 2.17.0
- jackson 2.17.2 -> 2.18.0
- snakeyaml 2.2 -> 2.3
- okio 3.9.0 -> 3.9.1
- byte-buddy 1.14.19 -> 1.15.3
- commons-csv 1.11.0 -> 1.12.0
- commons-lang3 3.16.0 -> 3.17.0
- commons-compress 1.27.0 -> 1.27.1
- commons-io 2.16.1 -> 2.17.0
- jinjava 2.7.2 -> 2.7.3
- nimbus-jose-jwt 9.40 -> 9.41.2
- json-schema-validator 1.5.1 -> 1.5.2
- snappy 1.1.10.6 -> 1.1.10.7
- jquery 1.13.3 -> 1.14.0

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
