### PR TITLE
#5087 - Interactive recommender sidebar does not invoke the right recommender

### DIFF
--- a/inception/inception-imls-ollama/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/ollama/OllamaRecommender.java
+++ b/inception/inception-imls-ollama/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/ollama/OllamaRecommender.java
@@ -20,6 +20,7 @@ package de.tudarmstadt.ukp.inception.recommendation.imls.ollama;
 import static de.tudarmstadt.ukp.inception.recommendation.imls.support.llm.prompt.PromptContextGenerator.VAR_EXAMPLES;
 import static de.tudarmstadt.ukp.inception.recommendation.imls.support.llm.prompt.PromptContextGenerator.getPromptContextGenerator;
 import static de.tudarmstadt.ukp.inception.recommendation.imls.support.llm.response.ResponseExtractor.getResponseExtractor;
+import static java.lang.System.currentTimeMillis;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
@@ -99,11 +100,11 @@ public class OllamaRecommender
                 .withFormat(traits.getFormat()) //
                 .withRaw(traits.isRaw()) //
                 .withStream(false) //
-                // FIXME: Make NUM_PREDICT accessible in UI
-                .withOption(OllamaGenerateRequest.NUM_PREDICT, 300) //
                 .build();
+        var startTime = currentTimeMillis();
         var response = client.generate(traits.getUrl(), request).trim();
-        LOG.trace("Ollama [{}] responds: [{}]", traits.getModel(), response);
+        LOG.trace("Ollama [{}] responds ({} ms): [{}]", traits.getModel(),
+                currentTimeMillis() - startTime, response);
         return response;
     }
 }

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/EvaluatedRecommender.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/EvaluatedRecommender.java
@@ -56,10 +56,16 @@ public class EvaluatedRecommender
         return reasonForState;
     }
 
-    public static EvaluatedRecommender makeActiveWithoutEvaluation(Recommender aRecommender)
+    @Override
+    public String toString()
     {
-        return new EvaluatedRecommender(aRecommender, EvaluationResult.skipped(), true,
-                "Recommender is always active (without evaluation).");
+        return "EvaluatedRecommender [" + recommender + " -> " + (active ? "ACTIVE" : "OFF") + "]";
+    }
+
+    public static EvaluatedRecommender makeActiveWithoutEvaluation(Recommender aRecommender,
+            String aReason)
+    {
+        return new EvaluatedRecommender(aRecommender, EvaluationResult.skipped(), true, aReason);
     }
 
     public static EvaluatedRecommender makeActive(Recommender aRecommender,

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
@@ -43,7 +43,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.commons.collections4.MapIterator;
 import org.apache.commons.collections4.MultiValuedMap;
 import org.apache.commons.collections4.multimap.HashSetValuedHashMap;
 import org.apache.commons.lang3.Validate;
@@ -1406,10 +1405,9 @@ public class RecommendationServiceImpl
 
         public MultiValuedMap<AnnotationLayer, EvaluatedRecommender> getActiveRecommenders()
         {
-            MultiValuedMap<AnnotationLayer, EvaluatedRecommender> active = new HashSetValuedHashMap<>();
+            var active = new HashSetValuedHashMap<AnnotationLayer, EvaluatedRecommender>();
 
-            MapIterator<AnnotationLayer, EvaluatedRecommender> i = evaluatedRecommenders
-                    .mapIterator();
+            var i = evaluatedRecommenders.mapIterator();
             while (i.hasNext()) {
                 i.next();
                 if (i.getValue().isActive()) {

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/NonTrainableRecommenderActivationTask.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/NonTrainableRecommenderActivationTask.java
@@ -146,6 +146,10 @@ public class NonTrainableRecommenderActivationTask
 
         var engine = factory.build(recommender);
 
+        if (factory.isInteractive(recommender)) {
+            return Optional.of(activateNonTrainableRecommender(user, recommender, engine));
+        }
+
         return switch (engine.getTrainingCapability()) {
         case TRAINING_NOT_SUPPORTED, TRAINING_SUPPORTED -> Optional
                 .of(activateNonTrainableRecommender(user, recommender, engine));
@@ -169,7 +173,8 @@ public class NonTrainableRecommenderActivationTask
         LOG.debug("[{}][{}]: Activating [{}] non-trainable recommender", user.getUsername(),
                 recommenderName, recommenderName);
         info("Recommender [%s] activated because it is not trainable", recommenderName);
-        return EvaluatedRecommender.makeActiveWithoutEvaluation(recommender);
+        return EvaluatedRecommender.makeActiveWithoutEvaluation(recommender,
+                "Non-trainable recommenders is always active (without evaluation)");
     }
 
     private EvaluatedRecommender skipTrainableRecommender(User user, Recommender recommender)
@@ -237,8 +242,6 @@ public class NonTrainableRecommenderActivationTask
     public static class Builder<T extends Builder<?>>
         extends RecommendationTask_ImplBase.Builder<T>
     {
-        private Recommender recommender;
-
         public NonTrainableRecommenderActivationTask build()
         {
             return new NonTrainableRecommenderActivationTask(this);

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/SelectionTask.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/SelectionTask.java
@@ -148,7 +148,7 @@ public class SelectionTask
                         seenRecommender = true;
                     }
 
-                    Recommender recommender = optRecommender.get();
+                    var recommender = optRecommender.get();
                     try {
                         long start = System.currentTimeMillis();
 
@@ -281,7 +281,7 @@ public class SelectionTask
         }
 
         if (factory.isInteractive(recommender)) {
-            return Optional.of(skipInteractiveRecommender(user, recommender));
+            return Optional.of(activateInteractiveRecommender(user, recommender));
         }
 
         if (recommender.isAlwaysSelected()) {
@@ -359,31 +359,32 @@ public class SelectionTask
             Recommender recommender)
     {
         String recommenderName = recommender.getName();
-        LOG.debug("[{}][{}]: Activating [{}] without evaluating - not evaluable", userName,
+        LOG.debug("[{}][{}]: Activating [{}] without evaluation - not evaluable", userName,
                 recommenderName, recommenderName);
-        info("Recommender [%s] activated without evaluating - not evaluable", recommenderName);
-        return EvaluatedRecommender.makeActiveWithoutEvaluation(recommender);
+        info("Recommender [%s] activated without evaluation - not evaluable", recommenderName);
+        return EvaluatedRecommender.makeActiveWithoutEvaluation(recommender,
+                "Non-evaluatable recommender is always active (without evaluation).");
     }
 
     private EvaluatedRecommender activateAlwaysOnRecommender(String userName,
             Recommender recommender)
     {
         String recommenderName = recommender.getName();
-        LOG.debug("[{}][{}]: Activating [{}] without evaluating - always selected", userName,
+        LOG.debug("[{}][{}]: Activating [{}] without evaluation - always selected", userName,
                 recommenderName, recommenderName);
-        info("Recommender [%s] activated without evaluating - always selected", recommenderName);
-        return EvaluatedRecommender.makeActiveWithoutEvaluation(recommender);
+        info("Recommender [%s] activated without evaluation - always selected", recommenderName);
+        return EvaluatedRecommender.makeActiveWithoutEvaluation(recommender,
+                "Recommender is always active (without evaluation).");
     }
 
-    private EvaluatedRecommender skipInteractiveRecommender(User user, Recommender recommender)
+    private EvaluatedRecommender activateInteractiveRecommender(User user, Recommender recommender)
     {
         var recommenderName = recommender.getName();
-        LOG.info("[{}][{}]: Recommender reserved for interactive use " + "- skipping recommender",
-                user.getUsername(), recommenderName);
-        info("Recommender [%s] reserved for interactive use - skipping recommender",
-                recommenderName);
-        return EvaluatedRecommender.makeInactiveWithoutEvaluation(recommender,
-                "Reserved for interactive use");
+        LOG.info("[{}][{}]: Activating [{}] without evaluation - interactive use",
+                user.getUsername(), recommenderName, recommenderName);
+        info("Recommender [%s] without evaluation - interactive use", recommenderName);
+        return EvaluatedRecommender.makeActiveWithoutEvaluation(recommender,
+                "Interactive recommender is always active (without evaluation).");
     }
 
     private EvaluatedRecommender skipRecommenderWithInvalidSettings(User user,


### PR DESCRIPTION
**What's in the PR**
- Remove the response limit for Ollama
- Distingish different auto-activation reasons in the recommender sidebar
- Mark interactive recommender as "active" so that the PredictionTask considers them (not yet sure if that is the best approach, but then at least also the "accept best" buttons in the recommender sidebar are there)
- Skip interactive recommenders unless they are explicitly included to be run in a PredictionTask
- Log a bit more timing information

**How to test manually**
* Try using the interactive recommender sidebar

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
