### PR TITLE
#5129 - Dynamic workflow may kick in for curator when try to view document from non-curator

### DIFF
--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/annotation/DynamicWorkflowActionBarExtension.java
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/annotation/DynamicWorkflowActionBarExtension.java
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.actionbar.ActionBarExtension;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
+import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.inception.project.api.ProjectService;
 import de.tudarmstadt.ukp.inception.workload.dynamic.config.DynamicWorkloadManagerAutoConfiguration;
 import de.tudarmstadt.ukp.inception.workload.extension.WorkloadManagerExtension;
@@ -41,13 +42,15 @@ public class DynamicWorkflowActionBarExtension
 {
     private final WorkloadManagementService workloadManagementService;
     private final ProjectService projectService;
+    private final UserDao userService;
 
     @Autowired
     public DynamicWorkflowActionBarExtension(WorkloadManagementService aWorkloadManagementService,
-            ProjectService aProjectService)
+            ProjectService aProjectService, UserDao aUserService)
     {
         workloadManagementService = aWorkloadManagementService;
         projectService = aProjectService;
+        userService = aUserService;
     }
 
     @Override
@@ -65,17 +68,18 @@ public class DynamicWorkflowActionBarExtension
     @Override
     public boolean accepts(AnnotationPageBase aPage)
     {
-        // #Issue 1813 fix
-        if (aPage.getModelObject().getProject() == null) {
+        // Issue #1813 fix
+        var project = aPage.getModelObject().getProject();
+        if (project == null) {
             return false;
         }
 
         // Curator are excluded from the feature
-        return DYNAMIC_WORKLOAD_MANAGER_EXTENSION_ID
-                .equals(workloadManagementService.loadOrCreateWorkloadManagerConfiguration(
-                        aPage.getModelObject().getProject()).getType())
-                && !projectService.hasRole(aPage.getModelObject().getUser(),
-                        aPage.getModelObject().getProject(), CURATOR);
+        var sessionOwner = userService.getCurrentUser();
+        var workloadConfig = workloadManagementService
+                .loadOrCreateWorkloadManagerConfiguration(project);
+        return DYNAMIC_WORKLOAD_MANAGER_EXTENSION_ID.equals(workloadConfig.getType())
+                && !projectService.hasRole(sessionOwner, project, CURATOR);
     }
 
     @Override

--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/config/DynamicWorkloadManagerAutoConfiguration.java
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/config/DynamicWorkloadManagerAutoConfiguration.java
@@ -84,9 +84,11 @@ public class DynamicWorkloadManagerAutoConfiguration
 
     @Bean
     public DynamicWorkflowActionBarExtension dynamicWorkflowActionBarExtension(
-            WorkloadManagementService aWorkloadManagementService, ProjectService aProjectService)
+            WorkloadManagementService aWorkloadManagementService, ProjectService aProjectService,
+            UserDao aUserService)
     {
-        return new DynamicWorkflowActionBarExtension(aWorkloadManagementService, aProjectService);
+        return new DynamicWorkflowActionBarExtension(aWorkloadManagementService, aProjectService,
+                aUserService);
     }
 
     @Bean


### PR DESCRIPTION
**What's in the PR**
- Use the session owner instead of the data owner when checking for curator role

**How to test manually**
* Open a project using dynamic workload where all documents are finished
* As a curator, try opening a document from a non-curator on the curation page or annotation page with curation sidebar enabled

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
