### PR TITLE
#5141 - Interactive recommenders should not be listed in the bulk-processing

### DIFF
--- a/inception/inception-processing/src/main/java/de/tudarmstadt/ukp/inception/processing/recommender/BulkRecommenderPanel.java
+++ b/inception/inception-processing/src/main/java/de/tudarmstadt/ukp/inception/processing/recommender/BulkRecommenderPanel.java
@@ -165,6 +165,10 @@ public class BulkRecommenderPanel
             var factory = maybeFactory.get();
             var engine = factory.build(recommender);
 
+            if (factory.isInteractive(recommender)) {
+                continue;
+            }
+
             // If a recommender requires training, it would yield no results if the user has not yet
             // annotated any documents. So in this case, we do currently not offer it for
             // processing.


### PR DESCRIPTION
**What's in the PR**
- Skip interactive recommenders on the bulk processing panel

**How to test manually**
* Mark a recommender as interactive
* Check it does not appear on the bulk processing page

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
