### PR TITLE
#5147 - Relations should be visible in the annotation sidebar when render mode is never

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/RelationRenderer.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/RelationRenderer.java
@@ -260,12 +260,18 @@ public class RelationRenderer
                     labelFeatures);
         case WHEN_SELECTED:
             if (aRequest.getState() == null || isSelected(aRequest, aFS, sourceFs, targetFs)) {
+                // State == null is when we render for the annotation sidebar...
                 return renderRelationAsArcs(aRequest, aVDocument, aFS, typeAdapter, sourceFs,
                         targetFs, labelFeatures);
             }
             return renderRelationOnLabel(aVDocument, typeAdapter, sourceFs, targetFs,
                     labelFeatures);
         case NEVER:
+            if (aRequest.getState() == null) {
+                // State == null is when we render for the annotation sidebar...
+                return renderRelationAsArcs(aRequest, aVDocument, aFS, typeAdapter, sourceFs,
+                        targetFs, labelFeatures);
+            }
             return renderRelationOnLabel(aVDocument, typeAdapter, sourceFs, targetFs,
                     labelFeatures);
         default:


### PR DESCRIPTION
**What's in the PR**
- Render relations in never mode when rendering for the annotation sidebar

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
