### PR TITLE
#5157 - Ability to hide images/tables in HTML files

### DIFF
--- a/inception/inception-html-apache-annotator-editor/src/main/java/de/tudarmstadt/ukp/inception/apacheannotatoreditor/ApacheAnnotatorHtmlAnnotationEditorFactoryUserPreferences.schema.json
+++ b/inception/inception-html-apache-annotator-editor/src/main/java/de/tudarmstadt/ukp/inception/apacheannotatoreditor/ApacheAnnotatorHtmlAnnotationEditorFactoryUserPreferences.schema.json
@@ -16,6 +16,12 @@
     },
     "documentStructureWidth": {
       "type": "number"
+    },
+    "showImages": {
+      "type": "boolean"
+    },
+    "showTables": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorEditor.scss
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorEditor.scss
@@ -309,3 +309,39 @@ html > body {
   font-size: 80%;
   padding-left: 15px;
 }
+
+.iaa-hide-tables {
+  table-wrap {
+    table {
+      display: none !important;
+    }
+  
+    &::after {
+      font-size: small;
+      content: "Tables hidden";
+      opacity: 50%;
+      display: block;
+      text-align: center;
+    }
+  }
+}
+
+.iaa-hide-images {
+  graphic {
+    border: none;
+    margin: 0px;
+    padding: 0px;
+
+    img {
+      display: none !important;
+    }
+  
+    &::after {
+      font-size: small;
+      content: "Images hidden";
+      opacity: 50%;
+      display: block;
+      text-align: center;
+    }
+  }
+}

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorEditor.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorEditor.ts
@@ -15,11 +15,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { AnnotationEditor, DiamAjax, calculateStartOffset } from '@inception-project/inception-js-api'
+import { AnnotationEditor, DiamAjax, Offsets, calculateStartOffset } from '@inception-project/inception-js-api'
 import { highlights, ApacheAnnotatorVisualizer } from './ApacheAnnotatorVisualizer'
 import { ApacheAnnotatorSelector } from './ApacheAnnotatorSelector'
 import ApacheAnnotatorToolbar from './ApacheAnnotatorToolbar.svelte'
-import { showDocumentStructure, documentStructureWidth, showLabels, showEmptyHighlights, showAggregatedLabels } from './ApacheAnnotatorState'
+import { showDocumentStructure, documentStructureWidth, showLabels, showImages, showTables, showEmptyHighlights, showAggregatedLabels } from './ApacheAnnotatorState'
 import AnnotationDetailPopOver from '@inception-project/inception-js-api/src/widget/AnnotationDetailPopOver.svelte'
 import { Writable } from 'svelte/store'
 
@@ -51,6 +51,8 @@ export class ApacheAnnotatorEditor implements AnnotationEditor {
       showAggregatedLabels: true,
       showEmptyHighlights: false,
       showDocumentStructure: false,
+      showImages: true,
+      showTables: true,
       documentStructureWidth: 0.2,
     }
     let preferences = Object.assign({}, defaultPreferences)
@@ -84,6 +86,8 @@ export class ApacheAnnotatorEditor implements AnnotationEditor {
       bindPreference(showAggregatedLabels, "showAggregatedLabels")
       bindPreference(showEmptyHighlights, "showEmptyHighlights")
       bindPreference(showDocumentStructure, "showDocumentStructure")
+      bindPreference(showImages, "showImages")
+      bindPreference(showTables, "showTables")
       bindPreference(documentStructureWidth, "documentStructureWidth")
     }).then(() => {
       this.ensureSectionElementsHaveAnId()
@@ -132,6 +136,24 @@ export class ApacheAnnotatorEditor implements AnnotationEditor {
 
       showDocumentStructure.subscribe(enabled => {
         navigatorContainer.style.display = enabled ? 'flex' : 'none'
+      })
+
+      showImages.subscribe(enabled => {
+        if (enabled) {
+          this.root.classList.remove("iaa-hide-images")
+        }
+        else {
+          this.root.classList.add("iaa-hide-images")
+        }
+      })
+
+      showTables.subscribe(enabled => {
+        if (enabled) {
+          this.root.classList.remove("iaa-hide-tables")
+        }
+        else {
+          this.root.classList.add("iaa-hide-tables")
+        }
       })
 
       // Delay subscription a bit so the browser has time to render and we can obtain the width
@@ -228,7 +250,7 @@ export class ApacheAnnotatorEditor implements AnnotationEditor {
     return new ApacheAnnotatorToolbar({ target: toolbarContainer, props: { sectionSelector: this.sectionSelector } })
   }
 
-  private createDocumentNavigator (target: HTMLElement): DocumentStructureNavigator {
+  private createDocumentNavigator (target: HTMLElement) {
     return this.root.ownerDocument.createElement('div');
   }
 

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorState.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorState.ts
@@ -27,3 +27,7 @@ export const showEmptyHighlights = writable(false)
 export const showDocumentStructure = writable(false)
 
 export const documentStructureWidth = writable(0.2)
+
+export const showImages = writable(true)
+
+export const showTables = writable(true)

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorToolbar.svelte
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorToolbar.svelte
@@ -16,7 +16,7 @@
   limitations under the License.
 -->
 <script lang="ts">
-  import { showLabels, showAggregatedLabels, showEmptyHighlights } from './ApacheAnnotatorState'
+  import { showLabels, showAggregatedLabels, showEmptyHighlights, showImages, showTables } from './ApacheAnnotatorState'
 
   export let sectionSelector : string
 </script>
@@ -27,7 +27,7 @@
       <input class="form-check-input" type="checkbox" role="switch" id="inlineLabelsEnabled" bind:checked={$showLabels}>
       <label class="form-check-label" for="inlineLabelsEnabled">Inline labels</label>
     </div>
-    {#if sectionSelector}      
+    {#if sectionSelector}
       <div class="form-check form-switch mx-2">
         <input class="form-check-input" type="checkbox" role="switch" id="aggregatedLabelsEnabled" bind:checked={$showAggregatedLabels}>
         <label class="form-check-label" for="aggregatedLabelsEnabled">Section labels</label>
@@ -39,6 +39,14 @@
       <label class="form-check-label" for="showEmptyHighlights">Empties</label>
     </div>
     -->
+    <div class="form-check form-switch mx-2">
+      <input class="form-check-input" type="checkbox" role="switch" id="imagesEnabled" bind:checked={$showImages}>
+      <label class="form-check-label" for="imagesEnabled">Images</label>
+    </div>
+    <div class="form-check form-switch mx-2">
+      <input class="form-check-input" type="checkbox" role="switch" id="tablesEnabled" bind:checked={$showTables}>
+      <label class="form-check-label" for="tablesEnabled">Tables</label>
+    </div>
   </div>
 </div>
 


### PR DESCRIPTION
**What's in the PR**
- Added corresponding switches

**How to test manually**
* Open MHTML document with images / tables
* Use the switches (note that tables may be used for layout which may cause the entire document to disappear...)

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
