### PR TITLE
#5159 - Improve HTML render performance

### DIFF
--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorVisualizer.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorVisualizer.ts
@@ -262,12 +262,17 @@ export class ApacheAnnotatorVisualizer {
    * Some highlights may only contain whitepace. This method removes such highlights.
    */
   private removeWhitepaceOnlyHighlights (selector: string = '.iaa-highlighted') {
-    this.root.querySelectorAll(selector).forEach(e => {
+    let candidates = this.root.querySelectorAll(selector)
+    console.log(`Found ${candidates.length} elements matching [${selector}] to remove whitespace-only highlights`)
+    let start = performance.now();
+    candidates.forEach(e => {
       if (!e.classList.contains('iaa-zero-width') && !e.textContent?.trim()) {
         e.after(...e.childNodes)
         e.remove()
       }
     })
+    let end = performance.now();
+    console.log(`Time taken: ${end - start} milliseconds`)
   }
 
   private postProcessHighlights () {

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionAnnotationCreator.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionAnnotationCreator.ts
@@ -35,9 +35,6 @@ export class SectionAnnotationCreator {
     if (this.sectionSelector) {
       this.initializeElementTracking()
       this.initializeSectionTypeAttributes()
-
-      // on scrolling the window, we need to ensure that the panels stay visible
-      this.root.addEventListener('scroll', () => this.ensureVisibility())
     }
   }
 
@@ -92,8 +89,8 @@ export class SectionAnnotationCreator {
       if (entry.isIntersecting && !panel) {
         panel = this.createControl()
         panel.setAttribute('data-iaa-applies-to', sectionId)
-        this.root.appendChild(panel)
         panel.style.top = `${sectionRect.top + scrollY}px`
+        this.root.appendChild(panel)
       }
 
       if (!entry.isIntersecting && panel) {


### PR DESCRIPTION
**What's in the PR**
- Reorganize code to reduce layout calculation by the browser
- Avoid calling SectionAnnotationCreator.ensureVisibility during scrolling - not necessary because the position of the section creators do not change when scrolling
- No need to align panels with spacers in render method because ensurePanelVisibility is called directly after
- Switch between absolute and fixed position for section labels to make the rendering look smoother

**How to test manually**
* Look at performance console in browser while rendering a large document

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
