### PR TITLE
#5178 - Resizing a span does not update offsets of attached relations

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/RelationEndpointChangeListener.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/RelationEndpointChangeListener.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.annotation.layer.relation;
+
+import org.apache.uima.jcas.tcas.Annotation;
+import org.springframework.context.event.EventListener;
+
+import de.tudarmstadt.ukp.inception.annotation.layer.span.SpanMovedEvent;
+import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
+
+public class RelationEndpointChangeListener
+{
+    private final AnnotationSchemaService schemaService;
+
+    public RelationEndpointChangeListener(AnnotationSchemaService aSchemaService)
+    {
+        schemaService = aSchemaService;
+    }
+
+    @EventListener
+    public void onSpanMovedEvent(SpanMovedEvent aEvent)
+    {
+        var span = aEvent.getAnnotation();
+        var cas = span.getCAS();
+
+        for (var relLayer : schemaService.listAttachedRelationLayers(aEvent.getLayer())) {
+            var relAdapter = (RelationAdapter) schemaService.getAdapter(relLayer);
+            var maybeRelType = relAdapter.getAnnotationType(cas);
+            if (!maybeRelType.isPresent()) {
+                continue;
+            }
+
+            var relCandidates = cas.<Annotation> select(maybeRelType.get()) //
+                    .at(aEvent.getOldBegin(), aEvent.getOldEnd()) //
+                    .asList();
+
+            for (var relCandidate : relCandidates) {
+                if (!span.equals(relAdapter.getTargetAnnotation(relCandidate))) {
+                    continue;
+                }
+
+                relCandidate.removeFromIndexes();
+                relCandidate.setBegin(span.getBegin());
+                relCandidate.setEnd(span.getEnd());
+                relCandidate.addToIndexes();
+            }
+        }
+    }
+}

--- a/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/config/AnnotationSchemaServiceAutoConfiguration.java
+++ b/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/config/AnnotationSchemaServiceAutoConfiguration.java
@@ -44,6 +44,7 @@ import de.tudarmstadt.ukp.inception.annotation.layer.behaviors.LayerSupportRegis
 import de.tudarmstadt.ukp.inception.annotation.layer.chain.ChainLayerSupport;
 import de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationAttachmentBehavior;
 import de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationCrossSentenceBehavior;
+import de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationEndpointChangeListener;
 import de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationLayerSupport;
 import de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationOverlapBehavior;
 import de.tudarmstadt.ukp.inception.annotation.layer.span.SpanAnchoringModeBehavior;
@@ -149,6 +150,13 @@ public class AnnotationSchemaServiceAutoConfiguration
     {
         return new RelationLayerSupport(aFeatureSupportRegistry, aEventPublisher,
                 aLayerBehaviorsRegistry, aConstraintsService);
+    }
+
+    @Bean
+    public RelationEndpointChangeListener relationEndpointChangeListener(
+            AnnotationSchemaService aSchemaService)
+    {
+        return new RelationEndpointChangeListener(aSchemaService);
     }
 
     @Bean


### PR DESCRIPTION
**What's in the PR**
- Added listener that reacts when a span moves and updates the attaching relations

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
