### PR TITLE
#5184 - Display slot name instead of layer name on slot arcs without a role

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanRenderer.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanRenderer.java
@@ -40,6 +40,7 @@ import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.rendering.Renderer_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.inception.annotation.feature.link.LinkFeatureTraits;
 import de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationRenderer;
 import de.tudarmstadt.ukp.inception.rendering.request.RenderRequest;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VArc;
@@ -208,6 +209,7 @@ public class SpanRenderer
         var typeAdapter = getTypeAdapter();
         var aWindowBegin = aVDocument.getWindowBegin();
         var aWindowEnd = aVDocument.getWindowEnd();
+        var layer = typeAdapter.getLayer();
 
         int fi = 0;
         nextFeature: for (var feat : typeAdapter.listFeatures()) {
@@ -217,6 +219,8 @@ public class SpanRenderer
             }
 
             if (feat.getMultiValueMode() == ARRAY && feat.getLinkMode() == WITH_ROLE) {
+                var traits = getTraits(feat, LinkFeatureTraits.class);
+
                 List<LinkWithRoleModel> links = typeAdapter.getFeatureValue(feat, aFS);
                 for (var li = 0; li < links.size(); li++) {
                     var link = links.get(li);
@@ -234,12 +238,16 @@ public class SpanRenderer
                                 .withSlot(li) //
                                 .build();
 
+                        var label = traits.map(LinkFeatureTraits::isEnableRoleLabels).orElse(false)
+                                ? link.role
+                                : feat.getUiName();
+
                         var arc = VArc.builder() //
-                                .withLayer(typeAdapter.getLayer()) //
+                                .withLayer(layer) //
                                 .withVid(vid) //
                                 .withSource(aSource) //
                                 .withTarget(target) //
-                                .withLabel(link.role) //
+                                .withLabel(label) //
                                 .build();
 
                         aSpansAndSlots.add(arc);


### PR DESCRIPTION
**What's in the PR**
- Use the feature name as arc label if roles are turned off

**How to test manually**
* Configure a slot feature to not have a role
* Fill a slot
* See what is rendered on the arc to the slot filler

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
