### PR TITLE
#5188 - Export diff does not work when sentence and token editing is activate

### DIFF
--- a/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/service/AnnotationSchemaServiceImpl.java
+++ b/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/service/AnnotationSchemaServiceImpl.java
@@ -1640,6 +1640,7 @@ public class AnnotationSchemaServiceImpl
     }
 
     @Override
+    @Transactional
     public boolean isSentenceLayerEditable(Project aProject)
     {
         if (!annotationEditorProperties.isSentenceLayerEditable()) {
@@ -1656,6 +1657,7 @@ public class AnnotationSchemaServiceImpl
     }
 
     @Override
+    @Transactional
     public boolean isTokenLayerEditable(Project aProject)
     {
         if (!annotationEditorProperties.isTokenLayerEditable()) {


### PR DESCRIPTION
**What's in the PR**
- Need to start a transaction when entering the schema service to avoid the bug

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
