### PR TITLE
#5196  - Improve display of plain text files in HTML editor

### DIFF
--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorEditor.scss
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorEditor.scss
@@ -74,6 +74,10 @@ html > body {
   cursor: col-resize; 
 }
 
+.i7n-plain-text-document {
+  white-space: pre-line;
+}
+
 .i7n-wrapper {
   position: relative;
   line-height: 1.8;

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorVisualizer.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorVisualizer.ts
@@ -376,7 +376,7 @@ export class ApacheAnnotatorVisualizer {
       const startTime = new Date().getTime()
       this.renderHighlight(span, begin, end, attributes)
       const endTime = new Date().getTime()
-      console.debug(`Rendering span with size ${end - begin} took ${Math.abs(endTime - startTime)}ms`)
+      // console.debug(`Rendering span with size ${end - begin} took ${Math.abs(endTime - startTime)}ms`)
     } else {
       // Try optimizing for long spans to improve rendering performance
       let fragmentCount = 0
@@ -400,7 +400,7 @@ export class ApacheAnnotatorVisualizer {
         fragmentCount++
       }
       const endTime = new Date().getTime()
-      console.debug(`Rendering span with size ${end - begin} took ${Math.abs(endTime - startTime)}ms (${fragmentCount} fragments)`)
+      // console.debug(`Rendering span with size ${end - begin} took ${Math.abs(endTime - startTime)}ms (${fragmentCount} fragments)`)
     }
   }
 

--- a/inception/inception-js-api/src/main/ts/src/util/ViewportTracker.ts
+++ b/inception/inception-js-api/src/main/ts/src/util/ViewportTracker.ts
@@ -25,6 +25,7 @@ export type ViewportTrackerOptions = {
 }
 
 export const NO_TRACKING_CLASS = 'data-i7n-no-tracking'
+export const TRACKING_CLASS = 'data-i7n-tracking'
 
 export class ViewportTracker {
   private _visibleElements = new Set<Element>()
@@ -68,6 +69,10 @@ export class ViewportTracker {
   }
 
   private shouldTrack (element: Element): boolean {
+    if (element.classList.contains(TRACKING_CLASS)) {
+      return true
+    }
+
     if (this.options?.ignoreSelector && element.matches(this.options.ignoreSelector)) {
       return false
     }


### PR DESCRIPTION
**What's in the PR**
- Use pre-line whitespace handling when displaying a plain text file in the HTML edior
- Assist the viewport tracker by introducing span annotations at the line level

**How to test manually**
* Try viewing a plain text file using the Apache Annotator HTML editor

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
