### PR TITLE
#5203 - Disable export of data for annotators by default

### DIFF
--- a/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/Project.java
+++ b/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/Project.java
@@ -78,7 +78,7 @@ public class Project
     private int version = 1;
 
     // Disable users from exporting annotation documents
-    private boolean disableExport = false;
+    private boolean disableExport = true;
 
     @Type(ScriptDirectionType.class)
     private ScriptDirection scriptDirection;


### PR DESCRIPTION
**What's in the PR**
- Disable export flag for new projects

**How to test manually**
* Create a new project
* Access the annotation page as a user who is just an annotator
* Check if export is available

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
