### PR TITLE
#5253 - Undo action buttons sometimes appear in wrong position

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/actionbar/ActionBarExtension.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/actionbar/ActionBarExtension.java
@@ -25,6 +25,16 @@ import de.tudarmstadt.ukp.inception.support.extensionpoint.Extension;
 public interface ActionBarExtension
     extends Extension<AnnotationPageBase>
 {
+    public static final int ORDER_DOCUMENT_NAVIGATOR = 0;
+    public static final int ORDER_UNDO = 1000;
+    public static final int ORDER_PAGING = 2000;
+    public static final int ORDER_GUIDELINES = 3000;
+    public static final int ORDER_SCRIPT_DIRECTION = 4000;
+    public static final int ORDER_WORKFLOW = 5000;
+    public static final int ORDER_RECOMMENDER = 6000;
+    public static final int ORDER_SETTINGS = 7000;
+    public static final int ORDER_CLOSE_SESSION = 10000;
+
     public static final String ROLE_NAVIGATOR = "navigator";
 
     @Override

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/paging/PagingActionBarExtension.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/paging/PagingActionBarExtension.java
@@ -23,7 +23,7 @@ import org.springframework.core.annotation.Order;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.actionbar.ActionBarExtension;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
 
-@Order(500)
+@Order(ActionBarExtension.ORDER_PAGING)
 @org.springframework.stereotype.Component
 public class PagingActionBarExtension
     implements ActionBarExtension

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/preferences/UserPreferencesActionBarExtension.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/preferences/UserPreferencesActionBarExtension.java
@@ -29,7 +29,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationEditorSta
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
 import de.tudarmstadt.ukp.inception.preferences.PreferencesService;
 
-@Order(10000)
+@Order(ActionBarExtension.ORDER_SETTINGS)
 @Component
 public class UserPreferencesActionBarExtension
     implements ActionBarExtension

--- a/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/actionbar/script/ScriptDirectionActionBarExtension.java
+++ b/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/actionbar/script/ScriptDirectionActionBarExtension.java
@@ -36,7 +36,7 @@ import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
  * {@link BratAnnotationEditorAutoConfiguration#scriptDirectionActionBarExtension}.
  * </p>
  */
-@Order(900)
+@Order(ActionBarExtension.ORDER_SCRIPT_DIRECTION)
 public class ScriptDirectionActionBarExtension
     implements ActionBarExtension
 {

--- a/inception/inception-guidelines/src/main/java/de/tudarmstadt/ukp/inception/guidelines/GuidelinesActionBarExtension.java
+++ b/inception/inception-guidelines/src/main/java/de/tudarmstadt/ukp/inception/guidelines/GuidelinesActionBarExtension.java
@@ -24,7 +24,7 @@ import org.springframework.stereotype.Component;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.actionbar.ActionBarExtension;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
 
-@Order(800)
+@Order(ActionBarExtension.ORDER_GUIDELINES)
 @Component
 public class GuidelinesActionBarExtension
     implements ActionBarExtension

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/actionbar/RecommenderActionBarExtension.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/actionbar/RecommenderActionBarExtension.java
@@ -33,7 +33,7 @@ import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
  * {@link RecommenderServiceAutoConfiguration#recommenderActionBarExtension}.
  * </p>
  */
-@Order(2000)
+@Order(ActionBarExtension.ORDER_RECOMMENDER)
 public class RecommenderActionBarExtension
     implements ActionBarExtension
 {

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/AnnotationDocumentNavigatorActionBarExtension.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/AnnotationDocumentNavigatorActionBarExtension.java
@@ -28,7 +28,7 @@ import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.docnav.Document
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.open.OpenDocumentDialog;
 import de.tudarmstadt.ukp.clarin.webanno.ui.core.page.ApplicationPageBase;
 
-@Order(0)
+@Order(ActionBarExtension.ORDER_DOCUMENT_NAVIGATOR)
 @Component
 public class AnnotationDocumentNavigatorActionBarExtension
     implements ActionBarExtension

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/closesession/CloseSessionActionBarExtension.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/closesession/CloseSessionActionBarExtension.java
@@ -31,7 +31,7 @@ import de.tudarmstadt.ukp.inception.ui.core.menubar.MenuBar;
  * {@link AnnotationUIAutoConfiguration#closeSessionActionBarExtension}.
  * </p>
  */
-@Order(10000)
+@Order(ActionBarExtension.ORDER_CLOSE_SESSION)
 public class CloseSessionActionBarExtension
     implements ActionBarExtension
 {

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/AnnotationUndoActionBarExtension.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/undo/AnnotationUndoActionBarExtension.java
@@ -31,7 +31,7 @@ import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.config.AnnotationUIAutoCo
  * {@link AnnotationUIAutoConfiguration#annotationUndoActionBarExtension}.
  * </p>
  */
-@Order(0)
+@Order(ActionBarExtension.ORDER_UNDO)
 public class AnnotationUndoActionBarExtension
     implements ActionBarExtension
 {

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/actionbar/CurationDocumentNavigatorActionBarExtension.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/actionbar/CurationDocumentNavigatorActionBarExtension.java
@@ -29,7 +29,7 @@ import de.tudarmstadt.ukp.clarin.webanno.ui.curation.page.LegacyCurationPage;
 import de.tudarmstadt.ukp.inception.ui.curation.actionbar.opendocument.CurationOpenDocumentDialog;
 import de.tudarmstadt.ukp.inception.ui.curation.page.CurationPage;
 
-@Order(0)
+@Order(ActionBarExtension.ORDER_DOCUMENT_NAVIGATOR)
 public class CurationDocumentNavigatorActionBarExtension
     implements ActionBarExtension
 {

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/actionbar/CurationUndoActionBarExtension.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/actionbar/CurationUndoActionBarExtension.java
@@ -33,7 +33,7 @@ import de.tudarmstadt.ukp.inception.ui.curation.page.CurationPage;
  * {@link LegacyCurationUIAutoConfiguration#curationUndoActionBarExtension}.
  * </p>
  */
-@Order(0)
+@Order(ActionBarExtension.ORDER_UNDO)
 public class CurationUndoActionBarExtension
     implements ActionBarExtension
 {

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/actionbar/CurationWorkflowActionBarExtension.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/actionbar/CurationWorkflowActionBarExtension.java
@@ -27,7 +27,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
 import de.tudarmstadt.ukp.clarin.webanno.ui.curation.page.LegacyCurationPage;
 import de.tudarmstadt.ukp.inception.workload.extension.WorkloadManagerExtension;
 
-@Order(1000)
+@Order(ActionBarExtension.ORDER_WORKFLOW)
 public class CurationWorkflowActionBarExtension
     implements ActionBarExtension
 {

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebarDocumentNavigatorActionBarExtension.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebarDocumentNavigatorActionBarExtension.java
@@ -37,7 +37,7 @@ import de.tudarmstadt.ukp.inception.ui.curation.page.CurationPage;
  * @forRemoval 35.0
  */
 @Deprecated(forRemoval = true)
-@Order(0)
+@Order(ActionBarExtension.ORDER_DOCUMENT_NAVIGATOR)
 public class CurationSidebarDocumentNavigatorActionBarExtension
     implements ActionBarExtension
 {

--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/annotation/DynamicWorkflowActionBarExtension.java
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/annotation/DynamicWorkflowActionBarExtension.java
@@ -22,6 +22,7 @@ import static de.tudarmstadt.ukp.inception.workload.dynamic.DynamicWorkloadExten
 
 import org.apache.wicket.markup.html.panel.Panel;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.annotation.Order;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.actionbar.ActionBarExtension;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
@@ -37,6 +38,7 @@ import de.tudarmstadt.ukp.inception.workload.model.WorkloadManagementService;
  * {@link DynamicWorkloadManagerAutoConfiguration#dynamicWorkflowActionBarExtension}
  * </p>
  */
+@Order(1000)
 public class DynamicWorkflowActionBarExtension
     implements ActionBarExtension
 {

--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/annotation/DynamicWorkflowDocumentNavigationActionBarExtension.java
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/annotation/DynamicWorkflowDocumentNavigationActionBarExtension.java
@@ -26,6 +26,7 @@ import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.request.cycle.RequestCycle;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.annotation.Order;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.actionbar.ActionBarExtension;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
@@ -47,6 +48,7 @@ import de.tudarmstadt.ukp.inception.workload.model.WorkloadManagementService;
  * {@link DynamicWorkloadManagerAutoConfiguration#dynamicWorkflowDocumentNavigationActionBarExtension}
  * </p>
  */
+@Order(ActionBarExtension.ORDER_WORKFLOW)
 public class DynamicWorkflowDocumentNavigationActionBarExtension
     implements ActionBarExtension, Serializable
 {

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/annotation/MatrixWorkflowActionBarExtension.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/annotation/MatrixWorkflowActionBarExtension.java
@@ -31,7 +31,7 @@ import de.tudarmstadt.ukp.inception.workload.matrix.config.MatrixWorkloadManager
  * {@link MatrixWorkloadManagerAutoConfiguration#matrixWorkflowActionBarExtension}
  * </p>
  */
-@Order(1000)
+@Order(ActionBarExtension.ORDER_WORKFLOW)
 public class MatrixWorkflowActionBarExtension
     implements ActionBarExtension
 {

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/annotation/MatrixWorkflowNoRandomAccessDocumentNavigationActionBarExtension.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/annotation/MatrixWorkflowNoRandomAccessDocumentNavigationActionBarExtension.java
@@ -26,6 +26,7 @@ import org.apache.wicket.markup.html.panel.EmptyPanel;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.annotation.Order;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.actionbar.ActionBarExtension;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
@@ -46,6 +47,7 @@ import jakarta.persistence.EntityManager;
  * {@link MatrixWorkloadManagerAutoConfiguration#matrixWorkflowNoRandomAccessDocumentNavigationActionBarExtension}
  * </p>
  */
+@Order(ActionBarExtension.ORDER_WORKFLOW)
 public class MatrixWorkflowNoRandomAccessDocumentNavigationActionBarExtension
     implements ActionBarExtension, Serializable
 {


### PR DESCRIPTION
**What's in the PR**
- Adjust the order of action bar items

**How to test manually**
* Try opening the annotation/curation pages with different workflow modes or different types of editors (e.g. brat, html, pdf, etc.)

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
