### PR TITLE
#5270 - Resizing a span also resizes other overlapping or stacked spans

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,11 +32,13 @@ jobs:
         egress-policy: block
         disable-sudo: true
         allowed-endpoints: >
+          api.github.com:443
           archive.ics.uci.edu:80
           auth.docker.io:443
           build.shibboleth.net:443
+          centralus.data.mcr.microsoft.com:443
+          download.eclipse.org:443
           eastus.data.mcr.microsoft.com:443
-          api.github.com:443
           github.com:443
           mcr.microsoft.com:443
           nodejs.org:443
@@ -45,6 +47,8 @@ jobs:
           registry-1.docker.io:443
           registry.npmjs.org:443
           repo.maven.apache.org:443
+          repo.spring.io:443
+          repo1.maven.org:443
           westus.data.mcr.microsoft.com:443
           westus2.data.mcr.microsoft.com:443
           www.ims.uni-stuttgart.de:443

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/TokenAttachedSpanChangeListener.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/TokenAttachedSpanChangeListener.java
@@ -25,6 +25,7 @@ import org.apache.uima.cas.text.AnnotationFS;
 import org.apache.uima.jcas.tcas.Annotation;
 import org.springframework.context.event.EventListener;
 
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 
 public class TokenAttachedSpanChangeListener
@@ -39,9 +40,11 @@ public class TokenAttachedSpanChangeListener
     @EventListener
     public void onSpanMovedEvent(SpanMovedEvent aEvent)
     {
-        adjustAttachedAnnotations(aEvent);
-        adjustSingleTokenAnchoredAnnotations(aEvent);
-        adjustTokenAnchoredAnnotations(aEvent);
+        if (aEvent.getAnnotation() instanceof Token) {
+            adjustAttachedAnnotations(aEvent);
+            adjustSingleTokenAnchoredAnnotations(aEvent);
+            adjustTokenAnchoredAnnotations(aEvent);
+        }
     }
 
     void adjustTokenAnchoredAnnotations(SpanMovedEvent aEvent)


### PR DESCRIPTION
**What's in the PR**
- Only resize token-attached annotations if the annotation being resized is actually a token - not for any arbitrary annotations

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
