### PR TITLE
#5294 - Advanced LLM options not saved

### DIFF
--- a/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/support/traits/LlmRecommenderTraitsEditor_ImplBase.html
+++ b/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/support/traits/LlmRecommenderTraitsEditor_ImplBase.html
@@ -102,8 +102,8 @@
           <textarea wicket:id="prompt" class="form-control" rows="10"/>
         </div>
       </div>
-      <div wicket:id="optionsPanel"/>
     </div>
+    <div wicket:id="optionsPanel"/>
   </form>
 </wicket:panel>
 </html>

--- a/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/support/traits/LlmRecommenderTraitsEditor_ImplBase.java
+++ b/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/support/traits/LlmRecommenderTraitsEditor_ImplBase.java
@@ -25,6 +25,7 @@ import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
 
@@ -144,11 +145,11 @@ public abstract class LlmRecommenderTraitsEditor_ImplBase
                 optionSettingsList.add(new OptionSetting(option, e.getValue()));
             });
         }
-        optionSettings = new ListModel<>(optionSettingsList);
 
+        optionSettings = new ListModel<>(optionSettingsList);
         optionSettingsContainer = new OptionsPanel(MID_OPTIONS_PANEL, options, optionSettings);
         optionSettingsContainer.setOutputMarkupPlaceholderTag(true);
-        promptContainer.add(optionSettingsContainer);
+        form.add(optionSettingsContainer);
 
         var presetSelect = new DropDownChoice<Preset>(MID_PRESET);
         presetSelect.setModel(Model.of());
@@ -189,6 +190,12 @@ public abstract class LlmRecommenderTraitsEditor_ImplBase
     protected void onSubmit()
     {
         authenticationTraitsEditor.commit();
+        var optionsMap = new LinkedHashMap<String, Object>();
+        for (var optionSetting : optionSettings.getObject()) {
+            var option = optionSetting.getOption();
+            optionsMap.put(option.getName(), option.parseValue(optionSetting.getValue()));
+        }
+        traits.getObject().setOptions(optionsMap);
         getToolFactory().writeTraits(getModelObject(), traits.getObject());
     }
 


### PR DESCRIPTION
**What's in the PR**
- Fix issue that options are not saved
- Advanced options should remain visible even when recommender is set to interactive mode

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
