### PR TITLE
#5308 - Error during indexing if document is being curated but no AnnotationDocument entry exists

### DIFF
--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/ReindexTask.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/ReindexTask.java
@@ -185,12 +185,20 @@ public class ReindexTask
                         if (documentService.existsCas(doc, CURATION_USER)
                                 && asList(CURATION_IN_PROGRESS, CURATION_FINISHED)
                                         .contains(doc.getState())) {
-                            var aDoc = documentService.getAnnotationDocument(doc, CURATION_USER);
-                            var curationCasAsByteArray = casToByteArray(
-                                    documentService.readAnnotationCas(doc, CURATION_USER,
-                                            casUpgradeMode, accessModeInitialCas));
-                            searchService.indexDocument(pooledIndex, aDoc, "reindex",
-                                    curationCasAsByteArray);
+                            try {
+                                var aDoc = documentService.getAnnotationDocument(doc,
+                                        CURATION_USER);
+                                var curationCasAsByteArray = casToByteArray(
+                                        documentService.readAnnotationCas(doc, CURATION_USER,
+                                                casUpgradeMode, accessModeInitialCas));
+                                searchService.indexDocument(pooledIndex, aDoc, "reindex",
+                                        curationCasAsByteArray);
+                            }
+                            catch (NoResultException e) {
+                                LOG.warn(
+                                        "Found curation CAS for document {} but no annotation document",
+                                        doc);
+                            }
                         }
                     }
                     catch (Exception e) {


### PR DESCRIPTION
**What's in the PR**
- Warn about the missing AnnotationDocument entry, but do not fail (although the particular document won't be indexed)

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
