### PR TITLE
#5348 - Krippendorff Alpha Unitizing does not filter out self-overlapping annotations

### DIFF
--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/AgreementServiceImpl.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/AgreementServiceImpl.java
@@ -261,7 +261,7 @@ public class AgreementServiceImpl
 
                 var diff = doDiff(adapters, casMap);
 
-                var result = AgreementUtils.makeCodingStudy(diff, aLayer.getName(), featureName,
+                var result = CodingStudyUtils.makeCodingStudy(diff, aLayer.getName(), featureName,
                         tagset, aTraits.isExcludeIncomplete(), casMap);
 
                 try (var printer = new CSVPrinter(

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/CodingStudyUtils.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/CodingStudyUtils.java
@@ -54,7 +54,7 @@ import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.relation.RelationDiffA
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.relation.RelationPosition;
 import de.tudarmstadt.ukp.inception.annotation.feature.link.LinkFeatureMultiplicityMode;
 
-public class AgreementUtils
+public class CodingStudyUtils
 {
     public static FullCodingAgreementResult makeCodingStudy(CasDiff aDiff, String aType,
             String aFeature, Set<String> aTagSet, boolean aExcludeIncomplete,
@@ -334,7 +334,7 @@ public class AgreementUtils
         }
     }
 
-    public static void dumpAgreementStudy(PrintStream aOut, FullCodingAgreementResult aAgreement)
+    public static void dumpCodingStudy(PrintStream aOut, FullCodingAgreementResult aAgreement)
     {
         try {
             aOut.printf("Category count: %d%n", aAgreement.getCategoryCount());

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/cohenkappa/CohenKappaAgreementMeasure.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/cohenkappa/CohenKappaAgreementMeasure.java
@@ -17,7 +17,7 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.agreement.measures.cohenkappa;
 
-import static de.tudarmstadt.ukp.clarin.webanno.agreement.AgreementUtils.makeCodingStudy;
+import static de.tudarmstadt.ukp.clarin.webanno.agreement.CodingStudyUtils.makeCodingStudy;
 import static de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.doDiff;
 import static de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.DiffAdapterRegistry.getDiffAdapters;
 import static java.util.Arrays.asList;

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/fleisskappa/FleissKappaAgreementMeasure.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/fleisskappa/FleissKappaAgreementMeasure.java
@@ -17,7 +17,7 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.agreement.measures.fleisskappa;
 
-import static de.tudarmstadt.ukp.clarin.webanno.agreement.AgreementUtils.makeCodingStudy;
+import static de.tudarmstadt.ukp.clarin.webanno.agreement.CodingStudyUtils.makeCodingStudy;
 import static de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.doDiff;
 import static de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.DiffAdapterRegistry.getDiffAdapters;
 import static java.util.Arrays.asList;

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/krippendorffalpha/KrippendorffAlphaAgreementMeasure.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/krippendorffalpha/KrippendorffAlphaAgreementMeasure.java
@@ -17,7 +17,7 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.agreement.measures.krippendorffalpha;
 
-import static de.tudarmstadt.ukp.clarin.webanno.agreement.AgreementUtils.makeCodingStudy;
+import static de.tudarmstadt.ukp.clarin.webanno.agreement.CodingStudyUtils.makeCodingStudy;
 import static de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.doDiff;
 import static de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.DiffAdapterRegistry.getDiffAdapters;
 import static java.lang.Double.NaN;

--- a/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/AgreementServiceImplTest.java
+++ b/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/AgreementServiceImplTest.java
@@ -17,7 +17,7 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.agreement;
 
-import static de.tudarmstadt.ukp.clarin.webanno.agreement.AgreementUtils.makeCodingStudy;
+import static de.tudarmstadt.ukp.clarin.webanno.agreement.CodingStudyUtils.makeCodingStudy;
 import static de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff.doDiff;
 import static de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.span.SpanDiffAdapter.NER_DIFF_ADAPTER;
 import static java.util.Arrays.asList;

--- a/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/AgreementMeasureTestSuite_ImplBase.java
+++ b/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/AgreementMeasureTestSuite_ImplBase.java
@@ -71,7 +71,6 @@ import de.tudarmstadt.ukp.inception.annotation.layer.span.SpanLayerSupport;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureSupportRegistryImpl;
 import de.tudarmstadt.ukp.inception.schema.api.layer.LayerSupportRegistryImpl;
-import de.tudarmstadt.ukp.inception.support.uima.AnnotationBuilder;
 
 @ExtendWith(MockitoExtension.class)
 public class AgreementMeasureTestSuite_ImplBase
@@ -180,14 +179,60 @@ public class AgreementMeasureTestSuite_ImplBase
 
         var user1 = createCas(createMultiValueStringTestTypeSystem());
         user1.setDocumentText("This is a test.");
-        AnnotationBuilder.buildAnnotation(user1, MULTI_VALUE_SPAN_TYPE) //
+        buildAnnotation(user1, MULTI_VALUE_SPAN_TYPE) //
                 .at(0, 4) //
                 .withFeature("values", asList("a")) //
                 .buildAndAddToIndexes();
 
         var user2 = createCas(createMultiValueStringTestTypeSystem());
         user2.setDocumentText("This is a test.");
-        AnnotationBuilder.buildAnnotation(user2, MULTI_VALUE_SPAN_TYPE) //
+        buildAnnotation(user2, MULTI_VALUE_SPAN_TYPE) //
+                .at(0, 4) //
+                .withFeature("values", asList("a", "b")) //
+                .buildAndAddToIndexes();
+
+        AgreementMeasure<R> measure = aSupport.createMeasure(feature, traits);
+
+        return measure.getAgreement(Map.of( //
+                "user1", user1, //
+                "user2", user2));
+    }
+
+    public <R extends FullAgreementResult_ImplBase<S>, T extends DefaultAgreementTraits, S extends IAnnotationStudy> //
+    R selfOverlappingAgreement(AgreementMeasureSupport<T, R, S> aSupport) throws Exception
+    {
+        var layer = new AnnotationLayer(MULTI_VALUE_SPAN_TYPE, MULTI_VALUE_SPAN_TYPE,
+                SpanLayerSupport.TYPE, project, false, SINGLE_TOKEN, NO_OVERLAP);
+        layer.setId(1l);
+        layers.add(layer);
+
+        var feature = new AnnotationFeature(project, layer, "values", "values",
+                CAS.TYPE_NAME_STRING_ARRAY);
+        feature.setId(1l);
+        feature.setLinkMode(NONE);
+        feature.setMode(ARRAY);
+        features.add(feature);
+
+        var traits = aSupport.createTraits();
+
+        var user1 = createCas(createMultiValueStringTestTypeSystem());
+        user1.setDocumentText("This is a test.");
+        buildAnnotation(user1, MULTI_VALUE_SPAN_TYPE) //
+                .at(0, 4) //
+                .withFeature("values", asList("a")) //
+                .buildAndAddToIndexes();
+        buildAnnotation(user1, MULTI_VALUE_SPAN_TYPE) //
+                .at(0, 7) //
+                .withFeature("values", asList("a")) //
+                .buildAndAddToIndexes();
+        buildAnnotation(user1, MULTI_VALUE_SPAN_TYPE) //
+                .at(0, 7) //
+                .withFeature("values", asList("b")) //
+                .buildAndAddToIndexes();
+
+        var user2 = createCas(createMultiValueStringTestTypeSystem());
+        user2.setDocumentText("This is a test.");
+        buildAnnotation(user2, MULTI_VALUE_SPAN_TYPE) //
                 .at(0, 4) //
                 .withFeature("values", asList("a", "b")) //
                 .buildAndAddToIndexes();

--- a/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/AgreementTestUtils.java
+++ b/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/AgreementTestUtils.java
@@ -18,8 +18,8 @@
 
 package de.tudarmstadt.ukp.clarin.webanno.agreement.measures;
 
-import static de.tudarmstadt.ukp.clarin.webanno.agreement.AgreementUtils.dumpAgreementStudy;
-import static de.tudarmstadt.ukp.clarin.webanno.agreement.AgreementUtils.makeCodingStudy;
+import static de.tudarmstadt.ukp.clarin.webanno.agreement.CodingStudyUtils.dumpCodingStudy;
+import static de.tudarmstadt.ukp.clarin.webanno.agreement.CodingStudyUtils.makeCodingStudy;
 import static de.tudarmstadt.ukp.clarin.webanno.agreement.measures.ConcreteAgreementMeasure.COHEN_KAPPA_AGREEMENT;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptySet;
@@ -377,7 +377,7 @@ public class AgreementTestUtils
         }
         catch (RuntimeException e) {
             // FIXME
-            dumpAgreementStudy(System.out, agreementResult);
+            dumpCodingStudy(System.out, agreementResult);
             throw e;
         }
 

--- a/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/KrippendorffAlphaUnitizingAgreementMeasureTest.java
+++ b/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/KrippendorffAlphaUnitizingAgreementMeasureTest.java
@@ -95,4 +95,12 @@ public class KrippendorffAlphaUnitizingAgreementMeasureTest
 
         assertEquals(0.4893, result.getAgreement(), 0.001);
     }
+
+    @Test
+    public void selfOverlappingAgreementTest() throws Exception
+    {
+        var result = selfOverlappingAgreement(sut);
+
+        assertEquals(0.6783, result.getAgreement(), 0.001);
+    }
 }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanOverlapBehavior.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanOverlapBehavior.java
@@ -103,7 +103,7 @@ public class SpanOverlapBehavior
         final CAS aCas = aRequest.getCas();
         final int aBegin = aRequest.getBegin();
         final int aEnd = aRequest.getEnd();
-        Type type = getType(aCas, aAdapter.getAnnotationTypeName());
+        var type = getType(aCas, aAdapter.getAnnotationTypeName());
 
         switch (aAdapter.getLayer().getOverlapMode()) {
         case ANY_OVERLAP:
@@ -149,7 +149,7 @@ public class SpanOverlapBehavior
 
         // The following code requires annotations with the same offsets to be adjacent during
         // iteration, so we sort the entries here
-        AnnotationComparator cmp = new AnnotationComparator();
+        var cmp = new AnnotationComparator();
         final List<AnnotationFS> sortedSpans = aAnnoToSpanIdx.keySet().stream().sorted(cmp)
                 .collect(Collectors.toList());
 
@@ -224,15 +224,15 @@ public class SpanOverlapBehavior
     static int overlappingOrStackingSpans(Collection<? extends AnnotationFS> aSpans,
             Collection<AnnotationFS> aStacking, Collection<AnnotationFS> aOverlapping)
     {
-        AnnotationFS[] spans = aSpans.toArray(AnnotationFS[]::new);
+        var spans = aSpans.toArray(AnnotationFS[]::new);
 
         int n = 0;
 
         outer: for (int o = 0; o < spans.length - 1; o++) {
-            AnnotationFS span1 = spans[o];
+            var span1 = spans[o];
 
             inner: for (int i = o + 1; i < spans.length; i++) {
-                AnnotationFS span2 = spans[i];
+                var span2 = spans[i];
 
                 n++;
 
@@ -260,15 +260,15 @@ public class SpanOverlapBehavior
 
     static Set<AnnotationFS> overlappingNonStackingSpans(Collection<? extends AnnotationFS> aSpans)
     {
-        Set<AnnotationFS> overlapping = new HashSet<>();
+        var overlapping = new HashSet<AnnotationFS>();
 
-        AnnotationFS[] spans = aSpans.toArray(AnnotationFS[]::new);
+        var spans = aSpans.toArray(AnnotationFS[]::new);
 
         outer: for (int o = 0; o < spans.length - 1; o++) {
-            AnnotationFS span1 = spans[o];
+            var span1 = spans[o];
 
             inner: for (int i = o + 1; i < spans.length; i++) {
-                AnnotationFS span2 = spans[i];
+                var span2 = spans[i];
 
                 if (span2.getBegin() > span1.getEnd()) {
                     continue outer;
@@ -292,9 +292,9 @@ public class SpanOverlapBehavior
         // Since the annotations are sorted, we can easily find stacked annotation by scanning
         // through the entire list and checking if two adjacent annotations have the same
         // offsets
-        Set<AnnotationFS> stacking = new HashSet<>();
+        var stacking = new HashSet<AnnotationFS>();
         AnnotationFS prevFS = null;
-        for (AnnotationFS fs : aSpans) {
+        for (var fs : aSpans) {
             if (prevFS != null && prevFS.getBegin() == fs.getBegin()
                     && prevFS.getEnd() == fs.getEnd()) {
                 stacking.add(prevFS);

--- a/inception/inception-ui-agreement/src/main/resources/META-INF/asciidoc/user-guide/agreement.adoc
+++ b/inception/inception-ui-agreement/src/main/resources/META-INF/asciidoc/user-guide/agreement.adoc
@@ -82,6 +82,7 @@ The basic idea is to divide the estimated variance of within the items by the es
 | Chance-corrected inter-rater agreement for unitizing studies with multiple raters.
 As a model for expected disagreement, all possible unitizations for the given continuum and raters are considered.
 Note that units coded with the same categories by a single annotator may not overlap with each other.
+If such units are detected, the system will pass the unit starting earliest and being longest to the agreement and will skip all of the other overlapping units. 
 |====
 
 
@@ -97,8 +98,6 @@ For a span layer, the begin and end offsets are used.
 For a relation layer, the begin and end offsets of the source and target annotation are used.
 Chains are currently not supported. 
 
-Unitizing measures basically work by internally concatenating all documents into a single long virtual document and then consider partial overlaps of annotations from different annotations.
-I.e. there is no averaging over documents.
 The partial overlap agreement is calculated based on character positions, not on token positions.
 So if one annotator annotates *the blackboard* and another annotator just *blackboard*, then the partial overlap is comparatively high because *blackboard* is a longish word.
 Relation and chain layers are presently not supported by the unitizing measures.


### PR DESCRIPTION
**What's in the PR**
- Filter out all but the first and longest of the overlapping annotations with the same label in Krippendorff Unitzing Alpha

**How to test manually**
* No specific test procedure

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
