### PR TITLE
#5348 - Krippendorff Alpha Unitizing does not filter out self-overlapping annotations

### DIFF
--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/AgreementSummary.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/AgreementSummary.java
@@ -30,6 +30,8 @@ import java.util.stream.DoubleStream;
 
 import de.tudarmstadt.ukp.clarin.webanno.agreement.results.coding.FullCodingAgreementResult;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.results.unitizing.FullUnitizingAgreementResult;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 
 public class AgreementSummary
     implements Serializable
@@ -124,9 +126,10 @@ public class AgreementSummary
                 "Unsupported result type: [" + aResult.getClass().getName() + "]");
     }
 
-    public static AgreementSummary skipped(String aType, String aFeature)
+    public static AgreementSummary skipped(AnnotationLayer aLayer, AnnotationFeature aFeature)
     {
-        return new AgreementSummary(aType, aFeature);
+        var featureName = aFeature != null ? aFeature.getName() : null;
+        return new AgreementSummary(aLayer.getName(), featureName);
     }
 
     public AgreementSummary(String aType, String aFeature)

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/krippendorffalphaunitizing/KrippendorffAlphaUnitizingAgreementMeasure.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/krippendorffalphaunitizing/KrippendorffAlphaUnitizingAgreementMeasure.java
@@ -110,9 +110,13 @@ public class KrippendorffAlphaUnitizingAgreementMeasure
                 var values = getValues(ann, f);
 
                 for (var value : values) {
-                    if (activeAnnotations.values().stream().anyMatch($ -> $.contains(value))) {
-                        LOG.trace("Not adding unit at [{}-{}] with value [{}] to to overlap",
-                                ann.getBegin(), ann.getEnd(), value);
+                    var maybeOverlapAnn = activeAnnotations.entrySet().stream()
+                            .filter($ -> $.getValue().contains(value)).findFirst();
+                    if (maybeOverlapAnn.isPresent()) {
+                        var overlapAnn = maybeOverlapAnn.get().getKey();
+                        LOG.trace("[{}] Not adding unit [{}]@[{}-{}] due to overlap with [{}-{}]",
+                                set.getKey(), value, ann.getBegin(), ann.getEnd(),
+                                overlapAnn.getBegin(), overlapAnn.getEnd());
                         continue;
                     }
 
@@ -124,8 +128,31 @@ public class KrippendorffAlphaUnitizingAgreementMeasure
             }
         }
 
-        LOG.trace("Units in study : {}", study.getUnitCount());
         LOG.trace("Raters im study: {}", study.getRaterCount());
+        LOG.trace("Units in study : {}", study.getUnitCount());
+
+        // for (var u : study.getUnits()) {
+        // System.out.printf("addUnit(study, %d, %d, %d);%n", u.getOffset(), u.getEndOffset(),
+        // u.getRaterIdx());
+        // }
+        //
+        // for (var r = 0; r < study.getRaterCount(); r++) {
+        // var finalr = r;
+        // var runits = study.getUnits().stream().filter(u -> u.getRaterIdx() == finalr).toList();
+        // for (var u1 : runits) {
+        // for (var u2 : runits) {
+        // if (u1 == u2) {
+        // continue;
+        // }
+        //
+        // if (AnnotationPredicates.overlapping((int) u1.getOffset(),
+        // (int) u1.getEndOffset(), (int) u2.getOffset(), (int) u2.getEndOffset())
+        // && Objects.equals(u1.getCategory(), u2.getCategory())) {
+        // LOG.trace("Oops");
+        // }
+        // }
+        // }
+        // }
 
         var featureName = getFeature() != null ? getFeature().getName() : null;
         var result = new FullUnitizingAgreementResult(typeName, featureName, study,

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/task/CalculatePairwiseAgreementTask.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/task/CalculatePairwiseAgreementTask.java
@@ -46,6 +46,7 @@ import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.DefaultAgreementTrai
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.scheduling.Task;
@@ -63,6 +64,7 @@ public class CalculatePairwiseAgreementTask
 
     private final List<String> annotators;
     private final DefaultAgreementTraits traits;
+    private final AnnotationLayer layer;
     private final AnnotationFeature feature;
     private final AgreementMeasure<?> measure;
     private final Map<SourceDocument, List<AnnotationDocument>> allAnnDocs;
@@ -75,6 +77,7 @@ public class CalculatePairwiseAgreementTask
 
         annotators = aBuilder.annotators;
         traits = aBuilder.traits;
+        layer = aBuilder.layer;
         feature = aBuilder.feature;
         measure = aBuilder.measure;
         allAnnDocs = aBuilder.allAnnDocs;
@@ -127,16 +130,16 @@ public class CalculatePairwiseAgreementTask
                                 LOG.trace(
                                         "Skipping combination {}/{}@{}: {} not in a curation state",
                                         annotator1, annotator2, doc, annotator1);
-                                summary.mergeResult(annotator1, annotator2, AgreementSummary
-                                        .skipped(feature.getLayer().getName(), feature.getName()));
+                                summary.mergeResult(annotator1, annotator2,
+                                        AgreementSummary.skipped(layer, feature));
                                 continue;
                             }
 
                             if (maybeCas1.get().isEmpty()) {
                                 LOG.trace("Skipping combination {}/{}@{}: {} has no data",
                                         annotator1, annotator2, doc, annotator1);
-                                summary.mergeResult(annotator1, annotator2, AgreementSummary
-                                        .skipped(feature.getLayer().getName(), feature.getName()));
+                                summary.mergeResult(annotator1, annotator2,
+                                        AgreementSummary.skipped(layer, feature));
                                 continue;
                             }
 
@@ -147,8 +150,8 @@ public class CalculatePairwiseAgreementTask
                             if (maybeCas2.get().isEmpty()) {
                                 LOG.trace("Skipping combination {}/{}@{}: {} has no data",
                                         annotator1, annotator2, doc, annotator2);
-                                summary.mergeResult(annotator1, annotator2, AgreementSummary
-                                        .skipped(feature.getLayer().getName(), feature.getName()));
+                                summary.mergeResult(annotator1, annotator2,
+                                        AgreementSummary.skipped(layer, feature));
                                 continue;
                             }
 
@@ -235,6 +238,7 @@ public class CalculatePairwiseAgreementTask
     {
         private List<String> annotators;
         private DefaultAgreementTraits traits;
+        private AnnotationLayer layer;
         private AnnotationFeature feature;
         private AgreementMeasure<?> measure;
         private Map<SourceDocument, List<AnnotationDocument>> allAnnDocs;
@@ -255,6 +259,13 @@ public class CalculatePairwiseAgreementTask
         public T withTraits(DefaultAgreementTraits aTraits)
         {
             traits = aTraits;
+            return (T) this;
+        }
+
+        @SuppressWarnings("unchecked")
+        public T withLayer(AnnotationLayer aLayer)
+        {
+            layer = aLayer;
             return (T) this;
         }
 

--- a/inception/inception-ui-agreement/src/main/java/de/tudarmstadt/ukp/inception/ui/agreement/page/AgreementPage.java
+++ b/inception/inception-ui-agreement/src/main/java/de/tudarmstadt/ukp/inception/ui/agreement/page/AgreementPage.java
@@ -517,6 +517,7 @@ public class AgreementPage
                 .withTrigger("Agreement page") //
                 .withAnnotators(annotators) //
                 .withTraits(traits) //
+                .withLayer(model.layerAndFeature.getKey()) //
                 .withFeature(model.layerAndFeature.getValue()) //
                 .withMeasure(measure) //
                 .withDocuments(allAnnDocs) //


### PR DESCRIPTION
**What's in the PR**
- Improve logging
- Fix NPE when calculating agreement only on positions

**How to test manually**
* Try calculating agreement only on span position and observe log

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
