### PR TITLE
#5350 - Interpret plain text documents as Markdown when displaying in HTML-based editor

### DIFF
--- a/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/sidebar/WatchAnnotationTask.java
+++ b/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/sidebar/WatchAnnotationTask.java
@@ -36,6 +36,8 @@ import org.apache.commons.lang3.Validate;
 import org.apache.uima.jcas.tcas.Annotation;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
@@ -169,7 +171,7 @@ public class WatchAnnotationTask
         return toPrettyJsonString(instance);
     }
 
-    private static record BooleanQuestion(boolean answer) {};
+    private static record BooleanQuestion(@JsonProperty(required = true) boolean answer) {};
 
     public static Builder<Builder<?>> builder()
     {

--- a/inception/inception-assistant/src/main/ts/src/AssistantPanel.svelte
+++ b/inception/inception-assistant/src/main/ts/src/AssistantPanel.svelte
@@ -275,13 +275,18 @@
         }
 
         // Speak when sentence seems complete (we don't handle abbreviations)
-        if (utteranceBuffer.trimEnd().endsWith(".")) {
+        const trimmedBuffer = utteranceBuffer.trimEnd()
+        const lastChar = trimmedBuffer.charAt(trimmedBuffer.length - 1);
+        // console.log(`Checking if utterance ending in [${lastChar}] is complete: [${utteranceBuffer}]`);
+        if ([".", "!", "?", ":", ";"].includes(lastChar)) {
+            // console.log(`Enqueuing utterance at sentence end: [${utteranceBuffer}]`);
             enqueueUtterance(utteranceBuffer);
             utteranceBuffer = "";
         } else {
             // Speak line by line
             let lineBreak = utteranceBuffer.indexOf("\n");
             if (lineBreak > 0) {
+                // console.log(`Enqueuing utterance at line end: [${utteranceBuffer}]`);
                 enqueueUtterance(utteranceBuffer.substring(0, lineBreak));
                 utteranceBuffer = utteranceBuffer.substring(lineBreak);
             }

--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/policy/DefaultHtmlDocumentPolicy.yaml
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/policy/DefaultHtmlDocumentPolicy.yaml
@@ -53,6 +53,9 @@ policies:
                "thead", "tr"]
   - action: PASS
     elements: ["table-wrap"]
+  - on_elements: ["td","th"]
+    action: PASS
+    attributes: ["colspan", "rowspan"]
   # Deprecated stuff
   - action: PASS
     elements: ["font", "center"]

--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/xhtml/XHtmlConstants.java
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/xhtml/XHtmlConstants.java
@@ -25,4 +25,27 @@ public class XHtmlConstants
     public static final String HEAD = "head";
     public static final String P = "p";
     public static final String SPAN = "span";
+    public static final String PRE = "pre";
+    public static final String OL = "ol";
+    public static final String UL = "ul";
+    public static final String TBODY = "tbody";
+    public static final String THEAD = "thead";
+    public static final String CODE = "code";
+    public static final String STRONG = "strong";
+    public static final String EM = "em";
+    public static final String BLOCKQUOTE = "blockquote";
+    public static final String BR = "br";
+    public static final String HR = "hr";
+    public static final String S = "s";
+    public static final String LI = "li";
+    public static final String TD = "td";
+    public static final String CDATA = "CDATA";
+    public static final String TH = "th";
+    public static final String TR = "tr";
+    public static final String TABLE = "table";
+
+    public static final String ATTR_CLASS = "class";
+
+    // INCEpTION special elements
+    public static final String TABLE_WRAP = "table-wrap";
 }

--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/xhtml/XHtmlXmlDocumentViewControllerImpl.java
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/xhtml/XHtmlXmlDocumentViewControllerImpl.java
@@ -169,8 +169,12 @@ public class XHtmlXmlDocumentViewControllerImpl
             renderHead(doc, rawHandler);
 
             if (maybeXmlDocument.isEmpty()) {
-                // renderTextContent(cas, finalHandler);
+                // try {
                 renderMarkdownContent(cas, finalHandler);
+                // }
+                // catch (Exception e) {
+                // // renderTextContent(cas, finalHandler);
+                // }
             }
             else {
                 finalHandler.startElement(null, null, BODY, null);

--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/xhtml/XHtmlXmlMarkdownProcessor.java
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/xhtml/XHtmlXmlMarkdownProcessor.java
@@ -17,6 +17,28 @@
  */
 package de.tudarmstadt.ukp.inception.externaleditor.xhtml;
 
+import static de.tudarmstadt.ukp.inception.externaleditor.xhtml.XHtmlConstants.ATTR_CLASS;
+import static de.tudarmstadt.ukp.inception.externaleditor.xhtml.XHtmlConstants.BLOCKQUOTE;
+import static de.tudarmstadt.ukp.inception.externaleditor.xhtml.XHtmlConstants.BR;
+import static de.tudarmstadt.ukp.inception.externaleditor.xhtml.XHtmlConstants.CDATA;
+import static de.tudarmstadt.ukp.inception.externaleditor.xhtml.XHtmlConstants.CODE;
+import static de.tudarmstadt.ukp.inception.externaleditor.xhtml.XHtmlConstants.EM;
+import static de.tudarmstadt.ukp.inception.externaleditor.xhtml.XHtmlConstants.HR;
+import static de.tudarmstadt.ukp.inception.externaleditor.xhtml.XHtmlConstants.LI;
+import static de.tudarmstadt.ukp.inception.externaleditor.xhtml.XHtmlConstants.OL;
+import static de.tudarmstadt.ukp.inception.externaleditor.xhtml.XHtmlConstants.P;
+import static de.tudarmstadt.ukp.inception.externaleditor.xhtml.XHtmlConstants.S;
+import static de.tudarmstadt.ukp.inception.externaleditor.xhtml.XHtmlConstants.SPAN;
+import static de.tudarmstadt.ukp.inception.externaleditor.xhtml.XHtmlConstants.STRONG;
+import static de.tudarmstadt.ukp.inception.externaleditor.xhtml.XHtmlConstants.TABLE;
+import static de.tudarmstadt.ukp.inception.externaleditor.xhtml.XHtmlConstants.TABLE_WRAP;
+import static de.tudarmstadt.ukp.inception.externaleditor.xhtml.XHtmlConstants.TBODY;
+import static de.tudarmstadt.ukp.inception.externaleditor.xhtml.XHtmlConstants.TD;
+import static de.tudarmstadt.ukp.inception.externaleditor.xhtml.XHtmlConstants.TH;
+import static de.tudarmstadt.ukp.inception.externaleditor.xhtml.XHtmlConstants.THEAD;
+import static de.tudarmstadt.ukp.inception.externaleditor.xhtml.XHtmlConstants.TR;
+import static de.tudarmstadt.ukp.inception.externaleditor.xhtml.XHtmlConstants.UL;
+import static java.lang.String.join;
 import static java.util.Arrays.asList;
 
 import java.lang.invoke.MethodHandles;
@@ -99,6 +121,9 @@ public class XHtmlXmlMarkdownProcessor
     static class XHtmlVisitor
         extends NodeVisitor
     {
+        private static final String IAA_MD_CHECKBOX_UNCHECKED = "iaa-md-checkbox-unchecked";
+        private static final String IAA_MD_CHECKBOX_CHECKED = "iaa-md-checkbox-checked";
+        private static final String IAA_MD_D_NONE = "iaa-md-d-none";
         private int processedText = 0;
         private ContentHandler ch;
         private Map<Class<?>, NodeHandler<?>> handlers = new HashMap<>();
@@ -113,26 +138,26 @@ public class XHtmlXmlMarkdownProcessor
             addHandler(WhiteSpace.class, this::text);
             addHandler(HardLineBreak.class, this::text);
             addHandler(Document.class, this::noop);
-            addHandler(ThematicBreak.class, (h, n, cont) -> milestoneBefore(h, n, cont, "hr"));
-            addHandler(HardLineBreak.class, (h, n, cont) -> milestoneBefore(h, n, cont, "br"));
-            addHandler(SoftLineBreak.class, (h, n, cont) -> milestoneBefore(h, n, cont, "br"));
-            addHandler(BlockQuote.class, (h, n, cont) -> wrap(h, n, cont, "blockquote"));
-            addHandler(Emphasis.class, (h, n, cont) -> wrap(h, n, cont, "em"));
-            addHandler(StrongEmphasis.class, (h, n, cont) -> wrap(h, n, cont, "strong"));
-            addHandler(Strikethrough.class, (h, n, cont) -> wrap(h, n, cont, "s"));
-            addHandler(Code.class, (h, n, cont) -> wrap(h, n, cont, "code"));
+            addHandler(ThematicBreak.class, (h, n, cont) -> milestoneBefore(h, n, cont, HR));
+            addHandler(HardLineBreak.class, (h, n, cont) -> milestoneBefore(h, n, cont, BR));
+            addHandler(SoftLineBreak.class, (h, n, cont) -> milestoneBefore(h, n, cont, BR));
+            addHandler(BlockQuote.class, (h, n, cont) -> wrap(h, n, cont, BLOCKQUOTE));
+            addHandler(Emphasis.class, (h, n, cont) -> wrap(h, n, cont, EM));
+            addHandler(StrongEmphasis.class, (h, n, cont) -> wrap(h, n, cont, STRONG));
+            addHandler(Strikethrough.class, (h, n, cont) -> wrap(h, n, cont, S));
+            addHandler(Code.class, (h, n, cont) -> wrap(h, n, cont, CODE));
             addHandler(TableBlock.class, this::tableBlock);
-            addHandler(TableHead.class, (h, n, cont) -> wrap(h, n, cont, "thead"));
+            addHandler(TableHead.class, (h, n, cont) -> wrap(h, n, cont, THEAD));
             addHandler(TableSeparator.class, this::tableSeparator);
-            addHandler(TableBody.class, (h, n, cont) -> wrap(h, n, cont, "tbody"));
+            addHandler(TableBody.class, (h, n, cont) -> wrap(h, n, cont, TBODY));
             addHandler(TableRow.class, this::tableRow);
             addHandler(TableCell.class, this::tableCell);
             addHandler(Paragraph.class, this::paragraph);
-            addHandler(BulletList.class, (h, n, cont) -> wrap(h, n, cont, "ul"));
-            addHandler(BulletListItem.class, (h, n, cont) -> wrap(h, n, cont, "li"));
+            addHandler(BulletList.class, (h, n, cont) -> wrap(h, n, cont, UL));
+            addHandler(BulletListItem.class, (h, n, cont) -> wrap(h, n, cont, LI));
             addHandler(TaskListItem.class, this::taskListItem);
-            addHandler(OrderedList.class, (h, n, cont) -> wrap(h, n, cont, "ol"));
-            addHandler(OrderedListItem.class, (h, n, cont) -> wrap(h, n, cont, "li"));
+            addHandler(OrderedList.class, (h, n, cont) -> wrap(h, n, cont, OL));
+            addHandler(OrderedListItem.class, (h, n, cont) -> wrap(h, n, cont, LI));
             addHandler(Heading.class, this::heading);
             addHandler(FencedCodeBlock.class, this::codeBlock);
             addHandler(FootnoteBlock.class, this::noop);
@@ -196,9 +221,13 @@ public class XHtmlXmlMarkdownProcessor
             alignStart(aHandler, aCodeBlock);
 
             fencedCodeBlock = true;
-            ch.startElement(null, null, "code", null);
+            var attrs = new AttributesImpl();
+            attrs.addAttribute("", "", ATTR_CLASS, CDATA, "iaa-md-codeblock");
+            attrs.addAttribute("", "", "data-iaa-md-info", CDATA, aCodeBlock.getInfo().toString());
+
+            ch.startElement(null, null, CODE, attrs);
             aProceessChildren.run();
-            ch.endElement(null, null, "code");
+            ch.endElement(null, null, CODE);
             fencedCodeBlock = false;
 
             alignEnd(aHandler, aCodeBlock);
@@ -224,9 +253,9 @@ public class XHtmlXmlMarkdownProcessor
                 }
             }
 
-            ch.startElement(null, null, "p", null);
+            ch.startElement(null, null, P, null);
             aProceessChildren.run();
-            ch.endElement(null, null, "p");
+            ch.endElement(null, null, P);
         }
 
         private void taskListItem(ContentHandler aHandler, TaskListItem aTaskListItem,
@@ -239,17 +268,17 @@ public class XHtmlXmlMarkdownProcessor
 
             var checkboxAttrs = new AttributesImpl();
             if (aTaskListItem.isItemDoneMarker()) {
-                classes.add("iaa-md-checkbox-checked");
+                classes.add(IAA_MD_CHECKBOX_CHECKED);
             }
             else {
-                classes.add("iaa-md-checkbox-unchecked");
+                classes.add(IAA_MD_CHECKBOX_UNCHECKED);
             }
 
-            checkboxAttrs.addAttribute("", "", "class", "CDATA", String.join(" ", classes));
+            checkboxAttrs.addAttribute("", "", ATTR_CLASS, CDATA, join(" ", classes));
 
-            ch.startElement(null, null, "li", checkboxAttrs);
+            ch.startElement(null, null, LI, checkboxAttrs);
             aProceessChildren.run();
-            ch.endElement(null, null, "li");
+            ch.endElement(null, null, LI);
 
             alignEnd(aHandler, aTaskListItem);
         }
@@ -272,11 +301,11 @@ public class XHtmlXmlMarkdownProcessor
         {
             alignStart(aHandler, aTable);
 
-            ch.startElement(null, null, "table-wrap", null);
-            ch.startElement(null, null, "table", null);
+            ch.startElement(null, null, TABLE_WRAP, null);
+            ch.startElement(null, null, TABLE, null);
             aProceessChildren.run();
-            ch.endElement(null, null, "table");
-            ch.endElement(null, null, "table-wrap");
+            ch.endElement(null, null, TABLE);
+            ch.endElement(null, null, TABLE_WRAP);
 
             alignEnd(aHandler, aTable);
         }
@@ -289,17 +318,17 @@ public class XHtmlXmlMarkdownProcessor
                 alignStart(aHandler, aTableCell);
 
                 var attrsTd = new AttributesImpl();
-                attrsTd.addAttribute("", "", "class", "CDATA", "iaa-md-d-none");
+                attrsTd.addAttribute("", "", ATTR_CLASS, CDATA, IAA_MD_D_NONE);
 
-                ch.startElement(null, null, "tr", attrsTd);
+                ch.startElement(null, null, TR, attrsTd);
                 aProceessChildren.run();
-                ch.endElement(null, null, "tr");
+                ch.endElement(null, null, TR);
 
                 alignEnd(aHandler, aTableCell);
                 return;
             }
 
-            wrap(aHandler, aTableCell, aProceessChildren, "tr");
+            wrap(aHandler, aTableCell, aProceessChildren, TR);
         }
 
         private void tableCell(ContentHandler aHandler, TableCell aTableCell,
@@ -307,11 +336,11 @@ public class XHtmlXmlMarkdownProcessor
             throws SAXException
         {
             if (aTableCell.isHeader()) {
-                wrap(aHandler, aTableCell, aProceessChildren, "th");
+                wrap(aHandler, aTableCell, aProceessChildren, TH);
                 return;
             }
 
-            wrap(aHandler, aTableCell, aProceessChildren, "td");
+            wrap(aHandler, aTableCell, aProceessChildren, TD);
         }
 
         private void footnote(ContentHandler aHandler, Footnote aHeading,
@@ -320,9 +349,9 @@ public class XHtmlXmlMarkdownProcessor
         {
             alignStart(aHandler, aHeading);
 
-            ch.startElement(null, null, "span", null);
+            ch.startElement(null, null, SPAN, null);
             aProceessChildren.run();
-            ch.endElement(null, null, "span");
+            ch.endElement(null, null, SPAN);
 
             alignEnd(aHandler, aHeading);
         }
@@ -365,6 +394,10 @@ public class XHtmlXmlMarkdownProcessor
 
         private void alignStart(ContentHandler aHandler, Node aNode) throws SAXException
         {
+            if (processedText > aNode.getStartOffset()) {
+                throw new IllegalStateException("Misalignment between node and text. Aborting!");
+            }
+
             while (processedText < aNode.getStartOffset()) {
                 aHandler.characters(new char[] { ' ' }, 0, 1);
                 processedText++;
@@ -373,6 +406,10 @@ public class XHtmlXmlMarkdownProcessor
 
         private void alignEnd(ContentHandler aHandler, Node aNode) throws SAXException
         {
+            if (processedText > aNode.getEndOffset()) {
+                throw new IllegalStateException("Misalignment between node and text. Aborting!");
+            }
+
             while (processedText < aNode.getEndOffset()) {
                 aHandler.characters(new char[] { ' ' }, 0, 1);
                 processedText++;

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorEditor.scss
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorEditor.scss
@@ -382,10 +382,10 @@ html > body {
     margin-right: 0px;
   }
 
-  table {
-    $table-border: #ddd;
-    $table-header-bg: #f4f4f4;
+  $table-border: #ddd;
+  $table-header-bg: #f4f4f4;
 
+  table {
     width: 100%;
     border-collapse: collapse;
   
@@ -409,10 +409,24 @@ html > body {
     }
   }
 
-  code pre {
-    background-color: var(--bs-tertiary-bg);
-    padding: 10px;
-    border-radius: 5px;
-    margin: 10px 0;
+  code {  
+    color: var(--bs-code-color);
+
+    &.iaa-md-codeblock {
+      border-radius: 0.5em;
+      color: var(--bs-body-color);
+      display: block;
+      background-color: var(--bs-tertiary-bg);
+      padding: 10px;
+      border-radius: 5px;
+      margin: 10px 0;
+
+      &::before {
+        float: right;
+        content: attr(data-iaa-md-info);
+        opacity: 50%;
+        font-size: 80%;
+      }
+    }
   }
 }


### PR DESCRIPTION
**What's in the PR**
- Display language name in fenced code block
- Cleaning up

**How to test manually**
* Try annotating markdown documents containing code blocks

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
