### PR TITLE
#5350 - Interpret plain text documents as Markdown when displaying in HTML-based editor

### DIFF
--- a/inception/inception-api-formats/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/format/FormatSupport.java
+++ b/inception/inception-api-formats/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/format/FormatSupport.java
@@ -19,6 +19,7 @@ package de.tudarmstadt.ukp.clarin.webanno.api.format;
 
 import static de.tudarmstadt.ukp.inception.support.io.ZipUtils.zipFolder;
 import static java.io.File.createTempFile;
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.unmodifiableSet;
 import static java.util.Optional.empty;
@@ -133,7 +134,7 @@ public interface FormatSupport
      */
     default List<String> getSectionElements()
     {
-        return emptyList();
+        return asList("p");
     }
 
     default Optional<PolicyCollection> getPolicy() throws IOException

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionAnnotationCreator.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionAnnotationCreator.ts
@@ -104,11 +104,11 @@ export class SectionAnnotationCreator {
 
   private handleIntersect(entries: IntersectionObserverEntry[], observer: IntersectionObserver): void {
     if (this.observerDebounceTimeout) {
-      window.cancelIdleCallback(this.observerDebounceTimeout)
+      window.cancelAnimationFrame(this.observerDebounceTimeout)
       this.observerDebounceTimeout = undefined
     }
 
-    this.observerDebounceTimeout = window.requestIdleCallback(() => {
+    this.observerDebounceTimeout = window.requestAnimationFrame(() => {
       const rootRect = this.root.getBoundingClientRect()
       const scrollY = (this.root.scrollTop || 0) - rootRect.top
 
@@ -128,7 +128,7 @@ export class SectionAnnotationCreator {
           panel.remove()
         }
       }
-    }, { timeout: 100 }) 
+    });
   }
 
   private createControl(): HTMLElement {
@@ -214,6 +214,11 @@ export class SectionAnnotationCreator {
     })
     const root = this.root.closest('.i7n-wrapper') || this.root
     const copy = root.cloneNode(true) as HTMLElement
+    if (!doc.body) {
+      // Fix for browsers like Firefox, which do not create a body element by default
+      const body = doc.createElement('body');
+      doc.documentElement ? doc.documentElement.appendChild(body) : doc.appendChild(body);
+    }
     doc.body.appendChild(copy)
     copy.querySelectorAll(".iaa-preview-frame, .iaa-section-control, " + 
       ".iaa-visible-annotations-panel, .iaa-visible-annotations-panel-spacer").forEach(n => n.remove())


### PR DESCRIPTION
**What's in the PR**
- Add section elements to plaintext format
- Fix preview panel in Firefox and Safari

**How to test manually**
* Try section annotation and section-end preview

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
