### PR TITLE
#5375 - Enforce use of tagset by LLM recommender

### DIFF
--- a/inception/inception-imls-llm-support/pom.xml
+++ b/inception/inception-imls-llm-support/pom.xml
@@ -127,6 +127,10 @@
       <groupId>com.github.victools</groupId>
       <artifactId>jsonschema-module-jackson</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml</groupId>
+      <artifactId>classmate</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/support/response/Mention.java
+++ b/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/support/response/Mention.java
@@ -22,8 +22,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class Mention
 {
-    private final @JsonProperty(required = true) String coveredText;
-    private final @JsonProperty(required = true) String label;
+    public static final String PROP_COVERED_TEXT = "coveredText";
+    public static final String PROP_LABEL = "label";
+
+    private final @JsonProperty(value = PROP_COVERED_TEXT, required = true) String coveredText;
+    private final @JsonProperty(value = PROP_LABEL, required = true) String label;
 
     @JsonCreator
     public Mention( //

--- a/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/support/response/MentionResult.java
+++ b/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/support/response/MentionResult.java
@@ -28,10 +28,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class MentionResult
 {
-    private final @JsonProperty(required = true) List<Mention> mentions;
+    public static final String PROP_MENTIONS = "mentions";
+
+    private final @JsonProperty(value = PROP_MENTIONS, required = true) List<Mention> mentions;
 
     @JsonCreator
-    public MentionResult(@JsonProperty("mentions") List<Mention> aMentions)
+    public MentionResult(@JsonProperty(PROP_MENTIONS) List<Mention> aMentions)
     {
         if (aMentions != null) {
             mentions = unmodifiableList(new ArrayList<>(aMentions));

--- a/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/support/response/ResponseAsLabelExtractor.java
+++ b/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/support/response/ResponseAsLabelExtractor.java
@@ -57,7 +57,8 @@ public class ResponseAsLabelExtractor
     }
 
     @Override
-    public Optional<JsonNode> getJsonSchema()
+    public Optional<JsonNode> getJsonSchema(Recommender aRecommender,
+            AnnotationSchemaService aSchemaService)
     {
         return Optional.empty();
     }

--- a/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/support/response/ResponseExtractor.java
+++ b/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/support/response/ResponseExtractor.java
@@ -41,7 +41,8 @@ public interface ResponseExtractor
 
     Map<String, MentionResult> generateExamples(RecommendationEngine aEngine, CAS aCas, int aNum);
 
-    default Optional<JsonNode> getJsonSchema()
+    default Optional<JsonNode> getJsonSchema(Recommender aRecommender,
+            AnnotationSchemaService aSchemaService)
     {
         return Optional.empty();
     }

--- a/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/support/traits/ChatBasedLlmRecommenderImplBase.java
+++ b/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/support/traits/ChatBasedLlmRecommenderImplBase.java
@@ -98,7 +98,7 @@ public abstract class ChatBasedLlmRecommenderImplBase<T extends LlmRecommenderTr
                 responseExtractor.getFormatDefiningMessages(getRecommender(), schemaService));
 
         var responseformat = responseExtractor.getResponseFormat();
-        var jsonSchema = responseExtractor.getJsonSchema();
+        var jsonSchema = responseExtractor.getJsonSchema(getRecommender(), schemaService);
 
         var globalBindings = prepareGlobalBindings(aCas);
         var contexts = getPromptContextGenerator(traits.getPromptingMode()) //

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/span/SpanSuggestionRenderer.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/span/SpanSuggestionRenderer.java
@@ -120,7 +120,9 @@ public class SpanSuggestionRenderer
                 v.setActionButtons(recommenderProperties.isActionButtonsEnabled());
                 vdoc.add(v);
 
-                vdoc.add(new VAnnotationMarker(VMarker.WARN, v.getVid()));
+                if (suggestion.isCorrection()) {
+                    vdoc.add(new VAnnotationMarker(VMarker.WARN, v.getVid()));
+                }
             }
         }
     }


### PR DESCRIPTION
**What's in the PR**
- Add allows tags to JSON schema instead of just having them in the task description
- Warn marker should only be displayed for corrections, not generally on all suggestions

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
