### PR TITLE
#5377 - Abbreviate long tag descriptions in popover

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiValueStringFeatureSupport.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiValueStringFeatureSupport.java
@@ -19,6 +19,7 @@ package de.tudarmstadt.ukp.inception.annotation.feature.multistring;
 
 import static java.util.Arrays.asList;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+import static org.apache.commons.lang3.StringUtils.abbreviate;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.uima.cas.CAS.TYPE_NAME_STRING_ARRAY;
 
@@ -307,7 +308,8 @@ public class MultiValueStringFeatureSupport
                     }
 
                     if (tag.map(t -> isNotBlank(t.getDescription())).orElse(false)) {
-                        results.addDetail(new VLazyDetail(value, tag.get().getDescription()));
+                        results.addDetail(new VLazyDetail(value,
+                                abbreviate(tag.get().getDescription(), "…", 128)));
                     }
                 }
             }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/StringFeatureSupport.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/StringFeatureSupport.java
@@ -22,6 +22,7 @@ import static de.tudarmstadt.ukp.inception.annotation.feature.string.StringFeatu
 import static de.tudarmstadt.ukp.inception.annotation.feature.string.StringFeatureTraits.EditorType.RADIOGROUP;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
+import static org.apache.commons.lang3.StringUtils.abbreviate;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.lang.invoke.MethodHandles;
@@ -229,8 +230,8 @@ public class StringFeatureSupport
             }
 
             if (tag.map(t -> isNotBlank(t.getDescription())).orElse(false)) {
-                return asList(
-                        new VLazyDetailGroup(new VLazyDetail(value, tag.get().getDescription())));
+                return asList(new VLazyDetailGroup(
+                        new VLazyDetail(value, abbreviate(tag.get().getDescription(), "…", 128))));
             }
         }
 


### PR DESCRIPTION
**What's in the PR**
- Abbreviate tag in lazy detail

**How to test manually**
* Create tag with long description and use it in an annotation
* Hover over the annotation to cause the popover to come up
* Ensure the tag description is abbreviated

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
