### PR TITLE
#5373 - Creating zero-width annotations does not work on Firefox

### DIFF
--- a/inception/inception-brat-editor/src/main/ts/src/annotator_ui/AnnotatorUI.ts
+++ b/inception/inception-brat-editor/src/main/ts/src/annotator_ui/AnnotatorUI.ts
@@ -651,7 +651,8 @@ export class AnnotatorUI {
     if (evt.ctrlKey) return
 
     const sel = window.getSelection()
-    const offsets = this.visualizer.selectionToOffsets(sel)
+    let offsets = evt.shiftKey ? this.visualizer.selectionToPoint(sel) : this.visualizer.selectionToOffsets(sel)
+
     this.clearSelection()
     this.stopArcDrag(evt.target)
 

--- a/inception/inception-brat-editor/src/main/ts/src/visualizer/Visualizer.ts
+++ b/inception/inception-brat-editor/src/main/ts/src/visualizer/Visualizer.ts
@@ -4271,6 +4271,21 @@ export class Visualizer {
     return this.svg.node.querySelectorAll(`[data-span-id="${id}"]`)
   }
 
+  selectionToPoint (sel: Selection | null) : Offsets | null {
+    if (!sel || !sel.rangeCount) return null
+
+    const anchorNode = sel.getRangeAt(0).startContainer
+    const anchorOffset = sel.getRangeAt(0).startOffset
+
+    if (!anchorNode) return null
+
+    const range = new Range()
+    range.setStart(anchorNode, anchorOffset)
+    range.setEnd(anchorNode, anchorOffset)
+
+    return this.rangeToOffsets(range)
+  }
+
   selectionToOffsets (sel: Selection | null) : Offsets | null {
     if (!sel || !sel.rangeCount) return null
 


### PR DESCRIPTION
**What's in the PR**
- Fixed issue by handling selection differently depending on whether the user presses shift or not

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
