### PR TITLE
#5380 - Upgrade dependencies

### DIFF
--- a/inception/inception-dependencies/pom.xml
+++ b/inception/inception-dependencies/pom.xml
@@ -615,23 +615,6 @@
       </dependency>
 
       <dependency>
-        <groupId>org.pf4j</groupId>
-        <artifactId>pf4j</artifactId>
-        <version>${pf4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.pf4j</groupId>
-        <artifactId>pf4j-spring</artifactId>
-        <version>${pf4j-spring.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-
-      <dependency>
         <groupId>commons-logging</groupId>
         <artifactId>commons-logging-api</artifactId>
         <version>${commons-logging-api.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -74,12 +74,12 @@
     <build-ant-version>1.10.15</build-ant-version>
     <build-groovy-version>4.0.26</build-groovy-version>
 
-    <junit-jupiter.version>5.12.1</junit-jupiter.version>
-    <junit-platform.version>1.12.1</junit-platform.version>
-    <mockito.version>5.16.1</mockito.version>
+    <junit-jupiter.version>5.12.2</junit-jupiter.version>
+    <junit-platform.version>1.12.2</junit-platform.version>
+    <mockito.version>5.17.0</mockito.version>
     <assertj.version>3.26.3</assertj.version>
     <xmlunit.version>2.10.0</xmlunit.version>
-    <testcontainers.version>1.20.6</testcontainers.version>
+    <testcontainers.version>1.21.0</testcontainers.version>
 
     <awaitility.version>4.3.0</awaitility.version>
 
@@ -89,12 +89,12 @@
 
     <pdfbox.version>3.0.4</pdfbox.version>
 
-    <spring.version>6.2.5</spring.version>
-    <spring.boot.version>3.4.4</spring.boot.version>
-    <spring.data.version>3.4.4</spring.data.version>
-    <spring.security.version>6.4.4</spring.security.version>
+    <spring.version>6.2.6</spring.version>
+    <spring.boot.version>3.4.5</spring.boot.version>
+    <spring.data.version>3.4.5</spring.data.version>
+    <spring.security.version>6.4.5</spring.security.version>
     <springdoc.version>2.8.6</springdoc.version>
-    <swagger.version>2.2.29</swagger.version>
+    <swagger.version>2.2.30</swagger.version>
     <jjwt.version>0.12.6</jjwt.version>
 
     <slf4j.version>2.0.17</slf4j.version>
@@ -103,17 +103,17 @@
     <sentry.version>7.22.5</sentry.version>
 
     <tomcat.version>10.1.39</tomcat.version>
-    <jetty.version>12.0.18</jetty.version>
+    <jetty.version>12.0.19</jetty.version>
     <servlet-api.version>6.0.0</servlet-api.version>
 
     <mariadb.driver.version>3.5.3</mariadb.driver.version>
     <mssql.driver.version>12.10.0.jre11</mssql.driver.version>
     <mysql.driver.version>9.2.0</mysql.driver.version>
     <postgres.driver.version>42.7.5</postgres.driver.version>
-    <hibernate.version>6.6.12.Final</hibernate.version>
+    <hibernate.version>6.6.13.Final</hibernate.version>
     <hibernate.validator.version>8.0.2.Final</hibernate.validator.version>
 
-    <wicket.version>10.4.0</wicket.version>
+    <wicket.version>10.5.0</wicket.version>
     <wicketstuff.version>10.4.0</wicketstuff.version>
     <wicket-bootstrap.version>7.0.9</wicket-bootstrap.version>
     <wicket-jquery-selectors.version>4.0.7</wicket-jquery-selectors.version>
@@ -128,7 +128,7 @@
     <opensearch.version>2.19.1</opensearch.version>
     <opensearch-runner.version>${opensearch.version}.0</opensearch-runner.version>
     <jena.version>5.3.0</jena.version>
-    <rdf4j.version>5.1.2</rdf4j.version> 
+    <rdf4j.version>5.1.3</rdf4j.version> 
     <owlapi-version>5.5.1</owlapi-version>
 
     <asciidoctor.plugin.version>2.2.3</asciidoctor.plugin.version>
@@ -138,17 +138,15 @@
 
     <ant-version>1.10.15</ant-version>
     <json.version>20230227</json.version>
-    <pf4j.version>2.6.0</pf4j.version>
-    <pf4j-spring.version>0.5.0</pf4j-spring.version>
-    <jackson.version>2.18.3</jackson.version>
+    <jackson.version>2.19.0</jackson.version>
     <snakeyaml.version>2.4</snakeyaml.version>
     <okhttp.version>4.12.0</okhttp.version>
-    <okio.version>3.10.2</okio.version>
+    <okio.version>3.11.0</okio.version>
     <byte-buddy.version>1.17.5</byte-buddy.version>
     <caffeine.version>3.2.0</caffeine.version>
     <commons-beanutils.version>1.10.1</commons-beanutils.version>
-    <commons-collections4.version>4.4</commons-collections4.version>
-    <commons-csv.version>1.13.0</commons-csv.version>
+    <commons-collections4.version>4.5.0</commons-collections4.version>
+    <commons-csv.version>1.14.0</commons-csv.version>
     <commons-fileupload.version>1.5</commons-fileupload.version>
     <commons-pool2.version>2.12.1</commons-pool2.version>
     <commons-lang3.version>3.17.0</commons-lang3.version>
@@ -156,9 +154,9 @@
     <commons-codec.version>1.18.0</commons-codec.version>
     <commons-compress.version>1.27.1</commons-compress.version>
     <commons-math3.version>3.6.1</commons-math3.version>
-    <commons-text.version>1.13.0</commons-text.version>
+    <commons-text.version>1.13.1</commons-text.version>
     <commons-validator.version>1.9.0</commons-validator.version>
-    <commons-io.version>2.18.0</commons-io.version>
+    <commons-io.version>2.19.0</commons-io.version>
     <commons-logging.version>1.3.5</commons-logging.version>
     <commons-logging-api.version>1.1</commons-logging-api.version>
     <flexmark.version>0.64.8</flexmark.version>
@@ -167,7 +165,7 @@
     <jinjava.version>2.7.4</jinjava.version>
     <fastutil.version>8.5.15</fastutil.version>
     <zjsonpatch.version>0.4.16</zjsonpatch.version>
-    <picocli.version>4.7.6</picocli.version>
+    <picocli.version>4.7.7</picocli.version>
     <woodstox-core.version>6.7.0</woodstox-core.version>
     <nimbus-jose-jwt.version>9.48</nimbus-jose-jwt.version>
     <json-schema-validator.version>1.5.6</json-schema-validator.version>


### PR DESCRIPTION
**What's in the PR**
* junit-jupiter 5.12.1 -> 5.12.2
* junit-platform 1.12.1 -> 1.12.2
* mockito 5.16.1 -> 5.17.0
* testcontainers 1.20.6 -> 1.21.0
* spring 6.2.5 -> 6.2.6
* spring.boot 3.4.4 -> 3.4.5
* spring.data 3.4.4 -> 3.4.5
* spring.security 6.4.4 -> 6.4.5
* swagger 2.2.29 -> 2.2.30
* jetty 12.0.18 -> 12.0.19
* hibernate 6.6.12.Final -> 6.6.13.Final
* wicket 10.4.0 -> 10.5.0
* rdf4j 5.1.2 -> 5.1.3
* jackson 2.18.3 -> 2.19.0
* okio 3.10.2 -> 3.11.0
* commons-collections4 4.4 -> 4.5.0
* commons-csv 1.13.0 -> 1.14.0
* commons-text 1.13.0 -> 1.13.1
* commons-io 2.18.0 -> 2.19.0
* picocli 4.7.6 -> 4.7.7

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
