### PR TITLE
#5408 - Text files with certain control characters break HTML-based editors

### DIFF
--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/text/TextUtils.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/text/TextUtils.java
@@ -96,6 +96,16 @@ public class TextUtils
 
     public static String sanitizeVisibleText(String aText, char aReplacementCharacter)
     {
+        char[] chars = aText.toCharArray();
+
+        sanitizeVisibleText(chars, aReplacementCharacter, 0, chars.length);
+
+        return new String(chars);
+    }
+
+    public static void sanitizeVisibleText(char[] aText, char aReplacementCharacter, int aStart,
+            int aLength)
+    {
         // NBSP is recognized by Firefox as a proper addressable character in
         // SVGText.getNumberOfChars()
         char whiteplaceReplacementChar = NBSP; // NBSP
@@ -103,14 +113,13 @@ public class TextUtils
             whiteplaceReplacementChar = aReplacementCharacter;
         }
 
-        char[] chars = aText.toCharArray();
-        for (int i = 0; i < chars.length; i++) {
-            switch (chars[i]) {
+        for (int i = aStart; i < aLength; i++) {
+            switch (aText[i]) {
             // Replace newline characters before sending to the client to avoid
             // rendering glitches in the client-side brat rendering code
             case '\n':
             case '\r':
-                chars[i] = ' ';
+                aText[i] = ' ';
                 break;
             // Some browsers (e.g. Firefox) do not count invisible chars in some functions
             // (e.g. SVGText.getNumberOfChars()) and this causes trouble. See:
@@ -160,13 +169,60 @@ public class TextUtils
             case '\u206D': // ACTIVATE ARABIC FORM SHAPING
             case '\u206E': // NATIONAL DIGIT SHAPES
             case '\u206F': // NOMINAL DIGIT SHAPES
-                chars[i] = whiteplaceReplacementChar;
+                aText[i] = whiteplaceReplacementChar;
                 break;
             default:
                 // Nothing to do
             }
         }
+    }
 
-        return new String(chars);
+    public static void sanitizeIllegalXmlCharacters(char[] aText, char aReplacementCharacter,
+            int aStart, int aLength)
+    {
+        char whiteplaceReplacementChar = ' '; // SPACE
+        if (aReplacementCharacter > 0) {
+            whiteplaceReplacementChar = aReplacementCharacter;
+        }
+
+        for (int i = aStart; i < aLength; i++) {
+            switch (aText[i]) {
+            case '\u0000': // NULL
+            case '\u0001': // START OF HEADING
+            case '\u0002': // START OF TEXT
+            case '\u0003': // END OF TEXT
+            case '\u0004': // END OF TRANSMISSION
+            case '\u0005': // ENQUIRY
+            case '\u0006': // ACKNOWLEDGE
+            case '\u0007': // BELL
+            case '\b': // BACKSPACE '\u0008'
+            case '\u000B': // VERTICAL TAB
+            case '\f': // FORM FEED '\u000C'
+            case '\u000E': // SHIFT OUT
+            case '\u000F': // SHIFT IN
+            case '\u0010': // DATA LINK ESCAPE
+            case '\u0011': // DEVICE CONTROL ONE
+            case '\u0012': // DEVICE CONTROL TWO
+            case '\u0013': // DEVICE CONTROL THREE
+            case '\u0014': // DEVICE CONTROL FOUR
+            case '\u0015': // NEGATIVE ACKNOWLEDGE
+            case '\u0016': // SYNCHRONOUS IDLE
+            case '\u0017': // END OF TRANSMISSION BLOCK
+            case '\u0018': // CANCEL
+            case '\u0019': // END OF MEDIUM
+            case '\u001A': // SUBSTITUTE
+            case '\u001B': // ESCAPE
+            case '\u001C': // FILE SEPARATOR
+            case '\u001D': // GROUP SEPARATOR
+            case '\u001E': // RECORD SEPARATOR
+            case '\u001F': // UNIT SEPARATOR
+            case '\uFFFE': // NONCHARACTER U+FFFE
+            case '\uFFFF': // NONCHARACTER U+FFFF
+                aText[i] = whiteplaceReplacementChar;
+                break;
+            default:
+                // Nothing to do
+            }
+        }
     }
 }

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/SanitizingContentHandler.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/sanitizer/SanitizingContentHandler.java
@@ -17,7 +17,9 @@
  */
 package de.tudarmstadt.ukp.inception.support.xml.sanitizer;
 
+import static de.tudarmstadt.ukp.inception.support.text.TextUtils.sanitizeIllegalXmlCharacters;
 import static de.tudarmstadt.ukp.inception.support.xml.XmlParserUtils.getQName;
+import static java.lang.System.arraycopy;
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.startsWith;
@@ -233,7 +235,11 @@ public class SanitizingContentHandler
             break;
         case SKIP: // pass-through
         case PASS:
-            super.characters(aCh, aStart, aLength);
+            var sanitizedChars = new char[aLength];
+            arraycopy(aCh, aStart, sanitizedChars, 0, aLength);
+            sanitizeIllegalXmlCharacters(sanitizedChars, filteredCharacter, 0,
+                    sanitizedChars.length);
+            super.characters(sanitizedChars, aStart, aLength);
             break;
         default:
             throw new SAXException("Unsupported element action: [" + action + "]");
@@ -253,7 +259,11 @@ public class SanitizingContentHandler
             break;
         case SKIP: // pass-through
         case PASS:
-            super.ignorableWhitespace(aCh, aStart, aLength);
+            var sanitizedChars = new char[aLength];
+            arraycopy(aCh, aStart, sanitizedChars, 0, aLength);
+            sanitizeIllegalXmlCharacters(sanitizedChars, filteredCharacter, 0,
+                    sanitizedChars.length);
+            super.ignorableWhitespace(sanitizedChars, aStart, aLength);
             break;
         default:
             throw new SAXException("Unsupported element action: [" + action + "]");


### PR DESCRIPTION
**What's in the PR**
- Change SanitizingContentHandler to replace illegal XML characters with space during rendering

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
