### PR TITLE
#5413 - Document metadata type is not available to be selected for Document classification task layer definition

### DIFF
--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/config/DocumentMetadataLayerSupportPropertiesImpl.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/config/DocumentMetadataLayerSupportPropertiesImpl.java
@@ -23,7 +23,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class DocumentMetadataLayerSupportPropertiesImpl
     implements DocumentMetadataLayerSupportProperties
 {
-    private boolean enabled;
+    private boolean enabled = true;
 
     @Override
     public boolean isEnabled()


### PR DESCRIPTION
**What's in the PR**
- Set enabled flag to true by default (same as it is in the Spring auto-configuration)

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
