### PR TITLE
#5424 - Keep search state and highlights when search sidebar is not active

### DIFF
--- a/inception/inception-search-mtas/src/main/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndex.java
+++ b/inception/inception-search-mtas/src/main/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndex.java
@@ -1177,7 +1177,7 @@ public class MtasDocumentIndex
             aResultsMap.get(aKey).add(aSearchResult);
         }
         else {
-            List<SearchResult> searchResultsForKey = new ArrayList<>();
+            var searchResultsForKey = new ArrayList<SearchResult>();
             searchResultsForKey.add(aSearchResult);
             aResultsMap.put(aKey, searchResultsForKey);
         }

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/wicket/WicketUtil.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/wicket/WicketUtil.java
@@ -19,13 +19,17 @@ package de.tudarmstadt.ukp.inception.support.wicket;
 
 import static java.lang.String.format;
 
+import java.io.Serializable;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import org.apache.wicket.Application;
 import org.apache.wicket.Component;
+import org.apache.wicket.IMetadataContext;
+import org.apache.wicket.MetaDataKey;
 import org.apache.wicket.Page;
 import org.apache.wicket.WicketRuntimeException;
 import org.apache.wicket.ajax.AjaxRequestTarget;
@@ -51,6 +55,17 @@ public final class WicketUtil
     private WicketUtil()
     {
         // No instances
+    }
+
+    public static <M extends Serializable> M getMetaData(IMetadataContext<M, ?> aContext,
+            MetaDataKey<M> aKey, Supplier<M> aSupplier)
+    {
+        var value = aContext.getMetaData(aKey);
+        if (value == null) {
+            value = aSupplier.get();
+            aContext.setMetaData(aKey, value);
+        }
+        return value;
     }
 
     public static void ajaxFallbackScript(IHeaderResponse aResponse, String aScript)

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebarServiceImpl.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebarServiceImpl.java
@@ -153,11 +153,13 @@ public class CurationSidebarServiceImpl
 
     private CurationSession getSession(String aSessionOwner, long aProjectId)
     {
-        if (sessions.containsKey(new CurationSessionKey(aSessionOwner, aProjectId))) {
-            return sessions.get(new CurationSessionKey(aSessionOwner, aProjectId));
-        }
-        else {
-            return readSession(aSessionOwner, aProjectId);
+        synchronized (sessions) {
+            if (sessions.containsKey(new CurationSessionKey(aSessionOwner, aProjectId))) {
+                return sessions.get(new CurationSessionKey(aSessionOwner, aProjectId));
+            }
+            else {
+                return readSession(aSessionOwner, aProjectId);
+            }
         }
     }
 

--- a/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/CreateAnnotationsOptionsMetaDataKey.java
+++ b/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/CreateAnnotationsOptionsMetaDataKey.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.app.ui.search.sidebar;
+
+import org.apache.wicket.Component;
+import org.apache.wicket.MetaDataKey;
+import org.apache.wicket.model.CompoundPropertyModel;
+
+import de.tudarmstadt.ukp.inception.app.ui.search.sidebar.options.CreateAnnotationsOptions;
+
+public class CreateAnnotationsOptionsMetaDataKey
+    extends MetaDataKey<CompoundPropertyModel<CreateAnnotationsOptions>>
+{
+    private static final long serialVersionUID = 102615176759478581L;
+
+    public final static CreateAnnotationsOptionsMetaDataKey INSTANCE = new CreateAnnotationsOptionsMetaDataKey();
+
+    public static CompoundPropertyModel<CreateAnnotationsOptions> get(Component aOwner)
+    {
+        var options = aOwner.getMetaData(INSTANCE);
+        if (options == null) {
+            options = CompoundPropertyModel.of(new CreateAnnotationsOptions());
+            aOwner.setMetaData(INSTANCE, options);
+        }
+        return options;
+    }
+}

--- a/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/DeleteAnnotationsOptionsMetaDataKey.java
+++ b/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/DeleteAnnotationsOptionsMetaDataKey.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.app.ui.search.sidebar;
+
+import org.apache.wicket.Component;
+import org.apache.wicket.MetaDataKey;
+import org.apache.wicket.model.CompoundPropertyModel;
+
+import de.tudarmstadt.ukp.inception.app.ui.search.sidebar.options.DeleteAnnotationsOptions;
+
+public class DeleteAnnotationsOptionsMetaDataKey
+    extends MetaDataKey<CompoundPropertyModel<DeleteAnnotationsOptions>>
+{
+    private static final long serialVersionUID = 102615176759478581L;
+
+    public final static DeleteAnnotationsOptionsMetaDataKey INSTANCE = new DeleteAnnotationsOptionsMetaDataKey();
+
+    public static CompoundPropertyModel<DeleteAnnotationsOptions> get(Component aOwner)
+    {
+        var options = aOwner.getMetaData(INSTANCE);
+        if (options == null) {
+            options = CompoundPropertyModel.of(new DeleteAnnotationsOptions());
+            aOwner.setMetaData(INSTANCE, options);
+        }
+        return options;
+    }
+}

--- a/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchAnnotationSidebarFactory.java
+++ b/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchAnnotationSidebarFactory.java
@@ -21,8 +21,6 @@ import org.apache.wicket.Component;
 import org.apache.wicket.model.IModel;
 import org.springframework.core.annotation.Order;
 
-import de.agilecoders.wicket.core.markup.html.bootstrap.image.Icon;
-import de.agilecoders.wicket.extensions.markup.html.bootstrap.icon.FontAwesome5IconType;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasProvider;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.AnnotationPageBase2;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar.AnnotationSidebarFactory_ImplBase;
@@ -56,7 +54,7 @@ public class SearchAnnotationSidebarFactory
     @Override
     public Component createIcon(String aId, IModel<AnnotatorState> aState)
     {
-        return new Icon(aId, FontAwesome5IconType.search_s);
+        return new SearchSidebarIcon(aId, aState);
     }
 
     @Override

--- a/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchOptionsMetaDataKey.java
+++ b/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchOptionsMetaDataKey.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.app.ui.search.sidebar;
+
+import org.apache.wicket.Component;
+import org.apache.wicket.MetaDataKey;
+import org.apache.wicket.model.CompoundPropertyModel;
+
+import de.tudarmstadt.ukp.inception.app.ui.search.sidebar.options.SearchOptions;
+
+public class SearchOptionsMetaDataKey
+    extends MetaDataKey<CompoundPropertyModel<SearchOptions>>
+{
+    private static final long serialVersionUID = 102615176759478581L;
+
+    public final static SearchOptionsMetaDataKey INSTANCE = new SearchOptionsMetaDataKey();
+
+    public static CompoundPropertyModel<SearchOptions> get(Component aOwner)
+    {
+        var options = aOwner.getMetaData(INSTANCE);
+        if (options == null) {
+            options = CompoundPropertyModel.of(new SearchOptions());
+            aOwner.setMetaData(INSTANCE, options);
+        }
+        return options;
+    }
+}

--- a/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchResultsProvider.java
+++ b/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchResultsProvider.java
@@ -59,25 +59,24 @@ public class SearchResultsProvider
 
     // Cache
     private long totalResults = 0;
-    private IModel<SearchResultsPagesCache> pagesCacheModel;
+    private SearchResultsPagesCache cache;
 
-    public SearchResultsProvider(SearchService aSearchService,
-            IModel<SearchResultsPagesCache> aPageCacheModel)
+    public SearchResultsProvider(SearchService aSearchService)
     {
         searchService = aSearchService;
-        pagesCacheModel = aPageCacheModel;
+        cache = new SearchResultsPagesCache();
     }
 
     @Override
     public Iterator<ResultsGroup> iterator(long first, long count)
     {
         if (query == null) {
-            pagesCacheModel.getObject().clear();
+            cache.clear();
             return IteratorUtils.emptyIterator();
         }
 
-        if (pagesCacheModel.getObject().containsPage(first, count)) {
-            return pagesCacheModel.getObject().getPage(first, count).iterator();
+        if (cache.containsPage(first, count)) {
+            return cache.getPage(first, count).iterator();
         }
 
         // Query if the results in the given range are not in the cache i.e. if we need to fetch
@@ -90,7 +89,7 @@ public class SearchResultsProvider
                     .map(e -> new ResultsGroup(e.getKey(), e.getValue())) //
                     .collect(Collectors.toList());
 
-            pagesCacheModel.getObject().putPage(first, count, queryResults);
+            cache.putPage(first, count, queryResults);
 
             return queryResults.iterator();
         }
@@ -150,14 +149,14 @@ public class SearchResultsProvider
         annotationFeature = aAnnotationFeature;
 
         totalResults = -1; // reset size cache
-        pagesCacheModel.getObject().clear(); // reset page cache
+        cache.clear(); // reset page cache
     }
 
     public void emptyQuery()
     {
         query = null;
         totalResults = 0;
-        pagesCacheModel.getObject().clear();
+        cache.clear();
     }
 
     public AnnotationLayer getAnnotationLayer()
@@ -170,8 +169,8 @@ public class SearchResultsProvider
         return annotationFeature;
     }
 
-    public IModel<SearchResultsPagesCache> getPagesCacheModel()
+    public SearchResultsPagesCache getCache()
     {
-        return pagesCacheModel;
+        return cache;
     }
 }

--- a/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchResultsProviderMetaDataKey.java
+++ b/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchResultsProviderMetaDataKey.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.app.ui.search.sidebar;
+
+import org.apache.wicket.Component;
+import org.apache.wicket.MetaDataKey;
+
+import de.tudarmstadt.ukp.inception.search.SearchService;
+
+public class SearchResultsProviderMetaDataKey
+    extends MetaDataKey<SearchResultsProviderWrapper>
+{
+    private static final long serialVersionUID = 102615176759478581L;
+
+    public final static SearchResultsProviderMetaDataKey INSTANCE = new SearchResultsProviderMetaDataKey();
+
+    public static SearchResultsProviderWrapper get(Component aOwner, SearchService aSearchService)
+    {
+        var provider = aOwner.getMetaData(INSTANCE);
+        if (provider == null) {
+            provider = new SearchResultsProviderWrapper(new SearchResultsProvider(aSearchService));
+            aOwner.setMetaData(INSTANCE, provider);
+        }
+        return provider;
+    }
+}

--- a/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchResultsProviderWrapper.java
+++ b/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchResultsProviderWrapper.java
@@ -40,13 +40,11 @@ public class SearchResultsProviderWrapper
     private SearchResultsProvider searchResultsProvider;
     private List<ResultsGroup> resultGroups;
     private boolean groupingActivated;
-    private IModel<Boolean> lowLevelPaging;
+    private boolean lowLevelPaging;
 
-    public SearchResultsProviderWrapper(SearchResultsProvider aSearchResultsProvider,
-            IModel<Boolean> aLowLevelPaging)
+    public SearchResultsProviderWrapper(SearchResultsProvider aSearchResultsProvider)
     {
         searchResultsProvider = aSearchResultsProvider;
-        lowLevelPaging = aLowLevelPaging;
     }
 
     @Override
@@ -65,13 +63,13 @@ public class SearchResultsProviderWrapper
         }
 
         var subList = resultsGroupsSublist(first, count);
-        searchResultsProvider.getPagesCacheModel().getObject().putPage(first, count, subList);
+        searchResultsProvider.getCache().putPage(first, count, subList);
         return subList.iterator();
     }
 
     public boolean applyLowLevelPaging()
     {
-        return !groupingActivated && lowLevelPaging.getObject();
+        return !groupingActivated && lowLevelPaging;
     }
 
     /**
@@ -117,6 +115,11 @@ public class SearchResultsProviderWrapper
         return resultsGroupsSubList;
     }
 
+    public boolean isEmpty()
+    {
+        return size() == 0;
+    }
+
     @Override
     public long size()
     {
@@ -141,8 +144,10 @@ public class SearchResultsProviderWrapper
 
     public void initializeQuery(User aUser, Project aProject, String aQuery,
             SourceDocument aDocument, AnnotationLayer aAnnotationLayer,
-            AnnotationFeature aAnnotationFeature)
+            AnnotationFeature aAnnotationFeature, boolean aLowLevelPaging)
     {
+        lowLevelPaging = aLowLevelPaging;
+
         searchResultsProvider.initializeQuery(aUser, aProject, aQuery, aDocument, aAnnotationLayer,
                 aAnnotationFeature);
 

--- a/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchSidebarIcon.html
+++ b/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchSidebarIcon.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<!--
+  Licensed to the Technische Universität Darmstadt under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The Technische Universität Darmstadt 
+  licenses this file to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.
+   
+  http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<html xmlns:wicket="http://wicket.apache.org">
+<wicket:panel>
+  <span wicket:id="icon"/>
+</wicket:panel>
+</html>

--- a/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchSidebarIcon.java
+++ b/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchSidebarIcon.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.app.ui.search.sidebar;
+
+import static de.tudarmstadt.ukp.inception.rendering.vmodel.VMarker.MATCH;
+import static de.tudarmstadt.ukp.inception.rendering.vmodel.VMarker.MATCH_FOCUS;
+import static org.apache.uima.cas.text.AnnotationPredicates.overlapping;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.spring.injection.annot.SpringBean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wicketstuff.event.annotation.OnEvent;
+
+import de.agilecoders.wicket.core.markup.html.bootstrap.image.Icon;
+import de.agilecoders.wicket.extensions.markup.html.bootstrap.icon.FontAwesome5IconType;
+import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
+import de.tudarmstadt.ukp.inception.app.ui.search.sidebar.options.SearchOptions;
+import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
+import de.tudarmstadt.ukp.inception.rendering.pipeline.RenderAnnotationsEvent;
+import de.tudarmstadt.ukp.inception.rendering.vmodel.VRange;
+import de.tudarmstadt.ukp.inception.rendering.vmodel.VTextMarker;
+import de.tudarmstadt.ukp.inception.search.ExecutionException;
+import de.tudarmstadt.ukp.inception.search.SearchService;
+
+public class SearchSidebarIcon
+    extends Panel
+{
+    private static final long serialVersionUID = -1870047500327624860L;
+
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    private @SpringBean SearchService searchService;
+    private @SpringBean UserDao userService;
+
+    public SearchSidebarIcon(String aId, IModel<AnnotatorState> aState)
+    {
+        super(aId, aState);
+
+        setOutputMarkupId(true);
+
+        queue(new Icon("icon", FontAwesome5IconType.search_s));
+    }
+
+    @SuppressWarnings("unchecked")
+    public IModel<AnnotatorState> getModel()
+    {
+        return (IModel<AnnotatorState>) getDefaultModel();
+    }
+
+    public AnnotatorState getModelObject()
+    {
+        return (AnnotatorState) getDefaultModelObject();
+    }
+
+    @OnEvent
+    public void onRenderAnnotations(RenderAnnotationsEvent aEvent)
+    {
+        var searchOptions = SearchOptionsMetaDataKey.get(getPage());
+
+        var query = searchOptions.map(SearchOptions::getQuery);
+        var selectedResult = searchOptions.map(SearchOptions::getSelectedResult).getObject();
+        if (query.map(StringUtils::isNotBlank).orElse(false).getObject()) {
+            try {
+                var state = getModelObject();
+                var results = searchService.query(state.getUser(), state.getProject(),
+                        query.getObject(), state.getDocument());
+                for (var result : results) {
+                    if (result.equals(selectedResult)) {
+                        // We render the selected result separately. Rendering it does not
+                        // require a query. So if the query fails, we can still highlight
+                        // the selected result.
+                        continue;
+                    }
+
+                    if (overlapping(aEvent.getVDocument().getWindowBegin(),
+                            aEvent.getVDocument().getWindowEnd(), result.getOffsetStart(),
+                            result.getOffsetEnd())) {
+                        var range = VRange.clippedRange(aEvent.getVDocument(),
+                                result.getOffsetStart(), result.getOffsetEnd());
+
+                        range.ifPresent(r -> aEvent.getVDocument().add(new VTextMarker(MATCH, r)));
+                    }
+                }
+            }
+            catch (IOException | ExecutionException e) {
+                LOG.error("Cannot render match highlights", e);
+            }
+        }
+
+        if (selectedResult != null) {
+            var range = VRange.clippedRange(aEvent.getVDocument(), selectedResult.getOffsetStart(),
+                    selectedResult.getOffsetEnd());
+
+            range.ifPresent(r -> aEvent.getVDocument().add(new VTextMarker(MATCH_FOCUS, r)));
+        }
+    }
+}

--- a/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/StatisticsAnnotationSidebar.java
+++ b/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/StatisticsAnnotationSidebar.java
@@ -122,7 +122,6 @@ public class StatisticsAnnotationSidebar
 
     private List<LayerStatistics> layerStatsList;
     private List<AnnotationFeature> features;
-    // private List<AnnotationLayer> layers;
     Set<Long> hiddenLayerIds;
 
     private CompoundPropertyModel<StatisticsOptions> statisticsOptions = CompoundPropertyModel

--- a/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/options/SearchOptions.java
+++ b/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/options/SearchOptions.java
@@ -21,21 +21,40 @@ import java.io.Serializable;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.inception.search.SearchResult;
 
 public class SearchOptions
     implements Serializable
 {
     private static final long serialVersionUID = 3030323391922717647L;
 
+    private String query;
+    private SearchResult selectedResult;
     private boolean limitedToCurrentDocument = false;
-
     private AnnotationLayer groupingLayer;
-
     private AnnotationFeature groupingFeature;
-
     private long itemsPerPage;
-
     private boolean lowLevelPaging;
+
+    public void setSelectedResult(SearchResult aSelectedResult)
+    {
+        selectedResult = aSelectedResult;
+    }
+
+    public SearchResult getSelectedResult()
+    {
+        return selectedResult;
+    }
+
+    public String getQuery()
+    {
+        return query;
+    }
+
+    public void setQuery(String aQuery)
+    {
+        query = aQuery;
+    }
 
     public boolean isLimitedToCurrentDocument()
     {


### PR DESCRIPTION
**What's in the PR**
- Store the state along with the page so it get retained when we switch to other sidebars.
- Move the rendering code from the sidebar itself to the icon so it does not get disabled when switching away from the sidebar.
- Trigger search when hitting ctrl-enter in the search field

**How to test manually**
* Search for something in the search sidebar
* Switch to another sidebar
* Reload page
* Switch back to search sidebar
* Search state and highlights should always be retained

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
