### PR TITLE
#5439 - Document name not available in document metadata

### DIFF
--- a/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/DocumentImportExportServiceImpl.java
+++ b/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/DocumentImportExportServiceImpl.java
@@ -550,15 +550,16 @@ public class DocumentImportExportServiceImpl
         return features;
     }
 
-    private void addOrUpdateDocumentMetadata(CAS aCas, SourceDocument aDocument, String aFileName)
+    static void addOrUpdateDocumentMetadata(CAS aCas, SourceDocument aDocument, String aFileName)
         throws MalformedURLException, CASException
     {
         var slug = aDocument.getProject().getSlug();
         var documentMetadata = DocumentMetaData.get(aCas.getJCas());
+        documentMetadata.setDocumentTitle(aDocument.getName());
+        documentMetadata.setCollectionId(slug);
+        documentMetadata.setDocumentId(aFileName);
         documentMetadata.setDocumentBaseUri(slug);
         documentMetadata.setDocumentUri(slug + "/" + aFileName);
-        documentMetadata.setCollectionId(slug + "/" + aFileName);
-        documentMetadata.setDocumentId(aFileName);
     }
 
     private void addLayerAndFeatureDefinitionAnnotations(CAS aCas, Project aProject,

--- a/inception/inception-export/src/test/java/de/tudarmstadt/ukp/inception/export/DocumentImportExportSerivceImplStaticsTest.java
+++ b/inception/inception-export/src/test/java/de/tudarmstadt/ukp/inception/export/DocumentImportExportSerivceImplStaticsTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.export;
+
+import static de.tudarmstadt.ukp.inception.export.DocumentImportExportServiceImpl.addOrUpdateDocumentMetadata;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.uima.fit.factory.JCasFactory;
+import org.junit.jupiter.api.Test;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData;
+
+public class DocumentImportExportSerivceImplStaticsTest
+{
+    @Test
+    void thatDocumentMetadataIsSetCorrectly() throws Exception
+    {
+        var project = Project.builder() //
+                .withSlug("test-project") //
+                .build();
+        var sourceDocument = SourceDocument.builder() //
+                .withName("Test Document.txt") //
+                .withProject(project) //
+                .build();
+
+        var slug = sourceDocument.getProject().getSlug();
+        var username = "username";
+
+        var jcas = JCasFactory.createJCas();
+        DocumentMetaData.create(jcas);
+
+        addOrUpdateDocumentMetadata(jcas.getCas(), sourceDocument, username);
+
+        var dmd = DocumentMetaData.get(jcas.getCas());
+        assertThat(dmd.getDocumentTitle()).isEqualTo(sourceDocument.getName());
+        assertThat(dmd.getDocumentUri()).isEqualTo(slug + "/" + username);
+        assertThat(dmd.getDocumentBaseUri()).isEqualTo(slug);
+        assertThat(dmd.getCollectionId()).isEqualTo(slug);
+        assertThat(dmd.getDocumentId()).isEqualTo(username);
+
+    }
+
+}


### PR DESCRIPTION
**What's in the PR**
- Set document name as the document title in DocumentMetadata
- Added test

**How to test manually**
* No specific test procedure

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
