### PR TITLE
#5443 - Intertext plugin renders too slow for large richly annotated documents

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/rendering/NopRenderer.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/rendering/NopRenderer.java
@@ -63,8 +63,7 @@ public class NopRenderer
     }
 
     @Override
-    public List<Annotation> selectAnnotationsInWindow(RenderRequest aRequest, int aWindowBegin,
-            int aWindowEnd)
+    public List<Annotation> selectAnnotationsInWindow(RenderRequest aRequest)
     {
         return Collections.emptyList();
     }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/chain/ChainRenderer.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/chain/ChainRenderer.java
@@ -90,8 +90,7 @@ public class ChainRenderer
     }
 
     @Override
-    public List<Annotation> selectAnnotationsInWindow(RenderRequest aRequest, int aWindowBegin,
-            int aWindowEnd)
+    public List<Annotation> selectAnnotationsInWindow(RenderRequest aRequest)
     {
         var cas = aRequest.getCas();
 

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanRenderer.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanRenderer.java
@@ -96,20 +96,17 @@ public class SpanRenderer
     }
 
     @Override
-    public List<Annotation> selectAnnotationsInWindow(RenderRequest aRequest, int aWindowBegin,
-            int aWindowEnd)
+    public List<Annotation> selectAnnotationsInWindow(RenderRequest aRequest)
     {
         var cas = aRequest.getCas();
+        var windowBegin = aRequest.getWindowBeginOffset();
+        var windowEnd = aRequest.getWindowEndOffset();
 
-        if (!aRequest.isLongArcs()) {
-            return cas.<Annotation> select(type) //
-                    .coveredBy(0, aWindowEnd) //
-                    .includeAnnotationsWithEndBeyondBounds() //
-                    .filter(ann -> AnnotationPredicates.overlapping(ann, aWindowBegin, aWindowEnd))
-                    .toList();
-        }
-
-        return aRequest.getCas().<Annotation> select(type).toList();
+        return cas.<Annotation> select(type) //
+                .coveredBy(0, windowEnd) //
+                .includeAnnotationsWithEndBeyondBounds() //
+                .filter(ann -> AnnotationPredicates.overlapping(ann, windowBegin, windowEnd))
+                .toList();
     }
 
     @Override
@@ -155,8 +152,7 @@ public class SpanRenderer
         // Index mapping annotations to the corresponding rendered spans
         var annoToSpanIdx = new HashMap<AnnotationFS, VSpan>();
 
-        var annotations = selectAnnotationsInWindow(aRequest, aResponse.getWindowBegin(),
-                aResponse.getWindowEnd());
+        var annotations = selectAnnotationsInWindow(aRequest);
 
         for (var fs : annotations) {
             for (var vobj : render(aRequest, aFeatures, aResponse, fs)) {

--- a/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/rendering/Renderer.java
+++ b/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/rendering/Renderer.java
@@ -161,6 +161,5 @@ public interface Renderer
         }
     }
 
-    List<Annotation> selectAnnotationsInWindow(RenderRequest aRequest, int aWindowBegin,
-            int aWindowEnd);
+    List<Annotation> selectAnnotationsInWindow(RenderRequest aRequest);
 }


### PR DESCRIPTION
**What's in the PR**
- Remove special handling of longArcs in SpanRenderer since RelationRenderer supports placeholders now
- A wee bit of cleaning up

**How to test manually**
* Try using the Intertext plugin on large richly annotated documents

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
