### PR TITLE
#5451 - Ability to control visibility of features and tags via sidebar

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/rendering/PreRendererImpl.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/rendering/PreRendererImpl.java
@@ -117,8 +117,9 @@ public class PreRendererImpl
 
         // Render (custom) layers
         for (var layer : aRequest.getVisibleLayers()) {
-            var layerSupportedFeatures = supportedFeatures.stream() //
+            var layerActiveFeatures = supportedFeatures.stream() //
                     .filter(feature -> feature.getLayer().equals(layer)) //
+                    .filter(feature -> !aRequest.getHiddenFeatures().contains(feature.getId()))
                     .toList();
             var layerAllFeatures = allFeatures.stream() //
                     .filter(feature -> feature.getLayer().equals(layer)) //
@@ -128,7 +129,7 @@ public class PreRendererImpl
             // the same because otherwise the IDs of armed slots would be inconsistent
             LayerSupport<?, ?> layerSupport = layerSupportRegistry.getLayerSupport(layer);
             var renderer = layerSupport.createRenderer(layer, () -> layerAllFeatures);
-            renderer.render(aRequest, layerSupportedFeatures, aResponse);
+            renderer.render(aRequest, layerActiveFeatures, aResponse);
         }
 
         if (LOG.isTraceEnabled()) {

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiValueStringFeatureSupport.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiValueStringFeatureSupport.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.inception.annotation.feature.multistring;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.apache.commons.lang3.StringUtils.abbreviate;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
@@ -29,10 +30,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.apache.uima.cas.CAS;
-import org.apache.uima.cas.Feature;
 import org.apache.uima.cas.FeatureStructure;
 import org.apache.uima.cas.StringArrayFS;
 import org.apache.uima.fit.util.FSUtil;
@@ -277,20 +276,20 @@ public class MultiValueStringFeatureSupport
     }
 
     @Override
-    public String renderFeatureValue(AnnotationFeature aFeature, FeatureStructure aFs)
+    public List<String> renderFeatureValues(AnnotationFeature aFeature, FeatureStructure aFs)
     {
-        Feature labelFeature = aFs.getType().getFeatureByBaseName(aFeature.getName());
+        var labelFeature = aFs.getType().getFeatureByBaseName(aFeature.getName());
 
         if (labelFeature == null) {
-            return null;
+            return emptyList();
         }
 
-        List<String> values = getFeatureValue(aFeature, aFs);
-        if (values == null || values.isEmpty()) {
-            return null;
+        List<String> value = getFeatureValue(aFeature, aFs);
+        if (value == null) {
+            return emptyList();
         }
 
-        return values.stream().collect(Collectors.joining(", "));
+        return value;
     }
 
     @Override

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/chain/ChainRenderer.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/chain/ChainRenderer.java
@@ -187,9 +187,14 @@ public class ChainRenderer
                         label = getUiLabelText(typeAdapter, prevLinkFs, emptyList());
                     }
 
-                    aResponse.add(new VArc(typeAdapter.getLayer(),
-                            new VID(prevLinkFs, 1, VID.NONE, VID.NONE), prevLinkFs, linkFs,
-                            colorIndex, label));
+                    aResponse.add(VArc.builder() //
+                            .withLayer(typeAdapter.getLayer()) //
+                            .withVid(new VID(prevLinkFs, 1, VID.NONE, VID.NONE)) //
+                            .withSource(prevLinkFs) //
+                            .withTarget(linkFs) //
+                            .withEquivalenceSet(colorIndex) //
+                            .withLabel(label) //
+                            .build());
                 }
 
                 // Render errors if required features are missing

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/RelationRenderer.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/RelationRenderer.java
@@ -257,31 +257,36 @@ public class RelationRenderer
             return emptyList();
         }
 
-        var labelFeatures = renderLabelFeatureValues(typeAdapter, aFS, aFeatures);
+        var labelFeatures = renderLabelFeatureValues(typeAdapter, aFS, aFeatures,
+                aRequest.getHiddenFeatureValues());
+
+        if (labelFeatures.isEmpty()) {
+            return emptyList();
+        }
 
         switch (traits.getRenderMode()) {
         case ALWAYS:
             return renderRelationAsArcs(aRequest, aVDocument, aFS, typeAdapter, sourceFs, targetFs,
-                    labelFeatures);
+                    labelFeatures.get());
         case WHEN_SELECTED:
             if (aRequest.getState() == null || isSelected(aRequest, aFS, sourceFs, targetFs)) {
                 // State == null is when we render for the annotation sidebar...
                 return renderRelationAsArcs(aRequest, aVDocument, aFS, typeAdapter, sourceFs,
-                        targetFs, labelFeatures);
+                        targetFs, labelFeatures.get());
             }
             return renderRelationOnLabel(aVDocument, typeAdapter, sourceFs, targetFs,
-                    labelFeatures);
+                    labelFeatures.get());
         case NEVER:
             if (aRequest.getState() == null) {
                 // State == null is when we render for the annotation sidebar...
                 return renderRelationAsArcs(aRequest, aVDocument, aFS, typeAdapter, sourceFs,
-                        targetFs, labelFeatures);
+                        targetFs, labelFeatures.get());
             }
             return renderRelationOnLabel(aVDocument, typeAdapter, sourceFs, targetFs,
-                    labelFeatures);
+                    labelFeatures.get());
         default:
             return renderRelationAsArcs(aRequest, aVDocument, aFS, typeAdapter, sourceFs, targetFs,
-                    labelFeatures);
+                    labelFeatures.get());
         }
     }
 
@@ -333,20 +338,20 @@ public class RelationRenderer
     }
 
     private List<VObject> renderRelationAsArcs(RenderRequest aRequest, VDocument aVDocument,
-            AnnotationFS aFS, RelationAdapter typeAdapter, FeatureStructure sourceFs,
-            FeatureStructure targetFs, Map<String, String> labelFeatures)
+            AnnotationFS aFS, RelationAdapter aTypeAdapter, FeatureStructure aSourceFs,
+            FeatureStructure aTargetFs, Map<String, String> aLabelFeatures)
     {
         var objects = new ArrayList<VObject>();
 
-        var source = createEndpoint(aRequest, aVDocument, (AnnotationFS) sourceFs, typeAdapter);
+        var source = createEndpoint(aRequest, aVDocument, (AnnotationFS) aSourceFs, aTypeAdapter);
 
-        var target = createEndpoint(aRequest, aVDocument, (AnnotationFS) targetFs, typeAdapter);
+        var target = createEndpoint(aRequest, aVDocument, (AnnotationFS) aTargetFs, aTypeAdapter);
 
         objects.add(VArc.builder().forAnnotation(aFS) //
-                .withLayer(typeAdapter.getLayer()) //
+                .withLayer(aTypeAdapter.getLayer()) //
                 .withSource(source) //
                 .withTarget(target) //
-                .withFeatures(labelFeatures) //
+                .withFeatures(aLabelFeatures) //
                 .build());
 
         return objects;

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanRenderer.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanRenderer.java
@@ -124,7 +124,9 @@ public class SpanRenderer
 
         if (aVid.getAttribute() != VID.NONE) {
             var adapter = getTypeAdapter();
-            var feature = adapter.listFeatures().stream().sequential().skip(aVid.getAttribute())
+            var feature = adapter.listFeatures().stream() //
+                    .sequential() //
+                    .skip(aVid.getAttribute()) //
                     .findFirst().get();
             List<LinkWithRoleModel> sourceLinks = adapter.getFeatureValue(feature, fs);
             var target = selectAnnotationByAddr(aCas, sourceLinks.get(aVid.getSlot()).targetAddr);
@@ -178,15 +180,20 @@ public class SpanRenderer
         if (!checkTypeSystem(aFS.getCAS())) {
             return emptyList();
         }
+        var typeAdapter = getTypeAdapter();
+        var labelFeatures = renderLabelFeatureValues(typeAdapter, aFS, aFeatures,
+                aRequest.getHiddenFeatureValues());
+
+        if (labelFeatures.isEmpty()) {
+            return Collections.emptyList();
+        }
 
         var range = VRange.clippedRange(aResponse, aFS);
 
         var spansAndSlots = new ArrayList<VObject>();
         VID source;
         if (range.isPresent()) {
-            var typeAdapter = getTypeAdapter();
-            var labelFeatures = renderLabelFeatureValues(typeAdapter, aFS, aFeatures);
-            var span = new VSpan(typeAdapter.getLayer(), aFS, range.get(), labelFeatures);
+            var span = new VSpan(typeAdapter.getLayer(), aFS, range.get(), labelFeatures.get());
             source = span.getVid();
             spansAndSlots.add(span);
         }

--- a/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/editorstate/AnnotationLayerVisibilityState.java
+++ b/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/editorstate/AnnotationLayerVisibilityState.java
@@ -42,8 +42,11 @@ public class AnnotationLayerVisibilityState
 
     private ReadonlyColoringStrategy readonlyLayerColoringStrategy = ReadonlyColoringStrategy.LEGACY;
 
-    // Id of annotation layers, to be stored in the properties file comma separated: 12, 34,....
     private Set<Long> hiddenLayers = new HashSet<>();
+
+    private Set<Long> hiddenFeatures = new HashSet<>();
+
+    private Map<Long, Set<String>> hiddenFeatureValues = new HashMap<>();
 
     public Map<Long, ColoringStrategyType> getLayerColoringStrategy()
     {
@@ -74,5 +77,25 @@ public class AnnotationLayerVisibilityState
     public void setHiddenLayers(Set<Long> aHiddenLayers)
     {
         hiddenLayers = aHiddenLayers;
+    }
+
+    public Set<Long> getHiddenFeatures()
+    {
+        return hiddenFeatures;
+    }
+
+    public void setHiddenFeatures(Set<Long> aHiddenFeatures)
+    {
+        hiddenFeatures = aHiddenFeatures;
+    }
+
+    public Map<Long, Set<String>> getHiddenFeatureValues()
+    {
+        return hiddenFeatureValues;
+    }
+
+    public void setHiddenFeatureValues(Map<Long, Set<String>> aHiddenFeatureValues)
+    {
+        hiddenFeatureValues = aHiddenFeatureValues;
     }
 }

--- a/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/editorstate/AnnotationPreference.java
+++ b/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/editorstate/AnnotationPreference.java
@@ -24,7 +24,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.Tag;
 import de.tudarmstadt.ukp.inception.rendering.coloring.ColoringStrategyType;
 import de.tudarmstadt.ukp.inception.rendering.coloring.ReadonlyColoringStrategy;
 
@@ -68,6 +70,8 @@ public class AnnotationPreference
     // BEGIN: Settings specific to layer visibility and coloring
     private @Deprecated List<Long> annotationLayers;
     private Set<Long> hiddenAnnotationLayerIds = new HashSet<>();
+    private Set<Long> hiddenAnnotationFeatureIds = new HashSet<>();
+    private Map<Long, Set<String>> hiddenTags = new HashMap<>();
     private Map<Long, ColoringStrategyType> colorPerLayer = new HashMap<>();
     private ReadonlyColoringStrategy readonlyLayerColoringBehaviour = ReadonlyColoringStrategy.LEGACY;
     private @Deprecated boolean staticColor = true;
@@ -114,6 +118,59 @@ public class AnnotationPreference
     public void setHiddenAnnotationLayerIds(Set<Long> aAnnotationLayerIds)
     {
         hiddenAnnotationLayerIds = aAnnotationLayerIds;
+    }
+
+    public void setFeatureVisible(AnnotationFeature aFeature, boolean aVisible)
+    {
+        if (aVisible) {
+            hiddenAnnotationFeatureIds.remove(aFeature.getId());
+        }
+        else {
+            hiddenAnnotationFeatureIds.add(aFeature.getId());
+        }
+    }
+
+    public Set<Long> getHiddenAnnotationFeatureIds()
+    {
+        return hiddenAnnotationFeatureIds;
+    }
+
+    public void setHiddenAnnotationFeatureIds(Set<Long> aAnnotationFeatureIds)
+    {
+        hiddenAnnotationFeatureIds = aAnnotationFeatureIds;
+    }
+
+    public void setTagVisible(AnnotationFeature aFeature, Tag aTag, boolean aVisible)
+    {
+        var tags = hiddenTags.get(aFeature.getId());
+        if (tags == null) {
+            if (!aVisible) {
+                tags = new HashSet<String>();
+                tags.add(aTag.getName());
+                hiddenTags.put(aFeature.getId(), tags);
+            }
+        }
+        else {
+            if (!aVisible) {
+                tags.add(aTag.getName());
+            }
+            else {
+                tags.remove(aTag.getName());
+                if (tags.isEmpty()) {
+                    hiddenTags.remove(aFeature.getId());
+                }
+            }
+        }
+    }
+
+    public Map<Long, Set<String>> getHiddenTags()
+    {
+        return hiddenTags;
+    }
+
+    public void setHiddenTags(Map<Long, Set<String>> aTags)
+    {
+        hiddenTags = aTags;
     }
 
     /**

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationSelectionPanel.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/sidebar/DocumentMetadataAnnotationSelectionPanel.java
@@ -474,40 +474,40 @@ public class DocumentMetadataAnnotationSelectionPanel
     }
 
     private void generateAnnotationItems(AnnotationLayer aLayer,
-            DocumentMetadataLayerSupport layerSupport, boolean singleton, CAS cas,
-            ArrayList<AnnotationListItem> items, List<AnnotationFeature> features)
+            DocumentMetadataLayerSupport aLayerSupport, boolean aSingleton, CAS aCas,
+            List<AnnotationListItem> aItems, List<AnnotationFeature> aFeatures)
     {
         var adapter = annotationService.getAdapter(aLayer);
-        var renderer = layerSupport.createRenderer(aLayer,
+        var renderer = aLayerSupport.createRenderer(aLayer,
                 () -> annotationService.listAnnotationFeature(aLayer));
 
-        var maybeType = adapter.getAnnotationType(cas);
+        var maybeType = adapter.getAnnotationType(aCas);
         if (!maybeType.isPresent()) {
             return;
         }
 
         var type = maybeType.get();
-        var annotations = cas.select(type).asList();
+        var annotations = aCas.select(type).asList();
         var hasOrderFeature = type.getFeatureByBaseName(FEATURE_NAME_ORDER) != null;
         if (hasOrderFeature) {
             annotations.sort(comparing(fs -> getFeature(fs, FEATURE_NAME_ORDER, Integer.class)));
         }
 
         for (var fs : annotations) {
-            var renderedFeatures = renderer.renderLabelFeatureValues(adapter, fs, features);
+            var renderedFeatures = renderer.renderLabelFeatureValues(adapter, fs, aFeatures);
             var labelText = TypeUtil.getUiLabelText(renderedFeatures);
             var order = hasOrderFeature ? getFeature(fs, FEATURE_NAME_ORDER, Integer.class) : 0;
-            items.add(
-                    new AnnotationListItem(VID.of(fs), labelText, aLayer, singleton, 0.0d, order));
+            aItems.add(
+                    new AnnotationListItem(VID.of(fs), labelText, aLayer, aSingleton, 0.0d, order));
         }
     }
 
     private void generateSuggestionItems(AnnotationLayer aLayer,
-            DocumentMetadataLayerSupport layerSupport, boolean singleton, CAS cas,
-            ArrayList<AnnotationListItem> items, List<AnnotationFeature> features)
+            DocumentMetadataLayerSupport aLayerSupport, boolean aSingleton, CAS aCas,
+            List<AnnotationListItem> aItems, List<AnnotationFeature> aFeatures)
     {
         var state = getModelObject();
-        var featuresIndex = features.stream()
+        var featuresIndex = aFeatures.stream()
                 .collect(toMap(AnnotationFeature::getName, identity()));
         var predictions = recommendationService.getPredictions(state.getUser(), state.getProject());
         if (predictions != null) {
@@ -518,7 +518,7 @@ public class DocumentMetadataAnnotationSelectionPanel
                     predictionsByDocument);
 
             recommendationService.calculateSuggestionVisibility(userService.getCurrentUsername(),
-                    state.getDocument(), cas, state.getUser().getUsername(), aLayer, group, -1, -1);
+                    state.getDocument(), aCas, state.getUser().getUsername(), aLayer, group, -1, -1);
 
             var pref = recommendationService.getPreferences(state.getUser(), state.getProject());
 
@@ -535,8 +535,8 @@ public class DocumentMetadataAnnotationSelectionPanel
                     var featureSupport = fsRegistry.findExtension(feature).orElseThrow();
                     var annotation = featureSupport.renderFeatureValue(feature,
                             suggestion.getLabel());
-                    items.add(new AnnotationListItem(suggestion.getVID(), annotation, aLayer, false,
-                            suggestion.getScore(), items.size()));
+                    aItems.add(new AnnotationListItem(suggestion.getVID(), annotation, aLayer, false,
+                            suggestion.getScore(), aItems.size()));
                 }
             }
         }

--- a/inception/inception-model-vdoc/src/main/java/de/tudarmstadt/ukp/inception/rendering/vmodel/VArc.java
+++ b/inception/inception-model-vdoc/src/main/java/de/tudarmstadt/ukp/inception/rendering/vmodel/VArc.java
@@ -17,8 +17,6 @@
  */
 package de.tudarmstadt.ukp.inception.rendering.vmodel;
 
-import static de.tudarmstadt.ukp.inception.support.uima.ICasUtil.getAddr;
-
 import java.util.Collections;
 import java.util.Map;
 
@@ -40,78 +38,9 @@ public class VArc
         super(builder.layer, builder.vid, builder.equivalenceSet, builder.features);
         setPlaceholder(builder.placeholder);
         setLabelHint(builder.label);
+        setColorHint(builder.color);
         source = builder.source;
         target = builder.target;
-    }
-
-    /**
-     * @deprecated Unused - to be removed without replacement
-     */
-    @Deprecated
-    @SuppressWarnings("javadoc")
-    public VArc(AnnotationLayer aLayer, AnnotationFS aFS, FeatureStructure aSourceFS,
-            FeatureStructure aTargetFS, String aLabelHint)
-    {
-        this(aLayer, VID.of(aFS), new VID(getAddr(aSourceFS)), new VID(getAddr(aTargetFS)),
-                aLabelHint, null, null);
-    }
-
-    /**
-     * @deprecated Unused - to be removed without replacement
-     */
-    @Deprecated
-    @SuppressWarnings("javadoc")
-    public VArc(AnnotationLayer aLayer, AnnotationFS aFS, FeatureStructure aSourceFS,
-            FeatureStructure aTargetFS, Map<String, String> aFeatures)
-    {
-        this(aLayer, VID.of(aFS), new VID(getAddr(aSourceFS)), new VID(getAddr(aTargetFS)), null,
-                aFeatures, null);
-    }
-
-    public VArc(AnnotationLayer aLayer, VID aVid, FeatureStructure aSourceFS,
-            FeatureStructure aTargetFS, String aLabelHint)
-    {
-        this(aLayer, aVid, VID.of(aSourceFS), VID.of(aTargetFS), aLabelHint, null, null);
-    }
-
-    /**
-     * @deprecated Unused - to be removed without replacement
-     */
-    @Deprecated
-    @SuppressWarnings("javadoc")
-    public VArc(AnnotationLayer aLayer, VID aVid, FeatureStructure aSourceFS,
-            FeatureStructure aTargetFS, String aLabelHint, Map<String, String> aFeatures)
-    {
-        this(aLayer, aVid, new VID(getAddr(aSourceFS)), new VID(getAddr(aTargetFS)), aLabelHint,
-                aFeatures, null);
-    }
-
-    public VArc(AnnotationLayer aLayer, VID aVid, FeatureStructure aSourceFS,
-            FeatureStructure aTargetFS, int aEquivalenceSet, String aLabel)
-    {
-        super(aLayer, aVid, aEquivalenceSet, null);
-        setLabelHint(aLabel);
-        source = new VID(getAddr(aSourceFS));
-        target = new VID(getAddr(aTargetFS));
-    }
-
-    /**
-     * @deprecated Unused - to be removed without replacement
-     */
-    @Deprecated
-    @SuppressWarnings("javadoc")
-    public VArc(AnnotationLayer aLayer, VID aVid, FeatureStructure aSourceFS,
-            FeatureStructure aTargetFS, int aEquivalenceSet, Map<String, String> aFeatures)
-    {
-        super(aLayer, aVid, aEquivalenceSet, aFeatures);
-        source = new VID(getAddr(aSourceFS));
-        target = new VID(getAddr(aTargetFS));
-    }
-
-    public VArc(AnnotationLayer aLayer, VID aVid, VID aSource, VID aTarget, String aLabel,
-            String aColor)
-    {
-        this(aLayer, aVid, aSource, aTarget, aLabel, null, aColor);
     }
 
     public VArc(AnnotationLayer aLayer, VID aVid, VID aSource, VID aTarget, String aLabel,
@@ -164,6 +93,7 @@ public class VArc
         private VID source;
         private VID target;
         private String label;
+        private String color;
         private boolean placeholder;
 
         private Builder()
@@ -227,6 +157,12 @@ public class VArc
         public Builder withLabel(String aLabel)
         {
             label = aLabel;
+            return this;
+        }
+        
+        public Builder withColor(String aColor)
+        {
+            color = aColor;
             return this;
         }
 

--- a/inception/inception-model-vdoc/src/main/java/de/tudarmstadt/ukp/inception/rendering/vmodel/VSpan.java
+++ b/inception/inception-model-vdoc/src/main/java/de/tudarmstadt/ukp/inception/rendering/vmodel/VSpan.java
@@ -60,18 +60,6 @@ public class VSpan
         ranges = asList(aOffsets);
     }
 
-    /**
-     * @deprecated Unused - to be removed without replacement
-     */
-    @SuppressWarnings("javadoc")
-    @Deprecated
-    public VSpan(AnnotationLayer aLayer, AnnotationFS aFS, VRange aOffsets, int aEquivalenceClass,
-            Map<String, String> aFeatures)
-    {
-        super(aLayer, VID.of(aFS), aEquivalenceClass, aFeatures);
-        ranges = asList(aOffsets);
-    }
-
     public VSpan(AnnotationLayer aLayer, VID aVid, VRange aOffsets, Map<String, String> aFeatures)
     {
         this(aLayer, aVid, asList(aOffsets), aFeatures, null);

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/relation/ArcSuggestionRenderer_ImplBase.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/relation/ArcSuggestionRenderer_ImplBase.java
@@ -120,7 +120,7 @@ public abstract class ArcSuggestionRenderer_ImplBase<T extends ArcSuggestion_Imp
                 FeatureSupport<?> featureSupport = fsRegistry.findExtension(feature).orElseThrow();
                 var annotation = featureSupport.renderFeatureValue(feature, suggestion.getLabel());
 
-                Map<String, String> featureAnnotation = annotation != null
+                Map<String, String> featureValues = annotation != null
                         ? Map.of(suggestion.getFeature(), annotation)
                         : Map.of();
 
@@ -133,7 +133,7 @@ public abstract class ArcSuggestionRenderer_ImplBase<T extends ArcSuggestion_Imp
                     return false;
                 });
 
-                var arc = renderArc(aLayer, suggestion, source, target, featureAnnotation);
+                var arc = renderArc(aLayer, suggestion, source, target, featureValues);
                 arc.setScore(suggestion.getScore());
                 arc.setHideScore(isRanker);
 

--- a/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/feature/FeatureSupport.java
+++ b/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/feature/FeatureSupport.java
@@ -19,10 +19,12 @@ package de.tudarmstadt.ukp.inception.schema.api.feature;
 
 import static de.tudarmstadt.ukp.inception.schema.api.feature.FeatureUtil.setFeature;
 import static de.tudarmstadt.ukp.inception.support.uima.ICasUtil.selectFsByAddr;
+import static java.lang.String.join;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -241,28 +243,6 @@ public interface FeatureSupport<T>
      * Gets the label that should be displayed for the given feature value in the UI. {@code null}
      * is an acceptable return value for this method.
      * 
-     * <b>NOTE:</b> If this method should never be overwritten! Overwrite
-     * {@link #renderFeatureValue(AnnotationFeature, String) instead}.
-     * 
-     * @param aFeature
-     *            the feature to be rendered.
-     * @param aFs
-     *            the feature structure from which to obtain the label.
-     * @return the UI label.
-     */
-    default String renderFeatureValue(AnnotationFeature aFeature, FeatureStructure aFs)
-    {
-        var labelFeature = aFs.getType().getFeatureByBaseName(aFeature.getName());
-        if (labelFeature == null) {
-            return null;
-        }
-        return renderFeatureValue(aFeature, aFs.getFeatureValueAsString(labelFeature));
-    }
-
-    /**
-     * Gets the label that should be displayed for the given feature value in the UI. {@code null}
-     * is an acceptable return value for this method.
-     * 
      * @param aFeature
      *            the feature to be rendered.
      * @param aLabel
@@ -274,9 +254,60 @@ public interface FeatureSupport<T>
         return aLabel;
     }
 
+    /**
+     * Gets the label values that should be displayed for the given feature value in the UI.
+     * {@code null} is an acceptable return value for this method.
+     * 
+     * <b>NOTE:</b> In most cases, it is better to overwrite
+     * {@link #renderFeatureValue(AnnotationFeature, String) instead}.
+     * 
+     * @param aFeature
+     *            the feature to be rendered.
+     * @param aFs
+     *            the feature structure from which to obtain the label.
+     * @return the UI label.
+     */
+    default List<String> renderFeatureValues(AnnotationFeature aFeature, FeatureStructure aFs)
+    {
+        var labelFeature = aFs.getType().getFeatureByBaseName(aFeature.getName());
+        if (labelFeature == null) {
+            return emptyList();
+        }
+
+        var featureValue = renderFeatureValue(aFeature, aFs.getFeatureValueAsString(labelFeature));
+        if (featureValue == null) {
+            return emptyList();
+        }
+
+        return asList(featureValue);
+    }
+
+    /**
+     * Gets the label that should be displayed for the given feature value in the UI. {@code null}
+     * is an acceptable return value for this method.
+     * 
+     * <b>NOTE:</b> In most cases, it is better to overwrite
+     * {@link #renderFeatureValue(AnnotationFeature, String) instead}.
+     * 
+     * @param aFeature
+     *            the feature to be rendered.
+     * @param aFs
+     *            the feature structure from which to obtain the label.
+     * @return the UI label.
+     */
+    default String renderFeatureValue(AnnotationFeature aFeature, FeatureStructure aFs)
+    {
+        var values = renderFeatureValues(aFeature, aFs);
+        if (values.isEmpty()) {
+            return null;
+        }
+
+        return join(", ", renderFeatureValues(aFeature, aFs));
+    }
+
     default List<VLazyDetailGroup> lookupLazyDetails(AnnotationFeature aFeature, Object aValue)
     {
-        return Collections.emptyList();
+        return emptyList();
     }
 
     /**

--- a/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/feature/TypeUtil.java
+++ b/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/feature/TypeUtil.java
@@ -18,12 +18,12 @@
 package de.tudarmstadt.ukp.inception.schema.api.feature;
 
 import static java.lang.Long.parseLong;
+import static org.apache.commons.lang3.StringUtils.defaultString;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.Feature;
 import org.apache.uima.cas.FeatureStructure;
@@ -102,9 +102,9 @@ public final class TypeUtil
      */
     public static String getUiLabelText(Map<String, String> aFeatures)
     {
-        StringBuilder labelText = new StringBuilder();
+        var labelText = new StringBuilder();
         for (Entry<String, String> feature : aFeatures.entrySet()) {
-            String label = StringUtils.defaultString(feature.getValue());
+            var label = defaultString(feature.getValue());
 
             if (labelText.length() > 0 && label.length() > 0) {
                 labelText.append(TypeAdapter.FEATURE_SEPARATOR);
@@ -137,8 +137,7 @@ public final class TypeUtil
     {
         StringBuilder bratHoverText = new StringBuilder();
         if (aHoverFeatures.containsKey("__spantext__")) {
-            bratHoverText.append("\"")
-                    .append(StringUtils.defaultString(aHoverFeatures.get("__spantext__")))
+            bratHoverText.append("\"").append(defaultString(aHoverFeatures.get("__spantext__")))
                     .append("\" ");
         }
 
@@ -147,7 +146,7 @@ public final class TypeUtil
             if ("__spantext__".equals(feature.getKey())) {
                 continue;
             }
-            String text = StringUtils.defaultString(feature.getValue());
+            String text = defaultString(feature.getValue());
 
             if (bratHoverText.length() > 0 && featuresToShowAvailable && text.length() > 0) {
                 bratHoverText.append(TypeAdapter.FEATURE_SEPARATOR);
@@ -190,7 +189,7 @@ public final class TypeUtil
             }
 
             Feature labelFeature = aFs.getType().getFeatureByBaseName(feature.getName());
-            String label = StringUtils.defaultString(aFs.getFeatureValueAsString(labelFeature));
+            String label = defaultString(aFs.getFeatureValueAsString(labelFeature));
 
             if (bratLabelText.length() > 0 && label.length() > 0) {
                 bratLabelText.append(TypeAdapter.FEATURE_SEPARATOR);

--- a/inception/inception-support-bootstrap/src/main/ts/bootstrap/shim-checkboxx.scss
+++ b/inception/inception-support-bootstrap/src/main/ts/bootstrap/shim-checkboxx.scss
@@ -16,28 +16,8 @@
  * limitations under the License.
  */
 
-// Override default variables. Apparently only the first declaration of a variable counts, so this
-// import must be first
-@import "inception-variables";
-
-// Import the original bootstrap
-@import "../node_modules/bootstrap/scss/bootstrap";
-
-// Customization
-// Custom styles that make use of Bootstrap and the new variables
-@import "inception-custom";
-@import "inception-card-actions";
-@import "inception-actionbar";
-@import "inception-navbar";
-@import "inception-feature-editors";
-@import "inception-dashboard";
-@import "inception-tables";
-
-@import "shim-bootstrap3";
-@import "shim-kendo";
-@import "shim-wicket";
-@import "shim-wicketstuff";
-@import "shim-bootstrapselect";
-@import "shim-jquery";
-@import "shim-fileinput";
-@import "shim-checkboxx.scss";
+.border-0 .cbx {
+  border: none;
+  box-shadow: none;
+  -webkit-box-shadow: none;
+}

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/sidebar/layer/LayerVisibilitySidebar.html
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/sidebar/layer/LayerVisibilitySidebar.html
@@ -17,17 +17,76 @@
   limitations under the License.
 -->
 <html xmlns:wicket="http://wicket.apache.org">
+<wicket:head>
+  <style>
+    .visibility-sidebar .showOnHover {
+      transition: opacity 0.3s ease-in-out;
+    }
+  
+    .visibility-sidebar .showOnHoverTrigger .showOnHover {
+      opacity: 0.1;
+    }
+    
+    .visibility-sidebar .showOnHoverTrigger:hover .showOnHover {
+      opacity: 1;
+    }
+    
+    /* Highlight which layers are hidden - note this is linked to which icon is set in Java! */
+    .visibility-sidebar .showOnHover:has(.fa-eye-slash),.showOnHover:has(.fa-low-vision) {
+      opacity: 1.0 !important;
+    }
+    
+    .visibility-sidebar .group-collapsed {
+      transform: rotate(-90deg);
+    }
+  </style>
+</wicket:head>
 <wicket:panel>
-  <div class="flex-content flex-v-container flex-gutter flex-only-internal-gutter">
+  <div class="flex-content flex-v-container flex-gutter flex-only-internal-gutter visibility-sidebar">
     <div class="flex-content card">
       <div class="card-header">
         <wicket:message key="layers"/>
       </div>
       <div class="scrolling card-body p-0">
         <ul class="list-group list-group-flush">
-          <li wicket:id="annotationLayers" class="list-group-item">
-            <span wicket:id="visibleToggle"/>
-            <wicket:container wicket:id="name"/>
+          <li wicket:id="layer" class="list-group-item p-0">
+            <div class="bg-body sticky-top border-bottom">
+              <div class="bg-light-subtle px-2 py-1 showOnHoverTrigger">
+                <button wicket:id="collapseLayer" class="btn btn-link p-0 text-reset">
+                  <i class="fas fa-caret-down d-inline-block"></i>
+                </button>
+                <span>
+                  <i class="fas fa-layer-group m-1 text-body-secondary"/>
+                  <span wicket:id="layerName" class="fw-bold"/>
+                </span>
+                <small class="float-end">
+                  <span wicket:id="visibleLayerToggle" class="showOnHover border-0"/>
+                </small>
+              </div>
+            </div>
+            <ul class="list-group list-group-flush">
+              <li wicket:id="feature" class="list-group-item p-0 px-2">
+                <div class="bg-body sticky-top" style="top: 33px; z-index: 1000">
+                  <div class="d-flex justify-content-between py-1 border-0 showOnHoverTrigger">
+                    <span wicket:id="featureName"/>
+                    <small>
+                      <span wicket:id="visibleFeatureToggle" class="showOnHover border-0"/>
+                    </small>
+                  </div>
+                </div>
+                <ul class="list-group list-group-flush ms-2">
+                  <li wicket:id="tag" class="list-group-item border-0 p-0">
+                    <div class="d-flex justify-content-between ps-2 py-1 p-0 border-0 showOnHoverTrigger">
+                      <small wicket:id="tagName"/>
+                      <small>
+                        <a wicket:id="focusTag" tabindex="1000" class="showOnHover text-reset text-decoration-none"><small style="margin: 1px;"><i class="fa-solid fa-arrows-to-eye"/></small></a>
+                        <span wicket:id="visibleTagToggle" class="showOnHover border-0"/>
+                      </small>
+                    </div>
+                  </li>
+                </ul>
+              </li>
+            </ul>
           </li>
         </ul>
       </div>

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/sidebar/layer/LayerVisibilitySidebar.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/sidebar/layer/LayerVisibilitySidebar.java
@@ -18,23 +18,34 @@
 package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar.layer;
 
 import static de.tudarmstadt.ukp.inception.support.lambda.HtmlElementEvents.CHANGE_EVENT;
+import static java.util.Collections.emptySet;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.list.ListItem;
 import org.apache.wicket.markup.html.list.ListView;
+import org.apache.wicket.markup.html.panel.EmptyPanel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.LoadableDetachableModel;
 import org.apache.wicket.model.Model;
+import org.apache.wicket.model.util.ListModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.icon.FontAwesome5IconType;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.preferences.UserPreferencesService;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasProvider;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.Tag;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.AnnotationPageBase2;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar.AnnotationSidebar_ImplBase;
@@ -43,10 +54,15 @@ import de.tudarmstadt.ukp.inception.editor.action.AnnotationActionHandler;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.api.config.AnnotationSchemaProperties;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxFormComponentUpdatingBehavior;
+import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxLink;
 
 public class LayerVisibilitySidebar
     extends AnnotationSidebar_ImplBase
 {
+    private static final FontAwesome5IconType ICON_HIDDEN = FontAwesome5IconType.eye_slash_r;
+    private static final FontAwesome5IconType ICON_VISIBLE = FontAwesome5IconType.eye_r;
+    private static final FontAwesome5IconType ICON_PARTIALLY_VISIBLE = FontAwesome5IconType.low_vision_s;
+
     private static final long serialVersionUID = 6127948490101336779L;
 
     private @SpringBean AnnotationSchemaService annotationService;
@@ -54,12 +70,14 @@ public class LayerVisibilitySidebar
     private @SpringBean UserPreferencesService userPreferencesService;
     private @SpringBean UserDao userService;
 
+    private Map<AnnotationLayer, Boolean> layerCollapseState = new HashMap<>();
+
     public LayerVisibilitySidebar(String aId, AnnotationActionHandler aActionHandler,
             CasProvider aCasProvider, AnnotationPageBase2 aAnnotationPage)
     {
         super(aId, aActionHandler, aCasProvider, aAnnotationPage);
 
-        add(createLayerContainer("annotationLayers", LoadableDetachableModel.of(this::listLayers)));
+        add(createLayerContainer("layer", LoadableDetachableModel.of(this::listLayers)));
     }
 
     private List<AnnotationLayer> listLayers()
@@ -70,12 +88,73 @@ public class LayerVisibilitySidebar
                 .toList();
     }
 
-    private void actionToggleVisibility(AnnotationLayer aLayer, boolean aHidden,
+    private void actionToggleLayerVisibility(AnnotationLayer aLayer, boolean aHidden,
             AjaxRequestTarget aTarget)
         throws IOException
     {
         getModelObject().getPreferences().setLayerVisible(aLayer, !aHidden);
 
+        saveVisibilityStateAndRerender(aTarget);
+    }
+
+    private void actionToggleFeatureVisibility(AnnotationFeature aFeature, boolean aHidden,
+            AjaxRequestTarget aTarget)
+        throws IOException
+    {
+        if (aFeature.getTagset() == null) {
+            getModelObject().getPreferences().setFeatureVisible(aFeature, !aHidden);
+        }
+        else {
+            if (!aHidden) {
+                getModelObject().getPreferences().setFeatureVisible(aFeature, true);
+            }
+
+            // If the feature has a tagset, we toggle the visibility of all tags in that tagset
+            // instead of just the feature itself.
+            var tags = listSelectableTags(aFeature);
+            for (var tag : tags) {
+                getModelObject().getPreferences().setTagVisible(aFeature, tag, !aHidden);
+            }
+            aTarget.add(this);
+        }
+
+        saveVisibilityStateAndRerender(aTarget);
+    }
+
+    private void actionToggleTagVisibility(AnnotationFeature aFeature, Tag aTag, boolean aHidden,
+            AjaxRequestTarget aTarget)
+        throws IOException
+    {
+        getModelObject().getPreferences().setTagVisible(aFeature, aTag, !aHidden);
+
+        saveVisibilityStateAndRerender(aTarget);
+        aTarget.add(this);
+    }
+
+    private void actionFocusTag(AjaxRequestTarget aTarget, AnnotationFeature aFeature, Tag aTag)
+        throws IOException
+    {
+        var preferences = getModelObject().getPreferences();
+
+        var tags = listSelectableTags(aFeature);
+        for (var tag : tags) {
+            var showTag = tag.getName().equals(aTag.getName());
+            preferences.setTagVisible(aFeature, tag, showTag);
+        }
+
+        saveVisibilityStateAndRerender(aTarget);
+        aTarget.add(this);
+    }
+
+    private void actionCollapseLayer(AjaxRequestTarget aTarget, AnnotationLayer aLayer)
+    {
+        var oldState = layerCollapseState.getOrDefault(aLayer, false);
+        layerCollapseState.put(aLayer, !oldState);
+        aTarget.add(this);
+    }
+
+    private void saveVisibilityStateAndRerender(AjaxRequestTarget aTarget) throws IOException
+    {
         var sessionOwner = userService.getCurrentUsername();
         userPreferencesService.savePreferences(getModelObject(), sessionOwner);
         userPreferencesService.loadPreferences(getModelObject(), sessionOwner);
@@ -83,12 +162,21 @@ public class LayerVisibilitySidebar
         getAnnotationPage().actionRefreshDocument(aTarget);
     }
 
+    private List<Tag> listSelectableTags(AnnotationFeature aFeature)
+    {
+        var tags = new ArrayList<Tag>();
+        tags.add(new Tag("", ""));
+        annotationService.listTags(aFeature.getTagset()).stream() //
+                .forEach(tags::add);
+        return tags;
+    }
+
     private ListView<AnnotationLayer> createLayerContainer(String aId,
             IModel<List<AnnotationLayer>> aLayers)
     {
         return new ListView<AnnotationLayer>(aId, aLayers)
         {
-            private static final long serialVersionUID = -4040731191748923013L;
+            private static final long serialVersionUID = -1L;
 
             @Override
             protected void populateItem(ListItem<AnnotationLayer> aItem)
@@ -97,18 +185,132 @@ public class LayerVisibilitySidebar
                 var layer = aItem.getModelObject();
                 var hiddenLayerIds = prefs.getHiddenAnnotationLayerIds();
 
-                var layerVisible = new IconToggleBox("visibleToggle") //
-                        .setCheckedIcon(FontAwesome5IconType.eye_s)
-                        .setCheckedTitle(Model.of("Visible"))
-                        .setUncheckedIcon(FontAwesome5IconType.eye_slash_s)
-                        .setUncheckedTitle(Model.of("Hidden"))
+                var layerVisible = new IconToggleBox("visibleLayerToggle") //
+                        .setCheckedIcon(ICON_VISIBLE) //
+                        .setCheckedTitle(Model.of("Visible")) //
+                        .setUncheckedIcon(ICON_HIDDEN) //
+                        .setUncheckedTitle(Model.of("Hidden")) //
                         .setModel(Model.of(!hiddenLayerIds.contains(layer.getId())));
                 layerVisible.add(new LambdaAjaxFormComponentUpdatingBehavior(CHANGE_EVENT,
-                        _target -> actionToggleVisibility(layer, layerVisible.getModelObject(),
+                        _target -> actionToggleLayerVisibility(layer, layerVisible.getModelObject(),
                                 _target)));
                 aItem.add(layerVisible);
 
-                aItem.add(new Label("name", layer.getUiName()));
+                aItem.add(new Label("layerName", layer.getUiName()));
+
+                var collapseLayer = new LambdaAjaxLink("collapseLayer",
+                        _target -> actionCollapseLayer(_target, layer));
+                collapseLayer.add(new AttributeAppender("class",
+                        () -> layerCollapseState.getOrDefault(layer, false) ? "group-collapsed"
+                                : "",
+                        " "));
+                aItem.add(collapseLayer);
+
+                if (layerCollapseState.getOrDefault(layer, false)) {
+                    aItem.add(new EmptyPanel("feature").setVisible(false));
+                }
+                else {
+                    var features = annotationService.listEnabledFeatures(layer).stream() //
+                            .filter(AnnotationFeature::isVisible) //
+                            .toList();
+                    aItem.add(createFeatureContainer("feature", new ListModel<>(features)));
+                }
+            }
+        };
+    }
+
+    protected ListView<AnnotationFeature> createFeatureContainer(String aId,
+            ListModel<AnnotationFeature> aFeatures)
+    {
+        return new ListView<AnnotationFeature>(aId, aFeatures)
+        {
+            private static final long serialVersionUID = -1L;
+
+            @Override
+            protected void populateItem(ListItem<AnnotationFeature> aItem)
+            {
+                var prefs = LayerVisibilitySidebar.this.getModelObject().getPreferences();
+                var feature = aItem.getModelObject();
+                var hiddenFeatureIds = prefs.getHiddenAnnotationFeatureIds();
+
+                var hiddenIcon = ICON_HIDDEN;
+                boolean visibilityState;
+                if (feature.getTagset() == null) {
+                    visibilityState = !hiddenFeatureIds.contains(feature.getId());
+                }
+                else {
+                    var hiddenTags = prefs.getHiddenTags().getOrDefault(feature.getId(),
+                            emptySet());
+                    visibilityState = hiddenTags.isEmpty();
+                    if (!visibilityState) {
+                        var selectableTags = listSelectableTags(feature).stream().map(Tag::getName)
+                                .toList();
+                        if (!hiddenTags.containsAll(selectableTags)) {
+                            hiddenIcon = ICON_PARTIALLY_VISIBLE;
+                        }
+                    }
+                }
+
+                var featureVisible = new IconToggleBox("visibleFeatureToggle") //
+                        .setCheckedIcon(ICON_VISIBLE) //
+                        .setCheckedTitle(Model.of("Visible")) //
+                        .setUncheckedIcon(hiddenIcon) //
+                        .setUncheckedTitle(Model.of("Hidden")) //
+                        .setModel(Model.of(visibilityState));
+                featureVisible.add(new LambdaAjaxFormComponentUpdatingBehavior(CHANGE_EVENT,
+                        _target -> actionToggleFeatureVisibility(feature,
+                                featureVisible.getModelObject(), _target)));
+                aItem.add(featureVisible);
+
+                aItem.add(new Label("featureName", feature.getUiName()));
+
+                if (feature.getTagset() == null) {
+                    aItem.add(new EmptyPanel("tag").setVisible(false));
+                }
+                else {
+                    var tags = listSelectableTags(feature).stream() //
+                            .map(tag -> Pair.of(feature, tag)) //
+                            .toList();
+
+                    aItem.add(createTagContainer("tag", new ListModel<>(tags)));
+                }
+            }
+        };
+    }
+
+    protected Component createTagContainer(String aId,
+            ListModel<Pair<AnnotationFeature, Tag>> aTags)
+    {
+        return new ListView<Pair<AnnotationFeature, Tag>>(aId, aTags)
+        {
+            private static final long serialVersionUID = -1L;
+
+            @Override
+            protected void populateItem(ListItem<Pair<AnnotationFeature, Tag>> aItem)
+            {
+                var prefs = LayerVisibilitySidebar.this.getModelObject().getPreferences();
+                var feature = aItem.getModelObject().getKey();
+                var tag = aItem.getModelObject().getValue();
+                var hiddenTags = prefs.getHiddenTags();
+
+                var featureVisible = new IconToggleBox("visibleTagToggle") //
+                        .setCheckedIcon(ICON_VISIBLE) //
+                        .setCheckedTitle(Model.of("Visible")) //
+                        .setUncheckedIcon(ICON_HIDDEN) //
+                        .setUncheckedTitle(Model.of("Hidden")) //
+                        .setModel(Model.of(!hiddenTags.getOrDefault(feature.getId(), emptySet())
+                                .contains(tag.getName())));
+                featureVisible.add(new LambdaAjaxFormComponentUpdatingBehavior(CHANGE_EVENT,
+                        _target -> actionToggleTagVisibility(feature, tag,
+                                featureVisible.getModelObject(), _target)));
+                aItem.add(featureVisible);
+
+                var focusTag = new LambdaAjaxLink("focusTag",
+                        _target -> actionFocusTag(_target, feature, tag));
+                aItem.add(focusTag);
+
+                var tagName = tag.getName().isBlank() ? "<None>" : tag.getName();
+                aItem.add(new Label("tagName", tagName));
             }
         };
     }

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/MultiValueConceptFeatureSupport.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/MultiValueConceptFeatureSupport.java
@@ -18,7 +18,7 @@
 package de.tudarmstadt.ukp.inception.ui.kb.feature;
 
 import static java.util.Arrays.asList;
-import static java.util.stream.Collectors.joining;
+import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
@@ -28,11 +28,9 @@ import java.io.Serializable;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 import org.apache.uima.cas.CAS;
-import org.apache.uima.cas.Feature;
 import org.apache.uima.cas.FeatureStructure;
 import org.apache.uima.cas.StringArrayFS;
 import org.apache.uima.fit.util.FSUtil;
@@ -223,7 +221,7 @@ public class MultiValueConceptFeatureSupport
     @Override
     public <V> V getNullFeatureValue(AnnotationFeature aFeature, FeatureStructure aFS)
     {
-        return (V) Collections.emptyList();
+        return (V) emptyList();
     }
 
     @SuppressWarnings("unchecked")
@@ -331,27 +329,27 @@ public class MultiValueConceptFeatureSupport
             return null;
         }
 
-        MultiValueConceptFeatureTraits traits = readTraits(aFeature);
+        var traits = readTraits(aFeature);
         return labelCache.get(aFeature, traits.getRepositoryId(), aIdentifier).getUiLabel();
     }
 
     @Override
-    public String renderFeatureValue(AnnotationFeature aFeature, FeatureStructure aFs)
+    public List<String> renderFeatureValues(AnnotationFeature aFeature, FeatureStructure aFs)
     {
-        Feature labelFeature = aFs.getType().getFeatureByBaseName(aFeature.getName());
+        var labelFeature = aFs.getType().getFeatureByBaseName(aFeature.getName());
 
         if (labelFeature == null) {
-            return null;
+            return emptyList();
         }
 
         List<KBHandle> handles = getFeatureValue(aFeature, aFs);
         if (handles == null || handles.isEmpty()) {
-            return null;
+            return emptyList();
         }
 
         return handles.stream() //
                 .map(KBHandle::getUiLabel) //
-                .collect(joining(", "));
+                .toList();
     }
 
     @Override


### PR DESCRIPTION
**What's in the PR**
- Display features of each layer below the layer in the sidebar
- Allow toggling visibility of individual features
- Hide features that are toggled off in annotations
- Display tagsets under string features
- Allow toggling visibility of individual tags
- Hide tags that are toggled off in annotations
- Persist user-specific visibility settings across sessions
- Persist settings per user and per project
- Include settings in project export
- Restore settings on project import
- Support hiding individual labels from multi-label features

**How to test manually**
* Try the visibility feature in different configurations, e.g. with single-values string features, multi-valued string features, annotations with multiple features with the same or different tagsets, etc.

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
