### PR TITLE
#5475 - Exported layers and features contain project name

### DIFF
--- a/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/LayerImportExportUtils.java
+++ b/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/LayerImportExportUtils.java
@@ -304,7 +304,7 @@ public class LayerImportExportUtils
         exLayer.setValidationMode(aLayer.getValidationMode());
         exLayer.setLinkedListBehavior(aLayer.isLinkedListBehavior());
         exLayer.setName(aLayer.getName());
-        exLayer.setProjectName(aLayer.getProject().getName());
+        exLayer.setProjectId(aLayer.getProject().getId());
         exLayer.setType(aLayer.getType());
         exLayer.setUiName(aLayer.getUiName());
         exLayer.setTraits(aLayer.getTraits());
@@ -322,7 +322,7 @@ public class LayerImportExportUtils
             exFeature.setRequired(feature.isRequired());
             exFeature.setHideUnconstraintFeature(feature.isHideUnconstraintFeature());
             exFeature.setName(feature.getName());
-            exFeature.setProjectName(feature.getProject().getName());
+            exFeature.setProjectId(feature.getProject().getId());
             exFeature.setType(feature.getType());
             exFeature.setUiName(feature.getUiName());
             exFeature.setVisible(feature.isVisible());

--- a/inception/inception-model-export/src/main/java/de/tudarmstadt/ukp/clarin/webanno/export/model/ExportedAnnotationFeature.java
+++ b/inception/inception-model-export/src/main/java/de/tudarmstadt/ukp/clarin/webanno/export/model/ExportedAnnotationFeature.java
@@ -17,6 +17,10 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.export.model;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -63,8 +67,8 @@ public class ExportedAnnotationFeature
     @JsonProperty("description")
     private String description;
 
-    @JsonProperty("project_name")
-    private String projectName;
+    @JsonIgnore
+    private Long projectId;
 
     @JsonProperty("multi_value_mode")
     private MultiValueMode multiValueMode;
@@ -170,14 +174,14 @@ public class ExportedAnnotationFeature
         this.tagSet = tagSet;
     }
 
-    public String getProjectName()
+    public Long getProjectId()
     {
-        return projectName;
+        return projectId;
     }
 
-    public void setProjectName(String projectName)
+    public void setProjectId(Long aProjectId)
     {
-        this.projectName = projectName;
+        projectId = aProjectId;
     }
 
     public MultiValueMode getMultiValueMode()
@@ -291,54 +295,26 @@ public class ExportedAnnotationFeature
     }
 
     @Override
-    public int hashCode()
+    public boolean equals(final Object other)
     {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ((name == null) ? 0 : name.hashCode());
-        result = prime * result + ((projectName == null) ? 0 : projectName.hashCode());
-        result = prime * result + ((type == null) ? 0 : type.hashCode());
-        return result;
+        if (!(other instanceof ExportedAnnotationFeature)) {
+            return false;
+        }
+        var castOther = (ExportedAnnotationFeature) other;
+        return new EqualsBuilder() //
+                .append(name, castOther.name) //
+                .append(type, castOther.type) //
+                .append(projectId, castOther.projectId) //
+                .isEquals();
     }
 
     @Override
-    public boolean equals(Object obj)
+    public int hashCode()
     {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        ExportedAnnotationFeature other = (ExportedAnnotationFeature) obj;
-        if (name == null) {
-            if (other.name != null) {
-                return false;
-            }
-        }
-        else if (!name.equals(other.name)) {
-            return false;
-        }
-        if (projectName == null) {
-            if (other.projectName != null) {
-                return false;
-            }
-        }
-        else if (!projectName.equals(other.projectName)) {
-            return false;
-        }
-        if (type == null) {
-            if (other.type != null) {
-                return false;
-            }
-        }
-        else if (!type.equals(other.type)) {
-            return false;
-        }
-        return true;
+        return new HashCodeBuilder() //
+                .append(name) //
+                .append(type) //
+                .append(projectId) //
+                .toHashCode();
     }
-
 }

--- a/inception/inception-model-export/src/main/java/de/tudarmstadt/ukp/clarin/webanno/export/model/ExportedAnnotationLayer.java
+++ b/inception/inception-model-export/src/main/java/de/tudarmstadt/ukp/clarin/webanno/export/model/ExportedAnnotationLayer.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -91,8 +92,8 @@ public class ExportedAnnotationLayer
     @JsonProperty("multiple_tokens")
     private boolean multipleTokens;
 
-    @JsonProperty("project_name")
-    private String projectName;
+    @JsonIgnore
+    private Long projectId;
 
     @JsonProperty("linked_list_behavior")
     private boolean linkedListBehavior;
@@ -315,14 +316,14 @@ public class ExportedAnnotationLayer
         this.attachFeature = attachFeature;
     }
 
-    public String isProjectName()
+    public Long getProjectId()
     {
-        return projectName;
+        return projectId;
     }
 
-    public void setProjectName(String projectName)
+    public void setProjectId(Long aProjectId)
     {
-        this.projectName = projectName;
+        this.projectId = aProjectId;
     }
 
     public boolean isLinkedListBehavior()
@@ -372,13 +373,20 @@ public class ExportedAnnotationLayer
             return false;
         }
         ExportedAnnotationLayer castOther = (ExportedAnnotationLayer) other;
-        return new EqualsBuilder().append(name, castOther.name).append(type, castOther.type)
-                .append(projectName, castOther.projectName).isEquals();
+        return new EqualsBuilder() //
+                .append(name, castOther.name) //
+                .append(type, castOther.type) //
+                .append(projectId, castOther.projectId) //
+                .isEquals();
     }
 
     @Override
     public int hashCode()
     {
-        return new HashCodeBuilder().append(name).append(type).append(projectName).toHashCode();
+        return new HashCodeBuilder() //
+                .append(name) //
+                .append(type) //
+                .append(projectId) //
+                .toHashCode();
     }
 }

--- a/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/exporters/LayerExporter.java
+++ b/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/exporters/LayerExporter.java
@@ -141,7 +141,7 @@ public class LayerExporter
         exLayer.setValidationMode(aLayer.getValidationMode());
         exLayer.setLinkedListBehavior(aLayer.isLinkedListBehavior());
         exLayer.setName(aLayer.getName());
-        exLayer.setProjectName(aLayer.getProject().getName());
+        exLayer.setProjectId(aLayer.getProject().getId());
         exLayer.setType(aLayer.getType());
         exLayer.setUiName(aLayer.getUiName());
         exLayer.setTraits(aLayer.getTraits());
@@ -153,7 +153,7 @@ public class LayerExporter
         // Export features
         var exFeatures = new ArrayList<ExportedAnnotationFeature>();
         for (var feature : annotationService.listAnnotationFeature(aLayer)) {
-            ExportedAnnotationFeature exFeature = exportFeatureDetails(feature);
+            var exFeature = exportFeatureDetails(feature);
             exFeatures.add(exFeature);
 
             if (aFeatureToExFeature != null) {
@@ -174,7 +174,7 @@ public class LayerExporter
         exFeature.setRequired(feature.isRequired());
         exFeature.setHideUnconstraintFeature(feature.isHideUnconstraintFeature());
         exFeature.setName(feature.getName());
-        exFeature.setProjectName(feature.getProject().getName());
+        exFeature.setProjectId(feature.getProject().getId());
         exFeature.setType(feature.getType());
         exFeature.setUiName(feature.getUiName());
         exFeature.setVisible(feature.isVisible());


### PR DESCRIPTION
**What's in the PR**
- Keep the project ID in the exported layers and features just for hashcode/equals (in case we ever compare them across projects which should never happen...)
- Do not export the project ID or name to JSON

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
