### PR TITLE
#5421 - Stacked annotations on same span not correctly represented for two annotators in CSV diff export

### DIFF
--- a/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/AgreementServiceImplTest.java
+++ b/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/AgreementServiceImplTest.java
@@ -90,7 +90,7 @@ class AgreementServiceImplTest
 
         assertThat(generateReport(userCount, data).lines()).contains( //
                 "SpanPosition,,,de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity,"
-                        + "value,8-12 [John],STACKED,\"LOC, PER\",<no annotation>");
+                        + "value,8-12 [John],STACKED,\"LOC, PER\",ORG");
     }
 
     @SuppressWarnings("unchecked")

--- a/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/ConfigurationSet.java
+++ b/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/ConfigurationSet.java
@@ -65,6 +65,15 @@ public class ConfigurationSet
         return this;
     }
 
+    public ConfigurationSet removeTags(Tag... aTag)
+    {
+        if (aTag != null) {
+            tags.removeAll(asList(aTag));
+        }
+
+        return this;
+    }
+
     /**
      * @return tags added during agreement calculation (not by {@link CasDiff}!)
      */


### PR DESCRIPTION
**What's in the PR**
- Fixed issue
- Adjusted test cases accordingly

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
