### PR TITLE
#3098 - Optionally skip closed documents when navigating between documents

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/page/AnnotationEditorManagerPrefs.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/page/AnnotationEditorManagerPrefs.java
@@ -23,13 +23,13 @@ import de.tudarmstadt.ukp.inception.preferences.PreferenceKey;
 import de.tudarmstadt.ukp.inception.preferences.PreferenceValue;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class AnnotationEditorState
+public class AnnotationEditorManagerPrefs
     implements PreferenceValue
 {
     private static final long serialVersionUID = -1637731874872789592L;
 
-    public static final PreferenceKey<AnnotationEditorState> KEY_EDITOR_STATE = new PreferenceKey<>(
-            AnnotationEditorState.class, "annotation/editor");
+    public static final PreferenceKey<AnnotationEditorManagerPrefs> KEY_ANNOTATION_EDITOR_MANAGER_PREFS = new PreferenceKey<>(
+            AnnotationEditorManagerPrefs.class, "annotation/editor");
 
     private String defaultEditor;
 

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/page/AnnotationNavigationUserPrefs.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/page/AnnotationNavigationUserPrefs.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.api.annotation.page;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import de.tudarmstadt.ukp.inception.preferences.PreferenceKey;
+import de.tudarmstadt.ukp.inception.preferences.PreferenceValue;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AnnotationNavigationUserPrefs
+    implements PreferenceValue
+{
+    private static final long serialVersionUID = -1637731874872789592L;
+
+    public static final PreferenceKey<AnnotationNavigationUserPrefs> KEY_ANNOTATION_NAVIGATION_USER_PREFS = new PreferenceKey<>(
+            AnnotationNavigationUserPrefs.class, "annotation/navigation");
+
+    private boolean finishedDocumentsSkippedByNavigation = false;
+
+    public boolean isFinishedDocumentsSkippedByNavigation()
+    {
+        return finishedDocumentsSkippedByNavigation;
+    }
+
+    public void setFinishedDocumentsSkippedByNavigation(
+            boolean aFinishedDocumentsSkippedByNavigation)
+    {
+        finishedDocumentsSkippedByNavigation = aFinishedDocumentsSkippedByNavigation;
+    }
+}

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/preferences/AnnotationPreferencesDialogContent.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/preferences/AnnotationPreferencesDialogContent.java
@@ -17,7 +17,7 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.api.annotation.preferences;
 
-import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationEditorState.KEY_EDITOR_STATE;
+import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationEditorManagerPrefs.KEY_ANNOTATION_EDITOR_MANAGER_PREFS;
 import static de.tudarmstadt.ukp.clarin.webanno.model.Mode.ANNOTATION;
 import static de.tudarmstadt.ukp.clarin.webanno.model.Mode.CURATION;
 import static de.tudarmstadt.ukp.inception.rendering.editorstate.AnchoringModePrefs.KEY_ANCHORING_MODE;
@@ -132,7 +132,7 @@ public class AnnotationPreferencesDialogContent
         fontZoomField.setMaximum(FONT_ZOOM_MAX);
         form.add(fontZoomField);
 
-        var state = preferencesService.loadDefaultTraitsForProject(KEY_EDITOR_STATE,
+        var state = preferencesService.loadDefaultTraitsForProject(KEY_ANNOTATION_EDITOR_MANAGER_PREFS,
                 stateModel.getObject().getProject());
 
         var editor = new DropDownChoice<Pair<String, String>>("editor");

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/preferences/UserPreferencesActionBarExtension.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/preferences/UserPreferencesActionBarExtension.java
@@ -17,7 +17,7 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.api.annotation.preferences;
 
-import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationEditorState.KEY_EDITOR_STATE;
+import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationEditorManagerPrefs.KEY_ANNOTATION_EDITOR_MANAGER_PREFS;
 import static de.tudarmstadt.ukp.clarin.webanno.model.Mode.CURATION;
 
 import org.apache.wicket.markup.html.panel.Panel;
@@ -25,7 +25,7 @@ import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.actionbar.ActionBarExtension;
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationEditorState;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationEditorManagerPrefs;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
 import de.tudarmstadt.ukp.inception.preferences.PreferencesService;
 
@@ -45,8 +45,8 @@ public class UserPreferencesActionBarExtension
     @Override
     public boolean accepts(AnnotationPageBase aPage)
     {
-        AnnotationEditorState editorState = preferencesService
-                .loadDefaultTraitsForProject(KEY_EDITOR_STATE, aPage.getProject());
+        AnnotationEditorManagerPrefs editorState = preferencesService
+                .loadDefaultTraitsForProject(KEY_ANNOTATION_EDITOR_MANAGER_PREFS, aPage.getProject());
 
         return editorState.isPreferencesAccessAllowed()
                 || aPage.getModelObject().getMode() == CURATION;

--- a/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/preferences/BratAnnotationEditorManagerPrefPanel.html
+++ b/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/preferences/BratAnnotationEditorManagerPrefPanel.html
@@ -42,7 +42,7 @@
         </div>
         <div class="row form-row">
           <div class="offset-sm-4 col-sm-8">
-            <div class="form-check">
+            <div class="form-check form-switch">
               <input wicket:id="changingScriptDirectionAllowed" class="form-check-input" type="checkbox"> 
               <label wicket:for="changingScriptDirectionAllowed" class="form-check-label" >
                 <wicket:label key="changingScriptDirectionAllowed"/>

--- a/inception/inception-curation/pom.xml
+++ b/inception/inception-curation/pom.xml
@@ -105,7 +105,10 @@
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-ui-dashboard</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-api-editor</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>

--- a/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/settings/CurationNavigationUserPrefs.java
+++ b/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/settings/CurationNavigationUserPrefs.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.curation.settings;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import de.tudarmstadt.ukp.inception.preferences.PreferenceKey;
+import de.tudarmstadt.ukp.inception.preferences.PreferenceValue;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CurationNavigationUserPrefs
+    implements PreferenceValue
+{
+    private static final long serialVersionUID = -1637731874872789592L;
+
+    public static final PreferenceKey<CurationNavigationUserPrefs> KEY_CURATION_NAVIGATION_USER_PREFS = new PreferenceKey<>(
+            CurationNavigationUserPrefs.class, "curation/navigation");
+
+    private boolean finishedDocumentsSkippedByNavigation = false;
+
+    public boolean isFinishedDocumentsSkippedByNavigation()
+    {
+        return finishedDocumentsSkippedByNavigation;
+    }
+
+    public void setFinishedDocumentsSkippedByNavigation(
+            boolean aFinishedDocumentsSkippedByNavigation)
+    {
+        finishedDocumentsSkippedByNavigation = aFinishedDocumentsSkippedByNavigation;
+    }
+}

--- a/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/settings/CurationNavigationUserPrefsPanel.html
+++ b/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/settings/CurationNavigationUserPrefsPanel.html
@@ -21,24 +21,19 @@
   <wicket:panel>
     <form wicket:id="form" class="card">
       <div class="card-header">
-        <wicket:message key="defaultAnnotationEditorState"/>
+        <wicket:message key="annotationNavigationUserPrefsPanel"/>
       </div>
       <div class="card-body">
         <div class="row form-row">
-          <label wicket:for="defaultEditor" class="col-sm-4 col-form-label">
-            <wicket:label key="defaultEditor" />
-          </label>
-          <div class="col-sm-8">
-            <select wicket:id="defaultEditor" class="form-select"/>
-          </div>
-        </div>
-        <div class="row form-row">
           <div class="offset-sm-4 col-sm-8">
-            <div class="form-check">
-              <input wicket:id="preferencesAccessAllowed" class="form-check-input" type="checkbox"> 
-              <label wicket:for="preferencesAccessAllowed" class="form-check-label" >
-                <wicket:label key="preferencesAccessAllowed"/>
+            <div class="form-check form-switch">
+              <input wicket:id="finishedDocumentsSkippedByNavigation" class="form-check-input" type="checkbox"> 
+              <label wicket:for="finishedDocumentsSkippedByNavigation" class="form-check-label" >
+                <wicket:label key="finishedDocumentsSkippedByNavigation"/>
               </label>
+            </div>
+            <div class="form-text">
+              <wicket:message key="finishedDocumentsSkippedByNavigation.description"/>
             </div>
           </div>
         </div>

--- a/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/settings/CurationNavigationUserPrefsPanel.java
+++ b/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/settings/CurationNavigationUserPrefsPanel.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.curation.settings;
+
+import static de.tudarmstadt.ukp.inception.curation.settings.CurationNavigationUserPrefs.KEY_CURATION_NAVIGATION_USER_PREFS;
+
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.markup.html.form.CheckBox;
+import org.apache.wicket.markup.html.form.Form;
+import org.apache.wicket.markup.html.panel.GenericPanel;
+import org.apache.wicket.model.CompoundPropertyModel;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.spring.injection.annot.SpringBean;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.inception.editor.AnnotationEditorRegistry;
+import de.tudarmstadt.ukp.inception.preferences.PreferencesService;
+import de.tudarmstadt.ukp.inception.support.lambda.LambdaForm;
+
+public class CurationNavigationUserPrefsPanel
+    extends GenericPanel<Project>
+{
+    private static final long serialVersionUID = 4663693446465391162L;
+
+    private @SpringBean AnnotationEditorRegistry annotationEditorRegistry;
+    private @SpringBean PreferencesService preferencesService;
+
+    private IModel<CurationNavigationUserPrefs> state;
+
+    public CurationNavigationUserPrefsPanel(String aId, IModel<Project> aProjectModel)
+    {
+        super(aId, aProjectModel);
+        setOutputMarkupPlaceholderTag(true);
+
+        state = CompoundPropertyModel.of(null);
+        actionLoad();
+
+        var form = new LambdaForm<CurationNavigationUserPrefs>("form", state);
+
+        form.add(new CheckBox("finishedDocumentsSkippedByNavigation").setOutputMarkupId(true));
+
+        form.onSubmit(this::actionSave);
+
+        add(form);
+    }
+
+    private void actionLoad()
+    {
+        state.setObject(preferencesService.loadDefaultTraitsForProject(
+                KEY_CURATION_NAVIGATION_USER_PREFS, getModel().getObject()));
+    }
+
+    private void actionSave(AjaxRequestTarget aTarget, Form<CurationNavigationUserPrefs> aDummy)
+    {
+        preferencesService.saveDefaultTraitsForProject(KEY_CURATION_NAVIGATION_USER_PREFS,
+                getModel().getObject(), state.getObject());
+    }
+}

--- a/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/settings/CurationNavigationUserPrefsPanel.utf8.properties
+++ b/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/settings/CurationNavigationUserPrefsPanel.utf8.properties
@@ -14,5 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-title=Annotation overview sidebar
-pinnedGroups=Pinned groups
+annotationNavigationUserPrefsPanel=Navigation
+finishedDocumentsSkippedByNavigation=Skip finished documents when navigating between them
+finishedDocumentsSkippedByNavigation.description=Users can customize this setting in the open document dialog. \
+  Changing this setting affects only users who have not customized the setting.

--- a/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/settings/CurationProjectSettingsPanel.html
+++ b/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/settings/CurationProjectSettingsPanel.html
@@ -19,38 +19,53 @@
 <html xmlns:wicket="http://wicket.apache.org">
 <body>
   <wicket:panel>
-    <form wicket:id="form" class="card border-0 flex-v-container flex-content">
-      <div class="flex-h-container flex-content flex-gutter">
+    <form wicket:id="form" class="card border-0 flex-content flex-v-container">
+      <div class="flex-content scrolling card-body">
         <div class="flex-v-container flex-content flex-gutter">
-          <div class="row form-row" wicket:enclosure="anonymousCuration">
-            <div class="offset-md-4 col-sm-8">
-              <div class="form-check form-switch">
-                <input class="form-check-input" type="checkbox" wicket:id="anonymousCuration"> <label
-                  class="form-check-label" wicket:for="anonymousCuration"> <wicket:label
-                    key="anonymousCuration" />
+          <div wicket:id="navigationPrefs"/>
+          <div class="card">
+            <div class="card-header">
+              Editor
+            </div>
+            <div class="card-body">
+              <div class="row form-row" wicket:enclosure="anonymousCuration">
+                <div class="offset-md-4 col-sm-8">
+                  <div class="form-check form-switch">
+                    <input class="form-check-input" type="checkbox" wicket:id="anonymousCuration"> <label
+                      class="form-check-label" wicket:for="anonymousCuration"> <wicket:label
+                        key="anonymousCuration" />
+                    </label>
+                  </div>
+                </div>
+              </div>
+              <div class="row form-row" wicket:enclosure="curationPageType">
+                <label wicket:for="curationPageType" class="col-sm-4 col-form-label">
+                  <wicket:label key="curationPageType"/>
                 </label>
+                <div class="col-sm-8">
+                  <select wicket:id="curationPageType" class="form-select" data-container="body"></select>
+                </div>
               </div>
             </div>
           </div>
-          <div class="row form-row" wicket:enclosure="autoMergeCurationSidebar">
-            <div class="offset-md-4 col-sm-8">
-              <div class="form-check form-switch">
-                <input class="form-check-input" type="checkbox" wicket:id="autoMergeCurationSidebar"> <label
-                  class="form-check-label" wicket:for="autoMergeCurationSidebar"> <wicket:label
-                    key="autoMergeCurationSidebar" />
-                </label>
+          <div class="card">
+            <div class="card-header">
+              Merging
+            </div>
+            <div class="card-body">
+              <div class="row form-row" wicket:enclosure="autoMergeCurationSidebar">
+                <div class="offset-md-4 col-sm-8">
+                  <div class="form-check form-switch">
+                    <input class="form-check-input" type="checkbox" wicket:id="autoMergeCurationSidebar"> <label
+                      class="form-check-label" wicket:for="autoMergeCurationSidebar"> <wicket:label
+                        key="autoMergeCurationSidebar" />
+                    </label>
+                  </div>
+                </div>
               </div>
+              <div wicket:id="mergeStrategy" />
             </div>
           </div>
-          <div class="row form-row" wicket:enclosure="curationPageType">
-            <label wicket:for="curationPageType" class="col-sm-4 col-form-label">
-              <wicket:label key="curationPageType"/>
-            </label>
-            <div class="col-sm-8">
-              <select wicket:id="curationPageType" class="form-select" data-container="body"></select>
-            </div>
-          </div>
-          <div wicket:id="mergeStrategy" />
         </div>
       </div>
       <div class="card-footer text-end">

--- a/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/settings/CurationProjectSettingsPanel.java
+++ b/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/settings/CurationProjectSettingsPanel.java
@@ -50,9 +50,10 @@ public class CurationProjectSettingsPanel
 {
     private static final long serialVersionUID = 4618192360418016955L;
 
-    private static final String MID_FORM = "form";
-    private static final String MID_MERGE_STRATEGY = "mergeStrategy";
-    private static final String MID_SAVE = "save";
+    private static final String CID_FORM = "form";
+    private static final String CID_MERGE_STRATEGY = "mergeStrategy";
+    private static final String CID_SAVE = "save";
+    private static final String CID_NAVIGATION_PREFS = "navigationPrefs";
 
     private @SpringBean CurationService curationService;
     private @SpringBean ProjectService projectService;
@@ -65,26 +66,26 @@ public class CurationProjectSettingsPanel
 
     private MarkupContainer mergeStrategyPanel;
 
-    public CurationProjectSettingsPanel(String aId, IModel<Project> aProjectModel)
+    public CurationProjectSettingsPanel(String aId, IModel<Project> aProject)
     {
-        super(aId, aProjectModel);
+        super(aId, CompoundPropertyModel.of(aProject));
         setOutputMarkupPlaceholderTag(true);
 
-        var form = new LambdaForm<Project>(MID_FORM, CompoundPropertyModel.of(aProjectModel));
+        var form = new LambdaForm<Project>(CID_FORM, CompoundPropertyModel.of(aProject));
         add(form);
 
         curationWorkflowModel = Model.of(loadCurationWorkflow());
         curationSidebarPrefs = new CompoundPropertyModel<>(Model.of(loadSidebarPrefs()));
         curationPrefs = new CompoundPropertyModel<>(Model.of(loadCurationPrefs()));
 
-        mergeStrategyPanel = new MergeStrategyPanel(MID_MERGE_STRATEGY, curationWorkflowModel);
+        mergeStrategyPanel = new MergeStrategyPanel(CID_MERGE_STRATEGY, curationWorkflowModel);
         form.add(mergeStrategyPanel);
 
         form.add(new CheckBox("anonymousCuration").setOutputMarkupPlaceholderTag(true));
 
         form.add(new CheckBox("autoMergeCurationSidebar") //
                 .setModel(curationSidebarPrefs.bind("autoMergeCurationSidebar")) //
-                .add(visibleWhen(() -> curationSidebarProperties.isEnabled())) //
+                .add(visibleWhen(curationSidebarProperties::isEnabled)) //
                 .setOutputMarkupPlaceholderTag(true));
 
         form.add(new DropDownChoice<CurationPageType>("curationPageType") //
@@ -93,7 +94,9 @@ public class CurationProjectSettingsPanel
                 .setModel(curationPrefs.bind("curationPageType")) //
                 .setOutputMarkupPlaceholderTag(true));
 
-        form.add(new LambdaAjaxButton<>(MID_SAVE, this::actionSave).triggerAfterSubmit());
+        queue(new CurationNavigationUserPrefsPanel(CID_NAVIGATION_PREFS, aProject));
+
+        form.add(new LambdaAjaxButton<>(CID_SAVE, this::actionSave).triggerAfterSubmit());
     }
 
     @Override

--- a/inception/inception-project-initializers-phi/src/main/java/de/tudarmstadt/ukp/inception/project/initializers/phi/PhiProjectInitializer.java
+++ b/inception/inception-project-initializers-phi/src/main/java/de/tudarmstadt/ukp/inception/project/initializers/phi/PhiProjectInitializer.java
@@ -17,7 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.project.initializers.phi;
 
-import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationEditorState.KEY_EDITOR_STATE;
+import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationEditorManagerPrefs.KEY_ANNOTATION_EDITOR_MANAGER_PREFS;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
@@ -160,10 +160,10 @@ public class PhiProjectInitializer
 
         var bratEditorFactory = context.getBean(BratTokenWrappingAnnotationEditorFactory.class);
         if (bratEditorFactory != null) {
-            var editorState = preferencesService.loadDefaultTraitsForProject(KEY_EDITOR_STATE,
+            var editorState = preferencesService.loadDefaultTraitsForProject(KEY_ANNOTATION_EDITOR_MANAGER_PREFS,
                     project);
             editorState.setDefaultEditor(bratEditorFactory.getBeanName());
-            preferencesService.saveDefaultTraitsForProject(KEY_EDITOR_STATE, project, editorState);
+            preferencesService.saveDefaultTraitsForProject(KEY_ANNOTATION_EDITOR_MANAGER_PREFS, project, editorState);
         }
     }
 

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPageBase2.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPageBase2.java
@@ -17,7 +17,7 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.ui.annotation;
 
-import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationEditorState.KEY_EDITOR_STATE;
+import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationEditorManagerPrefs.KEY_ANNOTATION_EDITOR_MANAGER_PREFS;
 import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasUpgradeMode.FORCE_CAS_UPGRADE;
 import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasUpgradeMode.NO_CAS_UPGRADE;
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState.IGNORE;
@@ -310,7 +310,7 @@ public abstract class AnnotationPageBase2
             return;
         }
 
-        var editorState = preferencesService.loadDefaultTraitsForProject(KEY_EDITOR_STATE,
+        var editorState = preferencesService.loadDefaultTraitsForProject(KEY_ANNOTATION_EDITOR_MANAGER_PREFS,
                 getProject());
 
         var editorId = editorState.getDefaultEditor();

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/open/OpenDocumentDialogPanel.html
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/open/OpenDocumentDialogPanel.html
@@ -33,6 +33,14 @@
         <div wicket:id="table" class="flex-content flex-v-container"/>
       </div>
     </div>
+    <div class="modal-footer flex-row justify-content-between py-0">
+      <div class="form-check form-switch">
+        <input wicket:id="finishedDocumentsSkippedByNavigation" class="form-check-input" type="checkbox"> 
+        <label wicket:for="finishedDocumentsSkippedByNavigation" class="form-check-label" >
+          <wicket:label key="finishedDocumentsSkippedByNavigation"/>
+        </label>
+      </div>
+    </div>
   </div>
 </wicket:panel>
 </html>

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/open/OpenDocumentDialogPanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/open/OpenDocumentDialogPanel.java
@@ -17,11 +17,13 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.open;
 
+import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationNavigationUserPrefs.KEY_ANNOTATION_NAVIGATION_USER_PREFS;
 import static de.tudarmstadt.ukp.clarin.webanno.model.Mode.ANNOTATION;
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.ANNOTATOR;
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.CURATOR;
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.MANAGER;
 import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.CURATION_USER;
+import static de.tudarmstadt.ukp.inception.support.lambda.HtmlElementEvents.CHANGE_EVENT;
 import static de.tudarmstadt.ukp.inception.support.lambda.LambdaBehavior.visibleWhen;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
@@ -34,10 +36,12 @@ import org.apache.wicket.RestartResponseException;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.form.OnChangeAjaxBehavior;
 import org.apache.wicket.extensions.ajax.markup.html.modal.ModalDialog;
+import org.apache.wicket.markup.html.form.CheckBox;
 import org.apache.wicket.markup.html.form.ChoiceRenderer;
 import org.apache.wicket.markup.html.form.DropDownChoice;
-import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.markup.html.panel.GenericPanel;
 import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.LambdaModel;
 import org.apache.wicket.model.LoadableDetachableModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.spring.injection.annot.SpringBean;
@@ -52,8 +56,10 @@ import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.clarin.webanno.ui.core.page.ProjectPageBase;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
+import de.tudarmstadt.ukp.inception.preferences.PreferencesService;
 import de.tudarmstadt.ukp.inception.project.api.ProjectService;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
+import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxFormComponentUpdatingBehavior;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxLink;
 import de.tudarmstadt.ukp.inception.support.wicket.DecoratedObject;
 import de.tudarmstadt.ukp.inception.support.wicket.input.InputBehavior;
@@ -64,46 +70,78 @@ import wicket.contrib.input.events.key.KeyType;
  * and associated documents
  */
 public class OpenDocumentDialogPanel
-    extends Panel
+    extends GenericPanel<AnnotatorState>
 {
     private static final long serialVersionUID = 1299869948010875439L;
+
+    private static final String CID_CLOSE_DIALOG = "closeDialog";
+    private static final String CID_TABLE = "table";
+    private static final String CID_FINISHED_DOCUMENTS_SKIPPED_BY_NAVIGATION = "finishedDocumentsSkippedByNavigation";
+    private static final String CID_USER = "user";
 
     private @SpringBean ProjectService projectService;
     private @SpringBean DocumentService documentService;
     private @SpringBean UserDao userRepository;
+    private @SpringBean PreferencesService preferencesService;
 
     private final DropDownChoice<DecoratedObject<User>> userListChoice;
     private final AnnotationDocumentTable table;
 
-    private final IModel<AnnotatorState> state;
+    private final IModel<Boolean> finishedDocumentsSkippedByNavigation;
 
     private final SerializableBiFunction<Project, User, List<AnnotationDocument>> docListProvider;
 
     public OpenDocumentDialogPanel(String aId, IModel<AnnotatorState> aState,
             SerializableBiFunction<Project, User, List<AnnotationDocument>> aDocListProvider)
     {
-        super(aId);
+        super(aId, aState);
 
-        state = aState;
         docListProvider = aDocListProvider;
 
         queue(userListChoice = createUserListChoice());
 
-        queue(new LambdaAjaxLink("closeDialog", this::actionCancel)
+        queue(new LambdaAjaxLink(CID_CLOSE_DIALOG, this::actionCancel)
                 .add(new InputBehavior(new KeyType[] { KeyType.Escape }, click)));
 
-        table = new AnnotationDocumentTable("table",
+        finishedDocumentsSkippedByNavigation = LambdaModel.of(
+                this::isFinishedDocumentsSkippedByNavigation,
+                this::setFinishedDocumentsSkippedByNavigation);
+        queue(new CheckBox(CID_FINISHED_DOCUMENTS_SKIPPED_BY_NAVIGATION,
+                finishedDocumentsSkippedByNavigation) //
+                        .add(new LambdaAjaxFormComponentUpdatingBehavior(CHANGE_EVENT)));
+
+        table = new AnnotationDocumentTable(CID_TABLE,
                 LoadableDetachableModel.of(this::listDocuments));
         table.setOutputMarkupId(true);
         queue(table);
     }
 
+    private boolean isFinishedDocumentsSkippedByNavigation()
+    {
+        var project = getModelObject().getProject();
+        var sessionOwner = userRepository.getCurrentUser();
+        return preferencesService.loadTraitsForUserAndProject(KEY_ANNOTATION_NAVIGATION_USER_PREFS,
+                sessionOwner, project).isFinishedDocumentsSkippedByNavigation();
+    }
+
+    private void setFinishedDocumentsSkippedByNavigation(boolean aBoolean)
+    {
+        var project = getModelObject().getProject();
+        var sessionOwner = userRepository.getCurrentUser();
+        var prefs = preferencesService.loadTraitsForUserAndProject(
+                KEY_ANNOTATION_NAVIGATION_USER_PREFS, sessionOwner, project);
+        prefs.setFinishedDocumentsSkippedByNavigation(aBoolean);
+        preferencesService.saveTraitsForUserAndProject(KEY_ANNOTATION_NAVIGATION_USER_PREFS,
+                sessionOwner, project, prefs);
+    }
+
     private DropDownChoice<DecoratedObject<User>> createUserListChoice()
     {
+        var sessionOwner = userRepository.getCurrentUser();
         var currentUser = DecoratedObject.of(userRepository.getCurrentUser());
-        var viewUser = DecoratedObject.of(state.getObject().getUser());
+        var viewUser = DecoratedObject.of(getModelObject().getUser());
 
-        var choice = new DropDownChoice<>("user", Model.of(), listUsers());
+        var choice = new DropDownChoice<>(CID_USER, Model.of(), listUsers());
         choice.setChoiceRenderer(new ChoiceRenderer<DecoratedObject<User>>()
         {
             private static final long serialVersionUID = 1L;
@@ -120,8 +158,8 @@ public class OpenDocumentDialogPanel
             }
         });
         choice.setOutputMarkupId(true);
-        choice.add(visibleWhen(state.map(s -> s.getMode().equals(ANNOTATION) && projectService
-                .hasRole(userRepository.getCurrentUser(), s.getProject(), MANAGER, CURATOR))));
+        choice.add(visibleWhen(getModel().map(s -> s.getMode().equals(ANNOTATION)
+                && projectService.hasRole(sessionOwner, s.getProject(), MANAGER, CURATOR))));
         choice.add(OnChangeAjaxBehavior.onChange(this::actionSelectUser));
 
         if (choice.getChoices().contains(viewUser)) {
@@ -149,16 +187,15 @@ public class OpenDocumentDialogPanel
 
     private List<DecoratedObject<User>> listUsers()
     {
+        var project = getModelObject().getProject();
+        var sessionOwner = userRepository.getCurrentUser();
+
         var users = new ArrayList<DecoratedObject<User>>();
-
-        var project = state.getObject().getProject();
-        var currentUser = userRepository.getCurrentUser();
-
         // cannot select other user than themselves if curating or not admin
-        if (state.getObject().getMode().equals(Mode.CURATION)
-                || !projectService.hasRole(currentUser, project, MANAGER, CURATOR)) {
-            var du = DecoratedObject.of(currentUser);
-            du.setLabel(currentUser.getUiName());
+        if (getModelObject().getMode().equals(Mode.CURATION)
+                || !projectService.hasRole(sessionOwner, project, MANAGER, CURATOR)) {
+            var du = DecoratedObject.of(sessionOwner);
+            du.setLabel(sessionOwner.getUiName());
             users.add(du);
             return users;
         }
@@ -166,7 +203,7 @@ public class OpenDocumentDialogPanel
         for (var user : projectService.listProjectUsersWithPermissions(project, ANNOTATOR)) {
             var du = DecoratedObject.of(user);
             du.setLabel(user.getUiName());
-            if (user.equals(currentUser)) {
+            if (user.equals(sessionOwner)) {
                 users.add(0, du);
             }
             else {
@@ -179,7 +216,7 @@ public class OpenDocumentDialogPanel
 
     private List<AnnotationDocument> listDocuments()
     {
-        var project = state.getObject().getProject();
+        var project = getModelObject().getProject();
         var user = userListChoice.getModel().map(DecoratedObject::get).orElse(null).getObject();
 
         if (project == null || user == null) {
@@ -196,13 +233,13 @@ public class OpenDocumentDialogPanel
                 .map(AnnotationDocument::getDocument) //
                 .collect(toList());
 
-        state.getObject().setDocument(aEvent.getAnnotationDocument().getDocument(), documents);
+        getModelObject().setDocument(aEvent.getAnnotationDocument().getDocument(), documents);
 
         // for curation view in inception: when curating into CURATION_USER's CAS
         // and opening new document it should also be from the CURATION_USER
-        if (state.getObject().getUser() != null
-                && !CURATION_USER.equals(state.getObject().getUser().getUsername())) {
-            state.getObject().setUser(userListChoice.getModelObject().get());
+        if (getModelObject().getUser() != null
+                && !CURATION_USER.equals(getModelObject().getUser().getUsername())) {
+            getModelObject().setUser(userListChoice.getModelObject().get());
         }
 
         ((AnnotationPageBase) getPage()).actionLoadDocument(aEvent.getTarget());
@@ -216,7 +253,7 @@ public class OpenDocumentDialogPanel
 
         // If the dialog is aborted without choosing a document, return to a sensible
         // location.
-        if (state.getObject().getProject() == null || state.getObject().getDocument() == null) {
+        if (getModelObject().getProject() == null || getModelObject().getDocument() == null) {
             try {
                 var ppb = findParent(ProjectPageBase.class);
                 if (ppb != null) {

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/open/OpenDocumentDialogPanel.utf8.properties
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/open/OpenDocumentDialogPanel.utf8.properties
@@ -17,3 +17,4 @@ user=User
 chooseDocument=Choose Document
 emptyChoiceMsg=None
 emptyChoiceExplanation=No suitable documents were found
+finishedDocumentsSkippedByNavigation=Skip finished documents when navigating between them

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/settings/ProjectSettingsPanelBase.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/settings/ProjectSettingsPanelBase.java
@@ -17,13 +17,13 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.ui.core.settings;
 
-import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.markup.html.panel.GenericPanel;
 import org.apache.wicket.model.IModel;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 
 public abstract class ProjectSettingsPanelBase
-    extends Panel
+    extends GenericPanel<Project>
 {
     private static final long serialVersionUID = -6844742938608503193L;
 
@@ -38,26 +38,4 @@ public abstract class ProjectSettingsPanelBase
         super(id, aProjectModel);
         setOutputMarkupId(true);
     }
-
-    public void setModel(IModel<Project> aModel)
-    {
-        setDefaultModel(aModel);
-    }
-
-    @SuppressWarnings("unchecked")
-    public IModel<Project> getModel()
-    {
-        return (IModel<Project>) getDefaultModel();
-    }
-
-    public void setModelObject(Project aModel)
-    {
-        setDefaultModelObject(aModel);
-    }
-
-    public Project getModelObject()
-    {
-        return (Project) getDefaultModelObject();
-    }
-
 }

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/actionbar/opendocument/CurationOpenDocumentDialogPanel.html
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/actionbar/opendocument/CurationOpenDocumentDialogPanel.html
@@ -27,6 +27,14 @@
     <div class="modal-body flex-content flex-v-container">
       <div wicket:id="table" class="flex-content flex-v-container"/>
     </div>
+    <div class="modal-footer flex-row justify-content-between py-0">
+      <div class="form-check form-switch">
+        <input wicket:id="finishedDocumentsSkippedByNavigation" class="form-check-input" type="checkbox"> 
+        <label wicket:for="finishedDocumentsSkippedByNavigation" class="form-check-label" >
+          <wicket:label key="finishedDocumentsSkippedByNavigation"/>
+        </label>
+      </div>
+    </div>
   </div>
 </wicket:panel>
 </html>

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/actionbar/opendocument/CurationOpenDocumentDialogPanel.utf8.properties
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/actionbar/opendocument/CurationOpenDocumentDialogPanel.utf8.properties
@@ -16,3 +16,4 @@
 chooseDocument=Choose Document
 emptyChoiceMsg=None
 emptyChoiceExplanation=No suitable documents were found
+finishedDocumentsSkippedByNavigation=Skip finished documents when navigating between them

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/AnnotationEditorManagerPrefsPanel.html
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/AnnotationEditorManagerPrefsPanel.html
@@ -19,22 +19,29 @@
 <html xmlns:wicket="http://wicket.apache.org">
 <body>
   <wicket:panel>
-    <form wicket:id="form" class="card border-0 flex-content flex-v-container">
-      <div class="flex-content scrolling card-body">
-        <div class="flex-v-container flex-content flex-gutter">
-          <div wicket:id="navigationPrefs"/>
-          <div wicket:id="annotationEditorManagerPrefsPanel"/>
-          <div wicket:id="bratAnnotationEditorManagerPrefs"/>
-          <div wicket:id="annotationSidebar"/>
-          <div wicket:id="diamAnnotationSidebarManagerPrefs"/>
-          <div wicket:id="annotationSearch"/>
-        </div>
+    <form wicket:id="form" class="card">
+      <div class="card-header">
+        <wicket:message key="annotationEditorManagerPrefs"/>
       </div>
-      <div class="card-footer text-end">
-        <button wicket:id="save" class="btn btn-primary">
-          <i class="fas fa-save"></i>&nbsp;
-          <wicket:message key="save"/>
-        </button>
+      <div class="card-body">
+        <div class="row form-row">
+          <label wicket:for="defaultEditor" class="col-sm-4 col-form-label">
+            <wicket:label key="defaultEditor" />
+          </label>
+          <div class="col-sm-8">
+            <select wicket:id="defaultEditor" class="form-select"/>
+          </div>
+        </div>
+        <div class="row form-row">
+          <div class="offset-sm-4 col-sm-8">
+            <div class="form-check form-switch">
+              <input wicket:id="preferencesAccessAllowed" class="form-check-input" type="checkbox"> 
+              <label wicket:for="preferencesAccessAllowed" class="form-check-label" >
+                <wicket:label key="preferencesAccessAllowed"/>
+              </label>
+            </div>
+          </div>
+        </div>
       </div>
     </form>
   </wicket:panel>

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/AnnotationEditorManagerPrefsPanel.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/AnnotationEditorManagerPrefsPanel.java
@@ -17,7 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.ui.core.dashboard.settings.annotation;
 
-import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationEditorState.KEY_EDITOR_STATE;
+import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationEditorManagerPrefs.KEY_ANNOTATION_EDITOR_MANAGER_PREFS;
 import static de.tudarmstadt.ukp.inception.support.lambda.LambdaBehavior.visibleWhen;
 
 import java.util.List;
@@ -29,30 +29,30 @@ import org.apache.wicket.markup.html.form.CheckBox;
 import org.apache.wicket.markup.html.form.ChoiceRenderer;
 import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.markup.html.form.Form;
-import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.markup.html.panel.GenericPanel;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationEditorState;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationEditorManagerPrefs;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.inception.editor.AnnotationEditorRegistry;
 import de.tudarmstadt.ukp.inception.preferences.PreferencesService;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaForm;
 
-public class DefaultAnnotationEditorStatePanel
-    extends Panel
+public class AnnotationEditorManagerPrefsPanel
+    extends GenericPanel<Project>
 {
     private static final long serialVersionUID = 4663693446465391162L;
 
     private @SpringBean AnnotationEditorRegistry annotationEditorRegistry;
     private @SpringBean PreferencesService preferencesService;
 
-    private IModel<AnnotationEditorState> state;
+    private IModel<AnnotationEditorManagerPrefs> state;
     private IModel<Pair<String, String>> defaultEditor;
 
-    public DefaultAnnotationEditorStatePanel(String aId, IModel<Project> aProjectModel)
+    public AnnotationEditorManagerPrefsPanel(String aId, IModel<Project> aProjectModel)
     {
         super(aId, aProjectModel);
         setOutputMarkupPlaceholderTag(true);
@@ -60,9 +60,9 @@ public class DefaultAnnotationEditorStatePanel
         state = CompoundPropertyModel.of(null);
         defaultEditor = Model.of();
 
-        var form = new LambdaForm<AnnotationEditorState>("form", state);
+        var form = new LambdaForm<AnnotationEditorManagerPrefs>("form", state);
 
-        DropDownChoice<Pair<String, String>> editor = new DropDownChoice<>("defaultEditor");
+        var editor = new DropDownChoice<Pair<String, String>>("defaultEditor");
         editor.setModel(defaultEditor);
         editor.setChoiceRenderer(new ChoiceRenderer<>("value"));
         editor.setChoices(listAvailableEditors());
@@ -86,16 +86,10 @@ public class DefaultAnnotationEditorStatePanel
                 .toList();
     }
 
-    @SuppressWarnings("unchecked")
-    public IModel<Project> getModel()
-    {
-        return (IModel<Project>) getDefaultModel();
-    }
-
     private void actionLoad()
     {
-        state.setObject(preferencesService.loadDefaultTraitsForProject(KEY_EDITOR_STATE,
-                getModel().getObject()));
+        state.setObject(preferencesService.loadDefaultTraitsForProject(
+                KEY_ANNOTATION_EDITOR_MANAGER_PREFS, getModel().getObject()));
 
         var defaultEditorId = state.getObject().getDefaultEditor();
         var factory = annotationEditorRegistry.getEditorFactory(defaultEditorId);
@@ -111,12 +105,12 @@ public class DefaultAnnotationEditorStatePanel
         }
     }
 
-    private void actionSave(AjaxRequestTarget aTarget, Form<AnnotationEditorState> aDummy)
+    private void actionSave(AjaxRequestTarget aTarget, Form<AnnotationEditorManagerPrefs> aDummy)
     {
         state.getObject()
                 .setDefaultEditor(defaultEditor.map(Pair::getKey).orElse(null).getObject());
 
-        preferencesService.saveDefaultTraitsForProject(KEY_EDITOR_STATE, getModel().getObject(),
-                state.getObject());
+        preferencesService.saveDefaultTraitsForProject(KEY_ANNOTATION_EDITOR_MANAGER_PREFS,
+                getModel().getObject(), state.getObject());
     }
 }

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/AnnotationEditorManagerPrefsPanel.utf8.properties
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/AnnotationEditorManagerPrefsPanel.utf8.properties
@@ -16,5 +16,5 @@
 
 defaultEditor=Editor
 defaultEditor.nullValid=Leave choice to annotator
-defaultAnnotationEditorState=Annotation editor
+annotationEditorManagerPrefs=Annotation editor
 preferencesAccessAllowed=Allow access to user-specific annotation editor preferences

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/AnnotationNavigationUserPrefsPanel.html
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/AnnotationNavigationUserPrefsPanel.html
@@ -19,22 +19,24 @@
 <html xmlns:wicket="http://wicket.apache.org">
 <body>
   <wicket:panel>
-    <form wicket:id="form" class="card border-0 flex-content flex-v-container">
-      <div class="flex-content scrolling card-body">
-        <div class="flex-v-container flex-content flex-gutter">
-          <div wicket:id="navigationPrefs"/>
-          <div wicket:id="annotationEditorManagerPrefsPanel"/>
-          <div wicket:id="bratAnnotationEditorManagerPrefs"/>
-          <div wicket:id="annotationSidebar"/>
-          <div wicket:id="diamAnnotationSidebarManagerPrefs"/>
-          <div wicket:id="annotationSearch"/>
-        </div>
+    <form wicket:id="form" class="card">
+      <div class="card-header">
+        <wicket:message key="annotationNavigationUserPrefsPanel"/>
       </div>
-      <div class="card-footer text-end">
-        <button wicket:id="save" class="btn btn-primary">
-          <i class="fas fa-save"></i>&nbsp;
-          <wicket:message key="save"/>
-        </button>
+      <div class="card-body">
+        <div class="row form-row">
+          <div class="offset-sm-4 col-sm-8">
+            <div class="form-check form-switch">
+              <input wicket:id="finishedDocumentsSkippedByNavigation" class="form-check-input" type="checkbox"> 
+              <label wicket:for="finishedDocumentsSkippedByNavigation" class="form-check-label" >
+                <wicket:label key="finishedDocumentsSkippedByNavigation"/>
+              </label>
+            </div>
+            <div class="form-text">
+              <wicket:message key="finishedDocumentsSkippedByNavigation.description"/>
+            </div>
+          </div>
+        </div>
       </div>
     </form>
   </wicket:panel>

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/AnnotationNavigationUserPrefsPanel.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/AnnotationNavigationUserPrefsPanel.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.core.dashboard.settings.annotation;
+
+import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationNavigationUserPrefs.KEY_ANNOTATION_NAVIGATION_USER_PREFS;
+
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.markup.html.form.CheckBox;
+import org.apache.wicket.markup.html.form.Form;
+import org.apache.wicket.markup.html.panel.GenericPanel;
+import org.apache.wicket.model.CompoundPropertyModel;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.spring.injection.annot.SpringBean;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationNavigationUserPrefs;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.inception.editor.AnnotationEditorRegistry;
+import de.tudarmstadt.ukp.inception.preferences.PreferencesService;
+import de.tudarmstadt.ukp.inception.support.lambda.LambdaForm;
+
+public class AnnotationNavigationUserPrefsPanel
+    extends GenericPanel<Project>
+{
+    private static final long serialVersionUID = 4663693446465391162L;
+
+    private @SpringBean AnnotationEditorRegistry annotationEditorRegistry;
+    private @SpringBean PreferencesService preferencesService;
+
+    private IModel<AnnotationNavigationUserPrefs> state;
+
+    public AnnotationNavigationUserPrefsPanel(String aId, IModel<Project> aProjectModel)
+    {
+        super(aId, aProjectModel);
+        setOutputMarkupPlaceholderTag(true);
+
+        state = CompoundPropertyModel.of(null);
+        actionLoad();
+
+        var form = new LambdaForm<AnnotationNavigationUserPrefs>("form", state);
+
+        form.add(new CheckBox("finishedDocumentsSkippedByNavigation").setOutputMarkupId(true));
+
+        form.onSubmit(this::actionSave);
+
+        add(form);
+    }
+
+    private void actionLoad()
+    {
+        state.setObject(preferencesService.loadDefaultTraitsForProject(
+                KEY_ANNOTATION_NAVIGATION_USER_PREFS, getModel().getObject()));
+    }
+
+    private void actionSave(AjaxRequestTarget aTarget, Form<AnnotationNavigationUserPrefs> aDummy)
+    {
+        preferencesService.saveDefaultTraitsForProject(KEY_ANNOTATION_NAVIGATION_USER_PREFS,
+                getModel().getObject(), state.getObject());
+    }
+}

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/AnnotationNavigationUserPrefsPanel.utf8.properties
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/AnnotationNavigationUserPrefsPanel.utf8.properties
@@ -14,5 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-title=Annotation overview sidebar
-pinnedGroups=Pinned groups
+annotationNavigationUserPrefsPanel=Navigation
+finishedDocumentsSkippedByNavigation=Skip finished documents when navigating between them
+finishedDocumentsSkippedByNavigation.description=Users can customize this setting in the open document dialog. \
+  Changing this setting affects only users who have not customized the setting.

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/AnnotationPreferencesProjectSettingsPanel.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/AnnotationPreferencesProjectSettingsPanel.java
@@ -37,26 +37,27 @@ public class AnnotationPreferencesProjectSettingsPanel
     private static final String CID_FORM = "form";
     private static final String CID_SAVE = "save";
     private static final String CID_ANNOTATION_SIDEBAR = "annotationSidebar";
-    private static final String CID_ANNOTATION_EDITOR = "annotationEditor";
+    private static final String CID_ANNOTATION_EDITOR_MANAGER_PREFS = "annotationEditorManagerPrefsPanel";
+    private static final String CID_NAVIGATION_PREFS = "navigationPrefs";
     private static final String CID_BRAT_ANNOTATION_EDITOR_MANAGER_PREFS = "bratAnnotationEditorManagerPrefs";
     private static final String CID_DIAM_ANNOTATION_SIDEBAR_MANAGER_PREFS = "diamAnnotationSidebarManagerPrefs";
     private static final String CID_ANNOTATION_SEARCH = "annotationSearch";
 
-    public AnnotationPreferencesProjectSettingsPanel(String aId, IModel<Project> aProjectModel)
+    public AnnotationPreferencesProjectSettingsPanel(String aId, IModel<Project> aProject)
     {
-        super(aId, aProjectModel);
+        super(aId, aProject);
         setOutputMarkupPlaceholderTag(true);
 
         queue(new LambdaForm<>(CID_FORM));
         queue(new LambdaAjaxButton<>(CID_SAVE, this::actionSave));
 
-        queue(new DefaultAnnotationSidebarStatePanel(CID_ANNOTATION_SIDEBAR, aProjectModel));
-        queue(new DiamSidebarManagerPrefPanel(CID_DIAM_ANNOTATION_SIDEBAR_MANAGER_PREFS,
-                aProjectModel));
-        queue(new DefaultAnnotationEditorStatePanel(CID_ANNOTATION_EDITOR, aProjectModel));
+        queue(new DefaultAnnotationSidebarStatePanel(CID_ANNOTATION_SIDEBAR, aProject));
+        queue(new DiamSidebarManagerPrefPanel(CID_DIAM_ANNOTATION_SIDEBAR_MANAGER_PREFS, aProject));
+        queue(new AnnotationEditorManagerPrefsPanel(CID_ANNOTATION_EDITOR_MANAGER_PREFS, aProject));
+        queue(new AnnotationNavigationUserPrefsPanel(CID_NAVIGATION_PREFS, aProject));
         queue(new BratAnnotationEditorManagerPrefPanel(CID_BRAT_ANNOTATION_EDITOR_MANAGER_PREFS,
-                aProjectModel));
-        queue(new AnnotationSearchStatePanel(CID_ANNOTATION_SEARCH, aProjectModel));
+                aProject));
+        queue(new AnnotationSearchStatePanel(CID_ANNOTATION_SEARCH, aProject));
     }
 
     private void actionSave(AjaxRequestTarget aTarget, Form<Void> aDummy)

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/AnnotationSearchStatePanel.html
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/AnnotationSearchStatePanel.html
@@ -26,19 +26,19 @@
       <div class="card-body">
         <div class="row form-row">
           <div class="offset-md-4 col-sm-8">
-            <div class="form-check">
+            <div class="form-check form-switch">
               <input class="form-check-input" type="checkbox" wicket:id="caseSensitiveDocumentText">
               <label class="form-check-label" wicket:for="caseSensitiveDocumentText">
                 <wicket:label key="caseSensitiveDocumentText"/>
               </label>
             </div>
-            <div class="form-check">
+            <div class="form-check form-switch">
               <input class="form-check-input" type="checkbox" wicket:id="caseSensitiveFeatureValues">
               <label class="form-check-label" wicket:for="caseSensitiveFeatureValues">
                 <wicket:label key="caseSensitiveFeatureValues"/>
               </label>
             </div>
-            <span class="ms-3 small text-muted">
+            <span class="small text-muted">
               When you disable case sensitivity, text or feature values in CQL queries need to be written in lower case to match!<br/>
               Only takes effect after index has been re-built.
             </span>

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/DefaultAnnotationSidebarStatePanel.utf8.properties
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/DefaultAnnotationSidebarStatePanel.utf8.properties
@@ -16,4 +16,4 @@
 
 defaultTab=Default tab
 defaultTab.nullValid=None
-defaultAnnotationSidebarState=Annotation sidebar
+defaultAnnotationSidebarState=Sidebars


### PR DESCRIPTION
**What's in the PR**
- Changed next/prev document buttons to switch only between unfinished documents
- Added toggle to switch between skipping finished documents and not to the open-document dialog
- Added default setting for this to the project settings annotation panel
- Same for curation open document dialog, curation document navigator and curation settings

**How to test manually**
* Try if/how the toggle in the document open dialog affects navigation on annotation / curation page
* Check if the default setting in the project settings properly apply

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
