### PR TITLE
#5509 - Support document-level annotations in auto-curation

### DIFF
--- a/inception/inception-curation/pom.xml
+++ b/inception/inception-curation/pom.xml
@@ -110,6 +110,11 @@
       <artifactId>inception-api-editor</artifactId>
     </dependency>
     <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-layer-docmetadata</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>

--- a/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/merge/CasMergeDocument.java
+++ b/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/merge/CasMergeDocument.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.curation.merge;
+
+import static de.tudarmstadt.ukp.clarin.webanno.model.LinkMode.NONE;
+import static de.tudarmstadt.ukp.inception.curation.merge.CasMerge.copyFeatures;
+import static de.tudarmstadt.ukp.inception.curation.merge.CasMergeOperationResult.ResultState.CREATED;
+import static de.tudarmstadt.ukp.inception.curation.merge.CasMergeOperationResult.ResultState.UPDATED;
+import static de.tudarmstadt.ukp.inception.support.uima.ICasUtil.getAddr;
+
+import java.util.stream.Stream;
+
+import org.apache.uima.cas.CAS;
+import org.apache.uima.cas.text.AnnotationFS;
+import org.apache.uima.jcas.cas.AnnotationBase;
+import org.apache.uima.jcas.tcas.Annotation;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
+import de.tudarmstadt.ukp.inception.schema.api.adapter.AnnotationException;
+import de.tudarmstadt.ukp.inception.schema.api.adapter.TypeAdapter;
+import de.tudarmstadt.ukp.inception.ui.core.docanno.layer.CreateDocumentAnnotationRequest;
+import de.tudarmstadt.ukp.inception.ui.core.docanno.layer.DocumentMetadataLayerAdapter;
+import de.tudarmstadt.ukp.inception.ui.core.docanno.layer.DocumentMetadataLayerTraits;
+
+class CasMergeDocument
+{
+    static CasMergeOperationResult mergeDocumentAnnotation(CasMergeContext aContext,
+            SourceDocument aDocument, String aDataOwner, AnnotationLayer aAnnotationLayer,
+            CAS aTargetCas, AnnotationBase aSourceFs)
+        throws AnnotationException
+    {
+        var adapter = (DocumentMetadataLayerAdapter) aContext.getAdapter(aAnnotationLayer);
+        if (aContext.isSilenceEvents()) {
+            adapter.silenceEvents();
+        }
+
+        var allowStacking = !adapter.getTraits(DocumentMetadataLayerTraits.class)
+                .map(DocumentMetadataLayerTraits::isSingleton).orElse(false);
+
+        if (existsEquivalent(aTargetCas, adapter, aSourceFs)) {
+            throw new AlreadyMergedException(
+                    "The annotation already exists in the target document.");
+        }
+
+        // a) if stacking allowed add this new annotation to the merge view
+        var targetType = adapter.getAnnotationType(aTargetCas).get();
+        var existingAnnos = aTargetCas.select(targetType);
+        if (existingAnnos.isEmpty() || allowStacking) {
+            // Create the annotation via the adapter - this also takes care of attaching to an
+            // annotation if necessary
+            var mergedAnn = adapter.handle(CreateDocumentAnnotationRequest.builder() //
+                    .withDocument(aDocument, aDataOwner, aTargetCas) //
+                    .build());
+
+            var mergedSpanAddr = -1;
+            try {
+                copyFeatures(aContext, aDocument, aDataOwner, adapter, mergedAnn, aSourceFs);
+                mergedSpanAddr = getAddr(mergedAnn);
+            }
+            catch (AnnotationException e) {
+                // If there was an error while setting the features, then we skip the entire
+                // annotation
+                adapter.delete(aDocument, aDataOwner, aTargetCas, VID.of(mergedAnn));
+                throw e;
+            }
+            return new CasMergeOperationResult(CREATED, mergedSpanAddr);
+        }
+        // b) if stacking is not allowed, modify the existing annotation with this one
+        else {
+            var annoToUpdate = existingAnnos.get(0);
+            copyFeatures(aContext, aDocument, aDataOwner, adapter, annoToUpdate, aSourceFs);
+            var mergedSpanAddr = getAddr(annoToUpdate);
+            return new CasMergeOperationResult(UPDATED, mergedSpanAddr);
+        }
+    }
+
+    static Stream<Annotation> selectCandidateSpansAt(CAS aTargetCas, TypeAdapter aAdapter,
+            AnnotationFS aOriginal)
+    {
+        var targetType = aAdapter.getAnnotationType(aTargetCas);
+        if (targetType.isEmpty()) {
+            return Stream.empty();
+        }
+
+        return aTargetCas.<Annotation> select(targetType.get()) //
+                .at(aOriginal.getBegin(), aOriginal.getEnd()) //
+                .sorted((a, b) -> aAdapter.countNonEqualFeatures(a, b,
+                        (fs, f) -> f.getLinkMode() == NONE));
+    }
+
+    private static boolean existsEquivalent(CAS aTargetCas, TypeAdapter aAdapter,
+            AnnotationBase aOriginal)
+    {
+        var targetType = aAdapter.getAnnotationType(aTargetCas);
+        if (targetType.isEmpty()) {
+            return false;
+        }
+
+        return aTargetCas.<AnnotationBase> select(targetType.get()) //
+                .anyMatch(fs -> aAdapter.isEquivalentAnnotation(fs, aOriginal));
+    }
+}

--- a/inception/inception-curation/src/test/java/de/tudarmstadt/ukp/inception/curation/merge/CasMergeDocumentTest.java
+++ b/inception/inception-curation/src/test/java/de/tudarmstadt/ukp/inception/curation/merge/CasMergeDocumentTest.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.curation.merge;
+
+import static de.tudarmstadt.ukp.inception.support.uima.FeatureStructureBuilder.buildFS;
+import static java.util.Arrays.asList;
+import static org.apache.uima.fit.util.FSUtil.getFeature;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import org.apache.uima.UIMAFramework;
+import org.apache.uima.cas.CAS;
+import org.apache.uima.fit.factory.CasFactory;
+import org.apache.uima.fit.factory.TypeSystemDescriptionFactory;
+import org.apache.uima.jcas.cas.AnnotationBase;
+import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.util.CasCreationUtils;
+import org.junit.jupiter.api.Test;
+
+import de.tudarmstadt.ukp.inception.schema.api.adapter.AnnotationException;
+import de.tudarmstadt.ukp.inception.support.json.JSONUtil;
+import de.tudarmstadt.ukp.inception.ui.core.docanno.layer.DocumentMetadataLayerTraits;
+
+class CasMergeDocumentTest
+    extends CasMergeTestBase
+{
+    private static final String DUMMY_USER = "dummyTargetUser";
+
+    @Test
+    void simpleCopyToEmptyTest() throws Exception
+    {
+        var sourceCas = createCas();
+        var sourceFS = createDocumentLabel(sourceCas, "NN");
+
+        var targetCas = createCas();
+
+        sut.mergeDocumentAnnotation(document, DUMMY_USER, documentLabelLayer, targetCas, sourceFS);
+
+        assertThat(targetCas.select(documentLabelLayer.getName()).asList()) //
+                .hasSize(1);
+    }
+
+    @Test
+    void simpleCopyToSameExistingAnnoTest() throws Exception
+    {
+        var sourceCas = createCas();
+        var sourceFS = createDocumentLabel(sourceCas, "NN");
+
+        var targetCas = createCas();
+        buildFS(targetCas, DOCUMENT_LABEL_TYPE) //
+                .withFeature("label", getFeature(sourceFS, "label", String.class)) //
+                .buildAndAddToIndexes();
+
+        assertThatExceptionOfType(AnnotationException.class) //
+                .isThrownBy(() -> sut.mergeDocumentAnnotation(document, DUMMY_USER,
+                        documentLabelLayer, targetCas, sourceFS))
+                .withMessageContaining("annotation already exists");
+    }
+
+    @Test
+    void simpleCopyToDiffExistingAnnoWithNoStackingTest() throws Exception
+    {
+        var sourceCas = createCas();
+        var sourceFS = createDocumentLabel(sourceCas, "NN");
+
+        var traits = new DocumentMetadataLayerTraits();
+        traits.setSingleton(true);
+        documentLabelLayer.setTraits(JSONUtil.toJsonString(traits));
+
+        var targetCas = createCas();
+        buildFS(targetCas, DOCUMENT_LABEL_TYPE) //
+                .withFeature("label", "NE") //
+                .buildAndAddToIndexes();
+
+        sut.mergeDocumentAnnotation(document, DUMMY_USER, documentLabelLayer, targetCas, sourceFS);
+
+        assertThat(targetCas.select(documentLabelLayer.getName()).asList()) //
+                .as("Target feature value should be overwritten by source feature value")
+                .extracting( //
+                        a -> getFeature(a, "label", String.class))
+                .containsExactly( //
+                        getFeature(sourceFS, "label", String.class));
+    }
+
+    @Test
+    void simpleCopyToDiffExistingAnnoWithStackingTest() throws Exception
+    {
+        var sourceCas = createCas();
+        var sourceFS = createDocumentLabel(sourceCas, "NN");
+
+        var targetCas = createCas();
+        var existingFs = buildFS(targetCas, DOCUMENT_LABEL_TYPE) //
+                .withFeature("label", "NE") //
+                .buildAndAddToIndexes();
+
+        sut.mergeDocumentAnnotation(document, DUMMY_USER, documentLabelLayer, targetCas, sourceFS);
+
+        assertThat(targetCas.select(documentLabelLayer.getName()).asList()) //
+                .as("Source FS should be added alongside existing FS in target") //
+                .extracting( //
+                        a -> getFeature(a, "label", String.class))
+                .containsExactlyInAnyOrder( //
+                        getFeature(existingFs, "label", String.class),
+                        getFeature(sourceFS, "label", String.class));
+    }
+
+    private CAS createCas() throws ResourceInitializationException
+    {
+        var tsd = UIMAFramework.getResourceSpecifierFactory().createTypeSystemDescription();
+        var dld = tsd.addType(documentLabelLayer.getName(), "", CAS.TYPE_NAME_ANNOTATION_BASE);
+        dld.addFeature("label", "", CAS.TYPE_NAME_STRING);
+        dld.addFeature("i7n_uiOrder", "", CAS.TYPE_NAME_INTEGER);
+        var fullTsd = CasCreationUtils.mergeTypeSystems( //
+                asList(tsd, TypeSystemDescriptionFactory.createTypeSystemDescription()));
+        return CasFactory.createCas(fullTsd);
+    }
+
+    private AnnotationBase createDocumentLabel(CAS aCas, String aLabel)
+    {
+        return (AnnotationBase) buildFS(aCas, documentLabelLayer.getName()) //
+                .withFeature("label", aLabel) //
+                .buildAndAddToIndexes();
+    }
+}

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/layer/CreateDocumentAnnotationRequest.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/layer/CreateDocumentAnnotationRequest.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.core.docanno.layer;
+
+import org.apache.uima.cas.CAS;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+
+public class CreateDocumentAnnotationRequest
+    extends DocumentAnnotationRequest_ImplBase<CreateDocumentAnnotationRequest>
+{
+    private CreateDocumentAnnotationRequest(Builder builder)
+    {
+        super(builder.original, builder.document, builder.documentOwner, builder.cas);
+    }
+
+    @Override
+    public CreateDocumentAnnotationRequest changeSpan(int aBegin, int aEnd,
+            AnchoringMode aAnchoringMode)
+    {
+        return CreateDocumentAnnotationRequest.builder() //
+                .withOriginal(this) //
+                .withDocument(getDocument(), getDocumentOwner(), getCas()) //
+                .build();
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static final class Builder
+    {
+        private CreateDocumentAnnotationRequest original;
+        private SourceDocument document;
+        private String documentOwner;
+        private CAS cas;
+
+        private Builder()
+        {
+        }
+
+        public Builder withOriginal(CreateDocumentAnnotationRequest aOriginal)
+        {
+            original = aOriginal;
+            return this;
+        }
+
+        public Builder withDocument(SourceDocument aDocument)
+        {
+            document = aDocument;
+            return this;
+        }
+
+        public Builder withDataOwner(String aDocumentOwner)
+        {
+            documentOwner = aDocumentOwner;
+            return this;
+        }
+
+        public Builder withCas(CAS aCas)
+        {
+            cas = aCas;
+            return this;
+        }
+
+        public Builder withDocument(SourceDocument aDocument, String aDocumentOwner, CAS aCas)
+        {
+            document = aDocument;
+            documentOwner = aDocumentOwner;
+            cas = aCas;
+            return this;
+        }
+
+        public CreateDocumentAnnotationRequest build()
+        {
+            return new CreateDocumentAnnotationRequest(this);
+        }
+    }
+}

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/layer/DocumentAnnotationRequest_ImplBase.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/layer/DocumentAnnotationRequest_ImplBase.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.core.docanno.layer;
+
+import java.util.Optional;
+
+import org.apache.uima.cas.CAS;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+
+public abstract class DocumentAnnotationRequest_ImplBase<T extends DocumentAnnotationRequest_ImplBase<T>>
+{
+    private final SourceDocument document;
+    private final String documentOwner;
+    private final CAS cas;
+    private final T originalRequest;
+
+    public DocumentAnnotationRequest_ImplBase(SourceDocument aDocument, String aDocumentOwner,
+            CAS aCas)
+    {
+        this(null, aDocument, aDocumentOwner, aCas);
+    }
+
+    protected DocumentAnnotationRequest_ImplBase(T aOriginal, SourceDocument aDocument,
+            String aDocumentOwner, CAS aCas)
+    {
+        originalRequest = aOriginal;
+        document = aDocument;
+        documentOwner = aDocumentOwner;
+        cas = aCas;
+    }
+
+    public SourceDocument getDocument()
+    {
+        return document;
+    }
+
+    public String getDocumentOwner()
+    {
+        return documentOwner;
+    }
+
+    public CAS getCas()
+    {
+        return cas;
+    }
+
+    public Optional<T> getOriginalRequest()
+    {
+        return Optional.ofNullable(originalRequest);
+    }
+
+    public abstract T changeSpan(int aBegin, int aEnd, AnchoringMode aAnchoringMode);
+}

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/layer/DocumentMetadataLayerAdapter.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/layer/DocumentMetadataLayerAdapter.java
@@ -34,6 +34,7 @@ import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.FeatureStructure;
 import org.apache.uima.cas.text.AnnotationFS;
 import org.apache.uima.fit.util.FSUtil;
+import org.apache.uima.jcas.cas.AnnotationBase;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 
@@ -112,12 +113,12 @@ public class DocumentMetadataLayerAdapter
      * @throws AnnotationException
      *             if the annotation cannot be created/updated.
      */
-    public AnnotationBaseFS add(SourceDocument aDocument, String aUsername, CAS aCas)
+    public AnnotationBase add(SourceDocument aDocument, String aUsername, CAS aCas)
         throws AnnotationException
     {
         var type = getType(aCas, getAnnotationTypeName());
 
-        AnnotationBaseFS newAnnotation = aCas.createFS(type);
+        AnnotationBase newAnnotation = aCas.createFS(type);
         var maxOrder = aCas.select(type) //
                 .mapToInt(fs -> FSUtil.getFeature(fs, FEATURE_NAME_ORDER, Integer.class)) //
                 .max() //
@@ -189,14 +190,23 @@ public class DocumentMetadataLayerAdapter
                     + "] but got [" + aFS2.getType().getName() + "]");
         }
 
-        if (aFS1 instanceof AnnotationBaseFS ann1 && aFS2 instanceof AnnotationBaseFS ann2) {
-            if (aFS1 == aFS2) {
-                return true;
-            }
-
-            return ann1.getView() == ann2.getView();
+        if (aFS1 instanceof AnnotationBaseFS && aFS2 instanceof AnnotationBaseFS) {
+            return true;
+            // if (aFS1 == aFS2) {
+            // return true;
+            // }
+            //
+            // return Objects.equals(ann1.getView().getViewName(), ann2.getView().getViewName());
         }
 
         throw new IllegalArgumentException("Feature structures need to be AnnotationBaseFS");
+    }
+
+    public AnnotationBase handle(CreateDocumentAnnotationRequest aCreateDocumentAnnotationRequest)
+        throws AnnotationException
+    {
+        return add(aCreateDocumentAnnotationRequest.getDocument(),
+                aCreateDocumentAnnotationRequest.getDocumentOwner(),
+                aCreateDocumentAnnotationRequest.getCas());
     }
 }

--- a/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/adapter/TypeAdapter.java
+++ b/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/adapter/TypeAdapter.java
@@ -236,7 +236,7 @@ public interface TypeAdapter
 
     <T> Optional<T> getFeatureTraits(AnnotationFeature aFeature, Class<T> aInterface);
 
-    default boolean isEquivalentAnnotation(AnnotationFS aFS1, AnnotationFS aFS2)
+    default boolean isEquivalentAnnotation(FeatureStructure aFS1, FeatureStructure aFS2)
     {
         if (!isSamePosition(aFS1, aFS2)) {
             return false;


### PR DESCRIPTION
**What's in the PR**
- Added the merge implementation

**How to test manually**
* Add document-level annotations with different annotators and mark the documents as finished
* Open the document in the integrated curation page (should trigger auto-merging the first time)
* also try the bulk-processing auto-curation

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
