### PR TITLE
#5527 - Export labels across documents in JSON and CSV formats to facilitate external processing

### DIFF
--- a/inception/inception-agreement/pom.xml
+++ b/inception/inception-agreement/pom.xml
@@ -133,11 +133,6 @@
       <artifactId>dkpro-statistics-agreement</artifactId>
     </dependency>
     
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-    </dependency>
-
     <!-- Spring dependencies -->
     <dependency>
       <groupId>org.springframework</groupId>
@@ -211,6 +206,12 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-layer-span</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-constraints</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
@@ -269,12 +270,6 @@
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-layer-chain</artifactId>
-      <version>${project.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
-      <artifactId>inception-layer-span</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/AgreementMeasureSupport.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/measures/AgreementMeasureSupport.java
@@ -39,6 +39,8 @@ public interface AgreementMeasureSupport<//
     /**
      * Checks whether the given feature is supported by the current agreement measure support.
      * 
+     * @param aLayer
+     *            a layer definition.
      * @param aFeature
      *            a feature definition.
      * @return whether the given feature is supported by the current agreement measure support.

--- a/inception/inception-documents-api/pom.xml
+++ b/inception/inception-documents-api/pom.xml
@@ -67,6 +67,10 @@
       <artifactId>spring-context</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-core</artifactId>
     </dependency>

--- a/inception/inception-documents-api/src/main/java/de/tudarmstadt/ukp/inception/documents/api/export/CrossDocumentExporter.java
+++ b/inception/inception-documents-api/src/main/java/de/tudarmstadt/ukp/inception/documents/api/export/CrossDocumentExporter.java
@@ -15,40 +15,39 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package de.tudarmstadt.ukp.clarin.webanno.agreement;
+package de.tudarmstadt.ukp.inception.documents.api.export;
 
+import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
 
-import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.DefaultAgreementTraits;
+import org.springframework.http.MediaType;
+
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
-import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.inception.support.extensionpoint.ExtensionPoint_ImplBase;
 
-public interface AgreementService
+public interface CrossDocumentExporter
 {
-    Map<SourceDocument, List<AnnotationDocument>> getDocumentsToEvaluate(Project aProject,
-            List<SourceDocument> aDocuments, DefaultAgreementTraits aTraits);
+    static final String EXT_CSV = ".csv";
+    static final String EXT_JSON = ".json";
 
     /**
-     * 
-     * @param aOut
-     *            target stream
-     * @param aLayer
-     *            the layer to diff.
-     * @param aFeature
-     *            the feature to diff. If this is null, then the diff is only based on positions.
-     * @param aTraits
-     *            the diff settings
-     * @param aDocuments
-     *            the documents to diff
-     * @param aAnnotators
-     *            the annotators to diff
+     * @return identifier for the extension unique within the respective
+     *         {@link ExtensionPoint_ImplBase}.
      */
-    void exportDiff(OutputStream aOut, AnnotationLayer aLayer, AnnotationFeature aFeature,
-            DefaultAgreementTraits aTraits, List<SourceDocument> aDocuments,
-            List<String> aAnnotators);
+    String getId();
+
+    boolean accepts(AnnotationLayer aLayer, AnnotationFeature aFeature);
+
+    void export(OutputStream aOut, AnnotationLayer aLayer, AnnotationFeature aFeature,
+            Map<SourceDocument, List<AnnotationDocument>> aAllAnnDocs, List<String> aAnnotators)
+        throws IOException;
+
+    String getFileExtension();
+
+    MediaType getMediaType();
 }

--- a/inception/inception-documents-api/src/main/java/de/tudarmstadt/ukp/inception/documents/api/export/CrossDocumentExporterRegistry.java
+++ b/inception/inception-documents-api/src/main/java/de/tudarmstadt/ukp/inception/documents/api/export/CrossDocumentExporterRegistry.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.documents.api.export;
+
+import java.util.List;
+import java.util.Optional;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+
+public interface CrossDocumentExporterRegistry
+{
+    List<CrossDocumentExporter> getExtensions();
+
+    List<CrossDocumentExporter> getExtensions(AnnotationLayer aLayer, AnnotationFeature aFeature);
+
+    <X extends CrossDocumentExporter> Optional<X> getExtension(String aId);
+
+}

--- a/inception/inception-documents-api/src/main/java/de/tudarmstadt/ukp/inception/documents/api/export/CrossDocumentExporter_ImplBase.java
+++ b/inception/inception-documents-api/src/main/java/de/tudarmstadt/ukp/inception/documents/api/export/CrossDocumentExporter_ImplBase.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.documents.api.export;
+
+import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode.SHARED_READ_ONLY_ACCESS;
+import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasUpgradeMode.AUTO_CAS_UPGRADE;
+import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.CURATION_FINISHED;
+import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.CURATION_IN_PROGRESS;
+import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.CURATION_USER;
+import static java.util.Arrays.asList;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.uima.cas.CAS;
+import org.springframework.http.MediaType;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
+
+public abstract class CrossDocumentExporter_ImplBase
+    implements CrossDocumentExporter
+{
+    protected static final MediaType MEDIA_TYPE_TEXT_CSV = MediaType.valueOf("text/csv");
+
+    protected final DocumentService documentService;
+
+    public CrossDocumentExporter_ImplBase(DocumentService aDocumentService)
+    {
+        documentService = aDocumentService;
+    }
+
+    @Override
+    public String getId()
+    {
+        return getClass().getName();
+    }
+
+    private CAS loadInitialCas(SourceDocument aDocument) throws IOException
+    {
+        return documentService.createOrReadInitialCas(aDocument, AUTO_CAS_UPGRADE,
+                SHARED_READ_ONLY_ACCESS);
+    }
+
+    private CAS loadCas(SourceDocument aDocument, String aDataOwner) throws IOException
+    {
+        return documentService.readAnnotationCas(aDocument, aDataOwner, AUTO_CAS_UPGRADE,
+                SHARED_READ_ONLY_ACCESS);
+    }
+
+    protected CAS loadCasOrInitialCas(SourceDocument aDocument, String aDataOwner,
+            List<AnnotationDocument> aAnnDocs)
+        throws IOException
+    {
+        // If the annotation document belongs to the curation user but the curation has not
+        // even started yet, then we load the initial CAS.
+        if (CURATION_USER.equals(aDataOwner)) {
+            if (!asList(CURATION_IN_PROGRESS, CURATION_FINISHED).contains(aDocument.getState())) {
+                return loadInitialCas(aDocument);
+            }
+
+            return loadCas(aDocument, aDataOwner);
+        }
+
+        // If the there is no annotation document for the data owner it implies that the
+        // annotation state is NEW - so we load the initial CAS.
+        if (aAnnDocs.stream().noneMatch(annDoc -> aDataOwner.equals(annDoc.getUser()))) {
+            return loadInitialCas(aDocument);
+        }
+
+        // If there is no CAS for the data owner, it also implies that the
+        // annotation state is NEW - so we load the initial CAS.
+        if (!documentService.existsCas(aDocument, aDataOwner)) {
+            return loadInitialCas(aDocument);
+        }
+
+        return loadCas(aDocument, aDataOwner);
+    }
+}

--- a/inception/inception-documents/pom.xml
+++ b/inception/inception-documents/pom.xml
@@ -112,6 +112,10 @@
 
     <dependency>
       <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
       <artifactId>spring-tx</artifactId>
     </dependency>
     <dependency>

--- a/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/config/DocumentServiceAutoConfiguration.java
+++ b/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/config/DocumentServiceAutoConfiguration.java
@@ -17,9 +17,13 @@
  */
 package de.tudarmstadt.ukp.inception.documents.config;
 
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasStorageService;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.DocumentImportExportService;
@@ -32,6 +36,9 @@ import de.tudarmstadt.ukp.inception.documents.api.DocumentAccess;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentStorageService;
 import de.tudarmstadt.ukp.inception.documents.api.RepositoryProperties;
+import de.tudarmstadt.ukp.inception.documents.api.export.CrossDocumentExporter;
+import de.tudarmstadt.ukp.inception.documents.api.export.CrossDocumentExporterRegistry;
+import de.tudarmstadt.ukp.inception.documents.exporters.CrossDocumentExporterRegistryImpl;
 import de.tudarmstadt.ukp.inception.documents.exporters.SourceDocumentExporter;
 import de.tudarmstadt.ukp.inception.project.api.ProjectService;
 import jakarta.persistence.EntityManager;
@@ -80,5 +87,12 @@ public class DocumentServiceAutoConfiguration
             DocumentStorageServiceImpl aDocumentStorageService)
     {
         return new DocumentFootprintProvider(aDocumentStorageService);
+    }
+
+    @Bean
+    public CrossDocumentExporterRegistry crossDocumentExporterRegistry(
+            @Lazy @Autowired(required = false) List<CrossDocumentExporter> aExtensions)
+    {
+        return new CrossDocumentExporterRegistryImpl(aExtensions);
     }
 }

--- a/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/exporters/CrossDocumentExporterRegistryImpl.java
+++ b/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/exporters/CrossDocumentExporterRegistryImpl.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.documents.exporters;
+
+import static de.tudarmstadt.ukp.inception.support.logging.BaseLoggers.BOOT_LOG;
+import static java.lang.invoke.MethodHandles.lookup;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.unmodifiableList;
+import static java.util.stream.Collectors.toList;
+import static org.apache.commons.lang3.ClassUtils.getAbbreviatedName;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.core.annotation.AnnotationAwareOrderComparator;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.inception.documents.api.export.CrossDocumentExporter;
+import de.tudarmstadt.ukp.inception.documents.api.export.CrossDocumentExporterRegistry;
+
+public class CrossDocumentExporterRegistryImpl
+    implements CrossDocumentExporterRegistry
+{
+    private static final Logger LOG = getLogger(lookup().lookupClass());
+
+    private final List<CrossDocumentExporter> extensionsListProxy;
+
+    private List<CrossDocumentExporter> extensionsList;
+
+    public CrossDocumentExporterRegistryImpl(
+            @Lazy @Autowired(required = false) List<CrossDocumentExporter> aExtensions)
+    {
+        extensionsListProxy = aExtensions;
+    }
+
+    @EventListener
+    public void onContextRefreshedEvent(ContextRefreshedEvent aEvent)
+    {
+        init();
+    }
+
+    public void init()
+    {
+        var extensions = new ArrayList<CrossDocumentExporter>();
+
+        if (extensionsListProxy != null) {
+            extensions.addAll(extensionsListProxy);
+            extensions.sort(makeComparator());
+
+            for (var fs : extensions) {
+                LOG.debug("Found {} extension: {}", getClass().getSimpleName(),
+                        getAbbreviatedName(fs.getClass(), 20));
+            }
+        }
+
+        BOOT_LOG.info("Found [{}] {} extensions", extensions.size(), getClass().getSimpleName());
+
+        extensionsList = unmodifiableList(extensions);
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    protected Comparator<CrossDocumentExporter> makeComparator()
+    {
+        return (Comparator) AnnotationAwareOrderComparator.INSTANCE;
+    }
+
+    @Override
+    public List<CrossDocumentExporter> getExtensions()
+    {
+        if (extensionsList == null) {
+            LOG.error(
+                    "List of extensions was accessed on this extension point before the extension "
+                            + "point was initialized!",
+                    new IllegalStateException());
+            return emptyList();
+        }
+
+        return extensionsList;
+    }
+
+    @Override
+    public List<CrossDocumentExporter> getExtensions(AnnotationLayer aLayer,
+            AnnotationFeature aFeature)
+    {
+        return getExtensions().stream() //
+                .filter(e -> e.accepts(aLayer, aFeature)) //
+                .collect(toList());
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public <X extends CrossDocumentExporter> Optional<X> getExtension(String aId)
+    {
+        return (Optional<X>) getExtensions().stream() //
+                .filter(fs -> fs.getId().equals(aId)) //
+                .findFirst();
+    }
+}

--- a/inception/inception-layer-chain-api/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/chain/ChainAdapter.java
+++ b/inception/inception-layer-chain-api/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/chain/ChainAdapter.java
@@ -24,6 +24,7 @@ import de.tudarmstadt.ukp.inception.annotation.layer.span.CreateSpanAnnotationRe
 import de.tudarmstadt.ukp.inception.rendering.selection.Selection;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.AnnotationException;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.TypeAdapter;
+import de.tudarmstadt.ukp.inception.support.WebAnnoConst;
 
 /**
  * Manage interactions with annotations on a chain layer.
@@ -35,7 +36,10 @@ public interface ChainAdapter
     public static final String LINK = "Link";
     public static final String FEAT_FIRST = "first";
     public static final String FEAT_NEXT = "next";
-    
+
+    public static final String ARC_LABEL_FEATURE = WebAnnoConst.COREFERENCE_RELATION_FEATURE;
+    public static final String SPAN_LABEL_FEATURE = WebAnnoConst.COREFERENCE_TYPE_FEATURE;
+
     String getChainTypeName();
 
     String getChainFirstFeatureName();

--- a/inception/inception-layer-chain/pom.xml
+++ b/inception/inception-layer-chain/pom.xml
@@ -15,7 +15,9 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>de.tudarmstadt.ukp.inception.app</groupId>
@@ -85,7 +87,17 @@
       <artifactId>inception-log</artifactId>
       <version>${project.version}</version>
     </dependency>
-    
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-documents-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-annotation-storage-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
     <dependency>
       <groupId>org.apache.uima</groupId>
       <artifactId>uimaj-core</artifactId>
@@ -99,10 +111,22 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-csv</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
@@ -130,7 +154,13 @@
       <groupId>org.danekja</groupId>
       <artifactId>jdk-serializable-functional</artifactId>
     </dependency>
-    
+
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-layer-behavior</artifactId>

--- a/inception/inception-layer-chain/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/chain/ChainAdapterImpl.java
+++ b/inception/inception-layer-chain/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/chain/ChainAdapterImpl.java
@@ -17,8 +17,6 @@
  */
 package de.tudarmstadt.ukp.inception.annotation.layer.chain;
 
-import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.COREFERENCE_RELATION_FEATURE;
-import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.COREFERENCE_TYPE_FEATURE;
 import static de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil.isSame;
 import static java.lang.System.currentTimeMillis;
 import static java.util.Collections.emptyList;
@@ -94,6 +92,7 @@ public class ChainAdapterImpl
         }
     }
 
+    @Override
     public AnnotationFS handle(CreateSpanAnnotationRequest aRequest) throws AnnotationException
     {
         var request = aRequest;
@@ -505,7 +504,7 @@ public class ChainAdapterImpl
     {
         var relationFeature = new AnnotationFeature();
         relationFeature.setType(CAS.TYPE_NAME_STRING);
-        relationFeature.setName(COREFERENCE_RELATION_FEATURE);
+        relationFeature.setName(ARC_LABEL_FEATURE);
         relationFeature.setLayer(getLayer());
         relationFeature.setEnabled(true);
         relationFeature.setUiName("Reference Relation");
@@ -515,7 +514,7 @@ public class ChainAdapterImpl
 
         var typeFeature = new AnnotationFeature();
         typeFeature.setType(CAS.TYPE_NAME_STRING);
-        typeFeature.setName(COREFERENCE_TYPE_FEATURE);
+        typeFeature.setName(SPAN_LABEL_FEATURE);
         typeFeature.setLayer(getLayer());
         typeFeature.setEnabled(true);
         typeFeature.setUiName("Reference Type");
@@ -552,6 +551,7 @@ public class ChainAdapterImpl
         return selection;
     }
 
+    @Override
     public Selection selectSpan(AnnotationFS aAnno)
     {
         var selection = new Selection();
@@ -559,6 +559,7 @@ public class ChainAdapterImpl
         return selection;
     }
 
+    @Override
     public Selection selectLink(AnnotationFS aAnno)
     {
         var selection = new Selection();

--- a/inception/inception-layer-chain/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/chain/ChainRenderer.java
+++ b/inception/inception-layer-chain/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/chain/ChainRenderer.java
@@ -66,7 +66,7 @@ public class ChainRenderer
             behaviors = emptyList();
         }
         else {
-            List<SpanLayerBehavior> temp = new ArrayList<>(aBehaviors);
+            var temp = new ArrayList<SpanLayerBehavior>(aBehaviors);
             AnnotationAwareOrderComparator.sort(temp);
             behaviors = temp;
         }

--- a/inception/inception-layer-chain/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/chain/config/ChainLayerAutoConfiguration.java
+++ b/inception/inception-layer-chain/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/chain/config/ChainLayerAutoConfiguration.java
@@ -25,7 +25,11 @@ import de.tudarmstadt.ukp.clarin.webanno.constraints.ConstraintsService;
 import de.tudarmstadt.ukp.inception.annotation.layer.behaviors.LayerBehaviorRegistry;
 import de.tudarmstadt.ukp.inception.annotation.layer.chain.ChainLayerSupport;
 import de.tudarmstadt.ukp.inception.annotation.layer.chain.ChainLayerSupportImpl;
+import de.tudarmstadt.ukp.inception.annotation.layer.chain.export.ChainLayerToCsvExporter;
+import de.tudarmstadt.ukp.inception.annotation.layer.chain.export.ChainLayerToJsonExporter;
 import de.tudarmstadt.ukp.inception.annotation.layer.chain.undo.ChainAnnotationActionUndoSupport;
+import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
+import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureSupportRegistry;
 
 @Configuration
@@ -39,10 +43,24 @@ public class ChainLayerAutoConfiguration
         return new ChainLayerSupportImpl(aFeatureSupportRegistry, aEventPublisher,
                 aLayerBehaviorsRegistry, aConstraintsService);
     }
-    
+
     @Bean
     public ChainAnnotationActionUndoSupport chainAnnotationActionUndoSupport()
     {
         return new ChainAnnotationActionUndoSupport();
+    }
+
+    @Bean
+    public ChainLayerToJsonExporter chainLayerToJsonExporter(AnnotationSchemaService aSchemaService,
+            DocumentService aDocumentService)
+    {
+        return new ChainLayerToJsonExporter(aSchemaService, aDocumentService);
+    }
+
+    @Bean
+    public ChainLayerToCsvExporter chainLayerToCsvExporter(AnnotationSchemaService aSchemaService,
+            DocumentService aDocumentService)
+    {
+        return new ChainLayerToCsvExporter(aSchemaService, aDocumentService);
     }
 }

--- a/inception/inception-layer-chain/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/chain/export/ChainLayerToCsvExporter.java
+++ b/inception/inception-layer-chain/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/chain/export/ChainLayerToCsvExporter.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.annotation.layer.chain.export;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.asList;
+import static java.util.Arrays.fill;
+import static java.util.Comparator.comparing;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import org.apache.uima.cas.text.AnnotationFS;
+import org.springframework.http.MediaType;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.inception.annotation.layer.chain.ChainAdapter;
+import de.tudarmstadt.ukp.inception.annotation.layer.chain.ChainLayerSupport;
+import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
+import de.tudarmstadt.ukp.inception.documents.api.export.CrossDocumentExporter_ImplBase;
+import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
+
+public class ChainLayerToCsvExporter
+    extends CrossDocumentExporter_ImplBase
+{
+    private final AnnotationSchemaService schemaService;
+
+    public ChainLayerToCsvExporter(AnnotationSchemaService aSchemaService,
+            DocumentService aDocumentService)
+    {
+        super(aDocumentService);
+        schemaService = aSchemaService;
+    }
+
+    @Override
+    public boolean accepts(AnnotationLayer aLayer, AnnotationFeature aFeature)
+    {
+        return ChainLayerSupport.TYPE.equals(aLayer.getType());
+    }
+
+    @Override
+    public void export(OutputStream aOut, AnnotationLayer aLayer, AnnotationFeature aFeature,
+            Map<SourceDocument, List<AnnotationDocument>> allAnnDocs, List<String> aAnnotators)
+        throws IOException
+    {
+        var docs = allAnnDocs.keySet().stream() //
+                .sorted(comparing(SourceDocument::getName)) //
+                .toList();
+
+        var adapter = (ChainAdapter) schemaService.getAdapter(aLayer);
+
+        var headers = new ArrayList<String>();
+        headers.addAll(asList("doc", "user", "chain", "index", "begin", "end", "text", "label"));
+        if (adapter.isLinkedListBehavior()) {
+            headers.add("link_label");
+        }
+
+        var rec = new Object[headers.size()];
+
+        try (var writer = new OutputStreamWriter(aOut, UTF_8);
+                var csvPrinter = new CSVPrinter(writer, CSVFormat.DEFAULT.builder()
+                        .setHeader(headers.toArray(String[]::new)).get())) {
+
+            for (var doc : docs) {
+                var annDocs = allAnnDocs.get(doc);
+                try (var session = CasStorageSession.openNested()) {
+                    for (var dataOwner : aAnnotators) {
+                        var cas = loadCasOrInitialCas(doc, dataOwner, annDocs);
+                        if (cas.getTypeSystem().getType(adapter.getChainTypeName()) == null) {
+                            // If the types are not defined, then we do not need to try and render
+                            // them because the CAS does not contain any instances of them
+                            continue;
+                        }
+
+                        var chainFirst = cas.getTypeSystem().getType(adapter.getChainTypeName())
+                                .getFeatureByBaseName(adapter.getChainFirstFeatureName());
+                        var spanLabelFeature = cas.getTypeSystem()
+                                .getType(adapter.getAnnotationTypeName())
+                                .getFeatureByBaseName(ChainAdapter.SPAN_LABEL_FEATURE);
+                        var arcLabelFeature = cas.getTypeSystem()
+                                .getType(adapter.getAnnotationTypeName())
+                                .getFeatureByBaseName(ChainAdapter.ARC_LABEL_FEATURE);
+
+                        var chainId = 1;
+                        for (var chainFs : cas.select(adapter.getChainTypeName())) {
+                            var linkFs = (AnnotationFS) chainFs.getFeatureValue(chainFirst);
+                            if (linkFs == null) {
+                                continue; // Skip empty chains
+                            }
+
+                            fill(rec, null);
+
+                            rec[0] = doc.getName();
+                            rec[1] = dataOwner;
+                            rec[2] = chainId;
+
+                            // Iterate over the links of the chain
+                            var linkIndex = 1;
+                            while (linkFs != null) {
+                                var linkNext = linkFs.getType()
+                                        .getFeatureByBaseName(adapter.getLinkNextFeatureName());
+                                var nextLinkFs = (AnnotationFS) linkFs.getFeatureValue(linkNext);
+
+                                rec[3] = linkIndex;
+                                rec[4] = linkFs.getBegin();
+                                rec[5] = linkFs.getEnd();
+                                rec[6] = linkFs.getCoveredText();
+
+                                if (spanLabelFeature != null) {
+                                    rec[7] = linkFs.getFeatureValueAsString(spanLabelFeature);
+                                }
+                                else {
+                                    rec[7] = "";
+                                }
+
+                                if (adapter.isLinkedListBehavior()) {
+                                    if (arcLabelFeature != null) {
+                                        rec[8] = linkFs.getFeatureValueAsString(arcLabelFeature);
+                                    }
+                                    else {
+                                        rec[8] = "";
+                                    }
+                                }
+
+                                csvPrinter.printRecord(rec);
+
+                                linkFs = nextLinkFs;
+                                linkIndex++;
+                            }
+
+                            chainId++;
+                        }
+
+                        csvPrinter.flush();
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public String getFileExtension()
+    {
+        return EXT_CSV;
+    }
+
+    @Override
+    public MediaType getMediaType()
+    {
+        return MEDIA_TYPE_TEXT_CSV;
+    }
+}

--- a/inception/inception-layer-chain/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/chain/export/ChainLayerToJsonExporter.java
+++ b/inception/inception-layer-chain/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/chain/export/ChainLayerToJsonExporter.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.annotation.layer.chain.export;
+
+import static java.util.Comparator.comparing;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.io.output.CloseShieldOutputStream;
+import org.apache.uima.cas.text.AnnotationFS;
+import org.springframework.http.MediaType;
+
+import com.fasterxml.jackson.core.JsonFactory;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.inception.annotation.layer.chain.ChainAdapter;
+import de.tudarmstadt.ukp.inception.annotation.layer.chain.ChainLayerSupport;
+import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
+import de.tudarmstadt.ukp.inception.documents.api.export.CrossDocumentExporter_ImplBase;
+import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
+
+public class ChainLayerToJsonExporter
+    extends CrossDocumentExporter_ImplBase
+{
+    private final AnnotationSchemaService schemaService;
+
+    public ChainLayerToJsonExporter(AnnotationSchemaService aSchemaService,
+            DocumentService aDocumentService)
+    {
+        super(aDocumentService);
+        schemaService = aSchemaService;
+    }
+
+    @Override
+    public boolean accepts(AnnotationLayer aLayer, AnnotationFeature aFeature)
+    {
+        return ChainLayerSupport.TYPE.equals(aLayer.getType());
+    }
+
+    @Override
+    public void export(OutputStream aOut, AnnotationLayer aLayer, AnnotationFeature aFeature,
+            Map<SourceDocument, List<AnnotationDocument>> allAnnDocs, List<String> aAnnotators)
+        throws IOException
+    {
+        var docs = allAnnDocs.keySet().stream() //
+                .sorted(comparing(SourceDocument::getName)) //
+                .toList();
+
+        var jsonFactory = new JsonFactory();
+
+        var adapter = (ChainAdapter) schemaService.getAdapter(aLayer);
+
+        try (var jg = jsonFactory.createGenerator(CloseShieldOutputStream.wrap(aOut))) {
+            jg.useDefaultPrettyPrinter();
+
+            jg.writeStartArray();
+
+            for (var doc : docs) {
+                var annDocs = allAnnDocs.get(doc);
+                try (var session = CasStorageSession.openNested()) {
+                    for (var dataOwner : aAnnotators) {
+                        var cas = loadCasOrInitialCas(doc, dataOwner, annDocs);
+                        if (cas.getTypeSystem().getType(adapter.getChainTypeName()) == null) {
+                            // If the types are not defined, then we do not need to try and render
+                            // them because the CAS does not contain any instances of them
+                            continue;
+                        }
+
+                        var chainFirst = cas.getTypeSystem().getType(adapter.getChainTypeName())
+                                .getFeatureByBaseName(adapter.getChainFirstFeatureName());
+                        var spanLabelFeature = cas.getTypeSystem()
+                                .getType(adapter.getAnnotationTypeName())
+                                .getFeatureByBaseName(ChainAdapter.SPAN_LABEL_FEATURE);
+                        var arcLabelFeature = cas.getTypeSystem()
+                                .getType(adapter.getAnnotationTypeName())
+                                .getFeatureByBaseName(ChainAdapter.ARC_LABEL_FEATURE);
+
+                        for (var chainFs : cas.select(adapter.getChainTypeName())) {
+                            var linkFs = (AnnotationFS) chainFs.getFeatureValue(chainFirst);
+                            if (linkFs == null) {
+                                continue; // Skip empty chains
+                            }
+
+                            jg.writeStartObject();
+                            jg.writeStringField("doc", doc.getName());
+                            jg.writeStringField("user", dataOwner);
+
+                            jg.writeArrayFieldStart("elements");
+
+                            // Iterate over the links of the chain
+                            while (linkFs != null) {
+                                var linkNext = linkFs.getType()
+                                        .getFeatureByBaseName(adapter.getLinkNextFeatureName());
+                                var nextLinkFs = (AnnotationFS) linkFs.getFeatureValue(linkNext);
+
+                                jg.writeStartObject();
+                                jg.writeNumberField("begin", linkFs.getBegin());
+                                jg.writeNumberField("end", linkFs.getEnd());
+                                jg.writeStringField("text", linkFs.getCoveredText());
+
+                                if (spanLabelFeature != null) {
+                                    var label = linkFs.getFeatureValueAsString(spanLabelFeature);
+                                    jg.writeStringField("label", label);
+                                }
+
+                                if (adapter.isLinkedListBehavior() && arcLabelFeature != null) {
+                                    var label = linkFs.getFeatureValueAsString(arcLabelFeature);
+                                    jg.writeStringField("link_label", label);
+                                }
+
+                                jg.writeEndObject();
+
+                                linkFs = nextLinkFs;
+                            }
+
+                            jg.writeEndArray();
+
+                            jg.writeEndObject();
+                        }
+
+                        jg.flush();
+                    }
+                }
+            }
+
+            jg.writeEndArray();
+            jg.flush();
+        }
+    }
+
+    @Override
+    public String getFileExtension()
+    {
+        return EXT_JSON;
+    }
+
+    @Override
+    public MediaType getMediaType()
+    {
+        return MediaType.APPLICATION_JSON;
+    }
+}

--- a/inception/inception-layer-docmetadata/pom.xml
+++ b/inception/inception-layer-docmetadata/pom.xml
@@ -126,10 +126,22 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-csv</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
@@ -184,6 +196,11 @@
     <dependency>
       <groupId>org.danekja</groupId>
       <artifactId>jdk-serializable-functional</artifactId>
+    </dependency>
+    
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/config/DocumentMetadataLayerSupportAutoConfiguration.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/config/DocumentMetadataLayerSupportAutoConfiguration.java
@@ -35,6 +35,8 @@ import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureSupportRegistry;
 import de.tudarmstadt.ukp.inception.schema.api.layer.LayerSupportRegistry;
 import de.tudarmstadt.ukp.inception.schema.api.layer.LayerType;
+import de.tudarmstadt.ukp.inception.ui.core.docanno.export.DocumentLayerToCsvExporter;
+import de.tudarmstadt.ukp.inception.ui.core.docanno.export.DocumentLayerToJsonExporter;
 import de.tudarmstadt.ukp.inception.ui.core.docanno.layer.DocumentMetadataLayerSingletonCreatingWatcher;
 import de.tudarmstadt.ukp.inception.ui.core.docanno.layer.DocumentMetadataLayerSupport;
 import de.tudarmstadt.ukp.inception.ui.core.docanno.layer.DocumentMetadataLayerSupportImpl;
@@ -89,6 +91,20 @@ public class DocumentMetadataLayerSupportAutoConfiguration
     public DocumentMetadataAnnotationActionUndoSupport documentMetadataAnnotationActionUndoSupport()
     {
         return new DocumentMetadataAnnotationActionUndoSupport();
+    }
+
+    @Bean
+    public DocumentLayerToJsonExporter documentLayerToJsonExporter(
+            AnnotationSchemaService aSchemaService, DocumentService aDocumentService)
+    {
+        return new DocumentLayerToJsonExporter(aSchemaService, aDocumentService);
+    }
+
+    @Bean
+    public DocumentLayerToCsvExporter documentLayerToCsvExporter(
+            AnnotationSchemaService aSchemaService, DocumentService aDocumentService)
+    {
+        return new DocumentLayerToCsvExporter(aSchemaService, aDocumentService);
     }
 
     @Bean

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/export/DocumentLayerToCsvExporter.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/export/DocumentLayerToCsvExporter.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.core.docanno.export;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.asList;
+import static java.util.Arrays.fill;
+import static java.util.Comparator.comparing;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import org.springframework.http.MediaType;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.LinkMode;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
+import de.tudarmstadt.ukp.inception.documents.api.export.CrossDocumentExporter_ImplBase;
+import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
+import de.tudarmstadt.ukp.inception.ui.core.docanno.layer.DocumentMetadataLayerSupport;
+
+public class DocumentLayerToCsvExporter
+    extends CrossDocumentExporter_ImplBase
+{
+    private final AnnotationSchemaService schemaService;
+
+    public DocumentLayerToCsvExporter(AnnotationSchemaService aSchemaService,
+            DocumentService aDocumentService)
+    {
+        super(aDocumentService);
+        schemaService = aSchemaService;
+    }
+
+    @Override
+    public boolean accepts(AnnotationLayer aLayer, AnnotationFeature aFeature)
+    {
+        if (aFeature != null && aFeature.getLinkMode() != LinkMode.NONE) {
+            return false;
+        }
+
+        return DocumentMetadataLayerSupport.TYPE.equals(aLayer.getType());
+    }
+
+    @Override
+    public void export(OutputStream aOut, AnnotationLayer aLayer, AnnotationFeature aFeature,
+            Map<SourceDocument, List<AnnotationDocument>> allAnnDocs, List<String> aAnnotators)
+        throws IOException
+    {
+        var docs = allAnnDocs.keySet().stream() //
+                .sorted(comparing(SourceDocument::getName)) //
+                .toList();
+
+        var featureName = aFeature != null ? aFeature.getName() : null;
+
+        var adapter = schemaService.getAdapter(aLayer);
+
+        var headers = new ArrayList<String>();
+        headers.addAll(asList("doc", "user"));
+        if (aFeature != null) {
+            headers.add("label");
+        }
+
+        var rec = new Object[headers.size()];
+
+        try (var writer = new OutputStreamWriter(aOut, UTF_8);
+                var csvPrinter = new CSVPrinter(writer, CSVFormat.DEFAULT.builder()
+                        .setHeader(headers.toArray(String[]::new)).get())) {
+
+            for (var doc : docs) {
+                var annDocs = allAnnDocs.get(doc);
+                try (var session = CasStorageSession.openNested()) {
+                    for (var dataOwner : aAnnotators) {
+                        var cas = loadCasOrInitialCas(doc, dataOwner, annDocs);
+                        if (cas.getTypeSystem().getType(adapter.getAnnotationTypeName()) == null) {
+                            // If the types are not defined, then we do not need to try and render
+                            // them because the CAS does not contain any instances of them
+                            continue;
+                        }
+
+                        for (var ann : cas.select(adapter.getAnnotationTypeName())) {
+                            fill(rec, null);
+                            rec[0] = doc.getName();
+                            rec[1] = dataOwner;
+                            if (aFeature != null) {
+                                rec[2] = adapter.renderFeatureValue(ann, featureName);
+                            }
+                            csvPrinter.printRecord(rec);
+                        }
+                    }
+                }
+            }
+            csvPrinter.flush();
+        }
+    }
+
+    @Override
+    public String getFileExtension()
+    {
+        return EXT_CSV;
+    }
+
+    @Override
+    public MediaType getMediaType()
+    {
+        return MEDIA_TYPE_TEXT_CSV;
+    }
+}

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/export/DocumentLayerToJsonExporter.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/ui/core/docanno/export/DocumentLayerToJsonExporter.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.core.docanno.export;
+
+import static java.util.Comparator.comparing;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.io.output.CloseShieldOutputStream;
+import org.springframework.http.MediaType;
+
+import com.fasterxml.jackson.core.JsonFactory;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.LinkMode;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
+import de.tudarmstadt.ukp.inception.documents.api.export.CrossDocumentExporter_ImplBase;
+import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
+import de.tudarmstadt.ukp.inception.ui.core.docanno.layer.DocumentMetadataLayerSupport;
+
+public class DocumentLayerToJsonExporter
+    extends CrossDocumentExporter_ImplBase
+{
+    private final AnnotationSchemaService schemaService;
+
+    public DocumentLayerToJsonExporter(AnnotationSchemaService aSchemaService,
+            DocumentService aDocumentService)
+    {
+        super(aDocumentService);
+        schemaService = aSchemaService;
+    }
+
+    @Override
+    public boolean accepts(AnnotationLayer aLayer, AnnotationFeature aFeature)
+    {
+        if (aFeature != null && aFeature.getLinkMode() != LinkMode.NONE) {
+            return false;
+        }
+
+        return DocumentMetadataLayerSupport.TYPE.equals(aLayer.getType());
+    }
+
+    @Override
+    public void export(OutputStream aOut, AnnotationLayer aLayer, AnnotationFeature aFeature,
+            Map<SourceDocument, List<AnnotationDocument>> allAnnDocs, List<String> aAnnotators)
+        throws IOException
+    {
+        var docs = allAnnDocs.keySet().stream() //
+                .sorted(comparing(SourceDocument::getName)) //
+                .toList();
+
+        var featureName = aFeature != null ? aFeature.getName() : null;
+
+        var jsonFactory = new JsonFactory();
+
+        var adapter = schemaService.getAdapter(aLayer);
+
+        try (var jg = jsonFactory.createGenerator(CloseShieldOutputStream.wrap(aOut))) {
+            jg.useDefaultPrettyPrinter();
+
+            jg.writeStartArray();
+
+            for (var doc : docs) {
+                var annDocs = allAnnDocs.get(doc);
+                try (var session = CasStorageSession.openNested()) {
+                    for (var dataOwner : aAnnotators) {
+                        var cas = loadCasOrInitialCas(doc, dataOwner, annDocs);
+                        if (cas.getTypeSystem().getType(adapter.getAnnotationTypeName()) == null) {
+                            // If the types are not defined, then we do not need to try and render
+                            // them because the CAS does not contain any instances of them
+                            continue;
+                        }
+
+                        for (var ann : cas.select(adapter.getAnnotationTypeName())) {
+                            jg.writeStartObject();
+                            jg.writeStringField("doc", doc.getName());
+                            jg.writeStringField("user", dataOwner);
+
+                            if (featureName != null) {
+                                var label = adapter.renderFeatureValue(ann, featureName);
+                                jg.writeStringField("label", label);
+                            }
+
+                            jg.writeEndObject();
+                        }
+
+                        jg.flush();
+                    }
+                }
+            }
+
+            jg.writeEndArray();
+            jg.flush();
+        }
+    }
+
+    @Override
+    public String getFileExtension()
+    {
+        return EXT_JSON;
+    }
+
+    @Override
+    public MediaType getMediaType()
+    {
+        return MediaType.APPLICATION_JSON;
+    }
+}

--- a/inception/inception-layer-relation/pom.xml
+++ b/inception/inception-layer-relation/pom.xml
@@ -93,6 +93,16 @@
       <artifactId>inception-layer-span-api</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-documents-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-annotation-storage-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
     
     <dependency>
       <groupId>org.apache.uima</groupId>
@@ -116,10 +126,22 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-collections4</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-csv</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
@@ -155,6 +177,11 @@
     <dependency>
       <groupId>org.danekja</groupId>
       <artifactId>jdk-serializable-functional</artifactId>
+    </dependency>
+    
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
     </dependency>
     
     <dependency>

--- a/inception/inception-layer-relation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/config/RelationLayerAutoConfiguration.java
+++ b/inception/inception-layer-relation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/config/RelationLayerAutoConfiguration.java
@@ -31,8 +31,11 @@ import de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationLayerSuppo
 import de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationLayerSupportImpl;
 import de.tudarmstadt.ukp.inception.annotation.layer.relation.behavior.RelationCrossSentenceBehavior;
 import de.tudarmstadt.ukp.inception.annotation.layer.relation.behavior.RelationOverlapBehavior;
+import de.tudarmstadt.ukp.inception.annotation.layer.relation.export.RelationLayerToCsvExporter;
+import de.tudarmstadt.ukp.inception.annotation.layer.relation.export.RelationLayerToJsonExporter;
 import de.tudarmstadt.ukp.inception.annotation.layer.relation.recommender.RelationSuggestionSupport;
 import de.tudarmstadt.ukp.inception.annotation.layer.relation.undo.RelationAnnotationActionUndoSupport;
+import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.recommendation.api.LearningRecordService;
 import de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
@@ -56,7 +59,7 @@ public class RelationLayerAutoConfiguration
     {
         return new RelationEndpointChangeListener(aSchemaService);
     }
-    
+
     @Bean
     public RelationEndpointFeatureSupport relationEndpointFeatureSupport()
     {
@@ -85,6 +88,20 @@ public class RelationLayerAutoConfiguration
     public RelationOverlapBehavior relationOverlapBehavior()
     {
         return new RelationOverlapBehavior();
+    }
+
+    @Bean
+    public RelationLayerToJsonExporter relationLayerToJsonExporter(
+            AnnotationSchemaService aSchemaService, DocumentService aDocumentService)
+    {
+        return new RelationLayerToJsonExporter(aSchemaService, aDocumentService);
+    }
+
+    @Bean
+    public RelationLayerToCsvExporter relationLayerToCsvExporter(
+            AnnotationSchemaService aSchemaService, DocumentService aDocumentService)
+    {
+        return new RelationLayerToCsvExporter(aSchemaService, aDocumentService);
     }
 
     @ConditionalOnProperty(prefix = "recommender", name = "enabled", havingValue = "true", matchIfMissing = true)

--- a/inception/inception-layer-relation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/export/RelationLayerToCsvExporter.java
+++ b/inception/inception-layer-relation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/export/RelationLayerToCsvExporter.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.annotation.layer.relation.export;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.asList;
+import static java.util.Arrays.fill;
+import static java.util.Comparator.comparing;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import org.apache.uima.jcas.tcas.Annotation;
+import org.springframework.http.MediaType;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.LinkMode;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationAdapter;
+import de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationLayerSupport;
+import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
+import de.tudarmstadt.ukp.inception.documents.api.export.CrossDocumentExporter_ImplBase;
+import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
+
+public class RelationLayerToCsvExporter
+    extends CrossDocumentExporter_ImplBase
+{
+    private final AnnotationSchemaService schemaService;
+
+    public RelationLayerToCsvExporter(AnnotationSchemaService aSchemaService,
+            DocumentService aDocumentService)
+    {
+        super(aDocumentService);
+        schemaService = aSchemaService;
+    }
+
+    @Override
+    public boolean accepts(AnnotationLayer aLayer, AnnotationFeature aFeature)
+    {
+        if (aFeature != null && aFeature.getLinkMode() != LinkMode.NONE) {
+            return false;
+        }
+
+        return RelationLayerSupport.TYPE.equals(aLayer.getType());
+    }
+
+    @Override
+    public void export(OutputStream aOut, AnnotationLayer aLayer, AnnotationFeature aFeature,
+            Map<SourceDocument, List<AnnotationDocument>> allAnnDocs, List<String> aAnnotators)
+        throws IOException
+    {
+        var docs = allAnnDocs.keySet().stream() //
+                .sorted(comparing(SourceDocument::getName)) //
+                .toList();
+
+        var featureName = aFeature != null ? aFeature.getName() : null;
+
+        var adapter = (RelationAdapter) schemaService.getAdapter(aLayer);
+
+        var headers = new ArrayList<String>();
+        headers.addAll(asList("doc", "user", "source-begin", "source-end", "source-text",
+                "target-begin", "target-end", "target-text"));
+        if (aFeature != null) {
+            headers.add("label");
+        }
+
+        var rec = new Object[headers.size()];
+
+        try (var writer = new OutputStreamWriter(aOut, UTF_8);
+                var csvPrinter = new CSVPrinter(writer, CSVFormat.DEFAULT.builder()
+                        .setHeader(headers.toArray(String[]::new)).get())) {
+
+            for (var doc : docs) {
+                var annDocs = allAnnDocs.get(doc);
+                try (var session = CasStorageSession.openNested()) {
+                    for (var dataOwner : aAnnotators) {
+                        var cas = loadCasOrInitialCas(doc, dataOwner, annDocs);
+                        if (cas.getTypeSystem().getType(adapter.getAnnotationTypeName()) == null) {
+                            // If the types are not defined, then we do not need to try and
+                            // render
+                            // them because the CAS does not contain any instances of them
+                            continue;
+                        }
+
+                        for (var ann : cas.<Annotation> select(adapter.getAnnotationTypeName())) {
+                            fill(rec, null);
+
+                            var source = adapter.getSourceAnnotation(ann);
+                            var target = adapter.getTargetAnnotation(ann);
+
+                            rec[0] = doc.getName();
+                            rec[1] = dataOwner;
+                            rec[2] = source != null ? source.getBegin() : "";
+                            rec[3] = source != null ? source.getEnd() : "";
+                            rec[4] = source != null ? source.getCoveredText() : "";
+                            rec[5] = target != null ? target.getBegin() : "";
+                            rec[6] = target != null ? target.getEnd() : "";
+                            rec[7] = target != null ? target.getCoveredText() : "";
+                            if (aFeature != null) {
+                                rec[8] = adapter.renderFeatureValue(ann, featureName);
+                            }
+                            csvPrinter.printRecord(rec);
+                        }
+                    }
+                }
+            }
+            csvPrinter.flush();
+        }
+    }
+
+    @Override
+    public String getFileExtension()
+    {
+        return EXT_CSV;
+    }
+
+    @Override
+    public MediaType getMediaType()
+    {
+        return MEDIA_TYPE_TEXT_CSV;
+    }
+}

--- a/inception/inception-layer-relation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/export/RelationLayerToJsonExporter.java
+++ b/inception/inception-layer-relation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/export/RelationLayerToJsonExporter.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.annotation.layer.relation.export;
+
+import static java.util.Comparator.comparing;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.io.output.CloseShieldOutputStream;
+import org.apache.uima.jcas.tcas.Annotation;
+import org.springframework.http.MediaType;
+
+import com.fasterxml.jackson.core.JsonFactory;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.LinkMode;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationAdapter;
+import de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationLayerSupport;
+import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
+import de.tudarmstadt.ukp.inception.documents.api.export.CrossDocumentExporter_ImplBase;
+import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
+
+public class RelationLayerToJsonExporter
+    extends CrossDocumentExporter_ImplBase
+{
+    private final AnnotationSchemaService schemaService;
+
+    public RelationLayerToJsonExporter(AnnotationSchemaService aSchemaService,
+            DocumentService aDocumentService)
+    {
+        super(aDocumentService);
+        schemaService = aSchemaService;
+    }
+
+    @Override
+    public boolean accepts(AnnotationLayer aLayer, AnnotationFeature aFeature)
+    {
+        if (aFeature != null && aFeature.getLinkMode() != LinkMode.NONE) {
+            return false;
+        }
+
+        return RelationLayerSupport.TYPE.equals(aLayer.getType());
+    }
+
+    @Override
+    public void export(OutputStream aOut, AnnotationLayer aLayer, AnnotationFeature aFeature,
+            Map<SourceDocument, List<AnnotationDocument>> allAnnDocs, List<String> aAnnotators)
+        throws IOException
+    {
+        var docs = allAnnDocs.keySet().stream() //
+                .sorted(comparing(SourceDocument::getName)) //
+                .toList();
+
+        var featureName = aFeature != null ? aFeature.getName() : null;
+
+        var jsonFactory = new JsonFactory();
+
+        var adapter = (RelationAdapter) schemaService.getAdapter(aLayer);
+
+        try (var jg = jsonFactory.createGenerator(CloseShieldOutputStream.wrap(aOut))) {
+            jg.useDefaultPrettyPrinter();
+
+            jg.writeStartArray();
+
+            for (var doc : docs) {
+                var annDocs = allAnnDocs.get(doc);
+                try (var session = CasStorageSession.openNested()) {
+                    for (var dataOwner : aAnnotators) {
+                        var cas = loadCasOrInitialCas(doc, dataOwner, annDocs);
+                        if (cas.getTypeSystem().getType(adapter.getAnnotationTypeName()) == null) {
+                            // If the types are not defined, then we do not need to try and
+                            // render
+                            // them because the CAS does not contain any instances of them
+                            continue;
+                        }
+
+                        for (var ann : cas.<Annotation> select(adapter.getAnnotationTypeName())) {
+                            var source = adapter.getSourceAnnotation(ann);
+                            var target = adapter.getTargetAnnotation(ann);
+
+                            jg.writeStartObject();
+                            jg.writeStringField("doc", doc.getName());
+                            jg.writeStringField("user", dataOwner);
+
+                            if (featureName != null) {
+                                var label = adapter.renderFeatureValue(ann, featureName);
+                                jg.writeStringField("label", label);
+                            }
+
+                            if (source != null) {
+                                jg.writeObjectFieldStart("source");
+                                jg.writeNumberField("begin", source.getBegin());
+                                jg.writeNumberField("end", source.getEnd());
+                                jg.writeStringField("text", source.getCoveredText());
+                                jg.writeEndObject();
+                            }
+
+                            if (target != null) {
+                                jg.writeObjectFieldStart("target");
+                                jg.writeNumberField("begin", target.getBegin());
+                                jg.writeNumberField("end", target.getEnd());
+                                jg.writeStringField("text", target.getCoveredText());
+                                jg.writeEndObject();
+                            }
+
+                            jg.writeEndObject();
+                        }
+
+                        jg.flush();
+                    }
+                }
+            }
+
+            jg.writeEndArray();
+            jg.flush();
+        }
+    }
+
+    @Override
+    public String getFileExtension()
+    {
+        return EXT_JSON;
+    }
+
+    @Override
+    public MediaType getMediaType()
+    {
+        return MediaType.APPLICATION_JSON;
+    }
+}

--- a/inception/inception-layer-span/pom.xml
+++ b/inception/inception-layer-span/pom.xml
@@ -15,7 +15,9 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>de.tudarmstadt.ukp.inception.app</groupId>
@@ -82,10 +84,20 @@
       <artifactId>inception-security</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-documents-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-annotation-storage-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
     <dependency>
-     <groupId>org.apache.wicket</groupId>
-     <artifactId>wicket-core</artifactId>
+      <groupId>org.apache.wicket</groupId>
+      <artifactId>wicket-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.wicket</groupId>
@@ -99,6 +111,10 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
@@ -116,7 +132,7 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
     </dependency>
-    
+
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
@@ -129,6 +145,14 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-collections4</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-csv</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
     </dependency>
 
     <dependency>
@@ -145,7 +169,11 @@
       <artifactId>dkpro-core-api-segmentation-asl</artifactId>
     </dependency>
 
-    
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-layer-behavior</artifactId>

--- a/inception/inception-layer-span/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/config/SpanLayerAutoConfiguration.java
+++ b/inception/inception-layer-span/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/config/SpanLayerAutoConfiguration.java
@@ -28,9 +28,12 @@ import de.tudarmstadt.ukp.inception.annotation.layer.behaviors.LayerBehaviorRegi
 import de.tudarmstadt.ukp.inception.annotation.layer.span.SpanLayerSupport;
 import de.tudarmstadt.ukp.inception.annotation.layer.span.SpanLayerSupportImpl;
 import de.tudarmstadt.ukp.inception.annotation.layer.span.TokenAttachedSpanChangeListener;
+import de.tudarmstadt.ukp.inception.annotation.layer.span.export.SpanLayerToCsvExporter;
+import de.tudarmstadt.ukp.inception.annotation.layer.span.export.SpanLayerToJsonExporter;
 import de.tudarmstadt.ukp.inception.annotation.layer.span.recommender.SpanSuggestionSupport;
 import de.tudarmstadt.ukp.inception.annotation.layer.span.undo.SpanAnnotationActionUndoSupport;
 import de.tudarmstadt.ukp.inception.annotation.layer.span.undo.UnitAnnotationActionUndoSupport;
+import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.recommendation.api.LearningRecordService;
 import de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
@@ -66,6 +69,20 @@ public class SpanLayerAutoConfiguration
     public UnitAnnotationActionUndoSupport unitAnnotationActionUndoSupport()
     {
         return new UnitAnnotationActionUndoSupport();
+    }
+
+    @Bean
+    public SpanLayerToJsonExporter spanLayerToJsonExporter(AnnotationSchemaService aSchemaService,
+            DocumentService aDocumentService)
+    {
+        return new SpanLayerToJsonExporter(aSchemaService, aDocumentService);
+    }
+
+    @Bean
+    public SpanLayerToCsvExporter spanLayerToCsvExporter(AnnotationSchemaService aSchemaService,
+            DocumentService aDocumentService)
+    {
+        return new SpanLayerToCsvExporter(aSchemaService, aDocumentService);
     }
 
     @ConditionalOnProperty(prefix = "recommender", name = "enabled", havingValue = "true", matchIfMissing = true)

--- a/inception/inception-layer-span/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/export/SpanLayerToCsvExporter.java
+++ b/inception/inception-layer-span/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/export/SpanLayerToCsvExporter.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.annotation.layer.span.export;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.asList;
+import static java.util.Arrays.fill;
+import static java.util.Comparator.comparing;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
+import org.apache.uima.jcas.tcas.Annotation;
+import org.springframework.http.MediaType;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.LinkMode;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.inception.annotation.layer.span.SpanLayerSupport;
+import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
+import de.tudarmstadt.ukp.inception.documents.api.export.CrossDocumentExporter_ImplBase;
+import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
+
+public class SpanLayerToCsvExporter
+    extends CrossDocumentExporter_ImplBase
+{
+    private final AnnotationSchemaService schemaService;
+
+    public SpanLayerToCsvExporter(AnnotationSchemaService aSchemaService,
+            DocumentService aDocumentService)
+    {
+        super(aDocumentService);
+        schemaService = aSchemaService;
+    }
+
+    @Override
+    public boolean accepts(AnnotationLayer aLayer, AnnotationFeature aFeature)
+    {
+        if (aFeature != null && aFeature.getLinkMode() != LinkMode.NONE) {
+            return false;
+        }
+
+        return SpanLayerSupport.TYPE.equals(aLayer.getType());
+    }
+
+    @Override
+    public void export(OutputStream aOut, AnnotationLayer aLayer, AnnotationFeature aFeature,
+            Map<SourceDocument, List<AnnotationDocument>> allAnnDocs, List<String> aAnnotators)
+        throws IOException
+    {
+        var docs = allAnnDocs.keySet().stream() //
+                .sorted(comparing(SourceDocument::getName)) //
+                .toList();
+
+        var featureName = aFeature != null ? aFeature.getName() : null;
+
+        var adapter = schemaService.getAdapter(aLayer);
+
+        var headers = new ArrayList<String>();
+        headers.addAll(asList("doc", "user", "begin", "end", "text"));
+        if (aFeature != null) {
+            headers.add("label");
+        }
+
+        var rec = new Object[headers.size()];
+
+        try (var writer = new OutputStreamWriter(aOut, UTF_8);
+                var csvPrinter = new CSVPrinter(writer, CSVFormat.DEFAULT.builder()
+                        .setHeader(headers.toArray(String[]::new)).get())) {
+
+            for (var doc : docs) {
+                var annDocs = allAnnDocs.get(doc);
+                try (var session = CasStorageSession.openNested()) {
+                    for (var dataOwner : aAnnotators) {
+                        var cas = loadCasOrInitialCas(doc, dataOwner, annDocs);
+                        if (cas.getTypeSystem().getType(adapter.getAnnotationTypeName()) == null) {
+                            // If the types are not defined, then we do not need to try and render
+                            // them because the CAS does not contain any instances of them
+                            continue;
+                        }
+
+                        for (var ann : cas.<Annotation> select(adapter.getAnnotationTypeName())) {
+                            fill(rec, null);
+                            rec[0] = doc.getName();
+                            rec[1] = dataOwner;
+                            rec[2] = ann.getBegin();
+                            rec[3] = ann.getEnd();
+                            rec[4] = ann.getCoveredText();
+                            if (aFeature != null) {
+                                rec[5] = adapter.renderFeatureValue(ann, featureName);
+                            }
+                            csvPrinter.printRecord(rec);
+                        }
+                    }
+                }
+            }
+            csvPrinter.flush();
+        }
+    }
+
+    @Override
+    public String getFileExtension()
+    {
+        return EXT_CSV;
+    }
+
+    @Override
+    public MediaType getMediaType()
+    {
+        return MEDIA_TYPE_TEXT_CSV;
+    }
+}

--- a/inception/inception-layer-span/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/export/SpanLayerToJsonExporter.java
+++ b/inception/inception-layer-span/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/export/SpanLayerToJsonExporter.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.annotation.layer.span.export;
+
+import static java.util.Comparator.comparing;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.io.output.CloseShieldOutputStream;
+import org.apache.uima.jcas.tcas.Annotation;
+import org.springframework.http.MediaType;
+
+import com.fasterxml.jackson.core.JsonFactory;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.LinkMode;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.inception.annotation.layer.span.SpanLayerSupport;
+import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
+import de.tudarmstadt.ukp.inception.documents.api.export.CrossDocumentExporter_ImplBase;
+import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
+
+public class SpanLayerToJsonExporter
+    extends CrossDocumentExporter_ImplBase
+{
+    private final AnnotationSchemaService schemaService;
+
+    public SpanLayerToJsonExporter(AnnotationSchemaService aSchemaService,
+            DocumentService aDocumentService)
+    {
+        super(aDocumentService);
+        schemaService = aSchemaService;
+    }
+
+    @Override
+    public boolean accepts(AnnotationLayer aLayer, AnnotationFeature aFeature)
+    {
+        if (aFeature != null && aFeature.getLinkMode() != LinkMode.NONE) {
+            return false;
+        }
+
+        return SpanLayerSupport.TYPE.equals(aLayer.getType());
+    }
+
+    @Override
+    public void export(OutputStream aOut, AnnotationLayer aLayer, AnnotationFeature aFeature,
+            Map<SourceDocument, List<AnnotationDocument>> allAnnDocs, List<String> aAnnotators)
+        throws IOException
+    {
+        var docs = allAnnDocs.keySet().stream() //
+                .sorted(comparing(SourceDocument::getName)) //
+                .toList();
+
+        var featureName = aFeature != null ? aFeature.getName() : null;
+
+        var jsonFactory = new JsonFactory();
+
+        var adapter = schemaService.getAdapter(aLayer);
+
+        try (var jg = jsonFactory.createGenerator(CloseShieldOutputStream.wrap(aOut))) {
+            jg.useDefaultPrettyPrinter();
+
+            jg.writeStartArray();
+
+            for (var doc : docs) {
+                var annDocs = allAnnDocs.get(doc);
+                try (var session = CasStorageSession.openNested()) {
+                    for (var dataOwner : aAnnotators) {
+                        var cas = loadCasOrInitialCas(doc, dataOwner, annDocs);
+                        if (cas.getTypeSystem().getType(adapter.getAnnotationTypeName()) == null) {
+                            // If the types are not defined, then we do not need to try and render
+                            // them because the CAS does not contain any instances of them
+                            continue;
+                        }
+
+                        for (var ann : cas.<Annotation> select(adapter.getAnnotationTypeName())) {
+                            jg.writeStartObject();
+                            jg.writeStringField("doc", doc.getName());
+                            jg.writeStringField("user", dataOwner);
+                            jg.writeNumberField("begin", ann.getBegin());
+                            jg.writeNumberField("end", ann.getEnd());
+                            jg.writeStringField("text", ann.getCoveredText());
+                            if (featureName != null) {
+                                var label = adapter.renderFeatureValue(ann, featureName);
+                                jg.writeStringField("label", label);
+                            }
+                            jg.writeEndObject();
+                        }
+
+                        jg.flush();
+                    }
+                }
+            }
+
+            jg.writeEndArray();
+            jg.flush();
+        }
+    }
+
+    @Override
+    public String getFileExtension()
+    {
+        return EXT_JSON;
+    }
+
+    @Override
+    public MediaType getMediaType()
+    {
+        return MediaType.APPLICATION_JSON;
+    }
+}

--- a/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/feature/TypeUtil.java
+++ b/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/feature/TypeUtil.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 import org.apache.uima.cas.CAS;
-import org.apache.uima.cas.Feature;
 import org.apache.uima.cas.FeatureStructure;
 import org.apache.uima.cas.Type;
 
@@ -188,8 +187,8 @@ public final class TypeUtil
                 continue;
             }
 
-            Feature labelFeature = aFs.getType().getFeatureByBaseName(feature.getName());
-            String label = defaultString(aFs.getFeatureValueAsString(labelFeature));
+            var labelFeature = aFs.getType().getFeatureByBaseName(feature.getName());
+            var label = defaultString(aFs.getFeatureValueAsString(labelFeature));
 
             if (bratLabelText.length() > 0 && label.length() > 0) {
                 bratLabelText.append(TypeAdapter.FEATURE_SEPARATOR);

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/WebAnnoConst.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/WebAnnoConst.java
@@ -17,8 +17,10 @@
  */
 package de.tudarmstadt.ukp.inception.support;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
+
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -27,11 +29,17 @@ import java.util.List;
 public class WebAnnoConst
 {
     // Annotation types, for span or arc annotations.
+    @Deprecated
     public static final String POS = "pos";
+    @Deprecated
     public static final String NAMEDENTITY = "named entity";
+    @Deprecated
     public static final String DEPENDENCY = "dependency";
+    @Deprecated
     public static final String COREFERENCE = "coreference";
+    @Deprecated
     public static final String COREFRELTYPE = "coreference type";
+    @Deprecated
     public static final String LEMMA = "lemma";
 
     /**
@@ -64,35 +72,42 @@ public class WebAnnoConst
     @Deprecated
     public static final String CHAIN_TYPE = "chain";
 
+    /**
+     * @deprecated Use {@code ChainAdapter.ARC_LABEL_FEATURE}
+     */
+    @Deprecated
     public static final String COREFERENCE_RELATION_FEATURE = "referenceRelation";
-    public static final String COREFERENCE_TYPE_FEATURE = "referenceType";
 
-    public static final String COREFERENCE_LAYER = "de.tudarmstadt.ukp.dkpro.core.api.coref.type.Coreference";
-    public static final String DOCUMENT = "/document/";
+    /**
+     * @deprecated Use {@code ChainAdapter.SPAN_LABEL_FEATURE}
+     */
+    @Deprecated
+    public static final String COREFERENCE_TYPE_FEATURE = "referenceType";
 
     public static final String CURATION_USER = "CURATION_USER";
     public static final String INITIAL_CAS_PSEUDO_USER = "INITIAL_CAS";
 
-    public static final List<String> RESTRICTED_FEATURE_NAMES = new ArrayList<String>(Arrays.asList(
-            "address", "begin", "end", "coveredText", "booleanValue", "doubleValue", "byteValue",
-            "CAS", "CASImpl", "class", "featureValue", "floatValue", "longValue", "lowLevelCas",
-            "printRefs", "sofa", "stringValue", "type", "typeIndexId", "view"))
-    {
+    public static final List<String> RESTRICTED_FEATURE_NAMES = unmodifiableList(
+            new ArrayList<String>(asList("address", "begin", "end", "coveredText", "booleanValue",
+                    "doubleValue", "byteValue", "CAS", "CASImpl", "class", "featureValue",
+                    "floatValue", "longValue", "lowLevelCas", "printRefs", "sofa", "stringValue",
+                    "type", "typeIndexId", "view"))
+            {
 
-        private static final long serialVersionUID = -8547798549706734147L;
+                private static final long serialVersionUID = -8547798549706734147L;
 
-        // Implement case-insensitive string comparison
-        @Override
-        public boolean contains(Object o)
-        {
+                // Implement case-insensitive string comparison
+                @Override
+                public boolean contains(Object o)
+                {
 
-            String inputString = (String) o;
-            for (String s : this) {
-                if (inputString.equalsIgnoreCase(s)) {
-                    return true;
+                    String inputString = (String) o;
+                    for (String s : this) {
+                        if (inputString.equalsIgnoreCase(s)) {
+                            return true;
+                        }
+                    }
+                    return false;
                 }
-            }
-            return false;
-        }
-    };
+            });
 }

--- a/inception/inception-ui-agreement/pom.xml
+++ b/inception/inception-ui-agreement/pom.xml
@@ -87,11 +87,6 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
-      <artifactId>inception-layer-span-api</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-layer-chain-api</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/inception/inception-ui-agreement/src/main/resources/META-INF/asciidoc/user-guide/agreement.adoc
+++ b/inception/inception-ui-agreement/src/main/resources/META-INF/asciidoc/user-guide/agreement.adoc
@@ -25,30 +25,41 @@ The set of available agreement measures depends on the layer configuration.
 --
 The agreement calculation functionality allows curators and managers to measure the consistency of annotations made by different users. 
 It computes inter-annotator agreement for span and relation layers on a per-feature basis, providing pair-wise agreement scores across all documents. 
-This helps in assessing the reliability and accuracy of the annotations.
+This process assists in assessing the reliability and accuracy of the annotations. 
 
 image::images/agreement_table.png[align="center"]
 
-To use the agreement calculation functionality you need to select a *Feature* and a *Measure*.
+To use the agreement calculation functionality, you need to select a *Feature* and a *Measure*. 
 
-The *Feature* indicates which layer and feature should be used for the agreement calculation.
+The *Feature* specifies which layer and feature are used for the agreement calculation. 
 
-The *Measure* indicates which agreement measure should be used for the calculation.
-A default measure is selected based on the feature.
-Depending on the feature settings, only certain measures may be available.
-A short description of available measures and their differences follows in the <<sect_agreement_measures, Measures>> section. 
+The *Measure* specifies which agreement measure is used for the calculation. 
+A default measure is selected based on the feature. 
+Depending on the feature settings, only certain measures may be available. 
+A short description of available measures and their differences is provided in the <<sect_agreement_measures, Measures>> section. 
 
-Optionally, you can choose to limit the process to specific *annotators* or *documents*. 
+NOTE: For some layers or features, there may not be any measures available. 
+      You may still be able to export the labels using the *CSV* and/or *JSON* options from the *Export...* dropdown. 
+
+Optionally, you can limit the process to specific *annotators* or *documents*. 
 If you do not make any selection here, all annotators and documents are considered. 
 If you select annotators, at least two annotators must be selected. 
-To select multiple annotators or documents, hold e.g. the kbd:[Shift] or kbd:[CTRL]/kbd:[CMD] keys while clicking depending on your browser and operating system.
+To select multiple annotators or documents, hold, for example, the kbd:[Shift] or kbd:[CTRL]/kbd:[CMD] keys while clicking, depending on your browser and operating system. 
 
-The *Calculate...*  button can be used to start the agreement calculation and the results will be shown in a <<sect_agreement_matrix,Pairwise agreement matrix>>. 
-Mind that the calculation may take a moment. 
-You can inspect the progress of the calculation by clicking on the background tasks indicator in the page footer.
+The *Pairwise...* button can be used to start the agreement calculation, and the results will be shown in a <<sect_agreement_matrix,Pairwise agreement matrix>>. 
 
-The *Export diff...* button can be used to export a CSV file comparing the annotations across all (selected) annotators and documents in a tabular fashion.
-Alternatively, a CSV file of the pair-wise comparison between two specific annotators can be exported by clicking on the agreement score in the upper triangle of the pairwise agreement table.
+The *Per document...* button can be used to start the agreement calculation, and the results will be shown in a per-document table. 
+
+NOTE: The calculation may take some time to complete. 
+      You can monitor the progress of the calculation by clicking on the background tasks indicator in the page footer. 
+
+The *Export...* menu provides access to several export options: 
+* The *CSV* format exports the labels for all selected annotators and documents in a tabular format, where each row represents a position and label. 
+  If there are multiple labels from an annotator or multiple annotators for a position, these are rendered as separate rows. 
+* The *JSON* format exports the labels for all selected annotators and documents in a JSON format. 
+* The *Diagnosis* format exports the labels for all selected annotators and documents in a tabular format where each labelled position is a row and there is one column for each annotator. 
+  This format includes the flags calculated by the agreement preprocessing step, such as whether the position is complete or incomplete, and whether it has been used during agreement calculation. 
+  It is useful for diagnosing the agreement calculation and understanding the data. 
 --
 
 [[sect_agreement_measures]]
@@ -88,40 +99,78 @@ If such units are detected, the system will pass the unit starting earliest and 
 
 == Coding vs. Unitizing
 
-Coding measures are based on positions.
-I.e. two annotations are either at the same position or not.
-If they are, they can be compared - otherwise they cannot be compared.
-This makes coding measures unsuitable in cases where partial overlap of annotations needs to be considered, e.g. in the case of named entity annotations where it is common that annotators do not agree on the boundaries of the entity.
-In order to calculate the positions, all documents are scanned for annotations and  annotations located at the same positions are collected in configuration sets.
-To determine if two annotations are at the same position, different approaches are used depending on the layer type.
-For a span layer, the begin and end offsets are used.
-For a relation layer, the begin and end offsets of the source and target annotation are used.
+Before diving into advanced agreement measures, it is helpful to understand two key concepts: *coding* and *unitizing*.
+
+*Coding* means comparing annotations at specific, fixed positions in the text—like checking if two annotators labeled the same word or phrase.
+This is straightforward when everyone agrees on the exact boundaries of what to annotate.
+
+*Unitizing* is used when annotators can mark spans of text that may start and end at different places, or even overlap.
+This is common in tasks like named entity recognition, where people might disagree on the exact boundaries of an entity.
+Unitizing measures are designed to handle these cases, allowing for partial matches and overlaps between annotations.
+
+.Coding measures
+Coding measures (e.g. Cohen's kappa) are based on positions. 
+Two annotations are either at the same position or not. 
+If they are, they can be compared; otherwise, they cannot be compared. 
+This characteristic makes coding measures unsuitable in cases where partial overlap of annotations must be considered, such as in named entity annotation, where annotators may not agree on the boundaries of the entity. 
+
+To calculate the positions, all documents are scanned for annotations, and annotations located at the same positions are collected into configuration sets. 
+A configuration set is a group of annotations that are considered to refer to the same position, based on the layer type. 
+For a span layer, the begin and end offsets are used. 
+For a relation layer, the begin and end offsets of the source and target annotation are used. 
+For a document metadata layer, the document is used.
 Chains are currently not supported. 
 
-The partial overlap agreement is calculated based on character positions, not on token positions.
-So if one annotator annotates *the blackboard* and another annotator just *blackboard*, then the partial overlap is comparatively high because *blackboard* is a longish word.
+.Unitizing measures
+Unitizing measures can deal with cases where the positions of annotations overlap or are not exactly the same. 
+This is especially useful in real-world annotation tasks, where people may interpret boundaries differently or highlight slightly different parts of the text.
+
+For example, imagine two annotators are asked to highlight the phrase referring to a specific object. One might select *the blackboard* while another selects just *blackboard*. 
+Although their selections are not identical, they share a substantial portion of text. In such cases, unitizing measures do not simply mark this as disagreement—instead, they recognize the *partial overlap* and give partial credit for the shared part.
+Partial overlap agreement is calculated based the character overlap, not on the token overlap.
+That means, if one annotator annotates *the blackboard* and another annotator annotates only *blackboard*, the partial overlap is comparatively high because *blackboard* is a substantial portion of the span, even though an entire word is missing from the first annotator's span.
 Relation and chain layers are presently not supported by the unitizing measures.
+For document metadata layers, partial overlap is not applicable, as the entire document is considered as a single position.
 
 == Incomplete annotations
 
-When working with coding measures, there is the concept of *incomplete annotations*.
-For a given position, the annotation is incomplete if at least one annotator has *not* provided a label.
-In the case of the pairwise comparisons that are used to generate the agreement table, this means that one annotator has produced a label and the other annotator has not.
-Due to the way that positions are generated, it also means that if one annotator annotates *the blackboard* and another annotator just *blackboard*, we are actually dealing with two positions (*the blackboard*, offsets 0-15 and *blackboard*, offsets 4-14), and both of them are incompletely annotated.
-Some measurs cannot deal with incomplete annotations because they require that every annotator has produced an annotation.
-In these cases, the incomplete annotations are *excluded* from the agreement calculation.
-The effect is that in the *(the) blackboard* example, there is actually no data to be compared.
-If we augment that example with some other word on which the annotators agree, then only this word is considered, meaning that we have a perfect agreement despite the annotators not having agreed on *(the) blackboard*.
-Thus, one should avoid measure that cannot deal with incomplete annotations such as Fleiss' kappa
-and Cohen's kappa except for tasks such as part-of-speech tagging where it is known that positions
-are the same for all annotators and all annotators are required (not expected) to provide an annotation.
+When using coding measures, there is the concept of *incomplete annotations*. 
+An annotation is incomplete if at least one annotator has not provided a label for a given position. 
+In pairwise comparisons, this means one annotator has made a label and the other has not. 
 
-The agreement calculations considers an unset feature (with a `null` value) to be equivalent to a feature with the value of an empty string.
-Empty strings are considered valid labels and are not excluded from agreement calculation.
-Thus, an *incomplete* annotation is not one where the label is missing, but rather one where the entire annotation is missing.
+Positions are matched based on the spans or relation endpoints chosen by annotators. 
+If one annotator labels *the blackboard* and another labels only *blackboard*, these are treated as two separate positions. 
+Both are considered incomplete because not all annotators labeled the same span. 
 
-In general, it is a good idea to use at least a measure that supports incomplete data (i.e. missing
-labels) or even a unitizing measure which is able to produce partial agreement scores.
+Some agreement measures cannot handle incomplete annotations. 
+These measures require every annotator to provide a label for each position. 
+If a measure cannot handle incomplete annotations, those positions are *excluded* from the calculation. 
+Note that this exclusion may lead to misleading results. 
+For example, results may appear overly positive because potential disagreements were not considered. 
+If the annotators disagreed on the *blackboard*/*the blackboard* position but then agree with position and label on *chalk* later in the same document, the agreement score will be perfect because it is based only on the *chalk* position. 
+
+This can affect the agreement score. 
+For example, if annotators only agree on one word, only that word is counted. 
+The agreement score may appear perfect even if they disagreed elsewhere. 
+
+Measures like Fleiss' kappa and Cohen's kappa cannot handle incomplete annotations. 
+They should only be used when all annotators are required to label every position, such as in part-of-speech tagging. 
+
+It is recommended to use a measure that supports incomplete data (missing labels), or a unitizing measure that can provide partial agreement scores. 
+
+.Distinction between "no annotation", "empty", and "null"
+* *No annotation*: The annotator did not create an annotation at the given position.
+  This means there is no annotation object at all for that position.
+* *Empty*: The annotator created an annotation, but the feature value is an empty string (`""`).
+  This is a valid label and is included in the agreement calculation.
+* *Null*: The annotator created an annotation, but the feature value is `null`.
+  This is treated the same as an empty string in the agreement calculation.
+
+For example:
+- If annotator 1 does not annotate a position and annotator 2 assigns the label `bar`, this is considered "no annotation" vs. a label.
+- If annotator 1 assigns an empty string and annotator 2 assigns `bar`, this is "empty" vs. a label.
+- If annotator 1 assigns `null` and annotator 2 assigns an empty string, this is "null" vs. "empty" and is treated as agreement.
+
 
 .Possible combinations for agreement
 |====
@@ -166,9 +215,8 @@ labels) or even a unitizing measure which is able to produce partial agreement s
 
 == Stacked annotations
 
-Multiple interpretations in the form of stacked annotations are not supported in the agreement 
-calculation! 
-This also includes relations for which source or targets spans are stacked.
+Multiple interpretations in the form of stacked annotations are not supported in the agreement calculation. 
+This also includes relations for which source or target spans are stacked.
 
 
 [[sect_agreement_matrix]]


### PR DESCRIPTION
**What's in the PR**
- Add CSV and JSON exports for document-metadata, relation and chain layers
- Allow exporting as CSV and JSON even if there is no measure
- Update the documentation

**How to test manually**
* Try exporting the annotations from the different layer types via the agreement page to JSON / CSV

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
