### PR TITLE
#5540 - Slow reaction times on large documents when search is active

### DIFF
--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchQueryRequest.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchQueryRequest.java
@@ -24,14 +24,12 @@ import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
-import de.tudarmstadt.ukp.inception.search.model.AnnotationSearchState;
 
 public class SearchQueryRequest
 {
     private final Project project;
     private final User user;
     private final String query;
-    private final AnnotationSearchState prefs;
 
     private final SourceDocument limitedToDocument;
 
@@ -40,38 +38,36 @@ public class SearchQueryRequest
 
     private final long offset;
     private final long limit;
+    private final boolean commitRequired;
 
-    private SearchQueryRequest(Builder builder)
+    private SearchQueryRequest(Builder aBuilder)
     {
-        this.project = builder.project;
-        this.user = builder.user;
-        this.query = builder.query;
-        this.prefs = builder.options;
-        this.limitedToDocument = builder.limitedToDocument;
-        this.annoationLayer = builder.annoationLayer;
-        this.annotationFeature = builder.annotationFeature;
-        this.offset = builder.offset;
-        this.limit = builder.limit;
+        project = aBuilder.project;
+        user = aBuilder.user;
+        query = aBuilder.query;
+        limitedToDocument = aBuilder.limitedToDocument;
+        annoationLayer = aBuilder.annoationLayer;
+        annotationFeature = aBuilder.annotationFeature;
+        offset = aBuilder.offset;
+        limit = aBuilder.limit;
+        commitRequired = aBuilder.commitRequired;
+    }
+
+    public SearchQueryRequest(Project aProject, User aUser, String aQuery)
+    {
+        this(aProject, aUser, aQuery, null);
     }
 
     public SearchQueryRequest(Project aProject, User aUser, String aQuery,
-            AnnotationSearchState aPrefs)
+            SourceDocument aLimitedToDocument)
     {
-        this(aProject, aUser, aQuery, null, aPrefs);
-    }
-
-    public SearchQueryRequest(Project aProject, User aUser, String aQuery,
-            SourceDocument aLimitedToDocument, AnnotationSearchState aPrefs)
-    {
-        this(aProject, aUser, aQuery, aLimitedToDocument, null, null, 0, Integer.MAX_VALUE, aPrefs);
+        this(aProject, aUser, aQuery, aLimitedToDocument, null, null, 0, Integer.MAX_VALUE);
     }
 
     public SearchQueryRequest(Project aProject, User aUser, String aQuery,
             SourceDocument aLimitedToDocument, AnnotationLayer aAnnotationLayer,
-            AnnotationFeature aAnnotationFeature, long aOffset, long aCount,
-            AnnotationSearchState aPrefs)
+            AnnotationFeature aAnnotationFeature, long aOffset, long aCount)
     {
-        super();
         project = aProject;
         user = aUser;
         query = aQuery;
@@ -80,7 +76,7 @@ public class SearchQueryRequest
         annotationFeature = aAnnotationFeature;
         offset = aOffset;
         limit = aCount;
-        prefs = aPrefs;
+        commitRequired = true;
     }
 
     public Project getProject()
@@ -132,9 +128,9 @@ public class SearchQueryRequest
         return limit;
     }
 
-    public AnnotationSearchState getSearchSettings()
+    public boolean isCommitRequired()
     {
-        return prefs;
+        return commitRequired;
     }
 
     public static Builder builder()
@@ -147,12 +143,12 @@ public class SearchQueryRequest
         private Project project;
         private User user;
         private String query;
-        private AnnotationSearchState options;
         private SourceDocument limitedToDocument;
         private AnnotationLayer annoationLayer;
         private AnnotationFeature annotationFeature;
-        private long offset;
-        private long limit;
+        private long offset = 0;
+        private long limit = Long.MAX_VALUE;
+        private boolean commitRequired = true;
 
         private Builder()
         {
@@ -173,12 +169,6 @@ public class SearchQueryRequest
         public Builder withQuery(String aQuery)
         {
             this.query = aQuery;
-            return this;
-        }
-
-        public Builder withOptions(AnnotationSearchState aOptions)
-        {
-            this.options = aOptions;
             return this;
         }
 
@@ -209,6 +199,12 @@ public class SearchQueryRequest
         public Builder withLimit(long aLimit)
         {
             this.limit = aLimit;
+            return this;
+        }
+
+        public Builder withCommitRequired(boolean aRequire)
+        {
+            this.commitRequired = aRequire;
             return this;
         }
 

--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchService.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchService.java
@@ -36,6 +36,9 @@ public interface SearchService
     List<SearchResult> query(User aUser, Project aProject, String aQuery)
         throws IOException, ExecutionException;
 
+    Map<String, List<SearchResult>> query(SearchQueryRequest aRequest)
+        throws ExecutionException, IOException;
+
     /**
      * @param aUser
      *            the current user

--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/index/PhysicalIndex.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/index/PhysicalIndex.java
@@ -30,6 +30,7 @@ import de.tudarmstadt.ukp.inception.search.SearchQueryRequest;
 import de.tudarmstadt.ukp.inception.search.SearchResult;
 import de.tudarmstadt.ukp.inception.search.StatisticRequest;
 import de.tudarmstadt.ukp.inception.search.StatisticsResult;
+import de.tudarmstadt.ukp.inception.search.model.AnnotationSearchState;
 
 public interface PhysicalIndex
 {
@@ -53,10 +54,11 @@ public interface PhysicalIndex
 
     void close();
 
-    Map<String, List<SearchResult>> executeQuery(SearchQueryRequest aRequest)
+    Map<String, List<SearchResult>> executeQuery(SearchQueryRequest aRequest,
+            AnnotationSearchState aPrefs)
         throws IOException, ExecutionException;
 
-    long numberOfQueryResults(SearchQueryRequest aSearchQueryRequest)
+    long numberOfQueryResults(SearchQueryRequest aSearchQueryRequest, AnnotationSearchState aPrefs)
         throws IOException, ExecutionException;
 
     public LayerStatistics getLayerStatistics(StatisticRequest aStatisticRequest,

--- a/inception/inception-workload-dynamic/src/test/java/de/tudarmstadt/ukp/inception/workload/dynamic/DynamicWorkloadExtensionImplTest.java
+++ b/inception/inception-workload-dynamic/src/test/java/de/tudarmstadt/ukp/inception/workload/dynamic/DynamicWorkloadExtensionImplTest.java
@@ -31,9 +31,10 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 
+import javax.sql.DataSource;
+
 import org.apache.uima.fit.factory.TypeSystemDescriptionFactory;
 import org.apache.uima.util.CasCreationUtils;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -104,6 +105,7 @@ public class DynamicWorkloadExtensionImplTest
     private @Autowired UserDao userService;
     private @Autowired WorkloadManagementService workloadManagementService;
     private @Autowired DynamicWorkloadExtension dynamicWorkloadExtension;
+    private @Autowired DataSource dataSource;
 
     private User annotator;
     private User otherAnnotator;
@@ -132,12 +134,6 @@ public class DynamicWorkloadExtensionImplTest
         traits.setAbandonationState(AnnotationDocumentState.NEW);
         traits.setWorkflowType(DefaultWorkflowExtension.DEFAULT_WORKFLOW);
         dynamicWorkloadExtension.writeTraits(traits, project);
-    }
-
-    @AfterEach
-    public void tearDown() throws Exception
-    {
-        projectService.removeProject(project);
     }
 
     @Test


### PR DESCRIPTION
**What's in the PR**
- Searches done as part of the rendering process (SearchSidebarIcon.onRenderAnnotations) do not wait for changes to the MTAS index to have been committed anymore (which can take up to several seconds for large documents)

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
