### PR TITLE
#5542 - Keep document structure only in INITIAL_CAS to reduce user CAS sizes

### DIFF
--- a/inception/inception-api-formats/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/format/FormatSupport.java
+++ b/inception/inception-api-formats/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/format/FormatSupport.java
@@ -241,4 +241,9 @@ public interface FormatSupport
         copyFile(exportedFile, exportFile);
         return exportFile;
     }
+
+    default void prepareAnnotationCas(CAS aInitialCas, SourceDocument aDocument)
+    {
+        // Do nothing by default
+    }
 }

--- a/inception/inception-curation/pom.xml
+++ b/inception/inception-curation/pom.xml
@@ -69,11 +69,6 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
-      <artifactId>inception-io-xml</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-model</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/merge/CasMerge.java
+++ b/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/merge/CasMerge.java
@@ -59,7 +59,6 @@ import de.tudarmstadt.ukp.inception.annotation.storage.CasMetadataUtils;
 import de.tudarmstadt.ukp.inception.curation.api.Position;
 import de.tudarmstadt.ukp.inception.curation.merge.strategy.DefaultMergeStrategy;
 import de.tudarmstadt.ukp.inception.curation.merge.strategy.MergeStrategy;
-import de.tudarmstadt.ukp.inception.io.xml.dkprocore.XmlNodeUtils;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.AnnotationException;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.IllegalFeatureValueException;
@@ -540,7 +539,6 @@ public class CasMerge
         aCas.setDocumentText(backup.getDocumentText());
 
         transferSegmentation(aDocument.getProject(), aCas, backup);
-        XmlNodeUtils.transferXmlDocumentStructure(aCas, backup);
     }
 
     /**

--- a/inception/inception-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/PdfStructurePresentInNonInitialCasCheck.java
+++ b/inception/inception-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/PdfStructurePresentInNonInitialCasCheck.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.diag.checks;
+
+import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.INITIAL_CAS_PSEUDO_USER;
+
+import java.util.List;
+
+import org.apache.uima.cas.CAS;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.inception.support.logging.LogMessage;
+
+public class PdfStructurePresentInNonInitialCasCheck
+    implements Check
+{
+    public static final String PDF_CHUNK_TYPE = "org.dkpro.core.api.pdf.type.PdfChunk";
+    public static final String PDF_PAGE_TYPE = "org.dkpro.core.api.pdf.type.PdfPage";
+
+    @Override
+    public boolean check(SourceDocument aDocument, String aDataOwner, CAS aCas,
+            List<LogMessage> aMessages)
+    {
+        if (INITIAL_CAS_PSEUDO_USER.equals(aDataOwner)) {
+            // We do not want to check the initial CAS
+            return true;
+        }
+
+        if (aCas.select(PDF_PAGE_TYPE).isEmpty() && aCas.select(PDF_CHUNK_TYPE).isEmpty()) {
+            // No PDF structure present - good
+            return true;
+        }
+
+        aMessages.add(
+                LogMessage.warn(this, "PDF document structure is present in a non-initial CAS."));
+        return false;
+    }
+}

--- a/inception/inception-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/XmlStructurePresentInCurationCasCheck.java
+++ b/inception/inception-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/XmlStructurePresentInCurationCasCheck.java
@@ -33,6 +33,11 @@ import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.support.logging.LogMessage;
 
+/**
+ * @deprecated We no longer store the document structure in the annotator/curator CASes, only in the
+ *             INITIAL_CAS.
+ */
+@Deprecated
 public class XmlStructurePresentInCurationCasCheck
     implements Check
 {

--- a/inception/inception-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/XmlStructurePresentInNonInitialCasCheck.java
+++ b/inception/inception-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/checks/XmlStructurePresentInNonInitialCasCheck.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.diag.checks;
+
+import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.INITIAL_CAS_PSEUDO_USER;
+
+import java.util.List;
+
+import org.apache.uima.cas.CAS;
+import org.dkpro.core.api.xml.type.XmlDocument;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.inception.support.logging.LogMessage;
+
+public class XmlStructurePresentInNonInitialCasCheck
+    implements Check
+{
+    @Override
+    public boolean check(SourceDocument aDocument, String aDataOwner, CAS aCas,
+            List<LogMessage> aMessages)
+    {
+        if (INITIAL_CAS_PSEUDO_USER.equals(aDataOwner)) {
+            // We do not want to check the initial CAS
+            return true;
+        }
+
+        if (aCas.select(XmlDocument.class).isEmpty()) {
+            // No XML structure present - good
+            return true;
+        }
+
+        aMessages.add(
+                LogMessage.warn(this, "XML document structure is present in a non-initial CAS."));
+        return false;
+    }
+}

--- a/inception/inception-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/config/CasDoctorAutoConfiguration.java
+++ b/inception/inception-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/config/CasDoctorAutoConfiguration.java
@@ -43,11 +43,12 @@ import de.tudarmstadt.ukp.clarin.webanno.diag.checks.LinksReachableThroughChains
 import de.tudarmstadt.ukp.clarin.webanno.diag.checks.NegativeSizeAnnotationsCheck;
 import de.tudarmstadt.ukp.clarin.webanno.diag.checks.NoMultipleIncomingRelationsCheck;
 import de.tudarmstadt.ukp.clarin.webanno.diag.checks.NoZeroSizeTokensAndSentencesCheck;
+import de.tudarmstadt.ukp.clarin.webanno.diag.checks.PdfStructurePresentInNonInitialCasCheck;
 import de.tudarmstadt.ukp.clarin.webanno.diag.checks.RelationOffsetsCheck;
 import de.tudarmstadt.ukp.clarin.webanno.diag.checks.TokensAndSententencedDoNotOverlapCheck;
 import de.tudarmstadt.ukp.clarin.webanno.diag.checks.UniqueDocumentAnnotationCheck;
 import de.tudarmstadt.ukp.clarin.webanno.diag.checks.UnreachableAnnotationsCheck;
-import de.tudarmstadt.ukp.clarin.webanno.diag.checks.XmlStructurePresentInCurationCasCheck;
+import de.tudarmstadt.ukp.clarin.webanno.diag.checks.XmlStructurePresentInNonInitialCasCheck;
 import de.tudarmstadt.ukp.clarin.webanno.diag.repairs.CoverAllTextInSentencesRepair;
 import de.tudarmstadt.ukp.clarin.webanno.diag.repairs.ReattachFeatureAttachedSpanAnnotationsAndDeleteExtrasRepair;
 import de.tudarmstadt.ukp.clarin.webanno.diag.repairs.ReattachFeatureAttachedSpanAnnotationsRepair;
@@ -57,13 +58,13 @@ import de.tudarmstadt.ukp.clarin.webanno.diag.repairs.RemoveBomRepair;
 import de.tudarmstadt.ukp.clarin.webanno.diag.repairs.RemoveDanglingChainLinksRepair;
 import de.tudarmstadt.ukp.clarin.webanno.diag.repairs.RemoveDanglingFeatureAttachedSpanAnnotationsRepair;
 import de.tudarmstadt.ukp.clarin.webanno.diag.repairs.RemoveDanglingRelationsRepair;
+import de.tudarmstadt.ukp.clarin.webanno.diag.repairs.RemovePdfStructureFromNonInitialCasRepair;
+import de.tudarmstadt.ukp.clarin.webanno.diag.repairs.RemoveXmlStructureFromNonInitialCasRepair;
 import de.tudarmstadt.ukp.clarin.webanno.diag.repairs.RemoveZeroSizeTokensAndSentencesRepair;
 import de.tudarmstadt.ukp.clarin.webanno.diag.repairs.Repair;
-import de.tudarmstadt.ukp.clarin.webanno.diag.repairs.ReplaceXmlStructureInCurationCasRepair;
 import de.tudarmstadt.ukp.clarin.webanno.diag.repairs.SwitchBeginAndEndOnNegativeSizedAnnotationsRepair;
 import de.tudarmstadt.ukp.clarin.webanno.diag.repairs.TrimAnnotationsRepair;
 import de.tudarmstadt.ukp.clarin.webanno.diag.repairs.UpgradeCasRepair;
-import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 
 @Configuration
@@ -271,16 +272,26 @@ public class CasDoctorAutoConfiguration
     }
 
     @Bean
-    public XmlStructurePresentInCurationCasCheck xmlStructurePresentInCurationCasCheck(
-            DocumentService aDocumentService)
+    public XmlStructurePresentInNonInitialCasCheck xmlStructurePresentInNonInitialCasCheck()
     {
-        return new XmlStructurePresentInCurationCasCheck(aDocumentService);
+        return new XmlStructurePresentInNonInitialCasCheck();
     }
 
     @Bean
-    public ReplaceXmlStructureInCurationCasRepair replaceXmlStructureInCurationCasRepair(
-            DocumentService aDocumentService)
+    public RemoveXmlStructureFromNonInitialCasRepair removeXmlStructureFromNonInitialCasRepair()
     {
-        return new ReplaceXmlStructureInCurationCasRepair(aDocumentService);
+        return new RemoveXmlStructureFromNonInitialCasRepair();
+    }
+
+    @Bean
+    public PdfStructurePresentInNonInitialCasCheck pdfStructurePresentInNonInitialCasCheck()
+    {
+        return new PdfStructurePresentInNonInitialCasCheck();
+    }
+
+    @Bean
+    public RemovePdfStructureFromNonInitialCasRepair removePdfStructureFromNonInitialCasRepair()
+    {
+        return new RemovePdfStructureFromNonInitialCasRepair();
     }
 }

--- a/inception/inception-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/repairs/RemovePdfStructureFromNonInitialCasRepair.java
+++ b/inception/inception-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/repairs/RemovePdfStructureFromNonInitialCasRepair.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.diag.repairs;
+
+import static de.tudarmstadt.ukp.clarin.webanno.diag.checks.PdfStructurePresentInNonInitialCasCheck.PDF_CHUNK_TYPE;
+import static de.tudarmstadt.ukp.clarin.webanno.diag.checks.PdfStructurePresentInNonInitialCasCheck.PDF_PAGE_TYPE;
+import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.INITIAL_CAS_PSEUDO_USER;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.uima.cas.CAS;
+import org.apache.uima.cas.FeatureStructure;
+
+import de.tudarmstadt.ukp.clarin.webanno.diag.repairs.Repair.Safe;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.inception.support.logging.LogMessage;
+
+@Safe(false)
+public class RemovePdfStructureFromNonInitialCasRepair
+    implements Repair
+{
+    @Override
+    public void repair(SourceDocument aDocument, String aDataOwner, CAS aCas,
+            List<LogMessage> aMessages)
+    {
+        if (INITIAL_CAS_PSEUDO_USER.equals(aDataOwner)) {
+            // We do not want to touch the initial CAS
+            return;
+        }
+
+        var deleted = removePdfLayout(aCas);
+
+        aMessages.add(LogMessage.info(this,
+                "Removed PDF structure from non-initial CAS (%d nodes removed)", deleted));
+    }
+
+    private static int removePdfLayout(CAS aCas)
+    {
+        var toDelete = new ArrayList<FeatureStructure>();
+        aCas.select(PDF_CHUNK_TYPE).forEach(toDelete::add);
+        aCas.select(PDF_PAGE_TYPE).forEach(toDelete::add);
+        toDelete.forEach(aCas::removeFsFromIndexes);
+        return toDelete.size();
+    }
+}

--- a/inception/inception-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/repairs/RemoveXmlStructureFromNonInitialCasRepair.java
+++ b/inception/inception-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/repairs/RemoveXmlStructureFromNonInitialCasRepair.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.diag.repairs;
+
+import static de.tudarmstadt.ukp.inception.io.xml.dkprocore.XmlNodeUtils.removeXmlDocumentStructure;
+import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.INITIAL_CAS_PSEUDO_USER;
+
+import java.util.List;
+
+import org.apache.uima.cas.CAS;
+
+import de.tudarmstadt.ukp.clarin.webanno.diag.repairs.Repair.Safe;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.inception.support.logging.LogMessage;
+
+@Safe(false)
+public class RemoveXmlStructureFromNonInitialCasRepair
+    implements Repair
+{
+    @Override
+    public void repair(SourceDocument aDocument, String aDataOwner, CAS aCas,
+            List<LogMessage> aMessages)
+    {
+        if (INITIAL_CAS_PSEUDO_USER.equals(aDataOwner)) {
+            // We do not want to touch the initial CAS
+            return;
+        }
+
+        var deleted = removeXmlDocumentStructure(aCas);
+
+        aMessages.add(LogMessage.info(this,
+                "Removed XML structure from non-initial CAS (%d nodes removed)", deleted));
+    }
+}

--- a/inception/inception-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/repairs/ReplaceXmlStructureInCurationCasRepair.java
+++ b/inception/inception-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/repairs/ReplaceXmlStructureInCurationCasRepair.java
@@ -33,6 +33,11 @@ import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.support.logging.LogMessage;
 
+/**
+ * @deprecated We no longer store the document structure in the annotator/curator CASes, only in the
+ *             INITIAL_CAS.
+ */
+@Deprecated
 @Safe(false)
 public class ReplaceXmlStructureInCurationCasRepair
     implements Repair
@@ -69,7 +74,7 @@ public class ReplaceXmlStructureInCurationCasRepair
                 operation = "added";
             }
 
-            aMessages.add(LogMessage.error(this,
+            aMessages.add(LogMessage.info(this,
                     "XML document structure has been %s using the structure from the initial CAS (nodes: %d removed, %d added)",
                     operation, deleted, added));
         }

--- a/inception/inception-diag/src/main/resources/META-INF/asciidoc/user-guide/casdoctor.adoc
+++ b/inception/inception-diag/src/main/resources/META-INF/asciidoc/user-guide/casdoctor.adoc
@@ -225,7 +225,8 @@ Removing them is harmless and reduces memory and disk space usage.
 ID:: `AllAnnotationsStartAndEndWithCharactersCheck`
 Related repairs:: <<repair_TrimAnnotationsRepair>>
 
-Checks if all annotations start and end with a character (i.e. not a whitespace). Annotations that start or end with a whitespace character can cause problems during rendering. 
+Checks if all annotations start and end with a character (i.e. not a whitespace).
+Annotations that start or end with a whitespace character can cause problems during rendering. 
 Trimming whitespace at the begin and end is typically as  harmless procedure.
 
 [[check_DocumentTextStartsWithBomCheck]]
@@ -236,14 +237,26 @@ Related repairs:: <<repair_RemoveBomRepair>>
 
 Checks if the document text starts with a Byte Order Mark (BOM).
 
-[[check_XmlStructurePresentInCurationCasCheck]]
-=== XML structure is present in curation CAS
+[[check_PdfStructurePresentInNonInitialCasCheck]]
+=== PDF structure present in non-initial CAS
 [horizontal]
-ID:: `XmlStructurePresentInCurationCasCheck`
-Related repairs:: <<repair_ReplaceXmlStructureInCurationCasRepair>>
+ID:: `PdfStructurePresentInNonInitialCasCheck`
+Related repairs:: <<repair_RemovePdfStructureFromNonInitialCasRepair>>
 
-Checks if an XML structure that may have been extracted from the source document is present in the curation CAS.
-If it is not present, this check will fail.
+Checks if a PDF document structure that may have been extracted from the source document is present in an annotator or curator CAS.
+If it is present, the check will fail.
+We keep the document structure only in the initial CAS now.
+
+
+[[check_XmlStructurePresentInNonInitialCasCheck]]
+=== XML structure present in non-initial CAS
+[horizontal]
+ID:: `XmlStructurePresentInNonInitialCasCheck`
+Related repairs:: <<repair_RemoveXmlStructureFromNonInitialCasRepair>>
+
+Checks if an XML document structure that may have been extracted from the source document is present in an annotator or curator CAS.
+If it is present, the check will fail.
+We keep the document structure only in the initial CAS now.
 
 
 [[sect_repairs]]
@@ -413,10 +426,22 @@ ID:: `RemoveBomRepair`
 
 This repair removes the Byte Order Mark at the start of the document and adjusts all annotation offsets accordingly.
 
-[[repair_ReplaceXmlStructureInCurationCasRepair]]
-=== Relace XML structure in the curation CAS
+[[repair_RemovePdfStructureFromNonInitialCasRepair]]
+=== Remove PDF structure from non-initial CASes
 
 [horizontal]
-ID:: `ReplaceXmlStructureInCurationCasRepair`
+ID:: `RemovePdfStructureFromNonInitialCasRepair`
 
-This repair ensures the XML document structure that may have been extracted from the source document is also present in the curation CAS. Any potentially existing XML document structure int he curation CAS will be removed and replaced with the structure from the source document. 
+This repair ensures the PDF document structure that may have been extracted from the source document from annotator and
+curator CASes.
+We keep the document structure only in the initial CAS now.
+
+[[repair_RemoveXmlStructureFromNonInitialCasRepair]]
+=== Remove Xml structure from non-initial CASes
+
+[horizontal]
+ID:: `RemoveXmlStructureFromNonInitialCasRepair`
+
+This repair ensures the XML document structure that may have been extracted from the source document from annotator and
+curator CASes.
+We keep the document structure only in the initial CAS now.

--- a/inception/inception-documents/pom.xml
+++ b/inception/inception-documents/pom.xml
@@ -83,6 +83,11 @@
       <artifactId>inception-workload</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-api-formats</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/DocumentServiceImpl.java
+++ b/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/DocumentServiceImpl.java
@@ -957,8 +957,17 @@ public class DocumentServiceImpl
         // If there is no CAS yet for the source document, create one.
         CAS cas = casStorageService.readOrCreateCas(aDocument, aUserName, aUpgradeMode,
                 // Convert the source file into an annotation CAS
-                () -> createOrReadInitialCas(aDocument, NO_CAS_UPGRADE, UNMANAGED_ACCESS, null),
-                aMode);
+                () -> {
+                    var initialCas = createOrReadInitialCas(aDocument, NO_CAS_UPGRADE,
+                            UNMANAGED_ACCESS, null);
+
+                    var maybeFormatSupport = importExportService
+                            .getFormatById(aDocument.getFormat());
+                    maybeFormatSupport
+                            .ifPresent(fmt -> fmt.prepareAnnotationCas(initialCas, aDocument));
+
+                    return initialCas;
+                }, aMode);
 
         // We intentionally do not upgrade the CAS here because in general the IDs
         // must remain stable. If an upgrade is required the caller should do it

--- a/inception/inception-io-bioc/src/main/java/de/tudarmstadt/ukp/inception/io/bioc/BioCXmlDocumentFormatSupport.java
+++ b/inception/inception-io-bioc/src/main/java/de/tudarmstadt/ukp/inception/io/bioc/BioCXmlDocumentFormatSupport.java
@@ -28,7 +28,9 @@ import org.apache.uima.resource.metadata.TypeSystemDescription;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.io.bioc.config.BioCAutoConfiguration;
+import de.tudarmstadt.ukp.inception.io.xml.dkprocore.XmlNodeUtils;
 
 /**
  * Support for BioC format.
@@ -84,5 +86,11 @@ public class BioCXmlDocumentFormatSupport
         throws ResourceInitializationException
     {
         return createEngineDescription(BioCXmlDocumentWriter.class, aTSD);
+    }
+
+    @Override
+    public void prepareAnnotationCas(CAS aInitialCas, SourceDocument aDocument)
+    {
+        XmlNodeUtils.removeXmlDocumentStructure(aInitialCas);
     }
 }

--- a/inception/inception-io-docx/src/main/java/de/tudarmstadt/ukp/inception/io/docx/DocxFormatSupport.java
+++ b/inception/inception-io-docx/src/main/java/de/tudarmstadt/ukp/inception/io/docx/DocxFormatSupport.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.uima.cas.CAS;
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
@@ -31,6 +32,8 @@ import org.apache.wicket.request.resource.ResourceReference;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.inception.io.xml.dkprocore.XmlNodeUtils;
 import de.tudarmstadt.ukp.inception.support.io.WatchedResourceFile;
 import de.tudarmstadt.ukp.inception.support.xml.sanitizer.PolicyCollection;
 import de.tudarmstadt.ukp.inception.support.xml.sanitizer.PolicyCollectionIOUtils;
@@ -80,5 +83,11 @@ public class DocxFormatSupport
     public List<ResourceReference> getCssStylesheets()
     {
         return asList(DocxCssReference.get());
+    }
+
+    @Override
+    public void prepareAnnotationCas(CAS aInitialCas, SourceDocument aDocument)
+    {
+        XmlNodeUtils.removeXmlDocumentStructure(aInitialCas);
     }
 }

--- a/inception/inception-io-docx/src/main/java/de/tudarmstadt/ukp/inception/io/docx/DocxToCas.java
+++ b/inception/inception-io-docx/src/main/java/de/tudarmstadt/ukp/inception/io/docx/DocxToCas.java
@@ -33,7 +33,7 @@ public class DocxToCas
 {
     public void loadXml(JCas aJCas, InputStream aInputStream) throws IOException
     {
-        CasXmlHandler handler = new CasXmlHandler(aJCas);
+        var handler = new CasXmlHandler(aJCas);
         handler.captureText(true);
 
         try {

--- a/inception/inception-io-html/src/main/java/de/tudarmstadt/ukp/inception/io/html/HtmlArchiveFormatSupport.java
+++ b/inception/inception-io-html/src/main/java/de/tudarmstadt/ukp/inception/io/html/HtmlArchiveFormatSupport.java
@@ -24,14 +24,17 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.uima.cas.CAS;
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.externaleditor.policy.DefaultHtmlDocumentPolicy;
 import de.tudarmstadt.ukp.inception.io.html.config.HtmlSupportAutoConfiguration;
+import de.tudarmstadt.ukp.inception.io.xml.dkprocore.XmlNodeUtils;
 import de.tudarmstadt.ukp.inception.support.xml.sanitizer.PolicyCollection;
 
 /**
@@ -78,6 +81,12 @@ public class HtmlArchiveFormatSupport
         throws ResourceInitializationException
     {
         return createReaderDescription(HtmlArchiveDocumentReader.class, aTSD);
+    }
+
+    @Override
+    public void prepareAnnotationCas(CAS aInitialCas, SourceDocument aDocument)
+    {
+        XmlNodeUtils.removeXmlDocumentStructure(aInitialCas);
     }
 
     @Override

--- a/inception/inception-io-html/src/main/java/de/tudarmstadt/ukp/inception/io/html/HtmlFormatSupport.java
+++ b/inception/inception-io-html/src/main/java/de/tudarmstadt/ukp/inception/io/html/HtmlFormatSupport.java
@@ -22,15 +22,18 @@ import static org.apache.uima.fit.factory.CollectionReaderFactory.createReaderDe
 import java.io.IOException;
 import java.util.Optional;
 
+import org.apache.uima.cas.CAS;
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.externaleditor.policy.DefaultHtmlDocumentPolicy;
 import de.tudarmstadt.ukp.inception.io.html.config.HtmlSupportAutoConfiguration;
 import de.tudarmstadt.ukp.inception.io.html.dkprocore.HtmlDocumentReader;
+import de.tudarmstadt.ukp.inception.io.xml.dkprocore.XmlNodeUtils;
 import de.tudarmstadt.ukp.inception.support.xml.sanitizer.PolicyCollection;
 
 /**
@@ -83,5 +86,11 @@ public class HtmlFormatSupport
     public Optional<PolicyCollection> getPolicy() throws IOException
     {
         return Optional.of(defaultPolicy.getPolicy());
+    }
+
+    @Override
+    public void prepareAnnotationCas(CAS aInitialCas, SourceDocument aDocument)
+    {
+        XmlNodeUtils.removeXmlDocumentStructure(aInitialCas);
     }
 }

--- a/inception/inception-io-html/src/main/java/de/tudarmstadt/ukp/inception/io/html/MHtmlFormatSupport.java
+++ b/inception/inception-io-html/src/main/java/de/tudarmstadt/ukp/inception/io/html/MHtmlFormatSupport.java
@@ -34,14 +34,17 @@ import org.apache.james.mime4j.dom.Message;
 import org.apache.james.mime4j.dom.Multipart;
 import org.apache.james.mime4j.dom.SingleBody;
 import org.apache.james.mime4j.message.DefaultMessageBuilder;
+import org.apache.uima.cas.CAS;
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.externaleditor.policy.DefaultHtmlDocumentPolicy;
 import de.tudarmstadt.ukp.inception.io.html.config.HtmlSupportAutoConfiguration;
+import de.tudarmstadt.ukp.inception.io.xml.dkprocore.XmlNodeUtils;
 import de.tudarmstadt.ukp.inception.support.xml.sanitizer.PolicyCollection;
 
 /**
@@ -88,6 +91,12 @@ public class MHtmlFormatSupport
         throws ResourceInitializationException
     {
         return createReaderDescription(MHtmlDocumentReader.class, aTSD);
+    }
+
+    @Override
+    public void prepareAnnotationCas(CAS aInitialCas, SourceDocument aDocument)
+    {
+        XmlNodeUtils.removeXmlDocumentStructure(aInitialCas);
     }
 
     @Override

--- a/inception/inception-io-tei/src/main/java/de/tudarmstadt/ukp/inception/io/tei/TeiXmlDocumentFormatSupport.java
+++ b/inception/inception-io-tei/src/main/java/de/tudarmstadt/ukp/inception/io/tei/TeiXmlDocumentFormatSupport.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.uima.cas.CAS;
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
@@ -31,6 +32,8 @@ import org.apache.wicket.request.resource.ResourceReference;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.inception.io.xml.dkprocore.XmlNodeUtils;
 import de.tudarmstadt.ukp.inception.support.io.WatchedResourceFile;
 import de.tudarmstadt.ukp.inception.support.xml.sanitizer.PolicyCollection;
 import de.tudarmstadt.ukp.inception.support.xml.sanitizer.PolicyCollectionIOUtils;
@@ -85,5 +88,11 @@ public class TeiXmlDocumentFormatSupport
         return new WatchedResourceFile<PolicyCollection>(
                 getClass().getResource("TeiXmlDocumentPolicy.yaml"),
                 PolicyCollectionIOUtils::loadPolicies).get();
+    }
+
+    @Override
+    public void prepareAnnotationCas(CAS aInitialCas, SourceDocument aDocument)
+    {
+        XmlNodeUtils.removeXmlDocumentStructure(aInitialCas);
     }
 }

--- a/inception/inception-io-xml/src/main/java/de/tudarmstadt/ukp/inception/io/xml/CustomXmlFormatFactory.java
+++ b/inception/inception-io-xml/src/main/java/de/tudarmstadt/ukp/inception/io/xml/CustomXmlFormatFactory.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.uima.cas.CAS;
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
@@ -38,7 +39,9 @@ import org.slf4j.LoggerFactory;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.io.xml.dkprocore.XmlDocumentReader;
+import de.tudarmstadt.ukp.inception.io.xml.dkprocore.XmlNodeUtils;
 import de.tudarmstadt.ukp.inception.support.io.WatchedResourceFile;
 import de.tudarmstadt.ukp.inception.support.xml.sanitizer.PolicyCollection;
 import de.tudarmstadt.ukp.inception.support.xml.sanitizer.PolicyCollectionIOUtils;
@@ -125,6 +128,12 @@ public class CustomXmlFormatFactory
                 XmlDocumentReader.PARAM_BLOCK_ELEMENTS, description.getBlockElements(), //
                 XmlDocumentReader.PARAM_SPLIT_SENTENCES_IN_BLOCK_ELEMENTS,
                 description.isSplitSentencesInBlockElements());
+    }
+
+    @Override
+    public void prepareAnnotationCas(CAS aInitialCas, SourceDocument aDocument)
+    {
+        XmlNodeUtils.removeXmlDocumentStructure(aInitialCas);
     }
 
     @Override

--- a/inception/inception-io-xml/src/main/java/de/tudarmstadt/ukp/inception/io/xml/XmlFormatSupport.java
+++ b/inception/inception-io-xml/src/main/java/de/tudarmstadt/ukp/inception/io/xml/XmlFormatSupport.java
@@ -28,8 +28,10 @@ import org.apache.uima.resource.metadata.TypeSystemDescription;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.io.xml.dkprocore.XmlDocumentReader;
 import de.tudarmstadt.ukp.inception.io.xml.dkprocore.XmlDocumentWriter;
+import de.tudarmstadt.ukp.inception.io.xml.dkprocore.XmlNodeUtils;
 
 public class XmlFormatSupport
     implements FormatSupport
@@ -75,5 +77,11 @@ public class XmlFormatSupport
         throws ResourceInitializationException
     {
         return createEngineDescription(XmlDocumentWriter.class, aTSD);
+    }
+
+    @Override
+    public void prepareAnnotationCas(CAS aInitialCas, SourceDocument aDocument)
+    {
+        XmlNodeUtils.removeXmlDocumentStructure(aInitialCas);
     }
 }

--- a/inception/inception-io-xml/src/main/java/de/tudarmstadt/ukp/inception/io/xml/dkprocore/Cas2SaxEvents.java
+++ b/inception/inception-io-xml/src/main/java/de/tudarmstadt/ukp/inception/io/xml/dkprocore/Cas2SaxEvents.java
@@ -23,10 +23,8 @@ import static org.apache.uima.fit.util.JCasUtil.selectSingle;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import org.apache.uima.jcas.JCas;
-import org.dkpro.core.api.xml.type.XmlAttribute;
 import org.dkpro.core.api.xml.type.XmlDocument;
 import org.dkpro.core.api.xml.type.XmlElement;
 import org.dkpro.core.api.xml.type.XmlNode;
@@ -59,7 +57,7 @@ public class Cas2SaxEvents
 
     public void process(JCas aJCas) throws SAXException
     {
-        XmlDocument doc = selectSingle(aJCas, XmlDocument.class);
+        var doc = selectSingle(aJCas, XmlDocument.class);
 
         process(doc);
     }
@@ -83,7 +81,7 @@ public class Cas2SaxEvents
         var localMappings = new LinkedHashMap<String, String>();
 
         if (namespaces) {
-            for (Entry<String, String> xmlns : prefixMappings(aElement).entrySet()) {
+            for (var xmlns : prefixMappings(aElement).entrySet()) {
                 var oldValue = namespaceMappings.put(xmlns.getKey(), xmlns.getValue());
                 if (oldValue == null) {
                     localMappings.put(xmlns.getKey(), xmlns.getValue());
@@ -92,10 +90,10 @@ public class Cas2SaxEvents
             }
         }
 
-        AttributesImpl attributes = attributes(aElement);
-        String uri = defaultString(aElement.getUri());
-        String localName = defaultString(aElement.getLocalName());
-        String qName = defaultString(aElement.getQName());
+        var attributes = attributes(aElement);
+        var uri = defaultString(aElement.getUri());
+        var localName = defaultString(aElement.getLocalName());
+        var qName = defaultString(aElement.getQName());
 
         handler.startElement(uri, localName, qName, attributes);
 
@@ -128,7 +126,7 @@ public class Cas2SaxEvents
     {
         var mappings = new LinkedHashMap<String, String>();
         if (aElement.getAttributes() != null) {
-            for (XmlAttribute attr : aElement.getAttributes()) {
+            for (var attr : aElement.getAttributes()) {
                 if (XMLNS.equals(attr.getQName())) {
                     mappings.put("", attr.getValue());
                 }
@@ -145,9 +143,9 @@ public class Cas2SaxEvents
         // FIXME: SAX parsers would skip xmlns attributes if namespace support is enabled. Maybe
         // we should do the same?
 
-        AttributesImpl attrs = new AttributesImpl();
+        var attrs = new AttributesImpl();
         if (aElement.getAttributes() != null) {
-            for (XmlAttribute attr : aElement.getAttributes()) {
+            for (var attr : aElement.getAttributes()) {
                 attrs.addAttribute(defaultString(attr.getUri()), defaultString(attr.getLocalName()),
                         defaultString(attr.getQName()), defaultString(attr.getValueType(), "CDATA"),
                         defaultString(attr.getValue()));

--- a/inception/inception-pdf-editor2/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor2/format/PdfFormatSupport.java
+++ b/inception/inception-pdf-editor2/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor2/format/PdfFormatSupport.java
@@ -20,14 +20,20 @@ package de.tudarmstadt.ukp.inception.pdfeditor2.format;
 import static org.apache.uima.fit.factory.AnalysisEngineFactory.createEngineDescription;
 import static org.apache.uima.fit.factory.CollectionReaderFactory.createReaderDescription;
 
+import java.util.ArrayList;
+
 import org.apache.uima.analysis_engine.AnalysisEngineDescription;
 import org.apache.uima.cas.CAS;
+import org.apache.uima.cas.FeatureStructure;
 import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
+import org.dkpro.core.api.pdf.type.PdfChunk;
+import org.dkpro.core.api.pdf.type.PdfPage;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.pdfeditor2.config.PdfAnnotationEditor2SupportAutoConfiguration;
 import de.tudarmstadt.ukp.inception.pdfeditor2.config.PdfFormatProperties;
 
@@ -102,5 +108,20 @@ public class PdfFormatSupport
         return createEngineDescription( //
                 VisualPdfWriter.class, aTSD, //
                 VisualPdfWriter.PARAM_PROJECT_ID, aProject.getId());
+    }
+
+    @Override
+    public void prepareAnnotationCas(CAS aCas, SourceDocument aDocument)
+    {
+        removePdfLayout(aCas);
+    }
+
+    public static int removePdfLayout(CAS aCas)
+    {
+        var toDelete = new ArrayList<FeatureStructure>();
+        aCas.select(PdfChunk.class).forEach(toDelete::add);
+        aCas.select(PdfPage.class).forEach(toDelete::add);
+        toDelete.forEach(aCas::removeFsFromIndexes);
+        return toDelete.size();
     }
 }


### PR DESCRIPTION
**What's in the PR**
- Added new checks and repairs to remove PDF/XML structure from non-initial CASes
- Added ability for format supports to prepare the CASes for annotators/curators (i.e. remove docment structure)

**How to test manually**
* ...

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
