### PR TITLE
#5536 - Use read-only transactions when possible

### DIFF
--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseService.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseService.java
@@ -128,6 +128,8 @@ public interface KnowledgeBaseService
      */
     List<KnowledgeBase> getEnabledKnowledgeBases(Project aProject);
 
+    boolean hasMoreThanOneEnabledKnowledgeBases(Project aProject);
+
     RepositoryImplConfig getNativeConfig();
 
     RepositoryImplConfig getRemoteConfig(String url);

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
@@ -491,6 +491,17 @@ public class KnowledgeBaseServiceImpl
         return query.getResultList();
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public boolean hasMoreThanOneEnabledKnowledgeBases(Project aProject)
+    {
+        var countQuery = entityManager.createQuery(
+                "SELECT COUNT(kb) FROM KnowledgeBase kb WHERE kb.project = :project AND kb.enabled = true",
+                Long.class);
+        countQuery.setParameter("project", aProject);
+        return countQuery.getSingleResult() > 1;
+    }
+
     @Transactional
     @Override
     public void removeKnowledgeBase(KnowledgeBase aKB)

--- a/inception/inception-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
+++ b/inception/inception-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
@@ -249,17 +249,17 @@ public class ProjectServiceImpl
     }
 
     @Override
-    @Transactional
+    @Transactional(readOnly = true)
     public List<PermissionLevel> listRoles(Project aProject, User aUser)
     {
         return listRoles(aProject, aUser.getUsername());
     }
 
     @Override
-    @Transactional
+    @Transactional(readOnly = true)
     public List<PermissionLevel> listRoles(Project aProject, String aUser)
     {
-        String query = join("\n", //
+        var query = join("\n", //
                 "SELECT level ", //
                 "FROM ProjectPermission ", //
                 "WHERE user =:user AND project =:project ", //

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureEditor.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureEditor.java
@@ -149,7 +149,7 @@ public class ConceptFeatureEditor
         // There is now KB selector in the browser yet, so we do not show it unless either the
         // feature is bound to a specific KB or there is only a single KB in the project.
         if (traits.getRepositoryId() == null && knowledgeBaseService
-                .getEnabledKnowledgeBases(getModelObject().feature.getProject()).size() > 1) {
+                .hasMoreThanOneEnabledKnowledgeBases(getModelObject().feature.getProject())) {
             return false;
         }
 

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/MultiValueConceptFeatureEditor.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/MultiValueConceptFeatureEditor.java
@@ -187,7 +187,7 @@ public class MultiValueConceptFeatureEditor
         // There is now KB selector in the browser yet, so we do not show it unless either the
         // feature is bound to a specific KB or there is only a single KB in the project.
         if (traits.getRepositoryId() == null && knowledgeBaseService
-                .getEnabledKnowledgeBases(getModelObject().feature.getProject()).size() > 1) {
+                .hasMoreThanOneEnabledKnowledgeBases(getModelObject().feature.getProject())) {
             return false;
         }
 

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/MultiValueConceptFeatureTraitsEditor.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/MultiValueConceptFeatureTraitsEditor.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.inception.ui.kb.feature;
 
 import static de.tudarmstadt.ukp.inception.kb.ConceptFeatureValueType.CONCEPT;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import java.io.Serializable;
 import java.util.Arrays;
@@ -25,7 +26,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.markup.html.form.Form;
@@ -36,7 +36,6 @@ import org.apache.wicket.model.LoadableDetachableModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
-import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.inception.conceptlinking.service.ConceptLinkingService;
 import de.tudarmstadt.ukp.inception.kb.ConceptFeatureTraits;
 import de.tudarmstadt.ukp.inception.kb.ConceptFeatureValueType;
@@ -84,7 +83,7 @@ public class MultiValueConceptFeatureTraitsEditor
         feature = aFeatureModel;
         traits = CompoundPropertyModel.of(readTraits());
 
-        Form<Traits> form = new Form<Traits>(MID_FORM, traits)
+        var form = new Form<Traits>(MID_FORM, traits)
         {
             private static final long serialVersionUID = -3109239605783291123L;
 
@@ -116,7 +115,7 @@ public class MultiValueConceptFeatureTraitsEditor
 
     private void refresh(AjaxRequestTarget aTarget)
     {
-        Traits t = traits.getObject();
+        var t = traits.getObject();
         t.setScope(loadConcept(t.getKnowledgeBase(),
                 t.getScope() != null ? t.getScope().getIdentifier() : null));
         aTarget.add(get(MID_FORM).get(MID_SCOPE));
@@ -148,11 +147,11 @@ public class MultiValueConceptFeatureTraitsEditor
      */
     private Traits readTraits()
     {
-        Project project = feature.getObject().getProject();
+        var project = feature.getObject().getProject();
 
-        Traits result = new Traits();
+        var result = new Traits();
 
-        MultiValueConceptFeatureTraits t = getFeatureSupport().readTraits(feature.getObject());
+        var t = getFeatureSupport().readTraits(feature.getObject());
 
         if (t.getRepositoryId() != null) {
             kbService.getKnowledgeBaseById(project, t.getRepositoryId())
@@ -178,7 +177,7 @@ public class MultiValueConceptFeatureTraitsEditor
      */
     private void writeTraits()
     {
-        MultiValueConceptFeatureTraits t = new MultiValueConceptFeatureTraits();
+        var t = new MultiValueConceptFeatureTraits();
         if (traits.getObject().knowledgeBase != null) {
             t.setRepositoryId(traits.getObject().knowledgeBase.getRepositoryId());
 
@@ -215,11 +214,11 @@ public class MultiValueConceptFeatureTraitsEditor
      */
     private List<KBHandle> listSearchResults(String aTypedString, ConceptFeatureValueType aType)
     {
-        if (StringUtils.isBlank(aTypedString)) {
+        if (isBlank(aTypedString)) {
             return Collections.emptyList();
         }
 
-        Traits t = traits.getObject();
+        var t = traits.getObject();
         return conceptLinkingService.getLinkingInstancesInKBScope(
                 t.knowledgeBase != null ? t.knowledgeBase.getRepositoryId() : null, null, aType,
                 aTypedString, null, -1, null, feature.getObject().getProject());


### PR DESCRIPTION
**What's in the PR**
- Add more read-only transactions
- Use more var
- Use a LoadableDetachableModel on the annotation page for the read-only status to avoid potential multiple DB lookups for this

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
