### PR TITLE
#5549 - Remove explicit deletion of index from DB on project remove and rely on CASCADE

### DIFF
--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchServiceImpl.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchServiceImpl.java
@@ -69,7 +69,6 @@ import de.tudarmstadt.ukp.inception.search.config.SearchServiceProperties;
 import de.tudarmstadt.ukp.inception.search.index.IndexRebuildRequiredException;
 import de.tudarmstadt.ukp.inception.search.index.PhysicalIndexRegistry;
 import de.tudarmstadt.ukp.inception.search.model.Index;
-import de.tudarmstadt.ukp.inception.search.model.Index_;
 import de.tudarmstadt.ukp.inception.search.scheduling.tasks.IndexAnnotationDocumentTask;
 import de.tudarmstadt.ukp.inception.search.scheduling.tasks.IndexSourceDocumentTask;
 import de.tudarmstadt.ukp.inception.search.scheduling.tasks.IndexingTask_ImplBase;
@@ -329,22 +328,6 @@ public class SearchServiceImpl
             if (index.getPhysicalIndex().isCreated()) {
                 index.getPhysicalIndex().delete();
             }
-
-            deleteIndexFromDb(index);
-        }
-    }
-
-    private void deleteIndexFromDb(Index aIndex)
-    {
-        var cb = entityManager.getCriteriaBuilder();
-        var delete = cb.createCriteriaDelete(Index.class);
-        var root = delete.from(Index.class);
-        delete.where(cb.equal(root.get(Index_.ID), aIndex.getId()));
-        int rowsDeleted = entityManager.createQuery(delete).executeUpdate();
-
-        if (rowsDeleted == 0) {
-            LOG.debug("Unable to delete index with ID {} from database - not found.",
-                    aIndex.getId());
         }
     }
 


### PR DESCRIPTION
**What's in the PR**
- Remove explicit index deletion on project remove - happens automatically

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
