### PR TITLE
#5534 - Option to retain recommender scores when accepting an annotation

### DIFF
--- a/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/ActiveLearningService.java
+++ b/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/ActiveLearningService.java
@@ -26,6 +26,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.inception.active.learning.ActiveLearningServiceImpl.ActiveLearningUserState;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordUserAction;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.Predictions;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.SpanSuggestion;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.SuggestionGroup;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.SuggestionGroup.Delta;
@@ -61,8 +62,8 @@ public interface ActiveLearningService
     Optional<Delta<SpanSuggestion>> generateNextSuggestion(String aSessionOwner, User aDataOwner,
             ActiveLearningUserState aAlState);
 
-    void acceptSpanSuggestion(SourceDocument aDocument, User aDataOwner, SpanSuggestion aSuggestion,
-            Object aValue)
+    void acceptSpanSuggestion(SourceDocument aDocument, User aDataOwner, Predictions aPredictions,
+            SpanSuggestion aSuggestion, Object aValue)
         throws IOException, AnnotationException;
 
     void rejectSpanSuggestion(String aSessionOwner, User aDataOwner, AnnotationLayer aLayer,

--- a/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/ActiveLearningServiceImpl.java
+++ b/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/ActiveLearningServiceImpl.java
@@ -54,6 +54,7 @@ import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.recommendation.api.LearningRecordService;
 import de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.AnnotationSuggestion;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.Predictions;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.SpanSuggestion;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.SuggestionGroup;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.SuggestionGroup.Delta;
@@ -190,7 +191,7 @@ public class ActiveLearningServiceImpl
     @Override
     @Transactional
     public void acceptSpanSuggestion(SourceDocument aDocument, User aDataOwner,
-            SpanSuggestion aSuggestion, Object aValue)
+            Predictions aPredictions, SpanSuggestion aSuggestion, Object aValue)
         throws IOException, AnnotationException
     {
         // Upsert an annotation based on the suggestion
@@ -219,11 +220,11 @@ public class ActiveLearningServiceImpl
         var action = aSuggestion.labelEquals(label) ? ACCEPTED : CORRECTED;
         if (action == CORRECTED) {
             recommendationService.correctSuggestion(sessionOwner, aDocument, dataOwner, cas,
-                    aSuggestion, suggestionWithUserSelectedLabel, AL_SIDEBAR);
+                    aPredictions, aSuggestion, suggestionWithUserSelectedLabel, AL_SIDEBAR);
         }
         else {
             recommendationService.acceptSuggestion(sessionOwner, aDocument, dataOwner, cas,
-                    suggestionWithUserSelectedLabel, AL_SIDEBAR);
+                    aPredictions, suggestionWithUserSelectedLabel, AL_SIDEBAR);
         }
 
         // Save CAS after annotation has been created

--- a/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.java
+++ b/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.java
@@ -717,10 +717,13 @@ public class ActiveLearningSidebar
         // from the update event created by acceptSuggestion/upsertSpanFeature.
         requestClearningSelectionAndJumpingToSuggestion();
 
+        var project = state.getProject();
+        var dataOwner = state.getUser();
         var document = documentService.getSourceDocument(state.getProject().getId(),
                 suggestion.getDocumentId());
-        activeLearningService.acceptSpanSuggestion(document, state.getUser(), suggestion,
-                editor.getModelObject().value);
+        var predictions = recommendationService.getPredictions(dataOwner, project);
+        activeLearningService.acceptSpanSuggestion(document, state.getUser(), predictions,
+                suggestion, editor.getModelObject().value);
 
         // If the currently displayed document is the same one where the annotation was created,
         // then update timestamp in state to avoid concurrent modification errors

--- a/inception/inception-feature-link/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/link/recommender/LinkSuggestionSupport.java
+++ b/inception/inception-feature-link/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/link/recommender/LinkSuggestionSupport.java
@@ -52,6 +52,7 @@ import de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordUserA
 import de.tudarmstadt.ukp.inception.recommendation.api.model.LinkPosition;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.LinkSuggestion;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Position;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.Predictions;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
 import de.tudarmstadt.ukp.inception.recommendation.api.recommender.ExtractionContext;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
@@ -106,8 +107,8 @@ public class LinkSuggestionSupport
     @Override
     public AnnotationFS acceptSuggestion(String aSessionOwner, SourceDocument aDocument,
             String aDataOwner, CAS aCas, TypeAdapter aAdapter, AnnotationFeature aFeature,
-            AnnotationSuggestion aSuggestion, LearningRecordChangeLocation aLocation,
-            LearningRecordUserAction aAction)
+            Predictions aPredictions, AnnotationSuggestion aSuggestion,
+            LearningRecordChangeLocation aLocation, LearningRecordUserAction aAction)
         throws AnnotationException
     {
         var suggestion = (LinkSuggestion) aSuggestion;

--- a/inception/inception-feature-string/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiValueStringFeatureSupport.java
+++ b/inception/inception-feature-string/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiValueStringFeatureSupport.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.annotation.feature.multistring;
 
+import static de.tudarmstadt.ukp.inception.annotation.type.StringSuggestionUtil.appendStringSuggestions;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.unmodifiableList;
@@ -54,7 +55,6 @@ import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.annotation.feature.misc.UimaPrimitiveFeatureSupport_ImplBase;
 import de.tudarmstadt.ukp.inception.annotation.feature.string.StringFeatureSupportProperties;
 import de.tudarmstadt.ukp.inception.annotation.feature.string.StringFeatureSupportPropertiesImpl;
-import de.tudarmstadt.ukp.inception.annotation.type.RecommenderDecl;
 import de.tudarmstadt.ukp.inception.annotation.type.StringSuggestion;
 import de.tudarmstadt.ukp.inception.editor.action.AnnotationActionHandler;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
@@ -244,26 +244,12 @@ public class MultiValueStringFeatureSupport
     }
 
     @Override
-    public void pushSuggestion(SourceDocument aDocument, String aDataOwner,
-            AnnotationBaseFS aAnnotation, AnnotationFeature aFeature, String aLabel, double aScore,
-            String aRecommenderName)
+    public void pushSuggestions(SourceDocument aDocument, String aDataOwner,
+            AnnotationBaseFS aAnnotation, AnnotationFeature aFeature,
+            List<SuggestionState> aSuggestions)
     {
-        var jcas = aAnnotation.getCAS().getJCasImpl();
-
-        var recommenderDecl = jcas.select(RecommenderDecl.class) //
-                .filter(rec -> aRecommenderName.equals(rec.getName())).findFirst().orElseGet(() -> {
-                    var decl = new RecommenderDecl(jcas);
-                    decl.setName(aRecommenderName);
-                    decl.addToIndexes();
-                    return decl;
-                });
-
-        var stringSuggestion = new StringSuggestion(jcas);
-        stringSuggestion.setLabel(aLabel);
-        stringSuggestion.setScore((float) aScore);
-        stringSuggestion.setRecommender(recommenderDecl);
-        FSUtil.setFeature(aAnnotation, aFeature.getName() + SUFFIX_SUGGESTION_INFO,
-                asList(stringSuggestion));
+        appendStringSuggestions(aAnnotation, aFeature.getName() + SUFFIX_SUGGESTION_INFO,
+                aSuggestions);
     }
 
     @Override

--- a/inception/inception-feature-string/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/StringFeatureSupport.java
+++ b/inception/inception-feature-string/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/StringFeatureSupport.java
@@ -20,6 +20,7 @@ package de.tudarmstadt.ukp.inception.annotation.feature.string;
 import static de.tudarmstadt.ukp.inception.annotation.feature.string.StringFeatureTraits.EditorType.AUTOCOMPLETE;
 import static de.tudarmstadt.ukp.inception.annotation.feature.string.StringFeatureTraits.EditorType.COMBOBOX;
 import static de.tudarmstadt.ukp.inception.annotation.feature.string.StringFeatureTraits.EditorType.RADIOGROUP;
+import static de.tudarmstadt.ukp.inception.annotation.type.StringSuggestionUtil.setStringSuggestions;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.unmodifiableList;
@@ -49,7 +50,6 @@ import de.tudarmstadt.ukp.clarin.webanno.model.MultiValueMode;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.annotation.feature.misc.UimaPrimitiveFeatureSupport_ImplBase;
 import de.tudarmstadt.ukp.inception.annotation.feature.string.StringFeatureTraits.EditorType;
-import de.tudarmstadt.ukp.inception.annotation.type.RecommenderDecl;
 import de.tudarmstadt.ukp.inception.annotation.type.StringSuggestion;
 import de.tudarmstadt.ukp.inception.editor.action.AnnotationActionHandler;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
@@ -279,26 +279,12 @@ public class StringFeatureSupport
     }
 
     @Override
-    public void pushSuggestion(SourceDocument aDocument, String aDataOwner,
-            AnnotationBaseFS aAnnotation, AnnotationFeature aFeature, String aLabel, double aScore,
-            String aRecommenderName)
+    public void pushSuggestions(SourceDocument aDocument, String aDataOwner,
+            AnnotationBaseFS aAnnotation, AnnotationFeature aFeature,
+            List<SuggestionState> aSuggestions)
     {
-        var jcas = aAnnotation.getCAS().getJCasImpl();
-
-        var recommenderDecl = jcas.select(RecommenderDecl.class) //
-                .filter(rec -> aRecommenderName.equals(rec.getName())).findFirst().orElseGet(() -> {
-                    var decl = new RecommenderDecl(jcas);
-                    decl.setName(aRecommenderName);
-                    decl.addToIndexes();
-                    return decl;
-                });
-
-        var stringSuggestion = new StringSuggestion(jcas);
-        stringSuggestion.setLabel(aLabel);
-        stringSuggestion.setScore((float) aScore);
-        stringSuggestion.setRecommender(recommenderDecl);
-        FSUtil.setFeature(aAnnotation, aFeature.getName() + SUFFIX_SUGGESTION_INFO,
-                asList(stringSuggestion));
+        setStringSuggestions(aAnnotation, aFeature.getName() + SUFFIX_SUGGESTION_INFO,
+                aSuggestions);
     }
 
     @Override

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/document/recommender/MetadataSuggestionSupport.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/document/recommender/MetadataSuggestionSupport.java
@@ -51,6 +51,7 @@ import de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecord;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordChangeLocation;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordUserAction;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.MetadataSuggestion;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.Predictions;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.SuggestionGroup;
 import de.tudarmstadt.ukp.inception.recommendation.api.recommender.ExtractionContext;
@@ -94,8 +95,8 @@ public class MetadataSuggestionSupport
     @Override
     public AnnotationBaseFS acceptSuggestion(String aSessionOwner, SourceDocument aDocument,
             String aDataOwner, CAS aCas, TypeAdapter aAdapter, AnnotationFeature aFeature,
-            AnnotationSuggestion aSuggestion, LearningRecordChangeLocation aLocation,
-            LearningRecordUserAction aAction)
+            Predictions aPredictions, AnnotationSuggestion aSuggestion,
+            LearningRecordChangeLocation aLocation, LearningRecordUserAction aAction)
         throws AnnotationException
     {
         var adapter = (DocumentMetadataLayerAdapter) aAdapter;
@@ -128,7 +129,8 @@ public class MetadataSuggestionSupport
             }
 
             try {
-                commitLabel(aDocument, aDataOwner, aAdapter, annotation, aFeature, aSuggestion);
+                commitLabel(aDocument, aDataOwner, aAdapter, annotation, aFeature, aPredictions,
+                        aSuggestion);
             }
             catch (Exception e) {
                 if (annotationCreated) {

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/document/sidebar/DocumentMetadataAnnotationSelectionPanel.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/document/sidebar/DocumentMetadataAnnotationSelectionPanel.java
@@ -183,13 +183,14 @@ public class DocumentMetadataAnnotationSelectionPanel
             var state = getModelObject();
             var dataOwner = state.getUser().getUsername();
             var sessionOwner = userService.getCurrentUser();
-            var suggestion = recommendationService.getPredictions(sessionOwner, state.getProject())
-                    .getPredictionByVID(state.getDocument(), aItem.vid).get();
+            var predictions = recommendationService.getPredictions(sessionOwner,
+                    state.getProject());
+            var suggestion = predictions.getPredictionByVID(state.getDocument(), aItem.vid).get();
 
             var aCas = casProvider.get();
 
             recommendationService.acceptSuggestion(sessionOwner.getUsername(), state.getDocument(),
-                    dataOwner, aCas, suggestion, MAIN_EDITOR);
+                    dataOwner, aCas, predictions, suggestion, MAIN_EDITOR);
 
             page.writeEditorCas(aCas);
 

--- a/inception/inception-layer-relation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/recommender/RelationSuggestionSupport.java
+++ b/inception/inception-layer-relation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/recommender/RelationSuggestionSupport.java
@@ -52,6 +52,7 @@ import de.tudarmstadt.ukp.inception.recommendation.api.model.AnnotationSuggestio
 import de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordChangeLocation;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordUserAction;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Position;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.Predictions;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.RelationPosition;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.RelationSuggestion;
@@ -132,8 +133,8 @@ public class RelationSuggestionSupport
     @Override
     public AnnotationFS acceptSuggestion(String aSessionOwner, SourceDocument aDocument,
             String aDataOwner, CAS aCas, TypeAdapter aAdapter, AnnotationFeature aFeature,
-            AnnotationSuggestion aSuggestion, LearningRecordChangeLocation aLocation,
-            LearningRecordUserAction aAction)
+            Predictions aPredictions, AnnotationSuggestion aSuggestion,
+            LearningRecordChangeLocation aLocation, LearningRecordUserAction aAction)
         throws AnnotationException
     {
         var suggestion = (RelationSuggestion) aSuggestion;
@@ -206,7 +207,8 @@ public class RelationSuggestionSupport
             }
 
             try {
-                commitLabel(aDocument, aDataOwner, aAdapter, annotation, aFeature, aSuggestion);
+                commitLabel(aDocument, aDataOwner, aAdapter, annotation, aFeature, aPredictions,
+                        aSuggestion);
             }
             catch (Exception e) {
                 if (annotationCreated) {

--- a/inception/inception-layer-span/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/recommender/SpanSuggestionSupport.java
+++ b/inception/inception-layer-span/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/recommender/SpanSuggestionSupport.java
@@ -72,6 +72,7 @@ import de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecord;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordChangeLocation;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordUserAction;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Offset;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.Predictions;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.RelationSuggestion;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.SpanSuggestion;
@@ -128,18 +129,19 @@ public class SpanSuggestionSupport
     @Override
     public AnnotationBaseFS acceptSuggestion(String aSessionOwner, SourceDocument aDocument,
             String aDataOwner, CAS aCas, TypeAdapter aAdapter, AnnotationFeature aFeature,
-            AnnotationSuggestion aSuggestion, LearningRecordChangeLocation aLocation,
-            LearningRecordUserAction aAction)
+            Predictions aPredictions, AnnotationSuggestion aSuggestion,
+            LearningRecordChangeLocation aLocation, LearningRecordUserAction aAction)
         throws AnnotationException
     {
         return acceptOrCorrectSuggestion(aSessionOwner, aDocument, aDataOwner, aCas,
-                (SpanAdapter) aAdapter, aFeature, (SpanSuggestion) aSuggestion, aLocation, aAction);
+                (SpanAdapter) aAdapter, aFeature, aPredictions, (SpanSuggestion) aSuggestion,
+                aLocation, aAction);
     }
 
     public AnnotationFS acceptOrCorrectSuggestion(String aSessionOwner, SourceDocument aDocument,
             String aDataOwner, CAS aCas, SpanAdapter aAdapter, AnnotationFeature aFeature,
-            SpanSuggestion aSuggestion, LearningRecordChangeLocation aLocation,
-            LearningRecordUserAction aAction)
+            Predictions aPredictions, SpanSuggestion aSuggestion,
+            LearningRecordChangeLocation aLocation, LearningRecordUserAction aAction)
         throws AnnotationException
     {
         var begin = aSuggestion.getBegin();
@@ -177,7 +179,8 @@ public class SpanSuggestionSupport
             }
 
             try {
-                commitLabel(aDocument, aDataOwner, aAdapter, annotation, aFeature, aSuggestion);
+                commitLabel(aDocument, aDataOwner, aAdapter, annotation, aFeature, aPredictions,
+                        aSuggestion);
             }
             catch (Exception e) {
                 if (annotationCreated) {

--- a/inception/inception-processing/src/main/java/de/tudarmstadt/ukp/inception/processing/recommender/BulkPredictionTask.java
+++ b/inception/inception-processing/src/main/java/de/tudarmstadt/ukp/inception/processing/recommender/BulkPredictionTask.java
@@ -246,12 +246,12 @@ public class BulkPredictionTask
         return predictionTask.getPredictions();
     }
 
-    private int autoAccept(SourceDocument aDocument, Predictions predictions, CAS cas)
+    private int autoAccept(SourceDocument aDocument, Predictions aPredictions, CAS aCas)
     {
         var accepted = 0;
         var suggestionSupportCache = new HashMap<Recommender, Optional<SuggestionSupport>>();
 
-        for (var prediction : predictions.getPredictionsByDocument(aDocument.getId())) {
+        for (var prediction : aPredictions.getPredictionsByDocument(aDocument.getId())) {
             if (!Objects.equals(prediction.getRecommenderId(), recommender.getId())) {
                 continue;
             }
@@ -267,8 +267,8 @@ public class BulkPredictionTask
             adapter.silenceEvents();
 
             try {
-                suggestionSupport.get().acceptSuggestion(null, aDocument, dataOwner, cas, adapter,
-                        feature, prediction, AUTO_ACCEPT, ACCEPTED);
+                suggestionSupport.get().acceptSuggestion(null, aDocument, dataOwner, aCas, adapter,
+                        feature, aPredictions, prediction, AUTO_ACCEPT, ACCEPTED);
                 accepted++;
             }
             catch (AnnotationException e) {
@@ -276,7 +276,7 @@ public class BulkPredictionTask
             }
         }
 
-        predictions.log(LogMessage.info(this, "Auto-accepted [%d] suggestions", accepted));
+        aPredictions.log(LogMessage.info(this, "Auto-accepted [%d] suggestions", accepted));
         LOG.debug("Auto-accepted [{}] suggestions", accepted);
         return accepted;
     }

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/RecommendationService.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/RecommendationService.java
@@ -125,6 +125,8 @@ public interface RecommendationService
 
     Predictions getPredictions(User aSessionOwner, Project aProject);
 
+    Predictions getPredictions(String aSessionOwner, Project aProject);
+
     Predictions getIncomingPredictions(User aSessionOwner, Project aProject);
 
     void putIncomingPredictions(User aSessionOwner, Project aProject, Predictions aPredictions);
@@ -190,8 +192,9 @@ public interface RecommendationService
      *             if there was an annotation-level problem
      */
     AnnotationFS correctSuggestion(String aSessionOwner, SourceDocument aDocument,
-            String aDataOwner, CAS aCas, SpanSuggestion aOriginalSuggestion,
-            SpanSuggestion aCorrectedSuggestion, LearningRecordChangeLocation aLocation)
+            String aDataOwner, CAS aCas, Predictions aPredictions,
+            SpanSuggestion aOriginalSuggestion, SpanSuggestion aCorrectedSuggestion,
+            LearningRecordChangeLocation aLocation)
         throws AnnotationException;
 
     /**
@@ -216,7 +219,7 @@ public interface RecommendationService
      *             if there was an annotation-level problem
      */
     AnnotationBaseFS acceptSuggestion(String aSessionOwner, SourceDocument aDocument,
-            String aDataOwner, CAS aCas, AnnotationSuggestion aSuggestion,
+            String aDataOwner, CAS aCas, Predictions aPredictions, AnnotationSuggestion aSuggestion,
             LearningRecordChangeLocation aLocation)
         throws AnnotationException;
 

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/SuggestionSupport.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/SuggestionSupport.java
@@ -31,6 +31,7 @@ import de.tudarmstadt.ukp.inception.recommendation.api.model.AnnotationSuggestio
 import de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecord;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordChangeLocation;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordUserAction;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.Predictions;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.SuggestionGroup;
 import de.tudarmstadt.ukp.inception.recommendation.api.recommender.ExtractionContext;
@@ -90,8 +91,8 @@ public interface SuggestionSupport
      */
     AnnotationBaseFS acceptSuggestion(String aSessionOwner, SourceDocument aDocument,
             String aDataOwner, CAS aCas, TypeAdapter aAdapter, AnnotationFeature aFeature,
-            AnnotationSuggestion aSuggestion, LearningRecordChangeLocation aLocation,
-            LearningRecordUserAction aAction)
+            Predictions aPredictions, AnnotationSuggestion aSuggestion,
+            LearningRecordChangeLocation aLocation, LearningRecordUserAction aAction)
         throws AnnotationException;
 
     /**

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/RecommendationEditorExtension.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/RecommendationEditorExtension.java
@@ -31,7 +31,6 @@ import static org.apache.wicket.event.Broadcast.BREADTH;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import org.apache.uima.cas.CAS;
 import org.apache.uima.jcas.tcas.Annotation;
@@ -62,6 +61,7 @@ import de.tudarmstadt.ukp.inception.recommendation.api.event.AjaxRecommendationA
 import de.tudarmstadt.ukp.inception.recommendation.api.event.AjaxRecommendationRejectedEvent;
 import de.tudarmstadt.ukp.inception.recommendation.api.event.PredictionsSwitchedEvent;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.AnnotationSuggestion;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.Predictions;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.RelationSuggestion;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.SpanSuggestion;
 import de.tudarmstadt.ukp.inception.recommendation.config.RecommenderServiceAutoConfiguration;
@@ -134,7 +134,10 @@ public class RecommendationEditorExtension
             ((AnnotationPageBase) aTarget.getPage()).ensureIsEditable();
 
             var recommendationVid = VID.parse(aVID.getExtensionPayload());
-            var prediction = getPrediction(aState, recommendationVid);
+            var predictions = recommendationService.getPredictions(aState.getUser(),
+                    aState.getProject());
+            var prediction = predictions.getPredictionByVID(aState.getDocument(),
+                    recommendationVid);
             var document = aState.getDocument();
 
             if (prediction.isEmpty()) {
@@ -145,8 +148,8 @@ public class RecommendationEditorExtension
                 return;
             }
 
-            actionAcceptPrediction(aActionHandler, aState, aTarget, aCas, aVID, prediction,
-                    document);
+            actionAcceptPrediction(aActionHandler, aState, aTarget, aCas, aVID, predictions,
+                    prediction.get(), document);
         }
         else if (DoActionResponse.is(aAction) || RejectActionResponse.is(aAction)) {
             ((AnnotationPageBase) aTarget.getPage()).ensureIsEditable();
@@ -155,7 +158,10 @@ public class RecommendationEditorExtension
         }
         else if (ScrollToHandler.COMMAND.equals(aAction)) {
             var recommendationVid = VID.parse(aVID.getExtensionPayload());
-            var prediction = getPrediction(aState, recommendationVid);
+            var predictions = recommendationService.getPredictions(aState.getUser(),
+                    aState.getProject());
+            var prediction = predictions.getPredictionByVID(aState.getDocument(),
+                    recommendationVid);
             var page = (AnnotationPageBase) aTarget.getPage();
             if (prediction.map(p -> p instanceof SpanSuggestion).orElse(false)) {
                 var suggestion = (SpanSuggestion) prediction.get();
@@ -183,18 +189,17 @@ public class RecommendationEditorExtension
      */
     private void actionAcceptPrediction(AnnotationActionHandler aActionHandler,
             AnnotatorState aState, AjaxRequestTarget aTarget, CAS aCas, VID aVID,
-            Optional<AnnotationSuggestion> aSuggestion, SourceDocument document)
+            Predictions aPredictions, AnnotationSuggestion aSuggestion, SourceDocument document)
         throws AnnotationException, IOException
     {
-        var suggestion = aSuggestion.get();
         var page = (AnnotationPage) aTarget.getPage();
         var dataOwner = aState.getUser().getUsername();
         var sessionOwner = userService.getCurrentUsername();
-        var layer = annotationService.getLayer(suggestion.getLayerId());
+        var layer = annotationService.getLayer(aSuggestion.getLayerId());
         var adapter = annotationService.getAdapter(layer);
 
         var annotation = (Annotation) recommendationService.acceptSuggestion(sessionOwner, document,
-                dataOwner, aCas, suggestion, MAIN_EDITOR);
+                dataOwner, aCas, aPredictions, aSuggestion, MAIN_EDITOR);
 
         page.writeEditorCas(aCas);
 
@@ -204,16 +209,6 @@ public class RecommendationEditorExtension
 
         // Send a UI event that the suggestion has been accepted
         page.send(page, BREADTH, new AjaxRecommendationAcceptedEvent(aTarget, aState, aVID));
-    }
-
-    private Optional<AnnotationSuggestion> getPrediction(AnnotatorState aState, VID aRecVid)
-    {
-        var predictions = recommendationService.getPredictions(aState.getUser(),
-                aState.getProject());
-        var document = aState.getDocument();
-        var prediction = predictions //
-                .getPredictionByVID(document, aRecVid);
-        return prediction;
     }
 
     /**

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
@@ -227,6 +227,13 @@ public class RecommendationServiceImpl
     }
 
     @Override
+    public Predictions getPredictions(String aSessionOwner, Project aProject)
+    {
+        var state = getState(aSessionOwner, aProject);
+        return state.getActivePredictions();
+    }
+
+    @Override
     public Predictions getPredictions(User aSessionOwner, Project aProject)
     {
         var state = getState(aSessionOwner.getUsername(), aProject);
@@ -710,8 +717,8 @@ public class RecommendationServiceImpl
 
             try {
                 suggestionSupport.get().acceptSuggestion(null, aDocument,
-                        aSessionOwner.getUsername(), cas, adapter, feature, prediction, AUTO_ACCEPT,
-                        ACCEPTED);
+                        aSessionOwner.getUsername(), cas, adapter, feature, predictions, prediction,
+                        AUTO_ACCEPT, ACCEPTED);
                 accepted++;
             }
             catch (AnnotationException e) {
@@ -1337,8 +1344,9 @@ public class RecommendationServiceImpl
     @Override
     @Transactional
     public AnnotationFS correctSuggestion(String aSessionOwner, SourceDocument aDocument,
-            String aDataOwner, CAS aCas, SpanSuggestion aOriginalSuggestion,
-            SpanSuggestion aCorrectedSuggestion, LearningRecordChangeLocation aLocation)
+            String aDataOwner, CAS aCas, Predictions aPredictions,
+            SpanSuggestion aOriginalSuggestion, SpanSuggestion aCorrectedSuggestion,
+            LearningRecordChangeLocation aLocation)
         throws AnnotationException
     {
         var layer = schemaService.getLayer(aOriginalSuggestion.getLayerId());
@@ -1361,8 +1369,8 @@ public class RecommendationServiceImpl
             var adapter = schemaService.getAdapter(layer);
 
             return (AnnotationFS) originalSuggestionSupport.get().acceptSuggestion(aSessionOwner,
-                    aDocument, aDataOwner, aCas, adapter, feature, aCorrectedSuggestion, aLocation,
-                    CORRECTED);
+                    aDocument, aDataOwner, aCas, adapter, feature, aPredictions,
+                    aCorrectedSuggestion, aLocation, CORRECTED);
         }
 
         return null;
@@ -1371,7 +1379,7 @@ public class RecommendationServiceImpl
     @Override
     @Transactional
     public AnnotationBaseFS acceptSuggestion(String aSessionOwner, SourceDocument aDocument,
-            String aDataOwner, CAS aCas, AnnotationSuggestion aSuggestion,
+            String aDataOwner, CAS aCas, Predictions aPredictions, AnnotationSuggestion aSuggestion,
             LearningRecordChangeLocation aLocation)
         throws AnnotationException
     {
@@ -1384,7 +1392,7 @@ public class RecommendationServiceImpl
 
         if (rls.isPresent()) {
             return rls.get().acceptSuggestion(aSessionOwner, aDocument, aDataOwner, aCas, adapter,
-                    feature, aSuggestion, aLocation, ACCEPTED);
+                    feature, aPredictions, aSuggestion, aLocation, ACCEPTED);
         }
 
         return null;

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommenderInfoPanel.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommenderInfoPanel.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.inception.recommendation.sidebar;
 
 import static de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService.KEY_RECOMMENDER_GENERAL_SETTINGS;
+import static de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordChangeLocation.REC_SIDEBAR;
 import static de.tudarmstadt.ukp.inception.support.lambda.LambdaBehavior.visibleWhen;
 import static java.util.stream.Collectors.groupingBy;
 
@@ -51,7 +52,6 @@ import de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService;
 import de.tudarmstadt.ukp.inception.recommendation.api.evaluation.EvaluationResult;
 import de.tudarmstadt.ukp.inception.recommendation.api.event.PredictionsSwitchedEvent;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.EvaluatedRecommender;
-import de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordChangeLocation;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.SpanSuggestion;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.SuggestionGroup;
@@ -297,8 +297,8 @@ public class RecommenderInfoPanel
                 // Upsert an annotation based on the suggestion
                 // int address =
                 recommendationService.acceptSuggestion(sessionOwner.getUsername(),
-                        state.getDocument(), state.getUser().getUsername(), cas, suggestion,
-                        LearningRecordChangeLocation.REC_SIDEBAR);
+                        state.getDocument(), state.getUser().getUsername(), cas, predictions,
+                        suggestion, REC_SIDEBAR);
 
                 // // Log the action to the learning record
                 // learningRecordService.logRecord(document, aState.getUser().getUsername(),

--- a/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImplIntegrationTest.java
+++ b/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImplIntegrationTest.java
@@ -225,7 +225,7 @@ public class RecommendationServiceImplIntegrationTest
 
         var s1 = SpanSuggestion.builder().withLabel("V1").withRecommender(spanLayerRecommender)
                 .withPosition(new Offset(targetFS)).build();
-        sut.acceptSuggestion(USER_NAME, doc, docOwner, cas.getCas(), s1, MAIN_EDITOR);
+        sut.acceptSuggestion(USER_NAME, doc, docOwner, cas.getCas(), null, s1, MAIN_EDITOR);
 
         assertThat(targetFS.getValue()) //
                 .as("Label was merged into existing annotation replacing unset label") //
@@ -233,7 +233,7 @@ public class RecommendationServiceImplIntegrationTest
 
         var s2 = SpanSuggestion.builder().withLabel("V2").withRecommender(spanLayerRecommender)
                 .withPosition(new Offset(targetFS)).build();
-        sut.acceptSuggestion(USER_NAME, doc, docOwner, cas.getCas(), s2, MAIN_EDITOR);
+        sut.acceptSuggestion(USER_NAME, doc, docOwner, cas.getCas(), null, s2, MAIN_EDITOR);
 
         assertThat(targetFS.getValue()) //
                 .as("Label was merged into existing annotation replacing previous label") //
@@ -241,7 +241,7 @@ public class RecommendationServiceImplIntegrationTest
 
         var s3 = SpanSuggestion.builder().withLabel("V3").withRecommender(spanLayerRecommender)
                 .withPosition(new Offset(10, 20)).build();
-        sut.acceptSuggestion(USER_NAME, doc, docOwner, cas.getCas(), s3, MAIN_EDITOR);
+        sut.acceptSuggestion(USER_NAME, doc, docOwner, cas.getCas(), null, s3, MAIN_EDITOR);
 
         assertThat(cas.select(NamedEntity.class).asList()) //
                 .as("Label was merged as new annotation") //
@@ -258,7 +258,7 @@ public class RecommendationServiceImplIntegrationTest
 
         var s4 = SpanSuggestion.builder().withLabel("V1").withRecommender(spanLayerRecommender)
                 .withPosition(new Offset(targetFS)).build();
-        sut.acceptSuggestion(USER_NAME, doc, docOwner, cas.getCas(), s4, MAIN_EDITOR);
+        sut.acceptSuggestion(USER_NAME, doc, docOwner, cas.getCas(), null, s4, MAIN_EDITOR);
 
         assertThat(targetFS.getValue()) //
                 .as("Label was merged into existing annotation replacing unset label") //
@@ -266,7 +266,7 @@ public class RecommendationServiceImplIntegrationTest
 
         var s5 = SpanSuggestion.builder().withLabel("V2").withRecommender(spanLayerRecommender)
                 .withPosition(new Offset(targetFS)).build();
-        sut.acceptSuggestion(USER_NAME, doc, docOwner, cas.getCas(), s5, MAIN_EDITOR);
+        sut.acceptSuggestion(USER_NAME, doc, docOwner, cas.getCas(), null, s5, MAIN_EDITOR);
 
         assertThat(cas.select(NamedEntity.class).asList()) //
                 .as("Label was merged as new annotation") //
@@ -277,7 +277,7 @@ public class RecommendationServiceImplIntegrationTest
 
         var s6 = SpanSuggestion.builder().withLabel("V3").withRecommender(spanLayerRecommender)
                 .withPosition(new Offset(10, 20)).build();
-        sut.acceptSuggestion(USER_NAME, doc, docOwner, cas.getCas(), s6, MAIN_EDITOR);
+        sut.acceptSuggestion(USER_NAME, doc, docOwner, cas.getCas(), null, s6, MAIN_EDITOR);
 
         assertThat(cas.select(NamedEntity.class).asList()) //
                 .as("Label was merged as new annotation") //
@@ -292,7 +292,7 @@ public class RecommendationServiceImplIntegrationTest
 
         var s7 = SpanSuggestion.builder().withLabel("V4").withRecommender(spanLayerRecommender)
                 .withPosition(new Offset(0, 10)).build();
-        sut.acceptSuggestion(USER_NAME, doc, docOwner, cas.getCas(), s7, MAIN_EDITOR);
+        sut.acceptSuggestion(USER_NAME, doc, docOwner, cas.getCas(), null, s7, MAIN_EDITOR);
 
         assertThat(cas.select(NamedEntity.class).asList()) //
                 .as("Label was merged again into one of the entities without a label") //

--- a/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/annotation/type/RecommenderDeclUtil.java
+++ b/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/annotation/type/RecommenderDeclUtil.java
@@ -15,13 +15,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package de.tudarmstadt.ukp.inception.rendering.editorstate;
+package de.tudarmstadt.ukp.inception.annotation.type;
 
-import java.io.Serializable;
+import org.apache.uima.cas.CAS;
 
-public record SuggestionState(String recommender, double score, Serializable value)
-    implements Serializable
+public final class RecommenderDeclUtil
 {
-    private static final long serialVersionUID = 840347251712535019L;
+    private RecommenderDeclUtil()
+    {
+        // No instances
+    }
 
+    public static RecommenderDecl getOrCreateRecommenderDecl(CAS aCas, String aRecommenderName)
+    {
+        return aCas.select(RecommenderDecl.class) //
+                .filter(rec -> aRecommenderName.equals(rec.getName())).findFirst().orElseGet(() -> {
+                    var decl = new RecommenderDecl(aCas.getJCasImpl());
+                    decl.setName(aRecommenderName);
+                    decl.addToIndexes();
+                    return decl;
+                });
+    }
 }

--- a/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/annotation/type/StringSuggestionUtil.java
+++ b/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/annotation/type/StringSuggestionUtil.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.annotation.type;
+
+import static java.util.Arrays.asList;
+import static org.apache.uima.fit.util.FSUtil.getFeature;
+import static org.apache.uima.fit.util.FSUtil.setFeature;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.uima.cas.AnnotationBaseFS;
+
+import de.tudarmstadt.ukp.inception.rendering.editorstate.SuggestionState;
+
+public final class StringSuggestionUtil
+{
+    private StringSuggestionUtil()
+    {
+        // No instances
+    }
+
+    public static void setStringSuggestions(AnnotationBaseFS aAnnotation, String aFeature,
+            List<SuggestionState> aSuggestions)
+    {
+        set(aAnnotation, aFeature, aSuggestions, false);
+
+    }
+
+    public static void appendStringSuggestions(AnnotationBaseFS aAnnotation, String aFeature,
+            List<SuggestionState> aSuggestions)
+    {
+        set(aAnnotation, aFeature, aSuggestions, true);
+    }
+
+    private static void set(AnnotationBaseFS aAnnotation, String aFeature,
+            List<SuggestionState> aSuggestions, boolean aAppend)
+    {
+        var cas = aAnnotation.getCAS();
+
+        var stringSuggestions = new ArrayList<StringSuggestion>();
+
+        if (aAppend) {
+            var existingStringSuggestions = getFeature(aAnnotation, aFeature,
+                    StringSuggestion[].class);
+            if (existingStringSuggestions != null) {
+                stringSuggestions.addAll(asList(existingStringSuggestions));
+            }
+        }
+
+        for (var suggestion : aSuggestions) {
+            var recommenderDecl = RecommenderDeclUtil.getOrCreateRecommenderDecl(cas,
+                    suggestion.recommender());
+
+            var stringSuggestion = new StringSuggestion(cas.getJCasImpl());
+            stringSuggestion.setLabel((String) suggestion.value());
+            stringSuggestion.setScore(suggestion.score());
+            stringSuggestion.setRecommender(recommenderDecl);
+            stringSuggestions.add(stringSuggestion);
+        }
+
+        setFeature(aAnnotation, aFeature, stringSuggestions);
+    }
+}

--- a/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/feature/FeatureSupport.java
+++ b/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/feature/FeatureSupport.java
@@ -539,9 +539,9 @@ public interface FeatureSupport<T>
         return true;
     }
 
-    default void pushSuggestion(SourceDocument aDocument, String aDataOwner,
-            AnnotationBaseFS aAnnotation, AnnotationFeature aFeature, String aLabel, double aScore,
-            String aRecommenderName)
+    default void pushSuggestions(SourceDocument aDocument, String aDataOwner,
+            AnnotationBaseFS aAnnotation, AnnotationFeature aFeature,
+            List<SuggestionState> aSuggestions)
     {
         // No default implementation;
     }

--- a/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/feature/SuggestionStatePanel.html
+++ b/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/feature/SuggestionStatePanel.html
@@ -18,13 +18,15 @@
 -->
 <html xmlns:wicket="http://wicket.apache.org">
 <wicket:panel>
-  <div wicket:id="suggestion" class="small text-muted d-flex flex-grow-1 justify-content-between">
-    <div>
-      <span class="fas fa-robot"/>
-      <span wicket:id="recommender" class="me-2"/>
-      <span wicket:id="value" class="me-2 badge rounded-pill text-bg-secondary"/>
+  <div class="d-flex flex-column flex-grow-1">
+    <div wicket:id="suggestion" class="small text-muted d-flex flex-grow-1 justify-content-between">
+      <div>
+        <span class="fas fa-robot"/>
+        <span wicket:id="recommender" class="me-2"/>
+        <span wicket:id="value" class="me-2 badge rounded-pill text-bg-secondary"/>
+      </div>
+      <small wicket:id="score" class="font-monospace"/>
     </div>
-    <small wicket:id="score" class="font-monospace"/>
   </div>
 </wicket:panel>
 </html>

--- a/inception/inception-schema-api/src/main/resources/de/tudarmstadt/ukp/inception/annotation/type/inception-static.xml
+++ b/inception/inception-schema-api/src/main/resources/de/tudarmstadt/ukp/inception/annotation/type/inception-static.xml
@@ -1,165 +1,46 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <typeSystemDescription xmlns="http://uima.apache.org/resourceSpecifier">
-        
-  
-  
   <name>INCEpTION Static Type System</name>
-        
-  
-  
-  <description>Contains types which may be used by INCEpTION as part of (custom) layers or other functionalities, but which themselves are static (i.e. do not change depending on user customization).</description>
-        
-  
-  
+  <description>Contains types which may be used by INCEpTION as part of (custom) layers or other
+    functionalities, but which themselves are static (i.e. do not change depending on user
+    customization).</description>
   <version>1.0</version>
-        
-  
-  
-  <vendor/>
-        
-  
-  
+  <vendor />
   <types>
-                
-    
-    
     <typeDescription>
-                        
-      
-      
       <name>de.tudarmstadt.ukp.inception.annotation.type.StringSuggestion</name>
-                        
-      
-      
-      <description/>
-                        
-      
-      
+      <description />
       <supertypeName>uima.cas.TOP</supertypeName>
-                        
-      
-      
       <features>
-                                
-        
-        
         <featureDescription>
-                                        
-          
-          
           <name>label</name>
-                                        
-          
-          
-          <description/>
-                                        
-          
-          
+          <description />
           <rangeTypeName>uima.cas.String</rangeTypeName>
-                                      
-        
-        
         </featureDescription>
-                                
-        
-        
         <featureDescription>
-                                        
-          
-          
           <name>score</name>
-                                        
-          
-          
-          <description/>
-                                        
-          
-          
-          <rangeTypeName>uima.cas.Float</rangeTypeName>
-                                      
-        
-        
+          <description />
+          <rangeTypeName>uima.cas.Double</rangeTypeName>
         </featureDescription>
-                                
-        
-        
         <featureDescription>
-                                        
-          
-          
           <name>recommender</name>
-                                        
-          
-          
-          <description/>
-                                        
-          
-          
-          <rangeTypeName>de.tudarmstadt.ukp.inception.annotation.type.RecommenderDecl</rangeTypeName>
-                                      
-        
-        
+          <description />
+          <rangeTypeName>de.tudarmstadt.ukp.inception.annotation.type.RecommenderDecl
+          </rangeTypeName>
         </featureDescription>
-                              
-      
-      
       </features>
-                      
-    
-    
     </typeDescription>
-                
-    
-    
     <typeDescription>
-                        
-      
-      
       <name>de.tudarmstadt.ukp.inception.annotation.type.RecommenderDecl</name>
-                        
-      
-      
-      <description/>
-                        
-      
-      
+      <description />
       <supertypeName>uima.cas.TOP</supertypeName>
-                        
-      
-      
       <features>
-                                
-        
-        
         <featureDescription>
-                                        
-          
-          
           <name>name</name>
-                                        
-          
-          
-          <description/>
-                                        
-          
-          
+          <description />
           <rangeTypeName>uima.cas.String</rangeTypeName>
-                                      
-        
-        
         </featureDescription>
-                              
-      
-      
       </features>
-                      
-    
-    
     </typeDescription>
-          
-  
   </types>
-      
-
-
 </typeSystemDescription>

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureSupport.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureSupport.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.ui.kb.feature;
 
+import static de.tudarmstadt.ukp.inception.annotation.type.StringSuggestionUtil.setStringSuggestions;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
@@ -43,7 +44,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
-import de.tudarmstadt.ukp.inception.annotation.type.RecommenderDecl;
 import de.tudarmstadt.ukp.inception.annotation.type.StringSuggestion;
 import de.tudarmstadt.ukp.inception.editor.action.AnnotationActionHandler;
 import de.tudarmstadt.ukp.inception.kb.ConceptFeatureTraits;
@@ -305,26 +305,12 @@ public class ConceptFeatureSupport
     }
 
     @Override
-    public void pushSuggestion(SourceDocument aDocument, String aDataOwner,
-            AnnotationBaseFS aAnnotation, AnnotationFeature aFeature, String aLabel, double aScore,
-            String aRecommenderName)
+    public void pushSuggestions(SourceDocument aDocument, String aDataOwner,
+            AnnotationBaseFS aAnnotation, AnnotationFeature aFeature,
+            List<SuggestionState> aSuggestions)
     {
-        var jcas = aAnnotation.getCAS().getJCasImpl();
-
-        var recommenderDecl = jcas.select(RecommenderDecl.class) //
-                .filter(rec -> aRecommenderName.equals(rec.getName())).findFirst().orElseGet(() -> {
-                    var decl = new RecommenderDecl(jcas);
-                    decl.setName(aRecommenderName);
-                    decl.addToIndexes();
-                    return decl;
-                });
-
-        var stringSuggestion = new StringSuggestion(jcas);
-        stringSuggestion.setLabel(aLabel);
-        stringSuggestion.setScore((float) aScore);
-        stringSuggestion.setRecommender(recommenderDecl);
-        FSUtil.setFeature(aAnnotation, aFeature.getName() + SUFFIX_SUGGESTION_INFO,
-                asList(stringSuggestion));
+        setStringSuggestions(aAnnotation, aFeature.getName() + SUFFIX_SUGGESTION_INFO,
+                aSuggestions);
     }
 
     @Override

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/MultiValueConceptFeatureSupport.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/MultiValueConceptFeatureSupport.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.ui.kb.feature;
 
+import static de.tudarmstadt.ukp.inception.annotation.type.StringSuggestionUtil.appendStringSuggestions;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
@@ -49,7 +50,6 @@ import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.MultiValueMode;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
-import de.tudarmstadt.ukp.inception.annotation.type.RecommenderDecl;
 import de.tudarmstadt.ukp.inception.annotation.type.StringSuggestion;
 import de.tudarmstadt.ukp.inception.editor.action.AnnotationActionHandler;
 import de.tudarmstadt.ukp.inception.kb.MultiValueConceptFeatureTraits;
@@ -178,26 +178,12 @@ public class MultiValueConceptFeatureSupport
     }
 
     @Override
-    public void pushSuggestion(SourceDocument aDocument, String aDataOwner,
-            AnnotationBaseFS aAnnotation, AnnotationFeature aFeature, String aLabel, double aScore,
-            String aRecommenderName)
+    public void pushSuggestions(SourceDocument aDocument, String aDataOwner,
+            AnnotationBaseFS aAnnotation, AnnotationFeature aFeature,
+            List<SuggestionState> aSuggestions)
     {
-        var jcas = aAnnotation.getCAS().getJCasImpl();
-
-        var recommenderDecl = jcas.select(RecommenderDecl.class) //
-                .filter(rec -> aRecommenderName.equals(rec.getName())).findFirst().orElseGet(() -> {
-                    var decl = new RecommenderDecl(jcas);
-                    decl.setName(aRecommenderName);
-                    decl.addToIndexes();
-                    return decl;
-                });
-
-        var stringSuggestion = new StringSuggestion(jcas);
-        stringSuggestion.setLabel(aLabel);
-        stringSuggestion.setScore((float) aScore);
-        stringSuggestion.setRecommender(recommenderDecl);
-        FSUtil.setFeature(aAnnotation, aFeature.getName() + SUFFIX_SUGGESTION_INFO,
-                asList(stringSuggestion));
+        appendStringSuggestions(aAnnotation, aFeature.getName() + SUFFIX_SUGGESTION_INFO,
+                aSuggestions);
     }
 
     @Override


### PR DESCRIPTION
**What's in the PR**
- Create utility function for getting or creating a new RecommenderDecl in the CAS
- Change score type in CAS from float to double
- Record the scores of all recommenders that predicted the same label
- Replace retained suggestions on single-value features and append on multi-value features when overriding a label (or setting one)
- Append on multi-value features
- Fix layout of SuggestionsStatePanel

**How to test manually**
* Enable the retain scores option and try with single/multi valued string/concept features and multiple recommenders

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
