### PR TITLE
#5534 - Option to retain recommender scores when accepting an annotation

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/coloring/ColoringRulesConfigurationPanel.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/coloring/ColoringRulesConfigurationPanel.java
@@ -35,7 +35,7 @@ import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.markup.html.list.ListItem;
 import org.apache.wicket.markup.html.list.ListView;
-import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.markup.html.panel.GenericPanel;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
@@ -54,7 +54,7 @@ import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxSubmitLink;
  * Can be added to a feature support traits editor to configure coloring rules.
  */
 public class ColoringRulesConfigurationPanel
-    extends Panel
+    extends GenericPanel<AnnotationLayer>
 {
     private static final long serialVersionUID = -8294428032177255299L;
 
@@ -71,23 +71,20 @@ public class ColoringRulesConfigurationPanel
 
         coloringRules = aColoringRules;
 
-        Form<ColoringRule> coloringRulesForm = new Form<>("coloringRulesForm",
-                CompoundPropertyModel.of(new ColoringRule()));
-        add(coloringRulesForm);
+        queue(new Form<ColoringRule>("coloringRulesForm",
+                CompoundPropertyModel.of(new ColoringRule())));
 
         coloringRulesContainer = new WebMarkupContainer("coloringRulesContainer");
         coloringRulesContainer.setOutputMarkupPlaceholderTag(true);
-        coloringRulesForm.add(coloringRulesContainer);
+        queue(coloringRulesContainer);
 
-        coloringRulesContainer.add(new TextField<String>("pattern"));
+        queue(new TextField<String>("pattern"));
         // We cannot make the color field a required one here because then we'd get a message
         // about color not being set when saving the entire feature details form!
-        coloringRulesContainer.add(
-                new ColorPickerTextField("color").add(new PatternValidator("#[0-9a-fA-F]{6}")));
-        coloringRulesContainer
-                .add(new LambdaAjaxSubmitLink<>("addColoringRule", this::addColoringRule));
+        queue(new ColorPickerTextField("color").add(new PatternValidator("#[0-9a-fA-F]{6}")));
+        queue(new LambdaAjaxSubmitLink<>("addColoringRule", this::addColoringRule));
 
-        coloringRulesContainer.add(createRulesList("coloringRules", coloringRules));
+        queue(createRulesList("coloringRules", coloringRules));
     }
 
     private ListView<ColoringRule> createRulesList(String aId,
@@ -100,9 +97,9 @@ public class ColoringRulesConfigurationPanel
             @Override
             protected void populateItem(ListItem<ColoringRule> aItem)
             {
-                ColoringRule coloringRule = aItem.getModelObject();
+                var coloringRule = aItem.getModelObject();
 
-                Label value = new Label("pattern", coloringRule.getPattern());
+                var value = new Label("pattern", coloringRule.getPattern());
 
                 value.add(new StyleAttributeModifier()
                 {
@@ -152,11 +149,6 @@ public class ColoringRulesConfigurationPanel
                 aTarget.add(coloringRulesContainer);
             }
         };
-    }
-
-    public AnnotationLayer getModelObject()
-    {
-        return (AnnotationLayer) getDefaultModelObject();
     }
 
     private void addColoringRule(AjaxRequestTarget aTarget, Form<ColoringRule> aForm)

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/keybindings/KeyBindingsConfigurationPanel.html
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/keybindings/KeyBindingsConfigurationPanel.html
@@ -21,9 +21,9 @@
 <wicket:panel>
   <form wicket:id="keyBindingForm">
     <div wicket:id="keyBindingsContainer">
-      <div class="d-flex flex-wrap">
+      <div class="d-flex flex-column">
         <div wicket:id="value" class="flex-fill"/>
-        <div class="form-row ms-2">
+        <div class="flex-fill">
           <div class="input-group">
             <input wicket:id="keyCombo" class="form-control" placeholder="Key combo..."/>
             <button wicket:id="addKeyBinding" class="btn btn-sm btn-primary pull-right">

--- a/inception/inception-feature-string/pom.xml
+++ b/inception/inception-feature-string/pom.xml
@@ -60,6 +60,11 @@
       <artifactId>inception-constraints</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-support-bootstrap</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.uima</groupId>

--- a/inception/inception-feature-string/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiValueStringFeatureSupport.java
+++ b/inception/inception-feature-string/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiValueStringFeatureSupport.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.annotation.feature.multistring;
 
+import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.CURATOR;
 import static de.tudarmstadt.ukp.inception.annotation.type.StringSuggestionUtil.appendStringSuggestions;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -321,7 +322,9 @@ public class MultiValueStringFeatureSupport
     @Override
     public MultiValueStringFeatureTraits createDefaultTraits()
     {
-        return new MultiValueStringFeatureTraits();
+        var traits = new MultiValueStringFeatureTraits();
+        traits.setRolesSeeingSuggestionInfo(asList(CURATOR));
+        return traits;
     }
 
     @Override

--- a/inception/inception-feature-string/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiValueStringFeatureTraits.java
+++ b/inception/inception-feature-string/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiValueStringFeatureTraits.java
@@ -17,11 +17,17 @@
  */
 package de.tudarmstadt.ukp.inception.annotation.feature.multistring;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
+
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
-import de.tudarmstadt.ukp.inception.annotation.feature.RecommendableFeatureTrait;
+import de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel;
+import de.tudarmstadt.ukp.inception.schema.api.feature.RecommendableFeatureTrait;
 
 /**
  * Traits for multi-value input field text features.
@@ -33,6 +39,7 @@ public class MultiValueStringFeatureTraits
     private static final long serialVersionUID = -8450181605003189055L;
 
     private boolean retainSuggestionInfo = false;
+    private @JsonInclude(NON_EMPTY) List<PermissionLevel> rolesSeeingSuggestionInfo = new ArrayList<>();
 
     public MultiValueStringFeatureTraits()
     {
@@ -49,5 +56,22 @@ public class MultiValueStringFeatureTraits
     public void setRetainSuggestionInfo(boolean aRetainSuggestionInfo)
     {
         retainSuggestionInfo = aRetainSuggestionInfo;
+    }
+
+    @Override
+    public void setRolesSeeingSuggestionInfo(List<PermissionLevel> aRolesSeeingSuggestionInfo)
+    {
+        if (aRolesSeeingSuggestionInfo == null) {
+            rolesSeeingSuggestionInfo = new ArrayList<>();
+        }
+        else {
+            rolesSeeingSuggestionInfo = aRolesSeeingSuggestionInfo;
+        }
+    }
+
+    @Override
+    public List<PermissionLevel> getRolesSeeingSuggestionInfo()
+    {
+        return rolesSeeingSuggestionInfo;
     }
 }

--- a/inception/inception-feature-string/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiValueStringFeatureTraitsEditor.html
+++ b/inception/inception-feature-string/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiValueStringFeatureTraitsEditor.html
@@ -28,10 +28,7 @@
       </div>
     </div>
     <div class="row form-row" wicket:enclosure="retainSuggestionInfo">
-      <label wicket:for="retainSuggestionInfo" class="col-sm-4 col-form-label">
-        Recommender
-      </label>
-      <div class="col-sm-8">
+      <div class="col-sm-8 offset-sm-4 mt-2">
         <div class="form-check">
           <input wicket:id="retainSuggestionInfo" class="form-check-input" type="checkbox">
           <label wicket:for="retainSuggestionInfo" class="form-check-label">
@@ -39,6 +36,12 @@
           </label>
         </div>
       </div>
+    </div>
+    <div class="row form-row" wicket:enclosure="rolesSeeingSuggestionInfo">
+      <label wicket:for="rolesSeeingSuggestionInfo" class="col-sm-4 col-form-label">
+        Suggestion info visible for
+      </label>
+      <div wicket:id="rolesSeeingSuggestionInfo" class="col-sm-8 mt-2"/>
     </div>
   </form>
 </wicket:panel>

--- a/inception/inception-feature-string/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiValueStringFeatureTraitsEditor.java
+++ b/inception/inception-feature-string/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiValueStringFeatureTraitsEditor.java
@@ -17,9 +17,16 @@
  */
 package de.tudarmstadt.ukp.inception.annotation.feature.multistring;
 
+import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.ANNOTATOR;
+import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.CURATOR;
+import static de.tudarmstadt.ukp.inception.support.lambda.HtmlElementEvents.CHANGE_EVENT;
+import static de.tudarmstadt.ukp.inception.support.lambda.LambdaBehavior.visibleWhen;
+import static java.util.Arrays.asList;
+
 import org.apache.wicket.markup.html.form.CheckBox;
 import org.apache.wicket.markup.html.form.ChoiceRenderer;
 import org.apache.wicket.markup.html.form.DropDownChoice;
+import org.apache.wicket.markup.html.form.EnumChoiceRenderer;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.panel.GenericPanel;
 import org.apache.wicket.model.CompoundPropertyModel;
@@ -29,10 +36,13 @@ import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel;
 import de.tudarmstadt.ukp.clarin.webanno.model.TagSet;
 import de.tudarmstadt.ukp.inception.annotation.feature.misc.UimaPrimitiveFeatureSupport_ImplBase;
+import de.tudarmstadt.ukp.inception.bootstrap.BootstrapCheckBoxMultipleChoice;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureSupportRegistry;
+import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxFormComponentUpdatingBehavior;
 
 public class MultiValueStringFeatureTraitsEditor
     extends GenericPanel<AnnotationFeature>
@@ -87,6 +97,19 @@ public class MultiValueStringFeatureTraitsEditor
         retainSuggestionInfo.setOutputMarkupId(true);
         retainSuggestionInfo.setModel(PropertyModel.of(traits, "retainSuggestionInfo"));
         form.add(retainSuggestionInfo);
+
+        var rolesSeeingSuggestionInfo = new BootstrapCheckBoxMultipleChoice<PermissionLevel>(
+                "rolesSeeingSuggestionInfo");
+        rolesSeeingSuggestionInfo.setOutputMarkupPlaceholderTag(true);
+        rolesSeeingSuggestionInfo.setModel(PropertyModel.of(traits, "rolesSeeingSuggestionInfo"));
+        rolesSeeingSuggestionInfo.setChoices(asList(ANNOTATOR, CURATOR));
+        rolesSeeingSuggestionInfo
+                .setChoiceRenderer(new EnumChoiceRenderer<>(rolesSeeingSuggestionInfo));
+        rolesSeeingSuggestionInfo.add(visibleWhen(retainSuggestionInfo.getModel()));
+        form.add(rolesSeeingSuggestionInfo);
+
+        retainSuggestionInfo.add(new LambdaAjaxFormComponentUpdatingBehavior(CHANGE_EVENT,
+                _target -> _target.add(rolesSeeingSuggestionInfo)));
     }
 
     @SuppressWarnings("unchecked")

--- a/inception/inception-feature-string/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/StringFeatureSupport.java
+++ b/inception/inception-feature-string/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/StringFeatureSupport.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.annotation.feature.string;
 
+import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.CURATOR;
 import static de.tudarmstadt.ukp.inception.annotation.feature.string.StringFeatureTraits.EditorType.AUTOCOMPLETE;
 import static de.tudarmstadt.ukp.inception.annotation.feature.string.StringFeatureTraits.EditorType.COMBOBOX;
 import static de.tudarmstadt.ukp.inception.annotation.feature.string.StringFeatureTraits.EditorType.RADIOGROUP;
@@ -219,7 +220,9 @@ public class StringFeatureSupport
     @Override
     public StringFeatureTraits createDefaultTraits()
     {
-        return new StringFeatureTraits();
+        var traits = new StringFeatureTraits();
+        traits.setRolesSeeingSuggestionInfo(asList(CURATOR));
+        return traits;
     }
 
     @Override

--- a/inception/inception-feature-string/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/StringFeatureTraits.java
+++ b/inception/inception-feature-string/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/StringFeatureTraits.java
@@ -30,7 +30,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.keybindings.KeyBinding;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.keybindings.KeyBindingTrait;
-import de.tudarmstadt.ukp.inception.annotation.feature.RecommendableFeatureTrait;
+import de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel;
+import de.tudarmstadt.ukp.inception.schema.api.feature.RecommendableFeatureTrait;
 
 /**
  * Traits for input field text features.
@@ -71,6 +72,7 @@ public class StringFeatureTraits
     private @JsonInclude(NON_DEFAULT) boolean dynamicSize = false;
     private @JsonInclude(NON_EMPTY) List<KeyBinding> keyBindings = new ArrayList<>();
     private @JsonInclude(NON_EMPTY) String defaultValue;
+    private @JsonInclude(NON_EMPTY) List<PermissionLevel> rolesSeeingSuggestionInfo = new ArrayList<>();
 
     public StringFeatureTraits()
     {
@@ -164,5 +166,22 @@ public class StringFeatureTraits
     public void setRetainSuggestionInfo(boolean aRetainSuggestionInfo)
     {
         retainSuggestionInfo = aRetainSuggestionInfo;
+    }
+
+    @Override
+    public void setRolesSeeingSuggestionInfo(List<PermissionLevel> aRolesSeeingSuggestionInfo)
+    {
+        if (aRolesSeeingSuggestionInfo == null) {
+            rolesSeeingSuggestionInfo = new ArrayList<>();
+        }
+        else {
+            rolesSeeingSuggestionInfo = aRolesSeeingSuggestionInfo;
+        }
+    }
+
+    @Override
+    public List<PermissionLevel> getRolesSeeingSuggestionInfo()
+    {
+        return rolesSeeingSuggestionInfo;
     }
 }

--- a/inception/inception-feature-string/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/StringFeatureTraitsEditor.html
+++ b/inception/inception-feature-string/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/StringFeatureTraitsEditor.html
@@ -80,10 +80,7 @@
       </div>
     </div>
     <div class="row form-row" wicket:enclosure="retainSuggestionInfo">
-      <label wicket:for="retainSuggestionInfo" class="col-sm-4 col-form-label">
-        Recommender
-      </label>
-      <div class="col-sm-8">
+      <div class="col-sm-8 offset-sm-4 mt-2">
         <div class="form-check">
           <input wicket:id="retainSuggestionInfo" class="form-check-input" type="checkbox">
           <label wicket:for="retainSuggestionInfo" class="form-check-label">
@@ -91,6 +88,12 @@
           </label>
         </div>
       </div>
+    </div>
+    <div class="row form-row" wicket:enclosure="rolesSeeingSuggestionInfo">
+      <label wicket:for="rolesSeeingSuggestionInfo" class="col-sm-4 col-form-label">
+        Suggestion info visible for
+      </label>
+      <div wicket:id="rolesSeeingSuggestionInfo" class="col-sm-8 mt-2"/>
     </div>
   </form>
   <div class="row form-row">

--- a/inception/inception-feature-string/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/StringFeatureTraitsEditor.java
+++ b/inception/inception-feature-string/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/StringFeatureTraitsEditor.java
@@ -17,7 +17,11 @@
  */
 package de.tudarmstadt.ukp.inception.annotation.feature.string;
 
+import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.ANNOTATOR;
+import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.CURATOR;
+import static de.tudarmstadt.ukp.inception.support.lambda.HtmlElementEvents.CHANGE_EVENT;
 import static de.tudarmstadt.ukp.inception.support.lambda.LambdaBehavior.visibleWhen;
+import static java.util.Arrays.asList;
 
 import java.util.Arrays;
 
@@ -26,6 +30,7 @@ import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.form.CheckBox;
 import org.apache.wicket.markup.html.form.ChoiceRenderer;
 import org.apache.wicket.markup.html.form.DropDownChoice;
+import org.apache.wicket.markup.html.form.EnumChoiceRenderer;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.markup.html.panel.Panel;
@@ -39,8 +44,10 @@ import org.wicketstuff.kendo.ui.form.NumberTextField;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.keybindings.KeyBindingsConfigurationPanel;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel;
 import de.tudarmstadt.ukp.clarin.webanno.model.TagSet;
 import de.tudarmstadt.ukp.inception.annotation.feature.misc.UimaPrimitiveFeatureSupport_ImplBase;
+import de.tudarmstadt.ukp.inception.bootstrap.BootstrapCheckBoxMultipleChoice;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureSupportRegistry;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxFormComponentUpdatingBehavior;
@@ -158,6 +165,7 @@ public class StringFeatureTraitsEditor
         editorTypeContainer.setOutputMarkupPlaceholderTag(true);
         editorTypeContainer.add(visibleWhen(() -> !traits.getObject().isMultipleRows()
                 && aFeature.getObject().getTagset() != null));
+        form.add(editorTypeContainer);
 
         var editorType = new DropDownChoice<StringFeatureTraits.EditorType>("editorType");
         editorType.setModel(PropertyModel.of(traits, "editorType"));
@@ -170,7 +178,18 @@ public class StringFeatureTraitsEditor
         retainSuggestionInfo.setModel(PropertyModel.of(traits, "retainSuggestionInfo"));
         form.add(retainSuggestionInfo);
 
-        form.add(editorTypeContainer);
+        var rolesSeeingSuggestionInfo = new BootstrapCheckBoxMultipleChoice<PermissionLevel>(
+                "rolesSeeingSuggestionInfo");
+        rolesSeeingSuggestionInfo.setOutputMarkupPlaceholderTag(true);
+        rolesSeeingSuggestionInfo.setModel(PropertyModel.of(traits, "rolesSeeingSuggestionInfo"));
+        rolesSeeingSuggestionInfo.setChoices(asList(ANNOTATOR, CURATOR));
+        rolesSeeingSuggestionInfo
+                .setChoiceRenderer(new EnumChoiceRenderer<>(rolesSeeingSuggestionInfo));
+        rolesSeeingSuggestionInfo.add(visibleWhen(retainSuggestionInfo.getModel()));
+        form.add(rolesSeeingSuggestionInfo);
+
+        retainSuggestionInfo.add(new LambdaAjaxFormComponentUpdatingBehavior(CHANGE_EVENT,
+                _target -> _target.add(rolesSeeingSuggestionInfo)));
     }
 
     private void refreshKeyBindings(AjaxRequestTarget aTarget, IModel<AnnotationFeature> aFeature)

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/ConceptFeatureTraits.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/ConceptFeatureTraits.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.keybindings.KeyBinding;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.keybindings.KeyBindingTrait;
-import de.tudarmstadt.ukp.inception.annotation.feature.RecommendableFeatureTrait;
+import de.tudarmstadt.ukp.inception.schema.api.feature.RecommendableFeatureTrait;
 
 /**
  * Traits for knowledge-base-related features.

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/ConceptFeatureTraits_ImplBase.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/ConceptFeatureTraits_ImplBase.java
@@ -17,16 +17,24 @@
  */
 package de.tudarmstadt.ukp.inception.kb;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
+
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel;
+import de.tudarmstadt.ukp.inception.schema.api.feature.RecommendableFeatureTrait;
 
 /**
  * Traits for knowledge-base-related features.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class ConceptFeatureTraits_ImplBase
-    implements Serializable
+    implements Serializable, RecommendableFeatureTrait
 {
     private static final long serialVersionUID = 3351053348043107018L;
 
@@ -34,6 +42,7 @@ public abstract class ConceptFeatureTraits_ImplBase
     private String scope;
     private ConceptFeatureValueType allowedValueType;
     private boolean retainSuggestionInfo = false;
+    private @JsonInclude(NON_EMPTY) List<PermissionLevel> rolesSeeingSuggestionInfo = new ArrayList<>();
 
     public ConceptFeatureTraits_ImplBase()
     {
@@ -70,13 +79,32 @@ public abstract class ConceptFeatureTraits_ImplBase
         allowedValueType = aAllowedType;
     }
 
+    @Override
     public boolean isRetainSuggestionInfo()
     {
         return retainSuggestionInfo;
     }
 
+    @Override
     public void setRetainSuggestionInfo(boolean aRetainSuggestionInfo)
     {
         retainSuggestionInfo = aRetainSuggestionInfo;
+    }
+
+    @Override
+    public void setRolesSeeingSuggestionInfo(List<PermissionLevel> aRolesSeeingSuggestionInfo)
+    {
+        if (aRolesSeeingSuggestionInfo == null) {
+            rolesSeeingSuggestionInfo = new ArrayList<>();
+        }
+        else {
+            rolesSeeingSuggestionInfo = aRolesSeeingSuggestionInfo;
+        }
+    }
+
+    @Override
+    public List<PermissionLevel> getRolesSeeingSuggestionInfo()
+    {
+        return rolesSeeingSuggestionInfo;
     }
 }

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/MultiValueConceptFeatureTraits.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/MultiValueConceptFeatureTraits.java
@@ -21,7 +21,7 @@ import java.io.Serializable;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
-import de.tudarmstadt.ukp.inception.annotation.feature.RecommendableFeatureTrait;
+import de.tudarmstadt.ukp.inception.schema.api.feature.RecommendableFeatureTrait;
 
 /**
  * Traits for knowledge-base-related features.

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/SuggestionSupport_ImplBase.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/SuggestionSupport_ImplBase.java
@@ -37,7 +37,6 @@ import org.springframework.context.ApplicationEventPublisher;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
-import de.tudarmstadt.ukp.inception.annotation.feature.RecommendableFeatureTrait;
 import de.tudarmstadt.ukp.inception.recommendation.api.event.RecommendationAcceptedEvent;
 import de.tudarmstadt.ukp.inception.recommendation.api.event.RecommendationRejectedEvent;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.AnnotationSuggestion;
@@ -49,6 +48,7 @@ import de.tudarmstadt.ukp.inception.rendering.editorstate.SuggestionState;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.AnnotationException;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.TypeAdapter;
+import de.tudarmstadt.ukp.inception.schema.api.feature.RecommendableFeatureTrait;
 import de.tudarmstadt.ukp.inception.support.uima.ICasUtil;
 
 public abstract class SuggestionSupport_ImplBase

--- a/inception/inception-schema-api/pom.xml
+++ b/inception/inception-schema-api/pom.xml
@@ -57,6 +57,16 @@
       <artifactId>inception-constraints</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-security</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-project-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.uima</groupId>
@@ -98,6 +108,10 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-collections4</artifactId>
     </dependency>
     
     <dependency>

--- a/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/feature/RecommendableFeatureTrait.java
+++ b/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/feature/RecommendableFeatureTrait.java
@@ -15,11 +15,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package de.tudarmstadt.ukp.inception.annotation.feature;
+package de.tudarmstadt.ukp.inception.schema.api.feature;
+
+import java.util.List;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel;
 
 public interface RecommendableFeatureTrait
 {
-    public boolean isRetainSuggestionInfo();
+    boolean isRetainSuggestionInfo();
 
-    public void setRetainSuggestionInfo(boolean aRetainSuggestionInfo);
+    void setRetainSuggestionInfo(boolean aRetainSuggestionInfo);
+
+    void setRolesSeeingSuggestionInfo(List<PermissionLevel> aRolesSeeingSuggestionInfo);
+
+    List<PermissionLevel> getRolesSeeingSuggestionInfo();
 }

--- a/inception/inception-support-bootstrap/pom.xml
+++ b/inception/inception-support-bootstrap/pom.xml
@@ -41,6 +41,10 @@
     </dependency>
     <dependency>
       <groupId>org.apache.wicket</groupId>
+      <artifactId>wicket-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.wicket</groupId>
       <artifactId>wicket-request</artifactId>
     </dependency>
     <dependency>

--- a/inception/inception-support-bootstrap/src/main/java/de/tudarmstadt/ukp/inception/bootstrap/BootstrapCheckBoxMultipleChoice.java
+++ b/inception/inception-support-bootstrap/src/main/java/de/tudarmstadt/ukp/inception/bootstrap/BootstrapCheckBoxMultipleChoice.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.bootstrap;
+
+import static org.apache.wicket.markup.html.form.AbstractChoice.LabelPosition.AFTER;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.wicket.markup.html.form.CheckBoxMultipleChoice;
+import org.apache.wicket.markup.html.form.IChoiceRenderer;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.util.value.AttributeMap;
+import org.apache.wicket.util.value.IValueMap;
+
+public class BootstrapCheckBoxMultipleChoice<T>
+    extends CheckBoxMultipleChoice<T>
+{
+    private static final long serialVersionUID = -3652114210853457364L;
+
+    public BootstrapCheckBoxMultipleChoice(String aId, IModel<? extends Collection<T>> aModel,
+            IModel<? extends List<? extends T>> aChoices, IChoiceRenderer<? super T> aRenderer)
+    {
+        super(aId, aModel, aChoices, aRenderer);
+    }
+
+    public BootstrapCheckBoxMultipleChoice(String aId, IModel<? extends Collection<T>> aModel,
+            IModel<? extends List<? extends T>> aChoices)
+    {
+        super(aId, aModel, aChoices);
+    }
+
+    public BootstrapCheckBoxMultipleChoice(String aId, IModel<? extends Collection<T>> aModel,
+            List<? extends T> aChoices, IChoiceRenderer<? super T> aRenderer)
+    {
+        super(aId, aModel, aChoices, aRenderer);
+    }
+
+    public BootstrapCheckBoxMultipleChoice(String aId, IModel<? extends Collection<T>> aModel,
+            List<? extends T> aChoices)
+    {
+        super(aId, aModel, aChoices);
+    }
+
+    public BootstrapCheckBoxMultipleChoice(String aId, IModel<? extends List<? extends T>> aChoices,
+            IChoiceRenderer<? super T> aRenderer)
+    {
+        super(aId, aChoices, aRenderer);
+    }
+
+    public BootstrapCheckBoxMultipleChoice(String aId, IModel<? extends List<? extends T>> aChoices)
+    {
+        super(aId, aChoices);
+    }
+
+    public BootstrapCheckBoxMultipleChoice(String aId, List<? extends T> aChoices,
+            IChoiceRenderer<? super T> aRenderer)
+    {
+        super(aId, aChoices, aRenderer);
+    }
+
+    public BootstrapCheckBoxMultipleChoice(String aId, List<? extends T> aChoices)
+    {
+        super(aId, aChoices);
+    }
+
+    public BootstrapCheckBoxMultipleChoice(String aId)
+    {
+        super(aId);
+    }
+
+    @Override
+    protected void onConfigure()
+    {
+        super.onConfigure();
+        setPrefix("<div class=\"form-check form-switch\">");
+        setSuffix("</div>");
+        setLabelPosition(AFTER);
+    }
+
+    @Override
+    protected IValueMap getAdditionalAttributesForLabel(int aIndex, T aChoice)
+    {
+        var attributes = new AttributeMap();
+        attributes.put("class", "form-check-label");
+        return attributes;
+    }
+
+    @Override
+    protected IValueMap getAdditionalAttributes(int aIndex, T aChoice)
+    {
+        var attributes = new AttributeMap();
+        attributes.put("class", "form-check-input");
+        return attributes;
+    }
+}

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureEditor_ImplBase.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureEditor_ImplBase.java
@@ -21,7 +21,6 @@ import static java.lang.System.currentTimeMillis;
 import static java.lang.invoke.MethodHandles.lookup;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
-import static org.apache.commons.lang3.StringUtils.containsIgnoreCase;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.substringAfter;
 import static org.apache.commons.lang3.StringUtils.substringBefore;
@@ -32,6 +31,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
 import org.apache.wicket.MarkupContainer;
 import org.apache.wicket.core.request.handler.IPartialPageRequestHandler;
 import org.apache.wicket.feedback.IFeedback;
@@ -171,7 +171,7 @@ public abstract class ConceptFeatureEditor_ImplBase
 
         if (labelFilter) {
             choices = choices.stream() //
-                    .filter(kb -> containsIgnoreCase(kb.getUiLabel(), finalInput))
+                    .filter(kb -> Strings.CI.contains(kb.getUiLabel(), finalInput))
                     .collect(Collectors.toList());
         }
 
@@ -190,12 +190,12 @@ public abstract class ConceptFeatureEditor_ImplBase
 
     private boolean applySecondaryFilter(KBHandle aObject, String aFilter)
     {
-        if (containsIgnoreCase(aObject.getDescription(), aFilter)) {
+        if (Strings.CI.contains(aObject.getDescription(), aFilter)) {
             return true;
         }
 
         if (aObject.getQueryBestMatchTerm() != null
-                && containsIgnoreCase(aObject.getUiLabel(), aFilter)) {
+                && Strings.CI.contains(aObject.getUiLabel(), aFilter)) {
             return true;
         }
 

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureSupport.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureSupport.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.ui.kb.feature;
 
+import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.CURATOR;
 import static de.tudarmstadt.ukp.inception.annotation.type.StringSuggestionUtil.setStringSuggestions;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -255,7 +256,9 @@ public class ConceptFeatureSupport
     @Override
     public ConceptFeatureTraits createDefaultTraits()
     {
-        return new ConceptFeatureTraits();
+        var traits = new ConceptFeatureTraits();
+        traits.setRolesSeeingSuggestionInfo(asList(CURATOR));
+        return traits;
     }
 
     @Override

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureTraitsEditor.html
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureTraitsEditor.html
@@ -48,10 +48,7 @@
       </div>
     </div>
     <div class="row form-row" wicket:enclosure="retainSuggestionInfo">
-      <label wicket:for="retainSuggestionInfo" class="col-sm-4 col-form-label">
-        Recommender
-      </label>
-      <div class="col-sm-8">
+      <div class="col-sm-8 offset-sm-4 mt-2">
         <div class="form-check">
           <input wicket:id="retainSuggestionInfo" class="form-check-input" type="checkbox">
           <label wicket:for="retainSuggestionInfo" class="form-check-label">
@@ -59,6 +56,12 @@
           </label>
         </div>
       </div>
+    </div>
+    <div class="row form-row" wicket:enclosure="rolesSeeingSuggestionInfo">
+      <label wicket:for="rolesSeeingSuggestionInfo" class="col-sm-4 col-form-label">
+        Suggestion info visible for
+      </label>
+      <div wicket:id="rolesSeeingSuggestionInfo" class="col-sm-8 mt-2"/>
     </div>
   </form>
   <div class="row form-row">

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/InstanceListDataProvider.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/InstanceListDataProvider.java
@@ -19,7 +19,6 @@ package de.tudarmstadt.ukp.inception.ui.kb.feature;
 
 import static de.tudarmstadt.ukp.inception.ui.kb.feature.InstanceListSortKeys.LABEL;
 import static java.util.stream.Collectors.toList;
-import static org.apache.commons.lang3.StringUtils.containsIgnoreCase;
 import static org.apache.wicket.extensions.markup.html.repeater.data.sort.SortOrder.ASCENDING;
 
 import java.io.Serializable;
@@ -27,6 +26,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Stream;
 
+import org.apache.commons.lang3.Strings;
 import org.apache.wicket.extensions.markup.html.repeater.data.table.filter.IFilterStateLocator;
 import org.apache.wicket.extensions.markup.html.repeater.util.SortableDataProvider;
 import org.apache.wicket.model.IModel;
@@ -90,7 +90,7 @@ public class InstanceListDataProvider
         // Filter by project name
         if (filterState.getUiLabel() != null) {
             dataStream = dataStream
-                    .filter($ -> containsIgnoreCase($.getUiLabel(), filterState.getUiLabel()));
+                    .filter($ -> Strings.CI.contains($.getUiLabel(), filterState.getUiLabel()));
         }
 
         return dataStream.collect(toList());

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/MultiValueConceptFeatureSupport.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/MultiValueConceptFeatureSupport.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.ui.kb.feature;
 
+import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.CURATOR;
 import static de.tudarmstadt.ukp.inception.annotation.type.StringSuggestionUtil.appendStringSuggestions;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -214,7 +215,9 @@ public class MultiValueConceptFeatureSupport
     @Override
     public MultiValueConceptFeatureTraits createDefaultTraits()
     {
-        return new MultiValueConceptFeatureTraits();
+        var traits = new MultiValueConceptFeatureTraits();
+        traits.setRolesSeeingSuggestionInfo(asList(CURATOR));
+        return traits;
     }
 
     @Override

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/MultiValueConceptFeatureTraitsEditor.html
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/MultiValueConceptFeatureTraitsEditor.html
@@ -45,10 +45,7 @@
       </div>
     </div>
     <div class="row form-row" wicket:enclosure="retainSuggestionInfo">
-      <label wicket:for="retainSuggestionInfo" class="col-sm-4 col-form-label">
-        Recommender
-      </label>
-      <div class="col-sm-8">
+      <div class="col-sm-8 offset-sm-4 mt-2">
         <div class="form-check">
           <input wicket:id="retainSuggestionInfo" class="form-check-input" type="checkbox">
           <label wicket:for="retainSuggestionInfo" class="form-check-label">
@@ -56,6 +53,12 @@
           </label>
         </div>
       </div>
+    </div>
+    <div class="row form-row" wicket:enclosure="rolesSeeingSuggestionInfo">
+      <label wicket:for="rolesSeeingSuggestionInfo" class="col-sm-4 col-form-label">
+        Suggestion info visible for
+      </label>
+      <div wicket:id="rolesSeeingSuggestionInfo" class="col-sm-8 mt-2"/>
     </div>
   </form>
 </wicket:panel>

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/layers/ProjectLayersPanel.html
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/layers/ProjectLayersPanel.html
@@ -294,7 +294,7 @@
                 <label class="col-sm-4 col-form-label">
                   <wicket:message key="options"/>
                 </label>
-                <div class="col-sm-8">
+                <div class="col-sm-8 mt-2">
                   <div class="form-check" wicket:enclosure="enabled">
                     <input wicket:id="enabled" class="form-check-input" type="checkbox">
                     <label wicket:for="enabled" class="form-check-label">
@@ -325,7 +325,7 @@
                 <label class="col-sm-4 col-form-label">
                   <wicket:message key="visibility"/>
                 </label>
-                <div class="col-sm-8">
+                <div class="col-sm-8 mt-2">
                   <div class="form-check" wicket:enclosure="visible">
                     <input wicket:id="visible" class="form-check-input" type="checkbox">
                     <label wicket:for="visible" class="form-check-label">

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/layers/ProjectLayersPanel.java
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/layers/ProjectLayersPanel.java
@@ -143,19 +143,20 @@ public class ProjectLayersPanel
 
         featureSelectionForm = new FeatureSelectionForm(MID_FEATURE_SELECTION_FORM,
                 selectedFeature);
+        queue(featureSelectionForm);
+
         featureDetailForm = new FeatureDetailForm(MID_FEATURE_DETAIL_FORM, selectedFeature);
+        queue(featureDetailForm);
 
         layerSelectionPane = new LayerSelectionPane("layerSelectionPane", selectedLayer);
+        queue(layerSelectionPane);
+
         layerDetailForm = new LayerDetailForm("layerDetailForm", selectedLayer,
                 featureSelectionForm, featureDetailForm);
-
-        add(layerSelectionPane);
-        add(featureSelectionForm);
-        add(layerDetailForm);
-        add(featureDetailForm);
+        queue(layerDetailForm);
 
         importLayerForm = new ImportLayerForm("importLayerForm");
-        layerSelectionPane.add(importLayerForm);
+        queue(importLayerForm);
     }
 
     @Override


### PR DESCRIPTION
**What's in the PR**
- Make it configurable which roles can see the retained suggestion information

**How to test manually**
* Try different visibility settings with different user roles

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
