### PR TITLE
#5567 - Disable snapshot isolation in MariaDB 11.6.2 integration test

### DIFF
--- a/inception/inception-app-webapp/src/test/java/de/tudarmstadt/ukp/inception/db/InceptionMariadb_11_6_IntegrationTest.java
+++ b/inception/inception-app-webapp/src/test/java/de/tudarmstadt/ukp/inception/db/InceptionMariadb_11_6_IntegrationTest.java
@@ -37,7 +37,8 @@ class InceptionMariadb_11_6_IntegrationTest
     static final MariaDBContainer<?> dbContainer = new MariaDBContainer<>("mariadb:11.6.2") //
             .withDatabaseName("testdb") //
             .withUsername("test") //
-            .withPassword("test");
+            .withPassword("test") //
+            .withConfigurationOverride("mariadb_11_6");
 
     static @TempDir Path tempDir;
 

--- a/inception/inception-app-webapp/src/test/resources/mariadb_11_6/my.cnf
+++ b/inception/inception-app-webapp/src/test/resources/mariadb_11_6/my.cnf
@@ -1,0 +1,6 @@
+[mysqld]
+# Looks like we have problems (at least in tests, possibly generally) with this feature which
+# seems to be on by default since MariaDB 11.6.2:
+# InceptionMariadb_11_6_IntegrationTest$SpringApplcationContext.testDeletingSourceDocumentWithLearningRecordAttached
+# could not execute statement [(conn=4) Record has changed since last read in table 'project'] [delete from project where id=?]
+innodb_snapshot_isolation=0

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/installation_database_mariadb.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/installation_database_mariadb.adoc
@@ -138,6 +138,7 @@ innodb_file_format=barracuda        # Removed in MariaDB 10.6.0
 innodb_file_per_table=1             # Deprecated in MariaDB 11.0.1
 innodb_strict_mode=1
 innodb_default_row_format='dynamic'
+innodb_snapshot_isolation=0         # Probably required with MariaDB >= 11.6.2
 ----
 
 

--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchServiceImpl.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchServiceImpl.java
@@ -606,11 +606,10 @@ public class SearchServiceImpl
     {
         var groupedResults = query(aUser, aProject, aQuery, aDocument, null, null, 0, MAX_VALUE);
 
-        var resultsAsList = new ArrayList<SearchResult>();
-        groupedResults.values().stream()
-                .forEach(resultsGroup -> resultsAsList.addAll(resultsGroup));
-
-        return resultsAsList;
+        return groupedResults.values().stream() //
+                .flatMap(resultsGroup -> resultsGroup.stream()) //
+                .distinct() //
+                .toList();
     }
 
     @Override

--- a/inception/inception-search-mtas/src/main/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndex.java
+++ b/inception/inception-search-mtas/src/main/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndex.java
@@ -1173,14 +1173,8 @@ public class MtasDocumentIndex
     private void addToResults(Map<String, List<SearchResult>> aResultsMap, String aKey,
             SearchResult aSearchResult)
     {
-        if (aResultsMap.containsKey(aKey)) {
-            aResultsMap.get(aKey).add(aSearchResult);
-        }
-        else {
-            var searchResultsForKey = new ArrayList<SearchResult>();
-            searchResultsForKey.add(aSearchResult);
-            aResultsMap.put(aKey, searchResultsForKey);
-        }
+        var results = aResultsMap.computeIfAbsent(aKey, $ -> new ArrayList<SearchResult>());
+        results.add(aSearchResult);
     }
 
     private List<String> featureValuesAtMatch(List<MtasTokenString> aTokens, int aMatchStart,


### PR DESCRIPTION
**What's in the PR**
- Add an override file which should disable snapshot isulation
- Added info to MariaDB setup guide about disabling snapshot isolation

**How to test manually**
* Wait and see if the integration tests run more stable now

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
