### PR TITLE
#5576 - Two users cannot have the same UI name

### DIFF
--- a/inception/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/cli/UsersMigratePreAuthenticatedToRealmCliCommand.java
+++ b/inception/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/cli/UsersMigratePreAuthenticatedToRealmCliCommand.java
@@ -19,7 +19,6 @@ package de.tudarmstadt.ukp.inception.cli;
 
 import static com.nimbusds.oauth2.sdk.util.CollectionUtils.contains;
 import static de.tudarmstadt.ukp.clarin.webanno.security.UserDao.EMPTY_PASSWORD;
-import static de.tudarmstadt.ukp.clarin.webanno.security.UserDao.REALM_PREAUTH;
 import static de.tudarmstadt.ukp.clarin.webanno.security.model.Role.ROLE_REMOTE;
 import static de.tudarmstadt.ukp.inception.support.SettingsUtil.getPropApplicationHome;
 import static de.tudarmstadt.ukp.inception.support.deployment.DeploymentModeService.PROFILE_AUTH_MODE_EXTERNAL_PREAUTH;
@@ -35,6 +34,7 @@ import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
+import de.tudarmstadt.ukp.clarin.webanno.security.Realm;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import picocli.CommandLine.Command;
@@ -84,7 +84,7 @@ public class UsersMigratePreAuthenticatedToRealmCliCommand
         }
 
         LOG.info("Looking for users with no password to migrate them to the [] realm...",
-                REALM_PREAUTH);
+                Realm.REALM_PREAUTH);
         if (dryRun) {
             LOG.info("Operating in dry-run mode - no changes applied to the database.");
         }
@@ -113,10 +113,10 @@ public class UsersMigratePreAuthenticatedToRealmCliCommand
             if (user.getPassword() == null
                     || passwordEncoder.matches(EMPTY_PASSWORD, user.getPassword())) {
                 if (!dryRun) {
-                    user.setRealm(REALM_PREAUTH);
+                    user.setRealm(Realm.REALM_PREAUTH);
                     userService.update(user);
                 }
-                LOG.info("User {} updated: moved to realm [{}]", user, REALM_PREAUTH);
+                LOG.info("User {} updated: moved to realm [{}]", user, Realm.REALM_PREAUTH);
                 updated++;
             }
         }

--- a/inception/inception-app-webapp/src/test/java/de/tudarmstadt/ukp/inception/InceptionRemoteApiJwtIntegrationTest.java
+++ b/inception/inception-app-webapp/src/test/java/de/tudarmstadt/ukp/inception/InceptionRemoteApiJwtIntegrationTest.java
@@ -47,6 +47,7 @@ import org.springframework.context.ConfigurableApplicationContext;
 
 import com.nimbusds.jwt.SignedJWT;
 
+import de.tudarmstadt.ukp.clarin.webanno.security.Realm;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import no.nav.security.mock.oauth2.MockOAuth2Server;
@@ -96,7 +97,7 @@ public class InceptionRemoteApiJwtIntegrationTest
         userService = context.getBean(UserDao.class);
 
         userService.create(User.builder().withUsername(REMOTE_ADMIN_USER_NAME)
-                .withRealm(UserDao.REALM_EXTERNAL_PREFIX + CLIENT_ID) //
+                .withRealm(Realm.REALM_EXTERNAL_PREFIX + CLIENT_ID) //
                 .withRoles(ROLE_REMOTE, ROLE_USER, ROLE_ADMIN) //
                 .withEnabled(true) //
                 .build());

--- a/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/service/CurationDocumentServiceImpl.java
+++ b/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/service/CurationDocumentServiceImpl.java
@@ -135,7 +135,7 @@ public class CurationDocumentServiceImpl
         Validate.notNull(aProject, "Project must be specified");
 
         // Get all annotators in the project
-        var users = projectService.listProjectUsersWithPermissions(aProject, ANNOTATOR);
+        var users = projectService.listUsersWithRoleInProject(aProject, ANNOTATOR);
         // Bail out already. HQL doesn't seem to like queries with an empty parameter right of "in"
         if (users.isEmpty()) {
             return new ArrayList<>();

--- a/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/DocumentServiceImpl.java
+++ b/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/DocumentServiceImpl.java
@@ -1323,7 +1323,7 @@ public class DocumentServiceImpl
     public Map<AnnotationDocumentState, Long> getAnnotationDocumentStats(SourceDocument aDocument)
     {
         var users = projectService
-                .listProjectUsersWithPermissions(aDocument.getProject(), ANNOTATOR).stream()
+                .listUsersWithRoleInProject(aDocument.getProject(), ANNOTATOR).stream()
                 .toList();
 
         var annDocs = listAnnotationDocuments(aDocument);

--- a/inception/inception-export/src/test/java/de/tudarmstadt/ukp/inception/export/exporters/ProjectPermissionsExporterTest.java
+++ b/inception/inception-export/src/test/java/de/tudarmstadt/ukp/inception/export/exporters/ProjectPermissionsExporterTest.java
@@ -19,8 +19,6 @@ package de.tudarmstadt.ukp.inception.export.exporters;
 
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.ANNOTATOR;
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.MANAGER;
-import static de.tudarmstadt.ukp.clarin.webanno.security.UserDao.REALM_GLOBAL;
-import static de.tudarmstadt.ukp.clarin.webanno.security.UserDao.REALM_PROJECT_PREFIX;
 import static de.tudarmstadt.ukp.clarin.webanno.security.model.Role.ROLE_USER;
 import static java.util.Arrays.asList;
 import static org.apache.commons.collections4.CollectionUtils.union;
@@ -51,6 +49,7 @@ import de.tudarmstadt.ukp.clarin.webanno.export.model.ExportedProject;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.ProjectPermission;
 import de.tudarmstadt.ukp.clarin.webanno.project.exporters.ProjectPermissionsExporter;
+import de.tudarmstadt.ukp.clarin.webanno.security.Realm;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.inception.project.api.ProjectService;
@@ -109,7 +108,7 @@ public class ProjectPermissionsExporterTest
     @Test
     public void thatUserPermissionsAreExportedAndImported() throws Exception
     {
-        annotator.setRealm(REALM_GLOBAL);
+        annotator.setRealm(Realm.REALM_GLOBAL);
 
         exportProject();
 
@@ -133,7 +132,7 @@ public class ProjectPermissionsExporterTest
     @Test
     public void thatUserPermissionsAreNotImported() throws Exception
     {
-        annotator.setRealm(REALM_GLOBAL);
+        annotator.setRealm(Realm.REALM_GLOBAL);
 
         exportProject();
 
@@ -157,7 +156,7 @@ public class ProjectPermissionsExporterTest
     @Test
     public void thatProjectSpecificPermissionsAreCreatedIfUserDidNotYetExist() throws Exception
     {
-        annotator.setRealm(REALM_PROJECT_PREFIX + project.getId());
+        annotator.setRealm(Realm.REALM_PROJECT_PREFIX + project.getId());
 
         exportProject();
 
@@ -185,7 +184,7 @@ public class ProjectPermissionsExporterTest
     @Test
     public void thatProjectSpecificPermissionsAreNotCreatedIfUserAlreadyExisted() throws Exception
     {
-        annotator.setRealm(REALM_PROJECT_PREFIX + project.getId());
+        annotator.setRealm(Realm.REALM_PROJECT_PREFIX + project.getId());
 
         exportProject();
 

--- a/inception/inception-export/src/test/java/de/tudarmstadt/ukp/inception/export/exporters/ProjectPermissionsExporterTest.java
+++ b/inception/inception-export/src/test/java/de/tudarmstadt/ukp/inception/export/exporters/ProjectPermissionsExporterTest.java
@@ -95,7 +95,7 @@ public class ProjectPermissionsExporterTest
 
         sut = new ProjectPermissionsExporter(projectService, userService);
 
-        when(projectService.listProjectUsersWithPermissions(any()))
+        when(projectService.listUsersWithAnyRoleInProject(any()))
                 .thenReturn(asList(manager, annotator));
         when(projectService.listProjectPermissionLevel(manager, project))
                 .thenReturn(managerPermissions);

--- a/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/table/PivotTable.java
+++ b/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/table/PivotTable.java
@@ -69,7 +69,8 @@ public class PivotTable<A extends Serializable, T>
         table.addTopToolbar(new AjaxFallbackHeadersToolbar<CompoundKey>(table, aDataProvider));
         table.add(new StickyRowHeaderBehavior("td.headers > div"));
         // Keeping the columns sticky does not seem to work
-        // table.add(new StickyColumnHeaderBehavior("tr.headers > th:not(:first-child) > a > span"));
+        // table.add(new StickyColumnHeaderBehavior("tr.headers > th:not(:first-child) > a >
+        // span"));
         queue(table);
 
         var navigatorLabel = new NavigatorLabel("navigatorLabel", table);

--- a/inception/inception-processing/src/main/java/de/tudarmstadt/ukp/inception/processing/recommender/BulkRecommenderPanel.java
+++ b/inception/inception-processing/src/main/java/de/tudarmstadt/ukp/inception/processing/recommender/BulkRecommenderPanel.java
@@ -154,7 +154,7 @@ public class BulkRecommenderPanel
 
     private List<User> listUsers()
     {
-        return projectService.listProjectUsersWithPermissions(getModelObject(), ANNOTATOR);
+        return projectService.listUsersWithRoleInProject(getModelObject(), ANNOTATOR);
     }
 
     private List<AnnotationLayer> listDocumentMetadataLayers()

--- a/inception/inception-project-api/src/main/java/de/tudarmstadt/ukp/inception/project/api/ProjectService.java
+++ b/inception/inception-project-api/src/main/java/de/tudarmstadt/ukp/inception/project/api/ProjectService.java
@@ -552,9 +552,11 @@ public interface ProjectService
 
     Realm getRealm(Project aProject);
 
-    Optional<User> getProjectUser(Project aProject, String aUsername);
+    Optional<User> getProjectBoundUser(Project aProject, String aUsername);
 
-    User getOrCreateProjectUser(Project aProject, String aUsername);
+    User getOrCreateProjectBoundUser(Project aProject, String aUsername);
 
     List<User> listProjectBoundUsers(Project aProject);
+
+    void deleteProjectBoundUser(Project aProject, User aUser);
 }

--- a/inception/inception-project-api/src/main/java/de/tudarmstadt/ukp/inception/project/api/ProjectService.java
+++ b/inception/inception-project-api/src/main/java/de/tudarmstadt/ukp/inception/project/api/ProjectService.java
@@ -183,7 +183,7 @@ public interface ProjectService
      *            the project.
      * @return the users.
      */
-    List<User> listProjectUsersWithPermissions(Project aProject);
+    List<User> listUsersWithAnyRoleInProject(Project aProject);
 
     /**
      * List of users with the a given {@link PermissionLevel}
@@ -194,7 +194,7 @@ public interface ProjectService
      *            The {@link PermissionLevel}
      * @return the users.
      */
-    List<User> listProjectUsersWithPermissions(Project aProject, PermissionLevel aPermissionLevel);
+    List<User> listUsersWithRoleInProject(Project aProject, PermissionLevel aPermissionLevel);
 
     /**
      * Removes all permissions for the given user to the given project.
@@ -550,7 +550,11 @@ public interface ProjectService
 
     Realm getRealm(String aRealmId);
 
+    Realm getRealm(Project aProject);
+
     Optional<User> getProjectUser(Project aProject, String aUsername);
 
     User getOrCreateProjectUser(Project aProject, String aUsername);
+
+    List<User> listProjectBoundUsers(Project aProject);
 }

--- a/inception/inception-project-api/src/main/java/de/tudarmstadt/ukp/inception/project/api/ProjectService.java
+++ b/inception/inception-project-api/src/main/java/de/tudarmstadt/ukp/inception/project/api/ProjectService.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import org.apache.commons.lang3.Validate;
@@ -548,4 +549,8 @@ public interface ProjectService
     String deriveUniqueSlug(String aSlug);
 
     Realm getRealm(String aRealmId);
+
+    Optional<User> getProjectUser(Project aProject, String aUsername);
+
+    User getOrCreateProjectUser(Project aProject, String aUsername);
 }

--- a/inception/inception-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
+++ b/inception/inception-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
@@ -643,7 +643,7 @@ public class ProjectServiceImpl
     }
 
     @Override
-    public Optional<User> getProjectUser(Project aProject, String aUiName)
+    public Optional<User> getProjectBoundUser(Project aProject, String aUiName)
     {
         var realm = getRealm(aProject);
 
@@ -658,7 +658,7 @@ public class ProjectServiceImpl
 
     @Override
     @Transactional
-    public User getOrCreateProjectUser(Project aProject, String aUiName)
+    public User getOrCreateProjectBoundUser(Project aProject, String aUiName)
     {
         var realm = getRealm(aProject);
 
@@ -676,6 +676,21 @@ public class ProjectServiceImpl
                 .withEnabled(true) //
                 .withRoles(ROLE_USER) //
                 .build());
+    }
+
+    @Override
+    @Transactional
+    public void deleteProjectBoundUser(Project aProject, User aUser)
+    {
+        var realm = getRealm(aProject);
+
+        var user = userRepository.getUserByRealmAndUiName(realm, aUser.getUiName());
+        if (user == null) {
+            throw new IllegalArgumentException(
+                    "User " + aUser + " does not exist in project " + aProject);
+        }
+
+        userRepository.delete(user);
     }
 
     private String generateRandomUsername()

--- a/inception/inception-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
+++ b/inception/inception-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
@@ -23,7 +23,6 @@ import static de.tudarmstadt.ukp.clarin.webanno.model.Project.MIN_PROJECT_SLUG_L
 import static de.tudarmstadt.ukp.clarin.webanno.model.Project.isValidProjectSlug;
 import static de.tudarmstadt.ukp.clarin.webanno.model.Project.isValidProjectSlugInitialCharacter;
 import static de.tudarmstadt.ukp.clarin.webanno.security.UserDao.EMPTY_PASSWORD;
-import static de.tudarmstadt.ukp.clarin.webanno.security.UserDao.REALM_PROJECT_PREFIX;
 import static de.tudarmstadt.ukp.clarin.webanno.security.model.Role.ROLE_USER;
 import static de.tudarmstadt.ukp.inception.project.api.ProjectService.withProjectLogger;
 import static java.lang.Math.min;
@@ -1207,12 +1206,12 @@ public class ProjectServiceImpl
     @Override
     public Realm getRealm(String aRealmId)
     {
-        if (!startsWith(aRealmId, REALM_PROJECT_PREFIX)) {
+        if (!startsWith(aRealmId, Realm.REALM_PROJECT_PREFIX)) {
             throw new IllegalArgumentException(
-                    "Project realm must start with [" + REALM_PROJECT_PREFIX + "]");
+                    "Project realm must start with [" + Realm.REALM_PROJECT_PREFIX + "]");
         }
 
-        var projectId = Long.valueOf(substringAfter(aRealmId, REALM_PROJECT_PREFIX));
+        var projectId = Long.valueOf(substringAfter(aRealmId, Realm.REALM_PROJECT_PREFIX));
         var project = getProject(projectId);
         if (project != null) {
             return new Realm(aRealmId, "<Project> " + project.getName());

--- a/inception/inception-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/exporters/ProjectPermissionsExporter.java
+++ b/inception/inception-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/exporters/ProjectPermissionsExporter.java
@@ -21,7 +21,6 @@ import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.ANNOTATOR;
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.CURATOR;
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.MANAGER;
 import static de.tudarmstadt.ukp.clarin.webanno.security.UserDao.EMPTY_PASSWORD;
-import static de.tudarmstadt.ukp.clarin.webanno.security.UserDao.REALM_PROJECT_PREFIX;
 import static de.tudarmstadt.ukp.clarin.webanno.security.model.Role.ROLE_USER;
 import static java.lang.String.format;
 import static org.apache.commons.lang3.StringUtils.startsWith;
@@ -49,6 +48,7 @@ import de.tudarmstadt.ukp.clarin.webanno.export.model.ExportedUser;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.ProjectPermission;
 import de.tudarmstadt.ukp.clarin.webanno.project.config.ProjectServiceAutoConfiguration;
+import de.tudarmstadt.ukp.clarin.webanno.security.Realm;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.inception.project.api.ProjectService;
@@ -84,7 +84,7 @@ public class ProjectPermissionsExporter
         List<ExportedUser> projectUsers = new ArrayList<>();
         List<ExportedProjectPermission> projectPermissions = new ArrayList<>();
         for (var user : projectService.listUsersWithAnyRoleInProject(project)) {
-            if (startsWith(user.getRealm(), REALM_PROJECT_PREFIX)) {
+            if (startsWith(user.getRealm(), Realm.REALM_PROJECT_PREFIX)) {
                 var exUser = new ExportedUser();
                 exUser.setCreated(user.getCreated());
                 exUser.setEmail(user.getEmail());
@@ -141,7 +141,7 @@ public class ProjectPermissionsExporter
             }
 
             var u = new User();
-            u.setRealm(REALM_PROJECT_PREFIX + aProject.getId());
+            u.setRealm(Realm.REALM_PROJECT_PREFIX + aProject.getId());
             u.setEmail(importedProjectUser.getEmail());
             u.setUiName(importedProjectUser.getUiName());
             u.setUsername(importedProjectUser.getUsername());

--- a/inception/inception-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/exporters/ProjectPermissionsExporter.java
+++ b/inception/inception-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/exporters/ProjectPermissionsExporter.java
@@ -83,7 +83,7 @@ public class ProjectPermissionsExporter
 
         List<ExportedUser> projectUsers = new ArrayList<>();
         List<ExportedProjectPermission> projectPermissions = new ArrayList<>();
-        for (var user : projectService.listProjectUsersWithPermissions(project)) {
+        for (var user : projectService.listUsersWithAnyRoleInProject(project)) {
             if (startsWith(user.getRealm(), REALM_PROJECT_PREFIX)) {
                 var exUser = new ExportedUser();
                 exUser.setCreated(user.getCreated());

--- a/inception/inception-project/src/test/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImplTest.java
+++ b/inception/inception-project/src/test/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImplTest.java
@@ -156,7 +156,7 @@ public class ProjectServiceImplTest
     @Test
     public void listProjectUsersWithPermissions_ShouldReturnUsers()
     {
-        List<User> foundUsers = sut.listProjectUsersWithPermissions(testProject);
+        List<User> foundUsers = sut.listUsersWithAnyRoleInProject(testProject);
 
         assertThat(foundUsers).containsExactly(beate, kevin);
     }
@@ -164,7 +164,7 @@ public class ProjectServiceImplTest
     @Test
     public void listProjectUsersWithSpecificPermissions_ShouldReturnUsers()
     {
-        List<User> foundUsers = sut.listProjectUsersWithPermissions(testProject, ANNOTATOR);
+        List<User> foundUsers = sut.listUsersWithRoleInProject(testProject, ANNOTATOR);
 
         assertThat(foundUsers).containsExactly(beate, kevin);
     }
@@ -172,7 +172,7 @@ public class ProjectServiceImplTest
     @Test
     public void listProjectUsersWithSpecificPermissions_ShouldReturnAUser()
     {
-        List<User> foundUsers = sut.listProjectUsersWithPermissions(testProject, CURATOR);
+        List<User> foundUsers = sut.listUsersWithRoleInProject(testProject, CURATOR);
 
         assertThat(foundUsers).containsExactly(beate);
     }
@@ -180,7 +180,7 @@ public class ProjectServiceImplTest
     @Test
     public void listProjectUsersWithSpecificPermissions_ShouldReturnNoUsers()
     {
-        List<User> foundUsers = sut.listProjectUsersWithPermissions(testProject, MANAGER);
+        List<User> foundUsers = sut.listUsersWithRoleInProject(testProject, MANAGER);
 
         assertThat(foundUsers).isEmpty();
     }
@@ -190,7 +190,7 @@ public class ProjectServiceImplTest
     {
         testEntityManager.persist(new ProjectPermission(testProject, "ghost", ANNOTATOR));
 
-        List<User> foundUsers = sut.listProjectUsersWithPermissions(testProject, ANNOTATOR);
+        List<User> foundUsers = sut.listUsersWithRoleInProject(testProject, ANNOTATOR);
 
         assertThat(foundUsers).containsExactly(beate, kevin);
     }

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/config/InceptionSecurityRemoteApiAutoConfiguration.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/config/InceptionSecurityRemoteApiAutoConfiguration.java
@@ -17,7 +17,6 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.config;
 
-import static de.tudarmstadt.ukp.clarin.webanno.security.UserDao.REALM_EXTERNAL_PREFIX;
 import static de.tudarmstadt.ukp.clarin.webanno.security.UserDao.SPEL_IS_ADMIN_ACCOUNT_RECOVERY_MODE;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
@@ -35,6 +34,7 @@ import org.springframework.security.provisioning.UserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 
 import de.tudarmstadt.ukp.clarin.webanno.security.InceptionDaoAuthenticationProvider;
+import de.tudarmstadt.ukp.clarin.webanno.security.Realm;
 import de.tudarmstadt.ukp.inception.security.oauth.OAuth2Adapter;
 
 @ConditionalOnExpression("!" + SPEL_IS_ADMIN_ACCOUNT_RECOVERY_MODE)
@@ -91,7 +91,7 @@ public class InceptionSecurityRemoteApiAutoConfiguration
             aHttp.oauth2ResourceServer().jwt().jwtAuthenticationConverter(jwt -> {
                 var token = authCon.convert(jwt);
                 aOAuth2Handling.validateToken(token,
-                        REALM_EXTERNAL_PREFIX + oauth2Properties.getRealm());
+                        Realm.REALM_EXTERNAL_PREFIX + oauth2Properties.getRealm());
                 return token;
             });
         }

--- a/inception/inception-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController_Authentication_Jwt_Test.java
+++ b/inception/inception-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroRemoteApiController_Authentication_Jwt_Test.java
@@ -17,7 +17,6 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.aero;
 
-import static de.tudarmstadt.ukp.clarin.webanno.security.UserDao.REALM_EXTERNAL_PREFIX;
 import static de.tudarmstadt.ukp.clarin.webanno.security.model.Role.ROLE_ADMIN;
 import static de.tudarmstadt.ukp.clarin.webanno.security.model.Role.ROLE_REMOTE;
 import static de.tudarmstadt.ukp.clarin.webanno.security.model.Role.ROLE_USER;
@@ -54,6 +53,7 @@ import org.springframework.util.FileSystemUtils;
 import com.giffing.wicket.spring.boot.starter.WicketAutoConfiguration;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.security.Realm;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.inception.log.config.EventLoggingAutoConfiguration;
@@ -154,17 +154,17 @@ class AeroRemoteApiController_Authentication_Jwt_Test
         projectService.createProject(project);
 
         remoteApiAdminUser = new User("admin", ROLE_ADMIN, ROLE_REMOTE);
-        remoteApiAdminUser.setRealm(REALM_EXTERNAL_PREFIX + REALM);
+        remoteApiAdminUser.setRealm(Realm.REALM_EXTERNAL_PREFIX + REALM);
         remoteApiAdminUser.setPassword(password);
         userRepository.create(remoteApiAdminUser);
 
         remoteApiNormalUser = new User("user", ROLE_USER, ROLE_REMOTE);
-        remoteApiNormalUser.setRealm(REALM_EXTERNAL_PREFIX + REALM);
+        remoteApiNormalUser.setRealm(Realm.REALM_EXTERNAL_PREFIX + REALM);
         remoteApiNormalUser.setPassword(password);
         userRepository.create(remoteApiNormalUser);
 
         nonRemoteNormalUser = new User("non-remote-user", ROLE_USER);
-        nonRemoteNormalUser.setRealm(REALM_EXTERNAL_PREFIX + REALM);
+        nonRemoteNormalUser.setRealm(Realm.REALM_EXTERNAL_PREFIX + REALM);
         nonRemoteNormalUser.setPassword(password);
         userRepository.create(nonRemoteNormalUser);
     }

--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/ReindexTask.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/ReindexTask.java
@@ -125,7 +125,7 @@ public class ReindexTask
                 // We can ignore this since we are rebuilding the index already anyway
             }
 
-            var usersWithPermissions = projectService.listProjectUsersWithPermissions(project)
+            var usersWithPermissions = projectService.listUsersWithAnyRoleInProject(project)
                     .stream() //
                     .map(User::getUsername) //
                     .collect(toUnmodifiableSet());

--- a/inception/inception-security/pom.xml
+++ b/inception/inception-security/pom.xml
@@ -32,6 +32,10 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-validator</groupId>
       <artifactId>commons-validator</artifactId>
     </dependency>

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/Realm.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/Realm.java
@@ -17,14 +17,11 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.security;
 
-import static de.tudarmstadt.ukp.clarin.webanno.security.UserDao.REALM_EXTERNAL_PREFIX;
-import static de.tudarmstadt.ukp.clarin.webanno.security.UserDao.REALM_PROJECT_PREFIX;
-import static org.apache.commons.lang3.StringUtils.startsWith;
+import static org.apache.commons.lang3.Strings.CS;
 
 import java.io.Serializable;
 import java.util.Objects;
 
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 
 public class Realm
@@ -34,7 +31,12 @@ public class Realm
 
     public static final String REALM_LOCAL_ID = null;
 
-    private static final Realm LOCAL_REALM = new Realm(REALM_LOCAL_ID);
+    public static final Realm LOCAL_REALM = new Realm(REALM_LOCAL_ID);
+
+    public static final String REALM_GLOBAL = null;
+    public static final String REALM_PROJECT_PREFIX = "project:";
+    public static final String REALM_EXTERNAL_PREFIX = "external:";
+    public static final String REALM_PREAUTH = "preauth";
 
     private final String id;
     private final String name;
@@ -98,7 +100,7 @@ public class Realm
             return 1;
         }
 
-        return StringUtils.compare(aOne.getName(), aOther.getName());
+        return CS.compare(aOne.getName(), aOther.getName());
     }
 
     public static Realm forProject(long aProjectId, String aProjectName)
@@ -124,6 +126,6 @@ public class Realm
 
     public static boolean isProjectRealm(String aRealm)
     {
-        return startsWith(aRealm, REALM_PROJECT_PREFIX);
+        return CS.startsWith(aRealm, Realm.REALM_PROJECT_PREFIX);
     }
 }

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/UserDao.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/UserDao.java
@@ -40,11 +40,6 @@ public interface UserDao
 
     static final String EMPTY_PASSWORD = "";
 
-    static final String REALM_GLOBAL = null;
-    static final String REALM_PROJECT_PREFIX = "project:";
-    static final String REALM_EXTERNAL_PREFIX = "external:";
-    static final String REALM_PREAUTH = "preauth";
-
     User getCurrentUser();
 
     /**

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/UserDao.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/UserDao.java
@@ -115,6 +115,8 @@ public interface UserDao
 
     User getCurationUser();
 
+    User getUserByRealmAndUiName(Realm aRealm, String aUiName);
+
     User getUserByRealmAndUiName(String aRealm, String aUiName);
 
     /**

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/UserDao.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/UserDao.java
@@ -102,6 +102,8 @@ public interface UserDao
 
     List<User> listAllUsersFromRealm(String aString);
 
+    List<User> listAllUsersFromRealm(Realm aRealm);
+
     /**
      * get a {@link User} using a username
      * 

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/UserDaoImpl.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/UserDaoImpl.java
@@ -182,7 +182,7 @@ public class UserDaoImpl
             var root = query.from(User.class);
 
             // WHERE u.realm LIKE :prefix AND u.optUniqueKey IS NULL
-            var realmPredicate = cb.like(root.get("realm"), UserDao.REALM_PROJECT_PREFIX + "%");
+            var realmPredicate = cb.like(root.get("realm"), Realm.REALM_PROJECT_PREFIX + "%");
             var keyNullPredicate = cb.isNull(root.get("optUniqueKey"));
             query.select(root).where(cb.and(realmPredicate, keyNullPredicate));
 
@@ -780,7 +780,7 @@ public class UserDaoImpl
             return false;
         }
 
-        if (startsWith(aUser.getRealm(), UserDao.REALM_PROJECT_PREFIX)) {
+        if (startsWith(aUser.getRealm(), Realm.REALM_PROJECT_PREFIX)) {
             // Project-bound users get no access to their profile. They could at most change their
             // display name and email, but since those are basically their logins, we don't want
             // them to be able to do that.

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/UserDaoImpl.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/UserDaoImpl.java
@@ -29,6 +29,7 @@ import static de.tudarmstadt.ukp.inception.support.deployment.DeploymentModeServ
 import static de.tudarmstadt.ukp.inception.support.text.TextUtils.containsAnyCharacterMatching;
 import static de.tudarmstadt.ukp.inception.support.text.TextUtils.sortAndRemoveDuplicateCharacters;
 import static de.tudarmstadt.ukp.inception.support.text.TextUtils.startsWithMatching;
+import static java.lang.String.join;
 import static org.apache.commons.lang3.StringUtils.contains;
 import static org.apache.commons.lang3.StringUtils.containsAny;
 import static org.apache.commons.lang3.StringUtils.isBlank;
@@ -259,9 +260,16 @@ public class UserDaoImpl
 
     @Override
     @Transactional
+    public List<User> listAllUsersFromRealm(Realm aRealm)
+    {
+        return listAllUsersFromRealm(aRealm.getId());
+    }
+
+    @Override
+    @Transactional
     public List<User> listAllUsersFromRealm(String aRealm)
     {
-        String query = String.join("\n", //
+        var query = join("\n", //
                 "FROM " + User.class.getName(), //
                 "WHERE realm = :realm");
 
@@ -286,7 +294,7 @@ public class UserDaoImpl
             return usersInRealm.size();
         }
 
-        String query = String.join("\n", //
+        String query = join("\n", //
                 "DELETE FROM " + User.class.getName(), //
                 "WHERE realm = :realm");
 
@@ -338,7 +346,7 @@ public class UserDaoImpl
     {
         Validate.notBlank(aUiName, "User must be specified");
 
-        var query = String.join("\n", //
+        var query = join("\n", //
                 "FROM " + User.class.getName(), //
                 "WHERE ((:realm is null and realm is null) or realm = :realm)", //
                 "AND   uiName = :uiName");
@@ -712,7 +720,7 @@ public class UserDaoImpl
     @Transactional(readOnly = true)
     public long countEnabledUsers()
     {
-        String query = String.join("\n", //
+        String query = join("\n", //
                 "SELECT COUNT(*)", //
                 "FROM " + User.class.getName(), //
                 "WHERE enabled = :enabled");

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/model/User.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/model/User.java
@@ -35,7 +35,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import de.tudarmstadt.ukp.clarin.webanno.security.Realm;
-import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.inception.support.spring.ApplicationContextProvider;
 import jakarta.persistence.Cacheable;
 import jakarta.persistence.CollectionTable;
@@ -215,7 +214,12 @@ public class User
 
     public void setPassword(String aPassword)
     {
-        password = getPasswordEncoder().encode(aPassword);
+        if (aPassword == null) {
+            password = null;
+        }
+        else {
+            password = getPasswordEncoder().encode(aPassword);
+        }
     }
 
     public void setEncodedPassword(String aPassword)
@@ -339,7 +343,7 @@ public class User
     {
         // For project-bound users, the UI name must be unique because in the guest annotator mode,
         // we use the UI name during "authentication".
-        if (realm != null && realm.startsWith(UserDao.REALM_PROJECT_PREFIX)) {
+        if (realm != null && realm.startsWith(Realm.REALM_PROJECT_PREFIX)) {
             var digest = DigestUtils.getSha256Digest();
             digest.update(realm.getBytes(UTF_8));
             digest.update((byte) 0x01);

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/model/User.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/model/User.java
@@ -144,16 +144,16 @@ public class User
 
     private User(Builder builder)
     {
-        this.username = builder.username;
-        this.password = builder.password;
-        this.realm = builder.realm;
-        this.uiName = builder.uiName;
-        this.enabled = builder.enabled;
-        this.lastLogin = builder.lastLogin;
-        this.email = builder.email;
-        this.roles = builder.roles;
-        this.created = builder.created;
-        this.updated = builder.updated;
+        username = builder.username;
+        realm = builder.realm;
+        uiName = builder.uiName;
+        enabled = builder.enabled;
+        lastLogin = builder.lastLogin;
+        email = builder.email;
+        roles = builder.roles;
+        created = builder.created;
+        updated = builder.updated;
+        setPassword(builder.password);
     }
 
     private synchronized PasswordEncoder getPasswordEncoder()
@@ -349,6 +349,29 @@ public class User
         else {
             optUniqueKey = null;
         }
+    }
+
+    public String toLongString()
+    {
+        var builder = new StringBuilder();
+
+        if (uiName != null) {
+            builder.append(uiName);
+            if (!username.equals(uiName)) {
+                builder.append(" (");
+                builder.append(username);
+                builder.append(")");
+            }
+        }
+        else {
+            builder.append(username);
+        }
+
+        if (!isEnabled()) {
+            builder.append(" (deactivated)");
+        }
+
+        return builder.toString();
     }
 
     @Override

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/preauth/ShibbolethRequestHeaderAuthenticationFilter.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/preauth/ShibbolethRequestHeaderAuthenticationFilter.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.web.authentication.preauth.RequestHeaderAuthenticationFilter;
 
+import de.tudarmstadt.ukp.clarin.webanno.security.Realm;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import jakarta.servlet.http.HttpServletRequest;
@@ -42,11 +43,11 @@ public class ShibbolethRequestHeaderAuthenticationFilter
 
     private void newUserLogin(String aUsername)
     {
-        User u = new User();
+        var u = new User();
         u.setUsername(aUsername);
         u.setPassword(EMPTY_PASSWORD);
         u.setEnabled(true);
-        u.setRealm(UserDao.REALM_PREAUTH);
+        u.setRealm(Realm.REALM_PREAUTH);
         u.setRoles(PreAuthUtils.getPreAuthenticationNewUserRoles(u));
 
         userRepository.create(u);
@@ -69,9 +70,9 @@ public class ShibbolethRequestHeaderAuthenticationFilter
     {
         denyAccessToUsersWithIllegalUsername(username);
 
-        User user = userRepository.get(username);
+        var user = userRepository.get(username);
         if (user != null) {
-            denyAccessOfRealmsDoNotMatch(UserDao.REALM_PREAUTH, user);
+            denyAccessOfRealmsDoNotMatch(Realm.REALM_PREAUTH, user);
             denyAccessToDeactivatedUsers(user);
         }
         else {
@@ -89,7 +90,7 @@ public class ShibbolethRequestHeaderAuthenticationFilter
 
         var userNameValidationResult = userRepository.validateUsername(aUsername);
         if (!userNameValidationResult.isEmpty()) {
-            String messages = userNameValidationResult.stream() //
+            var messages = userNameValidationResult.stream() //
                     .map(ValidationError::getMessage) //
                     .collect(joining("\n- ", "\n- ", ""));
             LOG.info("Prevented login of user [{}] with illegal username: {}", aUsername, messages);

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/oauth/OAuth2AdapterImpl.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/oauth/OAuth2AdapterImpl.java
@@ -17,7 +17,6 @@
  */
 package de.tudarmstadt.ukp.inception.security.oauth;
 
-import static de.tudarmstadt.ukp.clarin.webanno.security.UserDao.REALM_EXTERNAL_PREFIX;
 import static java.util.stream.Collectors.joining;
 import static org.springframework.security.oauth2.core.OAuth2ErrorCodes.ACCESS_DENIED;
 
@@ -53,6 +52,7 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.oauth2.jwt.Jwt;
 
 import de.tudarmstadt.ukp.clarin.webanno.security.OverridableUserDetailsManager;
+import de.tudarmstadt.ukp.clarin.webanno.security.Realm;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.clarin.webanno.security.preauth.PreAuthUtils;
@@ -142,7 +142,7 @@ public class OAuth2AdapterImpl
 
         denyAccessToUsersWithIllegalUsername(username);
 
-        var realm = REALM_EXTERNAL_PREFIX + userRequest.getClientRegistration().getRegistrationId();
+        var realm = Realm.REALM_EXTERNAL_PREFIX + userRequest.getClientRegistration().getRegistrationId();
 
         User u = userRepository.get(username);
         if (u != null) {

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/saml/Saml2AdapterImpl.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/saml/Saml2AdapterImpl.java
@@ -17,7 +17,6 @@
  */
 package de.tudarmstadt.ukp.inception.security.saml;
 
-import static de.tudarmstadt.ukp.clarin.webanno.security.UserDao.REALM_EXTERNAL_PREFIX;
 import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.joining;
 import static org.apache.commons.lang3.StringUtils.removeEnd;
@@ -44,6 +43,7 @@ import org.springframework.security.saml2.provider.service.registration.RelyingP
 import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistrationRepository;
 
 import de.tudarmstadt.ukp.clarin.webanno.security.OverridableUserDetailsManager;
+import de.tudarmstadt.ukp.clarin.webanno.security.Realm;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.clarin.webanno.security.preauth.PreAuthUtils;
@@ -122,7 +122,7 @@ public class Saml2AdapterImpl
     @Override
     public User loadSamlUser(String aUsername, String aRegistrationId)
     {
-        var realm = REALM_EXTERNAL_PREFIX + aRegistrationId;
+        var realm = Realm.REALM_EXTERNAL_PREFIX + aRegistrationId;
 
         denyAccessToUsersWithIllegalUsername(aUsername);
 

--- a/inception/inception-security/src/main/resources/de/tudarmstadt/ukp/clarin/webanno/security/model/db-changelog.xml
+++ b/inception/inception-security/src/main/resources/de/tudarmstadt/ukp/clarin/webanno/security/model/db-changelog.xml
@@ -182,4 +182,21 @@
   <changeSet author="INCEpTION Team" id="20220930-2-pg" dbms="postgresql">
     <sql>ALTER TABLE users ALTER "enabled" TYPE BOOLEAN USING ("enabled"::int::bool)</sql>
   </changeSet>
+  
+  <changeSet author="INCEpTION Team" id="20250830-01" failOnError="false">
+    <dropUniqueConstraint tableName="users" constraintName="UK_realm_uiName" />
+  </changeSet>
+
+  <changeSet author="INCEpTION Team" id="20250830-02">
+    <addColumn tableName="users">
+      <column name="opt_unique_key" type="VARCHAR(255)">
+        <constraints nullable="true" />
+      </column>
+    </addColumn>
+  </changeSet>
+
+  <changeSet author="INCEpTION Team" id="20250830-03">
+    <addUniqueConstraint tableName="users" columnNames="opt_unique_key"
+      constraintName="UK_users_opt_unique_key" />
+  </changeSet>
 </databaseChangeLog>

--- a/inception/inception-security/src/test/java/de/tudarmstadt/ukp/clarin/webanno/security/UserDaoImplTest.java
+++ b/inception/inception-security/src/test/java/de/tudarmstadt/ukp/clarin/webanno/security/UserDaoImplTest.java
@@ -17,7 +17,6 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.security;
 
-import static de.tudarmstadt.ukp.clarin.webanno.security.UserDao.REALM_EXTERNAL_PREFIX;
 import static de.tudarmstadt.ukp.clarin.webanno.security.config.SecurityPropertiesImpl.DEFAULT_MAXIMUM_USERNAME_LENGTH;
 import static de.tudarmstadt.ukp.clarin.webanno.security.config.SecurityPropertiesImpl.DEFAULT_MINIMUM_PASSWORD_LENGTH;
 import static de.tudarmstadt.ukp.clarin.webanno.security.config.SecurityPropertiesImpl.DEFAULT_MINIMUM_USERNAME_LENGTH;
@@ -298,7 +297,7 @@ class UserDaoImplTest
 
         userDao.create(User.builder() //
                 .withUsername("user3") //
-                .withRealm(new Realm(REALM_EXTERNAL_PREFIX + "client", "My SSO")) //
+                .withRealm(new Realm(Realm.REALM_EXTERNAL_PREFIX + "client", "My SSO")) //
                 .build());
 
         assertThat(userDao.listRealms()) //

--- a/inception/inception-security/src/test/java/de/tudarmstadt/ukp/clarin/webanno/security/preauth/ShibbolethRequestHeaderAuthenticationFilterTest.java
+++ b/inception/inception-security/src/test/java/de/tudarmstadt/ukp/clarin/webanno/security/preauth/ShibbolethRequestHeaderAuthenticationFilterTest.java
@@ -42,6 +42,7 @@ import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
+import de.tudarmstadt.ukp.clarin.webanno.security.Realm;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.security.config.InceptionSecurityAutoConfiguration;
 import de.tudarmstadt.ukp.clarin.webanno.security.config.SecurityAutoConfiguration;
@@ -98,7 +99,7 @@ class ShibbolethRequestHeaderAuthenticationFilterTest
                 .ignoringFields(User_.CREATED, User_.UPDATED, User_.PASSWORD, "passwordEncoder") //
                 .isEqualTo(User.builder() //
                         .withUsername(USERNAME) //
-                        .withRealm(UserDao.REALM_PREAUTH).withRoles(Set.of(Role.ROLE_USER)) //
+                        .withRealm(Realm.REALM_PREAUTH).withRoles(Set.of(Role.ROLE_USER)) //
                         .withEnabled(true) //
                         .build());
 
@@ -112,7 +113,7 @@ class ShibbolethRequestHeaderAuthenticationFilterTest
     {
         userService.create(User.builder() //
                 .withUsername(USERNAME) //
-                .withRealm(UserDao.REALM_PREAUTH) //
+                .withRealm(Realm.REALM_PREAUTH) //
                 .withRoles(Set.of(Role.ROLE_USER)) //
                 .withEnabled(true) //
                 .build());

--- a/inception/inception-security/src/test/java/de/tudarmstadt/ukp/inception/security/oauth/OAuth2AdapterImplTest.java
+++ b/inception/inception-security/src/test/java/de/tudarmstadt/ukp/inception/security/oauth/OAuth2AdapterImplTest.java
@@ -17,7 +17,6 @@
  */
 package de.tudarmstadt.ukp.inception.security.oauth;
 
-import static de.tudarmstadt.ukp.clarin.webanno.security.UserDao.REALM_EXTERNAL_PREFIX;
 import static java.time.Instant.now;
 import static java.time.temporal.ChronoUnit.MINUTES;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -48,6 +47,7 @@ import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
+import de.tudarmstadt.ukp.clarin.webanno.security.Realm;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.security.config.InceptionSecurityAutoConfiguration;
 import de.tudarmstadt.ukp.clarin.webanno.security.config.SecurityAutoConfiguration;
@@ -107,7 +107,7 @@ class OAuth2AdapterImplTest
                 .ignoringFields(User_.CREATED, User_.UPDATED, User_.PASSWORD, "passwordEncoder") //
                 .isEqualTo(User.builder() //
                         .withUsername(USERNAME) //
-                        .withRealm(REALM_EXTERNAL_PREFIX + clientRegistration.getRegistrationId())
+                        .withRealm(Realm.REALM_EXTERNAL_PREFIX + clientRegistration.getRegistrationId())
                         .withRoles(Set.of(Role.ROLE_USER)) //
                         .withEnabled(true) //
                         .build());
@@ -122,7 +122,7 @@ class OAuth2AdapterImplTest
     {
         userService.create(User.builder() //
                 .withUsername(USERNAME) //
-                .withRealm(REALM_EXTERNAL_PREFIX + clientRegistration.getRegistrationId())
+                .withRealm(Realm.REALM_EXTERNAL_PREFIX + clientRegistration.getRegistrationId())
                 .withRoles(Set.of(Role.ROLE_USER)) //
                 .withEnabled(true) //
                 .build());

--- a/inception/inception-security/src/test/java/de/tudarmstadt/ukp/inception/security/saml/Saml2AdapterImplTest.java
+++ b/inception/inception-security/src/test/java/de/tudarmstadt/ukp/inception/security/saml/Saml2AdapterImplTest.java
@@ -17,7 +17,6 @@
  */
 package de.tudarmstadt.ukp.inception.security.saml;
 
-import static de.tudarmstadt.ukp.clarin.webanno.security.UserDao.REALM_EXTERNAL_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatNoException;
@@ -40,6 +39,7 @@ import org.springframework.security.authentication.DisabledException;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
+import de.tudarmstadt.ukp.clarin.webanno.security.Realm;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.security.config.InceptionSecurityAutoConfiguration;
 import de.tudarmstadt.ukp.clarin.webanno.security.config.SecurityAutoConfiguration;
@@ -104,7 +104,7 @@ class Saml2AdapterImplTest
                 .ignoringFields(User_.CREATED, User_.UPDATED, User_.PASSWORD, "passwordEncoder") //
                 .isEqualTo(User.builder() //
                         .withUsername(USERNAME) //
-                        .withRealm(REALM_EXTERNAL_PREFIX + CLIENT_REGISTRATION_ID)
+                        .withRealm(Realm.REALM_EXTERNAL_PREFIX + CLIENT_REGISTRATION_ID)
                         .withRoles(Set.of(Role.ROLE_USER)) //
                         .withEnabled(true) //
                         .build());
@@ -119,7 +119,7 @@ class Saml2AdapterImplTest
     {
         userService.create(User.builder() //
                 .withUsername(USERNAME) //
-                .withRealm(REALM_EXTERNAL_PREFIX + CLIENT_REGISTRATION_ID)
+                .withRealm(Realm.REALM_EXTERNAL_PREFIX + CLIENT_REGISTRATION_ID)
                 .withRoles(Set.of(Role.ROLE_USER)) //
                 .withEnabled(true) //
                 .build());

--- a/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/AcceptInvitePage.java
+++ b/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/AcceptInvitePage.java
@@ -28,7 +28,6 @@ import static de.tudarmstadt.ukp.inception.support.lambda.LambdaBehavior.visible
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import java.io.Serializable;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -235,8 +234,7 @@ public class AcceptInvitePage
 
     private User signInAsProjectUser(FormData aFormData)
     {
-        Optional<User> existingUser = inviteService.getProjectUser(getProject(),
-                aFormData.username);
+        var existingUser = projectService.getProjectUser(getProject(), aFormData.username);
 
         if (existingUser.isPresent() && !existingUser.get().isEnabled()) {
             error("User deactivated");
@@ -251,7 +249,7 @@ public class AcceptInvitePage
             }
         }
 
-        User user = inviteService.getOrCreateProjectUser(getProject(), aFormData.username);
+        var user = projectService.getOrCreateProjectUser(getProject(), aFormData.username);
         if (aFormData.eMail != null && user.getEmail() == null) {
             user.setEmail(aFormData.eMail);
             userRepository.update(user);
@@ -266,7 +264,7 @@ public class AcceptInvitePage
 
     private User signInAsRegisteredUserIfNecessary()
     {
-        User user = userRepository.getCurrentUser();
+        var user = userRepository.getCurrentUser();
 
         if (user == null) {
             FormData data = formModel.getObject();

--- a/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/AcceptInvitePage.java
+++ b/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/AcceptInvitePage.java
@@ -234,7 +234,7 @@ public class AcceptInvitePage
 
     private User signInAsProjectUser(FormData aFormData)
     {
-        var existingUser = projectService.getProjectUser(getProject(), aFormData.username);
+        var existingUser = projectService.getProjectBoundUser(getProject(), aFormData.username);
 
         if (existingUser.isPresent() && !existingUser.get().isEnabled()) {
             error("User deactivated");
@@ -249,7 +249,7 @@ public class AcceptInvitePage
             }
         }
 
-        var user = projectService.getOrCreateProjectUser(getProject(), aFormData.username);
+        var user = projectService.getOrCreateProjectBoundUser(getProject(), aFormData.username);
         if (aFormData.eMail != null && user.getEmail() == null) {
             user.setEmail(aFormData.eMail);
             userRepository.update(user);

--- a/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/InviteService.java
+++ b/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/InviteService.java
@@ -18,10 +18,8 @@
 package de.tudarmstadt.ukp.inception.sharing;
 
 import java.util.Date;
-import java.util.Optional;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
-import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.inception.sharing.model.ProjectInvite;
 
 public interface InviteService
@@ -91,10 +89,6 @@ public interface InviteService
     ProjectInvite readProjectInvite(Project aProject);
 
     void writeProjectInvite(ProjectInvite aInvite);
-
-    Optional<User> getProjectUser(Project aProject, String aUsername);
-
-    User getOrCreateProjectUser(Project aProject, String aUsername);
 
     boolean isProjectAnnotationComplete(ProjectInvite aInvite);
 

--- a/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/InviteServiceImpl.java
+++ b/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/InviteServiceImpl.java
@@ -18,7 +18,6 @@
 package de.tudarmstadt.ukp.inception.sharing;
 
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.ANNOTATOR;
-import static de.tudarmstadt.ukp.clarin.webanno.security.UserDao.REALM_PROJECT_PREFIX;
 import static de.tudarmstadt.ukp.clarin.webanno.ui.core.page.ProjectPageBase.NS_PROJECT;
 import static de.tudarmstadt.ukp.inception.sharing.model.Mandatoriness.NOT_ALLOWED;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
@@ -39,6 +38,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.ProjectState;
+import de.tudarmstadt.ukp.clarin.webanno.security.Realm;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.inception.project.api.ProjectService;
 import de.tudarmstadt.ukp.inception.project.api.event.BeforeProjectRemovedEvent;
@@ -330,6 +330,6 @@ public class InviteServiceImpl
     @Transactional
     public void beforeProjectRemove(BeforeProjectRemovedEvent aEvent) throws IOException
     {
-        userRepository.deleteAllUsersFromRealm(REALM_PROJECT_PREFIX + aEvent.getProject().getId());
+        userRepository.deleteAllUsersFromRealm(Realm.REALM_PROJECT_PREFIX + aEvent.getProject().getId());
     }
 }

--- a/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/InviteServiceImpl.java
+++ b/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/InviteServiceImpl.java
@@ -18,11 +18,10 @@
 package de.tudarmstadt.ukp.inception.sharing;
 
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.ANNOTATOR;
-import static de.tudarmstadt.ukp.clarin.webanno.security.UserDao.EMPTY_PASSWORD;
 import static de.tudarmstadt.ukp.clarin.webanno.security.UserDao.REALM_PROJECT_PREFIX;
-import static de.tudarmstadt.ukp.clarin.webanno.security.model.Role.ROLE_USER;
 import static de.tudarmstadt.ukp.clarin.webanno.ui.core.page.ProjectPageBase.NS_PROJECT;
 import static de.tudarmstadt.ukp.inception.sharing.model.Mandatoriness.NOT_ALLOWED;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.io.IOException;
 import java.security.SecureRandom;
@@ -30,10 +29,7 @@ import java.util.Base64;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.apache.wicket.request.Url;
 import org.apache.wicket.request.cycle.RequestCycle;
@@ -44,7 +40,6 @@ import org.springframework.transaction.annotation.Transactional;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.ProjectState;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
-import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.inception.project.api.ProjectService;
 import de.tudarmstadt.ukp.inception.project.api.event.BeforeProjectRemovedEvent;
 import de.tudarmstadt.ukp.inception.sharing.config.InviteServiceAutoConfiguration;
@@ -64,7 +59,6 @@ public class InviteServiceImpl
     implements InviteService
 {
     public static final int INVITE_ID_BYTE_LENGTH = 16;
-    public static final int RANDOM_USERNAME_BYTE_LENGTH = 16;
 
     private @PersistenceContext EntityManager entityManager;
 
@@ -116,25 +110,6 @@ public class InviteServiceImpl
 
         entityManager.persist(new ProjectInvite(aProject, inviteID, expirationDate));
         return inviteID;
-    }
-
-    private String generateRandomUsername()
-    {
-        nextName: while (true) {
-            byte[] bytes = new byte[RANDOM_USERNAME_BYTE_LENGTH];
-            random.nextBytes(bytes);
-            String randomUserId = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
-
-            // Do not accept base64 values which contain characters that are not safe for file
-            // names / not valid as usernames
-            if (!userRepository.isValidUsername(randomUserId)) {
-                continue nextName;
-            }
-
-            if (!userRepository.exists(randomUserId)) {
-                return randomUserId;
-            }
-        }
     }
 
     /**
@@ -250,7 +225,7 @@ public class InviteServiceImpl
             return false;
         }
 
-        int annotatorCount = projectService
+        var annotatorCount = projectService
                 .listProjectUsersWithPermissions(aInvite.getProject(), ANNOTATOR).size();
 
         return annotatorCount >= aInvite.getMaxAnnotatorCount();
@@ -263,14 +238,14 @@ public class InviteServiceImpl
             return false;
         }
 
-        String expectedId = getValidInviteID(aProject);
+        var expectedId = getValidInviteID(aProject);
         return expectedId != null && aInviteId.equals(expectedId);
     }
 
     @Override
     public Date getExpirationDate(Project aProject)
     {
-        ProjectInvite invite = readProjectInvite(aProject);
+        var invite = readProjectInvite(aProject);
         if (invite == null) {
             return null;
         }
@@ -281,11 +256,12 @@ public class InviteServiceImpl
     @Override
     public void extendInviteLinkDate(Project aProject)
     {
-        ProjectInvite invite = readProjectInvite(aProject);
+        var invite = readProjectInvite(aProject);
         if (invite == null) {
             return;
         }
-        Date newExpirationDate = getDateOneYearForth(invite.getExpirationDate());
+
+        var newExpirationDate = getDateOneYearForth(invite.getExpirationDate());
         invite.setExpirationDate(newExpirationDate);
         entityManager.merge(invite);
     }
@@ -297,37 +273,31 @@ public class InviteServiceImpl
         if (aExpirationDate.getTime() < new Date().getTime()) {
             return false;
         }
-        ProjectInvite invite = readProjectInvite(aProject);
+
+        var invite = readProjectInvite(aProject);
         if (invite == null) {
             generateNewInvite(aProject, aExpirationDate);
             return true;
         }
+
         invite.setExpirationDate(aExpirationDate);
         entityManager.merge(invite);
         return true;
     }
 
     @Override
-    public Optional<User> getProjectUser(Project aProject, String aUsername)
-    {
-        String realm = REALM_PROJECT_PREFIX + aProject.getId();
-
-        return Optional.ofNullable(userRepository.getUserByRealmAndUiName(realm, aUsername));
-    }
-
-    @Override
     public String getFullInviteLinkUrl(ProjectInvite aInvite)
     {
         // If a base URL is set in the properties, we use that.
-        if (StringUtils.isNotBlank(inviteProperties.getInviteBaseUrl())) {
-            StringBuilder url = new StringBuilder();
+        if (isNotBlank(inviteProperties.getInviteBaseUrl())) {
+            var url = new StringBuilder();
             url.append(inviteProperties.getInviteBaseUrl().trim());
             while (url.charAt(url.length() - 1) == '/') {
                 url.setLength(url.length() - 1);
             }
 
-            Project project = aInvite.getProject();
-            String projectSegment = project.getSlug() != null ? project.getSlug()
+            var project = aInvite.getProject();
+            var projectSegment = project.getSlug() != null ? project.getSlug()
                     : String.valueOf(project.getId());
 
             url.append(NS_PROJECT);
@@ -341,43 +311,19 @@ public class InviteServiceImpl
         }
 
         // If we are in a Wicket context, we can use Wicket to render the URL for us
-        RequestCycle cycle = RequestCycle.get();
+        var cycle = RequestCycle.get();
         if (cycle != null) {
-            PageParameters pageParameters = new PageParameters();
+            var pageParameters = new PageParameters();
             AcceptInvitePage.setProjectPageParameter(pageParameters, aInvite.getProject());
             pageParameters.set(AcceptInvitePage.PAGE_PARAM_INVITE_ID, aInvite.getInviteId());
 
-            CharSequence url = cycle.urlFor(AcceptInvitePage.class, pageParameters);
+            var url = cycle.urlFor(AcceptInvitePage.class, pageParameters);
 
             return RequestCycle.get().getUrlRenderer().renderFullUrl(Url.parse(url));
         }
 
         throw new IllegalStateException("Please set the property [sharing.invites.invite-base-url] "
                 + "in the settings.properties file");
-    }
-
-    @Override
-    @Transactional
-    public User getOrCreateProjectUser(Project aProject, String aUsername)
-    {
-        String realm = REALM_PROJECT_PREFIX + aProject.getId();
-
-        User user = userRepository.getUserByRealmAndUiName(realm, aUsername);
-
-        if (user != null) {
-            return user;
-        }
-
-        User u = new User();
-        u.setUsername(generateRandomUsername());
-        u.setUiName(aUsername);
-        u.setPassword(EMPTY_PASSWORD);
-        u.setRealm(realm);
-        u.setEnabled(true);
-        u.setRoles(Set.of(ROLE_USER));
-        userRepository.create(u);
-
-        return u;
     }
 
     @EventListener

--- a/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/InviteServiceImpl.java
+++ b/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/InviteServiceImpl.java
@@ -226,7 +226,7 @@ public class InviteServiceImpl
         }
 
         var annotatorCount = projectService
-                .listProjectUsersWithPermissions(aInvite.getProject(), ANNOTATOR).size();
+                .listUsersWithRoleInProject(aInvite.getProject(), ANNOTATOR).size();
 
         return annotatorCount >= aInvite.getMaxAnnotatorCount();
     }

--- a/inception/inception-ui-agreement/src/main/java/de/tudarmstadt/ukp/inception/ui/agreement/page/AgreementPageMenuItem.java
+++ b/inception/inception-ui-agreement/src/main/java/de/tudarmstadt/ukp/inception/ui/agreement/page/AgreementPageMenuItem.java
@@ -68,7 +68,7 @@ public class AgreementPageMenuItem
     {
         // Show agreement menu item only if we have at least 2 annotators or we cannot calculate
         // pairwise agreement
-        if (projectService.listProjectUsersWithPermissions(aProject, ANNOTATOR).size() < 2) {
+        if (projectService.listUsersWithRoleInProject(aProject, ANNOTATOR).size() < 2) {
             return false;
         }
 

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/open/OpenDocumentDialogPanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/open/OpenDocumentDialogPanel.java
@@ -200,7 +200,7 @@ public class OpenDocumentDialogPanel
             return users;
         }
 
-        for (var user : projectService.listProjectUsersWithPermissions(project, ANNOTATOR)) {
+        for (var user : projectService.listUsersWithRoleInProject(project, ANNOTATOR)) {
             var du = DecoratedObject.of(user);
             du.setLabel(user.getUiName());
             if (user.equals(sessionOwner)) {

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/users/ManageUsersPage.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/users/ManageUsersPage.java
@@ -91,10 +91,10 @@ public class ManageUsersPage
 
     private void checkAccess(final PageParameters aPageParameters)
     {
-        String username = aPageParameters.get(PARAM_USER).toOptionalString();
+        var username = aPageParameters.get(PARAM_USER).toOptionalString();
 
-        User currentUser = userService.getCurrentUser();
-        User userToOpen = isBlank(username) ? currentUser : userService.get(username);
+        var currentUser = userService.getCurrentUser();
+        var userToOpen = isBlank(username) ? currentUser : userService.get(username);
 
         // Admins can manage any user
         if (userService.isCurrentUserAdmin()) {

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/users/UserDetailPanel.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/users/UserDetailPanel.java
@@ -185,7 +185,7 @@ public class UserDetailPanel
 
         userService.listRealms().stream() //
                 // Do not permit to move users to project realms
-                .filter(_id -> !startsWith(_id, UserDao.REALM_PROJECT_PREFIX)) //
+                .filter(_id -> !startsWith(_id, Realm.REALM_PROJECT_PREFIX)) //
                 .map(Realm::new) //
                 .forEach(realms::add);
 

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/users/UserDetailPanel.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/users/UserDetailPanel.java
@@ -168,11 +168,11 @@ public class UserDetailPanel
         realm.setChoices(LoadableDetachableModel.of(this::listRealms));
         realm.setChoiceRenderer(new ChoiceRenderer<>("name"));
         realm.setOutputMarkupId(true);
-        realm.add(enabledWhen(() -> !viewingOwnUserDetails()
+        realm.add(enabledWhen(() -> !viewingOwnUserDetails()));
+        realm.add(visibleWhen(() -> realm.getChoicesModel().getObject().size() > 1
+                && userService.isCurrentUserAdmin()
                 // Do not permit moving users out of project realms
                 && !Realm.isProjectRealm(aModel.getObject().getRealm())));
-        realm.add(visibleWhen(() -> realm.getChoicesModel().getObject().size() > 1
-                && userService.isCurrentUserAdmin()));
         realm.add(new LambdaAjaxFormComponentUpdatingBehavior(CHANGE_EVENT, _target -> {
             _target.add(oldPasswordField, passwordField, repeatPasswordField, passwordUnsetNotice);
         }));
@@ -285,7 +285,7 @@ public class UserDetailPanel
 
     private void validateUiName(IValidatable<String> aValidatable)
     {
-        User other = userService.getUserByRealmAndUiName(getModelObject().getRealm(),
+        var other = userService.getUserByRealmAndUiName(getModelObject().getRealm(),
                 aValidatable.getValue());
 
         if (other != null && !other.getUsername().equals(getModelObject().getUsername())) {
@@ -339,7 +339,7 @@ public class UserDetailPanel
             User user = getModelObject();
 
             if (password != null) {
-                success("Password for user [" + user.getUsername() + "] has been set.");
+                success("Password for user " + user + " has been set.");
                 user.setPassword(password);
             }
 
@@ -349,7 +349,7 @@ public class UserDetailPanel
             }
             else {
                 userService.update(user);
-                success("Details for user [" + user.getUsername() + "] have been updated.");
+                success("Details for user " + user + " have been updated.");
             }
 
             aTarget.addChildren(getPage(), IFeedback.class);

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/AddProjectUserPanel.html
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/AddProjectUserPanel.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<!--
+  Licensed to the Technische Universität Darmstadt under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The Technische Universität Darmstadt 
+  licenses this file to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.
+   
+  http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<html xmlns:wicket="http://wicket.apache.org">
+<wicket:panel>
+  <form wicket:id="form" class="card">
+    <div class="modal-header">
+      <h5 class="modal-title">
+        Create project user
+      </h5>
+      <button wicket:id="closeDialog" type="button" class="btn-close" aria-label="Close"></button>
+    </div>
+    <div class="modal-body">
+      <p>
+        Create a user that exists only in this project. The user cannot log in, but you can 
+        use it as a container for data.
+      </p>
+      <div class="container">
+        <div class="form-row form-floating">
+          <input wicket:id="uiName" class="form-control" wicket:message="placeholder:name"/>
+          <label wicket:for="uiName">
+            <wicket:label key="name"/>
+          </label>
+        </div>
+      </div>
+    </div>
+    
+    <div class="modal-footer text-end">
+      <button wicket:id="confirm" type="button" class="btn btn-primary text-nowrap">
+        Create user
+      </button>
+    </div>
+  </form>
+</wicket:panel>
+</html>

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/AddProjectUserPanel.java
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/AddProjectUserPanel.java
@@ -83,7 +83,7 @@ public class AddProjectUserPanel
 
     private void actionConfirm(AjaxRequestTarget aTarget, Form<FormData> aForm)
     {
-        var user = projectService.getOrCreateProjectUser(getModelObject(),
+        var user = projectService.getOrCreateProjectBoundUser(getModelObject(),
                 aForm.getModelObject().uiName);
         projectService.assignRole(getModelObject(), user, ANNOTATOR);
         aTarget.add(findParent(ProjectUsersPanel.class));

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/AddProjectUserPanel.java
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/AddProjectUserPanel.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.ui.project.users;
+
+import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.ANNOTATOR;
+
+import java.io.Serializable;
+
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.extensions.ajax.markup.html.modal.ModalDialog;
+import org.apache.wicket.markup.html.form.Form;
+import org.apache.wicket.markup.html.form.TextField;
+import org.apache.wicket.markup.html.panel.GenericPanel;
+import org.apache.wicket.model.CompoundPropertyModel;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.spring.injection.annot.SpringBean;
+import org.apache.wicket.validation.IValidatable;
+import org.apache.wicket.validation.ValidationError;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
+import de.tudarmstadt.ukp.inception.project.api.ProjectService;
+import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxButton;
+import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxLink;
+
+public class AddProjectUserPanel
+    extends GenericPanel<Project>
+{
+    private static final long serialVersionUID = 716627578324682205L;
+
+    private @SpringBean UserDao userService;
+    private @SpringBean ProjectService projectService;
+
+    public AddProjectUserPanel(String aId, IModel<Project> aModel)
+    {
+        super(aId, aModel);
+
+        queue(new Form<>("form", CompoundPropertyModel.of(new FormData())));
+
+        var uiName = new TextField<String>("uiName");
+        uiName.add(this::validateUiName);
+        queue(uiName);
+
+        queue(new LambdaAjaxButton<>("confirm", this::actionConfirm));
+
+        var closeDialogButton = new LambdaAjaxLink("closeDialog", this::actionCancel);
+        closeDialogButton.setOutputMarkupId(true);
+        queue(closeDialogButton);
+    }
+
+    private void validateUiName(IValidatable<String> aValidatable)
+    {
+        var realm = projectService.getRealm(getModelObject());
+        var other = userService.getUserByRealmAndUiName(realm, aValidatable.getValue());
+
+        if (other != null) {
+            aValidatable.error(new ValidationError().addKey("uiName.alreadyExistsError")
+                    .setVariable("name", aValidatable.getValue()));
+        }
+
+        userService.validateUiName(aValidatable.getValue()).forEach(aValidatable::error);
+    }
+
+    protected void actionCancel(AjaxRequestTarget aTarget)
+    {
+        findParent(ModalDialog.class).close(aTarget);
+    }
+
+    private void actionConfirm(AjaxRequestTarget aTarget, Form<FormData> aForm)
+    {
+        var user = projectService.getOrCreateProjectUser(getModelObject(),
+                aForm.getModelObject().uiName);
+        projectService.assignRole(getModelObject(), user, ANNOTATOR);
+        aTarget.add(findParent(ProjectUsersPanel.class));
+        findParent(ModalDialog.class).close(aTarget);
+    }
+
+    class FormData
+        implements Serializable
+    {
+        private static final long serialVersionUID = 1978074327564033679L;
+
+        String uiName;
+    }
+}

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/ProjectUserDetailPanel.html
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/ProjectUserDetailPanel.html
@@ -38,10 +38,33 @@
                 &nbsp;<wicket:message key="cancel"/>
               </span>
             </button>
+            <span class="dropdown" aria-haspopup="true" aria-expanded="false" wicket:enclosure="delete">
+              <button class="btn btn-action dropdown-toggle flex-content" type="button" data-bs-toggle="dropdown">
+                <i class="fas fa-ellipsis-v"/>
+              </button>
+              <ul class="dropdown-menu shadow-lg" role="menu" style="min-width: 220px;">
+                <li>
+                  <button wicket:id="delete" class="dropdown-item" type="button">
+                    <wicket:message key="delete"/>
+                    <span class="float-end badge badge-pill bg-danger">
+                      <i class="fas fa-trash"/>
+                    </span>
+                  </button>
+                </li>
+              </ul>
+            </span>
           </div>
         </div>
         <div class="card-body">
-          <div class="">
+          <div class="row form-row" wicket:enclosure="uiName">
+            <label wicket:for="uiName" class="col-sm-4 col-form-label">
+              <wicket:label key="uiName"/>
+            </label>
+            <div class="col-sm-8">
+              <input wicket:id="uiName" type="text" class="form-control"/>
+            </div>
+          </div>
+          <div class="row form-row">
             <div wicket:id="permissions"></div>
           </div>
         </div>

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/ProjectUserDetailPanel.java
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/ProjectUserDetailPanel.java
@@ -20,18 +20,23 @@ package de.tudarmstadt.ukp.clarin.webanno.ui.project.users;
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.ANNOTATOR;
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.CURATOR;
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.MANAGER;
+import static de.tudarmstadt.ukp.inception.support.lambda.LambdaBehavior.visibleWhen;
+import static de.tudarmstadt.ukp.inception.support.lambda.LambdaBehavior.visibleWhenModelIsNotNull;
 import static java.util.Arrays.asList;
 
 import java.util.Collection;
+import java.util.Optional;
 
+import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.markup.html.basic.Label;
-import org.apache.wicket.markup.html.form.AbstractChoice.LabelPosition;
 import org.apache.wicket.markup.html.form.CheckBoxMultipleChoice;
 import org.apache.wicket.markup.html.form.EnumChoiceRenderer;
 import org.apache.wicket.markup.html.form.Form;
-import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.markup.html.form.TextField;
+import org.apache.wicket.markup.html.panel.GenericPanel;
 import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.LambdaModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.apache.wicket.validation.IValidatable;
 import org.apache.wicket.validation.ValidationError;
@@ -39,62 +44,71 @@ import org.apache.wicket.validation.ValidationError;
 import de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.ProjectUserPermissions;
+import de.tudarmstadt.ukp.clarin.webanno.security.Realm;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
+import de.tudarmstadt.ukp.inception.bootstrap.BootstrapCheckBoxMultipleChoice;
 import de.tudarmstadt.ukp.inception.project.api.ProjectService;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxButton;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxLink;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaModelAdapter;
 
-public class UserPermissionsPanel
-    extends Panel
+public class ProjectUserDetailPanel
+    extends GenericPanel<ProjectUserPermissions>
 {
     private static final long serialVersionUID = -5278078988218713188L;
 
-    private @SpringBean ProjectService projectRepository;
-    private @SpringBean UserDao userRepository;
+    private @SpringBean ProjectService projectService;
+    private @SpringBean UserDao userService;
 
     private IModel<Project> project;
-    private IModel<ProjectUserPermissions> user;
     private Form<Void> form;
     private CheckBoxMultipleChoice<PermissionLevel> levels;
 
-    public UserPermissionsPanel(String aId, IModel<Project> aProject,
+    public ProjectUserDetailPanel(String aId, IModel<Project> aProject,
             IModel<ProjectUserPermissions> aUser)
     {
-        super(aId);
+        super(aId, aUser);
 
-        setOutputMarkupId(true);
         setOutputMarkupPlaceholderTag(true);
-
+        add(visibleWhenModelIsNotNull(this));
         project = aProject;
-        user = aUser;
 
         form = new Form<>("form");
-        add(form);
+        queue(form);
 
-        levels = new CheckBoxMultipleChoice<>("permissions");
-        levels.setPrefix("<div class=\"checkbox\">");
-        levels.setSuffix("</div>");
-        levels.setLabelPosition(LabelPosition.WRAP_AFTER);
+        queue(new TextField<String>("uiName") //
+                .setModel(LambdaModel.of( //
+                        aUser.map(ProjectUserPermissions::getUser).map(Optional::get), //
+                        User::getUiName, //
+                        User::setUiName))
+                .add(this::validateUiName) //
+                .setOutputMarkupPlaceholderTag(true) //
+                .add(visibleWhen(this::isProjectBoundUser)) //
+                .add(AttributeModifier.replace("placeholder",
+                        getModel().map(ProjectUserPermissions::getUsername))));
+
+        levels = new BootstrapCheckBoxMultipleChoice<>("permissions");
         // This model adapter handles loading/saving permissions directly to the DB
         levels.setModel(new LambdaModelAdapter<Collection<PermissionLevel>>( //
                 () -> {
-                    return projectRepository.listRoles(project.getObject(),
-                            user.map(ProjectUserPermissions::getUsername).getObject());
+                    return projectService.listRoles(project.getObject(),
+                            getModel().map(ProjectUserPermissions::getUsername).getObject());
                 }, //
-                (lvls) -> projectRepository.setProjectPermissionLevels(
-                        user.map(ProjectUserPermissions::getUsername).getObject(),
+                (lvls) -> projectService.setProjectPermissionLevels(
+                        getModel().map(ProjectUserPermissions::getUsername).getObject(),
                         project.getObject(), lvls)));
         levels.setChoices(asList(MANAGER, CURATOR, ANNOTATOR));
         levels.setChoiceRenderer(new EnumChoiceRenderer<>(levels));
         levels.add(this::ensureManagersNotRemovingThemselves);
-        form.add(levels);
+        queue(levels);
 
-        form.add(new Label("username",
+        queue(new Label("username",
                 aUser.map(u -> u.getUser().map(User::toLongString).orElse(u.getUsername()))));
-        form.add(new LambdaAjaxButton<>("save", this::actionSave));
-        form.add(new LambdaAjaxLink("cancel", this::actionCancel));
+        queue(new LambdaAjaxButton<>("save", this::actionSave));
+        queue(new LambdaAjaxLink("cancel", this::actionCancel));
+        queue(new LambdaAjaxLink("delete", this::actionDelete) //
+                .add(visibleWhen(this::isProjectBoundUser)));
     }
 
     @Override
@@ -105,23 +119,38 @@ public class UserPermissionsPanel
         super.onModelChanged();
     }
 
-    @Override
-    protected void onConfigure()
+    private boolean isProjectBoundUser()
     {
-        super.onConfigure();
+        var user = getModelObject().getUser().orElse(null);
+        if (user == null || user.getRealm() == null) {
+            return false;
+        }
 
-        setVisible(user.getObject() != null);
+        return user.getRealm().startsWith(Realm.REALM_PROJECT_PREFIX);
+    }
+
+    private void validateUiName(IValidatable<String> aValidatable)
+    {
+        var realm = projectService.getRealm(project.getObject());
+
+        var other = userService.getUserByRealmAndUiName(realm, aValidatable.getValue());
+        if (other != null && !other.getUsername().equals(getModel().getObject().getUsername())) {
+            aValidatable.error(new ValidationError().addKey("uiName.alreadyExistsError")
+                    .setVariable("name", aValidatable.getValue()));
+        }
+
+        userService.validateUiName(aValidatable.getValue()).forEach(aValidatable::error);
     }
 
     private void ensureManagersNotRemovingThemselves(
             IValidatable<Collection<PermissionLevel>> aValidatable)
     {
-        if (!userRepository.getCurrentUsername()
-                .equals(user.map(ProjectUserPermissions::getUsername).orElse(null).getObject())) {
+        if (!userService.getCurrentUsername().equals(
+                getModel().map(ProjectUserPermissions::getUsername).orElse(null).getObject())) {
             return;
         }
 
-        if (!projectRepository.hasRole(user.map(ProjectUserPermissions::getUsername).getObject(),
+        if (!projectService.hasRole(getModel().map(ProjectUserPermissions::getUsername).getObject(),
                 project.getObject(), MANAGER)) {
             return;
         }
@@ -137,7 +166,7 @@ public class UserPermissionsPanel
         // The model adapter already commits the changes for us as part of the normal form
         // processing cycle. So nothing special to do here.
 
-        success("Permissions saved");
+        success("User saved");
 
         // Reload whole page because master panel also needs to be reloaded.
         aTarget.add(getPage());
@@ -145,7 +174,18 @@ public class UserPermissionsPanel
 
     private void actionCancel(AjaxRequestTarget aTarget)
     {
-        user.setObject(null);
+        setModelObject(null);
+
+        // Reload whole page because master panel also needs to be reloaded.
+        aTarget.add(getPage());
+    }
+
+    private void actionDelete(AjaxRequestTarget aTarget)
+    {
+        projectService.deleteProjectBoundUser(project.getObject(),
+                getModelObject().getUser().get());
+
+        setModelObject(null);
 
         // Reload whole page because master panel also needs to be reloaded.
         aTarget.add(getPage());

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/ProjectUserPermissionChoiceRenderer.java
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/ProjectUserPermissionChoiceRenderer.java
@@ -18,11 +18,14 @@
 package de.tudarmstadt.ukp.clarin.webanno.ui.project.users;
 
 import static java.util.stream.Collectors.joining;
+import static org.apache.commons.lang3.Strings.CS;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.wicket.markup.html.form.ChoiceRenderer;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel;
 import de.tudarmstadt.ukp.clarin.webanno.model.ProjectUserPermissions;
+import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 
 public class ProjectUserPermissionChoiceRenderer
     extends ChoiceRenderer<ProjectUserPermissions>
@@ -30,6 +33,7 @@ public class ProjectUserPermissionChoiceRenderer
     private static final long serialVersionUID = -5097198610598977245L;
 
     private boolean showRoles = false;
+    private boolean markProjectBoundUsers = false;
 
     public ProjectUserPermissionChoiceRenderer setShowRoles(boolean aShowRoles)
     {
@@ -40,6 +44,18 @@ public class ProjectUserPermissionChoiceRenderer
     public boolean isShowRoles()
     {
         return showRoles;
+    }
+
+    public ProjectUserPermissionChoiceRenderer setMarkProjectBoundUsers(
+            boolean aMarkProjectBoundUsers)
+    {
+        markProjectBoundUsers = aMarkProjectBoundUsers;
+        return this;
+    }
+
+    public boolean isMarkProjectBoundUsers()
+    {
+        return markProjectBoundUsers;
     }
 
     @Override
@@ -60,7 +76,7 @@ public class ProjectUserPermissionChoiceRenderer
                 }, //
                 () -> builder.append(username));
 
-        if (showRoles) {
+        if (showRoles && !CollectionUtils.isEmpty(aPermissions.getRoles())) {
             builder.append(" ");
             builder.append(aPermissions.getRoles().stream() //
                     .map(PermissionLevel::getName) //
@@ -74,6 +90,13 @@ public class ProjectUserPermissionChoiceRenderer
                     }
                 }, //
                 () -> builder.append(" (missing!)"));
+
+        if (markProjectBoundUsers && aPermissions.getUser().isPresent()) {
+            var user = aPermissions.getUser().get();
+            if (CS.startsWith(user.getRealm(), UserDao.REALM_PROJECT_PREFIX)) {
+                builder.append(" (project user)");
+            }
+        }
 
         return builder.toString();
     }

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/ProjectUserPermissionChoiceRenderer.java
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/ProjectUserPermissionChoiceRenderer.java
@@ -25,7 +25,7 @@ import org.apache.wicket.markup.html.form.ChoiceRenderer;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel;
 import de.tudarmstadt.ukp.clarin.webanno.model.ProjectUserPermissions;
-import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
+import de.tudarmstadt.ukp.clarin.webanno.security.Realm;
 
 public class ProjectUserPermissionChoiceRenderer
     extends ChoiceRenderer<ProjectUserPermissions>
@@ -93,7 +93,7 @@ public class ProjectUserPermissionChoiceRenderer
 
         if (markProjectBoundUsers && aPermissions.getUser().isPresent()) {
             var user = aPermissions.getUser().get();
-            if (CS.startsWith(user.getRealm(), UserDao.REALM_PROJECT_PREFIX)) {
+            if (CS.startsWith(user.getRealm(), Realm.REALM_PROJECT_PREFIX)) {
                 builder.append(" (project user)");
             }
         }

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/ProjectUsersPanel.java
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/ProjectUsersPanel.java
@@ -42,7 +42,7 @@ public class ProjectUsersPanel
         selectedUser = Model.of();
         project = aProject;
 
-        var permissions = new UserPermissionsPanel("permissions", project, selectedUser);
+        var permissions = new ProjectUserDetailPanel("permissions", project, selectedUser);
         add(permissions);
 
         var users = new UserSelectionPanel("users", project, selectedUser);

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/ProjectUsersPanel.utf8.properties
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/ProjectUsersPanel.utf8.properties
@@ -16,3 +16,5 @@
 
 users.form.usersToAdd.placeholder=Start typing here or select from the drop-down list...
 usersToAdd=Add users
+uiName=Display name
+uiName.alreadyExistsError=A user with the display name '${name}' already exists.

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/UserPermissionsPanel.html
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/UserPermissionsPanel.html
@@ -24,7 +24,7 @@
         <div class="card-header rounded-0">
           <div class="flex-h-container flex-centered flex-gutter flex-only-internal-gutter">
             <div class="me-auto">
-              <wicket:message key="permissions.for"/> "<wicket:container wicket:id="username"/>"
+              <wicket:message key="permissions.for"/> <b><wicket:container wicket:id="username"/></b>
             </div>
             <button wicket:id="save" class="btn btn-primary">
               <i class="fas fa-save"></i>

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/UserPermissionsPanel.java
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/UserPermissionsPanel.java
@@ -32,7 +32,6 @@ import org.apache.wicket.markup.html.form.EnumChoiceRenderer;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
-import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.apache.wicket.validation.IValidatable;
 import org.apache.wicket.validation.ValidationError;
@@ -41,6 +40,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.ProjectUserPermissions;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
+import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.inception.project.api.ProjectService;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxButton;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxLink;
@@ -91,7 +91,8 @@ public class UserPermissionsPanel
         levels.add(this::ensureManagersNotRemovingThemselves);
         form.add(levels);
 
-        form.add(new Label("username", PropertyModel.of(aUser, "username")));
+        form.add(new Label("username",
+                aUser.map(u -> u.getUser().map(User::toLongString).orElse(u.getUsername()))));
         form.add(new LambdaAjaxButton<>("save", this::actionSave));
         form.add(new LambdaAjaxLink("cancel", this::actionCancel));
     }

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/UserSelectionPanel.html
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/UserSelectionPanel.html
@@ -28,13 +28,24 @@
           </label>
           <select class="flex-content" wicket:id="usersToAdd"></select>
           <button wicket:id="add" class="btn btn-primary text-nowrap">
-            <i class="fas fa-plus-square"></i>
-            <span class="d-none d-lg-inline me-2"><wicket:message key="add"/></span>
+            <i class="fas fa-plus-square me-2"></i>
+            <span class="d-none d-lg-inline"><wicket:message key="add"/></span>
           </button>
-          <button wicket:id="new" class="btn btn-primary text-nowrap">
-            <i class="fas fa-plus-square"></i>
-            <span class="d-none d-lg-inline me-2"><wicket:message key="create"/></span>
-          </button>
+          <span class="dropdown" aria-haspopup="true" aria-expanded="false">
+            <button class="btn btn-action dropdown-toggle flex-content" type="button" data-bs-toggle="dropdown">
+              <i class="fas fa-ellipsis-v"/>
+            </button>
+            <ul class="dropdown-menu shadow-lg" role="menu" style="min-width: 220px;">
+              <li>
+                <button wicket:id="new" class="dropdown-item" type="button">
+                  <wicket:message key="create"/>...
+                  <span class="float-end badge badge-pill bg-secondary">
+                    <i class="fas fa-plus-square"/>
+                  </span>
+                </button>
+              </li>
+            </ul>
+          </span>
         </div>
       </form>
       <div class="flex-content fit-child-snug">

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/UserSelectionPanel.html
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/UserSelectionPanel.html
@@ -19,6 +19,7 @@
 <html xmlns:wicket="http://wicket.apache.org">
 <body>
   <wicket:panel>
+    <div wicket:id="dialog"/>
     <div class="card border-0 rounded-0 flex-content flex-v-container border-end">
       <form wicket:id="form" class="card-header rounded-0">
         <div class="flex-h-container flex-centered flex-gutter flex-only-internal-gutter">

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/UserSelectionPanel.html
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/UserSelectionPanel.html
@@ -28,9 +28,11 @@
           <select class="flex-content" wicket:id="usersToAdd"></select>
           <button wicket:id="add" class="btn btn-primary text-nowrap">
             <i class="fas fa-plus-square"></i>
-            <span class="d-none d-lg-inline">
-              &nbsp;<wicket:message key="add"/>
-            </span>
+            <span class="d-none d-lg-inline me-2"><wicket:message key="add"/></span>
+          </button>
+          <button wicket:id="new" class="btn btn-primary text-nowrap">
+            <i class="fas fa-plus-square"></i>
+            <span class="d-none d-lg-inline me-2"><wicket:message key="create"/></span>
           </button>
         </div>
       </form>

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/UserSelectionPanel.java
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/UserSelectionPanel.java
@@ -84,7 +84,7 @@ class UserSelectionPanel
         add(overviewList);
 
         IModel<Collection<User>> usersToAddModel = new CollectionModel<>(new ArrayList<>());
-        Form<Collection<User>> form = new Form<>("form", usersToAddModel);
+        var form = new Form<>("form", usersToAddModel);
         add(form);
 
         var userRenderer = new ChoiceRenderer<User>("username")
@@ -131,12 +131,12 @@ class UserSelectionPanel
             @Override
             public List<User> getChoices(String aInput)
             {
-                List<User> result = new ArrayList<>();
+                var result = new ArrayList<User>();
 
                 if (config.isHideUsers()) {
                     // only offer the user matching what the input entered into the field
                     if (isNotBlank(aInput)) {
-                        User user = userRepository.get(aInput);
+                        var user = userRepository.get(aInput);
                         if (user != null) {
                             result.add(user);
                         }
@@ -166,13 +166,13 @@ class UserSelectionPanel
                     return;
                 }
 
-                final String[] values = this.getInputAsArray();
+                var values = this.getInputAsArray();
                 if (values == null) {
                     return;
                 }
 
                 List<User> result = new ArrayList<>();
-                for (String value : values) {
+                for (var value : values) {
                     if (isBlank(value)) {
                         continue;
                     }
@@ -190,7 +190,9 @@ class UserSelectionPanel
         };
         usersToAdd.setModel(usersToAddModel);
         form.add(usersToAdd);
+
         form.add(new LambdaAjaxButton<>("add", this::actionAdd));
+        form.add(new LambdaAjaxButton<>("new", this::actionNew));
     }
 
     private List<ProjectUserPermissions> listUsersWithPermissions()
@@ -198,9 +200,13 @@ class UserSelectionPanel
         return projectRepository.listProjectUserPermissions(projectModel.getObject());
     }
 
+    private void actionNew(AjaxRequestTarget aTarget, Form<List<User>> aForm)
+    {
+    }
+
     private void actionAdd(AjaxRequestTarget aTarget, Form<List<User>> aForm)
     {
-        for (User user : aForm.getModelObject()) {
+        for (var user : aForm.getModelObject()) {
             projectRepository.assignRole(projectModel.getObject(), user, ANNOTATOR);
         }
 

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/UserSelectionPanel.java
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/UserSelectionPanel.java
@@ -18,6 +18,8 @@
 package de.tudarmstadt.ukp.clarin.webanno.ui.project.users;
 
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.ANNOTATOR;
+import static java.util.Collections.emptySet;
+import static java.util.Comparator.comparing;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
@@ -28,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.extensions.ajax.markup.html.modal.ModalDialog;
 import org.apache.wicket.markup.html.form.Form;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.util.CollectionModel;
@@ -42,6 +45,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.ProjectUserPermissions;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
+import de.tudarmstadt.ukp.inception.bootstrap.BootstrapModalDialog;
 import de.tudarmstadt.ukp.inception.project.api.ProjectService;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxButton;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxFormComponentUpdatingBehavior;
@@ -53,6 +57,8 @@ class UserSelectionPanel
 {
     private static final long serialVersionUID = -9151455840010092452L;
 
+    private static final String MID_DIALOG = "dialog";
+
     private @SpringBean ProjectService projectRepository;
     private @SpringBean UserDao userRepository;
     private @SpringBean UserSelectionPanelConfiguration config;
@@ -63,6 +69,7 @@ class UserSelectionPanel
     private OverviewListChoice<ProjectUserPermissions> overviewList;
     private MultiSelect<User> usersToAdd;
     private Map<String, User> recentUsers;
+    private final BootstrapModalDialog dialog;
 
     public UserSelectionPanel(String id, IModel<Project> aProject,
             IModel<ProjectUserPermissions> aUser)
@@ -71,15 +78,20 @@ class UserSelectionPanel
 
         setOutputMarkupId(true);
 
+        dialog = new BootstrapModalDialog(MID_DIALOG);
+        dialog.trapFocus();
+        queue(dialog);
+
         projectModel = aProject;
         userModel = aUser;
         recentUsers = new HashMap<>();
 
         overviewList = new OverviewListChoice<>("user");
-        overviewList
-                .setChoiceRenderer(new ProjectUserPermissionChoiceRenderer().setShowRoles(true));
+        overviewList.setChoiceRenderer(new ProjectUserPermissionChoiceRenderer() //
+                .setShowRoles(true) //
+                .setMarkProjectBoundUsers(true));
         overviewList.setModel(userModel);
-        overviewList.setChoices(this::listUsersWithPermissions);
+        overviewList.setChoices(this::listProjectRelevantUsers);
         overviewList.add(new LambdaAjaxFormComponentUpdatingBehavior("change", this::onChange));
         add(overviewList);
 
@@ -102,7 +114,7 @@ class UserSelectionPanel
                     builder.append(")");
                 }
 
-                String text = builder.toString();
+                var text = builder.toString();
                 recentUsers.put(text, user);
                 return text;
             };
@@ -144,15 +156,27 @@ class UserSelectionPanel
                 }
                 else {
                     // offer all enabled users matching the input
-                    userRepository.listEnabledUsers().stream()
-                            .filter(user -> aInput == null || user.getUsername().contains(aInput)
+                    userRepository.listEnabledUsers().stream() //
+                            .filter(user -> {
+                                if (user.getRealm() == null) {
+                                    return true;
+                                }
+
+                                // Project-bound users from other projects cannot be added
+                                if (user.getRealm().startsWith(UserDao.REALM_PROJECT_PREFIX
+                                        + projectModel.getObject().getId())) {
+                                    return true;
+                                }
+
+                                return false;
+                            }).filter(user -> aInput == null || user.getUsername().contains(aInput)
                                     || user.getUiName().contains(aInput))
                             .forEach(result::add);
                 }
 
                 if (!result.isEmpty()) {
                     result.removeAll(projectRepository
-                            .listProjectUsersWithPermissions(projectModel.getObject()));
+                            .listUsersWithAnyRoleInProject(projectModel.getObject()));
                 }
 
                 return result;
@@ -195,13 +219,31 @@ class UserSelectionPanel
         form.add(new LambdaAjaxButton<>("new", this::actionNew));
     }
 
-    private List<ProjectUserPermissions> listUsersWithPermissions()
+    private List<ProjectUserPermissions> listProjectRelevantUsers()
     {
-        return projectRepository.listProjectUserPermissions(projectModel.getObject());
+        var project = projectModel.getObject();
+
+        var userMap = new HashMap<String, ProjectUserPermissions>();
+
+        projectRepository.listProjectUserPermissions(project)
+                .forEach(u -> userMap.put(u.getUsername(), u));
+
+        var boundUsers = projectRepository.listProjectBoundUsers(project);
+        for (var boundUser : boundUsers) {
+            if (!userMap.containsKey(boundUser.getUsername())) {
+                userMap.put(boundUser.getUsername(), new ProjectUserPermissions(project,
+                        boundUser.getUsername(), boundUser, emptySet()));
+            }
+        }
+
+        return userMap.values().stream() //
+                .sorted(comparing(u -> u.getUser().map(User::getUsername).orElse(u.getUsername())))
+                .toList();
     }
 
     private void actionNew(AjaxRequestTarget aTarget, Form<List<User>> aForm)
     {
+        dialog.open(new AddProjectUserPanel(ModalDialog.CONTENT_ID, projectModel), aTarget);
     }
 
     private void actionAdd(AjaxRequestTarget aTarget, Form<List<User>> aForm)

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/UserSelectionPanel.java
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/UserSelectionPanel.java
@@ -43,6 +43,7 @@ import org.wicketstuff.kendo.ui.renderer.ChoiceRenderer;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.ProjectUserPermissions;
+import de.tudarmstadt.ukp.clarin.webanno.security.Realm;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.inception.bootstrap.BootstrapModalDialog;
@@ -163,7 +164,7 @@ class UserSelectionPanel
                                 }
 
                                 // Project-bound users from other projects cannot be added
-                                if (user.getRealm().startsWith(UserDao.REALM_PROJECT_PREFIX
+                                if (user.getRealm().startsWith(Realm.REALM_PROJECT_PREFIX
                                         + projectModel.getObject().getId())) {
                                     return true;
                                 }

--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/management/DynamicWorkloadManagementPage.java
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/management/DynamicWorkloadManagementPage.java
@@ -553,7 +553,7 @@ public class DynamicWorkloadManagementPage
 
     private List<User> getUsersForCurrentProject()
     {
-        return projectService.listProjectUsersWithPermissions(currentProject.getObject());
+        return projectService.listUsersWithAnyRoleInProject(currentProject.getObject());
     }
 
     private void actionRefresh(AjaxRequestTarget aTarget)

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/MatrixWorkloadExtensionImpl.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/MatrixWorkloadExtensionImpl.java
@@ -160,7 +160,7 @@ public class MatrixWorkloadExtensionImpl
     @Transactional
     public ProjectState recalculate(Project aProject)
     {
-        var annotators = projectService.listProjectUsersWithPermissions(aProject, ANNOTATOR);
+        var annotators = projectService.listUsersWithRoleInProject(aProject, ANNOTATOR);
         var annDocs = documentService.listAnnotationDocuments(aProject);
 
         for (var doc : documentService.listSourceDocuments(aProject)) {
@@ -185,7 +185,7 @@ public class MatrixWorkloadExtensionImpl
     @Transactional
     public ProjectState freshenStatus(Project aProject)
     {
-        var annotators = projectService.listProjectUsersWithPermissions(aProject, ANNOTATOR);
+        var annotators = projectService.listUsersWithRoleInProject(aProject, ANNOTATOR);
         var annDocs = documentService.listAnnotationDocuments(aProject);
 
         // Update the annotation document and source document states for the abandoned documents

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/event/MatrixWorkloadUpdateDocumentStateTask.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/event/MatrixWorkloadUpdateDocumentStateTask.java
@@ -94,7 +94,7 @@ public class MatrixWorkloadUpdateDocumentStateTask
             return;
         }
 
-        int annotatorCount = projectService.listProjectUsersWithPermissions(project, ANNOTATOR)
+        int annotatorCount = projectService.listUsersWithRoleInProject(project, ANNOTATOR)
                 .size();
 
         matrixWorkloadExtension.updateDocumentState(doc, annotatorCount);

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/MatrixWorkloadManagementPage.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/MatrixWorkloadManagementPage.java
@@ -281,7 +281,7 @@ public class MatrixWorkloadManagementPage
 
     private IResourceStream exportWorkload()
     {
-        var annotators = projectService.listProjectUsersWithPermissions(getProject(), ANNOTATOR)
+        var annotators = projectService.listUsersWithRoleInProject(getProject(), ANNOTATOR)
                 .stream() //
                 .map(User::getUsername) //
                 .sorted() //
@@ -385,7 +385,7 @@ public class MatrixWorkloadManagementPage
         columns.add(new DocumentMatrixNameColumn());
         columns.add(new DocumentMatrixCuratorColumn());
 
-        var annotators = projectService.listProjectUsersWithPermissions(getProject(), ANNOTATOR);
+        var annotators = projectService.listUsersWithRoleInProject(getProject(), ANNOTATOR);
 
         if (StringUtils.isNotBlank(filter.getObject().getUserName())) {
             if (filter.getObject().isMatchUserNameAsRegex()) {
@@ -973,7 +973,7 @@ public class MatrixWorkloadManagementPage
 
     private List<DocumentMatrixRow> getMatrixData()
     {
-        var annotators = projectService.listProjectUsersWithPermissions(getProject(), ANNOTATOR)
+        var annotators = projectService.listUsersWithRoleInProject(getProject(), ANNOTATOR)
                 .stream().map(User::getUsername) //
                 .collect(toSet());
 

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/service/MatrixWorkloadServiceImpl.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/service/MatrixWorkloadServiceImpl.java
@@ -59,7 +59,7 @@ public class MatrixWorkloadServiceImpl
         var documentsPerUser = new LinkedHashMap<String, AtomicInteger>();
 
         // Pre-load the map so we have a stable order
-        var annotators = projectService.listProjectUsersWithPermissions(aProject, ANNOTATOR)
+        var annotators = projectService.listUsersWithRoleInProject(aProject, ANNOTATOR)
                 .stream() //
                 .map(User::getUsername) //
                 .sorted() //

--- a/inception/inception-workload-matrix/src/test/java/de/tudarmstadt/ukp/inception/workload/matrix/service/MatrixWorkloadServiceImplIntegrationTest.java
+++ b/inception/inception-workload-matrix/src/test/java/de/tudarmstadt/ukp/inception/workload/matrix/service/MatrixWorkloadServiceImplIntegrationTest.java
@@ -245,7 +245,7 @@ class MatrixWorkloadServiceImplIntegrationTest
     @Test
     void testAssignWorkloadMoreAnnotatorsThanAvailable()
     {
-        var annotators = projectService.listProjectUsersWithPermissions(project, ANNOTATOR);
+        var annotators = projectService.listUsersWithRoleInProject(project, ANNOTATOR);
 
         sut.assignWorkload(project, annotators.size() + 1, true);
 


### PR DESCRIPTION
**What's in the PR**
- Introduce a new optional "optUniqueKey" column in the users table where we store a sha265 hash over realm + uiName for project-bound users only. and then we have a unique constraint on that column.
- Drop the unique constraint on realm + uiName
- Fix the users table during start up to populate the optUniqueKey column
- Refactoring and cleaning up

**How to test manually**
* Start up on an instance with project bound users and check if the column is populated
* Create a new project-bound user and check if the column is populated
* Try creating two project-bound users with the same UI name

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
