### PR TITLE
#5596 - Send webhook events via Kafka instead of HTTP

### DIFF
--- a/inception/inception-remote/pom.xml
+++ b/inception/inception-remote/pom.xml
@@ -203,6 +203,7 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
     </dependency>
+    
     <!-- Spring security -->
     <dependency>
       <groupId>org.springframework.security</groupId>
@@ -258,6 +259,19 @@
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>
       <scope>provided</scope>
+    </dependency>
+    
+    <!-- Kafka -->
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+      <exclusions>
+        <exclusion>
+          <!-- Just to keep the dependency footprint smaller - we do not use this elsewhere -->
+          <groupId>com.github.luben</groupId>
+          <artifactId>zstd-jni</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- RDF4J -->
@@ -417,6 +431,21 @@
     <dependency>
       <groupId>io.jsonwebtoken</groupId>
       <artifactId>jjwt-gson</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>kafka</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/config/RemoteApiAutoConfiguration.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/config/RemoteApiAutoConfiguration.java
@@ -19,17 +19,18 @@ package de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.config;
 
 import static de.tudarmstadt.ukp.clarin.webanno.security.UserDao.SPEL_IS_ADMIN_ACCOUNT_RECOVERY_MODE;
 
-import java.security.KeyManagementException;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
+import java.security.GeneralSecurityException;
+import java.util.List;
 
 import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
 
 import de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.aero.AeroAnnotationController;
 import de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.aero.AeroCurationController;
@@ -38,6 +39,9 @@ import de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.aero.AeroKnowledgeBase
 import de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.aero.AeroProjectController;
 import de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.legacy.LegacyRemoteApiController;
 import de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.menubar.SwaggerUiMenuBarItemSupport;
+import de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.webhooks.HttpWebhookDriver;
+import de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.webhooks.KafkaWebhookDriver;
+import de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.webhooks.WebhookDriver;
 import de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.webhooks.WebhookService;
 import de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.webhooks.WebhooksConfiguration;
 import de.tudarmstadt.ukp.inception.remoteapi.Controller_ImplBase;
@@ -184,10 +188,23 @@ public class RemoteApiAutoConfiguration
 
     @Bean
     public WebhookService webhookService(WebhooksConfiguration aConfiguration,
-            RestTemplateBuilder aRestTemplateBuilder)
-        throws KeyManagementException, NoSuchAlgorithmException, KeyStoreException
+            @Lazy @Autowired(required = false) List<WebhookDriver> aExtensions)
+        throws GeneralSecurityException
     {
-        return new WebhookService(aConfiguration, aRestTemplateBuilder);
+        return new WebhookService(aConfiguration, aExtensions);
+    }
+
+    @Bean
+    public HttpWebhookDriver httpWebhookDriver(RestTemplateBuilder aRestTemplateBuilder)
+        throws GeneralSecurityException
+    {
+        return new HttpWebhookDriver(aRestTemplateBuilder);
+    }
+
+    @Bean
+    public KafkaWebhookDriver kafkaWebhookDriver()
+    {
+        return new KafkaWebhookDriver();
     }
 
     @ConditionalOnExpression(REMOTE_API_ENABLED_CONDITION)

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/webhooks/HttpWebhookDriver.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/webhooks/HttpWebhookDriver.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.webhooks;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSession;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy;
+import org.apache.hc.core5.ssl.SSLContexts;
+import org.apache.hc.core5.ssl.TrustStrategy;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+import de.tudarmstadt.ukp.inception.support.json.JSONUtil;
+
+public class HttpWebhookDriver
+    implements WebhookDriver
+{
+    public static final String ID = "http";
+
+    private final RestTemplateBuilder restTemplateBuilder;
+    private HttpComponentsClientHttpRequestFactory nonValidatingRequestFactory = null;
+
+    public HttpWebhookDriver(RestTemplateBuilder aRestTemplateBuilder)
+        throws KeyManagementException, NoSuchAlgorithmException, KeyStoreException
+    {
+        restTemplateBuilder = aRestTemplateBuilder;
+
+        TrustStrategy acceptingTrustStrategy = (X509Certificate[] chain, String authType) -> true;
+        HostnameVerifier verifier = (String aHostname, SSLSession aSession) -> true;
+
+        var sslContext = SSLContexts.custom() //
+                .loadTrustMaterial(null, acceptingTrustStrategy) //
+                .build();
+
+        var cm = PoolingHttpClientConnectionManagerBuilder.create() //
+                .setTlsSocketStrategy(new DefaultClientTlsStrategy(sslContext, verifier)) //
+                .build();
+
+        var httpClient = HttpClients.custom() //
+                .setConnectionManager(cm) //
+                .build();
+
+        nonValidatingRequestFactory = new HttpComponentsClientHttpRequestFactory();
+        nonValidatingRequestFactory.setHttpClient(httpClient);
+    }
+
+    @Override
+    public String getId()
+    {
+        return ID;
+    }
+
+    @Override
+    public void sendNotification(String aTopic, Object aMessage, Webhook aHook) throws IOException
+    {
+        WebhookService.LOG.trace("Sending webhook message on topic [{}] to [{}]", aTopic,
+                aHook.getUrl());
+
+        // Configure rest template without SSL certification check if that is disabled.
+        RestTemplate restTemplate;
+        if (aHook.isVerifyCertificates()) {
+            restTemplate = restTemplateBuilder.build();
+        }
+        else {
+            restTemplate = restTemplateBuilder.requestFactory(this::getNonValidatingRequestFactory)
+                    .build();
+        }
+
+        var requestHeaders = new HttpHeaders();
+        requestHeaders.setContentType(MediaType.APPLICATION_JSON);
+        requestHeaders.set(X_AERO_NOTIFICATION, aTopic);
+
+        // If a secret is set, then add a digest header that allows the client to verify
+        // the message integrity
+        var json = JSONUtil.toJsonString(aMessage);
+        if (isNotBlank(aHook.getSecret())) {
+            var digest = DigestUtils.sha1Hex(aHook.getSecret() + json);
+            requestHeaders.set(X_AERO_SIGNATURE, digest);
+        }
+
+        if (isNotBlank(aHook.getAuthHeader()) && isNotBlank(aHook.getAuthHeaderValue())) {
+            requestHeaders.set(aHook.getAuthHeader(), aHook.getAuthHeaderValue());
+        }
+
+        var httpEntity = new HttpEntity<Object>(json, requestHeaders);
+        restTemplate.postForEntity(aHook.getUrl(), httpEntity, Void.class);
+    }
+
+    private HttpComponentsClientHttpRequestFactory getNonValidatingRequestFactory()
+    {
+        return nonValidatingRequestFactory;
+    }
+}

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/webhooks/KafkaWebhookDriver.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/webhooks/KafkaWebhookDriver.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.webhooks;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import de.tudarmstadt.ukp.inception.support.json.JSONUtil;
+
+public class KafkaWebhookDriver
+    implements WebhookDriver
+{
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    public static final String ID = "kafka";
+
+    @Override
+    public String getId()
+    {
+        return ID;
+    }
+
+    @Override
+    public void sendNotification(String aTopic, Object aMessage, Webhook aHook)
+        throws IOException, InterruptedException
+    {
+        var producerProbs = new Properties();
+
+        // These settings can be overridden by the user in the properties of the webhook
+        producerProbs.put("bootstrap.servers", aHook.getUrl());
+        producerProbs.put("acks", "1");
+
+        // Apply the user overrides
+        if (aHook.getProperties() != null) {
+            producerProbs.putAll(aHook.getProperties());
+        }
+
+        // Our serializer and deserializer settings need to always be in effect
+        producerProbs.put("key.serializer", StringSerializer.class.getName());
+        producerProbs.put("key.deserializer", StringDeserializer.class.getName());
+        producerProbs.put("value.serializer", StringSerializer.class.getName());
+        producerProbs.put("value.deserializer", StringDeserializer.class.getName());
+
+        var json = JSONUtil.toJsonString(aMessage);
+
+        try (var producer = new KafkaProducer<Object, String>(producerProbs)) {
+            var record = new ProducerRecord<>(aTopic, json);
+            var metadata = producer.send(record).get(); // synchronous send
+            LOG.debug("Sent to partition [{}]  with offset [{}]", metadata.offset(),
+                    metadata.partition());
+        }
+        catch (ExecutionException e) {
+            throw new IOException(e);
+        }
+    }
+}

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/webhooks/Webhook.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/webhooks/Webhook.java
@@ -18,17 +18,52 @@
 package de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.webhooks;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class Webhook
 {
+    private String driver = HttpWebhookDriver.ID;
     private String url;
     private String secret;
     private String authHeader;
     private String authHeaderValue;
     private boolean enabled = true;
     private List<String> topics = new ArrayList<>();
+    private Map<String, String> routes = new HashMap<>();
     private boolean verifyCertificates = true;
+    private Map<String, String> properties = new HashMap<>();
+
+    public void setProperties(Map<String, String> aProperties)
+    {
+        properties = aProperties;
+    }
+
+    public Map<String, String> getProperties()
+    {
+        return properties;
+    }
+
+    public Map<String, String> getRoutes()
+    {
+        return routes;
+    }
+
+    public void setRoutes(Map<String, String> aRoutes)
+    {
+        routes = aRoutes;
+    }
+
+    public void setDriver(String aDriver)
+    {
+        driver = aDriver;
+    }
+
+    public String getDriver()
+    {
+        return driver;
+    }
 
     public String getUrl()
     {
@@ -103,7 +138,7 @@ public class Webhook
     @Override
     public String toString()
     {
-        StringBuilder builder = new StringBuilder();
+        var builder = new StringBuilder();
         builder.append("Webhook [url=");
         builder.append(url);
         builder.append("]");

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/webhooks/WebhookDriver.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/webhooks/WebhookDriver.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.webhooks;
+
+import java.io.IOException;
+
+public interface WebhookDriver
+{
+    String X_AERO_NOTIFICATION = "X-AERO-Notification";
+    String X_AERO_SIGNATURE = "X-AERO-Signature";
+
+    String getId();
+
+    void sendNotification(String aTopic, Object aMessage, Webhook aHook)
+        throws IOException, InterruptedException;
+}

--- a/inception/inception-remote/src/main/resources/META-INF/asciidoc/admin-guide/remote-api-webhooks.adoc
+++ b/inception/inception-remote/src/main/resources/META-INF/asciidoc/admin-guide/remote-api-webhooks.adoc
@@ -138,3 +138,49 @@ The `annotatorComment` field contains the comment that annotators can set when c
 and is typically used to report a problem with the document. Thus, it can typically be found only
 when the `annotatorState` is `COMPLETE` (document closed as successful) or `LOCKED` (document closed
 as not successful).
+
+== Kafka
+
+Instead of delivering webhook notifications via HTTP(S), it is also possible to send them to a Kafka topic.
+To turn a webhook into a Kafka webhook, set the `driver` property to 'kafka' and the url property to the kafka bootstrap servers to which the messages should be sent.
+
+.Example Kafka webhook configuration
+----
+webhooks.globalHooks[0].url=localhost:9092
+webhooks.globalHooks[0].driver=kafka
+webhooks.globalHooks[0].topics[0]=DOCUMENT_STATE
+webhooks.globalHooks[0].topics[1]=ANNOTATION_STATE
+webhooks.globalHooks[0].topics[2]=PROJECT_STATE
+----
+
+Most likely, you will want to customize the topic names to which the different event types are sent. 
+This can be done via the `routes` property:
+
+.Example Kafka webhook topic routing
+----
+webhooks.globalHooks[0].url=localhost:9092
+webhooks.globalHooks[0].driver=kafka
+webhooks.globalHooks[0].topics[0]=...
+webhooks.globalHooks[0].routes.DOCUMENT_STATE=doc-state-topic
+webhooks.globalHooks[0].routes.ANNOTATION_STATE=ann-state-topic
+webhooks.globalHooks[0].routes.PROJECT_STATE=proj-state-topic
+----
+
+There will be additional settings you need to make depending on your Kafka setup.
+These include most importantly authentication and security settings.
+Any additional Kafka-specific properties you may need to set can be specified via the `properties` property.
+
+.Example Kafka webhook with additional properties
+----
+webhooks.globalHooks[0].url=localhost:9092
+webhooks.globalHooks[0].driver=kafka
+...
+webhooks.globalHooks[0].properties.security.protocol=SSL
+webhooks.globalHooks[0].properties.ssl.truststore.location=<PATH TO CLIENT TRUSTSTORE>
+webhooks.globalHooks[0].properties.ssl.truststore.password=<PASSWORD>
+webhooks.globalHooks[0].properties.ssl.keystore.location=<PATH TO CLIENT KEYSTORE>
+webhooks.globalHooks[0].properties.ssl.keystore.password=<PASSWORD>
+webhooks.globalHooks[0].properties.ssl.key.password=<PASSWORD>
+----
+
+For more information about the available Kafka properties, see the link:https://kafka.apache.org/documentation/#producerconfigs[Kafka documentation].

--- a/inception/inception-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/webhooks/KafkaWebhookDriverTest.java
+++ b/inception/inception-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/webhooks/KafkaWebhookDriverTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.webapp.remoteapi.webhooks;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.Properties;
+
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.kafka.KafkaContainer;
+
+import de.tudarmstadt.ukp.inception.support.json.JSONUtil;
+
+@Testcontainers(disabledWithoutDocker = true)
+class KafkaWebhookDriverTest
+{
+    @Container
+    static KafkaContainer kafka = new KafkaContainer("apache/kafka")
+            .withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "true");
+
+    private KafkaWebhookDriver sut;
+
+    @BeforeEach
+    void setup()
+    {
+        sut = new KafkaWebhookDriver();
+    }
+
+    @Test
+    void testKafkaAvailable()
+    {
+        assertThat(kafka.isRunning()).isTrue();
+    }
+
+    @Test
+    void testSendAndReceive() throws Exception
+    {
+        var webhook = new Webhook();
+        webhook.setEnabled(true);
+        webhook.setUrl(kafka.getBootstrapServers());
+
+        var topic = "notifications";
+
+        var consumerProps = new Properties();
+        consumerProps.put("bootstrap.servers", kafka.getBootstrapServers());
+        consumerProps.put("group.id", "test-group");
+        consumerProps.put("auto.offset.reset", "earliest");
+        consumerProps.put("key.serializer", StringSerializer.class.getName());
+        consumerProps.put("key.deserializer", StringDeserializer.class.getName());
+        consumerProps.put("value.serializer", StringSerializer.class.getName());
+        consumerProps.put("value.deserializer", StringDeserializer.class.getName());
+
+        try (var consumer = new KafkaConsumer<String, String>(consumerProps)) {
+            consumer.subscribe(asList(topic));
+
+            sut.sendNotification(topic, "Hello Kafka!", webhook);
+
+            var records = consumer.poll(Duration.ofSeconds(5));
+            assertThat(records.count()).isGreaterThan(0);
+
+            var record = records.iterator().next();
+            assertThat(record.topic()).isEqualTo("notifications");
+            assertThat(JSONUtil.fromJsonString(String.class, record.value()))
+                    .isEqualTo("Hello Kafka!");
+        }
+    }
+}

--- a/inception/inception-testing/src/main/java/de/tudarmstadt/ukp/inception/support/test/http/HttpTestUtils.java
+++ b/inception/inception-testing/src/main/java/de/tudarmstadt/ukp/inception/support/test/http/HttpTestUtils.java
@@ -31,6 +31,8 @@ import java.net.http.HttpResponse;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import javax.net.ssl.SSLHandshakeException;
+
 public class HttpTestUtils
 {
     public static boolean checkURL(String urlString)
@@ -76,6 +78,11 @@ public class HttpTestUtils
 
             UNREACHABLE_ENDPOINTS.add(aUrl);
             return false;
+        }
+        catch (SSLHandshakeException e) {
+            // We ignore SSL handshake exceptions here because they usually indicate that the server
+            // is there but that there is a certificate problem (e.g. self-signed certificate)
+            return true;
         }
         catch (Exception e) {
             System.out.printf("[%s] Network-level check: %s%n", aUrl, e.getMessage());


### PR DESCRIPTION
**What's in the PR**
. Modularized code
- Added basic Kafka driver (no authentication or advanced configuratiion)
- Added topic mapping options

**How to test manually**
* Try configuring INCEpTION to send messages to a Kafka broker:
```
webhooks.globalHooks[0].url=<kafkahost>:<kafkaport>
webhooks.globalHooks[0].driver=kafka
webhooks.globalHooks[0].topics[0]=DOCUMENT_STATE
webhooks.globalHooks[0].topic-aliases.DOCUMENT_STATE=MyAlternativeDocumentStateTopic
```

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
