### PR TITLE
#5599 - Calling Ollama in non-structured mode is broken

### DIFF
--- a/inception/inception-imls-ollama/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/ollama/OllamaRecommender.java
+++ b/inception/inception-imls-ollama/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/ollama/OllamaRecommender.java
@@ -93,7 +93,7 @@ public class OllamaRecommender
         }
 
         if (aFormat == ResponseFormat.JSON) {
-            return JsonNodeFactory.instance.textNode("json_object");
+            return JsonNodeFactory.instance.textNode("json");
         }
 
         return null;


### PR DESCRIPTION
**What's in the PR**
- Send "json" instead of "json_object" if structured mode is not enabled and we cannot set a full schema

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
