### PR TITLE
#5603 - Keep document name column visible when scrolling horizontally on static workload page

### DIFF
--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/MatrixWorkloadManagementPage.html
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/MatrixWorkloadManagementPage.html
@@ -25,6 +25,7 @@
     .document-matrix thead td, .document-table thead th{ border-bottom-width: 0 !important; }
     .document-matrix tr td, .document-matrix tr th { text-align: center; }
     .document-matrix tr th { white-space: nowrap; }
+    .document-matrix tr td:nth-child(3), thead th:nth-child(3) { position: sticky; left: 0; }
     .document-matrix tr td:nth-child(3), .document-matrix tr th:nth-child(3) { text-align: left; width: 100%;}
     .document-matrix col.s, .document-matrix tr.s , .document-matrix td.s { background-color: var(--primary); }
     .document-matrix .state-toggle { white-space: nowrap; cursor: pointer; }

--- a/inception/inception-workload-ui/src/main/java/de/tudarmstadt/ukp/inception/workload/project/config/WorkloadUiAutoConfiguration.java
+++ b/inception/inception-workload-ui/src/main/java/de/tudarmstadt/ukp/inception/workload/project/config/WorkloadUiAutoConfiguration.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.workload.project.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import de.tudarmstadt.ukp.inception.workload.project.ProjectWorkloadMenuItem;
@@ -24,6 +25,7 @@ import de.tudarmstadt.ukp.inception.workload.project.ProjectWorkloadMenuItem;
 @Configuration
 public class WorkloadUiAutoConfiguration
 {
+    @Bean
     public ProjectWorkloadMenuItem projectWorkloadMenuItem()
     {
         return new ProjectWorkloadMenuItem();


### PR DESCRIPTION
**What's in the PR**
- Make document name column sticky
- Fix workload configuration not appearing in project settings

**How to test manually**
* Open project with many users and static workload management
* Scroll monitoring page horizontally

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
