### PR TITLE
#5637 - Allow viewing activity by curators on curation

### DIFF
--- a/inception/inception-app-webapp/src/test/java/de/tudarmstadt/ukp/inception/db/InceptionMariadb_11_7_IntegrationTest.java
+++ b/inception/inception-app-webapp/src/test/java/de/tudarmstadt/ukp/inception/db/InceptionMariadb_11_7_IntegrationTest.java
@@ -37,7 +37,8 @@ class InceptionMariadb_11_7_IntegrationTest
     static final MariaDBContainer<?> dbContainer = new MariaDBContainer<>("mariadb:11.7.2") //
             .withDatabaseName("testdb") //
             .withUsername("test") //
-            .withPassword("test");
+            .withPassword("test") //
+            .withConfigurationOverride("mariadb_11_7");
 
     static @TempDir Path tempDir;
 

--- a/inception/inception-app-webapp/src/test/java/de/tudarmstadt/ukp/inception/db/InceptionMariadb_11_8_IntegrationTest.java
+++ b/inception/inception-app-webapp/src/test/java/de/tudarmstadt/ukp/inception/db/InceptionMariadb_11_8_IntegrationTest.java
@@ -37,7 +37,8 @@ class InceptionMariadb_11_8_IntegrationTest
     static final MariaDBContainer<?> dbContainer = new MariaDBContainer<>("mariadb:11.8.2") //
             .withDatabaseName("testdb") //
             .withUsername("test") //
-            .withPassword("test");
+            .withPassword("test") //
+            .withConfigurationOverride("mariadb_11_8");
 
     static @TempDir Path tempDir;
 

--- a/inception/inception-app-webapp/src/test/resources/mariadb_11_7/my.cnf
+++ b/inception/inception-app-webapp/src/test/resources/mariadb_11_7/my.cnf
@@ -1,0 +1,6 @@
+[mysqld]
+# Looks like we have problems (at least in tests, possibly generally) with this feature which
+# seems to be on by default since MariaDB 11.6.2:
+# InceptionMariadb_11_6_IntegrationTest$SpringApplcationContext.testDeletingSourceDocumentWithLearningRecordAttached
+# could not execute statement [(conn=4) Record has changed since last read in table 'project'] [delete from project where id=?]
+innodb_snapshot_isolation=0

--- a/inception/inception-app-webapp/src/test/resources/mariadb_11_8/my.cnf
+++ b/inception/inception-app-webapp/src/test/resources/mariadb_11_8/my.cnf
@@ -1,0 +1,6 @@
+[mysqld]
+# Looks like we have problems (at least in tests, possibly generally) with this feature which
+# seems to be on by default since MariaDB 11.6.2:
+# InceptionMariadb_11_6_IntegrationTest$SpringApplcationContext.testDeletingSourceDocumentWithLearningRecordAttached
+# could not execute statement [(conn=4) Record has changed since last read in table 'project'] [delete from project where id=?]
+innodb_snapshot_isolation=0

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/EventRepository.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/EventRepository.java
@@ -33,62 +33,8 @@ public interface EventRepository
 
     void create(LoggedEvent... aEvents);
 
-    /**
-     * @param aProject
-     *            the project to query the events from
-     * @param aDataOwner
-     *            the user who generated the events
-     * @param aEventType
-     *            the type of event
-     * @param aMaxSize
-     *            the maximum number of events to return
-     * @param aRecommenderId
-     *            the recommender to which the events relate
-     * @return logged events of the given type, user name, project and recommender id from the db.
-     * @deprecated Not used anymore.
-     */
-    @Deprecated
-    List<LoggedEvent> listLoggedEventsForRecommender(Project aProject, String aDataOwner,
-            String aEventType, int aMaxSize, long aRecommenderId);
-
     <E extends Throwable> void forEachLoggedEvent(Project aProject,
             FailableConsumer<LoggedEvent, E> aConsumer);
-
-    /**
-     * @return logged events of the given types, user name and project for every document from the
-     *         db.
-     * @param aProject
-     *            the project to query the events from
-     * @param aDataOwner
-     *            the user who generated the events
-     * @param aEventType
-     *            the type of event
-     * @param aMaxSize
-     *            the maximum number of events to return
-     * @deprecated Not used anymore.
-     */
-    @Deprecated
-    List<LoggedEvent> listUniqueLoggedEventsForDoc(Project aProject, String aDataOwner,
-            String[] aEventType, int aMaxSize);
-
-    /**
-     * @return logged events of the given type, user name, project and detail string from the db.
-     * @param aProject
-     *            the project to query the events from
-     * @param aDataOwner
-     *            the user who generated the events
-     * @param aEventType
-     *            the type of event
-     * @param aMaxSize
-     *            the maximum number of events to return
-     * @param aDetail
-     *            the detail pattern per SQL LIKE operator, e.g. {@code "%recommender%"} finds all
-     *            events containing the string {@code "recommender"} in their detail
-     * @deprecated Not used anymore.
-     */
-    @Deprecated
-    List<LoggedEvent> listLoggedEventsForDetail(Project aProject, String aDataOwner,
-            String aEventType, int aMaxSize, String aDetail);
 
     List<LoggedEvent> listRecentActivity(Project aProject, String aDataOwner,
             Collection<String> aEventTypes, int aMaxSize);
@@ -103,6 +49,9 @@ public interface EventRepository
      */
     List<LoggedEvent> listRecentActivity(String aDataOwner, int aMaxSize);
 
-    List<SummarizedLoggedEvent> summarizeEvents(String aSessionOwner, Project aProject,
-            Instant aNow, Instant aMinus);
+    List<SummarizedLoggedEvent> summarizeEventsBySessionOwner(String aSessionOwner,
+            Project aProject, Instant aNow, Instant aMinus);
+
+    List<SummarizedLoggedEvent> summarizeEventsByDataOwner(String aDataOwner, Project aProject,
+            Instant aFrom, Instant aTo);
 }

--- a/inception/inception-log/src/test/java/de/tudarmstadt/ukp/inception/log/EventRepositoryImplIntegrationTest.java
+++ b/inception/inception-log/src/test/java/de/tudarmstadt/ukp/inception/log/EventRepositoryImplIntegrationTest.java
@@ -17,7 +17,6 @@
  */
 package de.tudarmstadt.ukp.inception.log;
 
-import static java.util.Calendar.HOUR_OF_DAY;
 import static org.apache.uima.fit.factory.TypeSystemDescriptionFactory.createTypeSystemDescription;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
@@ -25,8 +24,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneId;
@@ -80,7 +77,6 @@ public class EventRepositoryImplIntegrationTest
     private static final int RECOMMENDER_ID = 7;
     private static final String DETAIL_JSON = "{\"recommenderId\":" + RECOMMENDER_ID + "}";
     private static final String EVENT_TYPE_RECOMMENDER_EVALUATION_EVENT = "RecommenderEvaluationResultEvent";
-    private static final String EVENT_TYPE_AFTER_ANNO_EVENT = "AfterAnnotationUpdateEvent";
     private static final String SPAN_CREATED_EVENT = "SpanCreatedEvent";
 
     private @Autowired TestEntityManager testEntityManager;
@@ -107,169 +103,6 @@ public class EventRepositoryImplIntegrationTest
     @Test
     public void thatApplicationContextStarts()
     {
-    }
-
-    @Test
-    public void getLoggedEventsForDoc_WithoutLoggedEvent_ShouldReturnEmptyList()
-    {
-        var loggedEvents = sut.listUniqueLoggedEventsForDoc(project, user.getUsername(),
-                new String[] { EVENT_TYPE_AFTER_ANNO_EVENT }, 10);
-
-        assertThat(loggedEvents).as("Check that no logged event is found").isEmpty();
-    }
-
-    @Test
-    public void getLoggedEventsForDoc_WithStoredLoggedEvent_ShouldReturnStoredLoggedEvent()
-        throws ParseException
-    {
-        var df = new SimpleDateFormat("yy-MM-dd HH:mm:ss");
-        le = buildLoggedEvent(project, USERNAME, EVENT_TYPE_AFTER_ANNO_EVENT,
-                df.parse("19-04-03 10:00:00"), 1, DETAIL_JSON);
-        var excludeTypeEvent = buildLoggedEvent(project, USERNAME,
-                EVENT_TYPE_RECOMMENDER_EVALUATION_EVENT, df.parse("19-04-03 11:00:00"), 1,
-                DETAIL_JSON);
-        var includeTypeEvent = buildLoggedEvent(project, USERNAME, SPAN_CREATED_EVENT,
-                df.parse("19-04-03 07:00:00"), 1, DETAIL_JSON);
-        var le2 = buildLoggedEvent(project, USERNAME, EVENT_TYPE_AFTER_ANNO_EVENT,
-                df.parse("19-04-03 9:00:00"), 1, DETAIL_JSON);
-        var le3 = buildLoggedEvent(project, USERNAME, EVENT_TYPE_AFTER_ANNO_EVENT,
-                df.parse("19-04-03 8:00:00"), 2, DETAIL_JSON);
-
-        sut.create(le);
-        sut.create(includeTypeEvent);
-        sut.create(excludeTypeEvent);
-        sut.create(le2);
-        sut.create(le3);
-        var loggedEvents = sut.listUniqueLoggedEventsForDoc(project, user.getUsername(),
-                new String[] { EVENT_TYPE_AFTER_ANNO_EVENT, SPAN_CREATED_EVENT }, 5);
-
-        assertThat(loggedEvents).as("Check that last created logged events are found").hasSize(2)
-                .contains(le, le3);
-    }
-
-    @Test
-    public void getLoggedEvents_WithOneStoredLoggedEvent_ShouldReturnStoredLoggedEvent()
-    {
-        le = buildLoggedEvent(project, USERNAME, EVENT_TYPE_RECOMMENDER_EVALUATION_EVENT,
-                new Date(), -1, DETAIL_JSON);
-
-        sut.create(le);
-        var loggedEvents = sut.listLoggedEventsForRecommender(project, user.getUsername(),
-                EVENT_TYPE_RECOMMENDER_EVALUATION_EVENT, 5, RECOMMENDER_ID);
-
-        assertThat(loggedEvents).as("Check that only the previously created logged event is found")
-                .hasSize(1).contains(le);
-    }
-
-    @Test
-    public void getLoggedEvents_WithoutLoggedEvent_ShouldReturnEmptyList()
-    {
-        var loggedEvents = sut.listLoggedEventsForRecommender(project, user.getUsername(),
-                EVENT_TYPE_RECOMMENDER_EVALUATION_EVENT, 5, RECOMMENDER_ID);
-
-        assertThat(loggedEvents).as("Check that no logged event is found").isEmpty();
-    }
-
-    @Test
-    public void getLoggedEvents_WithLoggedEventOfOtherUser_ShouldReturnEmptyList()
-    {
-        le = buildLoggedEvent(project, "OtherUser", EVENT_TYPE_RECOMMENDER_EVALUATION_EVENT,
-                new Date(), -1, DETAIL_JSON);
-
-        sut.create(le);
-
-        var loggedEvents = sut.listLoggedEventsForRecommender(project, user.getUsername(),
-                EVENT_TYPE_RECOMMENDER_EVALUATION_EVENT, 5, RECOMMENDER_ID);
-
-        assertThat(loggedEvents).as("Check that no logged event is found").isEmpty();
-    }
-
-    @Test
-    public void getLoggedEvents_WithLoggedEventOfOtherProject_ShouldReturnEmptyList()
-    {
-        var otherProject = createProject("otherProject");
-        le = buildLoggedEvent(otherProject, user.getUsername(),
-                EVENT_TYPE_RECOMMENDER_EVALUATION_EVENT, new Date(), -1, DETAIL_JSON);
-
-        sut.create(le);
-
-        var loggedEvents = sut.listLoggedEventsForRecommender(project, user.getUsername(),
-                EVENT_TYPE_RECOMMENDER_EVALUATION_EVENT, 5, RECOMMENDER_ID);
-
-        assertThat(loggedEvents).as("Check that no logged event is found").isEmpty();
-    }
-
-    @Test
-    public void getLoggedEvents_WithLoggedEventOfOtherType_ShouldReturnEmptyList()
-    {
-        le = buildLoggedEvent(project, user.getUsername(), EVENT_TYPE_RECOMMENDER_EVALUATION_EVENT,
-                new Date(), -1, DETAIL_JSON);
-        le.setEvent("OTHER_TYPE");
-
-        sut.create(le);
-
-        var loggedEvents = sut.listLoggedEventsForRecommender(project, user.getUsername(),
-                EVENT_TYPE_RECOMMENDER_EVALUATION_EVENT, 5, RECOMMENDER_ID);
-
-        assertThat(loggedEvents).as("Check that no logged event is found").isEmpty();
-    }
-
-    @Test
-    public void getLoggedEvents_WithLoggedEventsMoreThanGivenSize_ShouldReturnListOfGivenSize()
-    {
-        for (var i = 0; i < 6; i++) {
-            le = buildLoggedEvent(project, user.getUsername(),
-                    EVENT_TYPE_RECOMMENDER_EVALUATION_EVENT, new Date(), -1, DETAIL_JSON);
-            var cal = Calendar.getInstance();
-            cal.set(HOUR_OF_DAY, i);
-            le.setCreated(cal.getTime());
-            sut.create(le);
-        }
-
-        var loggedEvents = sut.listLoggedEventsForRecommender(project, user.getUsername(),
-                EVENT_TYPE_RECOMMENDER_EVALUATION_EVENT, 5, RECOMMENDER_ID);
-
-        assertThat(loggedEvents).as("Check that the number of logged events is 5").hasSize(5);
-    }
-
-    @Test
-    public void getLoggedEvents_WithLoggedEventsCreatedAtDifferentTimes_ShouldReturnSortedList()
-    {
-        for (var i = 0; i < 5; i++) {
-            le = buildLoggedEvent(project, user.getUsername(),
-                    EVENT_TYPE_RECOMMENDER_EVALUATION_EVENT, new Date(), -1, DETAIL_JSON);
-
-            var cal = Calendar.getInstance();
-            cal.set(Calendar.HOUR_OF_DAY, i);
-            le.setCreated(cal.getTime());
-            sut.create(le);
-        }
-
-        var loggedEvents = sut.listLoggedEventsForRecommender(project, user.getUsername(),
-                EVENT_TYPE_RECOMMENDER_EVALUATION_EVENT, 5, RECOMMENDER_ID);
-
-        assertThat(loggedEvents).as("Check that the returned list is not empty").isNotEmpty();
-
-        for (var i = 1; i < 5; i++) {
-            assertThat(loggedEvents.get(i - 1).getCreated()).as(
-                    "Check that the list of logged events is ordered by created time in descending order")
-                    .isAfterOrEqualTo(loggedEvents.get(i).getCreated());
-        }
-    }
-
-    @Test
-    public void getLoggedEvents_WithLoggedEventOfOtherRecommenderId_ShouldReturnEmptyList()
-    {
-        le = buildLoggedEvent(project, user.getUsername(), EVENT_TYPE_RECOMMENDER_EVALUATION_EVENT,
-                new Date(), -1, DETAIL_JSON);
-        sut.create(le);
-
-        var otherRecommenderId = 6;
-
-        var loggedEvents = sut.listLoggedEventsForRecommender(project, user.getUsername(),
-                EVENT_TYPE_RECOMMENDER_EVALUATION_EVENT, 5, otherRecommenderId);
-
-        assertThat(loggedEvents).as("Check that no logged event is found").isEmpty();
     }
 
     @Test
@@ -305,7 +138,7 @@ public class EventRepositoryImplIntegrationTest
         var beginOfDay = today.atTime(LocalTime.MIN).atZone(ZoneId.of("UTC")).toInstant();
         var endOfDay = today.atTime(LocalTime.MAX).atZone(ZoneId.of("UTC")).toInstant();
 
-        var summarizedEvents = sut.summarizeEvents(USERNAME, project, beginOfDay, endOfDay);
+        var summarizedEvents = sut.summarizeEventsBySessionOwner(USERNAME, project, beginOfDay, endOfDay);
 
         assertThat(summarizedEvents).as("Check that the returned list is not empty").isNotEmpty();
 

--- a/inception/inception-ui-dashboard-activity/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/activity/panel/ActivityPanel.java
+++ b/inception/inception-ui-dashboard-activity/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/activity/panel/ActivityPanel.java
@@ -20,6 +20,7 @@ package de.tudarmstadt.ukp.inception.ui.core.dashboard.activity.panel;
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.MANAGER;
 import static de.tudarmstadt.ukp.inception.support.lambda.HtmlElementEvents.CHANGE_EVENT;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -112,6 +113,9 @@ public class ActivityPanel
 
     private List<User> getUsersForCurrentProject()
     {
-        return projectService.listUsersWithAnyRoleInProject(projectModel.getObject());
+        var users = new ArrayList<User>();
+        users.addAll(projectService.listUsersWithAnyRoleInProject(projectModel.getObject()));
+        users.add(userService.getCurationUser());
+        return users;
     }
 }


### PR DESCRIPTION
**What's in the PR**
- Added option to view activites on documents owned by the curation user

**How to test manually**
* Open the "show all" panel in the activity sidebar
* Select the curation user and check if the data looks sensible

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
