### PR TITLE
#5650 - Explorer table unusable when text from long annotations is used

### DIFF
--- a/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/aggregator/CompoundKeyPanel.html
+++ b/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/aggregator/CompoundKeyPanel.html
@@ -22,7 +22,7 @@
     <div wicket:id="container" class="compound-key flex-grow list-group">
       <div wicket:id="key" class="list-group-item p-1">
         <div wicket:id="name" style="font-weight: normal; font-size: 65%;"/>
-        <div wicket:id="value" class="fw-bold text-nowrap" style="font-size: 85%;"/>
+        <div wicket:id="value" class="fw-bold" style="font-size: 85%; max-width: 20em;"/>
       </div>
     </div>
   </wicket:panel>

--- a/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/aggregator/ValueMapCellPanel.html
+++ b/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/aggregator/ValueMapCellPanel.html
@@ -32,7 +32,7 @@
 <body>
   <wicket:panel>
     <div wicket:id="container" class="value-set flex-grow list-group">
-      <div wicket:id="item" class="list-group-item text-nowrap bg-transparent position-relative">
+      <div wicket:id="item" class="list-group-item text-wrap bg-transparent position-relative" style="max-width: 20em;">
         <div wicket:id="count" class="float-end position-absolute badge rounded-pill text-bg-secondary count"/>
         <div wicket:id="value" style="font-weight: normal;"/>
       </div>

--- a/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/aggregator/ValueSetCellPanel.html
+++ b/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/aggregator/ValueSetCellPanel.html
@@ -20,7 +20,7 @@
 <body>
   <wicket:panel>
     <div wicket:id="container" class="value-set flex-grow list-group">
-      <div wicket:id="item" class="list-group-item text-nowrap bg-transparent">
+      <div wicket:id="item" class="list-group-item text-wrap bg-transparent" style="max-width: 20em;">
         <div wicket:id="value" style="font-weight: normal; font-size: 65%;"/>
       </div>
     </div>

--- a/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/table/PivotHeader.html
+++ b/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/table/PivotHeader.html
@@ -22,7 +22,7 @@
     <div class="d-flex flex-row">
 <!--       <button wicket:id="toggle">T</button> -->
       <div class="flex-grow list-group list-group-flush">
-        <div wicket:id="key" class="list-group-item text-nowrap">
+        <div wicket:id="key" class="list-group-item text-wrap" style="max-width: 20em;">
           <div wicket:id="name" style="font-weight: normal; font-size: 65%;"/>
           <div wicket:id="value" style="font-weight: bold; font-size: 85%;"/>
         </div>


### PR DESCRIPTION
**What's in the PR**
- Limit cell width and enable wrapping

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
