### PR TITLE
#5640 - Decouple annotation storage from user management

### DIFF
--- a/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/ActiveLearningServiceImpl.java
+++ b/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/ActiveLearningServiceImpl.java
@@ -42,9 +42,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.transaction.annotation.Transactional;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
@@ -206,7 +206,7 @@ public class ActiveLearningServiceImpl
         // the suggestion has been loaded into the sidebar.
         var sessionOwner = userService.getCurrentUsername();
         var dataOwner = aDataOwner.getUsername();
-        var cas = documentService.readAnnotationCas(aDocument, CasSet.forUser(aDataOwner));
+        var cas = documentService.readAnnotationCas(aDocument, AnnotationSet.forUser(aDataOwner));
 
         // Create AnnotationFeature and FeatureSupport
         var featureSupport = featureSupportRegistry.findExtension(feature).orElseThrow();

--- a/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.java
+++ b/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.java
@@ -67,9 +67,9 @@ import org.wicketstuff.event.annotation.OnEvent;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.keybindings.KeyBindingsPanel;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasProvider;
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.ReorderableTag;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
@@ -729,7 +729,8 @@ public class ActiveLearningSidebar
         // If the currently displayed document is the same one where the annotation was created,
         // then update timestamp in state to avoid concurrent modification errors
         if (Objects.equals(state.getDocument().getId(), document.getId())) {
-            documentService.getAnnotationCasTimestamp(document, CasSet.forUser(state.getUser()))
+            documentService
+                    .getAnnotationCasTimestamp(document, AnnotationSet.forUser(state.getUser()))
                     .ifPresent(state::setAnnotationDocumentTimestamp);
         }
     }
@@ -887,7 +888,7 @@ public class ActiveLearningSidebar
         // access to the document which contains the current suggestion
         try {
             var cas = documentService.readAnnotationCas(sourceDocument,
-                    CasSet.forUser(getModelObject().getUser()), AUTO_CAS_UPGRADE,
+                    AnnotationSet.forUser(getModelObject().getUser()), AUTO_CAS_UPGRADE,
                     SHARED_READ_ONLY_ACCESS);
             var text = cas.getDocumentText();
 
@@ -1071,7 +1072,7 @@ public class ActiveLearningSidebar
             // methods provided by the AnnotationActionHandler and these operate ONLY on the
             // currently visible/selected document.
             var cas = documentService.readAnnotationCas(aRecord.getSourceDocument(),
-                    CasSet.forUser(aRecord.getUser()));
+                    AnnotationSet.forUser(aRecord.getUser()));
             if (getMatchingAnnotation(cas, aRecord).isPresent()) {
                 setActiveLearningHighlight(aRecord);
                 actionShowSelectedDocument(aTarget, aRecord.getSourceDocument(),
@@ -1249,7 +1250,8 @@ public class ActiveLearningSidebar
             annotationPage.actionRefreshDocument(aTarget);
 
             // Update visibility in case the that was created/deleted overlaps with any suggestions
-            var cas = documentService.readAnnotationCas(aDocument, CasSet.forUser(dataOwner));
+            var cas = documentService.readAnnotationCas(aDocument,
+                    AnnotationSet.forUser(dataOwner));
             var group = SuggestionDocumentGroup.groupsOfType(SpanSuggestion.class,
                     predictions.getPredictionsByDocument(aDocument.getId()));
             recommendationService.calculateSuggestionVisibility(sessionOwner, aDocument, cas,

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/AgreementServiceImpl.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/AgreementServiceImpl.java
@@ -57,12 +57,12 @@ import org.slf4j.LoggerFactory;
 
 import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.DefaultAgreementTraits;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.results.coding.FullCodingAgreementResult;
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.Tag;
@@ -180,7 +180,7 @@ public class AgreementServiceImpl
         var casMap = new LinkedHashMap<String, CAS>();
 
         for (var annotator : aAnnotators) {
-            var maybeCas = loadCas(aDocument, CasSet.forUser(annotator), aAnnDocs);
+            var maybeCas = loadCas(aDocument, AnnotationSet.forUser(annotator), aAnnDocs);
             var cas = maybeCas.isPresent() ? maybeCas.get() : loadInitialCas(aDocument);
             casMap.put(annotator, cas);
         }
@@ -188,11 +188,11 @@ public class AgreementServiceImpl
         return casMap;
     }
 
-    private Optional<CAS> loadCas(SourceDocument aDocument, CasSet aSet,
+    private Optional<CAS> loadCas(SourceDocument aDocument, AnnotationSet aSet,
             List<AnnotationDocument> aAnnDocs)
         throws IOException
     {
-        if (CasSet.CURATION_SET.equals(aSet)) {
+        if (AnnotationSet.CURATION_SET.equals(aSet)) {
             if (!asList(CURATION_IN_PROGRESS, CURATION_FINISHED).contains(aDocument.getState())) {
                 return Optional.empty();
             }
@@ -211,7 +211,7 @@ public class AgreementServiceImpl
         return loadCas(aDocument, aSet);
     }
 
-    private Optional<CAS> loadCas(SourceDocument aDocument, CasSet aSet) throws IOException
+    private Optional<CAS> loadCas(SourceDocument aDocument, AnnotationSet aSet) throws IOException
     {
         var cas = documentService.readAnnotationCas(aDocument, aSet, AUTO_CAS_UPGRADE,
                 SHARED_READ_ONLY_ACCESS);

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/task/CalculatePairwiseAgreementTask.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/task/CalculatePairwiseAgreementTask.java
@@ -18,8 +18,8 @@
 package de.tudarmstadt.ukp.clarin.webanno.agreement.task;
 
 import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode.SHARED_READ_ONLY_ACCESS;
-import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet.CURATION_SET;
 import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasUpgradeMode.AUTO_CAS_UPGRADE;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet.CURATION_SET;
 import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.CURATION_FINISHED;
 import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.CURATION_IN_PROGRESS;
 import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.CURATION_USER;
@@ -44,11 +44,11 @@ import de.tudarmstadt.ukp.clarin.webanno.agreement.AgreementSummary;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.PairwiseAgreementResult;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.AgreementMeasure;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.DefaultAgreementTraits;
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.scheduling.Task;
@@ -109,7 +109,7 @@ public class CalculatePairwiseAgreementTask
                             break;
                         }
 
-                        var annotator1 = CasSet.forUser(annotators.get(m));
+                        var annotator1 = AnnotationSet.forUser(annotators.get(m));
                         var maybeCas1 = LazyInitializer.<Optional<CAS>> builder()
                                 .setInitializer(() -> loadCas(doc, annotator1, allAnnDocs)).get();
 
@@ -146,8 +146,8 @@ public class CalculatePairwiseAgreementTask
                             }
 
                             var maybeCas2 = LazyInitializer.<Optional<CAS>> builder()
-                                    .setInitializer(() -> loadCas(doc, CasSet.forUser(annotator2),
-                                            allAnnDocs))
+                                    .setInitializer(() -> loadCas(doc,
+                                            AnnotationSet.forUser(annotator2), allAnnDocs))
                                     .get();
 
                             if (maybeCas2.get().isEmpty()) {
@@ -187,7 +187,7 @@ public class CalculatePairwiseAgreementTask
         return cas;
     }
 
-    private Optional<CAS> loadCas(SourceDocument aDocument, CasSet aSet,
+    private Optional<CAS> loadCas(SourceDocument aDocument, AnnotationSet aSet,
             Map<SourceDocument, List<AnnotationDocument>> aAllAnnDocs)
         throws IOException
     {
@@ -212,7 +212,7 @@ public class CalculatePairwiseAgreementTask
         return loadCas(aDocument, aSet);
     }
 
-    private Optional<CAS> loadCas(SourceDocument aDocument, CasSet aSet) throws IOException
+    private Optional<CAS> loadCas(SourceDocument aDocument, AnnotationSet aSet) throws IOException
     {
         var cas = documentService.readAnnotationCas(aDocument, aSet, AUTO_CAS_UPGRADE,
                 SHARED_READ_ONLY_ACCESS);

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/task/CalculatePerDocumentAgreementTask.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/task/CalculatePerDocumentAgreementTask.java
@@ -44,11 +44,11 @@ import de.tudarmstadt.ukp.clarin.webanno.agreement.AgreementSummary;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.PerDocumentAgreementResult;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.AgreementMeasure;
 import de.tudarmstadt.ukp.clarin.webanno.agreement.measures.DefaultAgreementTraits;
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.scheduling.Task;
@@ -150,11 +150,11 @@ public class CalculatePerDocumentAgreementTask
             }
         }
 
-        if (!documentService.existsCas(aDocument, CasSet.forUser(aDataOwner))) {
+        if (!documentService.existsCas(aDocument, AnnotationSet.forUser(aDataOwner))) {
             return loadInitialCas(aDocument);
         }
 
-        var cas = documentService.readAnnotationCas(aDocument, CasSet.forUser(aDataOwner),
+        var cas = documentService.readAnnotationCas(aDocument, AnnotationSet.forUser(aDataOwner),
                 AUTO_CAS_UPGRADE, SHARED_READ_ONLY_ACCESS);
 
         // Set the CAS name in the DocumentMetaData so that we can pick it

--- a/inception/inception-annotation-storage-api/pom.xml
+++ b/inception/inception-annotation-storage-api/pom.xml
@@ -34,11 +34,6 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
-      <artifactId>inception-security</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-support</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/inception/inception-annotation-storage-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/casstorage/CasStorageService.java
+++ b/inception/inception-annotation-storage-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/casstorage/CasStorageService.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import org.apache.uima.cas.CAS;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasSessionException;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 
 public interface CasStorageService
@@ -47,7 +48,7 @@ public interface CasStorageService
      * @throws IOException
      *             if there was and error writing the CAS
      */
-    void writeCas(SourceDocument aDocument, CAS aCas, CasSet aSet)
+    void writeCas(SourceDocument aDocument, CAS aCas, AnnotationSet aSet)
         throws IOException, CasSessionException;
 
     /**
@@ -65,7 +66,8 @@ public interface CasStorageService
      * @throws CasSessionException
      *             if no CAS storage session in available for the current thread.
      */
-    CAS readCas(SourceDocument aDocument, CasSet aSet) throws IOException, CasSessionException;
+    CAS readCas(SourceDocument aDocument, AnnotationSet aSet)
+        throws IOException, CasSessionException;
 
     /**
      * Retrieve the annotation CAS of a given user for a given {@link SourceDocument}. If
@@ -85,7 +87,7 @@ public interface CasStorageService
      * @throws CasSessionException
      *             if no CAS storage session in available for the current thread.
      */
-    CAS readCas(SourceDocument aDocument, CasSet aSet, CasAccessMode aAccessMode)
+    CAS readCas(SourceDocument aDocument, AnnotationSet aSet, CasAccessMode aAccessMode)
         throws IOException, CasSessionException;
 
     /**
@@ -113,7 +115,7 @@ public interface CasStorageService
      * @throws CasSessionException
      *             if no CAS storage session in available for the current thread.
      */
-    CAS readOrCreateCas(SourceDocument aDocument, CasSet aSet, CasUpgradeMode aUpgradeMode,
+    CAS readOrCreateCas(SourceDocument aDocument, AnnotationSet aSet, CasUpgradeMode aUpgradeMode,
             CasProvider aSupplier, CasAccessMode aAccessMode)
         throws IOException, CasSessionException;
 
@@ -131,14 +133,16 @@ public interface CasStorageService
      *             if no CAS storage session in available for the current thread or if the session
      *             does not permit writing.
      */
-    boolean deleteCas(SourceDocument aDocument, CasSet aSet)
+    boolean deleteCas(SourceDocument aDocument, AnnotationSet aSet)
         throws IOException, CasSessionException;
 
-    void exportCas(SourceDocument aDocument, CasSet aSet, OutputStream aStream) throws IOException;
+    void exportCas(SourceDocument aDocument, AnnotationSet aSet, OutputStream aStream)
+        throws IOException;
 
-    void importCas(SourceDocument aDocument, CasSet aSet, InputStream aStream) throws IOException;
+    void importCas(SourceDocument aDocument, AnnotationSet aSet, InputStream aStream)
+        throws IOException;
 
-    boolean existsCas(SourceDocument aDocument, CasSet aSet) throws IOException;
+    boolean existsCas(SourceDocument aDocument, AnnotationSet aSet) throws IOException;
 
     /**
      * Runs {@code CasDoctor} in repair mode on the given CAS (if repairs are active), otherwise it
@@ -154,11 +158,11 @@ public interface CasStorageService
      * @param aCas
      *            the CAS object
      */
-    void analyzeAndRepair(SourceDocument aDocument, CasSet aSet, CAS aCas);
+    void analyzeAndRepair(SourceDocument aDocument, AnnotationSet aSet, CAS aCas);
 
-    Optional<Long> getCasTimestamp(SourceDocument aDocument, CasSet aSet) throws IOException;
+    Optional<Long> getCasTimestamp(SourceDocument aDocument, AnnotationSet aSet) throws IOException;
 
-    Optional<Long> verifyCasTimestamp(SourceDocument aDocument, CasSet aSet,
+    Optional<Long> verifyCasTimestamp(SourceDocument aDocument, AnnotationSet aSet,
             long aExpectedTimeStamp, String aContextAction)
         throws IOException, ConcurentCasModificationException;
 
@@ -175,11 +179,12 @@ public interface CasStorageService
      *             if no CAS storage session in available for the current thread or if the session
      *             does not permit writing.
      */
-    void upgradeCas(SourceDocument aDocument, CasSet aSet) throws IOException, CasSessionException;
+    void upgradeCas(SourceDocument aDocument, AnnotationSet aSet)
+        throws IOException, CasSessionException;
 
-    void forceActionOnCas(SourceDocument aDocument, CasSet aSet, CasStorageServiceLoader aLoader,
-            CasStorageServiceAction aAction, boolean aSave)
+    void forceActionOnCas(SourceDocument aDocument, AnnotationSet aSet,
+            CasStorageServiceLoader aLoader, CasStorageServiceAction aAction, boolean aSave)
         throws IOException;
 
-    Optional<Long> getCasFileSize(SourceDocument aDocument, CasSet aSet) throws IOException;
+    Optional<Long> getCasFileSize(SourceDocument aDocument, AnnotationSet aSet) throws IOException;
 }

--- a/inception/inception-annotation-storage-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/casstorage/CasStorageServiceAction.java
+++ b/inception/inception-annotation-storage-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/casstorage/CasStorageServiceAction.java
@@ -19,10 +19,11 @@ package de.tudarmstadt.ukp.clarin.webanno.api.casstorage;
 
 import org.apache.uima.cas.CAS;
 
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 
 @FunctionalInterface
 public interface CasStorageServiceAction
 {
-    void apply(SourceDocument aDocument, CasSet aSet, CAS aCas) throws Exception;
+    void apply(SourceDocument aDocument, AnnotationSet aSet, CAS aCas) throws Exception;
 }

--- a/inception/inception-annotation-storage-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/casstorage/CasStorageServiceLoader.java
+++ b/inception/inception-annotation-storage-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/casstorage/CasStorageServiceLoader.java
@@ -19,10 +19,11 @@ package de.tudarmstadt.ukp.clarin.webanno.api.casstorage;
 
 import org.apache.uima.cas.CAS;
 
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 
 @FunctionalInterface
 public interface CasStorageServiceLoader
 {
-    CAS load(SourceDocument aSourceDocument, CasSet aSet) throws Exception;
+    CAS load(SourceDocument aSourceDocument, AnnotationSet aSet) throws Exception;
 }

--- a/inception/inception-annotation-storage-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/casstorage/session/CasKey.java
+++ b/inception/inception-annotation-storage-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/casstorage/session/CasKey.java
@@ -22,7 +22,7 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 
@@ -30,7 +30,7 @@ public class CasKey
 {
     private final long projectId;
     private final long documentId;
-    private final CasSet set;
+    private final AnnotationSet set;
 
     // These are just for information and are not included when checking for equality or building a
     // hash. Mind that the name of a project (possibly the name of a document) might change during
@@ -38,7 +38,7 @@ public class CasKey
     private String projectName;
     private String documentName;
 
-    public CasKey(SourceDocument aDocument, CasSet aSet)
+    public CasKey(SourceDocument aDocument, AnnotationSet aSet)
     {
         projectName = aDocument.getProject().getName();
         projectId = aDocument.getProject().getId();
@@ -47,7 +47,7 @@ public class CasKey
         set = aSet;
     }
 
-    public CasKey(long aProjectId, long aDocumentId, CasSet aSet)
+    public CasKey(long aProjectId, long aDocumentId, AnnotationSet aSet)
     {
         projectId = aProjectId;
         documentId = aDocumentId;
@@ -64,7 +64,7 @@ public class CasKey
         return documentId;
     }
 
-    public CasSet getSet()
+    public AnnotationSet getSet()
     {
         return set;
     }

--- a/inception/inception-annotation-storage-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/casstorage/session/CasStorageSession.java
+++ b/inception/inception-annotation-storage-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/casstorage/session/CasStorageSession.java
@@ -32,9 +32,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode;
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasStorageService;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.WriteAccessNotPermittedException;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil;
 
@@ -53,7 +53,7 @@ public class CasStorageSession
     private boolean closed = false;
     private StackTraceElement[] creatorStack;
 
-    private final Map<Long, Map<CasSet, SessionManagedCas>> managedCases = new LinkedHashMap<>();
+    private final Map<Long, Map<AnnotationSet, SessionManagedCas>> managedCases = new LinkedHashMap<>();
 
     private int maxManagedCases = 0;
 
@@ -214,7 +214,7 @@ public class CasStorageSession
      *            the CAS itself.
      * @return the managed CAS state.
      */
-    public SessionManagedCas add(CasSet aSpecialPurpose, CasAccessMode aMode, CAS aCas)
+    public SessionManagedCas add(AnnotationSet aSpecialPurpose, CasAccessMode aMode, CAS aCas)
     {
         Validate.notNull(aSpecialPurpose, "The purpose cannot be null");
         Validate.notNull(aMode, "The access mode cannot be null");
@@ -250,7 +250,7 @@ public class CasStorageSession
      * @param aSet
      *            the set to which CAS belongs
      */
-    public void remove(Long aDocumentId, CasSet aSet)
+    public void remove(Long aDocumentId, AnnotationSet aSet)
     {
         var casByUser = managedCases.get(aDocumentId);
 
@@ -274,7 +274,8 @@ public class CasStorageSession
      *            the CAS itself.
      * @return the managed CAS state.
      */
-    public SessionManagedCas add(Long aDocumentId, CasSet aSet, CasAccessMode aMode, CAS aCas)
+    public SessionManagedCas add(Long aDocumentId, AnnotationSet aSet, CasAccessMode aMode,
+            CAS aCas)
     {
         Validate.notNull(aDocumentId, "The document ID cannot be null");
         Validate.isTrue(aDocumentId >= 0, "The document ID cannot be negative");
@@ -302,7 +303,7 @@ public class CasStorageSession
      *            the CAS holder.
      * @return the managed CAS state.
      */
-    public SessionManagedCas add(Long aDocumentId, CasSet aSet, CasAccessMode aMode,
+    public SessionManagedCas add(Long aDocumentId, AnnotationSet aSet, CasAccessMode aMode,
             CasHolder aCasHolder)
     {
         Validate.notNull(aDocumentId, "The document ID cannot be null");
@@ -375,7 +376,7 @@ public class CasStorageSession
      *            the set to which the CAS belongs.
      * @return the managed CAS state.
      */
-    public Optional<SessionManagedCas> getManagedState(Long aDocumentId, CasSet aSet)
+    public Optional<SessionManagedCas> getManagedState(Long aDocumentId, AnnotationSet aSet)
     {
         Validate.notNull(aDocumentId, "The document ID cannot be null");
         Validate.notNull(aSet, "The set cannot be null");
@@ -401,7 +402,7 @@ public class CasStorageSession
      * @param aSet
      *            the set to which the CAS belongs.
      */
-    public boolean hasExclusiveAccess(SourceDocument aDocument, CasSet aSet)
+    public boolean hasExclusiveAccess(SourceDocument aDocument, AnnotationSet aSet)
     {
         return getManagedState(aDocument.getId(), aSet) //
                 .map(SessionManagedCas::isWritingPermitted) //

--- a/inception/inception-annotation-storage-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/casstorage/session/SessionManagedCas.java
+++ b/inception/inception-annotation-storage-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/casstorage/session/SessionManagedCas.java
@@ -27,12 +27,12 @@ import org.apache.commons.lang3.builder.ToStringStyle;
 import org.apache.uima.cas.CAS;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode;
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 
 public class SessionManagedCas
 {
     private final long sourceDocumentId;
-    private final CasSet set;
+    private final AnnotationSet set;
     private final CasAccessMode mode;
     private final CAS cas;
     private final CasHolder casHolder;
@@ -41,7 +41,8 @@ public class SessionManagedCas
     private int readCount;
     private int writeCount;
 
-    public SessionManagedCas(long aSourceDocumentId, CasSet aSet, CasAccessMode aMode, CAS aCas)
+    public SessionManagedCas(long aSourceDocumentId, AnnotationSet aSet, CasAccessMode aMode,
+            CAS aCas)
     {
         super();
 
@@ -55,7 +56,7 @@ public class SessionManagedCas
         shouldReleaseOnClose = true;
     }
 
-    public SessionManagedCas(long aSourceDocumentId, CasSet aSet, CasAccessMode aMode,
+    public SessionManagedCas(long aSourceDocumentId, AnnotationSet aSet, CasAccessMode aMode,
             CasHolder aCasHolder)
     {
         super();
@@ -79,7 +80,7 @@ public class SessionManagedCas
         return sourceDocumentId;
     }
 
-    public CasSet getSet()
+    public AnnotationSet getSet()
     {
         return set;
     }

--- a/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/CasStorageServiceImpl.java
+++ b/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/CasStorageServiceImpl.java
@@ -68,7 +68,6 @@ import com.github.benmanes.caffeine.cache.stats.CacheStats;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasProvider;
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasStorageService;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasStorageServiceAction;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasStorageServiceLoader;
@@ -81,6 +80,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSessio
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.SessionManagedCas;
 import de.tudarmstadt.ukp.clarin.webanno.diag.CasDoctor;
 import de.tudarmstadt.ukp.clarin.webanno.diag.CasDoctorException;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.annotation.storage.config.CasStorageCacheProperties;
 import de.tudarmstadt.ukp.inception.annotation.storage.config.CasStorageServiceAutoConfiguration;
@@ -205,7 +205,7 @@ public class CasStorageServiceImpl
     }
 
     @Override
-    public void writeCas(SourceDocument aDocument, CAS aCas, CasSet aSet)
+    public void writeCas(SourceDocument aDocument, CAS aCas, AnnotationSet aSet)
         throws IOException, CasSessionException
     {
         try (var logCtx = withProjectLogger(aDocument.getProject())) {
@@ -274,14 +274,14 @@ public class CasStorageServiceImpl
     }
 
     @Override
-    public CAS readCas(SourceDocument aDocument, CasSet aSet)
+    public CAS readCas(SourceDocument aDocument, AnnotationSet aSet)
         throws IOException, CasSessionException
     {
         return readOrCreateCas(aDocument, aSet, NO_CAS_UPGRADE, null, EXCLUSIVE_WRITE_ACCESS);
     }
 
     @Override
-    public CAS readCas(SourceDocument aDocument, CasSet aSet, CasAccessMode aAccessMode)
+    public CAS readCas(SourceDocument aDocument, AnnotationSet aSet, CasAccessMode aAccessMode)
         throws IOException, CasSessionException
     {
         return readOrCreateCas(aDocument, aSet,
@@ -290,8 +290,8 @@ public class CasStorageServiceImpl
     }
 
     @Override
-    public CAS readOrCreateCas(SourceDocument aDocument, CasSet aSet, CasUpgradeMode aUpgradeMode,
-            CasProvider aSupplier, CasAccessMode aAccessMode)
+    public CAS readOrCreateCas(SourceDocument aDocument, AnnotationSet aSet,
+            CasUpgradeMode aUpgradeMode, CasProvider aSupplier, CasAccessMode aAccessMode)
         throws IOException, CasSessionException
     {
 
@@ -518,8 +518,8 @@ public class CasStorageServiceImpl
         }
     }
 
-    private void repairAndUpgradeCasIfRequired(SourceDocument aDocument, CasSet aSet, CAS aCas,
-            CasUpgradeMode aUpgradeMode, RepairAndUpgradeFlags... aFlags)
+    private void repairAndUpgradeCasIfRequired(SourceDocument aDocument, AnnotationSet aSet,
+            CAS aCas, CasUpgradeMode aUpgradeMode, RepairAndUpgradeFlags... aFlags)
         throws IOException
     {
         try (var session = CasStorageSession.openNested(contains(aFlags, ISOLATED_SESSION))) {
@@ -560,7 +560,7 @@ public class CasStorageServiceImpl
      * @throws IOException
      *             if the CAS could not be obtained.
      */
-    private CAS readOrCreateUnmanagedCas(SourceDocument aDocument, CasSet aSet,
+    private CAS readOrCreateUnmanagedCas(SourceDocument aDocument, AnnotationSet aSet,
             CasProvider aSupplier, CasUpgradeMode aUpgradeMode, CasAccessMode aAccessMode)
         throws IOException
     {
@@ -625,7 +625,7 @@ public class CasStorageServiceImpl
         return cas;
     }
 
-    private void addOrUpdateCasMetadata(SourceDocument aDocument, CasSet aSet, CAS cas)
+    private void addOrUpdateCasMetadata(SourceDocument aDocument, AnnotationSet aSet, CAS cas)
         throws IOException
     {
         CasMetadataUtils.addOrUpdateCasMetadata(cas,
@@ -638,7 +638,7 @@ public class CasStorageServiceImpl
     }
 
     @Override
-    public boolean deleteCas(SourceDocument aDocument, CasSet aSet)
+    public boolean deleteCas(SourceDocument aDocument, AnnotationSet aSet)
         throws IOException, CasSessionException
     {
         try (var logCtx = withProjectLogger(aDocument.getProject());
@@ -676,7 +676,7 @@ public class CasStorageServiceImpl
     }
 
     @Override
-    public void analyzeAndRepair(SourceDocument aDocument, CasSet aSet, CAS aCas)
+    public void analyzeAndRepair(SourceDocument aDocument, AnnotationSet aSet, CAS aCas)
     {
         var project = aDocument.getProject();
 
@@ -718,7 +718,7 @@ public class CasStorageServiceImpl
      * @param aCas
      *            the CAS object
      */
-    private void analyze(SourceDocument aDocument, CasSet aSet, CAS aCas)
+    private void analyze(SourceDocument aDocument, AnnotationSet aSet, CAS aCas)
     {
         if (casDoctor == null) {
             return;
@@ -746,7 +746,7 @@ public class CasStorageServiceImpl
     }
 
     @Override
-    public void exportCas(SourceDocument aDocument, CasSet aSet, OutputStream aStream)
+    public void exportCas(SourceDocument aDocument, AnnotationSet aSet, OutputStream aStream)
         throws IOException
     {
         // Ensure that the CAS is not being re-written and temporarily unavailable while we export
@@ -770,7 +770,7 @@ public class CasStorageServiceImpl
     }
 
     @Override
-    public void importCas(SourceDocument aDocument, CasSet aSet, InputStream aStream)
+    public void importCas(SourceDocument aDocument, AnnotationSet aSet, InputStream aStream)
         throws IOException
     {
         // Ensure that the CAS is not being re-written and temporarily unavailable while we export
@@ -794,7 +794,7 @@ public class CasStorageServiceImpl
     }
 
     @Override
-    public void upgradeCas(SourceDocument aDocument, CasSet aSet) throws IOException
+    public void upgradeCas(SourceDocument aDocument, AnnotationSet aSet) throws IOException
     {
         Validate.notNull(aDocument, "Source document must be specified");
         Validate.notNull(aSet, "Set must be specified");
@@ -806,7 +806,7 @@ public class CasStorageServiceImpl
     }
 
     @Override
-    public void forceActionOnCas(SourceDocument aDocument, CasSet aSet,
+    public void forceActionOnCas(SourceDocument aDocument, AnnotationSet aSet,
             CasStorageServiceLoader aLoader, CasStorageServiceAction aAction, boolean aSave)
         throws IOException
     {
@@ -838,7 +838,7 @@ public class CasStorageServiceImpl
     }
 
     @Override
-    public boolean existsCas(SourceDocument aDocument, CasSet aSet) throws IOException
+    public boolean existsCas(SourceDocument aDocument, AnnotationSet aSet) throws IOException
     {
         Validate.notNull(aDocument, "Source document must be specified");
         Validate.notNull(aSet, "Set must be specified");
@@ -857,7 +857,8 @@ public class CasStorageServiceImpl
     }
 
     @Override
-    public Optional<Long> getCasFileSize(SourceDocument aDocument, CasSet aSet) throws IOException
+    public Optional<Long> getCasFileSize(SourceDocument aDocument, AnnotationSet aSet)
+        throws IOException
     {
         Validate.notNull(aDocument, "Source document must be specified");
         Validate.notNull(aSet, "Set must be specified");
@@ -882,9 +883,10 @@ public class CasStorageServiceImpl
         private CasHolder holder;
         private String documentName;
         private long documentId;
-        private CasSet set;
+        private AnnotationSet set;
 
-        public WithExclusiveAccess(SourceDocument aDocument, CasSet aSet) throws CasSessionException
+        public WithExclusiveAccess(SourceDocument aDocument, AnnotationSet aSet)
+            throws CasSessionException
         {
             key = new CasKey(aDocument, aSet);
             documentName = aDocument.getName();
@@ -1002,7 +1004,8 @@ public class CasStorageServiceImpl
     }
 
     @Override
-    public Optional<Long> getCasTimestamp(SourceDocument aDocument, CasSet aSet) throws IOException
+    public Optional<Long> getCasTimestamp(SourceDocument aDocument, AnnotationSet aSet)
+        throws IOException
     {
         Validate.notNull(aDocument, "Source document must be specified");
         Validate.notNull(aSet, "Set must be specified");
@@ -1021,7 +1024,7 @@ public class CasStorageServiceImpl
     }
 
     @Override
-    public Optional<Long> verifyCasTimestamp(SourceDocument aDocument, CasSet aSet,
+    public Optional<Long> verifyCasTimestamp(SourceDocument aDocument, AnnotationSet aSet,
             long aExpectedTimeStamp, String aContextAction)
         throws IOException, ConcurentCasModificationException
     {
@@ -1083,7 +1086,8 @@ public class CasStorageServiceImpl
                 .removeIf(key -> Objects.equals(key.getProjectId(), aEvent.getProject().getId()));
     }
 
-    private void realWriteCas(SourceDocument aDocument, CasSet aSet, CAS aCas) throws IOException
+    private void realWriteCas(SourceDocument aDocument, AnnotationSet aSet, CAS aCas)
+        throws IOException
     {
         analyze(aDocument, aSet, aCas);
 

--- a/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/driver/CasStorageDriver.java
+++ b/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/driver/CasStorageDriver.java
@@ -24,31 +24,33 @@ import java.util.Optional;
 
 import org.apache.uima.cas.CAS;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.ConcurentCasModificationException;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.annotation.storage.CasStorageMetadata;
 
 public interface CasStorageDriver
 {
-    CAS readCas(SourceDocument aDocument, CasSet aSet) throws IOException;
+    CAS readCas(SourceDocument aDocument, AnnotationSet aSet) throws IOException;
 
-    void writeCas(SourceDocument aDocument, CasSet aSet, CAS aCas) throws IOException;
+    void writeCas(SourceDocument aDocument, AnnotationSet aSet, CAS aCas) throws IOException;
 
-    void exportCas(SourceDocument aDocument, CasSet aSet, OutputStream aStream) throws IOException;
-
-    void importCas(SourceDocument aDocument, CasSet aSet, InputStream aStream) throws IOException;
-
-    boolean deleteCas(SourceDocument aDocument, CasSet aSet) throws IOException;
-
-    boolean existsCas(SourceDocument aDocument, CasSet aSet) throws IOException;
-
-    Optional<CasStorageMetadata> getCasMetadata(SourceDocument aDocument, CasSet aSet)
+    void exportCas(SourceDocument aDocument, AnnotationSet aSet, OutputStream aStream)
         throws IOException;
 
-    Optional<Long> verifyCasTimestamp(SourceDocument aDocument, CasSet aSet,
+    void importCas(SourceDocument aDocument, AnnotationSet aSet, InputStream aStream)
+        throws IOException;
+
+    boolean deleteCas(SourceDocument aDocument, AnnotationSet aSet) throws IOException;
+
+    boolean existsCas(SourceDocument aDocument, AnnotationSet aSet) throws IOException;
+
+    Optional<CasStorageMetadata> getCasMetadata(SourceDocument aDocument, AnnotationSet aSet)
+        throws IOException;
+
+    Optional<Long> verifyCasTimestamp(SourceDocument aDocument, AnnotationSet aSet,
             long aExpectedTimeStamp, String aContextAction)
         throws IOException, ConcurentCasModificationException;
 
-    Optional<Long> getCasFileSize(SourceDocument aDocument, CasSet aSet) throws IOException;
+    Optional<Long> getCasFileSize(SourceDocument aDocument, AnnotationSet aSet) throws IOException;
 }

--- a/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/driver/filesystem/FileSystemCasStorageDriver.java
+++ b/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/driver/filesystem/FileSystemCasStorageDriver.java
@@ -56,9 +56,9 @@ import org.slf4j.LoggerFactory;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.ConcurentCasModificationException;
 import de.tudarmstadt.ukp.clarin.webanno.api.type.CASMetadata;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.annotation.storage.CasMetadataUtils;
 import de.tudarmstadt.ukp.inception.annotation.storage.CasStorageMetadata;
@@ -110,7 +110,7 @@ public class FileSystemCasStorageDriver
     }
 
     @Override
-    public CAS readCas(SourceDocument aDocument, CasSet aSet) throws IOException
+    public CAS readCas(SourceDocument aDocument, AnnotationSet aSet) throws IOException
     {
         LOG.trace("Reading CAS [{}]@{}", aSet, aDocument);
 
@@ -167,7 +167,7 @@ public class FileSystemCasStorageDriver
     }
 
     @Override
-    public void writeCas(SourceDocument aDocument, CasSet aSet, CAS aCas) throws IOException
+    public void writeCas(SourceDocument aDocument, AnnotationSet aSet, CAS aCas) throws IOException
     {
         var t0 = currentTimeMillis();
 
@@ -294,7 +294,7 @@ public class FileSystemCasStorageDriver
         return annotationFolder;
     }
 
-    private void manageHistory(File aCurrentVersion, SourceDocument aDocument, CasSet aSet)
+    private void manageHistory(File aCurrentVersion, SourceDocument aDocument, AnnotationSet aSet)
         throws IOException
     {
         if (backupProperties.getInterval() <= 0) {
@@ -387,7 +387,7 @@ public class FileSystemCasStorageDriver
     }
 
     // Public for testing
-    public File getCasFile(SourceDocument aDocument, CasSet aSet) throws IOException
+    public File getCasFile(SourceDocument aDocument, AnnotationSet aSet) throws IOException
     {
         Validate.notNull(aDocument, "Source document must be specified");
         Validate.notNull(aSet, "Set must be specified");
@@ -396,7 +396,7 @@ public class FileSystemCasStorageDriver
     }
 
     @Override
-    public void exportCas(SourceDocument aDocument, CasSet aSet, OutputStream aStream)
+    public void exportCas(SourceDocument aDocument, AnnotationSet aSet, OutputStream aStream)
         throws IOException
     {
         Validate.notNull(aDocument, "Source document must be specified");
@@ -408,7 +408,7 @@ public class FileSystemCasStorageDriver
     }
 
     @Override
-    public void importCas(SourceDocument aDocument, CasSet aSet, InputStream aStream)
+    public void importCas(SourceDocument aDocument, AnnotationSet aSet, InputStream aStream)
         throws IOException
     {
         Validate.notNull(aDocument, "Source document must be specified");
@@ -419,14 +419,14 @@ public class FileSystemCasStorageDriver
         }
     }
 
-    public File getCasFile(long aProjectId, long aDocumentId, CasSet aSet) throws IOException
+    public File getCasFile(long aProjectId, long aDocumentId, AnnotationSet aSet) throws IOException
     {
         return new File(getAnnotationFolder(aProjectId, aDocumentId),
                 aSet.id() + SER_CAS_EXTENSION);
     }
 
     @Override
-    public boolean deleteCas(SourceDocument aDocument, CasSet aSet) throws IOException
+    public boolean deleteCas(SourceDocument aDocument, AnnotationSet aSet) throws IOException
     {
         var casFile = getCasFile(aDocument.getProject().getId(), aDocument.getId(), aSet);
 
@@ -438,13 +438,14 @@ public class FileSystemCasStorageDriver
     }
 
     @Override
-    public boolean existsCas(SourceDocument aDocument, CasSet aSet) throws IOException
+    public boolean existsCas(SourceDocument aDocument, AnnotationSet aSet) throws IOException
     {
         return getCasFile(aDocument, aSet).exists();
     }
 
     @Override
-    public Optional<Long> getCasFileSize(SourceDocument aDocument, CasSet aSet) throws IOException
+    public Optional<Long> getCasFileSize(SourceDocument aDocument, AnnotationSet aSet)
+        throws IOException
     {
         var file = getCasFile(aDocument, aSet);
         if (file.exists()) {
@@ -455,7 +456,7 @@ public class FileSystemCasStorageDriver
     }
 
     @Override
-    public Optional<CasStorageMetadata> getCasMetadata(SourceDocument aDocument, CasSet aSet)
+    public Optional<CasStorageMetadata> getCasMetadata(SourceDocument aDocument, AnnotationSet aSet)
         throws IOException
     {
         var casFile = getCasFile(aDocument, aSet);
@@ -468,7 +469,7 @@ public class FileSystemCasStorageDriver
     }
 
     @Override
-    public Optional<Long> verifyCasTimestamp(SourceDocument aDocument, CasSet aSet,
+    public Optional<Long> verifyCasTimestamp(SourceDocument aDocument, AnnotationSet aSet,
             long aExpectedTimeStamp, String aContextAction)
         throws IOException, ConcurentCasModificationException
     {
@@ -511,7 +512,7 @@ public class FileSystemCasStorageDriver
     }
 
     private void failOnConcurrentModification(CAS aCas, File aCasFile, SourceDocument aDocument,
-            CasSet aSet, String aContextAction)
+            AnnotationSet aSet, String aContextAction)
         throws IOException
     {
         // If the type system of the CAS does not yet support CASMetadata, then we do not add it

--- a/inception/inception-annotation-storage/src/test/java/de/tudarmstadt/ukp/inception/annotation/storage/CasStorageServiceImplTest.java
+++ b/inception/inception-annotation-storage/src/test/java/de/tudarmstadt/ukp/inception/annotation/storage/CasStorageServiceImplTest.java
@@ -21,11 +21,11 @@ import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode.EXC
 import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode.SHARED_READ_ONLY_ACCESS;
 import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode.UNMANAGED_ACCESS;
 import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode.UNMANAGED_NON_INITIALIZING_ACCESS;
-import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet.INITIAL_SET;
 import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasUpgradeMode.AUTO_CAS_UPGRADE;
 import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasUpgradeMode.FORCE_CAS_UPGRADE;
 import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasUpgradeMode.NO_CAS_UPGRADE;
 import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession.openNested;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet.INITIAL_SET;
 import static de.tudarmstadt.ukp.inception.annotation.storage.CasMetadataUtils.getInternalTypeSystem;
 import static de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil.createCas;
 import static java.lang.Thread.sleep;
@@ -63,10 +63,10 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasProvider;
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasSessionException;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
 import de.tudarmstadt.ukp.clarin.webanno.api.type.CASMetadata;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.annotation.storage.config.CasStorageBackupProperties;
@@ -131,9 +131,9 @@ public class CasStorageServiceImplTest
             var doc = makeSourceDocument(1l, 1l, "test");
             var templateCas = createCas(createTypeSystemDescription()).getJCas();
             templateCas.setDocumentText("This is a test");
-            casStorageSession.add(CasSet.forTest("cas"), EXCLUSIVE_WRITE_ACCESS,
+            casStorageSession.add(AnnotationSet.forTest("cas"), EXCLUSIVE_WRITE_ACCESS,
                     templateCas.getCas());
-            var set = CasSet.forTest("test");
+            var set = AnnotationSet.forTest("test");
 
             sut.writeCas(doc, templateCas.getCas(), set);
             assertThat(sut.existsCas(doc, set)).isTrue();
@@ -157,10 +157,11 @@ public class CasStorageServiceImplTest
             typeSystems.add(CasMetadataUtils.getInternalTypeSystem());
 
             var cas = WebAnnoCasUtil.createCas(mergeTypeSystems(typeSystems)).getJCas();
-            casStorageSession.add(CasSet.forTest("cas"), EXCLUSIVE_WRITE_ACCESS, cas.getCas());
+            casStorageSession.add(AnnotationSet.forTest("cas"), EXCLUSIVE_WRITE_ACCESS,
+                    cas.getCas());
 
             var doc = makeSourceDocument(2l, 2l, "test");
-            var set = CasSet.forTest("test");
+            var set = AnnotationSet.forTest("test");
 
             sut.writeCas(doc, cas.getCas(), set);
 
@@ -181,7 +182,7 @@ public class CasStorageServiceImplTest
         try (var casStorageSession = openNested(true)) {
             // Setup fixture
             var doc = makeSourceDocument(3l, 3l, "test");
-            var set = CasSet.forTest("test");
+            var set = AnnotationSet.forTest("test");
             var text = "This is a test";
             createCasFile(doc, set, text);
 
@@ -199,7 +200,7 @@ public class CasStorageServiceImplTest
     {
         // Setup fixture
         var doc = makeSourceDocument(4l, 4l, "test");
-        var set = CasSet.forTest("test");
+        var set = AnnotationSet.forTest("test");
         try (var session = openNested(true)) {
             var text = "This is a test";
             createCasFile(doc, set, text);
@@ -240,7 +241,7 @@ public class CasStorageServiceImplTest
     {
         // Setup fixture
         var doc = makeSourceDocument(5l, 5l, "test");
-        var set = CasSet.forTest("test");
+        var set = AnnotationSet.forTest("test");
 
         try (var session = openNested(true)) {
             createCasFile(doc, set, "This is a test");
@@ -270,7 +271,7 @@ public class CasStorageServiceImplTest
         try (CasStorageSession casStorageSession = openNested(true)) {
             // Setup fixture
             var doc = makeSourceDocument(6l, 6l, "test");
-            var set = CasSet.forTest("test");
+            var set = AnnotationSet.forTest("test");
             var casFile = driver.getCasFile(doc, set);
 
             long casFileSize;
@@ -317,7 +318,7 @@ public class CasStorageServiceImplTest
         };
 
         var doc = makeSourceDocument(7l, 7l, "doc");
-        var set = CasSet.forTest("annotator");
+        var set = AnnotationSet.forTest("annotator");
 
         // We interleave all the primary and secondary tasks into the main tasks list
         // Primary tasks run for a certain number of iterations
@@ -396,7 +397,7 @@ public class CasStorageServiceImplTest
         };
 
         var doc = makeSourceDocument(8l, 8l, "doc");
-        var set = CasSet.forTest("annotator");
+        var set = AnnotationSet.forTest("annotator");
         try (var session = openNested()) {
             // Make sure the CAS exists so that the threads should never be forced to call the
             // the initializer
@@ -459,11 +460,11 @@ public class CasStorageServiceImplTest
         extends Thread
     {
         private SourceDocument doc;
-        private CasSet set;
+        private AnnotationSet set;
         private int repeat;
         private CasProvider initializer;
 
-        public ExclusiveReadWriteTask(int n, SourceDocument aDoc, CasSet aUser,
+        public ExclusiveReadWriteTask(int n, SourceDocument aDoc, AnnotationSet aUser,
                 CasProvider aInitializer, int aRepeat)
         {
             super("RW" + n);
@@ -505,10 +506,10 @@ public class CasStorageServiceImplTest
         extends Thread
     {
         private SourceDocument doc;
-        private CasSet set;
+        private AnnotationSet set;
         private CasProvider initializer;
 
-        public SharedReadOnlyTask(int n, SourceDocument aDoc, CasSet aUser,
+        public SharedReadOnlyTask(int n, SourceDocument aDoc, AnnotationSet aUser,
                 CasProvider aInitializer)
         {
             super("RO" + n);
@@ -541,10 +542,10 @@ public class CasStorageServiceImplTest
         extends Thread
     {
         private SourceDocument doc;
-        private CasSet set;
+        private AnnotationSet set;
         private Random rnd;
 
-        public DeleterTask(int n, SourceDocument aDoc, CasSet aUser)
+        public DeleterTask(int n, SourceDocument aDoc, AnnotationSet aUser)
         {
             super("XX" + n);
             doc = aDoc;
@@ -579,10 +580,11 @@ public class CasStorageServiceImplTest
         extends Thread
     {
         private SourceDocument doc;
-        private CasSet set;
+        private AnnotationSet set;
         private CasProvider initializer;
 
-        public UnmanagedTask(int n, SourceDocument aDoc, CasSet aUser, CasProvider aInitializer)
+        public UnmanagedTask(int n, SourceDocument aDoc, AnnotationSet aUser,
+                CasProvider aInitializer)
         {
             super("UN" + n);
             doc = aDoc;
@@ -613,9 +615,9 @@ public class CasStorageServiceImplTest
         extends Thread
     {
         private SourceDocument doc;
-        private CasSet set;
+        private AnnotationSet set;
 
-        public UnmanagedNonInitializingTask(int n, SourceDocument aDoc, CasSet aUser)
+        public UnmanagedNonInitializingTask(int n, SourceDocument aDoc, AnnotationSet aUser)
         {
             super("U_" + n);
             doc = aDoc;
@@ -664,7 +666,7 @@ public class CasStorageServiceImplTest
         return CasCreationUtils.mergeTypeSystems(asList(globalTsd, internalTsd));
     }
 
-    private JCas createCasFile(SourceDocument aDoc, CasSet aSet, String aText)
+    private JCas createCasFile(SourceDocument aDoc, AnnotationSet aSet, String aText)
         throws CASException, CasSessionException, IOException
     {
         var casTemplate = sut.readOrCreateCas(aDoc, aSet, NO_CAS_UPGRADE, () -> makeCas(aText),

--- a/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/contextmenu/CheckAnnotationTask.java
+++ b/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/contextmenu/CheckAnnotationTask.java
@@ -39,8 +39,8 @@ import org.apache.commons.lang3.Validate;
 import org.apache.uima.jcas.tcas.Annotation;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
 import de.tudarmstadt.ukp.inception.assistant.AssistantService;
@@ -97,7 +97,7 @@ public class CheckAnnotationTask
     public void execute() throws Exception
     {
         try (var session = CasStorageSession.open()) {
-            var cas = documentService.readAnnotationCas(document, CasSet.forUser(dataOwner),
+            var cas = documentService.readAnnotationCas(document, AnnotationSet.forUser(dataOwner),
                     AUTO_CAS_UPGRADE, SHARED_READ_ONLY_ACCESS);
 
             var ann = selectAnnotationByAddr(cas, annotation.getId());

--- a/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/sidebar/WatchAnnotationTask.java
+++ b/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/sidebar/WatchAnnotationTask.java
@@ -38,8 +38,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
 import de.tudarmstadt.ukp.inception.assistant.AssistantService;
@@ -94,7 +94,7 @@ public class WatchAnnotationTask
     public void execute() throws Exception
     {
         try (var session = CasStorageSession.open()) {
-            var cas = documentService.readAnnotationCas(document, CasSet.forUser(dataOwner),
+            var cas = documentService.readAnnotationCas(document, AnnotationSet.forUser(dataOwner),
                     AUTO_CAS_UPGRADE, SHARED_READ_ONLY_ACCESS);
 
             var ann = selectAnnotationByAddr(cas, annotation.getId());

--- a/inception/inception-concept-linking/src/test/java/de/tudarmstadt/ukp/inception/conceptlinking/NamedEntityLinkerTest.java
+++ b/inception/inception-concept-linking/src/test/java/de/tudarmstadt/ukp/inception/conceptlinking/NamedEntityLinkerTest.java
@@ -35,10 +35,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.OverlapMode;
 import de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity;
 import de.tudarmstadt.ukp.inception.conceptlinking.recommender.NamedEntityLinker;
@@ -125,7 +125,7 @@ public class NamedEntityLinkerTest
                 conceptFeatureTraits);
 
         cas = CasFactory.createCas();
-        casStorageSession.add(CasSet.forTest("cas"), EXCLUSIVE_WRITE_ACCESS, cas);
+        casStorageSession.add(AnnotationSet.forTest("cas"), EXCLUSIVE_WRITE_ACCESS, cas);
         cas.setDocumentText(
                 "It was Barack Obama who became the 44th President of the United States of America.");
         buildAnnotation(cas, NamedEntity.class).on("Barack Obama").buildAllAndAddToIndexes();

--- a/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/export/CuratedDocumentsExporter.java
+++ b/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/export/CuratedDocumentsExporter.java
@@ -17,8 +17,8 @@
  */
 package de.tudarmstadt.ukp.inception.curation.export;
 
-import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet.CURATION_SET;
 import static de.tudarmstadt.ukp.clarin.webanno.api.export.FullProjectExportRequest.FORMAT_AUTO;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet.CURATION_SET;
 import static de.tudarmstadt.ukp.clarin.webanno.model.Mode.CURATION;
 import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.CURATION_FINISHED;
 import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.CURATION_IN_PROGRESS;
@@ -47,7 +47,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.DocumentImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.FullProjectExportRequest;
@@ -57,6 +56,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExporter;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectImportRequest;
 import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
 import de.tudarmstadt.ukp.clarin.webanno.export.model.ExportedProject;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.curation.config.CurationServiceAutoConfiguration;
@@ -267,7 +267,7 @@ public class CuratedDocumentsExporter
             var sourceDocument = documentService.getSourceDocument(aProject, fileName);
 
             try (var is = aZip.getInputStream(entry)) {
-                documentService.importCas(sourceDocument, CasSet.forUser(username), is);
+                documentService.importCas(sourceDocument, AnnotationSet.forUser(username), is);
             }
 
             LOG.info("Imported curation document content for user [" + username

--- a/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/service/CurationDocumentServiceImpl.java
+++ b/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/service/CurationDocumentServiceImpl.java
@@ -17,7 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.curation.service;
 
-import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet.CURATION_SET;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet.CURATION_SET;
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.ANNOTATOR;
 import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.CURATION_USER;
 

--- a/inception/inception-curation/src/test/java/de/tudarmstadt/ukp/inception/curation/export/CuratedDocumentsExporterTest.java
+++ b/inception/inception-curation/src/test/java/de/tudarmstadt/ukp/inception/curation/export/CuratedDocumentsExporterTest.java
@@ -39,12 +39,12 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasStorageService;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.DocumentImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectImportRequest;
 import de.tudarmstadt.ukp.clarin.webanno.diag.ChecksRegistry;
 import de.tudarmstadt.ukp.clarin.webanno.diag.RepairsRegistry;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.annotation.storage.CasStorageServiceImpl;
@@ -119,7 +119,7 @@ public class CuratedDocumentsExporterTest
         var zipFile = new ZipFile(
                 "src/test/resources/exports/Export+Test+-+Curated+annotation+project_3_6_1.zip");
         var sourceDocCaptor = ArgumentCaptor.forClass(SourceDocument.class);
-        var setCaptor = ArgumentCaptor.forClass(CasSet.class);
+        var setCaptor = ArgumentCaptor.forClass(AnnotationSet.class);
 
         // Import the project again
         var exProject = ProjectExportServiceImpl.loadExportedProject(zipFile);

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/service/DiamWebsocketController.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/service/DiamWebsocketController.java
@@ -54,11 +54,11 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.preferences.UserPreferencesService;
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
 import de.tudarmstadt.ukp.clarin.webanno.constraints.ConstraintsService;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Mode;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
@@ -284,7 +284,7 @@ public class DiamWebsocketController
 
         var constraints = constraintsService.getMergedConstraints(aProject);
 
-        var cas = documentService.readAnnotationCas(doc, CasSet.forUser(aDataOwner));
+        var cas = documentService.readAnnotationCas(doc, AnnotationSet.forUser(aDataOwner));
 
         var prefs = userPreferencesService.loadPreferences(doc.getProject(), sessionOwner,
                 Mode.ANNOTATION);

--- a/inception/inception-documents-api/src/main/java/de/tudarmstadt/ukp/inception/documents/api/DocumentService.java
+++ b/inception/inception-documents-api/src/main/java/de/tudarmstadt/ukp/inception/documents/api/DocumentService.java
@@ -31,12 +31,12 @@ import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.apache.wicket.validation.ValidationError;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode;
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasUpgradeMode;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.ConcurentCasModificationException;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentStateChangeFlag;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState;
@@ -272,7 +272,7 @@ public interface DocumentService
      * @throws IOException
      *             if an I/O error occurs.
      */
-    void writeAnnotationCas(CAS aCas, SourceDocument aDocument, CasSet aSet,
+    void writeAnnotationCas(CAS aCas, SourceDocument aDocument, AnnotationSet aSet,
             AnnotationDocumentStateChangeFlag... aFlags)
         throws IOException;
 
@@ -316,7 +316,7 @@ public interface DocumentService
      *            the set to which the CAS belongs.
      * @return if an annotation document metadata exists for the user.
      */
-    boolean existsAnnotationDocument(SourceDocument document, CasSet aSet);
+    boolean existsAnnotationDocument(SourceDocument document, AnnotationSet aSet);
 
     /**
      * check if the CAS for the {@link User} and {@link SourceDocument} in this {@link Project}
@@ -332,13 +332,15 @@ public interface DocumentService
      * @throws IOException
      *             if an I/O error occurs.
      */
-    boolean existsCas(SourceDocument sourceDocument, CasSet aSet) throws IOException;
+    boolean existsCas(SourceDocument sourceDocument, AnnotationSet aSet) throws IOException;
 
     boolean existsCas(AnnotationDocument annotationDocument) throws IOException;
 
-    void exportCas(SourceDocument aDocument, CasSet aSet, OutputStream aStream) throws IOException;
+    void exportCas(SourceDocument aDocument, AnnotationSet aSet, OutputStream aStream)
+        throws IOException;
 
-    void importCas(SourceDocument aDocument, CasSet aSet, InputStream aStream) throws IOException;
+    void importCas(SourceDocument aDocument, AnnotationSet aSet, InputStream aStream)
+        throws IOException;
 
     /**
      * Get the annotation document.
@@ -364,7 +366,7 @@ public interface DocumentService
      * @throws NoResultException
      *             if no annotation document exists for the given source/user.
      */
-    AnnotationDocument getAnnotationDocument(SourceDocument aDocument, CasSet aSet);
+    AnnotationDocument getAnnotationDocument(SourceDocument aDocument, AnnotationSet aSet);
 
     /**
      * Gets the CAS for the given annotation document. Converts it form the source document if
@@ -403,7 +405,7 @@ public interface DocumentService
 
     void deleteAnnotationCas(AnnotationDocument annotationDocument) throws IOException;
 
-    void deleteAnnotationCas(SourceDocument aSourceDocument, CasSet aSet) throws IOException;
+    void deleteAnnotationCas(SourceDocument aSourceDocument, AnnotationSet aSet) throws IOException;
 
     /**
      * Gets the CAS for the given source document. Converts it form the source document if
@@ -417,7 +419,7 @@ public interface DocumentService
      * @throws IOException
      *             if there was an I/O error.
      */
-    CAS readAnnotationCas(SourceDocument document, CasSet aSet) throws IOException;
+    CAS readAnnotationCas(SourceDocument document, AnnotationSet aSet) throws IOException;
 
     /**
      * Gets the CAS for the given source document. Converts it form the source document if
@@ -433,7 +435,7 @@ public interface DocumentService
      * @throws IOException
      *             if there was an I/O error.
      */
-    CAS readAnnotationCas(SourceDocument aDocument, CasSet aSet, CasUpgradeMode aUpgradeMode)
+    CAS readAnnotationCas(SourceDocument aDocument, AnnotationSet aSet, CasUpgradeMode aUpgradeMode)
         throws IOException;
 
     /**
@@ -452,7 +454,7 @@ public interface DocumentService
      * @throws IOException
      *             if there was an I/O error.
      */
-    CAS readAnnotationCas(SourceDocument aDocument, CasSet aSet, CasUpgradeMode aUpgradeMode,
+    CAS readAnnotationCas(SourceDocument aDocument, AnnotationSet aSet, CasUpgradeMode aUpgradeMode,
             CasAccessMode aAccessMode)
         throws IOException;
 
@@ -670,7 +672,7 @@ public interface DocumentService
      *            the user.
      * @return if the user has finished annotation.
      */
-    boolean isAnnotationFinished(SourceDocument document, CasSet username);
+    boolean isAnnotationFinished(SourceDocument document, AnnotationSet username);
 
     /**
      * Check if at least one annotation document is finished for this {@link SourceDocument} in the
@@ -701,7 +703,7 @@ public interface DocumentService
 
     AnnotationDocument createOrGetAnnotationDocument(SourceDocument aDocument, User aUser);
 
-    AnnotationDocument createOrGetAnnotationDocument(SourceDocument aDocument, CasSet aSet);
+    AnnotationDocument createOrGetAnnotationDocument(SourceDocument aDocument, AnnotationSet aSet);
 
     List<AnnotationDocument> createOrGetAnnotationDocuments(SourceDocument aDocument,
             Collection<User> aUsers);
@@ -742,7 +744,7 @@ public interface DocumentService
      *            the set to which the CASes belong.
      * @return documents.
      */
-    Map<SourceDocument, AnnotationDocument> listAllDocuments(Project aProject, CasSet aSet);
+    Map<SourceDocument, AnnotationDocument> listAllDocuments(Project aProject, AnnotationSet aSet);
 
     AnnotationDocumentState setAnnotationDocumentState(AnnotationDocument aDocument,
             AnnotationDocumentState aState, AnnotationDocumentStateChangeFlag... aFlags);
@@ -780,10 +782,10 @@ public interface DocumentService
      * @throws IOException
      *             if there was an I/O-level problem
      */
-    Optional<Long> getAnnotationCasTimestamp(SourceDocument aDocument, CasSet aSet)
+    Optional<Long> getAnnotationCasTimestamp(SourceDocument aDocument, AnnotationSet aSet)
         throws IOException;
 
-    Optional<Long> verifyAnnotationCasTimestamp(SourceDocument aDocument, CasSet aSet,
+    Optional<Long> verifyAnnotationCasTimestamp(SourceDocument aDocument, AnnotationSet aSet,
             long aExpectedTimeStamp, String aContextAction)
         throws IOException, ConcurentCasModificationException;
 

--- a/inception/inception-documents-api/src/main/java/de/tudarmstadt/ukp/inception/documents/api/export/CrossDocumentExporter_ImplBase.java
+++ b/inception/inception-documents-api/src/main/java/de/tudarmstadt/ukp/inception/documents/api/export/CrossDocumentExporter_ImplBase.java
@@ -30,8 +30,8 @@ import java.util.List;
 import org.apache.uima.cas.CAS;
 import org.springframework.http.MediaType;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 
@@ -61,7 +61,7 @@ public abstract class CrossDocumentExporter_ImplBase
 
     private CAS loadCas(SourceDocument aDocument, String aDataOwner) throws IOException
     {
-        return documentService.readAnnotationCas(aDocument, CasSet.forUser(aDataOwner),
+        return documentService.readAnnotationCas(aDocument, AnnotationSet.forUser(aDataOwner),
                 AUTO_CAS_UPGRADE, SHARED_READ_ONLY_ACCESS);
     }
 
@@ -87,7 +87,7 @@ public abstract class CrossDocumentExporter_ImplBase
 
         // If there is no CAS for the data owner, it also implies that the
         // annotation state is NEW - so we load the initial CAS.
-        if (!documentService.existsCas(aDocument, CasSet.forUser(aDataOwner))) {
+        if (!documentService.existsCas(aDocument, AnnotationSet.forUser(aDataOwner))) {
             return loadInitialCas(aDocument);
         }
 

--- a/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/DocumentAccessImpl.java
+++ b/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/DocumentAccessImpl.java
@@ -31,8 +31,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.access.AccessDeniedException;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
@@ -90,7 +90,8 @@ public class DocumentAccessImpl
 
             // Does the user have the permission to access the project at all?
             if (permissionLevels.isEmpty()) {
-                LOG.trace("Access denied: User {} has no acccess to project {}", sessionOwner, project);
+                LOG.trace("Access denied: User {} has no acccess to project {}", sessionOwner,
+                        project);
                 return false;
             }
 
@@ -111,7 +112,7 @@ public class DocumentAccessImpl
 
             // Annotators cannot view blocked documents
             var doc = documentService.getSourceDocument(project.getId(), aDocumentId);
-            var dataOwnerSet = CasSet.forUser(aDataOwner);
+            var dataOwnerSet = AnnotationSet.forUser(aDataOwner);
             if (documentService.existsAnnotationDocument(doc, dataOwnerSet)) {
                 var aDoc = documentService.getAnnotationDocument(doc, dataOwnerSet);
                 if (aDoc.getState() == AnnotationDocumentState.IGNORE) {
@@ -191,7 +192,7 @@ public class DocumentAccessImpl
             }
 
             // Blocked or finished documents cannot be edited
-            var dataOwnerSet = CasSet.forUser(aDataOwner);
+            var dataOwnerSet = AnnotationSet.forUser(aDataOwner);
             if (documentService.existsAnnotationDocument(aDocument, dataOwnerSet)) {
                 var aDoc = documentService.getAnnotationDocument(aDocument, dataOwnerSet);
                 if (aDoc.getState() == AnnotationDocumentState.FINISHED) {

--- a/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/DocumentServiceImpl.java
+++ b/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/DocumentServiceImpl.java
@@ -20,13 +20,13 @@ package de.tudarmstadt.ukp.inception.documents;
 import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode.EXCLUSIVE_WRITE_ACCESS;
 import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode.SHARED_READ_ONLY_ACCESS;
 import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode.UNMANAGED_ACCESS;
-import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet.CURATION_SET;
-import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet.INITIAL_SET;
 import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasUpgradeMode.AUTO_CAS_UPGRADE;
 import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasUpgradeMode.FORCE_CAS_UPGRADE;
 import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasUpgradeMode.NO_CAS_UPGRADE;
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState.IGNORE;
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentStateChangeFlag.EXPLICIT_ANNOTATOR_USER_ACTION;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet.CURATION_SET;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet.INITIAL_SET;
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.ANNOTATOR;
 import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.ANNOTATION_FINISHED;
 import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.ANNOTATION_IN_PROGRESS;
@@ -91,7 +91,6 @@ import org.springframework.context.event.EventListener;
 import org.springframework.transaction.annotation.Transactional;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode;
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasStorageService;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasUpgradeMode;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.ConcurentCasModificationException;
@@ -100,6 +99,7 @@ import de.tudarmstadt.ukp.clarin.webanno.api.export.DocumentImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentStateChangeFlag;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState;
@@ -248,12 +248,12 @@ public class DocumentServiceImpl
     {
         Validate.notNull(aUser, "User must be specified");
 
-        return existsAnnotationDocument(aDocument, CasSet.forUser(aUser));
+        return existsAnnotationDocument(aDocument, AnnotationSet.forUser(aUser));
     }
 
     @Override
     @Transactional(readOnly = true)
-    public boolean existsAnnotationDocument(SourceDocument aDocument, CasSet aSet)
+    public boolean existsAnnotationDocument(SourceDocument aDocument, AnnotationSet aSet)
     {
         Validate.notNull(aDocument, "Source document must be specified");
         Validate.notNull(aSet, "Set must be specified");
@@ -299,7 +299,7 @@ public class DocumentServiceImpl
     // NO TRANSACTION REQUIRED - This does not do any should not do a database access, so we do not
     // need to be in a transaction here. Avoiding the transaction speeds up the call.
     @Override
-    public boolean existsCas(SourceDocument aDocument, CasSet aSet) throws IOException
+    public boolean existsCas(SourceDocument aDocument, AnnotationSet aSet) throws IOException
     {
         return casStorageService.existsCas(aDocument, aSet);
     }
@@ -312,7 +312,7 @@ public class DocumentServiceImpl
         Validate.notNull(aAnnotationDocument, "Annotation document must be specified");
 
         return existsCas(aAnnotationDocument.getDocument(),
-                CasSet.forUser(aAnnotationDocument.getUser()));
+                AnnotationSet.forUser(aAnnotationDocument.getUser()));
     }
 
     @Override
@@ -352,14 +352,14 @@ public class DocumentServiceImpl
     }
 
     @Override
-    public void exportCas(SourceDocument aDocument, CasSet aSet, OutputStream aStream)
+    public void exportCas(SourceDocument aDocument, AnnotationSet aSet, OutputStream aStream)
         throws IOException
     {
         casStorageService.exportCas(aDocument, aSet, aStream);
     }
 
     @Override
-    public void importCas(SourceDocument aDocument, CasSet aSet, InputStream aStream)
+    public void importCas(SourceDocument aDocument, AnnotationSet aSet, InputStream aStream)
         throws IOException
     {
         casStorageService.importCas(aDocument, aSet, aStream);
@@ -425,12 +425,13 @@ public class DocumentServiceImpl
     @Transactional(noRollbackFor = NoResultException.class)
     public AnnotationDocument createOrGetAnnotationDocument(SourceDocument aDocument, User aUser)
     {
-        return createOrGetAnnotationDocument(aDocument, CasSet.forUser(aUser));
+        return createOrGetAnnotationDocument(aDocument, AnnotationSet.forUser(aUser));
     }
 
     @Override
     @Transactional(noRollbackFor = NoResultException.class)
-    public AnnotationDocument createOrGetAnnotationDocument(SourceDocument aDocument, CasSet aSet)
+    public AnnotationDocument createOrGetAnnotationDocument(SourceDocument aDocument,
+            AnnotationSet aSet)
     {
         Validate.notNull(aDocument, "Source document must be specified");
         Validate.notNull(aSet, "Set must be specified");
@@ -452,12 +453,12 @@ public class DocumentServiceImpl
     {
         Validate.notNull(aUser, "User must be specified");
 
-        return getAnnotationDocument(aDocument, CasSet.forUser(aUser.getUsername()));
+        return getAnnotationDocument(aDocument, AnnotationSet.forUser(aUser.getUsername()));
     }
 
     @Override
     @Transactional(noRollbackFor = NoResultException.class)
-    public AnnotationDocument getAnnotationDocument(SourceDocument aDocument, CasSet aSet)
+    public AnnotationDocument getAnnotationDocument(SourceDocument aDocument, AnnotationSet aSet)
     {
         Validate.notNull(aDocument, "Source document must be specified");
         Validate.notNull(aSet, "Set must be specified");
@@ -776,7 +777,7 @@ public class DocumentServiceImpl
     {
         Validate.notNull(aAnnotationDocument, "Annotation document must be specified");
         casStorageService.deleteCas(aAnnotationDocument.getDocument(),
-                CasSet.forUser(aAnnotationDocument.getUser()));
+                AnnotationSet.forUser(aAnnotationDocument.getUser()));
         entityManager.remove(aAnnotationDocument);
     }
 
@@ -914,7 +915,7 @@ public class DocumentServiceImpl
     // NO TRANSACTION REQUIRED - This does not do any should not do a database access, so we do not
     // need to be in a transaction here. Avoiding the transaction speeds up the call.
     @Override
-    public CAS readAnnotationCas(SourceDocument aDocument, CasSet aSet) throws IOException
+    public CAS readAnnotationCas(SourceDocument aDocument, AnnotationSet aSet) throws IOException
     {
         return readAnnotationCas(aDocument, aSet, NO_CAS_UPGRADE, EXCLUSIVE_WRITE_ACCESS);
     }
@@ -926,13 +927,14 @@ public class DocumentServiceImpl
         throws IOException
     {
         return readAnnotationCas(aAnnotationDocument.getDocument(),
-                CasSet.forUser(aAnnotationDocument.getUser()), NO_CAS_UPGRADE, aMode);
+                AnnotationSet.forUser(aAnnotationDocument.getUser()), NO_CAS_UPGRADE, aMode);
     }
 
     // NO TRANSACTION REQUIRED - This does not do any should not do a database access, so we do not
     // need to be in a transaction here. Avoiding the transaction speeds up the call.
     @Override
-    public CAS readAnnotationCas(SourceDocument aDocument, CasSet aSet, CasUpgradeMode aUpgradeMode)
+    public CAS readAnnotationCas(SourceDocument aDocument, AnnotationSet aSet,
+            CasUpgradeMode aUpgradeMode)
         throws IOException
     {
         return readAnnotationCas(aDocument, aSet, aUpgradeMode, EXCLUSIVE_WRITE_ACCESS);
@@ -945,15 +947,15 @@ public class DocumentServiceImpl
             CasAccessMode aMode)
         throws IOException
     {
-        return readAnnotationCas(aAnnDoc.getDocument(), CasSet.forUser(aAnnDoc.getUser()),
+        return readAnnotationCas(aAnnDoc.getDocument(), AnnotationSet.forUser(aAnnDoc.getUser()),
                 aUpgradeMode, aMode);
     }
 
     // NO TRANSACTION REQUIRED - This does not do any should not do a database access, so we do not
     // need to be in a transaction here. Avoiding the transaction speeds up the call.
     @Override
-    public CAS readAnnotationCas(SourceDocument aDocument, CasSet aSet, CasUpgradeMode aUpgradeMode,
-            CasAccessMode aMode)
+    public CAS readAnnotationCas(SourceDocument aDocument, AnnotationSet aSet,
+            CasUpgradeMode aUpgradeMode, CasAccessMode aMode)
         throws IOException
     {
         // If there is no CAS yet for the source document, create one.
@@ -994,7 +996,7 @@ public class DocumentServiceImpl
         Validate.notNull(aAnnotationDocument, "Annotation document must be specified");
 
         var doc = aAnnotationDocument.getDocument();
-        var set = CasSet.forUser(aAnnotationDocument.getUser());
+        var set = AnnotationSet.forUser(aAnnotationDocument.getUser());
 
         return readAnnotationCas(doc, set, aUpgradeMode);
     }
@@ -1049,7 +1051,7 @@ public class DocumentServiceImpl
 
         var casses = new HashMap<String, CAS>();
         for (var username : aUsernames) {
-            var cas = readAnnotationCas(aDoc, CasSet.forUser(username), AUTO_CAS_UPGRADE,
+            var cas = readAnnotationCas(aDoc, AnnotationSet.forUser(username), AUTO_CAS_UPGRADE,
                     SHARED_READ_ONLY_ACCESS);
             casses.put(username, cas);
         }
@@ -1059,7 +1061,7 @@ public class DocumentServiceImpl
     // NO TRANSACTION REQUIRED - This does not do any should not do a database access, so we do not
     // need to be in a transaction here. Avoiding the transaction speeds up the call.
     @Override
-    public Optional<Long> getAnnotationCasTimestamp(SourceDocument aDocument, CasSet aSet)
+    public Optional<Long> getAnnotationCasTimestamp(SourceDocument aDocument, AnnotationSet aSet)
         throws IOException
     {
         Validate.notNull(aDocument, "Source document must be specified");
@@ -1071,7 +1073,7 @@ public class DocumentServiceImpl
     // NO TRANSACTION REQUIRED - This does not do any should not do a database access, so we do not
     // need to be in a transaction here. Avoiding the transaction speeds up the call.
     @Override
-    public Optional<Long> verifyAnnotationCasTimestamp(SourceDocument aDocument, CasSet aSet,
+    public Optional<Long> verifyAnnotationCasTimestamp(SourceDocument aDocument, AnnotationSet aSet,
             long aExpectedTimeStamp, String aContextAction)
         throws IOException, ConcurentCasModificationException
     {
@@ -1101,7 +1103,7 @@ public class DocumentServiceImpl
         throws IOException
     {
         casStorageService.writeCas(aAnnotationDocument.getDocument(), aCas,
-                CasSet.forUser(aAnnotationDocument.getUser()));
+                AnnotationSet.forUser(aAnnotationDocument.getUser()));
 
         if (asList(aFlags).contains(EXPLICIT_ANNOTATOR_USER_ACTION)) {
             aAnnotationDocument.setTimestamp(new Timestamp(new Date().getTime()));
@@ -1113,7 +1115,8 @@ public class DocumentServiceImpl
     // NO TRANSACTION REQUIRED - This does not do any should not do a database access, so we do not
     // need to be in a transaction here. Avoiding the transaction speeds up the call.
     @Override
-    public void deleteAnnotationCas(SourceDocument aSourceDocument, CasSet aSet) throws IOException
+    public void deleteAnnotationCas(SourceDocument aSourceDocument, AnnotationSet aSet)
+        throws IOException
     {
         casStorageService.deleteCas(aSourceDocument, aSet);
     }
@@ -1124,12 +1127,12 @@ public class DocumentServiceImpl
     public void deleteAnnotationCas(AnnotationDocument aAnnotationDocument) throws IOException
     {
         casStorageService.deleteCas(aAnnotationDocument.getDocument(),
-                CasSet.forUser(aAnnotationDocument.getUser()));
+                AnnotationSet.forUser(aAnnotationDocument.getUser()));
     }
 
     @Override
     @Transactional
-    public void writeAnnotationCas(CAS aCas, SourceDocument aDocument, CasSet aUser,
+    public void writeAnnotationCas(CAS aCas, SourceDocument aDocument, AnnotationSet aUser,
             AnnotationDocumentStateChangeFlag... aFlags)
         throws IOException
     {
@@ -1161,7 +1164,7 @@ public class DocumentServiceImpl
 
         // Add/update the CAS metadata
         var timestamp = casStorageService.getCasTimestamp(aDocument,
-                CasSet.forUser(aUser.getUsername()));
+                AnnotationSet.forUser(aUser.getUsername()));
         if (timestamp.isPresent()) {
             addOrUpdateCasMetadata(cas, timestamp.get(), aDocument, aUser.getUsername());
         }
@@ -1179,12 +1182,12 @@ public class DocumentServiceImpl
     @Transactional(readOnly = true)
     public boolean isAnnotationFinished(SourceDocument aDocument, User aUser)
     {
-        return isAnnotationFinished(aDocument, CasSet.forUser(aUser));
+        return isAnnotationFinished(aDocument, AnnotationSet.forUser(aUser));
     }
 
     @Override
     @Transactional(noRollbackFor = NoResultException.class, readOnly = true)
-    public boolean isAnnotationFinished(SourceDocument aDocument, CasSet aSet)
+    public boolean isAnnotationFinished(SourceDocument aDocument, AnnotationSet aSet)
     {
         var query = String.join("\n", //
                 "SELECT COUNT(*) FROM AnnotationDocument", //
@@ -1273,7 +1276,7 @@ public class DocumentServiceImpl
     public Map<SourceDocument, AnnotationDocument> listAnnotatableDocuments(Project aProject,
             User aUser)
     {
-        var map = listAllDocuments(aProject, CasSet.forUser(aUser));
+        var map = listAllDocuments(aProject, AnnotationSet.forUser(aUser));
 
         var i = map.entrySet().iterator();
         while (i.hasNext()) {
@@ -1288,7 +1291,8 @@ public class DocumentServiceImpl
 
     @Override
     @Transactional(noRollbackFor = NoResultException.class)
-    public Map<SourceDocument, AnnotationDocument> listAllDocuments(Project aProject, CasSet aSet)
+    public Map<SourceDocument, AnnotationDocument> listAllDocuments(Project aProject,
+            AnnotationSet aSet)
     {
         // First get the source documents
         var sourceDocsQuery = "FROM SourceDocument WHERE project = (:project)";
@@ -1579,7 +1583,7 @@ public class DocumentServiceImpl
         for (SourceDocument doc : listSourceDocuments(aProject)) {
             for (AnnotationDocument ann : listAllAnnotationDocuments(doc)) {
                 try {
-                    casStorageService.upgradeCas(doc, CasSet.forUser(ann.getUser()));
+                    casStorageService.upgradeCas(doc, AnnotationSet.forUser(ann.getUser()));
                 }
                 catch (FileNotFoundException e) {
                     // If there is no CAS file, we do not have to upgrade it. Ignoring.

--- a/inception/inception-example-imls-data-majority/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/datamajority/DataMajorityNerRecommenderTest.java
+++ b/inception/inception-example-imls-data-majority/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/datamajority/DataMajorityNerRecommenderTest.java
@@ -53,10 +53,10 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity;
 import de.tudarmstadt.ukp.inception.recommendation.api.evaluation.DataSplitter;
 import de.tudarmstadt.ukp.inception.recommendation.api.evaluation.EvaluationResult;
@@ -105,7 +105,7 @@ public class DataMajorityNerRecommenderTest
 
         CAS cas = casList.get(0);
         try (CasStorageSession session = CasStorageSession.open()) {
-            session.add(CasSet.forTest("testCas"), EXCLUSIVE_WRITE_ACCESS, cas);
+            session.add(AnnotationSet.forTest("testCas"), EXCLUSIVE_WRITE_ACCESS, cas);
             addPredictionFeatures(cas, NamedEntity.class.getName(), "value");
         }
 

--- a/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/DocumentImportExportServiceImpl.java
+++ b/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/DocumentImportExportServiceImpl.java
@@ -62,7 +62,6 @@ import org.springframework.context.event.EventListener;
 import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 import org.springframework.transaction.annotation.Transactional;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasStorageService;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.DocumentImportExportService;
@@ -72,6 +71,7 @@ import de.tudarmstadt.ukp.clarin.webanno.diag.ChecksRegistry;
 import de.tudarmstadt.ukp.clarin.webanno.diag.RepairsRegistry;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Mode;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
@@ -238,14 +238,14 @@ public class DocumentImportExportServiceImpl
                 bulkOperationContext = new HashMap<>();
             }
 
-            CasSet set;
+            AnnotationSet set;
             switch (aMode) {
             case ANNOTATION:
-                set = CasSet.forUser(aDataOwner);
+                set = AnnotationSet.forUser(aDataOwner);
                 break;
             case CURATION:
                 // The merge result will be exported
-                set = CasSet.CURATION_SET;
+                set = AnnotationSet.CURATION_SET;
                 break;
             default:
                 throw new IllegalArgumentException("Unknown mode [" + aMode + "]");
@@ -457,7 +457,7 @@ public class DocumentImportExportServiceImpl
 
             try (var session = CasStorageSession.openNested()) {
                 var exportCas = WebAnnoCasUtil.createCas();
-                session.add(CasSet.EXPORT_SET, EXCLUSIVE_WRITE_ACCESS, exportCas);
+                session.add(AnnotationSet.EXPORT_SET, EXCLUSIVE_WRITE_ACCESS, exportCas);
 
                 // Update type system the CAS, compact it (remove all non-reachable feature
                 // structures) and remove all internal feature structures in the process

--- a/inception/inception-export/src/test/java/de/tudarmstadt/ukp/inception/export/DocumentImportExportServiceImplTest.java
+++ b/inception/inception-export/src/test/java/de/tudarmstadt/ukp/inception/export/DocumentImportExportServiceImplTest.java
@@ -66,13 +66,13 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.MDC;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
 import de.tudarmstadt.ukp.clarin.webanno.api.type.CASMetadata;
 import de.tudarmstadt.ukp.clarin.webanno.diag.ChecksRegistry;
 import de.tudarmstadt.ukp.clarin.webanno.diag.RepairsRegistry;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData;
@@ -226,7 +226,7 @@ public class DocumentImportExportServiceImplTest
         // Prepare a test CAS with a CASMetadata annotation (DocumentMetaData is added as well
         // because the DKPro Core writers used by the ImportExportService expect it.
         var jcas = createJCas(typesystem);
-        casStorageSession.add(CasSet.forTest("jcas"), EXCLUSIVE_WRITE_ACCESS, jcas.getCas());
+        casStorageSession.add(AnnotationSet.forTest("jcas"), EXCLUSIVE_WRITE_ACCESS, jcas.getCas());
         jcas.setDocumentText("This is a test .");
         DocumentMetaData.create(jcas);
         var cmd = new CASMetadata(jcas);
@@ -243,7 +243,8 @@ public class DocumentImportExportServiceImplTest
         // Read the XMI back from the ZIP that was created by the exporter. This is because XMI
         // files are always serialized as XMI file + type system file.
         var jcas = JCasFactory.createJCas(tsd);
-        casStorageSession.add(CasSet.forTest("jcas2"), EXCLUSIVE_WRITE_ACCESS, jcas.getCas());
+        casStorageSession.add(AnnotationSet.forTest("jcas2"), EXCLUSIVE_WRITE_ACCESS,
+                jcas.getCas());
         try (var zipInput = new ZipArchiveInputStream(new FileInputStream(exportedXmi))) {
             ZipArchiveEntry entry;
             while ((entry = zipInput.getNextEntry()) != null) {

--- a/inception/inception-imls-external/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/v1/ExternalRecommenderIntegrationTest.java
+++ b/inception/inception-imls-external/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/v1/ExternalRecommenderIntegrationTest.java
@@ -49,12 +49,12 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
 import de.tudarmstadt.ukp.clarin.webanno.api.type.CASMetadata;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity;
 import de.tudarmstadt.ukp.inception.annotation.storage.CasMetadataUtils;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
@@ -210,8 +210,8 @@ public class ExternalRecommenderIntegrationTest
             for (int i = 0; i < data.size(); i++) {
                 var cas = data.get(i);
                 addCasMetadata(cas.getJCas(), i);
-                casStorageSession.add(CasSet.forTest("testDataCas" + i), EXCLUSIVE_WRITE_ACCESS,
-                        cas);
+                casStorageSession.add(AnnotationSet.forTest("testDataCas" + i),
+                        EXCLUSIVE_WRITE_ACCESS, cas);
             }
             return data;
         }

--- a/inception/inception-imls-opennlp/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/doccat/OpenNlpDoccatRecommenderTest.java
+++ b/inception/inception-imls-opennlp/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/doccat/OpenNlpDoccatRecommenderTest.java
@@ -48,10 +48,10 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
 import de.tudarmstadt.ukp.inception.recommendation.api.evaluation.IncrementalSplitter;
@@ -104,7 +104,7 @@ public class OpenNlpDoccatRecommenderTest
 
         var cas = casList.get(0);
         try (var session = CasStorageSession.open()) {
-            session.add(CasSet.forTest("testCas"), EXCLUSIVE_WRITE_ACCESS, cas);
+            session.add(AnnotationSet.forTest("testCas"), EXCLUSIVE_WRITE_ACCESS, cas);
             RecommenderTestHelper.addPredictionFeatures(cas, NamedEntity.class, "value");
         }
 

--- a/inception/inception-imls-opennlp/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/ner/OpenNlpNerRecommenderTest.java
+++ b/inception/inception-imls-opennlp/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/ner/OpenNlpNerRecommenderTest.java
@@ -48,10 +48,10 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
 import de.tudarmstadt.ukp.inception.recommendation.api.evaluation.IncrementalSplitter;
@@ -150,7 +150,7 @@ public class OpenNlpNerRecommenderTest
 
         var cas = casList.get(0);
         try (var session = CasStorageSession.open()) {
-            session.add(CasSet.forTest("testCas"), EXCLUSIVE_WRITE_ACCESS, cas);
+            session.add(AnnotationSet.forTest("testCas"), EXCLUSIVE_WRITE_ACCESS, cas);
             RecommenderTestHelper.addPredictionFeatures(cas, NamedEntity.class, "value");
         }
 
@@ -180,7 +180,7 @@ public class OpenNlpNerRecommenderTest
 
         var cas = casList.get(0);
         try (var session = CasStorageSession.open()) {
-            session.add(CasSet.forTest("testCas"), EXCLUSIVE_WRITE_ACCESS, cas);
+            session.add(AnnotationSet.forTest("testCas"), EXCLUSIVE_WRITE_ACCESS, cas);
             RecommenderTestHelper.addPredictionFeatures(cas, NamedEntity.class,
                     NamedEntity._FeatName_value);
         }
@@ -281,7 +281,7 @@ public class OpenNlpNerRecommenderTest
     {
         var cas = CasFactory.createCas();
         try (var session = CasStorageSession.open()) {
-            session.add(CasSet.forTest("testCas"), EXCLUSIVE_WRITE_ACCESS, cas);
+            session.add(AnnotationSet.forTest("testCas"), EXCLUSIVE_WRITE_ACCESS, cas);
             RecommenderTestHelper.addPredictionFeatures(cas, NamedEntity.class,
                     NamedEntity._FeatName_value);
         }

--- a/inception/inception-imls-opennlp/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/pos/OpenNlpPosRecommenderTest.java
+++ b/inception/inception-imls-opennlp/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/opennlp/pos/OpenNlpPosRecommenderTest.java
@@ -41,10 +41,10 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.POS;
 import de.tudarmstadt.ukp.inception.recommendation.api.evaluation.DataSplitter;
 import de.tudarmstadt.ukp.inception.recommendation.api.evaluation.EvaluationResult;
@@ -98,7 +98,7 @@ public class OpenNlpPosRecommenderTest
 
         CAS cas = casList.get(0);
         try (CasStorageSession session = CasStorageSession.open()) {
-            session.add(CasSet.forTest("testCas"), EXCLUSIVE_WRITE_ACCESS, cas);
+            session.add(AnnotationSet.forTest("testCas"), EXCLUSIVE_WRITE_ACCESS, cas);
             RecommenderTestHelper.addPredictionFeatures(cas, POS.class, "PosValue");
         }
 

--- a/inception/inception-imls-stringmatch/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/relation/StringMatchingRelationRecommenderTest.java
+++ b/inception/inception-imls-stringmatch/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/relation/StringMatchingRelationRecommenderTest.java
@@ -39,10 +39,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
 import de.tudarmstadt.ukp.inception.recommendation.api.recommender.PredictionContext;
 import de.tudarmstadt.ukp.inception.recommendation.api.recommender.RecommenderContext;
@@ -156,7 +156,8 @@ public class StringMatchingRelationRecommenderTest
 
         try (var is = newInputStream(root.resolve("relation_test.xmi"))) {
             XmlCasDeserializer.deserialize(is, cas);
-            casStorageSession.add(CasSet.forTest("testDataCas"), EXCLUSIVE_WRITE_ACCESS, cas);
+            casStorageSession.add(AnnotationSet.forTest("testDataCas"), EXCLUSIVE_WRITE_ACCESS,
+                    cas);
             RecommenderTestHelper.addPredictionFeatures(cas, RELATION_LAYER, "value");
 
             return cas;

--- a/inception/inception-imls-stringmatch/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/span/StringMatchingRecommenderTest.java
+++ b/inception/inception-imls-stringmatch/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/span/StringMatchingRecommenderTest.java
@@ -52,10 +52,10 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
@@ -162,7 +162,7 @@ public class StringMatchingRecommenderTest
         var builder = new TokenBuilder<>(Token.class, Sentence.class);
         builder.buildTokens(jcas, "John Smith. Peter Johnheim .");
         var cas = jcas.getCas();
-        casStorageSession.add(CasSet.forTest("cas"), EXCLUSIVE_WRITE_ACCESS, cas);
+        casStorageSession.add(AnnotationSet.forTest("cas"), EXCLUSIVE_WRITE_ACCESS, cas);
 
         RecommenderTestHelper.addPredictionFeatures(cas, NamedEntity.class, "value");
 
@@ -192,7 +192,7 @@ public class StringMatchingRecommenderTest
         var builder = new TokenBuilder<>(Token.class, Sentence.class);
         builder.buildTokens(jcas, "John Smith .\nPeter Johnheim .");
         var cas = jcas.getCas();
-        casStorageSession.add(CasSet.forTest("cas"), EXCLUSIVE_WRITE_ACCESS, cas);
+        casStorageSession.add(AnnotationSet.forTest("cas"), EXCLUSIVE_WRITE_ACCESS, cas);
 
         RecommenderTestHelper.addPredictionFeatures(cas, NamedEntity.class, "value");
 
@@ -477,7 +477,7 @@ public class StringMatchingRecommenderTest
             var cas = JCasFactory.createJCas();
             reader.getNext(cas.getCas());
             casList.add(cas.getCas());
-            casStorageSession.add(CasSet.forTest("testDataCas" + n), EXCLUSIVE_WRITE_ACCESS,
+            casStorageSession.add(AnnotationSet.forTest("testDataCas" + n), EXCLUSIVE_WRITE_ACCESS,
                     cas.getCas());
         }
 

--- a/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/AnnotationDocument.java
+++ b/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/AnnotationDocument.java
@@ -54,7 +54,7 @@ public class AnnotationDocument
     private Long id;
 
     @Deprecated
-    @Column(nullable = false)
+    @Column(name = "name", nullable = false)
     private String name;
 
     @Deprecated
@@ -62,6 +62,7 @@ public class AnnotationDocument
     @JoinColumn(name = "project")
     private Project project;
 
+    @Column(name = "user")
     private String user;
 
     @ManyToOne
@@ -72,7 +73,7 @@ public class AnnotationDocument
      * The effective state of the annotation document. This state may be set by the annotator user
      * or by a third person (e.g. curator/manager) or the system (e.g. workload manager).
      */
-    @Column(nullable = false)
+    @Column(name = "state", nullable = false)
     @Type(AnnotationDocumentStateType.class)
     private AnnotationDocumentState state = AnnotationDocumentState.NEW;
 
@@ -84,7 +85,7 @@ public class AnnotationDocument
      * allow managers to see whether an annotation document as marked as finished by the annotator
      * or if it was marked as finished by the manager or by the system.
      */
-    @Column(nullable = true)
+    @Column(name = "annotatorState", nullable = true)
     @Type(AnnotationDocumentStateType.class)
     private AnnotationDocumentState annotatorState;
 
@@ -92,7 +93,7 @@ public class AnnotationDocument
      * Comment the anntoator can leave when marking a document as finished. Typically used to report
      * problems to the curator.
      */
-    @Column(length = 64000)
+    @Column(name = "annotatorComment", length = 64000)
     private String annotatorComment;
 
     /**
@@ -112,11 +113,11 @@ public class AnnotationDocument
     private int sentenceAccessed = 0;
 
     @Temporal(TemporalType.TIMESTAMP)
-    @Column(nullable = true)
+    @Column(name = "created", nullable = true)
     private Date created;
 
     @Temporal(TemporalType.TIMESTAMP)
-    @Column(nullable = true)
+    @Column(name = "updated", nullable = true)
     private Date updated;
 
     private AnnotationDocument(Builder builder)
@@ -200,14 +201,32 @@ public class AnnotationDocument
         project = aProject;
     }
 
+    /**
+     * @deprecated Use {@link #getAnnotationSet}
+     */
+    @Deprecated
     public String getUser()
     {
         return user;
     }
 
+    /**
+     * @deprecated Use {@link #setAnnotationSet}
+     */
+    @Deprecated
     public void setUser(String aUser)
     {
         user = aUser;
+    }
+
+    public AnnotationSet getAnnotationSet()
+    {
+        return AnnotationSet.forUser(user);
+    }
+
+    public void setAnnotationSet(AnnotationSet aSet)
+    {
+        user = aSet.id();
     }
 
     public AnnotationDocumentState getState()

--- a/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/AnnotationSet.java
+++ b/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/AnnotationSet.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package de.tudarmstadt.ukp.clarin.webanno.api.casstorage;
+package de.tudarmstadt.ukp.clarin.webanno.model;
 
 import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.CURATION_USER;
 import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.INITIAL_CAS_PSEUDO_USER;
@@ -24,14 +24,14 @@ import org.apache.commons.lang3.Validate;
 
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 
-public record CasSet(String id) {
-    public static final CasSet EXPORT_SET = forSpecialPurpose("exportCas");
-    public static final CasSet PREDICTION_SET = forSpecialPurpose("predictionCas");
-    public static final CasSet INITIAL_SET = forSpecialPurpose(INITIAL_CAS_PSEUDO_USER);
-    public static final CasSet CURATION_SET = forSpecialPurpose(CURATION_USER);
+public record AnnotationSet(String id) {
+    public static final AnnotationSet EXPORT_SET = forSpecialPurpose("exportCas");
+    public static final AnnotationSet PREDICTION_SET = forSpecialPurpose("predictionCas");
+    public static final AnnotationSet INITIAL_SET = forSpecialPurpose(INITIAL_CAS_PSEUDO_USER);
+    public static final AnnotationSet CURATION_SET = forSpecialPurpose(CURATION_USER);
 
     @Deprecated
-    public CasSet(String id)
+    public AnnotationSet(String id)
     {
         Validate.notBlank(id, "id must not be blank");
 
@@ -44,23 +44,23 @@ public record CasSet(String id) {
         return id;
     }
 
-    public static CasSet forUser(String aUsername)
+    public static AnnotationSet forUser(String aUsername)
     {
-        return new CasSet(aUsername);
+        return new AnnotationSet(aUsername);
     }
 
-    public static CasSet forUser(User aUser)
+    public static AnnotationSet forUser(User aUser)
     {
         return forUser(aUser.getUsername());
     }
 
-    public static CasSet forTest(String aName)
+    public static AnnotationSet forTest(String aName)
     {
-        return new CasSet(aName);
+        return new AnnotationSet(aName);
     }
 
-    public static CasSet forSpecialPurpose(String aPurpose)
+    public static AnnotationSet forSpecialPurpose(String aPurpose)
     {
-        return new CasSet(aPurpose);
+        return new AnnotationSet(aPurpose);
     }
 }

--- a/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/page/CollectTableDataTask.java
+++ b/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/page/CollectTableDataTask.java
@@ -40,10 +40,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
@@ -191,8 +191,8 @@ public class CollectTableDataTask<A extends Serializable, T extends FeatureStruc
 
     private Optional<CAS> loadCas(SourceDocument aDocument, String aDataOwner) throws IOException
     {
-        var cas = documentService.readAnnotationCas(aDocument, CasSet.forUser(aDataOwner), AUTO_CAS_UPGRADE,
-                SHARED_READ_ONLY_ACCESS);
+        var cas = documentService.readAnnotationCas(aDocument, AnnotationSet.forUser(aDataOwner),
+                AUTO_CAS_UPGRADE, SHARED_READ_ONLY_ACCESS);
 
         // Set the CAS name in the DocumentMetaData so that we can pick it
         // up in the Diff position for the purpose of debugging / transparency.

--- a/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/page/PivotTablePage.java
+++ b/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/page/PivotTablePage.java
@@ -118,7 +118,7 @@ public class PivotTablePage
 
     private final WebMarkupContainer cellExtractorsContainer;
     private final ListView<ExtractorDecl> cellExtractors;
-    
+
     private final IModel<PivotTableFilterState> filterStateModel;
 
     public PivotTablePage(PageParameters aParameters)
@@ -129,8 +129,8 @@ public class PivotTablePage
 
         requireProjectRole(sessionOwner, MANAGER, CURATOR);
 
-        filterStateModel = Model.of(new PivotTableFilterState()); 
-        
+        filterStateModel = Model.of(new PivotTableFilterState());
+
         pivotTable = buildExampleTable();
         queue(pivotTable);
 
@@ -413,8 +413,8 @@ public class PivotTablePage
 
         var result = task.getResult();
         result.setFilterState(filterStateModel.getObject());
-        pivotTable = (PivotTable) pivotTable.replaceWith(
-                new PivotTable<>("pivotTable", result, agg.createCellRenderer()));
+        pivotTable = (PivotTable) pivotTable
+                .replaceWith(new PivotTable<>("pivotTable", result, agg.createCellRenderer()));
         aTarget.add(pivotTable);
     }
 

--- a/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/table/PivotTable.java
+++ b/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/table/PivotTable.java
@@ -129,9 +129,9 @@ public class PivotTable<A extends Serializable, T>
                         (s, v) -> s.setHideRowsWithSameValuesInAllColumns(!v)));
         hideRowsWithSameValuesInAllColumns.setOutputMarkupId(true);
         hideRowsWithSameValuesInAllColumns
-        .add(new LambdaAjaxFormComponentUpdatingBehavior(CHANGE_EVENT, _target -> {
-            _target.add(table, navigator, navigatorLabel, filterPanel);
-        }));
+                .add(new LambdaAjaxFormComponentUpdatingBehavior(CHANGE_EVENT, _target -> {
+                    _target.add(table, navigator, navigatorLabel, filterPanel);
+                }));
         queue(hideRowsWithSameValuesInAllColumns);
 
         var hideRowsWithAnyDifferentValue = new CheckBox("showRowsWithAnyDifferentValue",
@@ -140,11 +140,10 @@ public class PivotTable<A extends Serializable, T>
                         (s, v) -> s.setHideRowsWithAnyDifferentValue(!v)));
         hideRowsWithAnyDifferentValue.setOutputMarkupId(true);
         hideRowsWithAnyDifferentValue
-        .add(new LambdaAjaxFormComponentUpdatingBehavior(CHANGE_EVENT, _target -> {
-            _target.add(table, navigator, navigatorLabel, filterPanel);
-        }));
+                .add(new LambdaAjaxFormComponentUpdatingBehavior(CHANGE_EVENT, _target -> {
+                    _target.add(table, navigator, navigatorLabel, filterPanel);
+                }));
         queue(hideRowsWithAnyDifferentValue);
-
 
         var showRowsWithEmptyValues = new CheckBox("showRowsWithEmptyValues",
                 LambdaModel.of(filterState, //
@@ -152,9 +151,9 @@ public class PivotTable<A extends Serializable, T>
                         (s, v) -> s.setHideRowsWithEmptyValues(!v)));
         showRowsWithEmptyValues.setOutputMarkupId(true);
         showRowsWithEmptyValues
-        .add(new LambdaAjaxFormComponentUpdatingBehavior(CHANGE_EVENT, _target -> {
-            _target.add(table, navigator, navigatorLabel, filterPanel);
-        }));
+                .add(new LambdaAjaxFormComponentUpdatingBehavior(CHANGE_EVENT, _target -> {
+                    _target.add(table, navigator, navigatorLabel, filterPanel);
+                }));
         queue(showRowsWithEmptyValues);
 
         var showRowsWithoutEmptyValues = new CheckBox("showRowsWithoutEmptyValues",
@@ -163,9 +162,9 @@ public class PivotTable<A extends Serializable, T>
                         (s, v) -> s.setHideRowsWithoutEmptyValues(!v)));
         showRowsWithoutEmptyValues.setOutputMarkupId(true);
         showRowsWithoutEmptyValues
-        .add(new LambdaAjaxFormComponentUpdatingBehavior(CHANGE_EVENT, _target -> {
-            _target.add(table, navigator, navigatorLabel, filterPanel);
-        }));
+                .add(new LambdaAjaxFormComponentUpdatingBehavior(CHANGE_EVENT, _target -> {
+                    _target.add(table, navigator, navigatorLabel, filterPanel);
+                }));
         queue(showRowsWithoutEmptyValues);
     }
 

--- a/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/table/PivotTableDataProvider.java
+++ b/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/table/PivotTableDataProvider.java
@@ -68,32 +68,33 @@ public class PivotTableDataProvider<A extends Serializable, T>
         setSort(ROW_KEY, ASCENDING);
         filterState = new PivotTableFilterState();
     }
-    
+
     @Override
     public PivotTableFilterState getFilterState()
     {
         return filterState;
     }
-    
+
     @Override
     public void setFilterState(PivotTableFilterState aState)
     {
         filterState = aState;
     }
-    
+
     private Stream<CompoundKey> filter(Map<CompoundKey, Map<CompoundKey, A>> aData)
     {
         var rowKeyStream = aData.keySet().stream();
 
-        if (filterState.isHideRowsWithSameValuesInAllColumns() || filterState.isHideRowsWithAnyDifferentValue()) {
+        if (filterState.isHideRowsWithSameValuesInAllColumns()
+                || filterState.isHideRowsWithAnyDifferentValue()) {
             rowKeyStream = rowKeyStream.filter(row -> {
                 var values = aData.get(row).values();
                 if (isNotEmpty(values)) {
                     var first = values.iterator().next();
                     var matchCount = values.stream() //
-                        .filter(v -> Objects.equals(first, v)) //
-                        .count();
-                    
+                            .filter(v -> Objects.equals(first, v)) //
+                            .count();
+
                     if (filterState.isHideRowsWithSameValuesInAllColumns()) {
                         // There is at least one column that has a different value than the others
                         return matchCount != columnKeys.size();
@@ -104,7 +105,7 @@ public class PivotTableDataProvider<A extends Serializable, T>
                         return matchCount == columnKeys.size();
                     }
                 }
-                
+
                 // All columns are empty (have the same value)
                 return !filterState.isHideRowsWithSameValuesInAllColumns();
             });
@@ -115,8 +116,8 @@ public class PivotTableDataProvider<A extends Serializable, T>
                 var values = aData.get(row).values();
                 if (isNotEmpty(values)) {
                     var nonNullCount = values.stream() //
-                        .filter(Objects::nonNull) //
-                        .count();
+                            .filter(Objects::nonNull) //
+                            .count();
                     if (filterState.isHideRowsWithEmptyValues()) {
                         return nonNullCount == columnKeys.size();
                     }
@@ -125,7 +126,7 @@ public class PivotTableDataProvider<A extends Serializable, T>
                         return nonNullCount < columnKeys.size();
                     }
                 }
-                
+
                 // All columns are empty
                 return !filterState.isHideRowsWithEmptyValues();
             });
@@ -139,9 +140,10 @@ public class PivotTableDataProvider<A extends Serializable, T>
         var rowKeyStream = aRowKeyStream;
         if (getSort() != null && getSort().getProperty() != null) {
             var ascending = getSort().isAscending();
-            rowKeyStream = rowKeyStream.sorted(ascending ? this::rowComparator : (a, b) -> rowComparator(b, a));
+            rowKeyStream = rowKeyStream
+                    .sorted(ascending ? this::rowComparator : (a, b) -> rowComparator(b, a));
         }
-        
+
         return rowKeyStream;
     }
 
@@ -181,7 +183,7 @@ public class PivotTableDataProvider<A extends Serializable, T>
     public Iterator<Row<A>> iterator(long first, long count)
     {
         var visibleRowKeys = sort(filter(rows)).toList();
-        
+
         return new Iterator<Row<A>>()
         {
             private final Iterator<CompoundKey> rowKeyIterator = visibleRowKeys.iterator();

--- a/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/table/PivotTableFilterState.java
+++ b/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/table/PivotTableFilterState.java
@@ -39,7 +39,7 @@ public class PivotTableFilterState
         if (aHideRowsWithSameValuesInAllColumns) {
             hideRowsWithAnyDifferentValue = false;
         }
-        
+
         hideRowsWithSameValuesInAllColumns = aHideRowsWithSameValuesInAllColumns;
     }
 
@@ -66,7 +66,7 @@ public class PivotTableFilterState
         if (aHideRowsWithEmptyValues) {
             hideRowsWithoutEmptyValues = false;
         }
-        
+
         hideRowsWithEmptyValues = aHideRowsWithEmptyValues;
     }
 
@@ -80,7 +80,7 @@ public class PivotTableFilterState
         if (aHideRowsWithoutEmptyValues) {
             hideRowsWithEmptyValues = false;
         }
-        
+
         hideRowsWithoutEmptyValues = aHideRowsWithoutEmptyValues;
     }
 }

--- a/inception/inception-processing/src/main/java/de/tudarmstadt/ukp/inception/processing/curation/BulkCurationTask.java
+++ b/inception/inception-processing/src/main/java/de/tudarmstadt/ukp/inception/processing/curation/BulkCurationTask.java
@@ -42,9 +42,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.inception.curation.api.DiffAdapterRegistry;
 import de.tudarmstadt.ukp.inception.curation.merge.strategy.MergeStrategy;
 import de.tudarmstadt.ukp.inception.curation.merge.strategy.MergeStrategyFactory;
@@ -109,7 +109,8 @@ public class BulkCurationTask
                     users.removeIf(u -> targetUser.equals(u.getUsername()));
 
                     var targetCas = documentService.readAnnotationCas(doc,
-                            CasSet.forUser(targetUser), FORCE_CAS_UPGRADE, EXCLUSIVE_WRITE_ACCESS);
+                            AnnotationSet.forUser(targetUser), FORCE_CAS_UPGRADE,
+                            EXCLUSIVE_WRITE_ACCESS);
 
                     var annotatorCasses = documentService.readAllCasesSharedNoUpgrade(doc, users);
 
@@ -120,7 +121,7 @@ public class BulkCurationTask
                             mergeStrategy, annotationLayers, true);
 
                     var targetAnnDoc = documentService.createOrGetAnnotationDocument(doc,
-                            CasSet.forUser(targetUser));
+                            AnnotationSet.forUser(targetUser));
                     documentService.writeAnnotationCas(targetCas, targetAnnDoc,
                             EXPLICIT_ANNOTATOR_USER_ACTION);
 

--- a/inception/inception-processing/src/main/java/de/tudarmstadt/ukp/inception/processing/recommender/BulkPredictionTask.java
+++ b/inception/inception-processing/src/main/java/de/tudarmstadt/ukp/inception/processing/recommender/BulkPredictionTask.java
@@ -46,12 +46,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.inception.annotation.layer.document.api.DocumentMetadataLayerAdapter;
@@ -159,8 +159,9 @@ public class BulkPredictionTask
 
                     documentService.setAnnotationDocumentState(annDoc, IN_PROGRESS,
                             EXPLICIT_ANNOTATOR_USER_ACTION);
-                    var cas = documentService.readAnnotationCas(doc, CasSet.forUser(dataOwner),
-                            AUTO_CAS_UPGRADE, EXCLUSIVE_WRITE_ACCESS);
+                    var cas = documentService.readAnnotationCas(doc,
+                            AnnotationSet.forUser(dataOwner), AUTO_CAS_UPGRADE,
+                            EXCLUSIVE_WRITE_ACCESS);
 
                     addProcessingMetadataAnnotation(doc, cas);
 
@@ -168,8 +169,8 @@ public class BulkPredictionTask
                     annotationsCount.addAndGet(autoAcceptedSuggestions);
 
                     if (autoAcceptedSuggestions > 0) {
-                        documentService.writeAnnotationCas(cas, doc, CasSet.forUser(dataOwner),
-                                EXPLICIT_ANNOTATOR_USER_ACTION);
+                        documentService.writeAnnotationCas(cas, doc,
+                                AnnotationSet.forUser(dataOwner), EXPLICIT_ANNOTATOR_USER_ACTION);
                     }
 
                     if (autoAcceptedSuggestions > 0 || finishDocumentsWithoutRecommendations) {

--- a/inception/inception-project-export/src/main/java/de/tudarmstadt/ukp/inception/project/export/task/curated/CuratedDocumentsProjectExportTask.java
+++ b/inception/inception-project-export/src/main/java/de/tudarmstadt/ukp/inception/project/export/task/curated/CuratedDocumentsProjectExportTask.java
@@ -17,8 +17,8 @@
  */
 package de.tudarmstadt.ukp.inception.project.export.task.curated;
 
-import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet.CURATION_SET;
 import static de.tudarmstadt.ukp.clarin.webanno.api.export.FullProjectExportRequest.FORMAT_AUTO;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet.CURATION_SET;
 import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.CURATION_USER;
 import static java.lang.invoke.MethodHandles.lookup;
 import static org.apache.commons.io.FileUtils.forceDelete;

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/LazyCasLoader.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/LazyCasLoader.java
@@ -37,8 +37,8 @@ import org.apache.uima.fit.util.CasUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
@@ -92,7 +92,8 @@ public class LazyCasLoader
     {
         var casses = new ArrayList<TrainingDocument>();
 
-        var allDocuments = documentService.listAllDocuments(project, CasSet.forUser(dataOwner));
+        var allDocuments = documentService.listAllDocuments(project,
+                AnnotationSet.forUser(dataOwner));
         for (var entry : allDocuments.entrySet()) {
             var sourceDocument = entry.getKey();
             var annotationDocument = entry.getValue();
@@ -137,7 +138,7 @@ public class LazyCasLoader
     private class TrainingDocument
     {
         private final SourceDocument document;
-        private final CasSet set;
+        private final AnnotationSet set;
         private final AnnotationDocumentState state;
 
         private boolean attemptedLoading = false;
@@ -147,7 +148,7 @@ public class LazyCasLoader
                 AnnotationDocumentState aState)
         {
             document = aDocument;
-            set = CasSet.forUser(aDataOwner);
+            set = AnnotationSet.forUser(aDataOwner);
             state = aState;
         }
 

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/PredictionTask.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/PredictionTask.java
@@ -50,8 +50,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
@@ -1049,8 +1049,9 @@ public class PredictionTask
         public CAS get() throws IOException
         {
             if (originalCas == null) {
-                originalCas = documentService.readAnnotationCas(document, CasSet.forUser(dataOwner),
-                        AUTO_CAS_UPGRADE, SHARED_READ_ONLY_ACCESS);
+                originalCas = documentService.readAnnotationCas(document,
+                        AnnotationSet.forUser(dataOwner), AUTO_CAS_UPGRADE,
+                        SHARED_READ_ONLY_ACCESS);
             }
 
             return originalCas;
@@ -1065,7 +1066,7 @@ public class PredictionTask
         public PredictionCasHolder() throws ResourceInitializationException
         {
             cas = WebAnnoCasUtil.createCas();
-            CasStorageSession.get().add(CasSet.PREDICTION_SET, EXCLUSIVE_WRITE_ACCESS, cas);
+            CasStorageSession.get().add(AnnotationSet.PREDICTION_SET, EXCLUSIVE_WRITE_ACCESS, cas);
         }
 
         @Override

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/SelectionTask.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/SelectionTask.java
@@ -37,9 +37,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
@@ -426,8 +426,9 @@ public class SelectionTask
         for (var document : documentService.listSourceDocuments(aProject)) {
             try {
                 // We should not have to modify the CASes... right? Fingers crossed.
-                CAS cas = documentService.readAnnotationCas(document, CasSet.forUser(aUserName),
-                        AUTO_CAS_UPGRADE, SHARED_READ_ONLY_ACCESS);
+                CAS cas = documentService.readAnnotationCas(document,
+                        AnnotationSet.forUser(aUserName), AUTO_CAS_UPGRADE,
+                        SHARED_READ_ONLY_ACCESS);
                 casses.add(cas);
             }
             catch (IOException e) {

--- a/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/tasks/PredictionTaskTest.java
+++ b/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/tasks/PredictionTaskTest.java
@@ -44,10 +44,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
@@ -120,7 +120,7 @@ class PredictionTaskTest
                 any(TypeSystemDescription.class));
 
         try (var session = CasStorageSession.open()) {
-            session.add(CasSet.forTest("jCas"), EXCLUSIVE_WRITE_ACCESS, jCas.getCas());
+            session.add(AnnotationSet.forTest("jCas"), EXCLUSIVE_WRITE_ACCESS, jCas.getCas());
             sut.cloneAndMonkeyPatchCAS(project, jCas.getCas(), jCas.getCas());
         }
 

--- a/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/exporters/AnnotationDocumentExporter.java
+++ b/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/exporters/AnnotationDocumentExporter.java
@@ -17,8 +17,8 @@
  */
 package de.tudarmstadt.ukp.inception.schema.exporters;
 
-import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet.INITIAL_SET;
 import static de.tudarmstadt.ukp.clarin.webanno.api.export.FullProjectExportRequest.FORMAT_AUTO;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet.INITIAL_SET;
 import static de.tudarmstadt.ukp.clarin.webanno.model.Mode.ANNOTATION;
 import static de.tudarmstadt.ukp.clarin.webanno.security.UserDaoImpl.RESERVED_USERNAMES;
 import static de.tudarmstadt.ukp.inception.project.api.ProjectService.ANNOTATION_FOLDER;
@@ -62,7 +62,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.DocumentImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.FullProjectExportRequest;
@@ -75,6 +74,7 @@ import de.tudarmstadt.ukp.clarin.webanno.export.model.ExportedAnnotationDocument
 import de.tudarmstadt.ukp.clarin.webanno.export.model.ExportedProject;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
@@ -252,7 +252,7 @@ public class AnnotationDocumentExporter
                         ProjectExporter.writeEntry(aStage, ANNOTATION_CAS_FOLDER + srcDoc.getName()
                                 + "/" + annDoc.getUser() + ".ser", os -> {
                                     documentService.exportCas(srcDoc,
-                                            CasSet.forUser(annDoc.getUser()), os);
+                                            AnnotationSet.forUser(annDoc.getUser()), os);
                                 });
 
                         if (format != null) {

--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/ReindexTask.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/ReindexTask.java
@@ -23,8 +23,8 @@ package de.tudarmstadt.ukp.inception.search;
 
 import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode.UNMANAGED_ACCESS;
 import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode.UNMANAGED_NON_INITIALIZING_ACCESS;
-import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet.CURATION_SET;
 import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasUpgradeMode.NO_CAS_UPGRADE;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet.CURATION_SET;
 import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.CURATION_FINISHED;
 import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.CURATION_IN_PROGRESS;
 import static de.tudarmstadt.ukp.inception.scheduling.MatchResult.DISCARD_OR_QUEUE_THIS;

--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/scheduling/tasks/IndexAnnotationDocumentTask.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/scheduling/tasks/IndexAnnotationDocumentTask.java
@@ -36,8 +36,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.scheduling.MatchResult;
 import de.tudarmstadt.ukp.inception.scheduling.Progress;
@@ -80,7 +80,8 @@ public class IndexAnnotationDocumentTask
         try (CasStorageSession session = CasStorageSession.open()) {
             var aDoc = getAnnotationDocument();
             var cas = documentService.readAnnotationCas(aDoc.getDocument(),
-                    CasSet.forUser(aDoc.getUser()), AUTO_CAS_UPGRADE, SHARED_READ_ONLY_ACCESS);
+                    AnnotationSet.forUser(aDoc.getUser()), AUTO_CAS_UPGRADE,
+                    SHARED_READ_ONLY_ACCESS);
             searchService.indexDocument(aDoc, WebAnnoCasUtil.casToByteArray(cas));
         }
         catch (IOException e) {

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPageBase2.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPageBase2.java
@@ -60,11 +60,11 @@ import de.tudarmstadt.ukp.clarin.webanno.api.annotation.actionbar.ActionBar;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.paging.NoPagingStrategy;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.preferences.UserPreferencesService;
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.constraints.ConstraintsService;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentStateChangeFlag;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Mode;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
@@ -393,13 +393,13 @@ public abstract class AnnotationPageBase2
         if (isEditable() && state.getAnnotationDocumentTimestamp().isPresent()) {
             documentService
                     .verifyAnnotationCasTimestamp(state.getDocument(),
-                            CasSet.forUser(state.getUser()),
+                            AnnotationSet.forUser(state.getUser()),
                             state.getAnnotationDocumentTimestamp().get(), "reading the editor CAS")
                     .ifPresent(state::setAnnotationDocumentTimestamp);
         }
 
         return documentService.readAnnotationCas(state.getDocument(),
-                CasSet.forUser(state.getUser()));
+                AnnotationSet.forUser(state.getUser()));
     }
 
     @Override
@@ -416,7 +416,8 @@ public abstract class AnnotationPageBase2
     public void bumpAnnotationCasTimestamp(AnnotatorState aState) throws IOException
     {
         documentService
-                .getAnnotationCasTimestamp(aState.getDocument(), CasSet.forUser(aState.getUser()))
+                .getAnnotationCasTimestamp(aState.getDocument(),
+                        AnnotationSet.forUser(aState.getUser()))
                 .ifPresent(aState::setAnnotationDocumentTimestamp);
     }
 
@@ -738,7 +739,7 @@ public abstract class AnnotationPageBase2
     public List<AnnotationDocument> listAccessibleDocuments(Project aProject, User aUser)
     {
         var allDocuments = new ArrayList<AnnotationDocument>();
-        var docs = documentService.listAllDocuments(aProject, CasSet.forUser(aUser));
+        var docs = documentService.listAllDocuments(aProject, AnnotationSet.forUser(aUser));
 
         var sessionOwner = userRepository.getCurrentUser();
         for (var e : docs.entrySet()) {

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/AnnotatorsPanel.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/AnnotatorsPanel.java
@@ -60,11 +60,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wicketstuff.jquery.ui.widget.menu.IMenuItem;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.brat.schema.BratSchemaGenerator;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.ConfigurationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
@@ -381,7 +381,7 @@ public class AnnotatorsPanel
     private CAS readAnnotatorCas(AnnotatorSegmentState aSegment) throws IOException
     {
         return documentService.readAnnotationCas(aSegment.getAnnotatorState().getDocument(),
-                CasSet.forUser(aSegment.getUser()));
+                AnnotationSet.forUser(aSegment.getUser()));
     }
 
     /**
@@ -447,7 +447,7 @@ public class AnnotatorsPanel
         // The source CASes from the annotators are all ready read-only / shared
         for (var user : curationDocumentService.listCuratableUsers(aDocument)) {
             casses.put(user.getUsername(),
-                    documentService.readAnnotationCas(aDocument, CasSet.forUser(user)));
+                    documentService.readAnnotationCas(aDocument, AnnotationSet.forUser(user)));
         }
 
         return casses;

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/BratSuggestionVisualizer.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/BratSuggestionVisualizer.java
@@ -56,13 +56,13 @@ import de.agilecoders.wicket.core.markup.html.bootstrap.image.Icon;
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.icon.FontAwesome5IconType;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.comment.AnnotatorCommentDialogPanel;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasProvider;
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.brat.annotation.BratRequestUtils;
 import de.tudarmstadt.ukp.clarin.webanno.brat.message.GetCollectionInformationResponse;
 import de.tudarmstadt.ukp.clarin.webanno.brat.render.BratSerializer;
 import de.tudarmstadt.ukp.clarin.webanno.brat.resource.BratCurationResourceReference;
 import de.tudarmstadt.ukp.clarin.webanno.brat.schema.BratSchemaGenerator;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.ui.curation.component.model.AnnotatorSegmentState;
@@ -193,7 +193,7 @@ public abstract class BratSuggestionVisualizer
     {
         var username = getModelObject().getUser().getUsername();
         var doc = getModelObject().getAnnotatorState().getDocument();
-        var annDoc = documentService.getAnnotationDocument(doc, CasSet.forUser(username));
+        var annDoc = documentService.getAnnotationDocument(doc, AnnotationSet.forUser(username));
         var annDocState = annDoc.getState();
 
         switch (annDocState) {
@@ -217,7 +217,7 @@ public abstract class BratSuggestionVisualizer
     {
         var username = getModelObject().getUser().getUsername();
         var doc = getModelObject().getAnnotatorState().getDocument();
-        return documentService.getAnnotationDocument(doc, CasSet.forUser(username));
+        return documentService.getAnnotationDocument(doc, AnnotationSet.forUser(username));
     }
 
     private String maybeAnonymizeUsername(AnnotatorSegmentState aSegment)
@@ -389,7 +389,7 @@ public abstract class BratSuggestionVisualizer
                 AnnotatorState state = segment.getAnnotatorState();
                 CasProvider casProvider = () -> documentService.readAnnotationCas(
                         segment.getAnnotatorState().getDocument(),
-                        CasSet.forUser(segment.getUser().getUsername()));
+                        AnnotationSet.forUser(segment.getUser().getUsername()));
                 var result = lazyDetailsLookupService.lookupLazyDetails(request, paramId,
                         casProvider, state.getDocument(), segment.getUser(),
                         state.getWindowBeginOffset(), state.getWindowEndOffset());

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/LegacyCurationPage.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/LegacyCurationPage.java
@@ -69,12 +69,12 @@ import org.wicketstuff.kendo.ui.widget.splitter.SplitterBehavior;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.actionbar.ActionBar;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.paging.SentenceOrientedPagingStrategy;
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.brat.annotation.BratLineOrientedAnnotationEditorFactory;
 import de.tudarmstadt.ukp.clarin.webanno.brat.annotation.BratSentenceOrientedAnnotationEditorFactory;
 import de.tudarmstadt.ukp.clarin.webanno.constraints.ConstraintsService;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiffSummaryState;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Mode;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
@@ -759,8 +759,8 @@ public class LegacyCurationPage
             // We need a modifiable copy of some annotation document which we can use to initialize
             // the curation CAS. This is an exceptional case where UNMANAGED_ACCESS is the correct
             // choice
-            mergeCas = documentService.readAnnotationCas(aDocument, CasSet.forUser(aTemplateUser),
-                    FORCE_CAS_UPGRADE, UNMANAGED_ACCESS);
+            mergeCas = documentService.readAnnotationCas(aDocument,
+                    AnnotationSet.forUser(aTemplateUser), FORCE_CAS_UPGRADE, UNMANAGED_ACCESS);
             curationMergeService.mergeCasses(aState.getDocument(), aState.getUser().getUsername(),
                     mergeCas, aCasses, aMergeStrategy, aState.getAnnotationLayers(), true);
             curationDocumentService.deleteCurationCas(aDocument);

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationEditorExtension.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationEditorExtension.java
@@ -40,10 +40,10 @@ import org.springframework.context.ApplicationEventPublisher;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.NotEditableException;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
@@ -132,7 +132,7 @@ public class CurationEditorExtension
         var doc = aState.getDocument();
         var srcUser = curationVid.getUsername();
 
-        if (!documentService.existsAnnotationDocument(doc, CasSet.forUser(srcUser))) {
+        if (!documentService.existsAnnotationDocument(doc, AnnotationSet.forUser(srcUser))) {
             LOG.error("Source CAS of [{}] for curation not found", srcUser);
             return;
         }
@@ -153,7 +153,7 @@ public class CurationEditorExtension
         // get user CAS and annotation (to be merged into curator's)
         var vid = VID.parse(curationVid.getExtensionPayload());
 
-        var srcCas = documentService.readAnnotationCas(doc, CasSet.forUser(srcUser));
+        var srcCas = documentService.readAnnotationCas(doc, AnnotationSet.forUser(srcUser));
         var sourceAnnotation = selectAnnotationByAddr(srcCas, vid.getId());
 
         aActionHandler.actionJump(aTarget, sourceAnnotation.getBegin(), sourceAnnotation.getEnd());
@@ -191,7 +191,7 @@ public class CurationEditorExtension
             return null;
         }
 
-        var srcSet = CasSet.forUser(curationVid.getUsername());
+        var srcSet = AnnotationSet.forUser(curationVid.getUsername());
 
         if (!documentService.existsAnnotationDocument(aDocument, srcSet)) {
             LOG.error("Source CAS of [{}] for curation not found", srcSet);
@@ -220,7 +220,7 @@ public class CurationEditorExtension
 
         var vid = VID.parse(aCurationVid.getExtensionPayload());
 
-        var srcCas = documentService.readAnnotationCas(doc, CasSet.forUser(srcUser));
+        var srcCas = documentService.readAnnotationCas(doc, AnnotationSet.forUser(srcUser));
         var sourceAnnotation = selectAnnotationByAddr(srcCas, vid.getId());
         var layer = annotationService.findLayer(aState.getProject(), sourceAnnotation);
 
@@ -295,7 +295,8 @@ public class CurationEditorExtension
             var curationVid = CurationVID.parse(aVid.getExtensionPayload());
             var vid = VID.parse(curationVid.getExtensionPayload());
             var srcUser = curationVid.getUsername();
-            var srcCas = documentService.readAnnotationCas(aDocument, CasSet.forUser(srcUser));
+            var srcCas = documentService.readAnnotationCas(aDocument,
+                    AnnotationSet.forUser(srcUser));
             var features = annotationService.listEnabledFeatures(aLayer).stream() //
                     .filter(f -> f.isIncludeInHover()) //
                     .filter(f -> NONE == f.getMultiValueMode()) //
@@ -386,7 +387,7 @@ public class CurationEditorExtension
         for (var user : selectedUsers) {
             try {
                 var userCas = documentService.readAnnotationCas(aDocument,
-                        CasSet.forUser(user.getUsername()));
+                        AnnotationSet.forUser(user.getUsername()));
                 casses.put(user.getUsername(), userCas);
             }
             catch (IOException e) {

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebarBehavior.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebarBehavior.java
@@ -39,7 +39,7 @@ import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.slf4j.Logger;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
@@ -161,7 +161,7 @@ public class CurationSidebarBehavior
                 // currently see a good way to avoid this duplication. At least we only do it twice
                 // if an initial merge is required.
                 documentService.readAnnotationCas(state.getDocument(),
-                        CasSet.forUser(state.getUser()), FORCE_CAS_UPGRADE);
+                        AnnotationSet.forUser(state.getUser()), FORCE_CAS_UPGRADE);
                 var selectedUsers = curationSidebarService.getSelectedUsers(sessionOwner,
                         project.getId());
 

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebarServiceImpl.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebarServiceImpl.java
@@ -54,8 +54,8 @@ import org.springframework.security.core.session.SessionDestroyedEvent;
 import org.springframework.security.core.session.SessionRegistry;
 import org.springframework.transaction.annotation.Transactional;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasStorageService;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
@@ -285,7 +285,8 @@ public class CurationSidebarServiceImpl
             return empty();
         }
 
-        return Optional.of(documentService.readAnnotationCas(aDoc, CasSet.forUser(curationUser)));
+        return Optional
+                .of(documentService.readAnnotationCas(aDoc, AnnotationSet.forUser(curationUser)));
     }
 
     /**
@@ -308,7 +309,7 @@ public class CurationSidebarServiceImpl
         var doc = aState.getDocument();
         var annoDoc = documentService.createOrGetAnnotationDocument(doc, curator);
         documentService.writeAnnotationCas(aTargetCas, annoDoc, EXPLICIT_ANNOTATOR_USER_ACTION);
-        casStorageService.getCasTimestamp(doc, CasSet.forUser(curator.getUsername()))
+        casStorageService.getCasTimestamp(doc, AnnotationSet.forUser(curator.getUsername()))
                 .ifPresent(aState::setAnnotationDocumentTimestamp);
     }
 

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/render/CurationSidebarRenderer.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/render/CurationSidebarRenderer.java
@@ -37,12 +37,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.annotation.Order;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.Configuration;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.DiffResult;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.internal.AID;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.inception.annotation.layer.span.api.SpanPosition;
@@ -320,7 +320,7 @@ public class CurationSidebarRenderer
         for (var user : selectedUsers) {
             try {
                 var userCas = documentService.readAnnotationCas(aRequest.getSourceDocument(),
-                        CasSet.forUser(user));
+                        AnnotationSet.forUser(user));
                 casses.put(user.getUsername(), userCas);
             }
             catch (IOException e) {

--- a/inception/inception-ui-curation/src/test/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/render/CurationSidebarRendererTest.java
+++ b/inception/inception-ui-curation/src/test/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/render/CurationSidebarRendererTest.java
@@ -44,12 +44,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.constraints.ConstraintsService;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.DiffAdapterRegistryImpl;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.DiffSupportRegistryImpl;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.OverlapMode;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
@@ -612,9 +612,9 @@ class CurationSidebarRendererTest
         vdoc.setText(aText);
         vdoc.setWindow(0, aText.length());
 
-        when(documentService.readAnnotationCas(doc, CasSet.forUser(anno1.getUsername())))
+        when(documentService.readAnnotationCas(doc, AnnotationSet.forUser(anno1.getUsername())))
                 .thenReturn(anno1Cas);
-        when(documentService.readAnnotationCas(doc, CasSet.forUser(anno2.getUsername())))
+        when(documentService.readAnnotationCas(doc, AnnotationSet.forUser(anno2.getUsername())))
                 .thenReturn(anno2Cas);
 
         return RenderRequest.builder() //

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/casdoctor/CasDoctorTask_ImplBase.java
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/casdoctor/CasDoctorTask_ImplBase.java
@@ -18,7 +18,7 @@
 package de.tudarmstadt.ukp.clarin.webanno.ui.project.casdoctor;
 
 import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode.UNMANAGED_NON_INITIALIZING_ACCESS;
-import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet.INITIAL_SET;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet.INITIAL_SET;
 import static de.tudarmstadt.ukp.inception.scheduling.TaskScope.PROJECT;
 
 import java.io.IOException;

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/casdoctor/CheckTask.java
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/casdoctor/CheckTask.java
@@ -18,8 +18,8 @@
 package de.tudarmstadt.ukp.clarin.webanno.ui.project.casdoctor;
 
 import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode.UNMANAGED_NON_INITIALIZING_ACCESS;
-import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet.CURATION_SET;
-import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet.INITIAL_SET;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet.CURATION_SET;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet.INITIAL_SET;
 import static de.tudarmstadt.ukp.inception.scheduling.TaskScope.PROJECT;
 import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.CURATION_USER;
 import static java.util.Arrays.asList;
@@ -34,11 +34,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasStorageService;
 import de.tudarmstadt.ukp.clarin.webanno.diag.CasDoctorImpl;
 import de.tudarmstadt.ukp.clarin.webanno.diag.ChecksRegistry;
 import de.tudarmstadt.ukp.clarin.webanno.diag.RepairsRegistry;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.support.logging.LogMessage;
 
@@ -153,7 +153,7 @@ public class CheckTask
                         if (documentService.existsCas(ad)) {
                             objectCount++;
                             casStorageService.forceActionOnCas(ad.getDocument(),
-                                    CasSet.forUser(ad.getUser()),
+                                    AnnotationSet.forUser(ad.getUser()),
                                     (doc, set) -> casStorageService.readCas(doc, set,
                                             UNMANAGED_NON_INITIALIZING_ACCESS),
                                     (doc, set, cas) -> casDoctor.analyze(doc, set.id(), cas,

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/casdoctor/RepairTask.java
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/casdoctor/RepairTask.java
@@ -18,8 +18,8 @@
 package de.tudarmstadt.ukp.clarin.webanno.ui.project.casdoctor;
 
 import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode.UNMANAGED_NON_INITIALIZING_ACCESS;
-import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet.CURATION_SET;
-import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet.INITIAL_SET;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet.CURATION_SET;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet.INITIAL_SET;
 import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.CURATION_FINISHED;
 import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.CURATION_IN_PROGRESS;
 import static de.tudarmstadt.ukp.inception.scheduling.TaskScope.PROJECT;
@@ -36,11 +36,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasStorageService;
 import de.tudarmstadt.ukp.clarin.webanno.diag.CasDoctorImpl;
 import de.tudarmstadt.ukp.clarin.webanno.diag.ChecksRegistry;
 import de.tudarmstadt.ukp.clarin.webanno.diag.RepairsRegistry;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.support.logging.LogMessage;
 
@@ -157,7 +157,8 @@ public class RepairTask
                     var messageSet = new LogMessageSet(sd.getName() + " [" + ad.getUser() + "]");
                     try {
                         if (documentService.existsCas(ad)) {
-                            casStorageService.forceActionOnCas(sd, CasSet.forUser(ad.getUser()),
+                            casStorageService.forceActionOnCas(sd,
+                                    AnnotationSet.forUser(ad.getUser()),
                                     (doc, set) -> casStorageService.readCas(doc, set,
                                             UNMANAGED_NON_INITIALIZING_ACCESS),
                                     (doc, set, cas) -> casDoctor.repair(doc, set.id(), cas,

--- a/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchAnnotationSidebar.java
+++ b/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchAnnotationSidebar.java
@@ -82,9 +82,9 @@ import de.agilecoders.wicket.core.markup.html.bootstrap.navigation.BootstrapPagi
 import de.agilecoders.wicket.core.markup.html.bootstrap.navigation.ajax.BootstrapAjaxPagingNavigator;
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.icon.FontAwesome5IconType;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasProvider;
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.LinkMode;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
@@ -916,7 +916,7 @@ public class SearchAnnotationSidebar
             return;
         }
 
-        documentService.writeAnnotationCas(aCas, aSourceDoc, CasSet.forUser(state.getUser()),
+        documentService.writeAnnotationCas(aCas, aSourceDoc, AnnotationSet.forUser(state.getUser()),
                 EXPLICIT_ANNOTATOR_USER_ACTION);
     }
 

--- a/inception/inception-versioning/src/main/java/de/tudarmstadt/ukp/inception/versioning/VersioningServiceImpl.java
+++ b/inception/inception-versioning/src/main/java/de/tudarmstadt/ukp/inception/versioning/VersioningServiceImpl.java
@@ -42,11 +42,11 @@ import org.springframework.context.event.EventListener;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.FileSystemUtils;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasStorageService;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
 import de.tudarmstadt.ukp.clarin.webanno.export.model.ExportedAnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.export.model.ExportedAnnotationLayerReference;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.inception.curation.service.CurationDocumentService;
@@ -154,7 +154,7 @@ public class VersioningServiceImpl
             // Dump annotation documents
             for (var annotationDocument : documentService.listAnnotationDocuments(sourceDocument)) {
 
-                var set = CasSet.forUser(annotationDocument.getUser());
+                var set = AnnotationSet.forUser(annotationDocument.getUser());
                 var annotationDocumentPath = sourceDir.resolve(set + ".xmi");
 
                 try (var session = CasStorageSession.openNested();

--- a/inception/inception-workload-dynamic/src/test/java/de/tudarmstadt/ukp/inception/workload/dynamic/DynamicWorkloadExtensionImpl2Test.java
+++ b/inception/inception-workload-dynamic/src/test/java/de/tudarmstadt/ukp/inception/workload/dynamic/DynamicWorkloadExtensionImpl2Test.java
@@ -58,11 +58,11 @@ import org.springframework.jdbc.datasource.DriverManagerDataSource;
 import org.springframework.security.core.session.SessionRegistry;
 import org.springframework.util.FileSystemUtils;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.DocumentImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.constraints.config.ConstraintsServiceAutoConfiguration;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState;
@@ -180,7 +180,7 @@ class DynamicWorkloadExtensionImpl2Test
         dynamicWorkloadExtension.writeTraits(traits, project);
 
         var ann = documentService.getAnnotationDocument(annotationDocument.getDocument(),
-                CasSet.forUser(annotationDocument.getUser()));
+                AnnotationSet.forUser(annotationDocument.getUser()));
         assertThat(ann.getState()) //
                 .as("Effective state is in-progress after the CAS update")
                 .isEqualTo(AnnotationDocumentState.IN_PROGRESS);
@@ -193,7 +193,8 @@ class DynamicWorkloadExtensionImpl2Test
         dynamicWorkloadExtension.freshenStatus(project);
 
         var annAfterRefresh = documentService.getAnnotationDocument(
-                annotationDocument.getDocument(), CasSet.forUser(annotationDocument.getUser()));
+                annotationDocument.getDocument(),
+                AnnotationSet.forUser(annotationDocument.getUser()));
         assertThat(annAfterRefresh.getState())
                 .as("After the abandonation timeout has passed, the effective state has been reset")
                 .isEqualTo(traits.getAbandonationState());
@@ -211,7 +212,7 @@ class DynamicWorkloadExtensionImpl2Test
         dynamicWorkloadExtension.writeTraits(traits, project);
 
         var ann = documentService.getAnnotationDocument(annotationDocument.getDocument(),
-                CasSet.forUser(annotationDocument.getUser()));
+                AnnotationSet.forUser(annotationDocument.getUser()));
         assertThat(ann.getState()) //
                 .as("Effective state is in-progress after the CAS update")
                 .isEqualTo(AnnotationDocumentState.IN_PROGRESS);
@@ -231,7 +232,7 @@ class DynamicWorkloadExtensionImpl2Test
         }
 
         var annAfterRefresh = documentService.getAnnotationDocument(ann.getDocument(),
-                CasSet.forUser(ann.getUser()));
+                AnnotationSet.forUser(ann.getUser()));
 
         assertThat(annAfterRefresh.getUpdated()) //
                 .as("Database record was not updated at all") //

--- a/inception/inception-workload-dynamic/src/test/java/de/tudarmstadt/ukp/inception/workload/dynamic/DynamicWorkloadExtensionImplTest.java
+++ b/inception/inception-workload-dynamic/src/test/java/de/tudarmstadt/ukp/inception/workload/dynamic/DynamicWorkloadExtensionImplTest.java
@@ -48,11 +48,11 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.util.FileSystemUtils;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasSet;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.DocumentImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.constraints.config.ConstraintsServiceAutoConfiguration;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.project.config.ProjectServiceAutoConfiguration;
@@ -183,7 +183,7 @@ public class DynamicWorkloadExtensionImplTest
         Fixtures.importTestSourceDocumentAndAddNamedEntity(documentService, ann);
         ann.setState(AnnotationDocumentState.IN_PROGRESS);
         ann = documentService.getAnnotationDocument(ann.getDocument(),
-                CasSet.forUser(ann.getUser()));
+                AnnotationSet.forUser(ann.getUser()));
         ann.setTimestamp(new Date(Instant.now().plus(1, ChronoUnit.HOURS).toEpochMilli()));
         documentService.createOrUpdateAnnotationDocument(ann);
 


### PR DESCRIPTION
**What's in the PR**
- Rename CasSet to AnnotationSet and move it to the model module

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
