### PR TITLE
#5657 - Filter in annotation sidebar causes browser to lock up

### DIFF
--- a/inception/inception-diam-editor/src/main/ts/build.mjs
+++ b/inception/inception-diam-editor/src/main/ts/build.mjs
@@ -43,7 +43,8 @@ const defaults = {
     sassPlugin(),
     esbuildSvelte({
       compilerOptions: { 
-        runes: true
+        runes: true,
+        dev: argv.live
       },
       preprocess: sveltePreprocess()
     })


### PR DESCRIPTION
**What's in the PR**
- Use derivedBy instead of effect to avoid endless update loop

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
