### PR TITLE
#5660 - Line breaks from multi-line string features are removed in annotation popover

### DIFF
--- a/inception/inception-js-api/src/main/ts/src/widget/AnnotationDetailPopOver.svelte
+++ b/inception/inception-js-api/src/main/ts/src/widget/AnnotationDetailPopOver.svelte
@@ -190,7 +190,7 @@
     </div>
     {#if annotation}
         <div class="popover-body p-0">
-            {#if annotation.comments}
+            {#if annotation.comments && annotation.comments.length > 0}
                 <div class="p-1">
                     {#each annotation.comments as comment}
                         <div class="i7n-marker-{comment.type}">{comment.comment}</div>
@@ -214,7 +214,7 @@
                                 <div class="fw-bold">{detailGroup.title}</div>
                             {/if}
                             {#each detailGroup.details as detail}
-                                <div class:ps-2={detailGroup.title}>
+                                <div class:ps-2={detailGroup.title} style="white-space: pre-line;">
                                     <span class="fw-semibold">{detail.label}:</span>
                                     {detail.value}
                                 </div>


### PR DESCRIPTION
**What's in the PR**
- Fix empty element when no annotation comments are provided
- Preserve manual line-breaks in popover. This currently affects all detail groups including the "text". Need to see if this is a good idea.

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
