### PR TITLE
#5679 - Allow calculating agreement vs original document

### DIFF
--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/unitizing/PairwiseUnitizingAgreementTable.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/results/unitizing/PairwiseUnitizingAgreementTable.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.clarin.webanno.agreement.results.unitizing;
 
 import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.CURATION_USER;
+import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.INITIAL_CAS_PSEUDO_USER;
 import static de.tudarmstadt.ukp.inception.support.lambda.HtmlElementEvents.CLICK_EVENT;
 import static de.tudarmstadt.ukp.inception.support.lambda.LambdaBehavior.visibleWhen;
 import static java.lang.String.format;
@@ -102,6 +103,10 @@ public class PairwiseUnitizingAgreementTable
 
                 if (getModelObject().getRaters().contains(CURATION_USER)) {
                     raters.add(userRepository.getCurationUser());
+                }
+
+                if (getModelObject().getRaters().contains(INITIAL_CAS_PSEUDO_USER)) {
+                    raters.add(userRepository.getInitialCasUser());
                 }
             }
             return raters;

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/UserDao.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/UserDao.java
@@ -112,6 +112,8 @@ public interface UserDao
 
     User getCurationUser();
 
+    User getInitialCasUser();
+
     User getUserByRealmAndUiName(Realm aRealm, String aUiName);
 
     User getUserByRealmAndUiName(String aRealm, String aUiName);

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/UserDaoImpl.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/UserDaoImpl.java
@@ -314,6 +314,14 @@ public class UserDaoImpl
     }
 
     @Override
+    public User getInitialCasUser()
+    {
+        var user = new User(INITIAL_CAS_PSEUDO_USER);
+        user.setUiName("Original");
+        return user;
+    }
+
+    @Override
     @Transactional
     public User getUserOrCurationUser(String aUsername)
     {

--- a/inception/inception-ui-agreement/src/main/java/de/tudarmstadt/ukp/inception/ui/agreement/page/AgreementPage.html
+++ b/inception/inception-ui-agreement/src/main/java/de/tudarmstadt/ukp/inception/ui/agreement/page/AgreementPage.html
@@ -44,6 +44,14 @@
               </div>
               <div class="form-row">
                 <div class="form-check form-switch">
+                  <input wicket:id="compareWithInitialCas" class="form-check-input" type="checkbox"/>
+                  <label wicket:for="compareWithInitialCas" class="form-check-label">
+                    <wicket:label key="compareWithInitialCas"/>
+                  </label>
+                </div>
+              </div>
+              <div class="form-row">
+                <div class="form-check form-switch">
                   <input wicket:id="compareWithCurator" class="form-check-input" type="checkbox"/>
                   <label wicket:for="compareWithCurator" class="form-check-label">
                     <wicket:label key="compareWithCurator"/>

--- a/inception/inception-ui-agreement/src/main/java/de/tudarmstadt/ukp/inception/ui/agreement/page/AgreementPage.java
+++ b/inception/inception-ui-agreement/src/main/java/de/tudarmstadt/ukp/inception/ui/agreement/page/AgreementPage.java
@@ -26,6 +26,7 @@ import static de.tudarmstadt.ukp.inception.documents.api.export.CrossDocumentExp
 import static de.tudarmstadt.ukp.inception.documents.api.export.CrossDocumentExporter.EXT_JSON;
 import static de.tudarmstadt.ukp.inception.scheduling.TaskScope.LAST_USER_SESSION;
 import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.CURATION_USER;
+import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.INITIAL_CAS_PSEUDO_USER;
 import static de.tudarmstadt.ukp.inception.support.lambda.HtmlElementEvents.CHANGE_EVENT;
 import static de.tudarmstadt.ukp.inception.support.lambda.LambdaBehavior.enabledWhen;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -186,6 +187,8 @@ public class AgreementPage
         queue(measureDropDown = makeMeasuresDropdown("measure"));
 
         queue(new CheckBox("compareWithCurator").setOutputMarkupId(true));
+
+        queue(new CheckBox("compareWithInitialCas").setOutputMarkupId(true));
 
         var annotatorList = new ListMultipleChoice<ProjectUserPermissions>("annotators");
         annotatorList.setChoiceRenderer(new ProjectUserPermissionChoiceRenderer());
@@ -606,6 +609,10 @@ public class AgreementPage
     {
         var annotators = new ArrayList<String>();
 
+        if (model.compareWithInitialCas) {
+            annotators.add(INITIAL_CAS_PSEUDO_USER);
+        }
+
         if (model.compareWithCurator) {
             annotators.add(CURATION_USER);
         }
@@ -737,5 +744,7 @@ public class AgreementPage
         List<SourceDocument> documents = new ArrayList<>();
 
         boolean compareWithCurator;
+
+        boolean compareWithInitialCas;
     }
 }

--- a/inception/inception-ui-agreement/src/main/java/de/tudarmstadt/ukp/inception/ui/agreement/page/AgreementPage.utf8.properties
+++ b/inception/inception-ui-agreement/src/main/java/de/tudarmstadt/ukp/inception/ui/agreement/page/AgreementPage.utf8.properties
@@ -35,4 +35,6 @@ export = Export...
 exportCsvDiff = Diagnosis
 exportJson = JSON
 exportCsv = CSV
+
+compareWithInitialCas = Include original
 compareWithCurator = Include curator

--- a/inception/inception-ui-agreement/src/main/resources/META-INF/asciidoc/user-guide/agreement.adoc
+++ b/inception/inception-ui-agreement/src/main/resources/META-INF/asciidoc/user-guide/agreement.adoc
@@ -45,6 +45,8 @@ Optionally, you can limit the process to specific *annotators* or *documents*.
 If you do not make any selection here, all annotators and documents are considered. 
 If you select annotators, at least two annotators must be selected. 
 To select multiple annotators or documents, hold, for example, the kbd:[Shift] or kbd:[CTRL]/kbd:[CMD] keys while clicking, depending on your browser and operating system. 
+The option *include original* is useful if you have imported pre-annotated documents as it can be used to compare annotators against the original pre-annotated.
+The option *include curator* is useful if you want to compare the annotator's performance (or even the original) to the final curated version.
 
 The *Pairwise...* button can be used to start the agreement calculation, and the results will be shown in a <<sect_agreement_matrix,Pairwise agreement matrix>>. 
 


### PR DESCRIPTION
**What's in the PR**
- Add option "include original" to the curation page

**How to test manually**
* Try the new option on the agreement page, in particular in conjunction with pre-annotated documents

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
