### PR TITLE
#5682 - Option to summarize activity across documents

### DIFF
--- a/inception/inception-ui-dashboard-activity/pom.xml
+++ b/inception/inception-ui-dashboard-activity/pom.xml
@@ -45,6 +45,11 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-layer-docmetadata-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-ui-dashboard</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/inception/inception-ui-dashboard-activity/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/activity/ActivitiesDashletControllerImpl.java
+++ b/inception/inception-ui-dashboard-activity/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/activity/ActivitiesDashletControllerImpl.java
@@ -62,6 +62,8 @@ import de.tudarmstadt.ukp.inception.annotation.layer.chain.api.event.ChainLinkCr
 import de.tudarmstadt.ukp.inception.annotation.layer.chain.api.event.ChainLinkDeletedEvent;
 import de.tudarmstadt.ukp.inception.annotation.layer.chain.api.event.ChainSpanCreatedEvent;
 import de.tudarmstadt.ukp.inception.annotation.layer.chain.api.event.ChainSpanDeletedEvent;
+import de.tudarmstadt.ukp.inception.annotation.layer.document.api.event.DocumentMetadataCreatedEvent;
+import de.tudarmstadt.ukp.inception.annotation.layer.document.api.event.DocumentMetadataDeletedEvent;
 import de.tudarmstadt.ukp.inception.annotation.layer.relation.api.event.RelationCreatedEvent;
 import de.tudarmstadt.ukp.inception.annotation.layer.relation.api.event.RelationDeletedEvent;
 import de.tudarmstadt.ukp.inception.annotation.layer.span.api.event.SpanCreatedEvent;
@@ -105,8 +107,8 @@ public class ActivitiesDashletControllerImpl
             ChainSpanCreatedEvent.class.getSimpleName(), //
             ChainSpanDeletedEvent.class.getSimpleName(), //
             FeatureValueUpdatedEvent.class.getSimpleName(), //
-            "DocumentMetadataCreatedEvent", //
-            "DocumentMetadataDeletedEvent");
+            DocumentMetadataCreatedEvent.class.getSimpleName(), //
+            DocumentMetadataDeletedEvent.class.getSimpleName());
 
     @Autowired
     public ActivitiesDashletControllerImpl(EventRepository aEventRepository,
@@ -271,16 +273,13 @@ public class ActivitiesDashletControllerImpl
     private List<SummarizedLoggedEvent> summarizeEvents(Project project, Instant begin, Instant end,
             User dataOwner)
     {
-        List<SummarizedLoggedEvent> recentEvents;
         if (userRepository.getCurationUser().equals(dataOwner)) {
-            recentEvents = eventRepository.summarizeEventsByDataOwner(dataOwner.getUsername(),
-                    project, begin, end);
+            return eventRepository.summarizeEventsByDataOwner(dataOwner.getUsername(), project,
+                    begin, end);
         }
-        else {
-            recentEvents = eventRepository.summarizeEventsBySessionOwner(dataOwner.getUsername(),
-                    project, begin, end);
-        }
-        return recentEvents;
+
+        return eventRepository.summarizeEventsBySessionOwner(dataOwner.getUsername(), project,
+                begin, end);
     }
 
     private User getDataOwner(Optional<String> aDataOwner, User aSessionOwner)


### PR DESCRIPTION
**What's in the PR**
- Added buttons to switch between broken-down and overall aggregate counts
- More fine-grained event summary
- Improved opacity calculation making low-activity dates more visible

**How to test manually**
* Try using the new buttons (after selecting a date)

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
