### PR TITLE
#5684 - Unable to add externally authenticated users to project

### DIFF
--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/UserSelectionPanel.java
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/UserSelectionPanel.java
@@ -157,19 +157,22 @@ class UserSelectionPanel
                 }
                 else {
                     // offer all enabled users matching the input
+                    var currentProjectRealm = projectRepository.getRealm(projectModel.getObject());
                     userRepository.listEnabledUsers().stream() //
                             .filter(user -> {
-                                if (user.getRealm() == null) {
+                                var userRealm = user.getRealm();
+
+                                if (userRealm == null) {
                                     return true;
                                 }
 
                                 // Project-bound users from other projects cannot be added
-                                if (user.getRealm().startsWith(Realm.REALM_PROJECT_PREFIX
-                                        + projectModel.getObject().getId())) {
-                                    return true;
+                                if (Realm.isProjectRealm(userRealm)
+                                        && !currentProjectRealm.getId().equals(userRealm)) {
+                                    return false;
                                 }
 
-                                return false;
+                                return true;
                             }).filter(user -> aInput == null || user.getUsername().contains(aInput)
                                     || user.getUiName().contains(aInput))
                             .forEach(result::add);


### PR DESCRIPTION
**What's in the PR**
- Fix filter mechanism that should prevent only project-bound users from other projects being added but instead also filtered out all non-local users

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
