### PR TITLE
#5698 - Separator line in multi-key rows in explorer does not cover entire cell

### DIFF
--- a/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/aggregator/CompoundKeyPanel.html
+++ b/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/aggregator/CompoundKeyPanel.html
@@ -19,7 +19,7 @@
 <html xmlns:wicket="http://wicket.apache.org">
 <body>
   <wicket:panel>
-    <div wicket:id="container" class="compound-key flex-grow list-group">
+    <div wicket:id="container" class="compound-key flex-grow-1 list-group">
       <div wicket:id="key" class="list-group-item p-1">
         <div wicket:id="name" style="font-weight: normal; font-size: 65%;"/>
         <div wicket:id="value" class="fw-bold" style="font-size: 85%; max-width: 20em;"/>

--- a/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/aggregator/ValueMapCellPanel.html
+++ b/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/aggregator/ValueMapCellPanel.html
@@ -31,7 +31,7 @@
 </head>
 <body>
   <wicket:panel>
-    <div wicket:id="container" class="value-set flex-grow list-group">
+    <div wicket:id="container" class="value-set flex-grow-1 list-group">
       <div wicket:id="item" class="list-group-item text-wrap bg-transparent position-relative" style="max-width: 20em;">
         <div wicket:id="count" class="float-end position-absolute badge rounded-pill text-bg-secondary count"/>
         <div wicket:id="value" style="font-weight: normal;"/>

--- a/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/aggregator/ValueSetCellPanel.html
+++ b/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/aggregator/ValueSetCellPanel.html
@@ -19,7 +19,7 @@
 <html xmlns:wicket="http://wicket.apache.org">
 <body>
   <wicket:panel>
-    <div wicket:id="container" class="value-set flex-grow list-group">
+    <div wicket:id="container" class="value-set flex-grow-1 list-group">
       <div wicket:id="item" class="list-group-item text-wrap bg-transparent" style="max-width: 20em;">
         <div wicket:id="value" style="font-weight: normal; font-size: 65%;"/>
       </div>

--- a/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/table/PivotHeader.html
+++ b/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/table/PivotHeader.html
@@ -21,7 +21,7 @@
   <wicket:panel>
     <div class="d-flex flex-row">
 <!--       <button wicket:id="toggle">T</button> -->
-      <div class="flex-grow list-group list-group-flush">
+      <div class="flex-grow-1 list-group list-group-flush">
         <div wicket:id="key" class="list-group-item text-wrap" style="max-width: 20em;">
           <div wicket:id="name" style="font-weight: normal; font-size: 65%;"/>
           <div wicket:id="value" style="font-weight: bold; font-size: 85%;"/>


### PR DESCRIPTION
**What's in the PR**
- Fixed CSS class

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
