### PR TITLE
#5662 - Option to disable confirmation dialog when deleting annotation with attached annotations

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/page/AnnotationEditorManagerPrefs.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/page/AnnotationEditorManagerPrefs.java
@@ -35,6 +35,18 @@ public class AnnotationEditorManagerPrefs
 
     private boolean preferencesAccessAllowed = true;
 
+    private boolean showDeleteAnnotationConfirmation = true;
+
+    public boolean isShowDeleteAnnotationConfirmation()
+    {
+        return showDeleteAnnotationConfirmation;
+    }
+
+    public void setShowDeleteAnnotationConfirmation(boolean aShowDeleteAnnotationConfirmation)
+    {
+        showDeleteAnnotationConfirmation = aShowDeleteAnnotationConfirmation;
+    }
+
     public String getDefaultEditor()
     {
         return defaultEditor;

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.detail;
 
+import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationEditorManagerPrefs.KEY_ANNOTATION_EDITOR_MANAGER_PREFS;
 import static de.tudarmstadt.ukp.inception.rendering.editorstate.AnchoringModePrefs.KEY_ANCHORING_MODE;
 import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.COREFERENCE_RELATION_FEATURE;
 import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.COREFERENCE_TYPE_FEATURE;
@@ -741,11 +742,17 @@ public abstract class AnnotationDetailEditorPanel
         }
 
         if (adapter instanceof SpanAdapter && attachStatus.attachCount > 0) {
-            var dialogContent = new DeleteAnnotationConfirmationDialogPanel(
-                    BootstrapModalDialog.CONTENT_ID, Model.of(layer), Model.of(attachStatus));
-            dialogContent.setConfirmAction(_target -> doDelete(_target, layer, vid));
-            confirmationDialog.open(dialogContent, aTarget);
-            return;
+            var sessionOwner = userService.getCurrentUser();
+            var confirmationPrefs = preferencesService.loadTraitsForUserAndProject(
+                    KEY_ANNOTATION_EDITOR_MANAGER_PREFS, sessionOwner, state.getProject());
+
+            if (confirmationPrefs.isShowDeleteAnnotationConfirmation()) {
+                var dialogContent = new DeleteAnnotationConfirmationDialogPanel(
+                        BootstrapModalDialog.CONTENT_ID, Model.of(layer), Model.of(attachStatus));
+                dialogContent.setConfirmAction(_target -> doDelete(_target, layer, vid));
+                confirmationDialog.open(dialogContent, aTarget);
+                return;
+            }
         }
 
         doDelete(aTarget, layer, vid);

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/AnnotationEditorManagerPrefsPanel.html
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/AnnotationEditorManagerPrefsPanel.html
@@ -32,12 +32,22 @@
             <select wicket:id="defaultEditor" class="form-select"/>
           </div>
         </div>
-        <div class="row form-row">
+        <div class="row form-row" wicket:enclosure="preferencesAccessAllowed">
           <div class="offset-sm-4 col-sm-8">
             <div class="form-check form-switch">
               <input wicket:id="preferencesAccessAllowed" class="form-check-input" type="checkbox"> 
               <label wicket:for="preferencesAccessAllowed" class="form-check-label" >
                 <wicket:label key="preferencesAccessAllowed"/>
+              </label>
+            </div>
+          </div>
+        </div>
+        <div class="row form-row" wicket:enclosure="showDeleteAnnotationConfirmation">
+          <div class="offset-sm-4 col-sm-8">
+            <div class="form-check form-switch">
+              <input wicket:id="showDeleteAnnotationConfirmation" class="form-check-input" type="checkbox"> 
+              <label wicket:for="showDeleteAnnotationConfirmation" class="form-check-label" >
+                <wicket:label key="showDeleteAnnotationConfirmation"/>
               </label>
             </div>
           </div>

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/AnnotationEditorManagerPrefsPanel.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/AnnotationEditorManagerPrefsPanel.java
@@ -72,6 +72,8 @@ public class AnnotationEditorManagerPrefsPanel
 
         form.add(new CheckBox("preferencesAccessAllowed").setOutputMarkupId(true));
 
+        form.add(new CheckBox("showDeleteAnnotationConfirmation").setOutputMarkupId(true));
+
         form.onSubmit(this::actionSave);
 
         add(form);

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/AnnotationEditorManagerPrefsPanel.utf8.properties
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/settings/annotation/AnnotationEditorManagerPrefsPanel.utf8.properties
@@ -18,3 +18,4 @@ defaultEditor=Editor
 defaultEditor.nullValid=Leave choice to annotator
 annotationEditorManagerPrefs=Annotation editor
 preferencesAccessAllowed=Allow access to user-specific annotation editor preferences
+showDeleteAnnotationConfirmation=Confirm deleting annotations with attached annotations


### PR DESCRIPTION
**What's in the PR**
- Added new setting to annotation panel in the project settings

**How to test manually**
* Try turning the delete confirmation off and check if the confirmation popup still appears on spans that have connected links or relations

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
