### PR TITLE
#5701 - Sort range in explorer numerically instead of alphabetically

### DIFF
--- a/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/model/Range.java
+++ b/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/model/Range.java
@@ -34,7 +34,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class Range
-    implements Serializable
+    implements Serializable, Comparable<Range>
 {
     private static final long serialVersionUID = -6261188569647696831L;
 
@@ -144,6 +144,23 @@ public class Range
     public String toString()
     {
         return "[" + begin + "-" + end + "]";
+    }
+
+    @Override
+    public int compareTo(Range aOther)
+    {
+        if (this == aOther) {
+            return 0;
+        }
+
+        // Sort by begin ascending
+        int cmp = Integer.compare(begin, aOther.begin);
+        if (cmp != 0) {
+            return cmp;
+        }
+
+        // Sort by end descending
+        return Integer.compare(aOther.end, end);
     }
 
     @Override

--- a/inception/inception-layer-span/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/pivot/SpanRangeExtractor.java
+++ b/inception/inception-layer-span/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/pivot/SpanRangeExtractor.java
@@ -22,9 +22,10 @@ import org.apache.uima.jcas.tcas.Annotation;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.inception.pivot.api.extractor.AnnotationExtractor_ImplBase;
 import de.tudarmstadt.ukp.inception.pivot.api.extractor.ContextualizedFS;
+import de.tudarmstadt.ukp.inception.rendering.model.Range;
 
 public class SpanRangeExtractor<T extends Annotation>
-    extends AnnotationExtractor_ImplBase<T, String>
+    extends AnnotationExtractor_ImplBase<T, Range>
 {
     public SpanRangeExtractor(AnnotationLayer aLayer)
     {
@@ -38,15 +39,15 @@ public class SpanRangeExtractor<T extends Annotation>
     }
 
     @Override
-    public Class<String> getResultType()
+    public Class<Range> getResultType()
     {
-        return String.class;
+        return Range.class;
     }
 
     @Override
-    public String extract(ContextualizedFS<T> aAnn)
+    public Range extract(ContextualizedFS<T> aAnn)
     {
         var ann = aAnn.fs();
-        return ann.getBegin() + "-" + ann.getEnd();
+        return new Range(ann.getBegin(), ann.getEnd());
     }
 }

--- a/inception/inception-layer-span/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/pivot/SpanRangeExtractorSupport.java
+++ b/inception/inception-layer-span/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/pivot/SpanRangeExtractorSupport.java
@@ -26,6 +26,7 @@ import de.tudarmstadt.ukp.inception.annotation.layer.span.api.SpanLayerSupport;
 import de.tudarmstadt.ukp.inception.pivot.api.extractor.ContextualizedFS;
 import de.tudarmstadt.ukp.inception.pivot.api.extractor.Extractor;
 import de.tudarmstadt.ukp.inception.pivot.api.extractor.LayerExtractorSupport;
+import de.tudarmstadt.ukp.inception.rendering.model.Range;
 
 public class SpanRangeExtractorSupport
     implements LayerExtractorSupport
@@ -47,7 +48,7 @@ public class SpanRangeExtractorSupport
     }
 
     @Override
-    public Extractor<ContextualizedFS<Annotation>, String> createExtractor(AnnotationLayer aLayer)
+    public Extractor<ContextualizedFS<Annotation>, Range> createExtractor(AnnotationLayer aLayer)
     {
         return new SpanRangeExtractor<>(aLayer);
     }


### PR DESCRIPTION
**What's in the PR**
- Extract a range instead of a string from annotations
- Make the range comparable

**How to test manually**
* Try adding the range to a row and e.g. the label to the column and then sort by row key

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
