### PR TITLE
#5712 - Support external recommenders that generate suggestions for multiple layers and features

### DIFF
--- a/inception/inception-feature-link/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/link/recommender/LinkSuggestionSupport.java
+++ b/inception/inception-feature-link/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/link/recommender/LinkSuggestionSupport.java
@@ -250,7 +250,7 @@ public class LinkSuggestionSupport
                 continue;
             }
 
-            var feature = ctx.getRecommender().getFeature();
+            var feature = ctx.getFeature();
             List<LinkWithRoleModel> links = adapter.getFeatureValue(feature, predictedFS);
             if (links.isEmpty()) {
                 continue;
@@ -260,7 +260,7 @@ public class LinkSuggestionSupport
             var link = links.get(0);
             var target = selectAnnotationByAddr(ctx.getPredictionCas(), link.targetAddr);
             var targetAdapter = adapterCache.computeIfAbsent(target.getType().getName(),
-                    $ -> schemaService.findAdapter(ctx.getRecommender().getProject(), target));
+                    $ -> schemaService.findAdapter(ctx.getProject(), target));
 
             var originalSource = findEquivalentSpan(adapter, ctx.getOriginalCas(), source);
             var originalTarget = findEquivalentSpan(targetAdapter, ctx.getOriginalCas(), target);
@@ -280,9 +280,7 @@ public class LinkSuggestionSupport
 
             var suggestion = LinkSuggestion.builder() //
                     .withId(LinkSuggestion.NEW_ID) //
-                    .withGeneration(ctx.getGeneration()) //
-                    .withRecommender(ctx.getRecommender()) //
-                    .withDocument(ctx.getDocument()) //
+                    .withContext(ctx) //
                     .withPosition(position) //
                     .withLabel(link.role) //
                     .withUiLabel(link.role) //

--- a/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/v1/ExternalRecommender.java
+++ b/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/v1/ExternalRecommender.java
@@ -394,4 +394,10 @@ public class ExternalRecommender
     {
         return traits.getTrainingCapability();
     }
+
+    @Override
+    public boolean isUniveralExtraction()
+    {
+        return traits.isUniversalExtraction();
+    }
 }

--- a/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/v1/ExternalRecommenderTraits.java
+++ b/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/v1/ExternalRecommenderTraits.java
@@ -34,6 +34,7 @@ public class ExternalRecommenderTraits
     private boolean verifyCertificates = true;
     private boolean ranker;
     private TrainingCapability trainingCapability;
+    private boolean universalExtraction;
 
     @Deprecated
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
@@ -100,5 +101,15 @@ public class ExternalRecommenderTraits
     public void setTrainingCapability(TrainingCapability aTrainingCapability)
     {
         trainingCapability = aTrainingCapability;
+    }
+
+    public boolean isUniversalExtraction()
+    {
+        return universalExtraction;
+    }
+
+    public void setUniversalExtraction(boolean aUniversalExtraction)
+    {
+        universalExtraction = aUniversalExtraction;
     }
 }

--- a/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/v1/ExternalRecommenderTraitsEditor.html
+++ b/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/v1/ExternalRecommenderTraitsEditor.html
@@ -55,6 +55,16 @@
         </div>
       </div>
     </div>
+    <div class="row form-row" wicket:enclosure="universalExtraction">
+      <div class="offset-sm-3 col-sm-9">
+        <div class="form-check form-switch">
+          <input wicket:id="universalExtraction" class="form-check-input" type="checkbox"/>
+          <label wicket:for="universalExtraction" class="form-check-label">
+            <wicket:label key="universalExtraction"/>
+          </label>
+        </div>
+      </div>
+    </div>
   </form>
 </wicket:extend>
 </html>

--- a/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/v1/ExternalRecommenderTraitsEditor.java
+++ b/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/v1/ExternalRecommenderTraitsEditor.java
@@ -93,6 +93,10 @@ public class ExternalRecommenderTraitsEditor
         ranker.setOutputMarkupId(true);
         form.add(ranker);
 
+        var universalExtraction = new CheckBox("universalExtraction");
+        universalExtraction.setOutputMarkupId(true);
+        form.add(universalExtraction);
+
         add(form);
     }
 }

--- a/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/v1/ExternalRecommenderTraitsEditor.utf8.properties
+++ b/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/v1/ExternalRecommenderTraitsEditor.utf8.properties
@@ -18,6 +18,7 @@ remoteUrl=Remote URL
 ranker=Ranker
 verifyCertificates=Verify certificates
 trainingCapability=Training capability
+universalExtraction=Extract all layers/features
 
 TrainingCapability.TRAINING_NOT_SUPPORTED=Training not supported
 TrainingCapability.TRAINING_SUPPORTED=Training supported

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/document/recommender/MetadataSuggestionSupport.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/document/recommender/MetadataSuggestionSupport.java
@@ -311,9 +311,7 @@ public class MetadataSuggestionSupport
             for (var label : labels) {
                 var suggestion = MetadataSuggestion.builder() //
                         .withId(MetadataSuggestion.NEW_ID) //
-                        .withGeneration(ctx.getGeneration()) //
-                        .withRecommender(ctx.getRecommender()) //
-                        .withDocument(ctx.getDocument()) //
+                        .withContext(ctx) //
                         .withLabel(label) //
                         .withUiLabel(label) //
                         .withCorrection(correction) //

--- a/inception/inception-layer-docmetadata/src/test/java/de/tudarmstadt/ukp/inception/annotation/layer/document/recommender/MetadataSuggestionExtractionTest.java
+++ b/inception/inception-layer-docmetadata/src/test/java/de/tudarmstadt/ukp/inception/annotation/layer/document/recommender/MetadataSuggestionExtractionTest.java
@@ -122,7 +122,8 @@ class MetadataSuggestionExtractionTest
                 .withFeature(FEATURE_NAME_IS_PREDICTION, true) //
                 .buildAndAddToIndexes();
 
-        var ctx = new ExtractionContext(0, recommender, document, originalCas, predictionCas);
+        var ctx = new ExtractionContext(0, recommender, recommender.getLayer(),
+                recommender.getFeature(), document, originalCas, predictionCas);
         var suggestions = sut.extractSuggestions(ctx);
 
         assertThat(suggestions) //

--- a/inception/inception-layer-relation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/recommender/RelationSuggestionSupport.java
+++ b/inception/inception-layer-relation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/recommender/RelationSuggestionSupport.java
@@ -301,9 +301,9 @@ public class RelationSuggestionSupport
             }
 
             var sourceAdapter = adapterCache.computeIfAbsent(source.getType().getName(),
-                    $ -> schemaService.findAdapter(ctx.getRecommender().getProject(), source));
+                    $ -> schemaService.findAdapter(ctx.getProject(), source));
             var targetAdapter = adapterCache.computeIfAbsent(target.getType().getName(),
-                    $ -> schemaService.findAdapter(ctx.getRecommender().getProject(), target));
+                    $ -> schemaService.findAdapter(ctx.getProject(), target));
 
             var originalSource = findEquivalentSpan(sourceAdapter, ctx.getOriginalCas(), source);
             var originalTarget = findEquivalentSpan(targetAdapter, ctx.getOriginalCas(), target);
@@ -325,9 +325,7 @@ public class RelationSuggestionSupport
             for (var label : labels) {
                 var suggestion = RelationSuggestion.builder() //
                         .withId(RelationSuggestion.NEW_ID) //
-                        .withGeneration(ctx.getGeneration()) //
-                        .withRecommender(ctx.getRecommender()) //
-                        .withDocument(ctx.getDocument()) //
+                        .withContext(ctx) //
                         .withPosition(position) //
                         .withLabel(label) //
                         .withUiLabel(label) //

--- a/inception/inception-layer-span/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/recommender/SpanSuggestionRenderer.java
+++ b/inception/inception-layer-span/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/recommender/SpanSuggestionRenderer.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.annotation.layer.span.recommender;
 
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
@@ -110,7 +111,7 @@ public class SpanSuggestionRenderer
 
                 Map<String, String> featureAnnotation = annotation != null
                         ? Map.of(suggestion.getFeature(), annotation)
-                        : Map.of();
+                        : emptyMap();
 
                 var isRanker = rankerCache.computeIfAbsent(suggestion.getRecommenderId(), id -> {
                     var recommender = recommendationService.getRecommender(id);

--- a/inception/inception-layer-span/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/recommender/SpanSuggestionSupport.java
+++ b/inception/inception-layer-span/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/recommender/SpanSuggestionSupport.java
@@ -508,9 +508,7 @@ public class SpanSuggestionSupport
         for (var label : labels) {
             aSuggestions.add(SpanSuggestion.builder() //
                     .withId(SpanSuggestion.NEW_ID) //
-                    .withGeneration(aCtx.getGeneration()) //
-                    .withRecommender(aCtx.getRecommender()) //
-                    .withDocument(aCtx.getDocument()) //
+                    .withContext(aCtx) //
                     .withPosition(offsets) //
                     .withCoveredText(coveredText) //
                     .withLabel(label) //

--- a/inception/inception-layer-span/src/test/java/de/tudarmstadt/ukp/inception/annotation/layer/span/recommender/Fixtures.java
+++ b/inception/inception-layer-span/src/test/java/de/tudarmstadt/ukp/inception/annotation/layer/span/recommender/Fixtures.java
@@ -59,14 +59,24 @@ public class Fixtures
     public static SuggestionDocumentGroup<SpanSuggestion> makeSpanSuggestionGroup(
             SourceDocument doc, AnnotationFeature aFeat, int[][] vals)
     {
-        var rec = Recommender.builder().withId(RECOMMENDER_ID).withName(RECOMMENDER_NAME)
-                .withLayer(aFeat.getLayer()).withFeature(aFeat).build();
+        var rec = Recommender.builder() //
+                .withId(RECOMMENDER_ID) //
+                .withName(RECOMMENDER_NAME) //
+                .withLayer(aFeat.getLayer()) //
+                .withFeature(aFeat) //
+                .build();
 
         List<SpanSuggestion> suggestions = new ArrayList<>();
         for (int[] val : vals) {
-            var suggestion = SpanSuggestion.builder().withId(val[0]).withRecommender(rec)
-                    .withDocument(doc).withPosition(val[1], val[2]).withCoveredText(COVERED_TEXT)
-                    .withScore(CONFIDENCE).withScoreExplanation(CONFIDENCE_EXPLANATION).build();
+            var suggestion = SpanSuggestion.builder() //
+                    .withId(val[0]) //
+                    .withRecommender(rec) //
+                    .withDocument(doc) //
+                    .withPosition(val[1], val[2]) //
+                    .withCoveredText(COVERED_TEXT) //
+                    .withScore(CONFIDENCE) //
+                    .withScoreExplanation(CONFIDENCE_EXPLANATION) //
+                    .build();
             suggestions.add(suggestion);
         }
 

--- a/inception/inception-layer-span/src/test/java/de/tudarmstadt/ukp/inception/annotation/layer/span/recommender/SpanSuggestionExtractionTest.java
+++ b/inception/inception-layer-span/src/test/java/de/tudarmstadt/ukp/inception/annotation/layer/span/recommender/SpanSuggestionExtractionTest.java
@@ -132,7 +132,8 @@ class SpanSuggestionExtractionTest
                 .withFeature(FEATURE_NAME_IS_PREDICTION, true) //
                 .buildAndAddToIndexes();
 
-        var ctx = new ExtractionContext(0, recommender, document, originalCas, predictionCas);
+        var ctx = new ExtractionContext(0, recommender, recommender.getLayer(),
+                recommender.getFeature(), document, originalCas, predictionCas);
         var suggestions = sut.extractSuggestions(ctx);
 
         assertThat(suggestions) //

--- a/inception/inception-layer-span/src/test/java/de/tudarmstadt/ukp/inception/annotation/layer/span/recommender/SpanSuggestionVisibilityCalculationTest.java
+++ b/inception/inception-layer-span/src/test/java/de/tudarmstadt/ukp/inception/annotation/layer/span/recommender/SpanSuggestionVisibilityCalculationTest.java
@@ -284,9 +284,12 @@ public class SpanSuggestionVisibilityCalculationTest
     @Test
     void thatRejectedSuggestionIsHidden()
     {
-        var rec1 = Recommender.builder().withId(1l).withLayer(layer).withFeature(feature).build();
-        var rec2 = Recommender.builder().withId(2l).withLayer(layer2).withFeature(feature).build();
-        var rec3 = Recommender.builder().withId(3l).withLayer(layer).withFeature(feature2).build();
+        var rec1 = Recommender.builder().withId(1l).withName("Rec1").withLayer(layer)
+                .withFeature(feature).build();
+        var rec2 = Recommender.builder().withId(2l).withName("Rec2").withLayer(layer2)
+                .withFeature(feature).build();
+        var rec3 = Recommender.builder().withId(3l).withName("Rec3").withLayer(layer)
+                .withFeature(feature2).build();
         var label = "x";
 
         var records = asList(LearningRecord.builder() //
@@ -299,8 +302,12 @@ public class SpanSuggestionVisibilityCalculationTest
                 .withUserAction(REJECTED) //
                 .build());
 
-        var docSuggestion = SpanSuggestion.builder().withRecommender(rec1).withDocument(doc)
-                .withLabel(label).withPosition(0, 10).build();
+        var docSuggestion = SpanSuggestion.builder() //
+                .withRecommender(rec1) //
+                .withDocument(doc) //
+                .withLabel(label) //
+                .withPosition(0, 10) //
+                .build();
         assertThat(docSuggestion.isVisible()).isTrue();
         hideSuggestionsRejectedOrSkipped(docSuggestion, records);
         assertThat(docSuggestion.isVisible()) //
@@ -308,8 +315,12 @@ public class SpanSuggestionVisibilityCalculationTest
                 .isFalse();
         assertThat(docSuggestion.getReasonForHiding().trim()).isEqualTo("rejected");
 
-        var doc2Suggestion = SpanSuggestion.builder().withRecommender(rec1).withDocument(doc2)
-                .withLabel(label).withPosition(0, 10).build();
+        var doc2Suggestion = SpanSuggestion.builder() //
+                .withRecommender(rec1) //
+                .withDocument(doc2) //
+                .withLabel(label) //
+                .withPosition(0, 10) //
+                .build();
         assertThat(doc2Suggestion.isVisible()).isTrue();
         hideSuggestionsRejectedOrSkipped(doc2Suggestion, records);
         assertThat(doc2Suggestion.isVisible()) //
@@ -336,9 +347,12 @@ public class SpanSuggestionVisibilityCalculationTest
     @Test
     void thatSkippedSuggestionIsHidden()
     {
-        var rec1 = Recommender.builder().withId(1l).withLayer(layer).withFeature(feature).build();
-        var rec2 = Recommender.builder().withId(2l).withLayer(layer2).withFeature(feature).build();
-        var rec3 = Recommender.builder().withId(3l).withLayer(layer).withFeature(feature2).build();
+        var rec1 = Recommender.builder().withId(1l).withName("Rec1").withLayer(layer)
+                .withFeature(feature).build();
+        var rec2 = Recommender.builder().withId(2l).withName("Rec2").withLayer(layer2)
+                .withFeature(feature).build();
+        var rec3 = Recommender.builder().withId(3l).withName("Rec3").withLayer(layer)
+                .withFeature(feature2).build();
         var label = "x";
 
         var records = asList(LearningRecord.builder() //
@@ -351,8 +365,14 @@ public class SpanSuggestionVisibilityCalculationTest
                 .withUserAction(SKIPPED) //
                 .build());
 
-        var docSuggestion = SpanSuggestion.builder().withRecommender(rec1).withDocument(doc)
-                .withLabel(label).withPosition(0, 10).build();
+        var docSuggestion = SpanSuggestion.builder() //
+                .withRecommender(rec1) //
+                .withLayer(rec1.getLayer()) //
+                .withFeature(rec1.getFeature()) //
+                .withDocument(doc) //
+                .withLabel(label) //
+                .withPosition(0, 10) //
+                .build();
         assertThat(docSuggestion.isVisible()).isTrue();
         hideSuggestionsRejectedOrSkipped(docSuggestion, records);
         assertThat(docSuggestion.isVisible()) //
@@ -360,8 +380,14 @@ public class SpanSuggestionVisibilityCalculationTest
                 .isFalse();
         assertThat(docSuggestion.getReasonForHiding().trim()).isEqualTo("skipped");
 
-        var doc2Suggestion = SpanSuggestion.builder().withRecommender(rec1).withDocument(doc2)
-                .withLabel(label).withPosition(0, 10).build();
+        var doc2Suggestion = SpanSuggestion.builder() //
+                .withRecommender(rec1) //
+                .withLayer(rec1.getLayer()) //
+                .withFeature(rec1.getFeature()) //
+                .withDocument(doc2) //
+                .withLabel(label) //
+                .withPosition(0, 10) //
+                .build();
         assertThat(doc2Suggestion.isVisible()).isTrue();
         hideSuggestionsRejectedOrSkipped(doc2Suggestion, records);
         assertThat(doc2Suggestion.isVisible()) //

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/SuggestionSupportQuery.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/SuggestionSupportQuery.java
@@ -22,6 +22,11 @@ import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
 
 public record SuggestionSupportQuery(AnnotationLayer layer, AnnotationFeature feature) {
+    public static SuggestionSupportQuery of(AnnotationFeature aFeature)
+    {
+        return new SuggestionSupportQuery(aFeature.getLayer(), aFeature);
+    }
+
     public static SuggestionSupportQuery of(Recommender aRecommender)
     {
         return new SuggestionSupportQuery(aRecommender.getLayer(), aRecommender.getFeature());

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/SuggestionSupportRegistry.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/SuggestionSupportRegistry.java
@@ -17,10 +17,13 @@
  */
 package de.tudarmstadt.ukp.inception.recommendation.api;
 
+import java.util.Optional;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.inception.support.extensionpoint.ContextLookupExtensionPoint;
 
 public interface SuggestionSupportRegistry
     extends ContextLookupExtensionPoint<SuggestionSupportQuery, SuggestionSupport>
 {
-
+    Optional<SuggestionSupport> findExtension(AnnotationFeature aFeature);
 }

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/SuggestionSupport_ImplBase.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/SuggestionSupport_ImplBase.java
@@ -190,14 +190,13 @@ public abstract class SuggestionSupport_ImplBase
             AnnotationSuggestion aSuggestion, LearningRecordChangeLocation aLocation)
         throws AnnotationException
     {
-        var suggestion = aSuggestion;
-
         // Hide the suggestion. This is faster than having to recalculate the visibility status
         // for the entire document or even for the part visible on screen.
-        suggestion.hide(FLAG_TRANSIENT_REJECTED);
+        aSuggestion.hide(FLAG_TRANSIENT_REJECTED);
 
-        var recommender = recommendationService.getRecommender(suggestion);
-        var feature = recommender.getFeature();
+        var layer = schemaService.getLayer(aSuggestion.getLayerId());
+        var feature = schemaService.getFeature(aSuggestion.getFeature(), layer);
+
         // Log the action to the learning record
         var record = toLearningRecord(aDocument, aDataOwner, aSuggestion, feature, REJECTED,
                 aLocation);
@@ -205,7 +204,7 @@ public abstract class SuggestionSupport_ImplBase
 
         // Send an application event that the suggestion has been rejected
         applicationEventPublisher.publishEvent(
-                new RecommendationRejectedEvent(this, aDocument, aDataOwner, feature, suggestion));
+                new RecommendationRejectedEvent(this, aDocument, aDataOwner, feature, aSuggestion));
     }
 
     @Override

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/AnnotationSuggestion.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/AnnotationSuggestion.java
@@ -17,6 +17,8 @@
  */
 package de.tudarmstadt.ukp.inception.recommendation.api.model;
 
+import static de.tudarmstadt.ukp.inception.recommendation.api.model.AutoAcceptMode.NEVER;
+
 import java.io.Serializable;
 import java.util.Objects;
 import java.util.Optional;
@@ -25,6 +27,10 @@ import javax.annotation.Nullable;
 
 import org.apache.uima.cas.text.AnnotationPredicates;
 
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.inception.recommendation.api.recommender.ExtractionContext;
 import de.tudarmstadt.ukp.inception.rendering.model.Range;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
 
@@ -92,28 +98,45 @@ public abstract class AnnotationSuggestion
     private int hidingFlags = 0;
     private int age = 0;
 
-    public AnnotationSuggestion(int aId, int aGeneration, int aAge, long aRecommenderId,
-            String aRecommenderName, long aLayerId, String aFeature, long aDocumentId,
-            String aLabel, String aUiLabel, double aScore, String aScoreExplanation,
-            AutoAcceptMode aAutoAcceptMode, int aHidingFlags, boolean aCorrection,
-            String aCorrectionExplanation)
+    public AnnotationSuggestion(Builder<?> aBuilder)
     {
-        generation = aGeneration;
-        age = aAge;
-        label = aLabel;
-        uiLabel = aUiLabel;
-        id = aId;
-        layerId = aLayerId;
-        feature = aFeature;
-        recommenderName = aRecommenderName;
-        score = aScore;
-        scoreExplanation = aScoreExplanation;
-        recommenderId = aRecommenderId;
-        documentId = aDocumentId;
-        autoAcceptMode = aAutoAcceptMode != null ? aAutoAcceptMode : AutoAcceptMode.NEVER;
-        hidingFlags = aHidingFlags;
-        correction = aCorrection;
-        correctionExplanation = aCorrectionExplanation;
+        generation = aBuilder.generation;
+        age = aBuilder.age;
+        label = aBuilder.label;
+        uiLabel = aBuilder.uiLabel;
+        id = aBuilder.id;
+        score = aBuilder.score;
+        scoreExplanation = aBuilder.scoreExplanation;
+        documentId = aBuilder.documentId;
+        autoAcceptMode = aBuilder.autoAcceptMode != null ? aBuilder.autoAcceptMode : NEVER;
+        hidingFlags = aBuilder.hidingFlags;
+        correction = aBuilder.correction;
+        correctionExplanation = aBuilder.correctionExplanation;
+
+        recommenderId = aBuilder.recommenderId != null ? aBuilder.recommenderId
+                : (aBuilder.recommender != null ? aBuilder.recommender.getId() : 0);
+
+        recommenderName = aBuilder.recommenderName != null ? aBuilder.recommenderName
+                : (aBuilder.recommender != null ? aBuilder.recommender.getName() : null);
+
+        layerId = aBuilder.layerId != null ? aBuilder.layerId
+                : (aBuilder.recommender != null && aBuilder.recommender.getLayer() != null
+                        ? aBuilder.recommender.getLayer().getId()
+                        : 0);
+
+        feature = aBuilder.feature != null ? aBuilder.feature
+                : (aBuilder.recommender != null && aBuilder.recommender.getFeature() != null
+                        ? aBuilder.recommender.getFeature().getName()
+                        : null);
+
+        assert layerId > 0l : "Layer must be persisted (id > 0) but was [" + layerId + "]";
+        assert recommenderId > 0l : "Recommender must be persisted (id > 0) but was "
+                + recommenderId + "]";
+        assert documentId > 0l : "Document must be persisted (id > 0) but was " + documentId + "]";
+        assert feature != null : "Feature cannot be null";
+        assert recommenderName != null : "Recommender name cannot be null";
+        assert generation >= 0 : "Generation cannot be negative but was [" + generation + "]";
+        assert age >= 0 : "Age cannot be negative but was [" + age + "]";
     }
 
     public int getId()
@@ -366,4 +389,165 @@ public abstract class AnnotationSuggestion
      *            the ID of the suggestion.
      */
     abstract public AnnotationSuggestion assignId(int aId);
+
+    public static abstract class Builder<T extends Builder<?>>
+    {
+        protected int generation;
+        protected int age;
+        protected int id;
+        protected Recommender recommender;
+        protected Long recommenderId;
+        protected String recommenderName;
+        protected Long layerId;
+        protected String feature;
+        protected long documentId;
+        protected String label;
+        protected String uiLabel;
+        protected double score;
+        protected String scoreExplanation;
+        protected AutoAcceptMode autoAcceptMode;
+        protected int hidingFlags;
+        protected boolean correction;
+        protected String correctionExplanation;
+
+        protected Builder()
+        {
+            // No initialization
+        }
+
+        public T withId(int aId)
+        {
+            id = aId;
+            return (T) this;
+        }
+
+        public T withContext(ExtractionContext aCtx)
+        {
+            withGeneration(aCtx.getGeneration());
+            withRecommender(aCtx.getRecommender());
+            withLayer(aCtx.getLayer());
+            withFeature(aCtx.getFeature());
+            withDocument(aCtx.getDocument());
+            return (T) this;
+        }
+
+        public T withGeneration(int aGeneration)
+        {
+            generation = aGeneration;
+            return (T) this;
+        }
+
+        public T withAge(int aAge)
+        {
+            age = aAge;
+            return (T) this;
+        }
+
+        public T withRecommender(Recommender aRecommender)
+        {
+            recommender = aRecommender;
+            return (T) this;
+        }
+
+        public T withLayer(AnnotationLayer aLayer)
+        {
+            layerId = aLayer.getId();
+            return (T) this;
+        }
+
+        public T withFeature(AnnotationFeature aFeature)
+        {
+            feature = aFeature.getName();
+            return (T) this;
+        }
+
+        @Deprecated
+        T withRecommenderId(long aRecommenderId)
+        {
+            recommenderId = aRecommenderId;
+            return (T) this;
+        }
+
+        @Deprecated
+        T withRecommenderName(String aRecommenderName)
+        {
+            recommenderName = aRecommenderName;
+            return (T) this;
+        }
+
+        @Deprecated
+        T withLayerId(long aLayerId)
+        {
+            layerId = aLayerId;
+            return (T) this;
+        }
+
+        @Deprecated
+        T withFeature(String aFeature)
+        {
+            feature = aFeature;
+            return (T) this;
+        }
+
+        public T withDocument(SourceDocument aDocument)
+        {
+            documentId = aDocument.getId();
+            return (T) this;
+        }
+
+        @Deprecated
+        public T withDocument(long aDocumentId)
+        {
+            documentId = aDocumentId;
+            return (T) this;
+        }
+
+        public T withLabel(String aLabel)
+        {
+            label = aLabel;
+            return (T) this;
+        }
+
+        public T withUiLabel(String aUiLabel)
+        {
+            uiLabel = aUiLabel;
+            return (T) this;
+        }
+
+        public T withScore(double aScore)
+        {
+            score = aScore;
+            return (T) this;
+        }
+
+        public T withScoreExplanation(String aScoreExplanation)
+        {
+            scoreExplanation = aScoreExplanation;
+            return (T) this;
+        }
+
+        public T withAutoAcceptMode(AutoAcceptMode aAutoAcceptMode)
+        {
+            autoAcceptMode = aAutoAcceptMode;
+            return (T) this;
+        }
+
+        public T withHidingFlags(int aFlags)
+        {
+            hidingFlags = aFlags;
+            return (T) this;
+        }
+
+        public T withCorrection(boolean aCorrection)
+        {
+            correction = aCorrection;
+            return (T) this;
+        }
+
+        public T withCorrectionExplanation(String aCorrectionExplanation)
+        {
+            correctionExplanation = aCorrectionExplanation;
+            return (T) this;
+        }
+    }
 }

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/ArcSuggestion_ImplBase.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/ArcSuggestion_ImplBase.java
@@ -21,8 +21,6 @@ import java.io.Serializable;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
-import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
-
 public abstract class ArcSuggestion_ImplBase<P extends ArcPosition_ImplBase<?>>
     extends AnnotationSuggestion
     implements Serializable
@@ -33,11 +31,7 @@ public abstract class ArcSuggestion_ImplBase<P extends ArcPosition_ImplBase<?>>
 
     protected ArcSuggestion_ImplBase(Builder<?, P> builder)
     {
-        super(builder.id, builder.generation, builder.age, builder.recommenderId,
-                builder.recommenderName, builder.layerId, builder.feature, builder.documentId,
-                builder.label, builder.uiLabel, builder.score, builder.scoreExplanation,
-                builder.autoAcceptMode, builder.hidingFlags, builder.correction,
-                builder.correctionExplanation);
+        super(builder);
 
         position = builder.position;
     }
@@ -96,151 +90,20 @@ public abstract class ArcSuggestion_ImplBase<P extends ArcPosition_ImplBase<?>>
         return toBuilder().withId(aId).build();
     }
 
-    public abstract Builder toBuilder();
+    public abstract Builder<? extends Builder, ?> toBuilder();
 
     public static abstract class Builder<T extends Builder<?, ?>, P extends ArcPosition_ImplBase<?>>
+        extends AnnotationSuggestion.Builder<T>
     {
-        protected int generation;
-        protected int age;
-        protected int id;
-        protected long recommenderId;
-        protected String recommenderName;
-        protected long layerId;
-        protected String feature;
-        protected long documentId;
-        protected String label;
-        protected String uiLabel;
-        protected double score;
-        protected String scoreExplanation;
         protected P position;
-        protected AutoAcceptMode autoAcceptMode;
-        protected int hidingFlags;
-        private boolean correction;
-        protected String correctionExplanation;
 
         protected Builder()
         {
         }
 
-        public T withId(int aId)
-        {
-            this.id = aId;
-            return (T) this;
-        }
-
-        public T withGeneration(int aGeneration)
-        {
-            this.generation = aGeneration;
-            return (T) this;
-        }
-
-        public T withAge(int aAge)
-        {
-            this.age = aAge;
-            return (T) this;
-        }
-
-        public T withRecommender(Recommender aRecommender)
-        {
-            this.recommenderId = aRecommender.getId();
-            this.recommenderName = aRecommender.getName();
-            this.feature = aRecommender.getFeature().getName();
-            this.layerId = aRecommender.getLayer().getId();
-            return (T) this;
-        }
-
-        @Deprecated
-        T withRecommenderId(long aRecommenderId)
-        {
-            this.recommenderId = aRecommenderId;
-            return (T) this;
-        }
-
-        @Deprecated
-        T withRecommenderName(String aRecommenderName)
-        {
-            this.recommenderName = aRecommenderName;
-            return (T) this;
-        }
-
-        @Deprecated
-        T withLayerId(long aLayerId)
-        {
-            this.layerId = aLayerId;
-            return (T) this;
-        }
-
-        @Deprecated
-        T withFeature(String aFeature)
-        {
-            this.feature = aFeature;
-            return (T) this;
-        }
-
-        public T withDocument(SourceDocument aDocument)
-        {
-            this.documentId = aDocument.getId();
-            return (T) this;
-        }
-
-        @Deprecated
-        public T withDocument(long aDocumentId)
-        {
-            this.documentId = aDocumentId;
-            return (T) this;
-        }
-
-        public T withLabel(String aLabel)
-        {
-            this.label = aLabel;
-            return (T) this;
-        }
-
-        public T withUiLabel(String aUiLabel)
-        {
-            this.uiLabel = aUiLabel;
-            return (T) this;
-        }
-
-        public T withScore(double aScore)
-        {
-            this.score = aScore;
-            return (T) this;
-        }
-
-        public T withScoreExplanation(String aScoreExplanation)
-        {
-            this.scoreExplanation = aScoreExplanation;
-            return (T) this;
-        }
-
         public T withPosition(P aPosition)
         {
-            this.position = aPosition;
-            return (T) this;
-        }
-
-        public T withAutoAcceptMode(AutoAcceptMode aAutoAcceptMode)
-        {
-            this.autoAcceptMode = aAutoAcceptMode;
-            return (T) this;
-        }
-
-        public T withHidingFlags(int aFlags)
-        {
-            this.hidingFlags = aFlags;
-            return (T) this;
-        }
-
-        public T withCorrection(boolean aCorrection)
-        {
-            this.correction = aCorrection;
-            return (T) this;
-        }
-
-        public T withCorrectionExplanation(String aCorrectionExplanation)
-        {
-            this.correctionExplanation = aCorrectionExplanation;
+            position = aPosition;
             return (T) this;
         }
 

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/MetadataSuggestion.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/MetadataSuggestion.java
@@ -19,8 +19,6 @@ package de.tudarmstadt.ukp.inception.recommendation.api.model;
 
 import java.io.Serializable;
 
-import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
-
 public class MetadataSuggestion
     extends AnnotationSuggestion
     implements Serializable
@@ -29,11 +27,7 @@ public class MetadataSuggestion
 
     private MetadataSuggestion(Builder builder)
     {
-        super(builder.id, builder.generation, builder.age, builder.recommenderId,
-                builder.recommenderName, builder.layerId, builder.feature, builder.documentId,
-                builder.label, builder.uiLabel, builder.score, builder.scoreExplanation,
-                builder.autoAcceptMode, builder.hidingFlags, builder.correction,
-                builder.correctionExplanation);
+        super(builder);
     }
 
     @Override
@@ -87,142 +81,10 @@ public class MetadataSuggestion
     }
 
     public static final class Builder
+        extends AnnotationSuggestion.Builder<Builder>
     {
-        private int id;
-        private int generation;
-        private int age;
-        private long recommenderId;
-        private String recommenderName;
-        private long layerId;
-        private String feature;
-        private long documentId;
-        private String label;
-        private String uiLabel;
-        private double score;
-        private String scoreExplanation;
-        private AutoAcceptMode autoAcceptMode;
-        private int hidingFlags;
-        boolean correction;
-        private String correctionExplanation;
-
         private Builder()
         {
-        }
-
-        public Builder withId(int aId)
-        {
-            this.id = aId;
-            return this;
-        }
-
-        public Builder withAge(int aAge)
-        {
-            this.age = aAge;
-            return this;
-        }
-
-        public Builder withGeneration(int aGeneration)
-        {
-            this.generation = aGeneration;
-            return this;
-        }
-
-        public Builder withRecommender(Recommender aRecommender)
-        {
-            this.recommenderId = aRecommender.getId();
-            this.recommenderName = aRecommender.getName();
-            this.feature = aRecommender.getFeature().getName();
-            this.layerId = aRecommender.getLayer().getId();
-            return this;
-        }
-
-        @Deprecated
-        Builder withRecommenderId(long aRecommenderId)
-        {
-            this.recommenderId = aRecommenderId;
-            return this;
-        }
-
-        @Deprecated
-        Builder withRecommenderName(String aRecommenderName)
-        {
-            this.recommenderName = aRecommenderName;
-            return this;
-        }
-
-        @Deprecated
-        Builder withLayerId(long aLayerId)
-        {
-            this.layerId = aLayerId;
-            return this;
-        }
-
-        @Deprecated
-        Builder withFeature(String aFeature)
-        {
-            this.feature = aFeature;
-            return this;
-        }
-
-        public Builder withDocument(SourceDocument aDocument)
-        {
-            this.documentId = aDocument.getId();
-            return this;
-        }
-
-        @Deprecated
-        Builder withDocument(long aDocumentId)
-        {
-            this.documentId = aDocumentId;
-            return this;
-        }
-
-        public Builder withLabel(String aLabel)
-        {
-            this.label = aLabel;
-            return this;
-        }
-
-        public Builder withUiLabel(String aUiLabel)
-        {
-            this.uiLabel = aUiLabel;
-            return this;
-        }
-
-        public Builder withScore(double aScore)
-        {
-            this.score = aScore;
-            return this;
-        }
-
-        public Builder withScoreExplanation(String aScoreExplanation)
-        {
-            this.scoreExplanation = aScoreExplanation;
-            return this;
-        }
-
-        public Builder withAutoAcceptMode(AutoAcceptMode aAutoAcceptMode)
-        {
-            this.autoAcceptMode = aAutoAcceptMode;
-            return this;
-        }
-
-        public Builder withHidingFlags(int aFlags)
-        {
-            this.hidingFlags = aFlags;
-            return this;
-        }
-
-        public Builder withCorrection(boolean aCorrection)
-        {
-            this.correction = aCorrection;
-            return this;
-        }
-
-        public Builder withCorrectionExplanation(String aCorrectionExplanation)
-        {
-            this.correctionExplanation = aCorrectionExplanation;
-            return this;
         }
 
         public MetadataSuggestion build()

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/SpanSuggestion.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/SpanSuggestion.java
@@ -21,8 +21,6 @@ import java.io.Serializable;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
-import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
-
 public class SpanSuggestion
     extends AnnotationSuggestion
     implements Serializable
@@ -34,11 +32,7 @@ public class SpanSuggestion
 
     private SpanSuggestion(Builder builder)
     {
-        super(builder.id, builder.generation, builder.age, builder.recommenderId,
-                builder.recommenderName, builder.layerId, builder.feature, builder.documentId,
-                builder.label, builder.uiLabel, builder.score, builder.scoreExplanation,
-                builder.autoAcceptMode, builder.hidingFlags, builder.correction,
-                builder.correctionExplanation);
+        super(builder);
 
         position = builder.position;
         coveredText = builder.coveredText;
@@ -138,160 +132,30 @@ public class SpanSuggestion
     }
 
     public static final class Builder
+        extends AnnotationSuggestion.Builder<Builder>
     {
-        private int id;
-        private int generation;
-        private int age;
-        private long recommenderId;
-        private String recommenderName;
-        private long layerId;
-        private String feature;
-        private long documentId;
-        private String label;
-        private String uiLabel;
-        private double score;
-        private String scoreExplanation;
         private Offset position;
         private String coveredText;
-        private AutoAcceptMode autoAcceptMode = AutoAcceptMode.NEVER;
-        private int hidingFlags;
-        private boolean correction;
-        private String correctionExplanation;
 
         private Builder()
         {
         }
 
-        public Builder withId(int aId)
-        {
-            this.id = aId;
-            return this;
-        }
-
-        public Builder withAge(int aAge)
-        {
-            this.age = aAge;
-            return this;
-        }
-
-        public Builder withGeneration(int aGeneration)
-        {
-            this.generation = aGeneration;
-            return this;
-        }
-
-        public Builder withRecommender(Recommender aRecommender)
-        {
-            this.recommenderId = aRecommender.getId();
-            this.recommenderName = aRecommender.getName();
-            this.feature = aRecommender.getFeature().getName();
-            this.layerId = aRecommender.getLayer().getId();
-            return this;
-        }
-
-        @Deprecated
-        Builder withRecommenderId(long aRecommenderId)
-        {
-            this.recommenderId = aRecommenderId;
-            return this;
-        }
-
-        @Deprecated
-        Builder withRecommenderName(String aRecommenderName)
-        {
-            this.recommenderName = aRecommenderName;
-            return this;
-        }
-
-        @Deprecated
-        Builder withLayerId(long aLayerId)
-        {
-            this.layerId = aLayerId;
-            return this;
-        }
-
-        @Deprecated
-        Builder withFeature(String aFeature)
-        {
-            this.feature = aFeature;
-            return this;
-        }
-
-        public Builder withDocument(SourceDocument aDocument)
-        {
-            this.documentId = aDocument.getId();
-            return this;
-        }
-
-        public Builder withDocument(long aDocumentId)
-        {
-            this.documentId = aDocumentId;
-            return this;
-        }
-
-        public Builder withLabel(String aLabel)
-        {
-            this.label = aLabel;
-            return this;
-        }
-
-        public Builder withUiLabel(String aUiLabel)
-        {
-            this.uiLabel = aUiLabel;
-            return this;
-        }
-
-        public Builder withScore(double aScore)
-        {
-            this.score = aScore;
-            return this;
-        }
-
-        public Builder withScoreExplanation(String aScoreExplanation)
-        {
-            this.scoreExplanation = aScoreExplanation;
-            return this;
-        }
-
         public Builder withPosition(int aBegin, int aEnd)
         {
-            this.position = new Offset(aBegin, aEnd);
+            position = new Offset(aBegin, aEnd);
             return this;
         }
 
         public Builder withPosition(Offset aPosition)
         {
-            this.position = aPosition;
+            position = aPosition;
             return this;
         }
 
         public Builder withCoveredText(String aCoveredText)
         {
-            this.coveredText = aCoveredText;
-            return this;
-        }
-
-        public Builder withAutoAcceptMode(AutoAcceptMode aAutoAcceptMode)
-        {
-            this.autoAcceptMode = aAutoAcceptMode;
-            return this;
-        }
-
-        public Builder withHidingFlags(int aFlags)
-        {
-            this.hidingFlags = aFlags;
-            return this;
-        }
-
-        public Builder withCorrection(boolean aCorrection)
-        {
-            this.correction = aCorrection;
-            return this;
-        }
-
-        public Builder withCorrectionExplanation(String aCorrectionExplanation)
-        {
-            this.correctionExplanation = aCorrectionExplanation;
+            coveredText = aCoveredText;
             return this;
         }
 

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/recommender/ExtractionContext.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/recommender/ExtractionContext.java
@@ -30,7 +30,9 @@ import org.apache.uima.cas.Feature;
 import org.apache.uima.cas.Type;
 import org.apache.uima.fit.util.CasUtil;
 
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
 
@@ -44,10 +46,8 @@ public final class ExtractionContext
     private final String documentText;
 
     private final Recommender recommender;
-
     private final AnnotationLayer layer;
-    private final String typeName;
-    private final String featureName;
+    private final AnnotationFeature feature;
 
     private final Type predictedType;
 
@@ -61,10 +61,13 @@ public final class ExtractionContext
 
     private final boolean isMultiLabels;
 
-    public ExtractionContext(int aGeneration, Recommender aRecommender, SourceDocument aDocument,
-            CAS aOriginalCas, CAS aPredictionCas)
+    public ExtractionContext(int aGeneration, Recommender aRecommender, AnnotationLayer aLayer,
+            AnnotationFeature aFeature, SourceDocument aDocument, CAS aOriginalCas,
+            CAS aPredictionCas)
     {
         recommender = aRecommender;
+        layer = aLayer;
+        feature = aFeature;
 
         document = aDocument;
         originalCas = aOriginalCas;
@@ -72,11 +75,9 @@ public final class ExtractionContext
         predictionCas = aPredictionCas;
 
         generation = aGeneration;
-        layer = aRecommender.getLayer();
-        featureName = aRecommender.getFeature().getName();
-        typeName = layer.getName();
 
-        predictedType = CasUtil.getType(aPredictionCas, typeName);
+        var featureName = feature.getName();
+        predictedType = CasUtil.getType(aPredictionCas, layer.getName());
         labelFeature = predictedType.getFeatureByBaseName(featureName);
         scoreFeature = predictedType.getFeatureByBaseName(featureName + FEATURE_NAME_SCORE_SUFFIX);
         scoreExplanationFeature = predictedType
@@ -116,6 +117,11 @@ public final class ExtractionContext
         return documentText;
     }
 
+    public Project getProject()
+    {
+        return document.getProject();
+    }
+
     public Recommender getRecommender()
     {
         return recommender;
@@ -126,14 +132,9 @@ public final class ExtractionContext
         return layer;
     }
 
-    public String getTypeName()
+    public AnnotationFeature getFeature()
     {
-        return typeName;
-    }
-
-    public String getFeatureName()
-    {
-        return featureName;
+        return feature;
     }
 
     public Type getPredictedType()

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/recommender/RecommendationEngine.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/recommender/RecommendationEngine.java
@@ -272,4 +272,13 @@ public abstract class RecommendationEngine
     {
         // Nothing do to
     }
+
+    /**
+     * @return whether to extract all layers and features or just the one configured in the
+     *         recommender settings.
+     */
+    public boolean isUniveralExtraction()
+    {
+        return false;
+    }
 }

--- a/inception/inception-recommendation-api/src/test/java/de/tudarmstadt/ukp/inception/recommendation/api/model/AnnotationSuggestionTest.java
+++ b/inception/inception-recommendation-api/src/test/java/de/tudarmstadt/ukp/inception/recommendation/api/model/AnnotationSuggestionTest.java
@@ -43,6 +43,8 @@ public class AnnotationSuggestionTest
         var rec2 = Recommender.builder().withId(2l).withLayer(layer).withFeature(feature).build();
 
         var builder = SpanSuggestion.builder() //
+                .withRecommenderId(1) //
+                .withRecommenderName("Recommender") //
                 .withLayerId(1) //
                 .withFeature("value") //
                 .withDocument(doc) //

--- a/inception/inception-recommendation-api/src/test/java/de/tudarmstadt/ukp/inception/recommendation/api/model/PredictionGroupTest.java
+++ b/inception/inception-recommendation-api/src/test/java/de/tudarmstadt/ukp/inception/recommendation/api/model/PredictionGroupTest.java
@@ -51,7 +51,8 @@ public class PredictionGroupTest
     @Test
     public void thatAddingElementsToGroupWorks()
     {
-        var builder = SpanSuggestion.builder().withDocument(doc).withPosition(0, 1);
+        var builder = SpanSuggestion.builder().withDocument(doc).withPosition(0, 1)
+                .withFeature("value");
 
         builder.withRecommender(rec1);
         var rec1Sug1 = builder.withId(1).withCoveredText("a").withLabel("A").withUiLabel("#A")

--- a/inception/inception-recommendation-api/src/test/java/de/tudarmstadt/ukp/inception/recommendation/api/model/PredictionsTest.java
+++ b/inception/inception-recommendation-api/src/test/java/de/tudarmstadt/ukp/inception/recommendation/api/model/PredictionsTest.java
@@ -122,6 +122,10 @@ class PredictionsTest
                 SpanSuggestion.builder() //
                         .withId(AnnotationSuggestion.NEW_ID) //
                         .withDocument(doc) //
+                        .withRecommenderId(1l) //
+                        .withRecommenderName("Recommender") //
+                        .withLayerId(1l) //
+                        .withFeature("feature") //
                         .build()));
 
         assertThat(sut.getSuggestionsByDocument(doc)) //
@@ -134,6 +138,10 @@ class PredictionsTest
                 SpanSuggestion.builder() //
                         .withId(AnnotationSuggestion.NEW_ID) //
                         .withDocument(doc) //
+                        .withRecommenderId(1l) //
+                        .withRecommenderName("Recommender") //
+                        .withLayerId(1l) //
+                        .withFeature("feature") //
                         .build()));
         sut.inheritSuggestions(inheritedPredictions);
 
@@ -152,13 +160,20 @@ class PredictionsTest
         var tokens = cas.select(Token.class).asList();
 
         var result = new ArrayList<AnnotationSuggestion>();
-        for (var docId = 0l; docId < aDocs; docId++) {
-            var doc = SourceDocument.builder().withId(docId).withName("doc" + docId).build();
-            for (var recId = 0l; recId < aRecommenders; recId++) {
+        for (var docId = 1l; docId <= aDocs; docId++) {
+            var doc = SourceDocument.builder() //
+                    .withId(docId) //
+                    .withName("doc" + docId) //
+                    .build();
+            for (var recId = 1l; recId <= aRecommenders; recId++) {
                 var feature = AnnotationFeature.builder().withId(recId).withName("feat" + recId)
                         .build();
-                var rec = Recommender.builder().withId(recId).withName("rec" + recId)
-                        .withLayer(layer).withFeature(feature).build();
+                var rec = Recommender.builder() //
+                        .withId(recId) //
+                        .withName("rec" + recId) //
+                        .withLayer(layer) //
+                        .withFeature(feature) //
+                        .build();
                 for (int annId = 0; annId < aSuggestions; annId++) {
                     var label = labels.get(rng.nextInt(labels.size()));
                     var token = tokens.get(rng.nextInt(tokens.size()));

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/RecommendationEditorExtension.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/RecommendationEditorExtension.java
@@ -24,6 +24,7 @@ package de.tudarmstadt.ukp.inception.recommendation;
 import static de.tudarmstadt.ukp.clarin.webanno.model.LinkMode.WITH_ROLE;
 import static de.tudarmstadt.ukp.clarin.webanno.model.Mode.ANNOTATION;
 import static de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordChangeLocation.MAIN_EDITOR;
+import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
 import static org.apache.wicket.event.Broadcast.BREADTH;
@@ -353,10 +354,10 @@ public class RecommendationEditorExtension
 
             for (var ao : sortedByScore) {
                 var detailGroup = new VLazyDetailGroup(ao.getRecommenderName());
+                detailGroup.addDetail(new VLazyDetail("Feature", aFeature.getUiName()));
                 // detailGroup.addDetail(new VLazyDetail("Age", String.valueOf(ao.getAge())));
                 if (ao.getScore() > 0.0d) {
-                    detailGroup.addDetail(
-                            new VLazyDetail("Score", String.format("%.2f", ao.getScore())));
+                    detailGroup.addDetail(new VLazyDetail("Score", format("%.2f", ao.getScore())));
                 }
                 if (ao.getScoreExplanation().isPresent()) {
                     detailGroup.addDetail(

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/config/RecommenderServiceAutoConfiguration.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/config/RecommenderServiceAutoConfiguration.java
@@ -196,10 +196,11 @@ public class RecommenderServiceAutoConfiguration
     public RecommendationRenderer recommendationRenderer(
             RecommendationService aRecommendationService,
             SuggestionSupportRegistry aSuggestionSupportRegistry,
-            PreferencesService aPreferencesService, UserDao aUserService)
+            PreferencesService aPreferencesService, UserDao aUserService,
+            AnnotationSchemaService aSchemaService)
     {
         return new RecommendationRenderer(aRecommendationService, aSuggestionSupportRegistry,
-                aPreferencesService, aUserService);
+                aPreferencesService, aUserService, aSchemaService);
     }
 
     @Bean

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImpl.java
@@ -1747,9 +1747,11 @@ public class RecommendationServiceImpl
         // All suggestions in the group must be of the same type. Even if they come from different
         // recommenders, the recommenders must all be producing the same type of suggestion, so we
         // can happily just take one of them in order to locate the suggestion support.
-        var recommender = getRecommender(maybeSuggestion.get());
-        var rls = suggestionSupportRegistry
-                .findGenericExtension(SuggestionSupportQuery.of(recommender));
+        var suggestion = maybeSuggestion.get();
+        var maybeFeature = schemaService.getFeature(suggestion.getLayerId(),
+                maybeSuggestion.get().getFeature());
+
+        var rls = maybeFeature.flatMap(suggestionSupportRegistry::findExtension);
 
         if (rls.isPresent()) {
             rls.get().calculateSuggestionVisibility(aSessionOwner, aDocument, aCas, aDataOwner,

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/SuggestionSupportRegistryImpl.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/service/SuggestionSupportRegistryImpl.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.inception.recommendation.api.SuggestionSupport;
 import de.tudarmstadt.ukp.inception.recommendation.api.SuggestionSupportQuery;
 import de.tudarmstadt.ukp.inception.recommendation.api.SuggestionSupportRegistry;
@@ -48,5 +49,11 @@ public class SuggestionSupportRegistryImpl
                 .filter(e -> e.accepts(aKey)) //
                 .map(e -> (X) e) //
                 .findFirst();
+    }
+
+    @Override
+    public Optional<SuggestionSupport> findExtension(AnnotationFeature aFeature)
+    {
+        return findGenericExtension(SuggestionSupportQuery.of(aFeature));
     }
 }

--- a/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/link/LinkSuggestionExtractionTest.java
+++ b/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/link/LinkSuggestionExtractionTest.java
@@ -179,7 +179,8 @@ class LinkSuggestionExtractionTest
         linkFeatureSupport.setFeatureValue(predictionCas, linkFeature, prediction.getAddress(),
                 asList(new LinkWithRoleModel("role", "label", preSlotFiller.getAddress())));
 
-        var ctx = new ExtractionContext(0, recommender, document, originalCas, predictionCas);
+        var ctx = new ExtractionContext(0, recommender, recommender.getLayer(),
+                recommender.getFeature(), document, originalCas, predictionCas);
         var suggestions = sut.extractSuggestions(ctx);
 
         assertThat(suggestions) //

--- a/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/relation/RelationSuggestionVisibilityCalculationTest.java
+++ b/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/relation/RelationSuggestionVisibilityCalculationTest.java
@@ -28,7 +28,6 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
-import java.util.List;
 
 import org.apache.uima.cas.CAS;
 import org.apache.uima.fit.factory.JCasFactory;
@@ -213,10 +212,12 @@ public class RelationSuggestionVisibilityCalculationTest
         var rec = Recommender.builder().withId(RECOMMENDER_ID).withName(RECOMMENDER_NAME)
                 .withLayer(aFeat.getLayer()).withFeature(aFeat).build();
 
-        List<RelationSuggestion> suggestions = new ArrayList<>();
+        var suggestions = new ArrayList<RelationSuggestion>();
         for (int[] val : vals) {
-            var suggestion = RelationSuggestion.builder().withId(val[0]).withRecommender(rec)
-                    .withDocument(doc)
+            var suggestion = RelationSuggestion.builder() //
+                    .withId(val[0]) //
+                    .withRecommender(rec) //
+                    .withDocument(doc) //
                     .withPosition(new RelationPosition(val[1], val[2], val[3], val[4]))
                     .withScore(CONFIDENCE).withScoreExplanation(CONFIDENCE_EXPLANATION).build();
             suggestions.add(suggestion);

--- a/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/Fixtures.java
+++ b/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/Fixtures.java
@@ -64,9 +64,14 @@ public class Fixtures
 
         List<SpanSuggestion> suggestions = new ArrayList<>();
         for (int[] val : vals) {
-            var suggestion = SpanSuggestion.builder().withId(val[0]).withRecommender(rec)
-                    .withDocument(doc).withPosition(val[1], val[2]).withCoveredText(COVERED_TEXT)
-                    .withScore(CONFIDENCE).withScoreExplanation(CONFIDENCE_EXPLANATION).build();
+            var suggestion = SpanSuggestion.builder().withId(val[0]) //
+                    .withRecommender(rec) //
+                    .withDocument(doc) //
+                    .withPosition(val[1], val[2]) //
+                    .withCoveredText(COVERED_TEXT) //
+                    .withScore(CONFIDENCE) //
+                    .withScoreExplanation(CONFIDENCE_EXPLANATION) //
+                    .build();
             suggestions.add(suggestion);
         }
 

--- a/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImplIntegrationTest.java
+++ b/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImplIntegrationTest.java
@@ -22,6 +22,7 @@ import static de.tudarmstadt.ukp.clarin.webanno.model.OverlapMode.NO_OVERLAP;
 import static de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordChangeLocation.DETAIL_EDITOR;
 import static de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordChangeLocation.MAIN_EDITOR;
 import static de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordUserAction.ACCEPTED;
+import static java.lang.System.identityHashCode;
 import static java.util.Arrays.asList;
 import static org.apache.uima.fit.factory.JCasFactory.createJCas;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -223,24 +224,36 @@ public class RecommendationServiceImplIntegrationTest
         targetFS.addToIndexes();
         assertThat(targetFS.getValue()).isNull();
 
-        var s1 = SpanSuggestion.builder().withLabel("V1").withRecommender(spanLayerRecommender)
-                .withPosition(new Offset(targetFS)).build();
+        var s1 = SpanSuggestion.builder() //
+                .withLabel("V1") //
+                .withRecommender(spanLayerRecommender) //
+                .withDocument(doc) //
+                .withPosition(new Offset(targetFS)) //
+                .build();
         sut.acceptSuggestion(USER_NAME, doc, docOwner, cas.getCas(), null, s1, MAIN_EDITOR);
 
         assertThat(targetFS.getValue()) //
                 .as("Label was merged into existing annotation replacing unset label") //
                 .isEqualTo("V1");
 
-        var s2 = SpanSuggestion.builder().withLabel("V2").withRecommender(spanLayerRecommender)
-                .withPosition(new Offset(targetFS)).build();
+        var s2 = SpanSuggestion.builder() //
+                .withLabel("V2") //
+                .withRecommender(spanLayerRecommender) //
+                .withDocument(doc) //
+                .withPosition(new Offset(targetFS)) //
+                .build();
         sut.acceptSuggestion(USER_NAME, doc, docOwner, cas.getCas(), null, s2, MAIN_EDITOR);
 
         assertThat(targetFS.getValue()) //
                 .as("Label was merged into existing annotation replacing previous label") //
                 .isEqualTo("V2");
 
-        var s3 = SpanSuggestion.builder().withLabel("V3").withRecommender(spanLayerRecommender)
-                .withPosition(new Offset(10, 20)).build();
+        var s3 = SpanSuggestion.builder() //
+                .withLabel("V3") //
+                .withRecommender(spanLayerRecommender) //
+                .withDocument(doc) //
+                .withPosition(new Offset(10, 20)) //
+                .build();
         sut.acceptSuggestion(USER_NAME, doc, docOwner, cas.getCas(), null, s3, MAIN_EDITOR);
 
         assertThat(cas.select(NamedEntity.class).asList()) //
@@ -256,16 +269,24 @@ public class RecommendationServiceImplIntegrationTest
         targetFS.addToIndexes();
         assertThat(targetFS.getValue()).isNull();
 
-        var s4 = SpanSuggestion.builder().withLabel("V1").withRecommender(spanLayerRecommender)
-                .withPosition(new Offset(targetFS)).build();
+        var s4 = SpanSuggestion.builder() //
+                .withLabel("V1") //
+                .withRecommender(spanLayerRecommender) //
+                .withDocument(doc) //
+                .withPosition(new Offset(targetFS)) //
+                .build();
         sut.acceptSuggestion(USER_NAME, doc, docOwner, cas.getCas(), null, s4, MAIN_EDITOR);
 
         assertThat(targetFS.getValue()) //
                 .as("Label was merged into existing annotation replacing unset label") //
                 .isEqualTo("V1");
 
-        var s5 = SpanSuggestion.builder().withLabel("V2").withRecommender(spanLayerRecommender)
-                .withPosition(new Offset(targetFS)).build();
+        var s5 = SpanSuggestion.builder() //
+                .withLabel("V2") //
+                .withRecommender(spanLayerRecommender) //
+                .withDocument(doc) //
+                .withPosition(new Offset(targetFS)) //
+                .build();
         sut.acceptSuggestion(USER_NAME, doc, docOwner, cas.getCas(), null, s5, MAIN_EDITOR);
 
         assertThat(cas.select(NamedEntity.class).asList()) //
@@ -275,8 +296,12 @@ public class RecommendationServiceImplIntegrationTest
                         tuple(0, 10, "V1"), //
                         tuple(0, 10, "V2"));
 
-        var s6 = SpanSuggestion.builder().withLabel("V3").withRecommender(spanLayerRecommender)
-                .withPosition(new Offset(10, 20)).build();
+        var s6 = SpanSuggestion.builder() //
+                .withLabel("V3") //
+                .withRecommender(spanLayerRecommender) //
+                .withDocument(doc) //
+                .withPosition(new Offset(10, 20)) //
+                .build();
         sut.acceptSuggestion(USER_NAME, doc, docOwner, cas.getCas(), null, s6, MAIN_EDITOR);
 
         assertThat(cas.select(NamedEntity.class).asList()) //
@@ -290,8 +315,12 @@ public class RecommendationServiceImplIntegrationTest
         new NamedEntity(cas, 0, 10).addToIndexes();
         new NamedEntity(cas, 0, 10).addToIndexes();
 
-        var s7 = SpanSuggestion.builder().withLabel("V4").withRecommender(spanLayerRecommender)
-                .withPosition(new Offset(0, 10)).build();
+        var s7 = SpanSuggestion.builder() //
+                .withLabel("V4") //
+                .withRecommender(spanLayerRecommender) //
+                .withDocument(doc) //
+                .withPosition(new Offset(0, 10)) //
+                .build();
         sut.acceptSuggestion(USER_NAME, doc, docOwner, cas.getCas(), null, s7, MAIN_EDITOR);
 
         assertThat(cas.select(NamedEntity.class).asList()) //
@@ -353,10 +382,16 @@ public class RecommendationServiceImplIntegrationTest
         var feature = createAnnotationFeature(layer, FEATURE_NAME);
         var rec = buildRecommender(feature);
 
-        var suggestion = RelationSuggestion.builder().withId(42).withRecommender(rec)
-                .withDocument(sourceDoc).withPosition(new RelationPosition(7, 14, 21, 28))
-                .withLabel("testLabel").withUiLabel("testUiLabel").withScore(0.42)
-                .withScoreExplanation("Test confidence").build();
+        var suggestion = RelationSuggestion.builder() //
+                .withId(42) //
+                .withRecommender(rec) //
+                .withDocument(sourceDoc) //
+                .withPosition(new RelationPosition(7, 14, 21, 28)) //
+                .withLabel("testLabel") //
+                .withUiLabel("testUiLabel") //
+                .withScore(0.42) //
+                .withScoreExplanation("Test confidence") //
+                .build();
 
         sut.logRecord(USER_NAME, sourceDoc, USER_NAME, suggestion, feature,
                 LearningRecordUserAction.REJECTED, DETAIL_EDITOR);
@@ -394,29 +429,37 @@ public class RecommendationServiceImplIntegrationTest
         var rec2 = buildRecommender(feature2);
 
         Offset position = new Offset(7, 14);
-        sut.logRecord(USER_NAME, sourceDoc1, USER_NAME,
-                SpanSuggestion.builder().withRecommender(rec1).withDocument(sourceDoc1)
-                        .withPosition(position).withLabel("testLabel")
-                        .withCoveredText("aCoveredText").build(),
-                feature1, ACCEPTED, MAIN_EDITOR);
+        sut.logRecord(USER_NAME, sourceDoc1, USER_NAME, SpanSuggestion.builder() //
+                .withRecommender(rec1) //
+                .withDocument(sourceDoc1) //
+                .withPosition(position) //
+                .withLabel("testLabel") //
+                .withCoveredText("aCoveredText") //
+                .build(), feature1, ACCEPTED, MAIN_EDITOR);
 
-        sut.logRecord(USER_NAME, sourceDoc1, USER_NAME,
-                SpanSuggestion.builder().withRecommender(rec2).withDocument(sourceDoc1)
-                        .withPosition(position).withLabel("testLabel")
-                        .withCoveredText("aCoveredText").build(),
-                feature2, ACCEPTED, MAIN_EDITOR);
+        sut.logRecord(USER_NAME, sourceDoc1, USER_NAME, SpanSuggestion.builder() //
+                .withRecommender(rec2) //
+                .withDocument(sourceDoc1) //
+                .withPosition(position) //
+                .withLabel("testLabel") //
+                .withCoveredText("aCoveredText") //
+                .build(), feature2, ACCEPTED, MAIN_EDITOR);
 
-        sut.logRecord(USER_NAME, sourceDoc2, USER_NAME,
-                SpanSuggestion.builder().withRecommender(rec1).withDocument(sourceDoc1)
-                        .withPosition(position).withLabel("testLabel")
-                        .withCoveredText("aCoveredText").build(),
-                feature1, ACCEPTED, MAIN_EDITOR);
+        sut.logRecord(USER_NAME, sourceDoc2, USER_NAME, SpanSuggestion.builder() //
+                .withRecommender(rec1) //
+                .withDocument(sourceDoc1) //
+                .withPosition(position) //
+                .withLabel("testLabel") //
+                .withCoveredText("aCoveredText") //
+                .build(), feature1, ACCEPTED, MAIN_EDITOR);
 
-        sut.logRecord(USER_NAME, sourceDoc2, USER_NAME,
-                SpanSuggestion.builder().withRecommender(rec2).withDocument(sourceDoc1)
-                        .withPosition(position).withLabel("testLabel")
-                        .withCoveredText("aCoveredText").build(),
-                feature2, ACCEPTED, MAIN_EDITOR);
+        sut.logRecord(USER_NAME, sourceDoc2, USER_NAME, SpanSuggestion.builder() //
+                .withRecommender(rec2) //
+                .withDocument(sourceDoc1) //
+                .withPosition(position) //
+                .withLabel("testLabel") //
+                .withCoveredText("aCoveredText") //
+                .build(), feature2, ACCEPTED, MAIN_EDITOR);
 
         assertThat(sut.listLearningRecords(USER_NAME, sourceDoc1, USER_NAME, feature1)).hasSize(1);
         assertThat(sut.listLearningRecords(USER_NAME, sourceDoc1, USER_NAME, feature2)).hasSize(1);
@@ -484,6 +527,7 @@ public class RecommendationServiceImplIntegrationTest
     private Recommender buildRecommender(AnnotationFeature aFeature)
     {
         var r = new Recommender();
+        r.setName("Rec-" + aFeature.getName() + "_" + identityHashCode(r));
         r.setLayer(aFeature.getLayer());
         r.setFeature(aFeature);
         r.setProject(aFeature.getProject());

--- a/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/AnnotationSchemaService.java
+++ b/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/schema/api/AnnotationSchemaService.java
@@ -292,6 +292,8 @@ public interface AnnotationSchemaService
      */
     AnnotationFeature getFeature(String aFeature, AnnotationLayer aLayer);
 
+    Optional<AnnotationFeature> getFeature(long aLayerId, String aName);
+
     /**
      * Check if an {@link AnnotationLayer} already exists.
      * 

--- a/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/service/AnnotationSchemaServiceImpl.java
+++ b/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/service/AnnotationSchemaServiceImpl.java
@@ -675,6 +675,25 @@ public class AnnotationSchemaServiceImpl
     }
 
     @Override
+    @Transactional(noRollbackFor = NoResultException.class)
+    public Optional<AnnotationFeature> getFeature(long aLayerId, String aName)
+    {
+        var cb = entityManager.getCriteriaBuilder();
+        var query = cb.createQuery(AnnotationFeature.class);
+        var feature = query.from(AnnotationFeature.class);
+
+        var namePredicate = cb.equal(feature.get(AnnotationFeature_.name), aName);
+        var layerPredicate = cb
+                .equal(feature.get(AnnotationFeature_.layer).get(AnnotationLayer_.id), aLayerId);
+
+        query.select(feature).where(cb.and(namePredicate, layerPredicate));
+
+        return entityManager.createQuery(query) //
+                .getResultStream() //
+                .findFirst();
+    }
+
+    @Override
     @Transactional(noRollbackFor = NoResultException.class, readOnly = true)
     public boolean existsType(String aName, String aType)
     {


### PR DESCRIPTION
**What's in the PR**
* Use ExtractionContext everywhere: replace manual generation/recommender/document/feature/layer wiring with a single .withContext(ctx) call for suggestion builders (Span/Relation/Link/Metadata).
* Add ExtractionContext fields (layer, feature, project) and constructor overload; expose getFeature() and getProject(); update tests to pass layer+feature.
* Add withContext, withLayer and withFeature helper methods to suggestion builders (Span/Arc/Metadata) and refactor builder usage.
* Make schemaService adapter lookups use ctx.getProject() instead of recommender.getProject().
* Enhance PredictionTask: only look up suggestion support early when recommender is bound; support extracting suggestions for all enabled features when unbound; add new extractSuggestions(...) overload and related stream handling.
* Small whitespace/test fixes and related test updates to new ExtractionContext constructor usage.

**How to test manually**
* Implement a suitable external recommender to test with

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
