### PR TITLE
#5714 - StringMatchingRelationRecommender is selectable for cross-layer relations but does not support them

### DIFF
--- a/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/v1/ExternalRecommenderFactory.java
+++ b/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/v1/ExternalRecommenderFactory.java
@@ -58,14 +58,14 @@ public class ExternalRecommenderFactory
     @Override
     public RecommendationEngine build(Recommender aRecommender)
     {
-        ExternalRecommenderTraits traits = readTraits(aRecommender);
+        var traits = readTraits(aRecommender);
         return new ExternalRecommender(properties, aRecommender, traits);
     }
 
     @Override
     public String getName()
     {
-        return "Remote classifier";
+        return "External recommender";
     }
 
     @Override

--- a/inception/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/relation/StringMatchingRelationRecommenderFactory.java
+++ b/inception/inception-imls-stringmatch/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/stringmatch/relation/StringMatchingRelationRecommenderFactory.java
@@ -71,6 +71,12 @@ public class StringMatchingRelationRecommenderFactory
             return false;
         }
 
+        if (aLayer.getAttachType() == null) {
+            // We need to know the attach type in order to find candidates between which to propose
+            // a relation. This recommender is not suitable for cross-layer relations.
+            return false;
+        }
+
         return RelationLayerSupport.TYPE.equals(aLayer.getType()) && !aLayer.isAllowStacking();
     }
 

--- a/inception/inception-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
+++ b/inception/inception-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
@@ -1266,7 +1266,6 @@ public class ProjectServiceImpl
             return new Realm(aRealmId, "<Project> " + project.getName());
         }
         catch (NoResultException e) {
-
             return new Realm(aRealmId, "<Project (deleted)>: " + projectId + ">");
         }
     }

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommenderInfoPanel.html
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommenderInfoPanel.html
@@ -34,8 +34,8 @@
         <div class="d-flex flex-row p-2 border-bottom">
           <span wicket:id="sampleUnit" title="Sample granularity"/>
           <span class="flex-grow-1 text-end">
-            <span title="Sample count in training set"><i class="fas fa-brain text-muted"/>&nbsp;<span wicket:id="trainingSampleCount"/></span>
-            <span title="Sample count in evaluation set"><i class="fas fa-vial text-muted ps-2"/>&nbsp;<span wicket:id="testSampleCount"/></span>
+            <span title="Sample count in training set"><i class="fas fa-brain text-muted pe-1"/><span wicket:id="trainingSampleCount"/></span>
+            <span title="Sample count in evaluation set"><i class="fas fa-vial text-muted ps-2 pe-3"/><span wicket:id="testSampleCount"/></span>
           </span>
         </div>
         <div class="flex-h-container">

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/TrainingTask.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/tasks/TrainingTask.java
@@ -414,7 +414,8 @@ public class TrainingTask
 
         appEventPublisher.publishEvent(RecommenderTaskNotificationEvent
                 .builder(this, getProject(), getMandatorySessionOwner().getUsername()) //
-                .withMessage(LogMessage.error(this, "Training failed with %s", e.getMessage()))
+                .withMessage(LogMessage.error(this, "Training [%s] failed: %s",
+                        recommender.getName(), e.getMessage()))
                 .build());
     }
 


### PR DESCRIPTION
**What's in the PR**
* Rename/standardize factory/recommender display name: "Remote classifier" -> "External recommender"; use var where appropriate.
* Improve logging in TrainingTask failure notification to include recommender name.
* Improve ExternalRecommender HTTP error handling: factor out communicationFailedException(...) and use Strings.CS.appendIfMissing(...) for URI building.
* Minor UI tweak: adjust spacing classes in RecommenderInfoPanel HTML for sample counts.
* Skip string-matching relation recommender for cross-layer relations by checking attach type (prevent unsuitable suggestions).

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
