### PR TITLE
#5727 - CAS export format including XML structure

### DIFF
--- a/inception/inception-io-xmi/pom.xml
+++ b/inception/inception-io-xmi/pom.xml
@@ -37,6 +37,26 @@
       <artifactId>inception-model</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-io-xml</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-support</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-documents-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+   <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-annotation-storage-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework</groupId>
@@ -54,6 +74,7 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
     </dependency>
+
     <dependency>
       <groupId>org.apache.uima</groupId>
       <artifactId>uimaj-core</artifactId>

--- a/inception/inception-io-xmi/src/main/java/de/tudarmstadt/ukp/inception/io/xmi/XmiXmlStructureFormatSupport.java
+++ b/inception/inception-io-xmi/src/main/java/de/tudarmstadt/ukp/inception/io/xmi/XmiXmlStructureFormatSupport.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.io.xmi;
+
+import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode.SHARED_READ_ONLY_ACCESS;
+import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasUpgradeMode.AUTO_CAS_UPGRADE;
+import static de.tudarmstadt.ukp.inception.io.xml.dkprocore.XmlNodeUtils.containsXmlDocumentStructure;
+import static de.tudarmstadt.ukp.inception.io.xml.dkprocore.XmlNodeUtils.transferXmlDocumentStructure;
+import static org.apache.uima.fit.factory.AnalysisEngineFactory.createEngineDescription;
+import static org.apache.uima.fit.factory.CollectionReaderFactory.createReaderDescription;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.uima.UIMAException;
+import org.apache.uima.analysis_engine.AnalysisEngineDescription;
+import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
+import org.apache.uima.cas.CAS;
+import org.apache.uima.collection.CollectionReaderDescription;
+import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
+import org.dkpro.core.io.xmi.XmiReader;
+import org.dkpro.core.io.xmi.XmiWriter;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
+import de.tudarmstadt.ukp.inception.io.xmi.config.UimaFormatsAutoConfiguration;
+import de.tudarmstadt.ukp.inception.io.xmi.config.UimaFormatsPropertiesImpl.XmiFormatProperties;
+import de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil;
+
+/**
+ * <p>
+ * This class is exposed as a Spring Component via
+ * {@link UimaFormatsAutoConfiguration#xmiXmlStructureFormatSupport}.
+ * </p>
+ */
+public class XmiXmlStructureFormatSupport
+    implements FormatSupport
+{
+    public static final String ID = "xmi-xmlstruct";
+    public static final String NAME = "UIMA CAS XMI (XML 1.0 + XML structure)";
+
+    private final XmiFormatProperties properties;
+    private final DocumentService documentService;
+
+    public XmiXmlStructureFormatSupport(XmiFormatProperties aProperties,
+            DocumentService aDocumentService)
+    {
+        properties = aProperties;
+        documentService = aDocumentService;
+    }
+
+    @Override
+    public String getId()
+    {
+        return ID;
+    }
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public boolean isReadable()
+    {
+        return true;
+    }
+
+    @Override
+    public boolean isWritable()
+    {
+        return true;
+    }
+
+    @Override
+    public boolean isProneToInconsistencies()
+    {
+        return true;
+    }
+
+    @Override
+    public File write(SourceDocument aDocument, CAS aCas, File aTargetFolder,
+            boolean aStripExtension)
+        throws ResourceInitializationException, AnalysisEngineProcessException, IOException
+    {
+        var cas = aCas;
+
+        if (!containsXmlDocumentStructure(aCas)) {
+            try {
+                cas = WebAnnoCasUtil.createCasCopy(aCas);
+                var initialCas = documentService.createOrReadInitialCas(aDocument, AUTO_CAS_UPGRADE,
+                        SHARED_READ_ONLY_ACCESS);
+                transferXmlDocumentStructure(cas, initialCas);
+            }
+            catch (ResourceInitializationException | AnalysisEngineProcessException e) {
+                throw e;
+            }
+            catch (UIMAException e) {
+                throw new ResourceInitializationException(e);
+            }
+        }
+
+        return FormatSupport.super.write(aDocument, cas, aTargetFolder, aStripExtension);
+    }
+
+    @Override
+    public CollectionReaderDescription getReaderDescription(Project aProject,
+            TypeSystemDescription aTSD)
+        throws ResourceInitializationException
+    {
+        return createReaderDescription( //
+                XmiReader.class, //
+                XmiReader.PARAM_LENIENT, true);
+    }
+
+    @Override
+    public AnalysisEngineDescription getWriterDescription(Project aProject,
+            TypeSystemDescription aTSD, CAS aCAS)
+        throws ResourceInitializationException
+    {
+        return createEngineDescription( //
+                XmiWriter.class, aTSD, //
+                XmiWriter.PARAM_VERSION, "1.0", //
+                XmiWriter.PARAM_SANITIZE_ILLEGAL_CHARACTERS,
+                properties.isSanitizeIllegalCharacters());
+    }
+}

--- a/inception/inception-io-xmi/src/main/java/de/tudarmstadt/ukp/inception/io/xmi/config/UimaFormatsAutoConfiguration.java
+++ b/inception/inception-io-xmi/src/main/java/de/tudarmstadt/ukp/inception/io/xmi/config/UimaFormatsAutoConfiguration.java
@@ -22,10 +22,12 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.io.xmi.BinaryCasFormatSupport;
 import de.tudarmstadt.ukp.inception.io.xmi.UimaInlineXmlFormatSupport;
 import de.tudarmstadt.ukp.inception.io.xmi.XmiFormatSupport;
 import de.tudarmstadt.ukp.inception.io.xmi.XmiXml11FormatSupport;
+import de.tudarmstadt.ukp.inception.io.xmi.XmiXmlStructureFormatSupport;
 
 @Configuration
 @EnableConfigurationProperties(UimaFormatsPropertiesImpl.class)
@@ -53,6 +55,15 @@ public class UimaFormatsAutoConfiguration
     public XmiFormatSupport xmiFormatSupport(UimaFormatsProperties aProperties)
     {
         return new XmiFormatSupport(aProperties.getUimaXmi());
+    }
+
+    @ConditionalOnProperty(prefix = "format.uima-xmi-struct", name = "enabled", //
+            havingValue = "true", matchIfMissing = true)
+    @Bean
+    public XmiXmlStructureFormatSupport xmiXmlStructureFormatSupport(
+            UimaFormatsProperties aProperties, DocumentService aDocumentService)
+    {
+        return new XmiXmlStructureFormatSupport(aProperties.getUimaXmi(), aDocumentService);
     }
 
     @ConditionalOnProperty(prefix = "format.uima-inline-xml", name = "enabled", //


### PR DESCRIPTION
**What's in the PR**
- Added CAS XML export support that integrates the XML structure from the initial CAS

**How to test manually**
* Import a file with XML structure, e.g. a HTML file
* Export with normal XMI CAS
* Export with XMI CAS + XML structure
* Check that there a no XMLElement annotations in the normal XMI but they are in the XMI CAS + XML structure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
