### PR TITLE
#5748 - Support searching concepts in certain KBs by ID instead of IRI

### DIFF
--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/model/KnowledgeBase.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/model/KnowledgeBase.java
@@ -500,6 +500,7 @@ public class KnowledgeBase
         setDefaultLanguage(aProfile.getDefaultLanguage());
         setDefaultDatasetIri(aProfile.getDefaultDataset());
         setReification(aProfile.getReification());
+        setBasePrefix(aProfile.getBasePrefix());
 
         applyRootConcepts(aProfile);
         applyMapping(aProfile.getMapping());

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/yaml/KnowledgeBaseProfile.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/yaml/KnowledgeBaseProfile.java
@@ -33,6 +33,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 
+import de.tudarmstadt.ukp.inception.kb.IriConstants;
 import de.tudarmstadt.ukp.inception.kb.RepositoryType;
 import de.tudarmstadt.ukp.inception.kb.reification.Reification;
 
@@ -78,6 +79,9 @@ public class KnowledgeBaseProfile
     @JsonProperty("default-dataset")
     private String defaultDataset;
 
+    @JsonProperty("base-prefix")
+    private String basePrefix = IriConstants.INCEPTION_NAMESPACE;
+
     public KnowledgeBaseProfile()
     {
     }
@@ -92,7 +96,8 @@ public class KnowledgeBaseProfile
             @JsonProperty("info") KnowledgeBaseInfo aInfo, //
             @JsonProperty("reification") Reification aReification, //
             @JsonProperty("default-language") String aDefaultLanguage, //
-            @JsonProperty("default-dataset") String aDefaultDataset)
+            @JsonProperty("default-dataset") String aDefaultDataset, //
+            @JsonProperty("base-prefix") String aBasePrefix)
     {
         name = aName;
         disabled = aDisabled;
@@ -102,13 +107,14 @@ public class KnowledgeBaseProfile
         rootConcepts = aRootConcepts;
         info = aInfo;
         defaultLanguage = aDefaultLanguage;
+        defaultDataset = aDefaultDataset;
 
         if (aReification != null) {
             reification = aReification;
         }
 
-        if (aDefaultDataset != null) {
-            defaultDataset = aDefaultDataset;
+        if (aBasePrefix != null) {
+            basePrefix = aBasePrefix;
         }
     }
 
@@ -236,6 +242,16 @@ public class KnowledgeBaseProfile
         defaultDataset = aDefaultDataset;
     }
 
+    public void setBasePrefix(String aBasePrefix)
+    {
+        basePrefix = aBasePrefix;
+    }
+
+    public String getBasePrefix()
+    {
+        return basePrefix;
+    }
+
     /**
      * Reads knowledge base profiles from a YAML file and stores them in a HashMap with the key that
      * is defined in the file and a corresponding {@link KnowledgeBaseProfile} object as value
@@ -277,14 +293,16 @@ public class KnowledgeBaseProfile
                 && Objects.equals(defaultLanguage, that.defaultLanguage) //
                 && Objects.equals(defaultDataset, that.defaultDataset) //
                 && Objects.equals(additionalMatchingProperties, that.additionalMatchingProperties) //
-                && Objects.equals(additionalLanguages, that.additionalLanguages);
+                && Objects.equals(additionalLanguages, that.additionalLanguages) //
+                && Objects.equals(basePrefix, that.basePrefix);
     }
 
     @Override
     public int hashCode()
     {
         return Objects.hash(name, disabled, type, access, mapping, rootConcepts, info, reification,
-                defaultLanguage, defaultDataset, additionalMatchingProperties, additionalLanguages);
+                defaultLanguage, defaultDataset, additionalMatchingProperties, additionalLanguages,
+                basePrefix);
     }
 
     @Override

--- a/inception/inception-kb/src/main/resources/de/tudarmstadt/ukp/inception/kb/yaml/knowledgebase-profiles.yaml
+++ b/inception/inception-kb/src/main/resources/de/tudarmstadt/ukp/inception/kb/yaml/knowledgebase-profiles.yaml
@@ -119,6 +119,7 @@ wikidata:
   name: Wikidata (direct mapping)
   type: REMOTE
   default-language: en
+  base-prefix: http://www.wikidata.org/entity/
   access:
     access-url: https://query.wikidata.org/sparql
     full-text-search: https://www.mediawiki.org/ontology#API/search
@@ -342,6 +343,7 @@ snomed-ct:
   name: SNOMED Clinical Terms (manual steps required!)
   type: LOCAL
   default-language: en
+  base-prefix: http://snomed.info/id/
   access:
     full-text-search: http://www.openrdf.org/contrib/lucenesail#matches
   mapping:

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/EventRepositoryImpl.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/EventRepositoryImpl.java
@@ -146,7 +146,6 @@ public class EventRepositoryImpl
                 root.get(LoggedEventEntity_.event).in(asList( //
                         "ChainLinkCreatedEvent", //
                         "ChainSpanCreatedEvent", //
-                        "DocumentMetadataCreatedEvent", //
                         "RelationCreatedEvent", //
                         "SpanCreatedEvent")),
                 cb.equal(root.get(LoggedEventEntity_.event), "SpanMovedEvent"), //
@@ -169,6 +168,11 @@ public class EventRepositoryImpl
         if ("FeatureValueUpdatedEvent".equals(latestEvent.getEvent())) {
             try {
                 var details = fromJsonString(FeatureChangeDetails.class, detailsString);
+                if (details.getAnnotation().getBegin() < 0
+                        || details.getAnnotation().getEnd() < 0) {
+                    return empty();
+                }
+
                 return Optional.of(new Range(details.getAnnotation().getBegin(),
                         details.getAnnotation().getEnd()));
             }
@@ -179,6 +183,9 @@ public class EventRepositoryImpl
 
         try {
             var details = fromJsonString(AnnotationDetails.class, detailsString);
+            if (details.getBegin() < 0 || details.getEnd() < 0) {
+                return empty();
+            }
             return Optional.of(new Range(details.getBegin(), details.getEnd()));
 
         }

--- a/inception/inception-ui-kb/src/main/resources/META-INF/asciidoc/user-guide/projects_knowledge-base.adoc
+++ b/inception/inception-ui-kb/src/main/resources/META-INF/asciidoc/user-guide/projects_knowledge-base.adoc
@@ -74,6 +74,11 @@ NOTE: **Changing the URL of a remote KB currently only takes affect after {produ
       take effect until you restart. It is usually easier to delete the remote KB configuration and create it from scratch
       with the new URL.
 
+=== General settings
+
+* **Base prefix:** A base IRI that is used as a prefix when creating new concepts.
+  Also, when users search for concepts, the system will try to construct a full IRI by prepending this base IRI to the search term and perform an exact IRI match.
+  This is useful for knowledge bases such as Wikidata where concepts are usually identified by short suffixes (e.g. "Q42") rather than full IRIs.
 
 === Query settings
 


### PR DESCRIPTION
**What's in the PR**
- Check if the user query used as a suffix of the base IRI results in a valid concept ID and if so return it
- Add appropriate base IRIs to SNOMED and Wikidata profiles

**How to test manually**
* Create a project using the "Entity linking (Wikidata)" concept and enter for example "Q42" into the knowledge base page search field or the concept field of an entity annotation. Try other Q... as well. Note that some might not exist in Wikidata.

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
