### PR TITLE
#5754 - Unable to add key bindings to labels when "Show only when constraints apply" box is checked

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/keybindings/KeyBindingsConfigurationPanel.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/keybindings/KeyBindingsConfigurationPanel.java
@@ -89,6 +89,10 @@ public class KeyBindingsConfigurationPanel
         var fs = featureSupportRegistry.findExtension(feature).orElseThrow();
         featureState = Model.of(new FeatureState(VID.NONE_ID, feature, null));
         if (feature.getTagset() != null) {
+            // Make sure editor is not hidden if hideUnconstraintFeature is enabled
+            featureState.getObject().indicator.setAffected(true);
+            featureState.getObject().indicator.rulesApplied();
+            // Load tagset
             featureState.getObject().tagset = schemaService
                     .listTagsReorderable(feature.getTagset());
         }


### PR DESCRIPTION
**What's in the PR**
- Emulate an active constraint such that the key binding faeture editor does not hide itself when hideUnconstraintFeature is enabled

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
