### PR TITLE
#5777 - Allow fetching resource metadata from the backend

### DIFF
--- a/inception/inception-dependencies/pom.xml
+++ b/inception/inception-dependencies/pom.xml
@@ -487,6 +487,12 @@
       </dependency>
 
       <dependency>
+        <groupId>com.twelvemonkeys.imageio</groupId>
+        <artifactId>imageio-tiff</artifactId>
+        <version>${imageio-tiff-version}</version>
+      </dependency>
+
+      <dependency>
         <groupId>com.github.rjeschke</groupId>
         <artifactId>txtmark</artifactId>
         <version>${txtmark.version}</version>

--- a/inception/inception-external-editor/pom.xml
+++ b/inception/inception-external-editor/pom.xml
@@ -225,6 +225,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.twelvemonkeys.imageio</groupId>
+      <artifactId>imageio-tiff</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
@@ -241,6 +246,7 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
   <build>
     <plugins>
       <plugin>
@@ -280,5 +286,19 @@
         </executions>
       </plugin>
     </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <configuration>
+            <ignoredDependencies>
+              <!-- imageio-tiff is activated via SPI -->
+              <ignoredDependency>com.twelvemonkeys.imageio:imageio-tiff</ignoredDependency>
+            </ignoredDependencies>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 </project>

--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/xhtml/ImageMetaData.java
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/xhtml/ImageMetaData.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.externaleditor.xhtml;
+
+public record ImageMetaData(int width, int height) {
+
+    private ImageMetaData(Builder builder)
+    {
+        this(builder.width, builder.height);
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static final class Builder
+    {
+        private int width;
+        private int height;
+
+        private Builder()
+        {
+        }
+
+        public Builder withWidth(int aWidth)
+        {
+            width = aWidth;
+            return this;
+        }
+
+        public Builder withHeight(int aHeight)
+        {
+            height = aHeight;
+            return this;
+        }
+
+        public ImageMetaData build()
+        {
+            return new ImageMetaData(this);
+        }
+    }
+}

--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/xhtml/XHtmlXmlDocumentViewController.java
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/xhtml/XHtmlXmlDocumentViewController.java
@@ -40,4 +40,8 @@ public interface XHtmlXmlDocumentViewController
     ResponseEntity<InputStreamResource> getResource(long aProjectId, long aDocumentId,
             String aResourceId, Principal aPrincipal)
         throws Exception;
+
+    ResponseEntity<String> getResourceMetadata(long aProjectId, long aDocumentId,
+            String aResourceId, Principal aPrincipal)
+        throws Exception;
 }

--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/xhtml/XHtmlXmlDocumentViewControllerImpl.java
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/xhtml/XHtmlXmlDocumentViewControllerImpl.java
@@ -23,21 +23,30 @@ import static de.tudarmstadt.ukp.inception.externaleditor.xhtml.XHtmlConstants.H
 import static de.tudarmstadt.ukp.inception.externaleditor.xhtml.XHtmlConstants.P;
 import static de.tudarmstadt.ukp.inception.externaleditor.xhtml.XHtmlConstants.SPAN;
 import static de.tudarmstadt.ukp.inception.externaleditor.xhtml.XHtmlConstants.XHTML_NS_URI;
+import static de.tudarmstadt.ukp.inception.support.json.JSONUtil.toJsonString;
 import static java.lang.invoke.MethodHandles.lookup;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Optional.ofNullable;
 import static javax.xml.XMLConstants.DEFAULT_NS_PREFIX;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.slf4j.LoggerFactory.getLogger;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.OK;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.http.MediaType.IMAGE_GIF;
 import static org.springframework.http.MediaType.IMAGE_JPEG;
 import static org.springframework.http.MediaType.IMAGE_PNG;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.StringWriter;
+import java.net.URLEncoder;
 import java.security.Principal;
 import java.util.Locale;
 import java.util.Optional;
+
+import javax.imageio.ImageIO;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.uima.cas.CAS;
@@ -56,11 +65,13 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.AttributesImpl;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.export.DocumentImportExportService;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentStorageService;
@@ -71,6 +82,7 @@ import de.tudarmstadt.ukp.inception.externaleditor.policy.DefaultHtmlDocumentPol
 import de.tudarmstadt.ukp.inception.externaleditor.policy.SafetyNetDocumentPolicy;
 import de.tudarmstadt.ukp.inception.externaleditor.xml.XmlCas2SaxEvents;
 import de.tudarmstadt.ukp.inception.support.wicket.ServletContextUtils;
+import de.tudarmstadt.ukp.inception.support.xml.NamespaceDecodingContentHandlerAdapter;
 import jakarta.servlet.ServletContext;
 
 @ConditionalOnWebApplication
@@ -86,6 +98,7 @@ public class XHtmlXmlDocumentViewControllerImpl
 
     private static final String GET_DOCUMENT_PATH = "/p/{projectId}/d/{documentId}/xml";
     private static final String GET_RESOURCE_PATH = "/p/{projectId}/d/{documentId}/res";
+    private static final String GET_METADATA_PATH = "/p/{projectId}/d/{documentId}/meta";
 
     private final DocumentService documentService;
     private final DocumentStorageService documentStorageService;
@@ -156,7 +169,8 @@ public class XHtmlXmlDocumentViewControllerImpl
             var rawHandler = XmlCas2SaxEvents.makeSerializer(out);
             var sanitizingHandler = applySanitizers(aEditor, doc, rawHandler);
             var resourceFilteringHandler = applyHtmlResourceUrlFilter(doc, sanitizingHandler);
-            var finalHandler = resourceFilteringHandler;
+            var imageDimensionHandler = applyImageDimensions(doc, resourceFilteringHandler);
+            var finalHandler = imageDimensionHandler;
 
             // If the CAS contains an actual HTML structure, then we send that. Mind that we do
             // not inject format-specific CSS then!
@@ -190,6 +204,126 @@ public class XHtmlXmlDocumentViewControllerImpl
 
             return toResponse(out);
         }
+    }
+
+    private ContentHandler applyImageDimensions(SourceDocument aDoc, ContentHandler aDelegate)
+    {
+        var maybyFormatSupport = formatRegistry.getFormatById(aDoc.getFormat());
+        if (maybyFormatSupport.isEmpty()) {
+            return aDelegate;
+        }
+
+        var formatSupport = maybyFormatSupport.get();
+
+        return new NamespaceDecodingContentHandlerAdapter(aDelegate)
+        {
+            @Override
+            public void startElement(String aUri, String aLocalName, String aQName,
+                    Attributes aAtts)
+                throws SAXException
+            {
+                var attributes = aAtts;
+
+                var element = toQName(aUri, aLocalName, aQName);
+                if ("img".equalsIgnoreCase(element.getLocalPart())) {
+                    attributes = applyImageDimensions(aQName, aAtts);
+                }
+
+                super.startElement(aUri, aLocalName, aQName, attributes);
+            }
+
+            private Attributes applyImageDimensions(String aQName, Attributes aAtts)
+            {
+                var src = aAtts.getValue("src");
+                if (isBlank(src)) {
+                    // Image has no source - no need to process
+                    return aAtts;
+                }
+
+                var atts = new AttributesImpl(aAtts);
+                var widthIdx = atts.getIndex("width");
+                var heightIdx = atts.getIndex("height");
+                if (widthIdx >= 0 || heightIdx >= 0) {
+                    // Leave original attributes
+                    return aAtts;
+                }
+
+                var srcDocFile = documentStorageService.getSourceDocumentFile(aDoc);
+                try (var is = formatSupport.openResourceStream(srcDocFile, src)) {
+                    var maybeMeta = getImageDimensions(is);
+                    if (maybeMeta.isEmpty()) {
+                        return aAtts;
+                    }
+
+                    var meta = maybeMeta.get();
+
+                    if (meta.width() > 0) {
+                        atts.addAttribute(null, "width", "width", "CDATA",
+                                String.valueOf(meta.width()));
+                    }
+                    if (meta.height() > 0) {
+                        atts.addAttribute(null, "height", "height", "CDATA",
+                                String.valueOf(meta.height()));
+                    }
+
+                    return atts;
+                }
+                catch (IOException e) {
+                    LOG.debug("Resource [{}] not found in [{}]", src, srcDocFile);
+                    // Ignore
+                }
+
+                return aAtts;
+            }
+        };
+
+    }
+
+    private ContentHandler applyHtmlResourceUrlFilter(SourceDocument aDoc, ContentHandler aDelegate)
+    {
+        var hasResources = formatRegistry.getFormatById(aDoc.getFormat())
+                .map(FormatSupport::hasResources).orElse(false);
+        if (!hasResources) {
+            return aDelegate;
+        }
+
+        return new NamespaceDecodingContentHandlerAdapter(aDelegate)
+        {
+            @Override
+            public void startElement(String aUri, String aLocalName, String aQName,
+                    Attributes aAtts)
+                throws SAXException
+            {
+                var atts = aAtts;
+
+                var element = toQName(aUri, aLocalName, aQName);
+
+                if ("a".equalsIgnoreCase(element.getLocalPart())
+                        || "link".equalsIgnoreCase(element.getLocalPart())) {
+                    atts = filterResourceUrl(aAtts, "href");
+                }
+
+                if ("img".equalsIgnoreCase(element.getLocalPart())
+                        || "audio".equalsIgnoreCase(element.getLocalPart())
+                        || "video".equalsIgnoreCase(element.getLocalPart())) {
+                    atts = filterResourceUrl(aAtts, "src");
+                }
+
+                super.startElement(aUri, aLocalName, aQName, atts);
+            }
+
+            private Attributes filterResourceUrl(Attributes aAttributes, String aAttribute)
+            {
+                var attributes = new AttributesImpl(aAttributes);
+                var index = attributes.getIndex(aAttribute);
+                if (index != -1) {
+                    var value = attributes.getValue(index);
+                    value = "res?resId=" + URLEncoder.encode(value, UTF_8);
+                    attributes.setValue(index, value);
+                }
+                return attributes;
+            }
+        };
     }
 
     private void renderXmlDocument(SourceDocument aDoc, XmlDocument aXmlDocument,
@@ -302,9 +436,10 @@ public class XHtmlXmlDocumentViewControllerImpl
     @PreAuthorize("@documentAccess.canViewAnnotationDocument(#aProjectId, #aDocumentId, #principal.name)")
     @Override
     @GetMapping(path = GET_RESOURCE_PATH)
-    public ResponseEntity<InputStreamResource> getResource(
-            @PathVariable("projectId") long aProjectId,
-            @PathVariable("documentId") long aDocumentId, @RequestParam("resId") String aResourceId,
+    public ResponseEntity<InputStreamResource> getResource( //
+            @PathVariable("projectId") long aProjectId, //
+            @PathVariable("documentId") long aDocumentId, //
+            @RequestParam("resId") String aResourceId, //
             Principal principal)
         throws Exception
     {
@@ -341,6 +476,84 @@ public class XHtmlXmlDocumentViewControllerImpl
             LOG.debug("Unable to load resource [{}] for document {}", aResourceId, srcDoc, e);
             return ResponseEntity.notFound().build();
         }
+    }
+
+    @PreAuthorize("@documentAccess.canViewAnnotationDocument(#aProjectId, #aDocumentId, #principal.name)")
+    @Override
+    @GetMapping(path = GET_METADATA_PATH)
+    public ResponseEntity<String> getResourceMetadata( //
+            @PathVariable("projectId") long aProjectId, //
+            @PathVariable("documentId") long aDocumentId, //
+            @RequestParam("resId") String aResourceId, //
+            Principal principal)
+        throws Exception
+    {
+        var srcDoc = documentService.getSourceDocument(aProjectId, aDocumentId);
+
+        var maybeFormatSupport = formatRegistry.getFormatById(srcDoc.getFormat());
+        if (maybeFormatSupport.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        var srcDocFile = documentStorageService.getSourceDocumentFile(srcDoc);
+
+        var formatSupport = maybeFormatSupport.get();
+
+        if (!formatSupport.hasResources()
+                || !formatSupport.isAccessibleResource(srcDocFile, aResourceId)) {
+            LOG.debug("Resource [{}] for document {} not found", aResourceId, srcDoc);
+            return ResponseEntity.notFound().build();
+        }
+
+        try {
+            var inputStream = formatSupport.openResourceStream(srcDocFile, aResourceId);
+
+            var httpHeaders = new HttpHeaders();
+            httpHeaders.setContentType(APPLICATION_JSON);
+
+            var imageMetaData = getImageDimensions(inputStream);
+            if (imageMetaData.isPresent()) {
+                return new ResponseEntity<>(toJsonString(imageMetaData.get()), httpHeaders, OK);
+            }
+
+            return new ResponseEntity<>("{}", httpHeaders, NOT_FOUND);
+        }
+        catch (FileNotFoundException e) {
+            LOG.debug("Resource [{}] for document {} not found", aResourceId, srcDoc);
+            return ResponseEntity.notFound().build();
+        }
+        catch (Exception e) {
+            LOG.debug("Unable to load resource [{}] for document {}", aResourceId, srcDoc, e);
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    public Optional<ImageMetaData> getImageDimensions(InputStream inputStream) throws IOException
+    {
+        // 1. Wrap the InputStream so ImageIO can read it
+        try (var in = ImageIO.createImageInputStream(inputStream)) {
+            if (in == null) {
+                // Content is not an image or stream is empty
+                return Optional.empty();
+            }
+
+            // 2. Detect the content type dynamically
+            var readers = ImageIO.getImageReaders(in);
+            if (readers.hasNext()) {
+                var reader = readers.next();
+                try {
+                    reader.setInput(in);
+                    return Optional.of(ImageMetaData.builder() //
+                            .withHeight(reader.getHeight(0)) //
+                            .withWidth(reader.getWidth(0)) //
+                            .build());
+                }
+                finally {
+                    reader.dispose();
+                }
+            }
+        }
+        return Optional.empty();
     }
 
     private Optional<MediaType> getContentType(String aResourceId)

--- a/inception/inception-pdf-editor2/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor2/view/pdfjs/PdfJsViewerPage.java
+++ b/inception/inception-pdf-editor2/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor2/view/pdfjs/PdfJsViewerPage.java
@@ -64,13 +64,14 @@ public class PdfJsViewerPage
         aResponse.render(CssContentHeaderItem.forReference(PdfJsViewerJavaCssReference.get()));
 
         // Render JavaScript dependencies as ES modules using Wicket's built-in module support
-        // First render a small script that must be present at viewer boot time (PDFViewerApplicationOptions)
+        // First render a small script that must be present at viewer boot time
+        // (PDFViewerApplicationOptions)
         aResponse.render(JavaScriptHeaderItem.forReference(PdfJsOptionsJavaScriptReference.get())
-            .setType(JavaScriptReferenceType.MODULE));
+                .setType(JavaScriptReferenceType.MODULE));
         aResponse.render(JavaScriptHeaderItem.forReference(PdfJsJavaScriptReference.get())
-            .setType(JavaScriptReferenceType.MODULE));
+                .setType(JavaScriptReferenceType.MODULE));
         aResponse.render(JavaScriptHeaderItem.forReference(PdfJsViewerJavaScriptReference.get())
-            .setType(JavaScriptReferenceType.MODULE));
+                .setType(JavaScriptReferenceType.MODULE));
     }
 
     private void renderLocaleReference(IHeaderResponse aResponse)

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/config/InceptionSecurityWebUIApiAutoConfiguration.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/config/InceptionSecurityWebUIApiAutoConfiguration.java
@@ -58,17 +58,17 @@ public class InceptionSecurityWebUIApiAutoConfiguration
         throws Exception
     {
         var imgSrcValue = new ArrayList<>(asList( //
-            SELF,  //
-            new FixedCSPValue("data:"),  //
-            // blob needed by pdf.js for the thumbnails
-            new FixedCSPValue("blob:")));
+                SELF, //
+                new FixedCSPValue("data:"), //
+                // blob needed by pdf.js for the thumbnails
+                new FixedCSPValue("blob:")));
         aCspProperties.getAllowedImageSources().stream() //
                 .map(FixedCSPValue::new) //
                 .forEachOrdered(imgSrcValue::add);
 
         var mediaSrcValue = new ArrayList<>(asList( //
-            SELF, //
-            new FixedCSPValue("data:")));
+                SELF, //
+                new FixedCSPValue("data:")));
         aCspProperties.getAllowedMediaSources().stream() //
                 .map(FixedCSPValue::new) //
                 .forEachOrdered(mediaSrcValue::add);

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/NamespaceDecodingContentHandlerAdapter.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/xml/NamespaceDecodingContentHandlerAdapter.java
@@ -32,7 +32,7 @@ import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 
-public abstract class NamspaceDecodingContentHandlerAdapter
+public abstract class NamespaceDecodingContentHandlerAdapter
     extends ContentHandlerAdapter
 {
     private static final String XMLNS = "xmlns";
@@ -42,7 +42,7 @@ public abstract class NamspaceDecodingContentHandlerAdapter
 
     private final Map<String, String> namespaceMappings = new LinkedHashMap<>();
 
-    public NamspaceDecodingContentHandlerAdapter(ContentHandler aDelegate)
+    public NamespaceDecodingContentHandlerAdapter(ContentHandler aDelegate)
     {
         super(aDelegate);
         stack = new Stack<>();

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/WicketApplicationBase.java
@@ -124,10 +124,10 @@ public abstract class WicketApplicationBase
         getSecuritySettings().setAuthorizationStrategy(authorizationStrategy);
 
         var imgSrcValue = new ArrayList<>(asList( //
-            SELF, //
-            new FixedCSPValue("data:"), //
-            // blob needed by pdf.js for the thumbnails
-            new FixedCSPValue("blob:")));
+                SELF, //
+                new FixedCSPValue("data:"), //
+                // blob needed by pdf.js for the thumbnails
+                new FixedCSPValue("blob:")));
         cspProperties.getAllowedImageSources().stream() //
                 .map(FixedCSPValue::new) //
                 .forEachOrdered(imgSrcValue::add);

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/MatrixWorkloadManagementPage.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/MatrixWorkloadManagementPage.java
@@ -1157,8 +1157,8 @@ public class MatrixWorkloadManagementPage
     @OnEvent
     public void onAnnotatorColumnCellClickEvent(AnnotatorColumnCellClickEvent aEvent)
     {
-        var annotationDocument = documentService
-                .createOrGetAnnotationDocument(aEvent.getSourceDocument(), aEvent.getAnnotationSet());
+        var annotationDocument = documentService.createOrGetAnnotationDocument(
+                aEvent.getSourceDocument(), aEvent.getAnnotationSet());
 
         var targetState = oneClickTransition(annotationDocument);
 

--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,7 @@
     <dom4j.version>2.2.0</dom4j.version>
     <flexmark.version>0.64.8</flexmark.version>
     <ivy.version>2.5.3</ivy.version>
+    <imageio-tiff-version>3.10.0</imageio-tiff-version>
     <txtmark.version>0.13</txtmark.version>
     <owasp-java-html-sanitizer.version>20220608.1</owasp-java-html-sanitizer.version>
     <jinjava.version>2.8.2</jinjava.version>


### PR DESCRIPTION
**What's in the PR**
- Ability to fetch image metadata via ImageIO
- Also embed width/height on img tags we render from the backend

**How to test manually**
* Import a MHTML archive which has images without dimensions declared in the HTML - those should now be added by INCEpTION
* Manually try accessing the metadata endpoint

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
