### PR TITLE
#5790 - Opening documents takes too long

### DIFF
--- a/inception/inception-layer-chain/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/chain/ChainAdapterImpl.java
+++ b/inception/inception-layer-chain/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/chain/ChainAdapterImpl.java
@@ -418,6 +418,7 @@ public class ChainAdapterImpl
         var linkType = CasUtil.getType(aCas, getAnnotationTypeName());
         var newLink = aCas.createAnnotation(linkType, aBegin, aEnd);
         aCas.addFsToIndexes(newLink);
+        setResumptionLocation(aCas, aBegin);
         return newLink;
     }
 

--- a/inception/inception-layer-relation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/RelationAdapterImpl.java
+++ b/inception/inception-layer-relation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/RelationAdapterImpl.java
@@ -159,6 +159,7 @@ public class RelationAdapterImpl
         newAnnotation.setFeatureValue(dependentFeature, targetFS);
         newAnnotation.setFeatureValue(governorFeature, originFS);
         cas.addFsToIndexes(newAnnotation);
+        setResumptionLocation(cas, targetFS.getBegin());
         return newAnnotation;
     }
 
@@ -177,6 +178,8 @@ public class RelationAdapterImpl
     {
         var fs = selectByAddr(aCas, AnnotationFS.class, aVid.getId());
         aCas.addFsToIndexes(fs);
+
+        setResumptionLocation(aCas, getTargetAnnotation(fs).getBegin());
 
         publishEvent(() -> new RelationCreatedEvent(this, aDocument, aUsername, getLayer(), fs,
                 getTargetAnnotation(fs), getSourceAnnotation(fs)));

--- a/inception/inception-layer-span/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanAdapterImpl.java
+++ b/inception/inception-layer-span/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanAdapterImpl.java
@@ -196,6 +196,8 @@ public class SpanAdapterImpl
 
         aCas.addFsToIndexes(newAnnotation);
 
+        setResumptionLocation(aCas, aBegin);
+
         return newAnnotation;
     }
 
@@ -219,6 +221,8 @@ public class SpanAdapterImpl
                 aAnnotation.getCoveredText());
 
         aCas.addFsToIndexes(aAnnotation);
+
+        setResumptionLocation(aCas, aAnnotation.getBegin());
 
         return aAnnotation;
     }
@@ -259,6 +263,8 @@ public class SpanAdapterImpl
         if (getAttachFeatureName() != null) {
             attach(aCas, fs.getBegin(), fs.getEnd(), fs);
         }
+
+        setResumptionLocation(aCas, fs.getBegin());
 
         aCas.addFsToIndexes(fs);
 

--- a/inception/inception-log-api/pom.xml
+++ b/inception/inception-log-api/pom.xml
@@ -33,11 +33,6 @@
       <artifactId>inception-model</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
-      <artifactId>inception-support</artifactId>
-      <version>${project.version}</version>
-    </dependency>
 
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/inception/inception-log-api/src/main/java/de/tudarmstadt/ukp/inception/log/api/EventRepository.java
+++ b/inception/inception-log-api/src/main/java/de/tudarmstadt/ukp/inception/log/api/EventRepository.java
@@ -20,16 +20,13 @@ package de.tudarmstadt.ukp.inception.log.api;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 
 import org.apache.commons.lang3.function.FailableConsumer;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
-import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.log.api.model.LoggedEvent;
 import de.tudarmstadt.ukp.inception.log.api.model.SummarizedLoggedEvent;
 import de.tudarmstadt.ukp.inception.log.api.model.UserSessionStats;
-import de.tudarmstadt.ukp.inception.support.uima.Range;
 
 public interface EventRepository
 {
@@ -40,8 +37,6 @@ public interface EventRepository
 
     <E extends Throwable> void forEachLoggedEventUpdatable(Project aProject,
             FailableConsumer<LoggedEvent, E> aConsumer);
-
-    Optional<Range> getLastEditRange(SourceDocument aDocument, String aDataOwner);
 
     List<LoggedEvent> listRecentActivity(Project aProject, String aDataOwner,
             Collection<String> aEventTypes, int aMaxSize);

--- a/inception/inception-schema-api/src/main/resources/de/tudarmstadt/ukp/inception/annotation/type/inception-static.xml
+++ b/inception/inception-schema-api/src/main/resources/de/tudarmstadt/ukp/inception/annotation/type/inception-static.xml
@@ -42,5 +42,17 @@
         </featureDescription>
       </features>
     </typeDescription>
+    <typeDescription>
+      <name>de.tudarmstadt.ukp.inception.annotation.type.ResumptionLocation</name>
+      <description />
+      <supertypeName>uima.cas.AnnotationBase</supertypeName>
+      <features>
+        <featureDescription>
+          <name>offset</name>
+          <description />
+          <rangeTypeName>uima.cas.Integer</rangeTypeName>
+        </featureDescription>
+      </features>
+    </typeDescription>
   </types>
 </typeSystemDescription>

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPageBase2.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPageBase2.java
@@ -85,6 +85,7 @@ import de.tudarmstadt.ukp.inception.annotation.events.BeforeDocumentOpenedEvent;
 import de.tudarmstadt.ukp.inception.annotation.events.DocumentOpenedEvent;
 import de.tudarmstadt.ukp.inception.annotation.events.FeatureValueUpdatedEvent;
 import de.tudarmstadt.ukp.inception.annotation.events.PreparingToOpenDocumentEvent;
+import de.tudarmstadt.ukp.inception.annotation.layer.TypeAdapter_ImplBase;
 import de.tudarmstadt.ukp.inception.annotation.layer.span.api.SpanLayerSupport;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentAccess;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
@@ -566,8 +567,8 @@ public abstract class AnnotationPageBase2
             }
             else if (dataOwnerName.equals(sessionOwnerName)
                     || dataOwnerName.equals(CURATION_USER)) {
-                eventRepository.getLastEditRange(state.getDocument(), dataOwnerName).ifPresent(
-                        range -> state.moveToOffset(editorCas, range.getBegin(), CENTERED));
+                var offset = TypeAdapter_ImplBase.getResumptionLocation(editorCas);
+                state.moveToOffset(editorCas, offset, CENTERED);
             }
             else {
                 state.moveToUnit(editorCas, 0, TOP);
@@ -758,9 +759,8 @@ public abstract class AnnotationPageBase2
                             || dataOwnerName.equals(CURATION_USER)) {
                         try {
                             var editorCas = getEditorCas();
-                            eventRepository.getLastEditRange(state.getDocument(), dataOwnerName)
-                                    .ifPresent(range -> state.moveToOffset(editorCas,
-                                            range.getBegin(), CENTERED));
+                            var offset = TypeAdapter_ImplBase.getResumptionLocation(editorCas);
+                            state.moveToOffset(editorCas, offset, CENTERED);
                         }
                         catch (Exception e) {
                             LOG.error("Error reading CAS of document {} for user {}",

--- a/inception/inception-ui-curation/src/test/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/render/CurationSidebarRendererTest.java
+++ b/inception/inception-ui-curation/src/test/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/render/CurationSidebarRendererTest.java
@@ -21,6 +21,8 @@ import static de.tudarmstadt.ukp.clarin.webanno.model.LinkMode.WITH_ROLE;
 import static de.tudarmstadt.ukp.clarin.webanno.model.MultiValueMode.ARRAY;
 import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.CURATION_USER;
 import static java.util.Arrays.asList;
+import static org.apache.uima.fit.factory.TypeSystemDescriptionFactory.createTypeSystemDescription;
+import static org.apache.uima.util.CasCreationUtils.mergeTypeSystems;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -601,11 +603,13 @@ class CurationSidebarRendererTest
             support.generateTypes(tsd, layer, schemaService.listSupportedFeatures(project));
         }
 
-        curatorCas = CasFactory.createCas(tsd);
+        var mergedTsd = mergeTypeSystems(asList(tsd, createTypeSystemDescription()));
+
+        curatorCas = CasFactory.createCas(mergedTsd);
         curatorCas.setDocumentText(aText);
-        anno1Cas = CasFactory.createCas(tsd);
+        anno1Cas = CasFactory.createCas(mergedTsd);
         anno1Cas.setDocumentText(aText);
-        anno2Cas = CasFactory.createCas(tsd);
+        anno2Cas = CasFactory.createCas(mergedTsd);
         anno2Cas.setDocumentText(aText);
 
         vdoc = new VDocument();


### PR DESCRIPTION
**What's in the PR**
- Save scrollTo location in the CAS instead of trying to derive it from the event log (which takes too long)

**How to test manually**
* Switching between documents should be faster than on 39.1 and scrolling to the last edited position should still work (worst case after making an edit after installing the new version)

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
