### PR TITLE
#5073 - When selecting a link, arrows and governor/dependent could blink too

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/page/AnnotationPageBase.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/page/AnnotationPageBase.java
@@ -308,14 +308,30 @@ public abstract class AnnotationPageBase
             int aBegin, int aEnd)
         throws IOException
     {
+        actionShowSelectedDocument(aTarget, aDocument, aBegin, aEnd, null);
+    }
+
+    public void actionShowSelectedDocument(AjaxRequestTarget aTarget, SourceDocument aDocument,
+            int aBegin, int aEnd, List<VRange> aAdditionalPingRanges)
+        throws IOException
+    {
         boolean switched = actionShowDocument(aTarget, aDocument);
 
         var state = getModelObject();
 
         var cas = getEditorCas();
         var range = rangeClippedToDocument(cas, aBegin, aEnd);
-        state.getPagingStrategy().moveToOffset(state, cas, aBegin,
-                new VRange(range.getBegin(), range.getEnd()), CENTERED);
+        
+        // Always include the target range as a ping range
+        List<VRange> pingRanges = new ArrayList<>();
+        pingRanges.add(new VRange(range.getBegin(), range.getEnd()));
+        
+        // Add any additional ping ranges if provided
+        if (aAdditionalPingRanges != null && !aAdditionalPingRanges.isEmpty()) {
+            pingRanges.addAll(aAdditionalPingRanges);
+        }
+        
+        state.getPagingStrategy().moveToOffset(state, cas, aBegin, pingRanges, CENTERED);
 
         if (!switched && state.getPagingStrategy() instanceof NoPagingStrategy) {
             return;

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/paging/PagingStrategy_ImplBase.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/paging/PagingStrategy_ImplBase.java
@@ -17,7 +17,10 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.api.annotation.paging;
 
+import static java.util.Arrays.asList;
 import static org.apache.wicket.event.Broadcast.BREADTH;
+
+import java.util.List;
 
 import org.apache.uima.cas.CAS;
 import org.apache.wicket.Page;
@@ -37,13 +40,13 @@ public abstract class PagingStrategy_ImplBase
     private static final long serialVersionUID = 928025483609029306L;
 
     @Override
-    public void moveToOffset(AnnotatorViewState aState, CAS aCas, int aOffset, VRange aPingRange,
-            FocusPosition aPos)
+    public void moveToOffset(AnnotatorViewState aState, CAS aCas, int aOffset,
+            List<VRange> aPingRanges, FocusPosition aPos)
     {
         switch (aPos) {
         case TOP: {
             aState.setPageBegin(aCas, aOffset);
-            fireScrollToEvent(aOffset, aPingRange, aPos);
+            fireScrollToEvent(aOffset, aPingRanges, aPos);
             break;
         }
         case CENTERED: {
@@ -62,7 +65,7 @@ public abstract class PagingStrategy_ImplBase
 
             aState.setPageBegin(aCas, firstUnit.getBegin());
             aState.setFocusUnitIndex(unit.getIndex());
-            fireScrollToEvent(aOffset, aPingRange, aPos);
+            fireScrollToEvent(aOffset, aPingRanges, aPos);
             break;
         }
         default:
@@ -70,7 +73,14 @@ public abstract class PagingStrategy_ImplBase
         }
     }
 
-    private void fireScrollToEvent(int aOffset, VRange aPingRange, FocusPosition aPos)
+    @Override
+    public void moveToOffset(AnnotatorViewState aState, CAS aCas, int aOffset, VRange aPingRange,
+            FocusPosition aPos)
+    {
+        moveToOffset(aState, aCas, aOffset, aPingRange != null ? asList(aPingRange) : null, aPos);
+    }
+
+    private void fireScrollToEvent(int aOffset, List<VRange> aPingRanges, FocusPosition aPos)
     {
         var requestCycle = RequestCycle.get();
 
@@ -82,7 +92,7 @@ public abstract class PagingStrategy_ImplBase
         if (handler.isPresent() && handler.get().isPageInstanceCreated()) {
             var page = (Page) handler.get().getPage();
             var target = requestCycle.find(AjaxRequestTarget.class).orElse(null);
-            page.send(page, BREADTH, new ScrollToEvent(target, aOffset, aPingRange, aPos));
+            page.send(page, BREADTH, new ScrollToEvent(target, aOffset, aPingRanges, aPos));
         }
     }
 }

--- a/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/selection/ScrollToEvent.java
+++ b/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/selection/ScrollToEvent.java
@@ -17,6 +17,10 @@
  */
 package de.tudarmstadt.ukp.inception.rendering.selection;
 
+import static java.util.Arrays.asList;
+
+import java.util.List;
+
 import org.apache.wicket.ajax.AjaxRequestTarget;
 
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VRange;
@@ -25,16 +29,22 @@ public class ScrollToEvent
 {
     private final AjaxRequestTarget requestHandler;
     private final int offset;
-    private final VRange pingRange;
+    private final List<VRange> pingRanges;
     private final FocusPosition position;
 
     public ScrollToEvent(AjaxRequestTarget aRequestHandler, int aOffset, VRange aPingRange,
             FocusPosition aPos)
     {
+        this(aRequestHandler, aOffset, aPingRange != null ? asList(aPingRange) : null, aPos);
+    }
+
+    public ScrollToEvent(AjaxRequestTarget aRequestHandler, int aOffset, List<VRange> aPingRanges,
+            FocusPosition aPos)
+    {
         requestHandler = aRequestHandler;
         offset = aOffset;
         position = aPos;
-        pingRange = aPingRange;
+        pingRanges = aPingRanges;
     }
 
     public AjaxRequestTarget getRequestHandler()
@@ -47,9 +57,18 @@ public class ScrollToEvent
         return offset;
     }
 
+    /**
+     * @deprecated Use {@link #getPingRanges()} instead.
+     */
+    @Deprecated
     public VRange getPingRange()
     {
-        return pingRange;
+        return pingRanges != null && !pingRanges.isEmpty() ? pingRanges.get(0) : null;
+    }
+
+    public List<VRange> getPingRanges()
+    {
+        return pingRanges;
     }
 
     public FocusPosition getPosition()

--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/ExternalAnnotationEditorBase.java
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/ExternalAnnotationEditorBase.java
@@ -180,7 +180,9 @@ public abstract class ExternalAnnotationEditorBase
         // hierarchy a this time
         if (aEvent.getPayload() instanceof ScrollToEvent event) {
             var command = new ScrollToCommand(event.getOffset(), event.getPosition());
-            command.setPingRange(event.getPingRange());
+            if (event.getPingRanges() != null && !event.getPingRanges().isEmpty()) {
+                command.setPingRanges(event.getPingRanges());
+            }
             QueuedEditorCommandsMetaDataKey.get().add(command);
 
             // Do not call our requestRender because we do not want to unnecessarily add the

--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/command/ScrollToCommand.java
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/command/ScrollToCommand.java
@@ -65,6 +65,18 @@ public class ScrollToCommand
         pingRanges = asList(new CompactRange(aRange.getBegin(), aRange.getEnd()));
     }
 
+    public void setPingRanges(List<VRange> aRanges)
+    {
+        if (aRanges == null || aRanges.isEmpty()) {
+            pingRanges = null;
+            return;
+        }
+
+        pingRanges = aRanges.stream() //
+                .map(range -> new CompactRange(range.getBegin(), range.getEnd())) //
+                .toList();
+    }
+
     @Override
     public String command(String aEditorVariable)
     {

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
@@ -103,6 +103,7 @@ import de.tudarmstadt.ukp.inception.rendering.editorstate.FeatureState;
 import de.tudarmstadt.ukp.inception.rendering.selection.Selection;
 import de.tudarmstadt.ukp.inception.rendering.selection.SelectionChangedEvent;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
+import de.tudarmstadt.ukp.inception.rendering.vmodel.VRange;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.api.AttachedAnnotation;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.AnnotationException;
@@ -446,8 +447,25 @@ public abstract class AnnotationDetailEditorPanel
         throws IOException, AnnotationException
     {
         actionSelect(aTarget, annoFs);
-        editorPage.actionShowSelectedDocument(aTarget, getModelObject().getDocument(),
-                annoFs.getBegin(), annoFs.getEnd());
+        
+        var state = getModelObject();
+        var doc = state.getDocument();
+        
+        // For arcs, pass the endpoint ranges as additional ping ranges
+        if (state.getSelection().isArc()) {
+            var cas = editorPage.getEditorCas();
+            var originFs = ICasUtil.selectAnnotationByAddr(cas, state.getSelection().getOrigin());
+            var targetFs = ICasUtil.selectAnnotationByAddr(cas, state.getSelection().getTarget());
+            var endpointRanges = List.of(
+                new VRange(originFs.getBegin(), originFs.getEnd()),
+                new VRange(targetFs.getBegin(), targetFs.getEnd())
+            );
+            editorPage.actionShowSelectedDocument(aTarget, doc, annoFs.getBegin(), annoFs.getEnd(), 
+                    endpointRanges);
+        }
+        else {
+            editorPage.actionShowSelectedDocument(aTarget, doc, annoFs.getBegin(), annoFs.getEnd());
+        }
     }
 
     @Override


### PR DESCRIPTION
**What's in the PR**
- Extend backend to support multiple ping ranges in some places where we didn't support it yet
- Handle selection of relations (or anything that looks like an arc) such that the begin/end ranges are used as ping ranges)

**How to test manually**
* Select a relation from the annotation overview sidebar
* Check if both endpoints are highlighted

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
