### PR TITLE
#5815 - Bulk action button visible when there are no projects

### DIFF
--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/projectlist/ProjectsOverviewPage.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/projectlist/ProjectsOverviewPage.java
@@ -270,6 +270,7 @@ public class ProjectsOverviewPage
         var sessionOwner = userRepository.getCurrentUser();
         toggleBulkChange = new LambdaAjaxLink(MID_TOGGLE_BULK_CHANGE, this::actionToggleBulkChange);
         toggleBulkChange.setOutputMarkupId(true);
+        toggleBulkChange.add(visibleWhen(() -> projectList.getItemCount() > 0));
         toggleBulkChange.setVisibilityAllowed(
                 projectUiProperties.getBulkActions().anyActionsAccessible(sessionOwner));
         toggleBulkChange.add(new CssClassNameAppender(LoadableDetachableModel


### PR DESCRIPTION
**What's in the PR**
- Hide the button when the project list is empty

**How to test manually**
* Start INCEpTION with bulk project actions enabled and without and projects and check if the button is gone

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
