### PR TITLE
#5810 - Document scrolls up when opening search sidebar

### DIFF
--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/sidebar/SidebarTabbedPanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/sidebar/SidebarTabbedPanel.java
@@ -23,7 +23,6 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.Component;
@@ -41,7 +40,6 @@ import de.tudarmstadt.ukp.inception.preferences.PreferenceKey;
 import de.tudarmstadt.ukp.inception.preferences.PreferencesService;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxLink;
-import de.tudarmstadt.ukp.inception.support.wicket.WicketUtil;
 
 public class SidebarTabbedPanel<T extends SidebarTab>
     extends AjaxTabbedPanel<T>
@@ -103,7 +101,11 @@ public class SidebarTabbedPanel<T extends SidebarTab>
         if (!expanded) {
             expanded = true;
             saveSidebarState();
-            aTarget.ifPresent(_target -> WicketUtil.refreshPage(_target, getPage()));
+            // Instead of re-rendering the entire page, let's see what happens when we just
+            // re-render the sidebar panel.
+            // See: #5810 - Document scrolls up when opening search sidebar
+            // aTarget.ifPresent(_target -> WicketUtil.refreshPage(_target, getPage()));
+            aTarget.ifPresent(_target -> _target.add(findParent(SidebarPanel.class)));
         }
     }
 
@@ -132,8 +134,7 @@ public class SidebarTabbedPanel<T extends SidebarTab>
                 state.getObject().getProject());
         expanded = sidebarState.isExpanded();
         if (isNotBlank(sidebarState.getSelectedTab())) {
-            var tabFactories = getTabs().stream().map(SidebarTab::getFactoryId)
-                    .collect(Collectors.toList());
+            var tabFactories = getTabs().stream().map(SidebarTab::getFactoryId).toList();
             var tabIndex = tabFactories.indexOf(sidebarState.getSelectedTab());
             if (tabIndex >= 0) {
                 super.setSelectedTab(tabIndex);


### PR DESCRIPTION
**What's in the PR**
- Try reloading only the sidebar, not the entire page

**How to test manually**
* See if reloading only the panel instead of the entire page causes any problems...

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
