### PR TITLE
#5824 - Long rows in concept tree browser fall apart

### DIFF
--- a/inception/inception-support-bootstrap/src/main/ts/bootstrap/shim-wicket.scss
+++ b/inception/inception-support-bootstrap/src/main/ts/bootstrap/shim-wicket.scss
@@ -28,3 +28,7 @@ a.tree-junction {
   // z-index 1020 is in Bootstrap's .sticky-top and we need to be above that
   z-index: 1030;
 }
+
+.tree-branch .tree-node {
+  white-space: nowrap;
+}


### PR DESCRIPTION
**What's in the PR**
- Disable wrapping in tree rows

**How to test manually**
* Create a few (sub)-concepts with very long labels

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
