### PR TITLE
#5829 - When creating character-level annotations whitespace is not trimmed

### DIFF
--- a/inception/inception-layer-span-api/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/api/SpanAdapter.java
+++ b/inception/inception-layer-span-api/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/api/SpanAdapter.java
@@ -34,7 +34,7 @@ public interface SpanAdapter
 {
     public enum SpanOption
     {
-        TRIM;
+        NO_TRIM;
     }
 
     AnnotationFS handle(CreateSpanAnnotationRequest aRequest) throws AnnotationException;

--- a/inception/inception-layer-span/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SegmentationUnitAdapter.java
+++ b/inception/inception-layer-span/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SegmentationUnitAdapter.java
@@ -17,8 +17,6 @@
  */
 package de.tudarmstadt.ukp.inception.annotation.layer.span;
 
-import static de.tudarmstadt.ukp.inception.annotation.layer.span.api.SpanAdapter.SpanOption.TRIM;
-
 import java.util.Set;
 
 import org.apache.uima.cas.CAS;
@@ -191,7 +189,7 @@ public class SegmentationUnitAdapter
             int oldBegin, int oldEnd, int newBegin, int newEnd)
     {
         aCas.removeFsFromIndexes(aAnnToBeRemoved);
-        spanAdapter.moveSpanAnnotation(aCas, aAnnToBeResized, newBegin, newEnd, TRIM);
+        spanAdapter.moveSpanAnnotation(aCas, aAnnToBeResized, newBegin, newEnd);
         spanAdapter.publishEvent(() -> new UnitMergedEvent(this, aDocument, aDocumentOwner,
                 spanAdapter.getLayer(), aAnnToBeResized, oldBegin, oldEnd, aAnnToBeRemoved));
     }
@@ -282,9 +280,8 @@ public class SegmentationUnitAdapter
                     "Splitting a unit may not create a zero-width unit.");
         }
 
-        var resizedUnit = spanAdapter.moveSpanAnnotation(cas, unit, headRange[0], headRange[1],
-                TRIM);
-        var newUnit = spanAdapter.createSpanAnnotation(cas, tailRange[0], tailRange[1], TRIM);
+        var resizedUnit = spanAdapter.moveSpanAnnotation(cas, unit, headRange[0], headRange[1]);
+        var newUnit = spanAdapter.createSpanAnnotation(cas, tailRange[0], tailRange[1]);
         spanAdapter.publishEvent(
                 () -> new UnitSplitEvent(this, aRequest.getDocument(), aRequest.getDocumentOwner(),
                         spanAdapter.getLayer(), resizedUnit, oldBegin, oldEnd, newUnit));
@@ -298,7 +295,7 @@ public class SegmentationUnitAdapter
         throws AnnotationException
     {
         var resizedUnit = ICasUtil.selectAnnotationByAddr(aCas, aResizedUnit.getId());
-        spanAdapter.moveSpanAnnotation(aCas, resizedUnit, aBegin, aEnd, TRIM);
+        spanAdapter.moveSpanAnnotation(aCas, resizedUnit, aBegin, aEnd);
         return spanAdapter.restore(aDocument, aDocumentOwner, aCas, aDeletedUnit);
     }
 
@@ -308,6 +305,6 @@ public class SegmentationUnitAdapter
     {
         spanAdapter.delete(aDocument, aDocumentOwner, aCas, aNewUnit);
         var resizedUnit = ICasUtil.selectAnnotationByAddr(aCas, aResizedUnit.getId());
-        return spanAdapter.moveSpanAnnotation(aCas, resizedUnit, aBegin, aEnd, TRIM);
+        return spanAdapter.moveSpanAnnotation(aCas, resizedUnit, aBegin, aEnd);
     }
 }

--- a/inception/inception-layer-span/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanAdapterImpl.java
+++ b/inception/inception-layer-span/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanAdapterImpl.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.annotation.layer.span;
 
+import static de.tudarmstadt.ukp.inception.annotation.layer.span.api.SpanAdapter.SpanOption.NO_TRIM;
 import static de.tudarmstadt.ukp.inception.support.uima.ICasUtil.selectByAddr;
 import static java.lang.System.currentTimeMillis;
 import static java.util.Arrays.asList;
@@ -174,7 +175,7 @@ public class SpanAdapterImpl
         var type = CasUtil.getType(aCas, getAnnotationTypeName());
         var newAnnotation = (Annotation) aCas.createAnnotation(type, aBegin, aEnd);
 
-        if (asList(aOptions).contains(SpanOption.TRIM)) {
+        if (!asList(aOptions).contains(NO_TRIM)) {
             TrimUtils.trim(aCas.getDocumentText(), newAnnotation);
         }
 
@@ -212,7 +213,7 @@ public class SpanAdapterImpl
         aAnnotation.setBegin(aBegin);
         aAnnotation.setEnd(aEnd);
 
-        if (asList(aOptions).contains(SpanOption.TRIM)) {
+        if (!asList(aOptions).contains(NO_TRIM)) {
             TrimUtils.trim(aCas.getDocumentText(), (Annotation) aAnnotation);
         }
 

--- a/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImplIntegrationTest.java
+++ b/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/service/RecommendationServiceImplIntegrationTest.java
@@ -220,6 +220,7 @@ public class RecommendationServiceImplIntegrationTest
 
         spanLayer.setOverlapMode(NO_OVERLAP);
         var cas = createJCas();
+        cas.setDocumentText("0123456789abcdefghijk");
         var targetFS = new NamedEntity(cas, 0, 10);
         targetFS.addToIndexes();
         assertThat(targetFS.getValue()).isNull();
@@ -265,6 +266,7 @@ public class RecommendationServiceImplIntegrationTest
 
         spanLayer.setOverlapMode(ANY_OVERLAP);
         cas.reset();
+        cas.setDocumentText("0123456789abcdefghijk");
         targetFS = new NamedEntity(cas, 0, 10);
         targetFS.addToIndexes();
         assertThat(targetFS.getValue()).isNull();


### PR DESCRIPTION
**What's in the PR**
- Always trim span annotations

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
