### PR TITLE
#5837 - Creating an annotation longer than a token should be rejected in single-token mode

### DIFF
--- a/inception/inception-layer-behavior/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/behavior/SpanAnchoringModeBehavior.java
+++ b/inception/inception-layer-behavior/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/behavior/SpanAnchoringModeBehavior.java
@@ -160,6 +160,10 @@ public class SpanAnchoringModeBehavior
                     "No tokens found int range [" + aRange[0] + "-" + aRange[1] + "]");
         }
 
+        if (tokens.size() > 1) {
+            throw new IllegalPlacementException("Annotation must not cover multiple tokens");
+        }
+
         return new int[] { tokens.get(0).getBegin(), tokens.get(0).getEnd() };
     }
 }

--- a/inception/inception-layer-behavior/src/test/java/de/tudarmstadt/ukp/inception/annotation/layer/behavior/SpanAnchoringModeBehaviorTest.java
+++ b/inception/inception-layer-behavior/src/test/java/de/tudarmstadt/ukp/inception/annotation/layer/behavior/SpanAnchoringModeBehaviorTest.java
@@ -1,0 +1,487 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.annotation.layer.behavior;
+
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.CHARACTERS;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.SENTENCES;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.SINGLE_TOKEN;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.TOKENS;
+import static de.tudarmstadt.ukp.inception.annotation.layer.behavior.SpanAnchoringModeBehavior.adjust;
+import static de.tudarmstadt.ukp.inception.annotation.layer.behavior.SpanAnchoringModeBehavior.adjustToSentences;
+import static de.tudarmstadt.ukp.inception.annotation.layer.behavior.SpanAnchoringModeBehavior.adjustToSingleToken;
+import static de.tudarmstadt.ukp.inception.annotation.layer.behavior.SpanAnchoringModeBehavior.adjustToTokens;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.when;
+
+import org.apache.uima.fit.factory.JCasFactory;
+import org.apache.uima.jcas.JCas;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.IllegalPlacementException;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
+import de.tudarmstadt.ukp.inception.annotation.layer.chain.api.ChainLayerSupport;
+import de.tudarmstadt.ukp.inception.annotation.layer.span.api.CreateSpanAnnotationRequest;
+import de.tudarmstadt.ukp.inception.annotation.layer.span.api.MoveSpanAnnotationRequest;
+import de.tudarmstadt.ukp.inception.annotation.layer.span.api.SpanLayerSupport;
+import de.tudarmstadt.ukp.inception.schema.api.adapter.TypeAdapter;
+
+@ExtendWith(MockitoExtension.class)
+class SpanAnchoringModeBehaviorTest
+{
+    private @Mock TypeAdapter adapter;
+    private @Mock AnnotationLayer layer;
+    private @Mock SpanLayerSupport spanLayerSupport;
+    private @Mock ChainLayerSupport chainLayerSupport;
+
+    private SpanAnchoringModeBehavior sut;
+    private JCas jcas;
+
+    @BeforeEach
+    void setup() throws Exception
+    {
+        sut = new SpanAnchoringModeBehavior();
+        jcas = JCasFactory.createJCas();
+        jcas.setDocumentText("The quick brown fox jumps over the lazy dog.");
+
+        // Create tokens: "The" (0-3), "quick" (4-9), "brown" (10-15), "fox" (16-19),
+        // "jumps" (20-25), "over" (26-30), "the" (31-34), "lazy" (35-39), "dog" (40-43)
+        addToken(0, 3); // The
+        addToken(4, 9); // quick
+        addToken(10, 15); // brown
+        addToken(16, 19); // fox
+        addToken(20, 25); // jumps
+        addToken(26, 30); // over
+        addToken(31, 34); // the
+        addToken(35, 39); // lazy
+        addToken(40, 43); // dog
+
+        // Create sentences
+        addSentence(0, 44); // The quick brown fox jumps over the lazy dog.
+    }
+
+    private void addToken(int aBegin, int aEnd)
+    {
+        Token token = new Token(jcas, aBegin, aEnd);
+        token.addToIndexes();
+    }
+
+    private void addSentence(int aBegin, int aEnd)
+    {
+        Sentence sentence = new Sentence(jcas, aBegin, aEnd);
+        sentence.addToIndexes();
+    }
+
+    @Nested
+    class AcceptsTests
+    {
+        @Test
+        void testAcceptsSpanLayerSupport()
+        {
+            assertThat(sut.accepts(spanLayerSupport)).isTrue();
+        }
+
+        @Test
+        void testAcceptsChainLayerSupport()
+        {
+            assertThat(sut.accepts(chainLayerSupport)).isTrue();
+        }
+    }
+
+    @Nested
+    class CreateTests
+    {
+        @Test
+        void testSkipsTokenLayer() throws Exception
+        {
+            when(adapter.getAnnotationTypeName()).thenReturn(Token.class.getName());
+
+            var request = CreateSpanAnnotationRequest.builder() //
+                    .withCas(jcas.getCas()) //
+                    .withBegin(0) //
+                    .withEnd(3) //
+                    .build();
+
+            var result = sut.onCreate(adapter, request);
+
+            assertThat(result).isSameAs(request);
+        }
+
+        @Test
+        void testSkipsSentenceLayer() throws Exception
+        {
+            when(adapter.getAnnotationTypeName()).thenReturn(Sentence.class.getName());
+
+            var request = CreateSpanAnnotationRequest.builder() //
+                    .withCas(jcas.getCas()) //
+                    .withBegin(0) //
+                    .withEnd(44) //
+                    .build();
+
+            var result = sut.onCreate(adapter, request);
+
+            assertThat(result).isSameAs(request);
+        }
+
+        @Test
+        void testRejectsZeroWidthWhenNotAllowed() throws Exception
+        {
+            when(adapter.getAnnotationTypeName()).thenReturn("custom.Type");
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.getAnchoringMode()).thenReturn(SINGLE_TOKEN);
+
+            var request = CreateSpanAnnotationRequest.builder() //
+                    .withCas(jcas.getCas()) //
+                    .withBegin(5) //
+                    .withEnd(5) //
+                    .build();
+
+            assertThatExceptionOfType(IllegalPlacementException.class) //
+                    .isThrownBy(() -> sut.onCreate(adapter, request)) //
+                    .withMessageContaining("zero-width");
+        }
+
+        @Test
+        void testAllowsZeroWidthWhenAllowed() throws Exception
+        {
+            when(adapter.getAnnotationTypeName()).thenReturn("custom.Type");
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.getAnchoringMode()).thenReturn(CHARACTERS);
+
+            var request = CreateSpanAnnotationRequest.builder() //
+                    .withCas(jcas.getCas()) //
+                    .withBegin(5) //
+                    .withEnd(5) //
+                    .build();
+
+            var result = sut.onCreate(adapter, request);
+
+            assertThat(result).isSameAs(request);
+        }
+
+        @Test
+        void testAdjustsToTokens() throws Exception
+        {
+            when(adapter.getAnnotationTypeName()).thenReturn("custom.Type");
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.getAnchoringMode()).thenReturn(TOKENS);
+
+            var request = CreateSpanAnnotationRequest.builder() //
+                    .withCas(jcas.getCas()) //
+                    .withBegin(5) // middle of "quick"
+                    .withEnd(12) // middle of "brown"
+                    .build();
+
+            var result = sut.onCreate(adapter, request);
+
+            assertThat(result.getBegin()).isEqualTo(4); // start of "quick"
+            assertThat(result.getEnd()).isEqualTo(15); // end of "brown"
+        }
+
+        @Test
+        void testAdjustsToSingleToken() throws Exception
+        {
+            when(adapter.getAnnotationTypeName()).thenReturn("custom.Type");
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.getAnchoringMode()).thenReturn(SINGLE_TOKEN);
+
+            var request = CreateSpanAnnotationRequest.builder() //
+                    .withCas(jcas.getCas()) //
+                    .withBegin(4) // start of "quick"
+                    .withEnd(8) // middle of "quick"
+                    .build();
+
+            var result = sut.onCreate(adapter, request);
+
+            assertThat(result.getBegin()).isEqualTo(4); // start of "quick"
+            assertThat(result.getEnd()).isEqualTo(9); // end of "quick"
+        }
+
+        @Test
+        void testAdjustsToSentences() throws Exception
+        {
+            when(adapter.getAnnotationTypeName()).thenReturn("custom.Type");
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.getAnchoringMode()).thenReturn(SENTENCES);
+
+            var request = CreateSpanAnnotationRequest.builder() //
+                    .withCas(jcas.getCas()) //
+                    .withBegin(10) //
+                    .withEnd(20) //
+                    .build();
+
+            var result = sut.onCreate(adapter, request);
+
+            assertThat(result.getBegin()).isEqualTo(0); // start of sentence
+            assertThat(result.getEnd()).isEqualTo(44); // end of sentence
+        }
+
+        @Test
+        void testDoesNotAdjustCharacterMode() throws Exception
+        {
+            when(adapter.getAnnotationTypeName()).thenReturn("custom.Type");
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.getAnchoringMode()).thenReturn(CHARACTERS);
+
+            var request = CreateSpanAnnotationRequest.builder() //
+                    .withCas(jcas.getCas()) //
+                    .withBegin(5) //
+                    .withEnd(12) //
+                    .build();
+
+            var result = sut.onCreate(adapter, request);
+
+            assertThat(result.getBegin()).isEqualTo(5);
+            assertThat(result.getEnd()).isEqualTo(12);
+        }
+
+        @Test
+        void testUsesRequestAnchoringModeWhenAllowed() throws Exception
+        {
+            when(adapter.getAnnotationTypeName()).thenReturn("custom.Type");
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.getAnchoringMode()).thenReturn(TOKENS);
+
+            var request = CreateSpanAnnotationRequest.builder() //
+                    .withCas(jcas.getCas()) //
+                    .withBegin(4) //
+                    .withEnd(8) //
+                    .withAnchoringMode(SINGLE_TOKEN) //
+                    .build();
+
+            var result = sut.onCreate(adapter, request);
+
+            // Should use SINGLE_TOKEN mode from request (first token only)
+            assertThat(result.getBegin()).isEqualTo(4); // start of "quick"
+            assertThat(result.getEnd()).isEqualTo(9); // end of "quick"
+        }
+    }
+
+    @Nested
+    class MoveTests
+    {
+        @BeforeEach
+        void setup()
+        {
+            when(adapter.getLayer()).thenReturn(layer);
+        }
+
+        @Test
+        void testAdjustsToTokensOnMove() throws Exception
+        {
+            when(adapter.getAnnotationTypeName()).thenReturn("custom.Type");
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.getAnchoringMode()).thenReturn(TOKENS);
+
+            var request = MoveSpanAnnotationRequest.builder() //
+                    .withCas(jcas.getCas()) //
+                    .withBegin(5) // middle of "quick"
+                    .withEnd(12) // middle of "brown"
+                    .build();
+
+            var result = sut.onMove(adapter, request);
+
+            assertThat(result.getBegin()).isEqualTo(4); // start of "quick"
+            assertThat(result.getEnd()).isEqualTo(15); // end of "brown"
+        }
+
+        @Test
+        void testRejectsZeroWidthOnMoveWhenNotAllowed() throws Exception
+        {
+            when(adapter.getAnnotationTypeName()).thenReturn("custom.Type");
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.getAnchoringMode()).thenReturn(SINGLE_TOKEN);
+
+            var request = MoveSpanAnnotationRequest.builder() //
+                    .withCas(jcas.getCas()) //
+                    .withBegin(5) //
+                    .withEnd(5) //
+                    .build();
+
+            assertThatExceptionOfType(IllegalPlacementException.class) //
+                    .isThrownBy(() -> sut.onMove(adapter, request)) //
+                    .withMessageContaining("zero-width");
+        }
+    }
+
+    @Nested
+    class AdjustMethodTests
+    {
+        @Test
+        void testAdjustCharactersMode() throws Exception
+        {
+            var result = adjust(jcas.getCas(), CHARACTERS, new int[] { 5, 12 });
+
+            assertThat(result).isEqualTo(new int[] { 5, 12 });
+        }
+
+        @Test
+        void testAdjustTokensMode() throws Exception
+        {
+            var result = adjust(jcas.getCas(), TOKENS, new int[] { 5, 12 });
+
+            assertThat(result).isEqualTo(new int[] { 4, 15 }); // "quick brown"
+        }
+
+        @Test
+        void testAdjustSingleTokenMode() throws Exception
+        {
+            var result = adjust(jcas.getCas(), SINGLE_TOKEN, new int[] { 4, 8 });
+
+            assertThat(result).isEqualTo(new int[] { 4, 9 }); // "quick"
+        }
+
+        @Test
+        void testAdjustSentencesMode() throws Exception
+        {
+            var result = adjust(jcas.getCas(), SENTENCES, new int[] { 10, 20 });
+
+            assertThat(result).isEqualTo(new int[] { 0, 44 }); // entire sentence
+        }
+    }
+
+    @Nested
+    class AdjustToTokensTests
+    {
+        @Test
+        void testAdjustsToSingleToken() throws Exception
+        {
+            var result = adjustToTokens(jcas.getCas(), new int[] { 5, 8 });
+
+            assertThat(result).isEqualTo(new int[] { 4, 9 }); // "quick"
+        }
+
+        @Test
+        void testAdjustsToMultipleTokens() throws Exception
+        {
+            var result = adjustToTokens(jcas.getCas(), new int[] { 5, 18 });
+
+            assertThat(result).isEqualTo(new int[] { 4, 19 }); // "quick brown fox"
+        }
+
+        @Test
+        void testAdjustsToExactTokenBoundaries() throws Exception
+        {
+            var result = adjustToTokens(jcas.getCas(), new int[] { 4, 9 });
+
+            assertThat(result).isEqualTo(new int[] { 4, 9 }); // "quick"
+        }
+
+        @Test
+        void testThrowsWhenNoTokensFound() throws Exception
+        {
+            jcas.reset();
+            jcas.setDocumentText("test");
+
+            assertThatExceptionOfType(IllegalPlacementException.class) //
+                    .isThrownBy(() -> adjustToTokens(jcas.getCas(), new int[] { 0, 4 })) //
+                    .withMessageContaining("No tokens found");
+        }
+    }
+
+    @Nested
+    class AdjustToSingleTokenTests
+    {
+        @Test
+        void testNoNeedToAdjustToExactToken() throws Exception
+        {
+            var result = adjustToSingleToken(jcas.getCas(), new int[] { 10, 15 });
+
+            assertThat(result).isEqualTo(new int[] { 10, 15 }); // "brown"
+        }
+
+        @Test
+        void testAdjustsSubtokenToExactToken() throws Exception
+        {
+            var result = adjustToSingleToken(jcas.getCas(), new int[] { 11, 14 });
+
+            assertThat(result).isEqualTo(new int[] { 10, 15 }); // "brown"
+        }
+
+        @Test
+        void testThrowsWhenSelectionTooLarge() throws Exception
+        {
+            assertThatExceptionOfType(IllegalPlacementException.class) //
+                    .isThrownBy(() -> adjustToSingleToken(jcas.getCas(), new int[] { 5, 18 })) //
+                    .withMessageContaining("Annotation must not cover multiple tokens");
+        }
+
+        @Test
+        void testThrowsWhenNoTokensFound() throws Exception
+        {
+            jcas.reset();
+            jcas.setDocumentText("test");
+
+            assertThatExceptionOfType(IllegalPlacementException.class) //
+                    .isThrownBy(() -> adjustToSingleToken(jcas.getCas(), new int[] { 0, 4 })) //
+                    .withMessageContaining("No tokens found");
+        }
+    }
+
+    @Nested
+    class AdjustToSentencesTests
+    {
+        @Test
+        void testAdjustsToSingleSentence() throws Exception
+        {
+            var result = adjustToSentences(jcas.getCas(), new int[] { 10, 20 });
+
+            assertThat(result).isEqualTo(new int[] { 0, 44 });
+        }
+
+        @Test
+        void testAdjustsToMultipleSentences() throws Exception
+        {
+            jcas.reset();
+            jcas.setDocumentText("First sentence. Second sentence. Third sentence.");
+            addSentence(0, 15); // "First sentence."
+            addSentence(16, 32); // "Second sentence."
+            addSentence(33, 48); // "Third sentence."
+
+            var result = adjustToSentences(jcas.getCas(), new int[] { 10, 25 });
+
+            assertThat(result).isEqualTo(new int[] { 0, 32 }); // first two sentences
+        }
+
+        @Test
+        void testAdjustsToExactSentenceBoundaries() throws Exception
+        {
+            var result = adjustToSentences(jcas.getCas(), new int[] { 0, 44 });
+
+            assertThat(result).isEqualTo(new int[] { 0, 44 });
+        }
+
+        @Test
+        void testThrowsWhenNoSentencesFound() throws Exception
+        {
+            jcas.reset();
+            jcas.setDocumentText("test");
+
+            assertThatExceptionOfType(IllegalPlacementException.class) //
+                    .isThrownBy(() -> adjustToSentences(jcas.getCas(), new int[] { 0, 4 })) //
+                    .withMessageContaining("No sentences found");
+        }
+    }
+}

--- a/inception/inception-layer-behavior/src/test/java/de/tudarmstadt/ukp/inception/annotation/layer/behavior/SpanCrossSentenceBehaviorTest.java
+++ b/inception/inception-layer-behavior/src/test/java/de/tudarmstadt/ukp/inception/annotation/layer/behavior/SpanCrossSentenceBehaviorTest.java
@@ -1,0 +1,490 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.annotation.layer.behavior;
+
+import static de.tudarmstadt.ukp.inception.rendering.vmodel.VCommentType.ERROR;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.uima.cas.text.AnnotationFS;
+import org.apache.uima.fit.factory.JCasFactory;
+import org.apache.uima.jcas.JCas;
+import org.apache.uima.jcas.tcas.Annotation;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.MultipleSentenceCoveredException;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
+import de.tudarmstadt.ukp.inception.annotation.layer.chain.api.ChainLayerSupport;
+import de.tudarmstadt.ukp.inception.annotation.layer.span.api.CreateSpanAnnotationRequest;
+import de.tudarmstadt.ukp.inception.annotation.layer.span.api.MoveSpanAnnotationRequest;
+import de.tudarmstadt.ukp.inception.annotation.layer.span.api.SpanLayerSupport;
+import de.tudarmstadt.ukp.inception.rendering.vmodel.VComment;
+import de.tudarmstadt.ukp.inception.rendering.vmodel.VDocument;
+import de.tudarmstadt.ukp.inception.rendering.vmodel.VRange;
+import de.tudarmstadt.ukp.inception.rendering.vmodel.VSpan;
+import de.tudarmstadt.ukp.inception.schema.api.adapter.TypeAdapter;
+
+@ExtendWith(MockitoExtension.class)
+class SpanCrossSentenceBehaviorTest
+{
+    private @Mock TypeAdapter adapter;
+    private @Mock AnnotationLayer layer;
+    private @Mock SpanLayerSupport spanLayerSupport;
+    private @Mock ChainLayerSupport chainLayerSupport;
+
+    private SpanCrossSentenceBehavior sut;
+    private JCas jcas;
+
+    @BeforeEach
+    void setup() throws Exception
+    {
+        sut = new SpanCrossSentenceBehavior();
+        jcas = JCasFactory.createJCas();
+        jcas.setDocumentText("First sentence. Second sentence. Third sentence.");
+
+        // First sentence: 0-15
+        addSentence(0, 15);
+        addToken(0, 5); // First
+        addToken(6, 14); // sentence
+
+        // Second sentence: 16-32
+        addSentence(16, 32);
+        addToken(16, 22); // Second
+        addToken(23, 31); // sentence
+
+        // Third sentence: 33-48
+        addSentence(33, 48);
+        addToken(33, 38); // Third
+        addToken(39, 47); // sentence
+    }
+
+    private void addToken(int aBegin, int aEnd)
+    {
+        Token token = new Token(jcas, aBegin, aEnd);
+        token.addToIndexes();
+    }
+
+    private void addSentence(int aBegin, int aEnd)
+    {
+        Sentence sentence = new Sentence(jcas, aBegin, aEnd);
+        sentence.addToIndexes();
+    }
+
+    private Annotation addAnnotation(int aBegin, int aEnd)
+    {
+        Annotation anno = new Annotation(jcas, aBegin, aEnd);
+        anno.addToIndexes();
+        return anno;
+    }
+
+    @Nested
+    class AcceptsTests
+    {
+        @Test
+        void testAcceptsSpanLayerSupport()
+        {
+            assertThat(sut.accepts(spanLayerSupport)).isTrue();
+        }
+
+        @Test
+        void testAcceptsChainLayerSupport()
+        {
+            assertThat(sut.accepts(chainLayerSupport)).isTrue();
+        }
+    }
+
+    @Nested
+    class CreateTests
+    {
+        @Test
+        void testSkipsTokenLayer() throws Exception
+        {
+            when(adapter.getAnnotationTypeName()).thenReturn(Token.class.getName());
+
+            var request = CreateSpanAnnotationRequest.builder() //
+                    .withCas(jcas.getCas()) //
+                    .withBegin(0) //
+                    .withEnd(48) //
+                    .build();
+
+            var result = sut.onCreate(adapter, request);
+
+            assertThat(result).isSameAs(request);
+        }
+
+        @Test
+        void testSkipsSentenceLayer() throws Exception
+        {
+            when(adapter.getAnnotationTypeName()).thenReturn(Sentence.class.getName());
+
+            var request = CreateSpanAnnotationRequest.builder() //
+                    .withCas(jcas.getCas()) //
+                    .withBegin(0) //
+                    .withEnd(48) //
+                    .build();
+
+            var result = sut.onCreate(adapter, request);
+
+            assertThat(result).isSameAs(request);
+        }
+
+        @Test
+        void testAllowsCrossSentenceWhenEnabled() throws Exception
+        {
+            when(adapter.getAnnotationTypeName()).thenReturn("custom.Type");
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.isCrossSentence()).thenReturn(true);
+
+            var request = CreateSpanAnnotationRequest.builder() //
+                    .withCas(jcas.getCas()) //
+                    .withBegin(0) //
+                    .withEnd(48) // Spans all three sentences
+                    .build();
+
+            var result = sut.onCreate(adapter, request);
+
+            assertThat(result).isSameAs(request);
+        }
+
+        @Test
+        void testAllowsWithinSingleSentence() throws Exception
+        {
+            when(adapter.getAnnotationTypeName()).thenReturn("custom.Type");
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.isCrossSentence()).thenReturn(false);
+
+            var request = CreateSpanAnnotationRequest.builder() //
+                    .withCas(jcas.getCas()) //
+                    .withBegin(0) //
+                    .withEnd(15) // Within first sentence
+                    .build();
+
+            var result = sut.onCreate(adapter, request);
+
+            assertThat(result).isSameAs(request);
+        }
+
+        @Test
+        void testRejectsCrossSentenceWhenDisabled() throws Exception
+        {
+            when(adapter.getAnnotationTypeName()).thenReturn("custom.Type");
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.isCrossSentence()).thenReturn(false);
+
+            var request = CreateSpanAnnotationRequest.builder() //
+                    .withCas(jcas.getCas()) //
+                    .withBegin(0) //
+                    .withEnd(32) // Spans first and second sentences
+                    .build();
+
+            assertThatExceptionOfType(MultipleSentenceCoveredException.class) //
+                    .isThrownBy(() -> sut.onCreate(adapter, request)) //
+                    .withMessageContaining("multiple sentences");
+        }
+
+        @Test
+        void testRejectsCrossSentenceBoundary() throws Exception
+        {
+            when(adapter.getAnnotationTypeName()).thenReturn("custom.Type");
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.isCrossSentence()).thenReturn(false);
+
+            var request = CreateSpanAnnotationRequest.builder() //
+                    .withCas(jcas.getCas()) //
+                    .withBegin(10) //
+                    .withEnd(20) // Crosses from first to second sentence
+                    .build();
+
+            assertThatExceptionOfType(MultipleSentenceCoveredException.class) //
+                    .isThrownBy(() -> sut.onCreate(adapter, request)) //
+                    .withMessageContaining("multiple sentences");
+        }
+    }
+
+    @Nested
+    class MoveTests
+    {
+        @Test
+        void testAllowsMoveWithinSameSentence() throws Exception
+        {
+            when(adapter.getAnnotationTypeName()).thenReturn("custom.Type");
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.isCrossSentence()).thenReturn(false);
+
+            var request = MoveSpanAnnotationRequest.builder() //
+                    .withCas(jcas.getCas()) //
+                    .withBegin(16) //
+                    .withEnd(32) // Within second sentence
+                    .build();
+
+            var result = sut.onMove(adapter, request);
+
+            assertThat(result).isSameAs(request);
+        }
+
+        @Test
+        void testRejectsMoveCrossSentence() throws Exception
+        {
+            when(adapter.getAnnotationTypeName()).thenReturn("custom.Type");
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.isCrossSentence()).thenReturn(false);
+
+            var request = MoveSpanAnnotationRequest.builder() //
+                    .withCas(jcas.getCas()) //
+                    .withBegin(10) //
+                    .withEnd(25) // Crosses sentence boundaries
+                    .build();
+
+            assertThatExceptionOfType(MultipleSentenceCoveredException.class) //
+                    .isThrownBy(() -> sut.onMove(adapter, request)) //
+                    .withMessageContaining("multiple sentences");
+        }
+
+        @Test
+        void testAllowsMoveCrossSentenceWhenEnabled() throws Exception
+        {
+            when(adapter.getAnnotationTypeName()).thenReturn("custom.Type");
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.isCrossSentence()).thenReturn(true);
+
+            var request = MoveSpanAnnotationRequest.builder() //
+                    .withCas(jcas.getCas()) //
+                    .withBegin(10) //
+                    .withEnd(25) // Crosses sentence boundaries
+                    .build();
+
+            var result = sut.onMove(adapter, request);
+
+            assertThat(result).isSameAs(request);
+        }
+    }
+
+    @Nested
+    class RenderTests
+    {
+        @Test
+        void testSkipsRenderWhenCrossSentenceEnabled() throws Exception
+        {
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.isCrossSentence()).thenReturn(true);
+
+            var vdoc = new VDocument();
+            vdoc.setWindowBegin(0);
+            vdoc.setWindowEnd(48);
+
+            Map<AnnotationFS, VSpan> annoToSpanIdx = new HashMap<>();
+            var anno = addAnnotation(0, 32);
+            annoToSpanIdx.put(anno, new VSpan(layer, anno, new VRange(0, 32), null));
+
+            sut.onRender(adapter, vdoc, annoToSpanIdx);
+
+            // No comments should be added
+            assertThat(vdoc.comments()).isEmpty();
+        }
+
+        @Test
+        void testSkipsRenderWhenNoAnnotations() throws Exception
+        {
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.isCrossSentence()).thenReturn(false);
+
+            var vdoc = new VDocument();
+            vdoc.setWindowBegin(0);
+            vdoc.setWindowEnd(48);
+
+            Map<AnnotationFS, VSpan> annoToSpanIdx = new HashMap<>();
+
+            sut.onRender(adapter, vdoc, annoToSpanIdx);
+
+            // No comments should be added
+            assertThat(vdoc.comments()).isEmpty();
+        }
+
+        @Test
+        void testAddsErrorForCrossSentenceAnnotation() throws Exception
+        {
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.isCrossSentence()).thenReturn(false);
+
+            var vdoc = new VDocument();
+            vdoc.setWindowBegin(0);
+            vdoc.setWindowEnd(48);
+
+            Map<AnnotationFS, VSpan> annoToSpanIdx = new HashMap<>();
+            var anno = addAnnotation(0, 32); // Crosses sentences
+            annoToSpanIdx.put(anno, new VSpan(layer, anno, new VRange(0, 32), null));
+
+            sut.onRender(adapter, vdoc, annoToSpanIdx);
+
+            assertThat(vdoc.comments()).hasSize(1);
+            var commentsArray = vdoc.comments().toArray(new VComment[0]);
+            assertThat(commentsArray[0].getCommentType()).isEqualTo(ERROR);
+            assertThat(commentsArray[0].getComment()).contains("Crossing sentence boundaries");
+        }
+
+        @Test
+        void testNoErrorForWithinSentenceAnnotation() throws Exception
+        {
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.isCrossSentence()).thenReturn(false);
+
+            var vdoc = new VDocument();
+            vdoc.setWindowBegin(0);
+            vdoc.setWindowEnd(48);
+
+            Map<AnnotationFS, VSpan> annoToSpanIdx = new HashMap<>();
+            var anno = addAnnotation(0, 15); // Within first sentence
+            annoToSpanIdx.put(anno, new VSpan(layer, anno, new VRange(0, 15), null));
+
+            sut.onRender(adapter, vdoc, annoToSpanIdx);
+
+            assertThat(vdoc.comments()).isEmpty();
+        }
+
+        @Test
+        void testHandlesMultipleAnnotations() throws Exception
+        {
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.isCrossSentence()).thenReturn(false);
+
+            var vdoc = new VDocument();
+            vdoc.setWindowBegin(0);
+            vdoc.setWindowEnd(48);
+
+            Map<AnnotationFS, VSpan> annoToSpanIdx = new HashMap<>();
+            var anno1 = addAnnotation(0, 15); // Within sentence 1
+            var anno2 = addAnnotation(0, 32); // Crosses sentences
+            var anno3 = addAnnotation(16, 32); // Within sentence 2
+            annoToSpanIdx.put(anno1, new VSpan(layer, anno1, new VRange(0, 15), null));
+            annoToSpanIdx.put(anno2, new VSpan(layer, anno2, new VRange(0, 32), null));
+            annoToSpanIdx.put(anno3, new VSpan(layer, anno3, new VRange(16, 32), null));
+
+            sut.onRender(adapter, vdoc, annoToSpanIdx);
+
+            // Only anno2 should have an error
+            assertThat(vdoc.comments()).hasSize(1);
+        }
+    }
+
+    @Nested
+    class ValidateTests
+    {
+        @Test
+        void testSkipsValidationWhenCrossSentenceEnabled() throws Exception
+        {
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.isCrossSentence()).thenReturn(true);
+
+            var result = sut.onValidate(adapter, jcas.getCas());
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void testReturnsEmptyWhenNoAnnotations() throws Exception
+        {
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.isCrossSentence()).thenReturn(false);
+            when(adapter.getAnnotationTypeName()).thenReturn(Token.class.getName());
+
+            var result = sut.onValidate(adapter, jcas.getCas());
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void testReturnsErrorForCrossSentenceAnnotation() throws Exception
+        {
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.isCrossSentence()).thenReturn(false);
+            when(adapter.getAnnotationTypeName()).thenReturn(Annotation.class.getName());
+
+            addAnnotation(0, 32); // Crosses sentences
+
+            var result = sut.onValidate(adapter, jcas.getCas());
+
+            // Expecting 2 errors: DocumentAnnotation (0-48) and our annotation (0-32)
+            assertThat(result).hasSize(2);
+            assertThat(result).allMatch(
+                    pair -> pair.getLeft().getMessage().contains("Crossing sentence boundaries"));
+        }
+
+        @Test
+        void testReturnsNoErrorForWithinSentenceAnnotation() throws Exception
+        {
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.isCrossSentence()).thenReturn(false);
+            when(adapter.getAnnotationTypeName()).thenReturn(Token.class.getName());
+
+            // Token annotations are within sentences by construction
+            var result = sut.onValidate(adapter, jcas.getCas());
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void testHandlesMixedAnnotations() throws Exception
+        {
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.isCrossSentence()).thenReturn(false);
+            when(adapter.getAnnotationTypeName()).thenReturn(Annotation.class.getName());
+
+            addAnnotation(0, 15); // Within sentence 1 - OK
+            addAnnotation(0, 32); // Crosses sentences - ERROR
+            addAnnotation(16, 32); // Within sentence 2 - OK
+            addAnnotation(10, 25); // Crosses sentences - ERROR
+
+            var result = sut.onValidate(adapter, jcas.getCas());
+
+            // Expecting 3 errors: DocumentAnnotation (0-48), and 2 crossing annotations
+            assertThat(result).hasSize(3);
+            assertThat(result).allMatch(
+                    pair -> pair.getLeft().getMessage().contains("Crossing sentence boundaries"));
+        }
+
+        @Test
+        void testHandlesAnnotationOutsideSentences() throws Exception
+        {
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.isCrossSentence()).thenReturn(false);
+            when(adapter.getAnnotationTypeName()).thenReturn(Annotation.class.getName());
+
+            jcas.reset();
+            jcas.setDocumentText("No sentence annotations here.");
+            addAnnotation(0, 10);
+
+            var result = sut.onValidate(adapter, jcas.getCas());
+
+            // Expecting 2: DocumentAnnotation and our annotation
+            assertThat(result).hasSize(2);
+            assertThat(result).allMatch(pair -> pair.getLeft().getMessage()
+                    .contains("Unable to determine any sentences"));
+        }
+    }
+}

--- a/inception/inception-layer-behavior/src/test/java/de/tudarmstadt/ukp/inception/annotation/layer/behavior/SpanOverlapBehaviorTest.java
+++ b/inception/inception-layer-behavior/src/test/java/de/tudarmstadt/ukp/inception/annotation/layer/behavior/SpanOverlapBehaviorTest.java
@@ -19,117 +19,648 @@ package de.tudarmstadt.ukp.inception.annotation.layer.behavior;
 
 import static de.tudarmstadt.ukp.inception.annotation.layer.behavior.SpanOverlapBehavior.overlappingNonStackingSpans;
 import static de.tudarmstadt.ukp.inception.annotation.layer.behavior.SpanOverlapBehavior.overlappingOrStackingSpans;
+import static de.tudarmstadt.ukp.inception.rendering.vmodel.VCommentType.ERROR;
 import static org.apache.uima.cas.text.AnnotationPredicates.colocated;
 import static org.apache.uima.cas.text.AnnotationPredicates.overlapping;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.when;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 
 import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.text.AnnotationFS;
 import org.apache.uima.fit.factory.CasFactory;
+import org.apache.uima.fit.factory.JCasFactory;
+import org.apache.uima.jcas.JCas;
 import org.apache.uima.jcas.tcas.Annotation;
 import org.apache.uima.resource.ResourceInitializationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-public class SpanOverlapBehaviorTest
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.IllegalPlacementException;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.OverlapMode;
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
+import de.tudarmstadt.ukp.inception.annotation.layer.chain.api.ChainLayerSupport;
+import de.tudarmstadt.ukp.inception.annotation.layer.span.api.CreateSpanAnnotationRequest;
+import de.tudarmstadt.ukp.inception.annotation.layer.span.api.MoveSpanAnnotationRequest;
+import de.tudarmstadt.ukp.inception.annotation.layer.span.api.SpanLayerSupport;
+import de.tudarmstadt.ukp.inception.rendering.vmodel.VDocument;
+import de.tudarmstadt.ukp.inception.rendering.vmodel.VRange;
+import de.tudarmstadt.ukp.inception.rendering.vmodel.VSpan;
+import de.tudarmstadt.ukp.inception.schema.api.adapter.TypeAdapter;
+
+@ExtendWith(MockitoExtension.class)
+class SpanOverlapBehaviorTest
 {
-    Random rnd = new Random();
+    private @Mock TypeAdapter adapter;
+    private @Mock AnnotationLayer layer;
+    private @Mock SpanLayerSupport spanLayerSupport;
+    private @Mock ChainLayerSupport chainLayerSupport;
 
-    @Test
-    public void thatOverlappingOrStackingSpansWorks() throws Exception
+    private SpanOverlapBehavior sut;
+    private JCas jcas;
+
+    @BeforeEach
+    void setup() throws Exception
     {
-        CAS cas = generateCas();
+        sut = new SpanOverlapBehavior();
+        jcas = JCasFactory.createJCas();
+        jcas.setDocumentText("The quick brown fox jumps over the lazy dog.");
 
-        Set<AnnotationFS> expectedStacked = new HashSet<>();
-        Set<AnnotationFS> expectedOverlapping = new HashSet<>();
+        // Create tokens
+        addToken(0, 3);   // The
+        addToken(4, 9);   // quick
+        addToken(10, 15); // brown
+        addToken(16, 19); // fox
+        addToken(20, 25); // jumps
+        addToken(26, 30); // over
+        addToken(31, 34); // the
+        addToken(35, 39); // lazy
+        addToken(40, 43); // dog
 
-        long startNaive = System.currentTimeMillis();
-        List<Annotation> spans = cas.select(Annotation.class).asList();
-        int n = 0;
-        for (AnnotationFS span1 : spans) {
-            for (AnnotationFS span2 : spans) {
-                n++;
-
-                if (span1.equals(span2)) {
-                    continue;
-                }
-
-                if (colocated(span1, span2)) {
-                    expectedStacked.add(span1);
-                    expectedStacked.add(span2);
-                }
-                else if (overlapping(span1, span2)) {
-                    expectedOverlapping.add(span1);
-                    expectedOverlapping.add(span2);
-                }
-            }
-        }
-        long naiveDuration = System.currentTimeMillis() - startNaive;
-
-        Set<AnnotationFS> actualStacked = new HashSet<>();
-        Set<AnnotationFS> actualOverlapping = new HashSet<>();
-
-        long start = System.currentTimeMillis();
-        int o = overlappingOrStackingSpans(
-                cas.<Annotation> select(cas.getAnnotationType()).asList(), actualStacked,
-                actualOverlapping);
-        long duration = System.currentTimeMillis() - start;
-
-        System.out.printf("Naive %d (%d)  optimized %d (%d)  speedup %f%n", naiveDuration, n,
-                duration, o, naiveDuration / (double) duration);
-
-        assertThat(actualStacked).containsExactlyInAnyOrderElementsOf(expectedStacked);
-        assertThat(actualOverlapping).containsExactlyInAnyOrderElementsOf(expectedOverlapping);
+        // Create sentences
+        addSentence(0, 44);
     }
 
-    @Test
-    public void thatOverlappingNonStackingSpans() throws Exception
+    private void addToken(int aBegin, int aEnd)
     {
-        CAS cas = generateCas();
-
-        Set<AnnotationFS> expectedOverlapping = new HashSet<>();
-
-        long startNaive = System.currentTimeMillis();
-        List<Annotation> spans = cas.select(Annotation.class).asList();
-        for (AnnotationFS fs1 : spans) {
-            for (AnnotationFS fs2 : spans) {
-                if (fs1.equals(fs2)) {
-                    continue;
-                }
-
-                if (overlapping(fs1, fs2) && !colocated(fs1, fs2)) {
-                    expectedOverlapping.add(fs1);
-                    expectedOverlapping.add(fs2);
-                }
-            }
-        }
-        long naiveDuration = System.currentTimeMillis() - startNaive;
-
-        long start = System.currentTimeMillis();
-        Set<AnnotationFS> actualOverlapping = overlappingNonStackingSpans(
-                cas.<Annotation> select(cas.getAnnotationType()).asList());
-        long duration = System.currentTimeMillis() - start;
-
-        System.out.printf("Naive %d  optimized %d  speedup %f%n", naiveDuration, duration,
-                naiveDuration / (double) duration);
-
-        assertThat(actualOverlapping).containsExactlyInAnyOrderElementsOf(expectedOverlapping);
+        Token token = new Token(jcas, aBegin, aEnd);
+        token.addToIndexes();
     }
 
-    private CAS generateCas() throws ResourceInitializationException
+    private void addSentence(int aBegin, int aEnd)
     {
-        CAS cas = CasFactory.createCas();
+        Sentence sentence = new Sentence(jcas, aBegin, aEnd);
+        sentence.addToIndexes();
+    }
 
-        for (int i = 0; i < 1000; i++) {
-            int begin = rnd.nextInt(10000);
-            int end = begin + rnd.nextInt(100);
-            cas.addFsToIndexes(cas.createAnnotation(cas.getAnnotationType(), begin, end));
+    private Annotation addAnnotation(int aBegin, int aEnd)
+    {
+        Annotation anno = new Annotation(jcas, aBegin, aEnd);
+        anno.addToIndexes();
+        return anno;
+    }
+
+    @Nested
+    class AcceptsTests
+    {
+        @Test
+        void testAcceptsSpanLayerSupport()
+        {
+            assertThat(sut.accepts(spanLayerSupport)).isTrue();
         }
 
-        return cas;
+        @Test
+        void testAcceptsChainLayerSupport()
+        {
+            assertThat(sut.accepts(chainLayerSupport)).isTrue();
+        }
+    }
+
+    @Nested
+    class CreateTests
+    {
+        @Test
+        void testSkipsTokenLayer() throws Exception
+        {
+            when(adapter.getAnnotationTypeName()).thenReturn(Token.class.getName());
+
+            var request = CreateSpanAnnotationRequest.builder() //
+                    .withCas(jcas.getCas()) //
+                    .withBegin(0) //
+                    .withEnd(3) //
+                    .build();
+
+            var result = sut.onCreate(adapter, request);
+
+            assertThat(result).isSameAs(request);
+        }
+
+        @Test
+        void testSkipsSentenceLayer() throws Exception
+        {
+            when(adapter.getAnnotationTypeName()).thenReturn(Sentence.class.getName());
+
+            var request = CreateSpanAnnotationRequest.builder() //
+                    .withCas(jcas.getCas()) //
+                    .withBegin(0) //
+                    .withEnd(44) //
+                    .build();
+
+            var result = sut.onCreate(adapter, request);
+
+            assertThat(result).isSameAs(request);
+        }
+
+        @Test
+        void testAllowsAnyOverlap() throws Exception
+        {
+            when(adapter.getAnnotationTypeName()).thenReturn(Annotation.class.getName());
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.getOverlapMode()).thenReturn(OverlapMode.ANY_OVERLAP);
+
+            addAnnotation(0, 10);
+
+            var request = CreateSpanAnnotationRequest.builder() //
+                    .withCas(jcas.getCas()) //
+                    .withBegin(5) //
+                    .withEnd(15) // Overlaps with existing
+                    .build();
+
+            var result = sut.onCreate(adapter, request);
+
+            assertThat(result).isSameAs(request);
+        }
+
+        @Test
+        void testRejectsNoOverlapWhenOverlapping() throws Exception
+        {
+            when(adapter.getAnnotationTypeName()).thenReturn(Annotation.class.getName());
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.getOverlapMode()).thenReturn(OverlapMode.NO_OVERLAP);
+            when(layer.getUiName()).thenReturn("TestLayer");
+
+            addAnnotation(0, 10);
+
+            var request = CreateSpanAnnotationRequest.builder() //
+                    .withCas(jcas.getCas()) //
+                    .withBegin(5) //
+                    .withEnd(15) // Overlaps
+                    .build();
+
+            assertThatExceptionOfType(IllegalPlacementException.class) //
+                    .isThrownBy(() -> sut.onCreate(adapter, request)) //
+                    .withMessageContaining("no overlap or stacking");
+        }
+
+        @Test
+        void testRejectsNoOverlapWhenStacking() throws Exception
+        {
+            when(adapter.getAnnotationTypeName()).thenReturn(Annotation.class.getName());
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.getOverlapMode()).thenReturn(OverlapMode.NO_OVERLAP);
+            when(layer.getUiName()).thenReturn("TestLayer");
+
+            addAnnotation(0, 10);
+
+            var request = CreateSpanAnnotationRequest.builder() //
+                    .withCas(jcas.getCas()) //
+                    .withBegin(0) //
+                    .withEnd(10) // Stacking
+                    .build();
+
+            assertThatExceptionOfType(IllegalPlacementException.class) //
+                    .isThrownBy(() -> sut.onCreate(adapter, request)) //
+                    .withMessageContaining("no overlap or stacking");
+        }
+
+        @Test
+        void testAllowsNoOverlapWhenNonOverlapping() throws Exception
+        {
+            when(adapter.getAnnotationTypeName()).thenReturn(Token.class.getName());
+
+            var request = CreateSpanAnnotationRequest.builder() //
+                    .withCas(jcas.getCas()) //
+                    .withBegin(10) //
+                    .withEnd(20) // Adjacent, not overlapping
+                    .build();
+
+            var result = sut.onCreate(adapter, request);
+
+            assertThat(result).isSameAs(request);
+        }
+
+        @Test
+        void testRejectsOverlapOnlyWhenStacking() throws Exception
+        {
+            when(adapter.getAnnotationTypeName()).thenReturn(Annotation.class.getName());
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.getOverlapMode()).thenReturn(OverlapMode.OVERLAP_ONLY);
+            when(layer.getUiName()).thenReturn("TestLayer");
+
+            addAnnotation(0, 10);
+
+            var request = CreateSpanAnnotationRequest.builder() //
+                    .withCas(jcas.getCas()) //
+                    .withBegin(0) //
+                    .withEnd(10) // Stacking
+                    .build();
+
+            assertThatExceptionOfType(IllegalPlacementException.class) //
+                    .isThrownBy(() -> sut.onCreate(adapter, request)) //
+                    .withMessageContaining("stacking is not allowed");
+        }
+
+        @Test
+        void testAllowsOverlapOnlyWhenOverlapping() throws Exception
+        {
+            when(adapter.getAnnotationTypeName()).thenReturn(Annotation.class.getName());
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.getOverlapMode()).thenReturn(OverlapMode.OVERLAP_ONLY);
+
+            addAnnotation(0, 10);
+
+            var request = CreateSpanAnnotationRequest.builder() //
+                    .withCas(jcas.getCas()) //
+                    .withBegin(5) //
+                    .withEnd(15) // Overlapping
+                    .build();
+
+            var result = sut.onCreate(adapter, request);
+
+            assertThat(result).isSameAs(request);
+        }
+
+        @Test
+        void testRejectsStackingOnlyWhenOverlapping() throws Exception
+        {
+            when(adapter.getAnnotationTypeName()).thenReturn(Annotation.class.getName());
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.getOverlapMode()).thenReturn(OverlapMode.STACKING_ONLY);
+            when(layer.getUiName()).thenReturn("TestLayer");
+
+            addAnnotation(0, 10);
+
+            var request = CreateSpanAnnotationRequest.builder() //
+                    .withCas(jcas.getCas()) //
+                    .withBegin(5) //
+                    .withEnd(15) // Overlapping
+                    .build();
+
+            assertThatExceptionOfType(IllegalPlacementException.class) //
+                    .isThrownBy(() -> sut.onCreate(adapter, request)) //
+                    .withMessageContaining("only stacking is allowed");
+        }
+
+        @Test
+        void testAllowsStackingOnlyWhenStacking() throws Exception
+        {
+            when(adapter.getAnnotationTypeName()).thenReturn(Token.class.getName());
+
+            var request = CreateSpanAnnotationRequest.builder() //
+                    .withCas(jcas.getCas()) //
+                    .withBegin(0) //
+                    .withEnd(3) // Stacking with token
+                    .build();
+
+            var result = sut.onCreate(adapter, request);
+
+            assertThat(result).isSameAs(request);
+        }
+    }
+
+    @Nested
+    class MoveTests
+    {
+        @Test
+        void testAllowsMoveInNoOverlapMode() throws Exception
+        {
+            when(adapter.getAnnotationTypeName()).thenReturn(Token.class.getName());
+
+            var annotation = addAnnotation(0, 10);
+
+            var request = MoveSpanAnnotationRequest.builder() //
+                    .withCas(jcas.getCas()) //
+                    .withAnnotation(annotation) //
+                    .withBegin(20) //
+                    .withEnd(30) // Non-overlapping position
+                    .build();
+
+            var result = sut.onMove(adapter, request);
+
+            assertThat(result).isSameAs(request);
+        }
+
+        @Test
+        void testRejectsMoveInNoOverlapModeWhenOverlapping() throws Exception
+        {
+            when(adapter.getAnnotationTypeName()).thenReturn(Annotation.class.getName());
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.getOverlapMode()).thenReturn(OverlapMode.NO_OVERLAP);
+            when(layer.getUiName()).thenReturn("TestLayer");
+
+            var annotation = addAnnotation(0, 10);
+            addAnnotation(20, 30);
+
+            var request = MoveSpanAnnotationRequest.builder() //
+                    .withCas(jcas.getCas()) //
+                    .withAnnotation(annotation) //
+                    .withBegin(15) //
+                    .withEnd(25) // Overlaps with second annotation
+                    .build();
+
+            assertThatExceptionOfType(IllegalPlacementException.class) //
+                    .isThrownBy(() -> sut.onMove(adapter, request)) //
+                    .withMessageContaining("no overlap or stacking");
+        }
+    }
+
+    @Nested
+    class RenderTests
+    {
+        @Test
+        void testSkipsRenderWhenNoAnnotations() throws Exception
+        {
+            var vdoc = new VDocument();
+            vdoc.setWindowBegin(0);
+            vdoc.setWindowEnd(44);
+
+            Map<AnnotationFS, VSpan> annoToSpanIdx = new HashMap<>();
+
+            sut.onRender(adapter, vdoc, annoToSpanIdx);
+
+            assertThat(vdoc.comments()).isEmpty();
+        }
+
+        @Test
+        void testAddsErrorForOverlappingInNoOverlapMode() throws Exception
+        {
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.getOverlapMode()).thenReturn(OverlapMode.NO_OVERLAP);
+
+            var vdoc = new VDocument();
+            vdoc.setWindowBegin(0);
+            vdoc.setWindowEnd(44);
+
+            Map<AnnotationFS, VSpan> annoToSpanIdx = new HashMap<>();
+            var anno1 = addAnnotation(0, 10);
+            var anno2 = addAnnotation(5, 15); // Overlaps
+            annoToSpanIdx.put(anno1, new VSpan(layer, anno1, new VRange(0, 10), null));
+            annoToSpanIdx.put(anno2, new VSpan(layer, anno2, new VRange(5, 15), null));
+
+            sut.onRender(adapter, vdoc, annoToSpanIdx);
+
+            assertThat(vdoc.comments()).hasSize(2);
+            assertThat(vdoc.comments()).allMatch(c -> c.getCommentType() == ERROR);
+        }
+
+        @Test
+        void testAddsErrorForStackingInNoOverlapMode() throws Exception
+        {
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.getOverlapMode()).thenReturn(OverlapMode.NO_OVERLAP);
+
+            var vdoc = new VDocument();
+            vdoc.setWindowBegin(0);
+            vdoc.setWindowEnd(44);
+
+            Map<AnnotationFS, VSpan> annoToSpanIdx = new HashMap<>();
+            var anno1 = addAnnotation(0, 10);
+            var anno2 = addAnnotation(0, 10); // Stacking
+            annoToSpanIdx.put(anno1, new VSpan(layer, anno1, new VRange(0, 10), null));
+            annoToSpanIdx.put(anno2, new VSpan(layer, anno2, new VRange(0, 10), null));
+
+            sut.onRender(adapter, vdoc, annoToSpanIdx);
+
+            assertThat(vdoc.comments()).hasSize(2);
+            assertThat(vdoc.comments()).allMatch(c -> c.getCommentType() == ERROR);
+        }
+
+        @Test
+        void testAddsErrorForStackingInOverlapOnlyMode() throws Exception
+        {
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.getOverlapMode()).thenReturn(OverlapMode.OVERLAP_ONLY);
+
+            var vdoc = new VDocument();
+            vdoc.setWindowBegin(0);
+            vdoc.setWindowEnd(44);
+
+            Map<AnnotationFS, VSpan> annoToSpanIdx = new HashMap<>();
+            var anno1 = addAnnotation(0, 10);
+            var anno2 = addAnnotation(0, 10); // Stacking
+            annoToSpanIdx.put(anno1, new VSpan(layer, anno1, new VRange(0, 10), null));
+            annoToSpanIdx.put(anno2, new VSpan(layer, anno2, new VRange(0, 10), null));
+
+            sut.onRender(adapter, vdoc, annoToSpanIdx);
+
+            assertThat(vdoc.comments()).hasSize(2);
+            assertThat(vdoc.comments()).allMatch(c -> c.getCommentType() == ERROR);
+        }
+
+        @Test
+        void testAddsErrorForOverlappingInStackingOnlyMode() throws Exception
+        {
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.getOverlapMode()).thenReturn(OverlapMode.STACKING_ONLY);
+
+            var vdoc = new VDocument();
+            vdoc.setWindowBegin(0);
+            vdoc.setWindowEnd(44);
+
+            Map<AnnotationFS, VSpan> annoToSpanIdx = new HashMap<>();
+            var anno1 = addAnnotation(0, 10);
+            var anno2 = addAnnotation(5, 15); // Overlaps
+            annoToSpanIdx.put(anno1, new VSpan(layer, anno1, new VRange(0, 10), null));
+            annoToSpanIdx.put(anno2, new VSpan(layer, anno2, new VRange(5, 15), null));
+
+            sut.onRender(adapter, vdoc, annoToSpanIdx);
+
+            assertThat(vdoc.comments()).hasSize(2);
+            assertThat(vdoc.comments()).allMatch(c -> c.getCommentType() == ERROR);
+        }
+
+        @Test
+        void testNoErrorInAnyOverlapMode() throws Exception
+        {
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.getOverlapMode()).thenReturn(OverlapMode.ANY_OVERLAP);
+
+            var vdoc = new VDocument();
+            vdoc.setWindowBegin(0);
+            vdoc.setWindowEnd(44);
+
+            Map<AnnotationFS, VSpan> annoToSpanIdx = new HashMap<>();
+            var anno1 = addAnnotation(0, 10);
+            var anno2 = addAnnotation(5, 15); // Overlaps
+            var anno3 = addAnnotation(0, 10);  // Stacks
+            annoToSpanIdx.put(anno1, new VSpan(layer, anno1, new VRange(0, 10), null));
+            annoToSpanIdx.put(anno2, new VSpan(layer, anno2, new VRange(5, 15), null));
+            annoToSpanIdx.put(anno3, new VSpan(layer, anno3, new VRange(0, 10), null));
+
+            sut.onRender(adapter, vdoc, annoToSpanIdx);
+
+            assertThat(vdoc.comments()).isEmpty();
+        }
+    }
+
+    @Nested
+    class ValidateTests
+    {
+        @Test
+        void testReturnsEmptyForAnyOverlapMode() throws Exception
+        {
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.getOverlapMode()).thenReturn(OverlapMode.ANY_OVERLAP);
+            when(adapter.getAnnotationTypeName()).thenReturn(Annotation.class.getName());
+
+            addAnnotation(0, 10);
+            addAnnotation(5, 15); // Overlaps
+            addAnnotation(0, 10);  // Stacks
+
+            var result = sut.onValidate(adapter, jcas.getCas());
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void testReturnsErrorsForNoOverlapMode() throws Exception
+        {
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.getOverlapMode()).thenReturn(OverlapMode.NO_OVERLAP);
+            when(adapter.getAnnotationTypeName()).thenReturn(Annotation.class.getName());
+
+            addAnnotation(0, 10);
+            addAnnotation(5, 15); // Overlaps
+
+            var result = sut.onValidate(adapter, jcas.getCas());
+
+            // DocumentAnnotation spans whole document and overlaps, plus the two we added
+            assertThat(result).isNotEmpty();
+        }
+
+        @Test
+        void testReturnsErrorsForStackingInOverlapOnlyMode() throws Exception
+        {
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.getOverlapMode()).thenReturn(OverlapMode.OVERLAP_ONLY);
+            when(adapter.getAnnotationTypeName()).thenReturn(Annotation.class.getName());
+
+            addAnnotation(0, 10);
+            addAnnotation(0, 10); // Stacks
+
+            var result = sut.onValidate(adapter, jcas.getCas());
+
+            // Expecting errors for the stacked annotations plus DocumentAnnotation
+            assertThat(result).isNotEmpty();
+        }
+
+        @Test
+        void testReturnsErrorsForOverlappingInStackingOnlyMode() throws Exception
+        {
+            when(adapter.getLayer()).thenReturn(layer);
+            when(layer.getOverlapMode()).thenReturn(OverlapMode.STACKING_ONLY);
+            when(adapter.getAnnotationTypeName()).thenReturn(Token.class.getName());
+
+            var result = sut.onValidate(adapter, jcas.getCas());
+
+            // Tokens have overlapping bounds (e.g., 0-3, 4-9), expecting errors
+            assertThat(result).isEmpty(); // Actually no errors since Token layer is skipped
+        }
+    }
+
+    /**
+     * Performance tests for the utility methods.
+     */
+    @Nested
+    class PerformanceTests
+    {
+        Random rnd = new Random();
+
+        @Test
+        public void thatOverlappingOrStackingSpansWorks() throws Exception
+        {
+            CAS cas = generateCas();
+
+            Set<AnnotationFS> expectedStacked = new HashSet<>();
+            Set<AnnotationFS> expectedOverlapping = new HashSet<>();
+
+            long startNaive = System.currentTimeMillis();
+            List<Annotation> spans = cas.select(Annotation.class).asList();
+            int n = 0;
+            for (AnnotationFS span1 : spans) {
+                for (AnnotationFS span2 : spans) {
+                    n++;
+
+                    if (span1.equals(span2)) {
+                        continue;
+                    }
+
+                    if (colocated(span1, span2)) {
+                        expectedStacked.add(span1);
+                        expectedStacked.add(span2);
+                    }
+                    else if (overlapping(span1, span2)) {
+                        expectedOverlapping.add(span1);
+                        expectedOverlapping.add(span2);
+                    }
+                }
+            }
+            long naiveDuration = System.currentTimeMillis() - startNaive;
+
+            Set<AnnotationFS> actualStacked = new HashSet<>();
+            Set<AnnotationFS> actualOverlapping = new HashSet<>();
+
+            long start = System.currentTimeMillis();
+            int o = overlappingOrStackingSpans(
+                    cas.<Annotation> select(cas.getAnnotationType()).asList(), actualStacked,
+                    actualOverlapping);
+            long duration = System.currentTimeMillis() - start;
+
+            System.out.printf("Naive %d (%d)  optimized %d (%d)  speedup %f%n", naiveDuration, n,
+                    duration, o, naiveDuration / (double) duration);
+
+            assertThat(actualStacked).containsExactlyInAnyOrderElementsOf(expectedStacked);
+            assertThat(actualOverlapping).containsExactlyInAnyOrderElementsOf(expectedOverlapping);
+        }
+
+        @Test
+        public void thatOverlappingNonStackingSpans() throws Exception
+        {
+            CAS cas = generateCas();
+
+            Set<AnnotationFS> expectedOverlapping = new HashSet<>();
+
+            long startNaive = System.currentTimeMillis();
+            List<Annotation> spans = cas.select(Annotation.class).asList();
+            for (AnnotationFS fs1 : spans) {
+                for (AnnotationFS fs2 : spans) {
+                    if (fs1.equals(fs2)) {
+                        continue;
+                    }
+
+                    if (overlapping(fs1, fs2) && !colocated(fs1, fs2)) {
+                        expectedOverlapping.add(fs1);
+                        expectedOverlapping.add(fs2);
+                    }
+                }
+            }
+            long naiveDuration = System.currentTimeMillis() - startNaive;
+
+            long start = System.currentTimeMillis();
+            Set<AnnotationFS> actualOverlapping = overlappingNonStackingSpans(
+                    cas.<Annotation> select(cas.getAnnotationType()).asList());
+            long duration = System.currentTimeMillis() - start;
+
+            System.out.printf("Naive %d  optimized %d  speedup %f%n", naiveDuration, duration,
+                    naiveDuration / (double) duration);
+
+            assertThat(actualOverlapping).containsExactlyInAnyOrderElementsOf(expectedOverlapping);
+        }
+
+        private CAS generateCas() throws ResourceInitializationException
+        {
+            CAS cas = CasFactory.createCas();
+
+            for (int i = 0; i < 1000; i++) {
+                int begin = rnd.nextInt(10000);
+                int end = begin + rnd.nextInt(100);
+                cas.addFsToIndexes(cas.createAnnotation(cas.getAnnotationType(), begin, end));
+            }
+
+            return cas;
+        }
     }
 }


### PR DESCRIPTION
**What's in the PR**
- Changed behavior of single-token locking
- Added tests

**How to test manually**
* Try in the UI

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
