### PR TITLE
#5839 - Pre-auth mode incompatible with websocket

### DIFF
--- a/inception/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/app/config/InceptionSecurityWebUIPreAuthenticatedAutoConfiguration.java
+++ b/inception/inception-app-webapp/src/main/java/de/tudarmstadt/ukp/inception/app/config/InceptionSecurityWebUIPreAuthenticatedAutoConfiguration.java
@@ -53,7 +53,6 @@ public class InceptionSecurityWebUIPreAuthenticatedAutoConfiguration
         aHttp
             .rememberMe()
             .and()
-            .csrf().disable()
             .addFilterBefore(aFilter, RequestHeaderAuthenticationFilter.class);
         
         var authorizations = aHttp.authorizeHttpRequests();


### PR DESCRIPTION
**What's in the PR**
- No longer disable CSRF when using pre-authentication to allow WebSocket to work

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
