### PR TITLE
#5865 - Allow access to vector extensions in Docker image

### DIFF
--- a/inception/inception-docker/src/main/docker/Dockerfile
+++ b/inception/inception-docker/src/main/docker/Dockerfile
@@ -60,4 +60,4 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
   CMD curl -sf http://localhost:8080/actuator/health | jq -e '.status=="UP"' || exit 1
 
 # Launch application
-CMD /opt/inception/launch.sh java ${JAVA_MEM_OPTS} ${JAVA_OPTS} -Djava.awt.headless=true -Dinception.home=/export -jar inception-app-standalone.jar ${APP_ARGS}
+CMD /opt/inception/launch.sh java ${JAVA_MEM_OPTS} ${JAVA_OPTS} --add-modules jdk.incubator.vector -Djava.awt.headless=true -Dinception.home=/export -jar inception-app-standalone.jar ${APP_ARGS}


### PR DESCRIPTION
**What's in the PR**
- Added parameter to allow access to the vector extensions

**How to test manually**
* Try running the docker image and see if the warning is gone

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
