### PR TITLE
#5923 - Unable to mark text in search field using cursor keys

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/config/KeyBindingsPropertiesImpl.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/config/KeyBindingsPropertiesImpl.java
@@ -82,8 +82,8 @@ public class KeyBindingsPropertiesImpl
         private KeyCombo lastPage = new KeyCombo(End);
         private KeyCombo nextDocument = new KeyCombo(Shift, Page_down);
         private KeyCombo previousDocument = new KeyCombo(Shift, Page_up);
-        private KeyCombo nextAnnotation = new KeyCombo(Shift, Right);
-        private KeyCombo previousAnnotation = new KeyCombo(Shift, Left);
+        private KeyCombo nextAnnotation = new KeyCombo(true, Shift, Right);
+        private KeyCombo previousAnnotation = new KeyCombo(true, Shift, Left);
 
         @Override
         public KeyCombo getNextPage()


### PR DESCRIPTION
**What's in the PR**
- Make keybinding inactive when cursor is in input fields

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
