### PR TITLE
#5928 - Improve error handling in CAS pool management

### DIFF
--- a/inception/inception-annotation-storage-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/casstorage/session/CasHolder.java
+++ b/inception/inception-annotation-storage-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/casstorage/session/CasHolder.java
@@ -30,15 +30,25 @@ import org.apache.uima.cas.CAS;
 public class CasHolder
 {
     private final CasKey key;
+    private final Exception exception;
 
     private CAS cas;
-    private Exception exception;
     private boolean typeSystemOutdated = false;
     private boolean deleted = false;
+
+    // Transient runtime owner information (set when the holder is handed out by the pool)
+    private transient volatile long ownerThreadId = -1L;
+    private transient volatile String ownerThreadName;
+    private transient volatile long ownerSinceMillis = 0L;
+    private transient volatile StackTraceElement[] ownerStackTrace;
+
+    // Toggle capturing stack traces for owners (disabled by default because of overhead)
+    private static volatile boolean traceAccessEnabled = false;
 
     public CasHolder(CasKey aKey)
     {
         key = aKey;
+        exception = null;
     }
 
     public CasHolder(CasKey aKey, Exception aException)
@@ -84,11 +94,6 @@ public class CasHolder
     public Exception getException()
     {
         return exception;
-    }
-
-    public void setException(Exception aException)
-    {
-        exception = aException;
     }
 
     public synchronized boolean isTypeSystemOutdated()
@@ -137,14 +142,79 @@ public class CasHolder
         }
     }
 
+    public synchronized void setOwner(Thread aThread)
+    {
+        if (aThread == null) {
+            ownerThreadId = -1L;
+            ownerThreadName = null;
+            ownerSinceMillis = 0L;
+            ownerStackTrace = null;
+        }
+        else {
+            ownerThreadId = aThread.threadId();
+            ownerThreadName = aThread.getName();
+            ownerSinceMillis = System.currentTimeMillis();
+            if (traceAccessEnabled) {
+                try {
+                    ownerStackTrace = aThread.getStackTrace();
+                }
+                catch (Throwable t) {
+                    ownerStackTrace = null;
+                }
+            }
+            else {
+                ownerStackTrace = null;
+            }
+        }
+    }
+
+    public synchronized void clearOwner()
+    {
+        ownerThreadId = -1L;
+        ownerThreadName = null;
+        ownerSinceMillis = 0L;
+        ownerStackTrace = null;
+    }
+
+    public long getOwnerThreadId()
+    {
+        return ownerThreadId;
+    }
+
+    public String getOwnerThreadName()
+    {
+        return ownerThreadName;
+    }
+
+    public long getOwnerSinceMillis()
+    {
+        return ownerSinceMillis;
+    }
+
+    public StackTraceElement[] getOwnerStackTrace()
+    {
+        return ownerStackTrace;
+    }
+
+    public static void setTraceAccessEnabled(boolean aEnabled)
+    {
+        traceAccessEnabled = aEnabled;
+    }
+
     @Override
     public String toString()
     {
-        return new ToStringBuilder(this, SHORT_PREFIX_STYLE).append("key", key)
+        var tb = new ToStringBuilder(this, SHORT_PREFIX_STYLE).append("key", key)
                 .append("cas", getCasHashCode()) //
                 .append("deleted", deleted) //
-                .append("typeSystemOutdated", typeSystemOutdated) //
-                .toString();
+                .append("typeSystemOutdated", typeSystemOutdated);
+
+        if (ownerThreadId > 0) {
+            tb.append("owner", ownerThreadName + "(" + ownerThreadId + ")").append("ownerSince",
+                    ownerSinceMillis);
+        }
+
+        return tb.toString();
     }
 
 }

--- a/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/CasStorageServiceImpl.java
+++ b/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/CasStorageServiceImpl.java
@@ -27,6 +27,7 @@ import static de.tudarmstadt.ukp.inception.annotation.storage.CasStorageServiceI
 import static de.tudarmstadt.ukp.inception.project.api.ProjectService.withProjectLogger;
 import static de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil.getRealCas;
 import static de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil.transferCasOwnershipToCurrentThread;
+import static java.lang.String.format;
 import static java.lang.System.currentTimeMillis;
 import static java.util.Collections.newSetFromMap;
 import static java.util.Collections.synchronizedSet;
@@ -56,7 +57,6 @@ import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.impl.CASImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataRetrievalFailureException;
 import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.util.ConcurrentReferenceHashMap;
@@ -109,7 +109,7 @@ public class CasStorageServiceImpl
     private final AtomicLong lastExclusiveAccessPoolSnapshotUpdate = new AtomicLong();
     private final AtomicInteger lastExclusiveAccessPoolSnapshotSize = new AtomicInteger();
 
-    private final GenericKeyedObjectPool<CasKey, CasHolder> exclusiveAccessPool;
+    private final GenericKeyedObjectPool<CasKey, CasHolder> _exclusiveAccessPool;
     private final Set<CasHolder> exclusiveAccessHolders = synchronizedSet(
             newSetFromMap(new WeakHashMap<>()));
     private final Cache<CasKey, CasHolder> sharedAccessCache;
@@ -135,17 +135,54 @@ public class CasStorageServiceImpl
      * @param aSchemaService
      *            (optional) if present, CAS upgrades can be performed
      */
-    @Autowired
     public CasStorageServiceImpl(CasStorageDriver aDriver,
-            CasStorageCacheProperties aCasStorageProperties,
-            @Autowired(required = false) CasDoctor aCasDoctor,
-            @Autowired(required = false) AnnotationSchemaService aSchemaService)
+            CasStorageCacheProperties aCasStorageProperties, CasDoctor aCasDoctor,
+            AnnotationSchemaService aSchemaService)
     {
         driver = aDriver;
         casDoctor = aCasDoctor;
         schemaService = aSchemaService;
         casStorageProperties = aCasStorageProperties;
+        _exclusiveAccessPool = createExclusiveAccessPool(casStorageProperties);
+        sharedAccessCache = createSharedAccessCache();
 
+        CasHolder.setTraceAccessEnabled(casStorageProperties.isTraceAccess());
+
+        if (casDoctor == null) {
+            LOG.info("CAS doctor not available - unable to check/repair CASes");
+        }
+
+        BaseLoggers.BOOT_LOG.info("CAS cache size: {} instances",
+                casStorageProperties.getSharedCasCacheSize());
+    }
+
+    private Cache<CasKey, CasHolder> createSharedAccessCache()
+    {
+        return Caffeine.newBuilder() //
+                .scheduler(Scheduler.systemScheduler()) //
+                .expireAfterAccess(casStorageProperties.getIdleCasEvictionDelay()) //
+                .maximumSize(casStorageProperties.getSharedCasCacheSize()) //
+                .recordStats() //
+                .evictionListener((key, value, cause) -> {
+                    LOG.debug("Marked CAS for eviction from shared-access pool: {} [{}]", value,
+                            cause);
+                }) //
+                .build();
+    }
+
+    /**
+     * Package-private so tests can inject a custom pool, e.g. to simulate flakiness.
+     * 
+     * @return the exclusive access pool.
+     */
+    GenericKeyedObjectPool<CasKey, CasHolder> getExclusiveAccessPool()
+    {
+        return _exclusiveAccessPool;
+    }
+
+    private GenericKeyedObjectPool<CasKey, CasHolder> createExclusiveAccessPool(
+            CasStorageCacheProperties aProperties)
+    {
         var config = new GenericKeyedObjectPoolConfig<CasHolder>();
         config.setEvictionPolicy(new LoggingDefaultEvictionPolicy());
         // Since we want the pool to control exclusive access to a particular CAS, we only ever
@@ -155,10 +192,10 @@ public class CasStorageServiceImpl
         // Setting this to 0 because we do not want any CAS to stick around in memory indefinitely
         config.setMinIdlePerKey(0);
         // Run an evictor thread periodically
-        config.setTimeBetweenEvictionRuns(casStorageProperties.getIdleCasEvictionDelay());
+        config.setTimeBetweenEvictionRuns(aProperties.getIdleCasEvictionDelay());
         // Allow the evictor to drop idle CASes from pool after a short time. This should avoid that
         // CASes that are used regularly are dropped from the pool too quickly.
-        config.setMinEvictableIdleDuration(casStorageProperties.getMinIdleCasTime());
+        config.setMinEvictableIdleDuration(aProperties.getMinIdleCasTime());
         // Allow the evictor to drop all idle CASes on every eviction run
         config.setNumTestsPerEvictionRun(-1);
         // Allow viewing the pool in JMX
@@ -171,27 +208,9 @@ public class CasStorageServiceImpl
         config.setTestOnBorrow(true);
         config.setTestWhileIdle(true);
         // Max. time we wait for a CAS to become available before giving up with an error
-        config.setMaxWait(casStorageProperties.getCasBorrowWaitTimeout());
+        config.setMaxWait(aProperties.getCasBorrowWaitTimeout());
         // We do not have to set maxTotal because the default is already to have no limit (-1)
-        exclusiveAccessPool = new GenericKeyedObjectPool<>(new PooledCasHolderFactory(), config);
-
-        sharedAccessCache = Caffeine.newBuilder() //
-                .scheduler(Scheduler.systemScheduler()) //
-                .expireAfterAccess(casStorageProperties.getIdleCasEvictionDelay()) //
-                .maximumSize(casStorageProperties.getSharedCasCacheSize()) //
-                .recordStats() //
-                .evictionListener((key, value, cause) -> {
-                    LOG.debug("Marked CAS for eviction from shared-access pool: {} [{}]", value,
-                            cause);
-                }) //
-                .build();
-
-        if (casDoctor == null) {
-            LOG.info("CAS doctor not available - unable to check/repair CASes");
-        }
-
-        BaseLoggers.BOOT_LOG.info("CAS cache size: {} instances",
-                casStorageProperties.getSharedCasCacheSize());
+        return new GenericKeyedObjectPool<>(new PooledCasHolderFactory(), config);
     }
 
     public long getSharedAccessCacheSize()
@@ -296,7 +315,7 @@ public class CasStorageServiceImpl
     {
 
         try (var logCtx = withProjectLogger(aDocument.getProject())) {
-            CasStorageSession session = CasStorageSession.get();
+            var session = CasStorageSession.get();
 
             LOG.debug(
                     "CAS storage session [{}]: reading annotations for [{}]@{} in {} with {} using {}",
@@ -329,120 +348,23 @@ public class CasStorageServiceImpl
             // If exclusive access is requested, then we check the CAS out of the exclusive access
             // pool
             if (EXCLUSIVE_WRITE_ACCESS.equals(aAccessMode)) {
-                CasKey key = null;
-                CasHolder holder = null;
-                try {
-                    LOG.trace("CAS storage session [{}]: trying to borrow CAS [{}]@{}",
-                            session.hashCode(), aSet, aDocument);
-
-                    key = new CasKey(aDocument, aSet);
-                    holder = borrowCas(key);
-
-                    // If the CAS has not been loaded into the exclusive access pool, then we need
-                    // to load it
-                    if (!holder.isCasSet()) {
-                        var finalKey = key;
-                        var finalHolder = holder;
-
-                        CAS cas;
-                        // Make sure the system knows that the session has legitimate access to the
-                        // CAS being loaded so that it won't lock itself up trying to acquire the
-                        // exclusive lock in CAS in readOrCreateUnmanagedCas
-                        try (var loaderSession = CasStorageSession.openNested(true)) {
-                            var mLoaderCas = loaderSession.add(aDocument.getId(), aSet,
-                                    EXCLUSIVE_WRITE_ACCESS, holder);
-                            // Do not try to release the CAS when the loader session closes because
-                            // in fact we won't even have set the CAS in the holder by then
-                            mLoaderCas.setReleaseOnClose(false);
-
-                            cas = readOrCreateUnmanagedCas(aDocument, aSet, aSupplier, aUpgradeMode,
-                                    aAccessMode);
-                        }
-
-                        holder.setCas(cas);
-
-                        // Hook up releasing of the CAS when CAS.release() is called via the
-                        // CasStorageSession
-                        ((CASImpl) getRealCas(cas))
-                                .setOwner(_cas -> returnBorrowedCas(_cas, finalKey, finalHolder));
-
-                        LOG.debug(
-                                "CAS storage session [{}]: borrowed CAS [{}] for [{}]@{} loaded from storage",
-                                session.hashCode(), holder.getCasHashCode(), aSet, aDocument);
-                    }
-                    else {
-                        LOG.debug(
-                                "CAS storage session [{}]: borrowed CAS [{}] for [{}]@{} was already in memory",
-                                session.hashCode(), holder.getCasHashCode(), aSet, aDocument);
-
-                        transferCasOwnershipToCurrentThread(holder.getCas());
-
-                        repairAndUpgradeCasIfRequired(aDocument, aSet, holder.getCas(),
-                                aUpgradeMode, ISOLATED_SESSION);
-                    }
-
-                    casHolder = holder;
-                }
-                catch (Exception e) {
-                    // If there was an exception, we need to return the CAS to the pool
-                    if (key != null && holder != null) {
-                        LOG.trace(
-                                "CAS storage session [{}]: returning borrowed CAS [{}] for [{}]@{} after failure to load CAS",
-                                session.hashCode(), holder.getCasHashCode(), aSet, aDocument);
-                        try {
-                            exclusiveAccessPool.returnObject(key, holder);
-                            logExclusiveAccessHolders();
-                        }
-                        catch (Exception e1) {
-                            LOG.error("Unable to return CAS to exclusive access pool", e1);
-                        }
-                    }
-                    casHolder = new CasHolder(key, e);
-                }
+                casHolder = readOrCreateCasExclusiveWriteAccess(aDocument, aSet, aUpgradeMode,
+                        aSupplier, aAccessMode, session);
             }
             // else if shared read access is requested, then we try fetching it from the shared
             // cache
             else if (SHARED_READ_ONLY_ACCESS.equals(aAccessMode)) {
-                if (!AUTO_CAS_UPGRADE.equals(aUpgradeMode)) {
-                    throw new IllegalArgumentException(
-                            "When requesting a shared read-only CAS, the " + "access mode must be "
-                                    + AUTO_CAS_UPGRADE);
-                }
-
-                // Ensure that the CAS is not being re-written and temporarily unavailable while we
-                // check for its existence
-                try (var access = new WithExclusiveAccess(aDocument, aSet)) {
-                    // Since we promise to only read the CAS, we don't have to worry about it being
-                    // locked to a particular thread...
-                    casHolder = sharedAccessCache.get(new CasKey(aDocument, aSet),
-                            (key) -> CasHolder.of(key,
-                                    () -> getRealCas(readOrCreateUnmanagedCas(aDocument, aSet,
-                                            aSupplier, aUpgradeMode, aAccessMode))));
-                    var size = getSharedAccessCacheSize();
-                    var max = casStorageProperties.getSharedCasCacheSize();
-                    if (size > (max * 0.9)) {
-                        LOG.warn("Shared access CAS cache is >= 90% full: {} / {}", size, max);
-                    }
-                }
+                casHolder = readOrCreateCasReadOnlyAccess(aDocument, aSet, aUpgradeMode, aSupplier,
+                        aAccessMode);
             }
             // else if the special bypass mode is requested, then we fetch directly from disk
             else if (UNMANAGED_ACCESS.equals(aAccessMode)) {
-                // Ensure that the CAS is not being re-written and temporarily unavailable while we
-                // check for its existence
-                try (var access = new WithExclusiveAccess(aDocument, aSet)) {
-                    casHolder = CasHolder.of(new CasKey(aDocument, aSet),
-                            () -> readOrCreateUnmanagedCas(aDocument, aSet, aSupplier, aUpgradeMode,
-                                    aAccessMode));
-                }
+                casHolder = readOrCreateCasUnmanagedAccess(aDocument, aSet, aUpgradeMode, aSupplier,
+                        aAccessMode);
             }
             // else if the special bypass mode is requested, then we fetch directly from disk
             else if (UNMANAGED_NON_INITIALIZING_ACCESS.equals(aAccessMode)) {
-                // Ensure that the CAS is not being re-written and temporarily unavailable while we
-                // check for its existence
-                try (var access = new WithExclusiveAccess(aDocument, aSet)) {
-                    casHolder = CasHolder.of(new CasKey(aDocument, aSet),
-                            () -> driver.readCas(aDocument, aSet));
-                }
+                casHolder = readOrCreateCasNonInitializingAccess(aDocument, aSet);
             }
             else {
                 throw new IllegalArgumentException("Unknown CAS access mode [" + aAccessMode + "]");
@@ -450,11 +372,20 @@ public class CasStorageServiceImpl
 
             // If there was a problem retrieving the CAS, then we throw an exception
             if (casHolder.getException() != null) {
-                if (casHolder.getException() instanceof IOException) {
-                    throw (IOException) casHolder.getException();
+                var diag = buildPoolDiagnostics(casHolder.getKey());
+                if (casHolder.getException() instanceof FileNotFoundException e) {
+                    var wrappedException = new FileNotFoundException(
+                            diag + ": " + casHolder.getException().getMessage());
+                    wrappedException.initCause(e);
+                    throw wrappedException;
                 }
 
-                throw new IOException(casHolder.getException());
+                if (casHolder.getException() instanceof IOException e) {
+                    throw new IOException(diag + ": " + casHolder.getException().getMessage(), e);
+                }
+
+                throw new IOException(diag + ": " + casHolder.getException().getMessage(),
+                        casHolder.getException());
             }
 
             var cas = casHolder.getCas();
@@ -467,15 +398,146 @@ public class CasStorageServiceImpl
         }
     }
 
+    private CasHolder readOrCreateCasExclusiveWriteAccess(SourceDocument aDocument,
+            AnnotationSet aSet, CasUpgradeMode aUpgradeMode, CasProvider aSupplier,
+            CasAccessMode aAccessMode, CasStorageSession aSession)
+        throws IOException
+    {
+        CasKey key = null;
+        CasHolder holder = null;
+        try {
+            LOG.trace("CAS storage session [{}]: trying to borrow CAS [{}]@{}", aSession.hashCode(),
+                    aSet, aDocument);
+
+            key = new CasKey(aDocument, aSet);
+            holder = borrowCas(key);
+
+            // If the CAS has not been loaded into the exclusive access pool, then we need
+            // to load it
+            if (!holder.isCasSet()) {
+                var finalKey = key;
+                var finalHolder = holder;
+
+                CAS cas;
+                // Make sure the system knows that the session has legitimate access to the
+                // CAS being loaded so that it won't lock itself up trying to acquire the
+                // exclusive lock in CAS in readOrCreateUnmanagedCas
+                try (var loaderSession = CasStorageSession.openNested(true)) {
+                    var mLoaderCas = loaderSession.add(aDocument.getId(), aSet,
+                            EXCLUSIVE_WRITE_ACCESS, holder);
+                    // Do not try to release the CAS when the loader session closes because
+                    // in fact we won't even have set the CAS in the holder by then
+                    mLoaderCas.setReleaseOnClose(false);
+
+                    cas = readOrCreateUnmanagedCas(aDocument, aSet, aSupplier, aUpgradeMode,
+                            aAccessMode);
+                }
+
+                holder.setCas(cas);
+
+                // Hook up releasing of the CAS when CAS.release() is called via the
+                // CasStorageSession
+                ((CASImpl) getRealCas(cas))
+                        .setOwner(_cas -> returnBorrowedCas(_cas, finalKey, finalHolder));
+
+                LOG.debug(
+                        "CAS storage session [{}]: borrowed CAS [{}] for [{}]@{} loaded from storage",
+                        aSession.hashCode(), holder.getCasHashCode(), aSet, aDocument);
+            }
+            else {
+                LOG.debug(
+                        "CAS storage session [{}]: borrowed CAS [{}] for [{}]@{} was already in memory",
+                        aSession.hashCode(), holder.getCasHashCode(), aSet, aDocument);
+
+                transferCasOwnershipToCurrentThread(holder.getCas());
+
+                repairAndUpgradeCasIfRequired(aDocument, aSet, holder.getCas(), aUpgradeMode,
+                        ISOLATED_SESSION);
+            }
+
+            return holder;
+        }
+        catch (Throwable e) {
+            cleanupBorrowedCasAfterFailure(aSession, aDocument, aSet, key, holder, e);
+
+            if (e instanceof Exception exception) {
+                return new CasHolder(key, exception);
+            }
+            else {
+                throw e;
+            }
+        }
+    }
+
+    private CasHolder readOrCreateCasUnmanagedAccess(SourceDocument aDocument, AnnotationSet aSet,
+            CasUpgradeMode aUpgradeMode, CasProvider aSupplier, CasAccessMode aAccessMode)
+    {
+        CasHolder casHolder;
+        // Ensure that the CAS is not being re-written and temporarily unavailable while we
+        // check for its existence
+        try (var access = new WithExclusiveAccess(aDocument, aSet)) {
+            casHolder = CasHolder.of(new CasKey(aDocument, aSet),
+                    () -> readOrCreateUnmanagedCas(aDocument, aSet, aSupplier, aUpgradeMode,
+                            aAccessMode));
+        }
+        return casHolder;
+    }
+
+    private CasHolder readOrCreateCasReadOnlyAccess(SourceDocument aDocument, AnnotationSet aSet,
+            CasUpgradeMode aUpgradeMode, CasProvider aSupplier, CasAccessMode aAccessMode)
+    {
+        if (!AUTO_CAS_UPGRADE.equals(aUpgradeMode)) {
+            throw new IllegalArgumentException("When requesting a shared read-only CAS, the "
+                    + "upgrade mode must be " + AUTO_CAS_UPGRADE);
+        }
+
+        // Ensure that the CAS is not being re-written and temporarily unavailable while we
+        // check for its existence
+        try (var access = new WithExclusiveAccess(aDocument, aSet)) {
+            // Since we promise to only read the CAS, we don't have to worry about it being
+            // locked to a particular thread...
+            var casHolder = sharedAccessCache.get(new CasKey(aDocument, aSet),
+                    (key) -> CasHolder.of(key, () -> getRealCas(readOrCreateUnmanagedCas(aDocument,
+                            aSet, aSupplier, aUpgradeMode, aAccessMode))));
+            var size = getSharedAccessCacheSize();
+            var max = casStorageProperties.getSharedCasCacheSize();
+            if (size > (max * 0.9)) {
+                LOG.warn("Shared access CAS cache is >= 90% full: {} / {}", size, max);
+            }
+
+            return casHolder;
+        }
+    }
+
+    private CasHolder readOrCreateCasNonInitializingAccess(SourceDocument aDocument,
+            AnnotationSet aSet)
+    {
+        // Ensure that the CAS is not being re-written and temporarily unavailable while we
+        // check for its existence
+        try (var access = new WithExclusiveAccess(aDocument, aSet)) {
+            return CasHolder.of(new CasKey(aDocument, aSet), () -> driver.readCas(aDocument, aSet));
+        }
+    }
+
     private CasHolder borrowCas(CasKey aKey)
     {
         try {
+            var exclusiveAccessPool = getExclusiveAccessPool();
             var holder = exclusiveAccessPool.borrowObject(aKey);
             // Add the holder to the set of known holder. Because this set it using weak
             // references, and because we use the set only to inform holders when they become
             // invalid we do never have to explicitly remove the holder from the set
             exclusiveAccessHolders.add(holder);
             LOG.trace("Added to exclusiveAccessHolders: {}", holder);
+
+            // Log detailed borrow info for debugging potential deadlocks: include thread
+            // id/name, key and holder identity.
+            if (LOG.isTraceEnabled()) {
+                LOG.trace(
+                        "Thread [{} - {}] borrowed holder [identity={}] for key [{}] (holder.casHash={})",
+                        Thread.currentThread().threadId(), Thread.currentThread().getName(),
+                        System.identityHashCode(holder), aKey, holder.getCasHashCode());
+            }
 
             if (currentTimeMillis()
                     - lastExclusiveAccessPoolSnapshotUpdate.get() > snapshotInterval) {
@@ -495,7 +557,8 @@ public class CasStorageServiceImpl
             return holder;
         }
         catch (Exception e) {
-            throw new CasSessionException("Unable to borrow CAS", e);
+            var diag = buildPoolDiagnostics(aKey);
+            throw new CasSessionException("Unable to borrow CAS - " + diag, e);
         }
     }
 
@@ -507,14 +570,191 @@ public class CasStorageServiceImpl
     private void returnBorrowedCas(AbstractCas cas, CasKey aKey, CasHolder aHolder)
     {
         try {
-            LOG.trace("Returning borrowed CAS [{}] for [{}]@[{}]({})", cas.hashCode(),
-                    aKey.getSet(), aKey.getDocumentName(), aKey.getDocumentId());
-            exclusiveAccessPool.returnObject(aKey, aHolder);
+            if (LOG.isTraceEnabled()) {
+                LOG.trace(
+                        "Thread [{} - {}] returning borrowed CAS [{}] for [{}]@[{}]({}), holder.identity={}",
+                        Thread.currentThread().threadId(), Thread.currentThread().getName(),
+                        cas.hashCode(), aKey.getSet(), aKey.getDocumentName(), aKey.getDocumentId(),
+                        System.identityHashCode(aHolder));
+            }
+
+            getExclusiveAccessPool().returnObject(aKey, aHolder);
             logExclusiveAccessHolders();
         }
         catch (Exception e) {
-            LOG.error("Unable to return CAS [{}] for [{}]@[{}]({}) to exclusive access pool",
-                    cas.hashCode(), aKey.getSet(), aKey.getDocumentName(), aKey.getDocumentId(), e);
+            LOG.error("Unable to return CAS [{}] for [{}]@[{}]({}) to exclusive access pool - {}",
+                    cas.hashCode(), aKey.getSet(), aKey.getDocumentName(), aKey.getDocumentId(),
+                    buildPoolDiagnostics(aKey), e);
+            invalidateBorrowedCasAfterReturnFailure(aKey, aHolder, e);
+        }
+    }
+
+    private void cleanupBorrowedCasAfterFailure(CasStorageSession aSession,
+            SourceDocument aDocument, AnnotationSet aSet, CasKey aKey, CasHolder aHolder,
+            Throwable aOriginalFailure)
+    {
+        if (aKey == null || aHolder == null) {
+            return;
+        }
+
+        if (LOG.isTraceEnabled()) {
+            LOG.trace(
+                    "CAS storage session [{}]: returning borrowed CAS [{}] for [{}]@{} after failure to load CAS",
+                    aSession.hashCode(), aHolder.getCasHashCode(), aSet, aDocument);
+        }
+
+        var exclusiveAccessPool = getExclusiveAccessPool();
+        try {
+            exclusiveAccessPool.returnObject(aKey, aHolder);
+            logExclusiveAccessHolders();
+        }
+        catch (Throwable e) {
+            LOG.error(
+                    "Unable to return CAS to exclusive access pool after failure to load CAS - {}",
+                    buildPoolDiagnostics(aKey), e);
+
+            try {
+                exclusiveAccessPool.invalidateObject(aKey, aHolder);
+                logExclusiveAccessHolders();
+            }
+            catch (Throwable e1) {
+                LOG.error("Unable to invalidate CAS [{}] after failed return - {}",
+                        aHolder.getCasHashCode(), buildPoolDiagnostics(aKey), e1);
+
+                // Always record the initial return failure on the original failure.
+                aOriginalFailure.addSuppressed(e);
+
+                // If the cleanup error is fatal, propagate it (it will have the
+                // original failure suppressed onto it via propagateCleanupFailure).
+                if (isFatalCleanupFailure(e1)) {
+                    throw propagateCleanupFailure(aOriginalFailure, e1);
+                }
+
+                // Non-fatal cleanup failures are recorded on the original failure.
+                aOriginalFailure.addSuppressed(e1);
+                return;
+            }
+
+            // If returning the object failed but invalidation succeeded, only
+            // propagate the return failure when it is fatal; otherwise record it
+            // as suppressed on the original failure.
+            if (isFatalCleanupFailure(e)) {
+                throw propagateCleanupFailure(aOriginalFailure, e);
+            }
+
+            aOriginalFailure.addSuppressed(e);
+        }
+    }
+
+    private RuntimeException propagateCleanupFailure(Throwable aOriginalFailure,
+            Throwable aCleanupFailure)
+    {
+        aCleanupFailure.addSuppressed(aOriginalFailure);
+
+        if (aCleanupFailure instanceof RuntimeException) {
+            return (RuntimeException) aCleanupFailure;
+        }
+
+        if (aCleanupFailure instanceof Error) {
+            throw (Error) aCleanupFailure;
+        }
+
+        return new RuntimeException(aCleanupFailure);
+    }
+
+    private boolean isFatalCleanupFailure(Throwable aFailure)
+    {
+        return aFailure instanceof VirtualMachineError || aFailure instanceof LinkageError;
+    }
+
+    private void invalidateBorrowedCasAfterReturnFailure(CasKey aKey, CasHolder aHolder,
+            Exception aOriginalError)
+    {
+        try {
+            getExclusiveAccessPool().invalidateObject(aKey, aHolder);
+            logExclusiveAccessHolders();
+        }
+        catch (Exception e) {
+            LOG.error("Unable to invalidate CAS [{}] after failed return - {}",
+                    aHolder.getCasHashCode(), buildPoolDiagnostics(aKey), e);
+            aOriginalError.addSuppressed(e);
+        }
+    }
+
+    private void releaseBorrowedCasWithFallback(CasKey aKey, CasHolder aHolder, String aContext)
+    {
+        try {
+            getExclusiveAccessPool().returnObject(aKey, aHolder);
+            logExclusiveAccessHolders();
+        }
+        catch (Exception e) {
+            LOG.error("Unable to return CAS [{}] during {} - {}", aHolder.getCasHashCode(),
+                    aContext, buildPoolDiagnostics(aKey), e);
+            invalidateBorrowedCasAfterReturnFailure(aKey, aHolder, e);
+        }
+    }
+
+    private String buildPoolDiagnostics(CasKey aKey)
+    {
+        try {
+            var exclusiveAccessPool = getExclusiveAccessPool();
+            var globalActive = exclusiveAccessPool.getNumActive();
+            var globalIdle = exclusiveAccessPool.getNumIdle();
+            var keyActive = aKey != null ? exclusiveAccessPool.getNumActive(aKey) : -1L;
+            var keyIdle = aKey != null ? exclusiveAccessPool.getNumIdle(aKey) : -1L;
+            var waitTimeout = casStorageProperties.getCasBorrowWaitTimeout().toMillis();
+
+            var projectName = aKey != null ? aKey.getProjectName() : "<unknown>";
+            var projectId = aKey != null ? aKey.getProjectId() : -1L;
+            var documentName = aKey != null ? aKey.getDocumentName() : "<unknown>";
+            var documentId = aKey != null ? aKey.getDocumentId() : -1L;
+            var setId = "<unknown>";
+            var setDisplay = "<unknown>";
+            if (aKey != null && aKey.getSet() != null) {
+                setId = aKey.getSet().toString();
+                try {
+                    setDisplay = aKey.getSet().displayName();
+                }
+                catch (Throwable t) {
+                    setDisplay = aKey.getSet().toString();
+                }
+            }
+
+            var ownerInfo = new StringBuilder();
+            if (aKey != null && keyActive > 0) {
+                exclusiveAccessHolders.forEach(h -> {
+                    if (!(Objects.equals(h.getKey(), aKey) && h.getOwnerThreadId() > 0)) {
+                        return;
+                    }
+                    try {
+                        ownerInfo.append(
+                                String.format(" owner(ownerName=%s,ownerId=%d,ownerSince=%d)",
+                                        h.getOwnerThreadName(), h.getOwnerThreadId(),
+                                        h.getOwnerSinceMillis()));
+
+                        var trace = h.getOwnerStackTrace();
+                        if (trace != null && trace.length > 0) {
+                            ownerInfo.append(" acquired holder at:\n");
+                            for (var e : trace) {
+                                ownerInfo.append("    ");
+                                ownerInfo.append(e);
+                                ownerInfo.append("\n");
+                            }
+                        }
+                    }
+                    catch (Throwable t) {
+                        // ignore holder inspection failures
+                    }
+                });
+            }
+
+            return format("project [%s](%d) document [%s](%d) set [%s](%s); "
+                    + "pool info(globalActive=%d,globalIdle=%d,keyActive=%d,keyIdle=%d,borrowMaxWaitMillis=%d)%s",
+                    projectName, projectId, documentName, documentId, setId, setDisplay,
+                    globalActive, globalIdle, keyActive, keyIdle, waitTimeout, ownerInfo);
+        }
+        catch (Exception e) {
+            return "<failed to collect pool diagnostics>";
         }
     }
 
@@ -734,8 +974,8 @@ public class CasStorageServiceImpl
             detailMsg.append("CAS Doctor found problems for set [").append(aSet)
                     .append("] in document ").append(aDocument).append(" in project ")
                     .append(project).append("\n");
-            e.getDetails().forEach(
-                    m -> detailMsg.append(String.format("- [%s] %s%n", m.level, m.message)));
+            e.getDetails()
+                    .forEach(m -> detailMsg.append(format("- [%s] %s%n", m.level, m.message)));
 
             throw new DataRetrievalFailureException(detailMsg.toString());
         }
@@ -982,9 +1222,8 @@ public class CasStorageServiceImpl
         public void release()
         {
             if (holder != null) {
-                exclusiveAccessPool.returnObject(key, holder);
+                releaseBorrowedCasWithFallback(key, holder, "WithExclusiveAccess.release");
                 holder = null;
-                logExclusiveAccessHolders();
             }
             else {
                 getCas().release();
@@ -997,8 +1236,7 @@ public class CasStorageServiceImpl
             if (holder != null) {
                 LOG.trace("Returning briefly borrowed CAS [{}]@[{}]({})", set, documentName,
                         documentId);
-                exclusiveAccessPool.returnObject(key, holder);
-                logExclusiveAccessHolders();
+                releaseBorrowedCasWithFallback(key, holder, "WithExclusiveAccess.close");
             }
         }
     }
@@ -1048,7 +1286,7 @@ public class CasStorageServiceImpl
      * When using the Spring {@link ConcurrentReferenceHashMap} for the
      * {@link #exclusiveAccessHolders}, we had some trouble that CASHolders disappeared from the set
      * even though they had not yet been garbage collected (i.e. still referenced from the
-     * {@link #exclusiveAccessPool}. To fix this, we switch to a simple synchronized
+     * {@link #_exclusiveAccessPool}. To fix this, we switch to a simple synchronized
      * {@link WeakHashMap} turned into a set. We keep the debug/logging code around for a little
      * more to facilitate debugging this again if need be.
      */

--- a/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/PooledCasHolderFactory.java
+++ b/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/PooledCasHolderFactory.java
@@ -61,4 +61,22 @@ public class PooledCasHolderFactory
 
         return true;
     }
+
+    @Override
+    public void activateObject(CasKey aKey, PooledObject<CasHolder> aP) throws Exception
+    {
+        // When the pool hands out the holder, mark the current thread as owner for diagnostics
+        var h = aP.getObject();
+        h.setOwner(Thread.currentThread());
+        super.activateObject(aKey, aP);
+    }
+
+    @Override
+    public void passivateObject(CasKey aKey, PooledObject<CasHolder> aP) throws Exception
+    {
+        // Clear owner info when the holder is returned to the pool
+        var h = aP.getObject();
+        h.clearOwner();
+        super.passivateObject(aKey, aP);
+    }
 }

--- a/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/config/CasStorageCacheProperties.java
+++ b/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/config/CasStorageCacheProperties.java
@@ -44,4 +44,12 @@ public interface CasStorageCacheProperties
      * @return number of CAS instances that should be kept in memory for shared-read-only access.
      */
     long getSharedCasCacheSize();
+
+    /**
+     * @return whether access to CASes in the cache should be traced by capturing stack traces; this
+     *         is useful for debugging but may incur noticeable overhead due to the additional
+     *         stack-trace capture on each access.
+     */
+    boolean isTraceAccess();
+
 }

--- a/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/config/CasStorageCachePropertiesImpl.java
+++ b/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/config/CasStorageCachePropertiesImpl.java
@@ -34,6 +34,18 @@ public class CasStorageCachePropertiesImpl
     private Duration minIdleCasTime = Duration.ofMinutes(5);
     private Duration casBorrowWaitTimeout = Duration.ofMinutes(3);
     private long sharedCasCacheSize = getDefaultCasCacheSize();
+    private boolean traceAccess = false;
+
+    @Override
+    public boolean isTraceAccess()
+    {
+        return traceAccess;
+    }
+
+    public void setTraceAccess(boolean aTraceAccess)
+    {
+        traceAccess = aTraceAccess;
+    }
 
     @Override
     public Duration getIdleCasEvictionDelay()

--- a/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/driver/filesystem/FileSystemCasStorageDriver.java
+++ b/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/driver/filesystem/FileSystemCasStorageDriver.java
@@ -482,15 +482,15 @@ public class FileSystemCasStorageDriver
         var diskLastModified = casFile.lastModified();
         if (Math.abs(diskLastModified - aExpectedTimeStamp) > casStorageProperties
                 .getFileSystemTimestampAccuracy().toMillis()) {
-            StringBuilder lastWriteMsg = new StringBuilder();
+            var lastWriteMsg = new StringBuilder();
             if (metadataCache != null) {
-                InternalMetadata meta = metadataCache.get(casFile);
+                var meta = metadataCache.get(casFile);
                 if (meta.lastWriteSuccessTrace != null) {
                     lastWriteMsg.append("\n");
                     lastWriteMsg.append("Last known successful write was at ");
                     lastWriteMsg.append(formatTimestamp(meta.lastWriteSuccessTimestamp));
                     lastWriteMsg.append(" by:\n");
-                    for (StackTraceElement e : meta.lastWriteSuccessTrace) {
+                    for (var e : meta.lastWriteSuccessTrace) {
                         lastWriteMsg.append("    ");
                         lastWriteMsg.append(e);
                         lastWriteMsg.append("\n");

--- a/inception/inception-annotation-storage/src/test/java/de/tudarmstadt/ukp/inception/annotation/storage/CasStorageServiceImplTest.java
+++ b/inception/inception-annotation-storage/src/test/java/de/tudarmstadt/ukp/inception/annotation/storage/CasStorageServiceImplTest.java
@@ -27,9 +27,13 @@ import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasUpgradeMode.NO
 import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession.openNested;
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet.INITIAL_SET;
 import static de.tudarmstadt.ukp.inception.annotation.storage.CasMetadataUtils.getInternalTypeSystem;
+import static de.tudarmstadt.ukp.inception.support.logging.Logging.KEY_REPOSITORY_PATH;
 import static de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil.createCas;
 import static java.lang.Thread.sleep;
 import static java.util.Arrays.asList;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.commons.lang3.StringUtils.repeat;
 import static org.apache.uima.fit.util.JCasUtil.select;
 import static org.apache.uima.util.CasCreationUtils.mergeTypeSystems;
@@ -42,11 +46,18 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Proxy;
+import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
+import org.apache.commons.pool2.impl.GenericKeyedObjectPool;
+import org.apache.commons.pool2.impl.GenericKeyedObjectPoolConfig;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.CASException;
 import org.apache.uima.fit.factory.TypeSystemDescriptionFactory;
@@ -63,6 +74,8 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasProvider;
+import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasHolder;
+import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasKey;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasSessionException;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
 import de.tudarmstadt.ukp.clarin.webanno.api.type.CASMetadata;
@@ -76,7 +89,6 @@ import de.tudarmstadt.ukp.inception.annotation.storage.driver.filesystem.FileSys
 import de.tudarmstadt.ukp.inception.documents.api.RepositoryProperties;
 import de.tudarmstadt.ukp.inception.documents.api.RepositoryPropertiesImpl;
 import de.tudarmstadt.ukp.inception.schema.api.event.LayerConfigurationChangedEvent;
-import de.tudarmstadt.ukp.inception.support.logging.Logging;
 import de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil;
 
 @Execution(CONCURRENT)
@@ -96,6 +108,7 @@ public class CasStorageServiceImplTest
     private CasStorageServiceImpl sut;
     private FileSystemCasStorageDriver driver;
     private RepositoryProperties repositoryProperties;
+    private GenericKeyedObjectPool<CasKey, CasHolder> exclusiveAccessPoolOverride;
 
     @TempDir
     File testFolder;
@@ -103,6 +116,7 @@ public class CasStorageServiceImplTest
     @BeforeEach
     public void setup() throws Exception
     {
+        exclusiveAccessPoolOverride = null;
         exception.set(false);
         rwTasksCompleted.set(false);
         managedReadCounter.set(0);
@@ -115,7 +129,7 @@ public class CasStorageServiceImplTest
         repositoryProperties = new RepositoryPropertiesImpl();
         repositoryProperties.setPath(testFolder);
 
-        MDC.put(Logging.KEY_REPOSITORY_PATH, repositoryProperties.getPath().toString());
+        MDC.put(KEY_REPOSITORY_PATH, repositoryProperties.getPath().toString());
 
         driver = new FileSystemCasStorageDriver(repositoryProperties,
                 new CasStorageBackupProperties(), new CasStoragePropertiesImpl());
@@ -456,6 +470,209 @@ public class CasStorageServiceImplTest
         assertThat(exception).isFalse();
     }
 
+    @Test
+    public void testExclusiveCasRemainsUnavailableUntilOwningSessionCloses() throws Exception
+    {
+        // This test enforces exclusive borrow and verifies that other borrowers
+        // are blocked until the owning session closes and that the blocking is
+        // resolved by the configured borrow timeout.
+
+        var shortTimeoutSut = createStorageService(Duration.ofMillis(250));
+        var doc = makeSourceDocument(9l, 9l, "test");
+        var set = AnnotationSet.forTest("test");
+        try (var session = openNested(true)) {
+            createCasFile(shortTimeoutSut, doc, set, "This is a test");
+        }
+
+        var ownerHasBorrowedCas = new CountDownLatch(1);
+        var ownerMayCloseSession = new CountDownLatch(1);
+        var ownerFailure = new AtomicReference<Throwable>();
+
+        // Replace the exclusive-access pool with a deterministic, test-only pool that
+        // blocks competing borrowers on `ownerMayCloseSession` and times out after the
+        // configured wait. This makes the test deterministic while preserving the
+        // real code's exception translation into `CasSessionException`.
+        var waitMs = 250L;
+        var deterministicPool = new GenericKeyedObjectPool<CasKey, CasHolder>(
+                new PooledCasHolderFactory(),
+                makeExclusiveAccessPoolConfig(Duration.ofMillis(waitMs)))
+        {
+            private final Map<CasKey, CasHolder> holders = new ConcurrentHashMap<>();
+            private final Map<CasKey, Boolean> inUse = new ConcurrentHashMap<>();
+
+            @Override
+            public CasHolder borrowObject(CasKey aKey) throws Exception
+            {
+                var existing = holders.get(aKey);
+                if (existing == null) {
+                    // First borrower loads/holds the CAS immediately
+                    var cas = makeCas("This is a test");
+                    var holder = new CasHolder(aKey, cas);
+                    holders.put(aKey, holder);
+                    inUse.put(aKey, true);
+                    return holder;
+                }
+
+                // If already in use, wait deterministically for owner release or timeout
+                if (inUse.getOrDefault(aKey, false)) {
+                    var released = ownerMayCloseSession.await(waitMs, MILLISECONDS);
+                    if (!released) {
+                        throw new java.util.NoSuchElementException("Timed out waiting for CAS");
+                    }
+                }
+
+                inUse.put(aKey, true);
+                return holders.get(aKey);
+            }
+
+            @Override
+            public void returnObject(CasKey aKey, CasHolder aObj)
+            {
+                inUse.put(aKey, false);
+            }
+        };
+
+        setExclusiveAccessPool(deterministicPool);
+
+        var ownerThread = new Thread(() -> {
+            MDC.put(KEY_REPOSITORY_PATH, repositoryProperties.getPath().toString());
+
+            try (var session = CasStorageSession.open()) {
+                shortTimeoutSut.readCas(doc, set, EXCLUSIVE_WRITE_ACCESS);
+                ownerHasBorrowedCas.countDown();
+                ownerMayCloseSession.await(5, SECONDS);
+            }
+            catch (Throwable e) {
+                ownerFailure.set(e);
+            }
+            finally {
+                MDC.remove(KEY_REPOSITORY_PATH);
+            }
+        }, "stuck-exclusive-owner");
+
+        ownerThread.start();
+
+        var ownerBorrowedCas = false;
+        for (var n = 0; n < 50; n++) {
+            if (ownerHasBorrowedCas.await(100, MILLISECONDS)) {
+                ownerBorrowedCas = true;
+                break;
+            }
+
+            if (ownerFailure.get() != null || !ownerThread.isAlive()) {
+                break;
+            }
+        }
+
+        assertThat(ownerFailure.get()).isNull();
+        assertThat(ownerBorrowedCas).isTrue();
+
+        try (var session = CasStorageSession.open()) {
+            var start = System.nanoTime();
+            assertThatExceptionOfType(IOException.class) //
+                    .isThrownBy(() -> shortTimeoutSut.readCas(doc, set, EXCLUSIVE_WRITE_ACCESS)) //
+                    .withMessageContaining("Unable to borrow CAS");
+            var elapsedMs = NANOSECONDS.toMillis(System.nanoTime() - start);
+            // Configured borrow timeout is 250ms; allow a small margin for scheduling.
+            assertThat(elapsedMs).as("borrow timed out roughly at configured timeout")
+                    .isGreaterThanOrEqualTo(200L);
+        }
+
+        ownerMayCloseSession.countDown();
+        ownerThread.join(5000);
+
+        if (ownerThread.isAlive()) {
+            ownerThread.interrupt();
+        }
+
+        assertThat(ownerThread.isAlive()).isFalse();
+        assertThat(ownerFailure.get()).isNull();
+
+        try (var session = CasStorageSession.open()) {
+            var cas = shortTimeoutSut.readCas(doc, set, EXCLUSIVE_WRITE_ACCESS);
+            assertThat(cas).isNotNull();
+        }
+    }
+
+    @Test
+    public void testOutOfMemoryDuringExclusiveCasLoadDoesNotStrandCasKey() throws Exception
+    {
+        var shortTimeoutSut = createStorageService(Duration.ofMillis(250));
+        var doc = makeSourceDocument(10l, 10l, "test");
+        var set = AnnotationSet.forTest("test");
+
+        try (var session = CasStorageSession.open()) {
+            assertThatExceptionOfType(OutOfMemoryError.class).isThrownBy(
+                    () -> shortTimeoutSut.readOrCreateCas(doc, set, NO_CAS_UPGRADE, () -> {
+                        throw new OutOfMemoryError("Injected OOM while loading CAS");
+                    }, EXCLUSIVE_WRITE_ACCESS));
+        }
+
+        try (var session = CasStorageSession.open()) {
+            var cas = shortTimeoutSut.readOrCreateCas(doc, set, NO_CAS_UPGRADE,
+                    () -> makeCas("This is a test"), EXCLUSIVE_WRITE_ACCESS);
+            assertThat(cas).isNotNull();
+            assertThat(cas.getDocumentText()).isEqualTo("This is a test");
+        }
+    }
+
+    @Test
+    public void testReturnValidationFailureRecoversViaInvalidation() throws Exception
+    {
+        var doc = makeSourceDocument(11l, 11l, "test");
+        var set = AnnotationSet.forTest("test");
+        try (var session = openNested(true)) {
+            createCasFile(sut, doc, set, "This is a test");
+        }
+
+        var shortTimeoutSut = createStorageService(Duration.ofMillis(250));
+        var brokenPool = new GenericKeyedObjectPool<CasKey, CasHolder>(
+                new ThrowingOnValidatePooledCasHolderFactory(),
+                makeExclusiveAccessPoolConfig(Duration.ofMillis(250)));
+        setExclusiveAccessPool(brokenPool);
+
+        try (var session = CasStorageSession.open()) {
+            var cas = shortTimeoutSut.readCas(doc, set, EXCLUSIVE_WRITE_ACCESS);
+            assertThat(cas).isNotNull();
+        }
+
+        assertThat(brokenPool.getNumActive()).isZero();
+        assertThat(brokenPool.getNumIdle()).isZero();
+
+        try (var session = CasStorageSession.open()) {
+            var cas = shortTimeoutSut.readCas(doc, set, EXCLUSIVE_WRITE_ACCESS);
+            assertThat(cas).isNotNull();
+            assertThat(cas.getDocumentText()).isEqualTo("This is a test");
+        }
+    }
+
+    @Test
+    public void testWithExclusiveAccessCloseRecoversViaInvalidation() throws Exception
+    {
+        var doc = makeSourceDocument(12l, 12l, "test");
+        var set = AnnotationSet.forTest("test");
+        try (var session = openNested(true)) {
+            createCasFile(sut, doc, set, "This is a test");
+        }
+
+        var shortTimeoutSut = createStorageService(Duration.ofMillis(250));
+        var brokenPool = new GenericKeyedObjectPool<CasKey, CasHolder>(
+                new ThrowingOnValidatePooledCasHolderFactory(),
+                makeExclusiveAccessPoolConfig(Duration.ofMillis(250)));
+        setExclusiveAccessPool(brokenPool);
+
+        try (var session = CasStorageSession.open()) {
+            assertThat(shortTimeoutSut.existsCas(doc, set)).isTrue();
+        }
+
+        assertThat(brokenPool.getNumActive()).isZero();
+        assertThat(brokenPool.getNumIdle()).isZero();
+
+        try (var session = CasStorageSession.open()) {
+            assertThat(shortTimeoutSut.existsCas(doc, set)).isTrue();
+        }
+    }
+
     private class ExclusiveReadWriteTask
         extends Thread
     {
@@ -477,7 +694,7 @@ public class CasStorageServiceImplTest
         @Override
         public void run()
         {
-            MDC.put(Logging.KEY_REPOSITORY_PATH, repositoryProperties.getPath().toString());
+            MDC.put(KEY_REPOSITORY_PATH, repositoryProperties.getPath().toString());
 
             for (var n = 0; n < repeat; n++) {
                 if (exception.get()) {
@@ -521,7 +738,7 @@ public class CasStorageServiceImplTest
         @Override
         public void run()
         {
-            MDC.put(Logging.KEY_REPOSITORY_PATH, repositoryProperties.getPath().toString());
+            MDC.put(KEY_REPOSITORY_PATH, repositoryProperties.getPath().toString());
 
             while (!(exception.get() || rwTasksCompleted.get())) {
                 try (var session = openNested()) {
@@ -556,7 +773,7 @@ public class CasStorageServiceImplTest
         @Override
         public void run()
         {
-            MDC.put(Logging.KEY_REPOSITORY_PATH, repositoryProperties.getPath().toString());
+            MDC.put(KEY_REPOSITORY_PATH, repositoryProperties.getPath().toString());
 
             while (!(exception.get() || rwTasksCompleted.get())) {
                 try (var session = openNested()) {
@@ -595,7 +812,7 @@ public class CasStorageServiceImplTest
         @Override
         public void run()
         {
-            MDC.put(Logging.KEY_REPOSITORY_PATH, repositoryProperties.getPath().toString());
+            MDC.put(KEY_REPOSITORY_PATH, repositoryProperties.getPath().toString());
 
             while (!(exception.get() || rwTasksCompleted.get())) {
                 try (var session = openNested()) {
@@ -627,7 +844,7 @@ public class CasStorageServiceImplTest
         @Override
         public void run()
         {
-            MDC.put(Logging.KEY_REPOSITORY_PATH, repositoryProperties.getPath().toString());
+            MDC.put(KEY_REPOSITORY_PATH, repositoryProperties.getPath().toString());
 
             while (!(exception.get() || rwTasksCompleted.get())) {
                 try (var session = openNested()) {
@@ -669,11 +886,68 @@ public class CasStorageServiceImplTest
     private JCas createCasFile(SourceDocument aDoc, AnnotationSet aSet, String aText)
         throws CASException, CasSessionException, IOException
     {
-        var casTemplate = sut.readOrCreateCas(aDoc, aSet, NO_CAS_UPGRADE, () -> makeCas(aText),
+        return createCasFile(sut, aDoc, aSet, aText);
+    }
+
+    private JCas createCasFile(CasStorageServiceImpl aSut, SourceDocument aDoc, AnnotationSet aSet,
+            String aText)
+        throws CASException, CasSessionException, IOException
+    {
+        var casTemplate = aSut.readOrCreateCas(aDoc, aSet, NO_CAS_UPGRADE, () -> makeCas(aText),
                 EXCLUSIVE_WRITE_ACCESS).getJCas();
-        assertThat(sut.existsCas(aDoc, aSet)).isTrue();
+        assertThat(aSut.existsCas(aDoc, aSet)).isTrue();
 
         return casTemplate;
+    }
+
+    private CasStorageServiceImpl createStorageService(Duration aBorrowWaitTimeout)
+    {
+        var cacheProperties = new CasStorageCachePropertiesImpl();
+        cacheProperties.setCasBorrowWaitTimeout(aBorrowWaitTimeout);
+
+        return new CasStorageServiceImpl(driver, cacheProperties, null, null)
+        {
+            @Override
+            GenericKeyedObjectPool<CasKey, CasHolder> getExclusiveAccessPool()
+            {
+                if (exclusiveAccessPoolOverride != null) {
+                    return exclusiveAccessPoolOverride;
+                }
+
+                return super.getExclusiveAccessPool();
+            }
+        };
+    }
+
+    private void setExclusiveAccessPool(GenericKeyedObjectPool<CasKey, CasHolder> aPool)
+        throws Exception
+    {
+        exclusiveAccessPoolOverride = aPool;
+    }
+
+    private static GenericKeyedObjectPoolConfig<CasHolder> makeExclusiveAccessPoolConfig(
+            Duration aBorrowWaitTimeout)
+    {
+        var config = new GenericKeyedObjectPoolConfig<CasHolder>();
+        config.setMaxTotalPerKey(1);
+        config.setMaxIdlePerKey(1);
+        config.setMinIdlePerKey(0);
+        config.setMaxWait(aBorrowWaitTimeout);
+        config.setTestOnReturn(true);
+        config.setTestOnBorrow(true);
+        return config;
+    }
+
+    private static class ThrowingOnValidatePooledCasHolderFactory
+        extends PooledCasHolderFactory
+    {
+        @Override
+        public void passivateObject(CasKey aKey,
+                org.apache.commons.pool2.PooledObject<CasHolder> aP)
+            throws Exception
+        {
+            throw new IllegalStateException("Injected validation failure");
+        }
     }
 
     private SourceDocument makeSourceDocument(long aProjectId, long aDocumentId, String aDocName)

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/settings_cas-storage.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/settings_cas-storage.adoc
@@ -75,4 +75,10 @@ This cache can be tuned using the following properties:
 | Time for an exclusive action to wait for another exclusive action to finish
 | `3m`
 | `5m`
+
+| `cas-storage.cache.trace-access`
+| Whether to capture and record the stack trace each time a CAS is checked out from the exclusive pool so it can be
+  included in diagnostics when errors occur. Capturing a stack trace on every checkout adds noticeable overhead!
+| `false`
+| `true`
 |===

--- a/inception/inception-documents/src/test/java/de/tudarmstadt/ukp/inception/documents/DocumentServiceImplConcurrencyTest.java
+++ b/inception/inception-documents/src/test/java/de/tudarmstadt/ukp/inception/documents/DocumentServiceImplConcurrencyTest.java
@@ -24,6 +24,7 @@ import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorag
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet.INITIAL_SET;
 import static de.tudarmstadt.ukp.inception.annotation.storage.CasMetadataUtils.getInternalTypeSystem;
 import static java.lang.Thread.sleep;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static org.apache.commons.lang3.StringUtils.repeat;
 import static org.apache.uima.fit.factory.CasFactory.createCas;
@@ -33,18 +34,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
+import java.io.PrintWriter;
 import java.lang.invoke.MethodHandles;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Random;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.uima.cas.CAS;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
@@ -227,7 +233,7 @@ public class DocumentServiceImplConcurrencyTest
         LOG.info("---- Wait for primary threads to complete ----");
         var done = false;
         while (!done) {
-            long running = primaryTasks.stream().filter(Thread::isAlive).count();
+            var running = primaryTasks.stream().filter(Thread::isAlive).count();
             done = running == 0l;
             sleep(1000);
             LOG.info("running {}  complete {}%  rw {}  ro {}  un {}  xx {} XX {}", running,
@@ -250,8 +256,6 @@ public class DocumentServiceImplConcurrencyTest
     public void testHighConcurrencyMultiUser() throws Exception
     {
         var docText = repeat("This is a test.\n", DOC_SIZE);
-        var typeSystem = mergeTypeSystems(
-                asList(createTypeSystemDescription(), getInternalTypeSystem()));
 
         when(importExportService.importCasFromFileNoChecks(any(File.class),
                 any(SourceDocument.class), any())).then(_invocation -> {
@@ -353,7 +357,7 @@ public class DocumentServiceImplConcurrencyTest
 
                 try (var session = openNested()) {
                     var cas = sut.readAnnotationCas(doc, user);
-                    Thread.sleep(50);
+                    sleep(50);
                     sut.writeAnnotationCas(cas, doc, user);
                     writeCounter.incrementAndGet();
                 }
@@ -387,7 +391,7 @@ public class DocumentServiceImplConcurrencyTest
                 try (var session = openNested()) {
                     sut.readAnnotationCas(doc, set, AUTO_CAS_UPGRADE, SHARED_READ_ONLY_ACCESS);
                     managedReadCounter.incrementAndGet();
-                    Thread.sleep(50);
+                    sleep(50);
                 }
                 catch (Exception e) {
                     exception.set(true);
@@ -419,9 +423,9 @@ public class DocumentServiceImplConcurrencyTest
 
             while (!(exception.get() || rwTasksCompleted.get())) {
                 try (var session = openNested()) {
-                    Thread.sleep(2500 + rnd.nextInt(2500));
+                    sleep(2500 + rnd.nextInt(2500));
                     if (rnd.nextInt(100) >= 75) {
-                        sut.deleteAnnotationCas(doc, AnnotationSet.INITIAL_SET);
+                        sut.deleteAnnotationCas(doc, INITIAL_SET);
                         deleteInitialCounter.incrementAndGet();
                     }
                     sut.deleteAnnotationCas(doc, set);
@@ -457,7 +461,7 @@ public class DocumentServiceImplConcurrencyTest
                 try (var session = openNested()) {
                     sut.readAnnotationCas(doc, set, AUTO_CAS_UPGRADE, UNMANAGED_ACCESS);
                     unmanagedReadCounter.incrementAndGet();
-                    Thread.sleep(50);
+                    sleep(50);
                 }
                 catch (Exception e) {
                     exception.set(true);
@@ -478,5 +482,124 @@ public class DocumentServiceImplConcurrencyTest
         doc.setName(aDocName);
 
         return doc;
+    }
+
+    @Disabled("Flaky deadlock reproducer; for manual debugging only")
+    @Test
+    public void thatCrossDocumentImportCanDeadlock() throws Exception
+    {
+        // Two documents that will try to import each other while holding exclusive CAS access
+        var docA = makeSourceDocument(10l, 10l, "docA");
+        var docB = makeSourceDocument(20l, 20l, "docB");
+
+        // Try the scenario multiple times to increase chance of reproducing the race
+        var attempts = 12;
+        var reproduced = false;
+
+        for (var attempt = 1; attempt <= attempts && !reproduced; attempt++) {
+            LOG.info("Deadlock reproduction attempt {}/{}", attempt, attempts);
+
+            var ready = new CountDownLatch(2);
+
+            // Override importer to attempt to create/read the other document's initial CAS
+            when(importExportService.importCasFromFileNoChecks(any(File.class),
+                    any(SourceDocument.class), any())).thenAnswer(invocation -> {
+                        var requested = invocation.getArgument(1, SourceDocument.class);
+                        ready.countDown();
+                        // Wait until both importer threads are in the importer to maximize chance
+                        // of cycle
+                        ready.await();
+
+                        // Small pause to increase overlap while holding the importer
+                        try {
+                            sleep(200);
+                        }
+                        catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+
+                        if (requested.getId() == docA.getId()) {
+                            // While creating A, try to create B (will block if B is held by other
+                            // thread)
+                            return sut.createOrReadInitialCas(docB);
+                        }
+                        else {
+                            return sut.createOrReadInitialCas(docA);
+                        }
+                    });
+
+            var t1 = new Thread(() -> {
+                try {
+                    MDC.put(Logging.KEY_REPOSITORY_PATH, repositoryProperties.getPath().toString());
+                    try (var session = CasStorageSession.open()) {
+                        sut.createOrReadInitialCas(docA);
+                    }
+                }
+                catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }, "T1");
+
+            var t2 = new Thread(() -> {
+                try {
+                    MDC.put(Logging.KEY_REPOSITORY_PATH, repositoryProperties.getPath().toString());
+                    try (var session = CasStorageSession.open()) {
+                        sut.createOrReadInitialCas(docB);
+                    }
+                }
+                catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }, "T2");
+
+            t1.start();
+            t2.start();
+
+            // Wait longer for deadlock to manifest
+            t1.join(10_000);
+            t2.join(10_000);
+
+            // If both threads are still alive after the join timeout, we reproduced a deadlock
+            var deadlocked = t1.isAlive() && t2.isAlive();
+
+            // Interrupt to clean up threads so test runner doesn't hang
+            t1.interrupt();
+            t2.interrupt();
+
+            if (deadlocked) {
+                reproduced = true;
+                LOG.warn("Deadlock reproduced on attempt {}/{}", attempt, attempts);
+            }
+
+            // Reset mock for next attempt
+            reset(importExportService);
+            lenient().when(importExportService.importCasFromFileNoChecks(any(File.class),
+                    any(SourceDocument.class), any())).thenReturn(createCas(typeSystem));
+        }
+
+        if (!reproduced) {
+            // Write thread dump to temp folder for inspection
+            try {
+                var dumpFile = new File(testFolder, "thread-dump.txt");
+                try (var pw = new PrintWriter(dumpFile, UTF_8)) {
+                    pw.println("Thread dump at " + Instant.now());
+                    for (var e : Thread.getAllStackTraces().entrySet()) {
+                        var t = e.getKey();
+                        pw.println("Thread " + t.getName() + " (id=" + t.threadId() + ") state="
+                                + t.getState());
+                        for (var st : e.getValue()) {
+                            pw.println("\t" + st.toString());
+                        }
+                        pw.println();
+                    }
+                }
+                LOG.info("Wrote thread dump to {}", dumpFile.getAbsolutePath());
+            }
+            catch (Exception e) {
+                LOG.error("Failed to write thread dump", e);
+            }
+        }
+
+        assertThat(reproduced).as("Expected deadlock reproduction in one of the attempts").isTrue();
     }
 }

--- a/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/exporters/AnnotationDocumentExporter.java
+++ b/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/exporters/AnnotationDocumentExporter.java
@@ -213,7 +213,7 @@ public class AnnotationDocumentExporter
 
                 // The initial CAS must always be exported to ensure that the converted source
                 // document will *always* have the state it had at the time of the initial import.
-                // We we do have a reliably initial CAS and instead lazily convert whenever an
+                // If we don't have a reliable initial CAS and instead lazily convert whenever an
                 // annotator starts annotating, then we could end up with two annotators having two
                 // different versions of their CAS e.g. if there was a code change in the reader
                 // component that affects its output.


### PR DESCRIPTION
**What's in the PR**
- Hardened exclusive CAS acquisition cleanup so failures after borrowing, including `Error`s during CAS load/initialization, do not strand pool entries.
- Added fallback invalidation when `returnObject(...)` fails in the normal CAS release callback.
- Applied the same return-or-invalidate recovery logic to `WithExclusiveAccess.release()` and `WithExclusiveAccess.close()`.
- Preserved original failures during cleanup and attached secondary cleanup problems as suppressed exceptions where appropriate.

**How to test manually**
* No specific test procecure

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [x] PR updates documentation
