### PR TITLE
#2389 - Prevent curation until ANNOTATION_FINISHED

### DIFF
--- a/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/SourceDocumentState.java
+++ b/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/SourceDocumentState.java
@@ -17,6 +17,11 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.model;
 
+import static java.util.Collections.unmodifiableSet;
+
+import java.util.EnumSet;
+import java.util.Set;
+
 import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -63,6 +68,9 @@ public enum SourceDocumentState
      */
     @JsonProperty("CURATION_FINISHED")
     CURATION_FINISHED("CURATION_FINISHED", "<i class=\"fas fa-clipboard-check\"></i>", "#3232FFFF");
+
+    public static final Set<SourceDocumentState> CURATION_DOCUMENT_STATES = unmodifiableSet(
+            EnumSet.of(CURATION_IN_PROGRESS, CURATION_FINISHED));
 
     private final String id;
     private final String symbol;

--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/DynamicWorkloadExtensionImpl.java
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/DynamicWorkloadExtensionImpl.java
@@ -22,9 +22,11 @@ import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.CURATOR;
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.MANAGER;
 import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.ANNOTATION_FINISHED;
 import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.ANNOTATION_IN_PROGRESS;
+import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.CURATION_DOCUMENT_STATES;
 import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.CURATION_FINISHED;
 import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.CURATION_IN_PROGRESS;
 import static de.tudarmstadt.ukp.inception.support.json.JSONUtil.fromJsonString;
+import static java.util.stream.Collectors.toList;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -32,12 +34,10 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.apache.uima.UIMAException;
 import org.slf4j.Logger;
@@ -59,7 +59,6 @@ import de.tudarmstadt.ukp.inception.project.api.ProjectService;
 import de.tudarmstadt.ukp.inception.support.json.JSONUtil;
 import de.tudarmstadt.ukp.inception.workload.dynamic.config.DynamicWorkloadManagerAutoConfiguration;
 import de.tudarmstadt.ukp.inception.workload.dynamic.trait.DynamicWorkloadTraits;
-import de.tudarmstadt.ukp.inception.workload.dynamic.workflow.WorkflowExtension;
 import de.tudarmstadt.ukp.inception.workload.dynamic.workflow.WorkflowExtensionPoint;
 import de.tudarmstadt.ukp.inception.workload.dynamic.workflow.types.DefaultWorkflowExtension;
 import de.tudarmstadt.ukp.inception.workload.model.WorkloadManagementService;
@@ -151,9 +150,9 @@ public class DynamicWorkloadExtensionImpl
     public void writeTraits(DynamicWorkloadTraits aTrait, Project aProject)
     {
         try {
-            WorkloadManager manager = workloadManagementService
+            var manager = workloadManagementService
                     .loadOrCreateWorkloadManagerConfiguration(aProject);
-            this.writeTraits(manager, aTrait);
+            writeTraits(manager, aTrait);
             workloadManagementService.saveConfiguration(manager);
         }
         catch (Exception e) {
@@ -166,8 +165,8 @@ public class DynamicWorkloadExtensionImpl
     {
         // First, check if there are other documents which have been in the state INPROGRESS
         // Load the first one found
-        List<AnnotationDocument> inProgressDocuments = documentService
-                .listAnnotationDocumentsWithStateForUser(aProject, aUser, IN_PROGRESS);
+        var inProgressDocuments = documentService.listAnnotationDocumentsWithStateForUser(aProject,
+                aUser, IN_PROGRESS);
         if (!inProgressDocuments.isEmpty()) {
             return Optional.of(inProgressDocuments.get(0).getDocument());
         }
@@ -176,27 +175,28 @@ public class DynamicWorkloadExtensionImpl
         // abandoned by another user are available
         freshenStatus(aProject);
 
-        WorkloadManager currentWorkload = workloadManagementService
+        var currentWorkload = workloadManagementService
                 .loadOrCreateWorkloadManagerConfiguration(aProject);
 
         // If there are no traits set yet, use the DefaultWorkflowExtension
         // otherwise select the current one
-        DynamicWorkloadTraits traits = readTraits(currentWorkload);
-        WorkflowExtension currentWorkflowExtension = workflowExtensionPoint
-                .getExtension(traits.getWorkflowType()) //
+        var traits = readTraits(currentWorkload);
+        var currentWorkflowExtension = workflowExtensionPoint.getExtension(traits.getWorkflowType()) //
                 .orElseGet(DefaultWorkflowExtension::new);
 
         // Get all documents for which the state is NEW, or which have not been created yet.
-        List<SourceDocument> sourceDocuments = documentService
-                .listAnnotatableDocuments(aProject, aUser).entrySet().stream()
+        var sourceDocuments = documentService.listAnnotatableDocuments(aProject, aUser).entrySet()
+                .stream() //
                 .filter(entry -> entry.getValue() == null
-                        || entry.getValue().getState() == AnnotationDocumentState.NEW)
-                .map(entry -> entry.getKey()).collect(Collectors.toList());
+                        || entry.getValue().getState() == AnnotationDocumentState.NEW) //
+                .filter(entry -> !CURATION_DOCUMENT_STATES.contains(entry.getKey().getState())) //
+                .map(entry -> entry.getKey()) //
+                .collect(toList());
 
         // Rearrange list of documents according to current workflow
         sourceDocuments = currentWorkflowExtension.rankDocuments(sourceDocuments);
 
-        for (SourceDocument doc : sourceDocuments) {
+        for (var doc : sourceDocuments) {
             // FIXME: repeated query to DB should be optimized into a single query returning
             // a map of documents / annotator counts
 

--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/management/DynamicWorkloadManagementPage.java
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/management/DynamicWorkloadManagementPage.java
@@ -21,6 +21,7 @@ import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState.NE
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState.oneClickTransition;
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.CURATOR;
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.MANAGER;
+import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.CURATION_DOCUMENT_STATES;
 import static de.tudarmstadt.ukp.clarin.webanno.ui.core.page.ProjectPageBase.NS_PROJECT;
 import static de.tudarmstadt.ukp.clarin.webanno.ui.core.page.ProjectPageBase.PAGE_PARAM_PROJECT;
 import static de.tudarmstadt.ukp.inception.support.lambda.LambdaBehavior.enabledWhen;
@@ -41,7 +42,6 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -553,9 +553,12 @@ public class DynamicWorkloadManagementPage
                         result.addAll(
                                 documentService.listAnnotatableDocuments(currentProject.getObject(),
                                         userSelection.getModelObject()).keySet());
-                        result.sort(Comparator.comparing(SourceDocument::getName));
+                        result.sort(comparing(SourceDocument::getName));
                     }
                 }
+
+                result.removeIf(doc -> CURATION_DOCUMENT_STATES.contains(doc.getState()));
+
                 return result;
             }
         };

--- a/inception/inception-workload-dynamic/src/test/java/de/tudarmstadt/ukp/inception/workload/dynamic/DynamicWorkloadExtensionImpl2Test.java
+++ b/inception/inception-workload-dynamic/src/test/java/de/tudarmstadt/ukp/inception/workload/dynamic/DynamicWorkloadExtensionImpl2Test.java
@@ -172,6 +172,19 @@ class DynamicWorkloadExtensionImpl2Test
     }
 
     @Test
+    void thatNextDocumentDoesNotReturnCurationStateDocuments() throws Exception
+    {
+        var otherAnnotator = userService.create(new User("anno2"));
+
+        documentService.setSourceDocumentState(sourceDocument,
+                SourceDocumentState.CURATION_IN_PROGRESS);
+
+        var next = dynamicWorkloadExtension.nextDocumentToAnnotate(project, otherAnnotator);
+
+        assertThat(next).isEmpty();
+    }
+
+    @Test
     void thatAbandonedDocumentsAreReset() throws Exception
     {
         traits = new DynamicWorkloadTraits();

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/service/MatrixWorkloadServiceImpl.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/service/MatrixWorkloadServiceImpl.java
@@ -20,6 +20,7 @@ package de.tudarmstadt.ukp.inception.workload.matrix.service;
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState.IGNORE;
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState.NEW;
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.ANNOTATOR;
+import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.CURATION_DOCUMENT_STATES;
 import static java.util.Comparator.comparing;
 
 import java.util.ArrayList;
@@ -54,7 +55,9 @@ public class MatrixWorkloadServiceImpl
     {
         Validate.validState(aAnnotatorsPerDocument > 0, "Annotators per document must be positive");
 
-        var documents = documentService.listSourceDocuments(aProject);
+        var documents = documentService.listSourceDocuments(aProject).stream() //
+                .filter(doc -> !CURATION_DOCUMENT_STATES.contains(doc.getState())) //
+                .toList();
 
         var documentsPerUser = new LinkedHashMap<String, AtomicInteger>();
 

--- a/inception/inception-workload-matrix/src/test/java/de/tudarmstadt/ukp/inception/workload/matrix/service/MatrixWorkloadServiceImplIntegrationTest.java
+++ b/inception/inception-workload-matrix/src/test/java/de/tudarmstadt/ukp/inception/workload/matrix/service/MatrixWorkloadServiceImplIntegrationTest.java
@@ -51,6 +51,7 @@ import de.tudarmstadt.ukp.clarin.webanno.constraints.config.ConstraintsServiceAu
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState;
 import de.tudarmstadt.ukp.clarin.webanno.project.config.ProjectServiceAutoConfiguration;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.security.config.SecurityAutoConfiguration;
@@ -256,6 +257,24 @@ class MatrixWorkloadServiceImplIntegrationTest
 
         assertThat(documentService.listAnnotationDocuments(project)) //
                 .isEmpty();
+    }
+
+    @Test
+    void testAssignWorkloadSkipsCurationStateDocuments()
+    {
+        // Put doc1 into curation in-progress state
+        documentService.setSourceDocumentState(doc1, SourceDocumentState.CURATION_IN_PROGRESS);
+
+        // Run assignment
+        sut.assignWorkload(project, 1, true);
+
+        // Ensure no annotation documents were created for the document in curation state
+        var annDocs = documentService.listAnnotationDocuments(project);
+        assertThat(annDocs) //
+                .isNotEmpty() //
+                .extracting(AnnotationDocument::getDocument) //
+                .doesNotContain(doc1) //
+                .containsAnyOf(doc2, doc3);
     }
 
     @SpringBootConfiguration


### PR DESCRIPTION
**What's in the PR**
- Prevent documents in curation states being assigned to annotators by dynamic or matrix auto-assignment
- Added tests

**How to test manually**
* Put a document into a curation state
* Try to get it auto-assigned in the matrix auto-assignment
* Try to get it auto-assigned in the dynamic auto-assignment

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
