### PR TITLE
#5936 - Explorer reports involving document-level features remain blank

### DIFF
--- a/inception/inception-feature-string/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/pivot/StringFeatureExtractor.java
+++ b/inception/inception-feature-string/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/pivot/StringFeatureExtractor.java
@@ -19,14 +19,14 @@ package de.tudarmstadt.ukp.inception.annotation.feature.string.pivot;
 
 import static org.apache.commons.lang3.StringUtils.trimToNull;
 
-import org.apache.uima.cas.text.AnnotationFS;
+import org.apache.uima.cas.FeatureStructure;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
-import de.tudarmstadt.ukp.inception.pivot.api.extractor.AnnotationExtractor_ImplBase;
 import de.tudarmstadt.ukp.inception.pivot.api.extractor.ContextualizedFS;
+import de.tudarmstadt.ukp.inception.pivot.api.extractor.FeatureStructureExtractor_ImplBase;
 
 public class StringFeatureExtractor
-    extends AnnotationExtractor_ImplBase<AnnotationFS, String>
+    extends FeatureStructureExtractor_ImplBase<FeatureStructure, String>
 {
     private final AnnotationFeature feature;
 
@@ -43,7 +43,7 @@ public class StringFeatureExtractor
     }
 
     @Override
-    public String extract(ContextualizedFS<AnnotationFS> aAnn)
+    public String extract(ContextualizedFS<FeatureStructure> aAnn)
     {
         var ann = aAnn.fs();
         var f = ann.getType().getFeatureByBaseName(feature.getName());

--- a/inception/inception-pivot-api/src/main/java/de/tudarmstadt/ukp/inception/pivot/api/extractor/AnnotationExtractor_ImplBase.java
+++ b/inception/inception-pivot-api/src/main/java/de/tudarmstadt/ukp/inception/pivot/api/extractor/AnnotationExtractor_ImplBase.java
@@ -17,57 +17,18 @@
  */
 package de.tudarmstadt.ukp.inception.pivot.api.extractor;
 
-import static java.util.Optional.empty;
-
 import java.io.Serializable;
-import java.util.Optional;
 
 import org.apache.uima.cas.text.AnnotationFS;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 
 public abstract class AnnotationExtractor_ImplBase<T extends AnnotationFS, R extends Serializable>
+    extends FeatureStructureExtractor_ImplBase<T, R>
     implements AnnotationExtractor<T, R>
 {
-    private final AnnotationLayer layer;
-
     public AnnotationExtractor_ImplBase(AnnotationLayer aLayer)
     {
-        layer = aLayer;
-    }
-
-    public AnnotationLayer getLayer()
-    {
-        return layer;
-    }
-
-    @Override
-    public Optional<String> getTriggerType()
-    {
-        if (layer == null) {
-            return empty();
-        }
-
-        return Optional.of(layer.getName());
-    }
-
-    @Override
-    public boolean isWeak()
-    {
-        return layer == null;
-    }
-
-    @Override
-    public boolean accepts(Object aSource)
-    {
-        if (aSource instanceof ContextualizedFS ann) {
-            if (layer == null) {
-                return true;
-            }
-
-            return layer.getName().equals(ann.fs().getType().getName());
-        }
-
-        return false;
+        super(aLayer);
     }
 }

--- a/inception/inception-pivot-api/src/main/java/de/tudarmstadt/ukp/inception/pivot/api/extractor/FeatureStructureExtractor_ImplBase.java
+++ b/inception/inception-pivot-api/src/main/java/de/tudarmstadt/ukp/inception/pivot/api/extractor/FeatureStructureExtractor_ImplBase.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.pivot.api.extractor;
+
+import static java.util.Optional.empty;
+
+import java.io.Serializable;
+import java.util.Optional;
+
+import org.apache.uima.cas.FeatureStructure;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+
+public abstract class FeatureStructureExtractor_ImplBase<T extends FeatureStructure, R extends Serializable>
+    implements Extractor<ContextualizedFS<T>, R>
+{
+    private final AnnotationLayer layer;
+
+    public FeatureStructureExtractor_ImplBase(AnnotationLayer aLayer)
+    {
+        layer = aLayer;
+    }
+
+    public AnnotationLayer getLayer()
+    {
+        return layer;
+    }
+
+    @Override
+    public Optional<String> getTriggerType()
+    {
+        if (layer == null) {
+            return empty();
+        }
+
+        return Optional.of(layer.getName());
+    }
+
+    @Override
+    public boolean isWeak()
+    {
+        return layer == null;
+    }
+
+    @Override
+    public boolean accepts(Object aSource)
+    {
+        if (aSource instanceof ContextualizedFS ann) {
+            if (layer == null) {
+                return true;
+            }
+
+            return layer.getName().equals(ann.fs().getType().getName());
+        }
+
+        return false;
+    }
+}

--- a/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/extractor/DocumentNameExtractor.java
+++ b/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/extractor/DocumentNameExtractor.java
@@ -17,15 +17,15 @@
  */
 package de.tudarmstadt.ukp.inception.pivot.extractor;
 
-import org.apache.uima.cas.text.AnnotationFS;
+import org.apache.uima.jcas.cas.AnnotationBase;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData;
-import de.tudarmstadt.ukp.inception.pivot.api.extractor.AnnotationExtractor_ImplBase;
 import de.tudarmstadt.ukp.inception.pivot.api.extractor.ContextualizedFS;
+import de.tudarmstadt.ukp.inception.pivot.api.extractor.FeatureStructureExtractor_ImplBase;
 
 public class DocumentNameExtractor
-    extends AnnotationExtractor_ImplBase<AnnotationFS, String>
+    extends FeatureStructureExtractor_ImplBase<AnnotationBase, String>
 {
     private Object cacheMarker;
     private String documentName;
@@ -48,7 +48,7 @@ public class DocumentNameExtractor
     }
 
     @Override
-    public String extract(ContextualizedFS<AnnotationFS> aAnn)
+    public String extract(ContextualizedFS<AnnotationBase> aAnn)
     {
         var ann = aAnn.fs();
         var cas = ann.getCAS();


### PR DESCRIPTION
**What's in the PR**
- Fix document name and string feature extractors to work on any kind of feature structures

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
