### PR TITLE
#5945 - Zero-width annotations can cause RTL mode to crash

### DIFF
--- a/inception/inception-brat-editor/src/main/ts/src/util/Util.ts
+++ b/inception/inception-brat-editor/src/main/ts/src/util/Util.ts
@@ -37,10 +37,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import { DiamAjax } from '@inception-project/inception-js-api';
+import { type DiamAjax } from '@inception-project/inception-js-api';
 import { Box } from '@svgdotjs/svg.js';
 import { Dispatcher } from '../dispatcher/Dispatcher';
-import { EntityTypeDto, RelationTypeDto } from '../protocol/Protocol';
+import { type EntityTypeDto, type RelationTypeDto } from '../protocol/Protocol';
 import { Fragment } from '../visualizer/Fragment';
 import { Visualizer } from '../visualizer/Visualizer';
 import { VisualizerUI } from '../visualizer_ui/VisualizerUI';

--- a/inception/inception-brat-editor/src/main/ts/src/visualizer/Visualizer.ts
+++ b/inception/inception-brat-editor/src/main/ts/src/visualizer/Visualizer.ts
@@ -1607,6 +1607,21 @@ export class Visualizer {
         firstChar -= textUpToFirstChar.length - textUpToFirstCharUnspaced.length;
         lastChar -= textUpToLastChar.length - textUpToLastCharUnspaced.length;
 
+        // Handle zero-width or invalid ranges (e.g., lastChar < firstChar)
+        // so we don't pass illegal ranges into the robust RTL routine.
+        if (lastChar < firstChar) {
+            let [startPos, endPos] = this.calculateSubstringPositionFast(text, firstChar, lastChar);
+            if (this.rtlmode) {
+                startPos = -startPos;
+                endPos = -endPos;
+            }
+            fragment.curly = {
+                from: Math.min(startPos, endPos),
+                to: Math.max(startPos, endPos),
+            };
+            return;
+        }
+
         let startPos: number, endPos: number;
         if (this.rtlmode) {
             // This rendering is much slower than the "old" version that brat uses, but it is more reliable in RTL mode.
@@ -1643,6 +1658,11 @@ export class Visualizer {
         firstChar: number,
         lastChar: number
     ): [number, number] {
+        if (firstChar < 0 || lastChar < 0 || firstChar >= text.getNumberOfChars() || lastChar >= text.getNumberOfChars()) {
+            console.error(`Invalid range [${firstChar}, ${lastChar}]`);
+            return [0, 0];
+        }
+
         if (text.textContent === null || text.textContent.length === 0) {
             return [0, 0];
         }
@@ -4119,7 +4139,7 @@ export class Visualizer {
         } catch (e) {
             // We are sure not to be drawing anymore, reset the state
             this.drawing = false;
-            console.error('Rendering terminated due to: ' + e, e.stack);
+            console.error('Rendering terminated', e);
         }
     }
 


### PR DESCRIPTION
**What's in the PR**
- Use TypeScript type-only imports in inception/inception-brat-editor/src/main/ts/src/util/Util.ts (convert DiamAjax, EntityTypeDto, RelationTypeDto imports to `type` imports).
- Add guard for zero-width/invalid character ranges in inception/inception-brat-editor/src/main/ts/src/visualizer/Visualizer.ts (handle `lastChar < firstChar` by using the fast-path measurement and set `fragment.curly`, with RTL adjustment).
- Add defensive validation in substring measurement in inception/inception-brat-editor/src/main/ts/src/visualizer/Visualizer.ts to log and return `[0, 0]` for out-of-bounds char indices.

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
