### PR TITLE
#5922 - Curation items may be shown on annotation page

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/editor/state/AnnotatorStateImpl.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/editor/state/AnnotatorStateImpl.java
@@ -19,16 +19,19 @@ package de.tudarmstadt.ukp.inception.editor.state;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableSet;
 import static org.apache.wicket.event.Broadcast.BREADTH;
 
 import java.io.Serializable;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Predicate;
 
 import org.apache.uima.cas.CAS;
@@ -167,6 +170,8 @@ public class AnnotatorStateImpl
      */
     @Deprecated
     private Mode mode;
+
+    private final Set<String> enabledExtensions = new HashSet<>();
 
     /**
      * The previously selected {@link TagSet} and {@link Tag} for a span/Arc annotation so as to
@@ -515,6 +520,30 @@ public class AnnotatorStateImpl
     public Mode getMode()
     {
         return mode;
+    }
+
+    @Override
+    public void enableExtension(String aExtension)
+    {
+        enabledExtensions.add(aExtension);
+    }
+
+    @Override
+    public void disableExtension(String aExtension)
+    {
+        enabledExtensions.remove(aExtension);
+    }
+
+    @Override
+    public boolean isExtensionEnabled(String aExtension)
+    {
+        return enabledExtensions.contains(aExtension);
+    }
+
+    @Override
+    public Set<String> getEnabledExtensions()
+    {
+        return unmodifiableSet(enabledExtensions);
     }
 
     @Override

--- a/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/editorstate/AnnotatorState.java
+++ b/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/editorstate/AnnotatorState.java
@@ -21,6 +21,7 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import de.tudarmstadt.ukp.clarin.webanno.constraints.model.ParsedConstraints;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
@@ -68,6 +69,14 @@ public interface AnnotatorState
     // curation, automation, correction, etc. should be local to the respective modules / pages
     @Deprecated
     Mode getMode();
+
+    void enableExtension(String aExtension);
+
+    void disableExtension(String aExtension);
+
+    boolean isExtensionEnabled(String aExtension);
+
+    Set<String> getEnabledExtensions();
 
     // ---------------------------------------------------------------------------------------------
     // Remembered feature values

--- a/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/request/RenderRequest.java
+++ b/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/request/RenderRequest.java
@@ -58,6 +58,7 @@ public class RenderRequest
     private final Map<Long, Set<String>> hiddenFeatureValues;
     private final CAS cas;
     private final ColoringStrategy coloringStrategyOverride;
+    private final Set<String> enabledExtensions;
 
     private RenderRequest(Builder builder)
     {
@@ -78,6 +79,7 @@ public class RenderRequest
         sessionOwner = builder.sessionOwner;
         hiddenFeatures = builder.hiddenFeatures;
         hiddenFeatureValues = builder.hiddenFeatureValues;
+        enabledExtensions = builder.enabledExtensions;
     }
 
     public Optional<ColoringStrategy> getColoringStrategyOverride()
@@ -171,6 +173,11 @@ public class RenderRequest
         return state;
     }
 
+    public Set<String> getEnabledExtensions()
+    {
+        return enabledExtensions;
+    }
+
     public ParsedConstraints getConstraints()
     {
         return constraints;
@@ -205,6 +212,7 @@ public class RenderRequest
         private final Map<Long, Set<String>> hiddenFeatureValues = new HashMap<>();
         private ColoringStrategy coloringStrategyOverride;
         private ParsedConstraints constraints;
+        private final Set<String> enabledExtensions = new HashSet<>();
 
         private Builder()
         {
@@ -235,6 +243,7 @@ public class RenderRequest
             withVisibleLayers(aState.getAnnotationLayers());
             withHiddenFeatures(aState.getPreferences().getHiddenAnnotationFeatureIds());
             withHiddenFeatureValues(aState.getPreferences().getHiddenTags());
+            withEnabledExtensions(aState.getEnabledExtensions());
             sourceDocument = state.getDocument();
             annotationUser = state.getUser();
             constraints = state.getConstraints();
@@ -324,6 +333,15 @@ public class RenderRequest
         public Builder withColoringStrategyOverride(ColoringStrategy aColoringStrategyOverride)
         {
             coloringStrategyOverride = aColoringStrategyOverride;
+            return this;
+        }
+
+        public Builder withEnabledExtensions(Collection<String> aExtensions)
+        {
+            enabledExtensions.clear();
+            if (aExtensions != null) {
+                enabledExtensions.addAll(aExtensions);
+            }
             return this;
         }
 

--- a/inception/inception-assistant/src/test/java/de/tudarmstadt/ukp/inception/assistant/AssistantServiceImplTest.java
+++ b/inception/inception-assistant/src/test/java/de/tudarmstadt/ukp/inception/assistant/AssistantServiceImplTest.java
@@ -197,7 +197,7 @@ class AssistantServiceImplTest
     }
 
     @Test
-    void thatMessageSentIsRecieved() throws Exception
+    void thatMessageSentIsReceived() throws Exception
     {
         projectService.assignRole(project, user, ANNOTATOR);
 

--- a/inception/inception-brat-editor/src/main/ts/src/visualizer/Visualizer.ts
+++ b/inception/inception-brat-editor/src/main/ts/src/visualizer/Visualizer.ts
@@ -3763,7 +3763,7 @@ export class Visualizer {
         if (!this.svgContainer.ownerDocument.contains(this.svg.node)) {
             if (TRACE_VISUALIZER) {
                 console.trace(
-                    'Recieved render request for stale SVG that is no longer on the page. Ignoring.'
+                    'Received render request for stale SVG that is no longer on the page. Ignoring.'
                 );
             }
             return;

--- a/inception/inception-diam-editor/src/main/java/de/tudarmstadt/ukp/inception/diam/sidebar/DiamAnnotationBrowser.java
+++ b/inception/inception-diam-editor/src/main/java/de/tudarmstadt/ukp/inception/diam/sidebar/DiamAnnotationBrowser.java
@@ -85,8 +85,11 @@ public class DiamAnnotationBrowser
             return;
         }
 
-        var viewport = new ViewportDefinition(state.getDocument(), state.getUser().getUsername(), 0,
-                Integer.MAX_VALUE, CompactSerializerV2Impl.ID);
+        var viewport = ViewportDefinition.builder() //
+                .withDocument(state.getDocument()) //
+                .withDataOwner(state.getUser().getUsername()) //
+                .withFormat(CompactSerializerV2Impl.ID) //
+                .build();
 
         var managerPrefs = userPrefService
                 .loadDefaultTraitsForProject(KEY_DIAM_SIDEBAR_MANAGER_PREFS, state.getProject());
@@ -97,6 +100,7 @@ public class DiamAnnotationBrowser
                 "csrfToken", getCsrfTokenFromSession(), //
                 "topicChannel", viewport.getTopic(), //
                 "pinnedGroups", managerPrefs.getPinnedGroups(), //
+                "enableExtensions", state.getEnabledExtensions(), //
                 "userPreferencesKey", userPreferencesKey);
 
         // model will be added as props to Svelte component

--- a/inception/inception-diam-editor/src/main/ts/src/DiamAnnotationBrowser.svelte
+++ b/inception/inception-diam-editor/src/main/ts/src/DiamAnnotationBrowser.svelte
@@ -29,7 +29,7 @@
     import AnnotationsByLabelList from "./AnnotationsByLabelList.svelte";
     import AnnotationsByLayerList from "./AnnotationsByLayerList.svelte";
 
-    let { wsEndpointUrl, csrfToken, topicChannel, ajaxEndpointUrl, pinnedGroups, userPreferencesKey } = $props();
+    let { wsEndpointUrl, csrfToken, topicChannel, ajaxEndpointUrl, pinnedGroups, userPreferencesKey, enableExtensions } = $props();
 
     let element: HTMLElement | undefined = $state(undefined);
     let connected = false;
@@ -51,13 +51,13 @@
 
     let wsClient = factory().createWebsocketClient();
     wsClient.onConnect = () =>
-        wsClient.subscribeToViewport(topicChannel, (d) => messageRecieved(d));
+        wsClient.subscribeToViewport(topicChannel, (d) => messageRecieved(d), {enableExtensions: enableExtensions});
 
     let ajaxClient = factory().createAjaxClient(ajaxEndpointUrl);
 
     ajaxClient.loadPreferences(userPreferencesKey).then((p) => {
         preferences = Object.assign(preferences, defaultPreferences, p);
-        console.log("Loaded preferences", preferences);
+        console.debug("Loaded preferences", preferences);
         stateStore.groupingMode = preferences.mode || defaultPreferences.mode;
         stateStore.sortByScore = preferences.sortByScore !== undefined
                 ? preferences.sortByScore

--- a/inception/inception-diam/pom.xml
+++ b/inception/inception-diam/pom.xml
@@ -201,6 +201,10 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-collections4</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/config/DiamAutoConfig.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/config/DiamAutoConfig.java
@@ -225,17 +225,25 @@ public class DiamAutoConfig
         return (aBuilder, aMAH) -> {
             LOG.debug("Configuring websocket security for annotation editor controller");
 
-            final var annotationEditorTopic = "/*" + TOPIC_ELEMENT_PROJECT + "{" + PARAM_PROJECT
-                    + "}" + TOPIC_ELEMENT_DOCUMENT + "{" + PARAM_DOCUMENT + "}" + TOPIC_ELEMENT_USER
-                    + "{" + PARAM_USER + "}/**";
+            final var annotationEditorTopic = TOPIC_ELEMENT_PROJECT + "{" + PARAM_PROJECT + "}"
+                    + TOPIC_ELEMENT_DOCUMENT + "{" + PARAM_DOCUMENT + "}" + TOPIC_ELEMENT_USER + "{"
+                    + PARAM_USER + "}/**";
 
-            aBuilder.simpSubscribeDestMatchers(annotationEditorTopic)
+            aBuilder.simpSubscribeDestMatchers("/app" + annotationEditorTopic)
                     .access(expression(aMAH, "@documentAccess.canViewAnnotationDocument(#"
                             + PARAM_PROJECT + ", #" + PARAM_DOCUMENT + ", #" + PARAM_USER + ")"));
 
-            aBuilder.simpMessageDestMatchers(annotationEditorTopic)
-                    .access(expression(aMAH, "@documentAccess.canEditAnnotationDocument(#"
+            aBuilder.simpSubscribeDestMatchers("/topic" + annotationEditorTopic)
+                    .access(expression(aMAH, "@documentAccess.canViewAnnotationDocument(#"
                             + PARAM_PROJECT + ", #" + PARAM_DOCUMENT + ", #" + PARAM_USER + ")"));
+
+            // aBuilder.simpSubscribeDestMatchers("/user/queue" + annotationEditorTopic)
+            // .access(expression(aMAH, "@documentAccess.canViewAnnotationDocument(#"
+            // + PARAM_PROJECT + ", #" + PARAM_DOCUMENT + ", #" + PARAM_USER + ")"));
+
+            // aBuilder.simpMessageDestMatchers(annotationEditorTopic)
+            // .access(expression(aMAH, "@documentAccess.canEditAnnotationDocument(#"
+            // + PARAM_PROJECT + ", #" + PARAM_DOCUMENT + ", #" + PARAM_USER + ")"));
         };
     }
 }

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/model/websocket/ViewportDefinition.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/model/websocket/ViewportDefinition.java
@@ -17,15 +17,25 @@
  */
 package de.tudarmstadt.ukp.inception.diam.model.websocket;
 
+import static java.lang.String.join;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.unmodifiableSet;
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+import static org.apache.commons.lang3.builder.ToStringStyle.NO_CLASS_NAME_STYLE;
+
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.Properties;
+import java.util.Set;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
 import org.apache.uima.cas.text.AnnotationPredicates;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.diam.service.DiamWebsocketController;
 import de.tudarmstadt.ukp.inception.websocket.config.WebSocketConstants;
@@ -34,46 +44,30 @@ public class ViewportDefinition
 {
     private final long projectId;
     private final long documentId;
-    private final String user;
+    private final String dataOwner;
+
     private final int begin;
     private final int end;
+
+    private final Set<String> enabledExtensions;
     private final String format;
 
-    public ViewportDefinition(AnnotationDocument aDoc, int aBegin, int aEnd, String aFormat)
+    private ViewportDefinition(Builder builder)
     {
-        projectId = aDoc.getProject().getId();
-        documentId = aDoc.getDocument().getId();
-        user = aDoc.getUser();
-        begin = aBegin;
-        end = aEnd;
-        format = aFormat;
+        projectId = builder.projectId;
+        documentId = builder.documentId;
+        dataOwner = builder.dataOwner;
+        begin = builder.begin;
+        end = builder.end;
+        format = builder.format;
+        enabledExtensions = isNotEmpty(builder.enabledExtensions)
+                ? unmodifiableSet(new HashSet<>(builder.enabledExtensions))
+                : emptySet();
     }
 
-    public ViewportDefinition(SourceDocument aDoc, String aUser, int aBegin, int aEnd,
-            String aFormat)
+    public boolean matches(long aDocumentId, AnnotationSet aSet, int aBegin, int aEnd)
     {
-        projectId = aDoc.getProject().getId();
-        documentId = aDoc.getId();
-        user = aUser;
-        begin = aBegin;
-        end = aEnd;
-        format = aFormat;
-    }
-
-    public ViewportDefinition(long aProjectId, long aDocumentId, String aUser, int aBegin, int aEnd,
-            String aFormat)
-    {
-        projectId = aProjectId;
-        documentId = aDocumentId;
-        user = aUser;
-        begin = aBegin;
-        end = aEnd;
-        format = aFormat;
-    }
-
-    public boolean matches(long aDocumentId, String aUser, int aBegin, int aEnd)
-    {
-        if (aDocumentId != documentId || !user.equals(aUser)) {
+        if (aDocumentId != documentId || !dataOwner.equals(aSet.id())) {
             return false;
         }
 
@@ -92,7 +86,7 @@ public class ViewportDefinition
 
     public String getUser()
     {
-        return user;
+        return dataOwner;
     }
 
     public int getBegin()
@@ -110,15 +104,19 @@ public class ViewportDefinition
         return format;
     }
 
+    public Set<String> getEnabledExtensions()
+    {
+        return enabledExtensions;
+    }
+
     public String getTopic()
     {
         var properties = new Properties();
         properties.setProperty(WebSocketConstants.PARAM_PROJECT, String.valueOf(projectId));
         properties.setProperty(WebSocketConstants.PARAM_DOCUMENT, String.valueOf(documentId));
-        properties.setProperty(WebSocketConstants.PARAM_USER, user);
+        properties.setProperty(WebSocketConstants.PARAM_USER, dataOwner);
         properties.setProperty(DiamWebsocketController.PARAM_FROM, String.valueOf(begin));
         properties.setProperty(DiamWebsocketController.PARAM_TO, String.valueOf(end));
-        properties.setProperty(DiamWebsocketController.PARAM_FORMAT, String.valueOf(format));
         return DiamWebsocketController.PLACEHOLDER_RESOLVER.replacePlaceholders(
                 DiamWebsocketController.DOCUMENT_VIEWPORT_TOPIC_TEMPLATE, properties);
     }
@@ -129,24 +127,152 @@ public class ViewportDefinition
         if (!(other instanceof ViewportDefinition)) {
             return false;
         }
-        ViewportDefinition castOther = (ViewportDefinition) other;
-        return new EqualsBuilder().append(documentId, castOther.documentId)
-                .append(user, castOther.user).append(begin, castOther.begin)
-                .append(end, castOther.end).append(format, castOther.format).isEquals();
+        var castOther = (ViewportDefinition) other;
+        return new EqualsBuilder() //
+                .append(documentId, castOther.documentId) //
+                .append(dataOwner, castOther.dataOwner) //
+                .append(begin, castOther.begin) //
+                .append(end, castOther.end) //
+                .append(format, castOther.format) //
+                .append(enabledExtensions, castOther.enabledExtensions) //
+                .isEquals();
     }
 
     @Override
     public int hashCode()
     {
-        return new HashCodeBuilder().append(documentId).append(user).append(begin).append(end)
-                .append(format).toHashCode();
+        return new HashCodeBuilder() //
+                .append(documentId) //
+                .append(dataOwner) //
+                .append(begin) //
+                .append(end) //
+                .append(format) //
+                .append(enabledExtensions) //
+                .toHashCode();
     }
 
     @Override
     public String toString()
     {
-        return new ToStringBuilder(this, ToStringStyle.NO_CLASS_NAME_STYLE)
-                .append("documentId", documentId).append("user", user).append("begin", begin)
-                .append("end", end).append("format", format).toString();
+        return new ToStringBuilder(this, NO_CLASS_NAME_STYLE) //
+                .append("documentId", documentId) //
+                .append("user", dataOwner) //
+                .append("begin", begin) //
+                .append("end", end) //
+                .append("format", format) //
+                .append("extensions", "[" + join(",", enabledExtensions) + "]") //
+                .toString();
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static final class Builder
+    {
+        private long projectId;
+        private long documentId;
+        private String dataOwner;
+        private int begin = 0;
+        private int end = Integer.MAX_VALUE;
+        private String format;
+        private Set<String> enabledExtensions = new HashSet<>();
+
+        private Builder()
+        {
+        }
+
+        public Builder withProjectId(long aProjectId)
+        {
+            projectId = aProjectId;
+            return this;
+        }
+
+        public Builder withDocumentId(long aDocumentId)
+        {
+            documentId = aDocumentId;
+            return this;
+        }
+
+        public Builder withDocument(SourceDocument aDocument)
+        {
+            projectId = aDocument.getProject().getId();
+            documentId = aDocument.getId();
+            return this;
+        }
+
+        public Builder withDocument(AnnotationDocument aDocument)
+        {
+            withDocument(aDocument.getDocument());
+            dataOwner = aDocument.getUser();
+            return this;
+        }
+
+        public Builder withDataOwner(String aDataOwner)
+        {
+            dataOwner = aDataOwner;
+            return this;
+        }
+
+        public Builder withBegin(int aBegin)
+        {
+            begin = aBegin;
+            return this;
+        }
+
+        public Builder withEnd(int aEnd)
+        {
+            end = aEnd;
+            return this;
+        }
+
+        public Builder withRange(int aBegin, int aEnd)
+        {
+            begin = aBegin;
+            end = aEnd;
+            return this;
+        }
+
+        public Builder withFormat(String aFormat)
+        {
+            format = aFormat;
+            return this;
+        }
+
+        public Builder enabledExtensions(Collection<String> aExtensions)
+        {
+            enabledExtensions.clear();
+            if (aExtensions != null) {
+                enabledExtensions.addAll(aExtensions);
+            }
+            return this;
+        }
+
+        public Builder enabledExtensions(String... aExtensions)
+        {
+            enabledExtensions.clear();
+            if (aExtensions != null) {
+                enabledExtensions.addAll(asList(aExtensions));
+            }
+            return this;
+        }
+
+        public ViewportDefinition build()
+        {
+            if (dataOwner == null) {
+                throw new IllegalStateException(
+                        "Cannot build ViewportDefinition: dataOwner must not be null");
+            }
+            if (format == null) {
+                throw new IllegalStateException(
+                        "Cannot build ViewportDefinition: format must not be null");
+            }
+            if (begin > end) {
+                throw new IllegalStateException(
+                        "Cannot build ViewportDefinition: begin must be less than or equal to end");
+            }
+            return new ViewportDefinition(this);
+        }
     }
 }

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/model/websocket/ViewportState.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/model/websocket/ViewportState.java
@@ -18,20 +18,20 @@
 package de.tudarmstadt.ukp.inception.diam.model.websocket;
 
 import static java.util.Collections.newSetFromMap;
+import static java.util.Collections.unmodifiableSet;
 
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-
-import org.apache.commons.lang3.tuple.Pair;
 
 import tools.jackson.databind.JsonNode;
 
 public class ViewportState
 {
+    public record Subscription(String sessionId, String subscriptionId) {}
+
     private final ViewportDefinition vpd;
 
-    private final Set<Pair<String, String>> subscriberSessionIds = newSetFromMap(
-            new ConcurrentHashMap<>());
+    private final Set<Subscription> subscriptions = newSetFromMap(new ConcurrentHashMap<>());
 
     private JsonNode json;
 
@@ -55,24 +55,29 @@ public class ViewportState
         return json;
     }
 
-    public void removeSubscriber(String aId)
+    public void removeSubscriptionsBySession(String aSessionId)
     {
-        subscriberSessionIds.removeIf(p -> p.getKey().equals(aId));
+        subscriptions.removeIf(p -> p.sessionId().equals(aSessionId));
     }
 
     public void addSubscription(String aSubscriberId, String aSubscriptionId)
     {
-        subscriberSessionIds.add(Pair.of(aSubscriberId, aSubscriptionId));
-    }
-
-    public boolean hasSubscribers()
-    {
-        return !subscriberSessionIds.isEmpty();
+        subscriptions.add(new Subscription(aSubscriberId, aSubscriptionId));
     }
 
     public void removeSubscription(String aSessionId, String aSubscriptionId)
     {
-        subscriberSessionIds.removeIf(
-                p -> p.getKey().equals(aSessionId) && p.getValue().equals(aSubscriptionId));
+        subscriptions.removeIf(p -> p.sessionId().equals(aSessionId)
+                && p.subscriptionId().equals(aSubscriptionId));
+    }
+
+    public boolean hasSubscriptions()
+    {
+        return !subscriptions.isEmpty();
+    }
+
+    public Set<Subscription> getSubscriptions()
+    {
+        return unmodifiableSet(subscriptions);
     }
 }

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/service/DiamWebsocketController.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/service/DiamWebsocketController.java
@@ -17,6 +17,8 @@
  */
 package de.tudarmstadt.ukp.inception.diam.service;
 
+import static de.tudarmstadt.ukp.inception.support.json.JSONUtil.fromJsonString;
+import static de.tudarmstadt.ukp.inception.support.json.JSONUtil.toJsonString;
 import static de.tudarmstadt.ukp.inception.support.logging.Logging.KEY_REPOSITORY_PATH;
 import static de.tudarmstadt.ukp.inception.support.logging.Logging.KEY_USERNAME;
 import static de.tudarmstadt.ukp.inception.websocket.config.WebSocketConstants.PARAM_DOCUMENT;
@@ -26,8 +28,10 @@ import static de.tudarmstadt.ukp.inception.websocket.config.WebSocketConstants.T
 import static de.tudarmstadt.ukp.inception.websocket.config.WebSocketConstants.TOPIC_ELEMENT_PROJECT;
 import static de.tudarmstadt.ukp.inception.websocket.config.WebSocketConstants.TOPIC_ELEMENT_USER;
 import static java.lang.Integer.MAX_VALUE;
+import static org.springframework.messaging.simp.SimpMessageType.MESSAGE;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.security.Principal;
 import java.time.Duration;
 
@@ -60,6 +64,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Mode;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.inception.diam.messages.MViewportInit;
 import de.tudarmstadt.ukp.inception.diam.messages.MViewportUpdate;
@@ -87,7 +92,10 @@ import tools.jackson.databind.JsonNode;
 @Controller
 public class DiamWebsocketController
 {
-    private final Logger log = LoggerFactory.getLogger(getClass());
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    public static final String X_DIAM_EXTENSIONS = "X-DIAM-EXTENSIONS";
+    public static final String X_DIAM_FORMAT = "X-DIAM-FORMAT";
 
     public static final String FORMAT_LEGACY = "legacy";
 
@@ -103,8 +111,7 @@ public class DiamWebsocketController
             + TOPIC_ELEMENT_USER + "{" + PARAM_USER + "}";
 
     public static final String DOCUMENT_VIEWPORT_TOPIC_TEMPLATE = //
-            DOCUMENT_BASE_TOPIC_TEMPLATE + "/from/{" + PARAM_FROM + "}/to/{" + PARAM_TO
-                    + "}/format/{" + PARAM_FORMAT + "}";
+            DOCUMENT_BASE_TOPIC_TEMPLATE + "/from/{" + PARAM_FROM + "}/to/{" + PARAM_TO + "}";
 
     // public static final String ANNOTATION_COMMAND_DELETE_TOPIC_TEMPLATE = //
     // DOCUMENT_BASE_TOPIC_TEMPLATE + "/delete";
@@ -158,12 +165,16 @@ public class DiamWebsocketController
     @EventListener
     public void onSessionDisconnect(SessionDisconnectEvent aEvent)
     {
-        log.trace("Unsubscribing {} from all viewports", aEvent.getSessionId());
+        if (LOG.isTraceEnabled()) {
+            var user = aEvent.getUser();
+            LOG.trace("Unsubscribing [{}]({}:*) from all viewports",
+                    user != null ? user.getName() : "anonymous", aEvent.getSessionId());
+        }
 
         activeViewports.asMap().entrySet().stream() //
                 .filter(e -> {
-                    e.getValue().removeSubscriber(aEvent.getSessionId());
-                    return !e.getValue().hasSubscribers();
+                    e.getValue().removeSubscriptionsBySession(aEvent.getSessionId());
+                    return !e.getValue().hasSubscriptions();
                 }) //
                 .forEach(e -> closeViewport(e.getKey()));
     }
@@ -176,19 +187,23 @@ public class DiamWebsocketController
         var sessionId = headers.getSessionId();
         var subscriptionId = headers.getSubscriptionId();
 
-        log.trace("Unsubscribing {} from subscription {}", sessionId, subscriptionId);
+        if (LOG.isTraceEnabled()) {
+            var user = aEvent.getUser();
+            LOG.trace("Unsubscribing [{}]({}:{})", user != null ? user.getName() : "anonymous",
+                    sessionId, subscriptionId);
+        }
 
         activeViewports.asMap().entrySet().stream() //
                 .filter(e -> {
                     e.getValue().removeSubscription(sessionId, subscriptionId);
-                    return !e.getValue().hasSubscribers();
+                    return !e.getValue().hasSubscriptions();
                 }) //
                 .forEach(e -> closeViewport(e.getKey()));
     }
 
     private void closeViewport(ViewportDefinition aVpd)
     {
-        log.trace("Closing viewport {}", aVpd);
+        LOG.trace("Closing viewport {}", aVpd);
         activeViewports.invalidate(aVpd);
     }
 
@@ -202,18 +217,17 @@ public class DiamWebsocketController
     public void onTransientAnnotationStateChanged(TransientAnnotationStateChangedEvent aEvent)
     {
         var doc = aEvent.getDocument();
-        sendUpdate(doc.getProject().getId(), doc.getId(), aEvent.getUser(), 0, MAX_VALUE);
+        sendUpdate(doc, AnnotationSet.forUser(aEvent.getUser()), 0, MAX_VALUE);
     }
 
     @SubscribeMapping(DOCUMENT_VIEWPORT_TOPIC_TEMPLATE)
-    public JsonNode onSubscribeToAnnotationDocument(SimpMessageHeaderAccessor aHeaderAccessor,
+    public JsonNode onSubscribeToViewport(SimpMessageHeaderAccessor aHeaderAccessor,
             Principal aPrincipal, //
             @DestinationVariable(PARAM_PROJECT) long aProjectId,
             @DestinationVariable(PARAM_DOCUMENT) long aDocumentId,
             @DestinationVariable(PARAM_USER) String aDataOwner,
             @DestinationVariable(PARAM_FROM) int aViewportBegin,
-            @DestinationVariable(PARAM_TO) int aViewportEnd,
-            @DestinationVariable(PARAM_FORMAT) String aFormat)
+            @DestinationVariable(PARAM_TO) int aViewportEnd)
         throws IOException
     {
         var project = getProject(aProjectId);
@@ -222,18 +236,33 @@ public class DiamWebsocketController
             MDC.put(KEY_REPOSITORY_PATH, repositoryProperties.getPath().toString());
             MDC.put(KEY_USERNAME, aPrincipal.getName());
 
-            var vpd = new ViewportDefinition(aProjectId, aDocumentId, aDataOwner, aViewportBegin,
-                    aViewportEnd, aFormat);
+            var format = aHeaderAccessor.getFirstNativeHeader(X_DIAM_FORMAT);
+            if (format == null) {
+                throw new IllegalArgumentException("Missing required websocket header ["
+                        + X_DIAM_FORMAT + "] specifying the DIAM format.");
+            }
+
+            var enabledExtensions = fromJsonString(String[].class,
+                    aHeaderAccessor.getFirstNativeHeader(X_DIAM_EXTENSIONS), new String[] {});
+
+            var vpd = ViewportDefinition.builder() //
+                    .withProjectId(aProjectId) //
+                    .withDocumentId(aDocumentId) //
+                    .withDataOwner(aDataOwner) //
+                    .withRange(aViewportBegin, aViewportEnd) //
+                    .withFormat(format) //
+                    .enabledExtensions(enabledExtensions) //
+                    .build();
 
             // Ensure that the viewport is registered
             var vps = activeViewports.get(vpd);
 
-            log.trace("Subscribing {} to {}", aHeaderAccessor.getSessionId(), vpd.getTopic());
+            LOG.trace("Subscribing [{}]({}:{}) to {}", aPrincipal.getName(),
+                    aHeaderAccessor.getSessionId(), aHeaderAccessor.getSubscriptionId(), vpd);
             vps.addSubscription(aHeaderAccessor.getSessionId(),
                     aHeaderAccessor.getSubscriptionId());
 
-            var json = render(project, aDocumentId, aDataOwner, aViewportBegin, aViewportEnd,
-                    aFormat);
+            var json = render(project, vpd);
             vps.setJson(json);
             return json;
         }
@@ -243,48 +272,15 @@ public class DiamWebsocketController
         }
     }
 
-    // @MessageMapping(ANNOTATION_COMMAND_DELETE_TOPIC_TEMPLATE)
-    // public void onDeleteAnnotationRequest(Principal aPrincipal,
-    // @DestinationVariable(PARAM_PROJECT) long aProjectId,
-    // @DestinationVariable(PARAM_DOCUMENT) long aDocumentId,
-    // @DestinationVariable(PARAM_USER) String aUser, @Header("vid") String aVid)
-    // throws IOException
-    // {
-    // Project project = getProject(aProjectId);
-    //
-    // try (CasStorageSession session = CasStorageSession.open()) {
-    // MDC.put(KEY_REPOSITORY_PATH, repositoryProperties.getPath().toString());
-    // MDC.put(KEY_USERNAME, aPrincipal.getName());
-    //
-    // VID vid = VID.parse(aVid);
-    //
-    // SourceDocument doc = documentService.getSourceDocument(project.getId(), aDocumentId);
-    // CAS cas = documentService.readAnnotationCas(doc, aUser);
-    // AnnotationFS fs = selectAnnotationByAddr(cas, vid.getId());
-    // TypeAdapter adapter = schemaService.getAdapter(schemaService.findLayer(project, fs));
-    //
-    // // FIXME Does not delete/clear up related annotations (relations, slots, etc.)
-    // adapter.delete(doc, aUser, cas, vid);
-    //
-    // documentService.writeAnnotationCas(cas, doc, aUser, true);
-    // }
-    // finally {
-    // MDC.remove(KEY_REPOSITORY_PATH);
-    // MDC.remove(KEY_USERNAME);
-    // }
-    // }
-
-    private JsonNode render(Project aProject, long aDocumentId, String aDataOwner,
-            int aViewportBegin, int aViewportEnd, String aFormat)
-        throws IOException
+    private JsonNode render(Project aProject, ViewportDefinition aVpd) throws IOException
     {
-        var doc = documentService.getSourceDocument(aProject.getId(), aDocumentId);
+        var doc = documentService.getSourceDocument(aProject.getId(), aVpd.getDocumentId());
         var sessionOwner = userRepository.getCurrentUsername();
-        var dataOwner = userRepository.getUserOrCurationUser(aDataOwner);
+        var dataOwner = userRepository.getUserOrCurationUser(aVpd.getUser());
 
         var constraints = constraintsService.getMergedConstraints(aProject);
 
-        var cas = documentService.readAnnotationCas(doc, AnnotationSet.forUser(aDataOwner));
+        var cas = documentService.readAnnotationCas(doc, AnnotationSet.forUser(aVpd.getUser()));
 
         var prefs = userPreferencesService.loadPreferences(doc.getProject(), sessionOwner,
                 Mode.ANNOTATION);
@@ -300,20 +296,22 @@ public class DiamWebsocketController
                 .withSessionOwner(userRepository.getCurrentUser()) //
                 .withDocument(doc, dataOwner) //
                 .withConstraints(constraints) //
-                .withWindow(aViewportBegin, aViewportEnd) //
+                .withWindow(aVpd.getBegin(), aVpd.getEnd()) //
                 .withCas(cas) //
                 .withVisibleLayers(layers) //
                 .withAllLayers(allLayers) //
+                .withEnabledExtensions(aVpd.getEnabledExtensions()) //
                 .build();
 
         var vdoc = renderingPipeline.render(request);
 
-        if (FORMAT_LEGACY.equals(aFormat)) {
+        if (FORMAT_LEGACY.equals(aVpd.getFormat())) {
             return JSONUtil.getObjectMapper().valueToTree(new MViewportInit(vdoc));
         }
 
-        var serializer = vDocumentSerializerExtensionPoint.getExtension(aFormat).orElseThrow(
-                () -> new IllegalStateException("Unsupported format [" + aFormat + "]"));
+        var serializer = vDocumentSerializerExtensionPoint.getExtension(aVpd.getFormat())
+                .orElseThrow(() -> new IllegalStateException(
+                        "Unsupported format [" + aVpd.getFormat() + "]"));
 
         return JSONUtil.getObjectMapper().valueToTree(serializer.render(vdoc, request));
     }
@@ -325,44 +323,58 @@ public class DiamWebsocketController
 
     private void sendUpdate(AnnotationDocument aDoc)
     {
-        sendUpdate(aDoc.getDocument().getProject().getId(), aDoc.getDocument().getId(),
-                aDoc.getUser(), 0, MAX_VALUE);
+        sendUpdate(aDoc.getDocument(), aDoc.getAnnotationSet(), 0, MAX_VALUE);
     }
 
     void sendUpdate(AnnotationDocument aDoc, int aUpdateBegin, int aUpdateEnd)
     {
-        sendUpdate(aDoc.getDocument().getProject().getId(), aDoc.getDocument().getId(),
-                aDoc.getUser(), aUpdateBegin, aUpdateEnd);
+        sendUpdate(aDoc.getDocument(), aDoc.getAnnotationSet(), aUpdateBegin, aUpdateEnd);
     }
 
-    private void sendUpdate(long aProjectId, long aDocumentId, String aUser, int aUpdateBegin,
+    private void sendUpdate(SourceDocument aDoc, AnnotationSet aSet, int aUpdateBegin,
             int aUpdateEnd)
     {
         activeViewports.asMap().entrySet().stream() //
-                .filter(e -> e.getKey().matches(aDocumentId, aUser, aUpdateBegin, aUpdateEnd)) //
-                .forEach(e -> sendUpdate(e.getKey(), e.getValue(), aProjectId, aDocumentId, aUser,
-                        aUpdateBegin, aUpdateEnd));
+                .filter(e -> e.getKey().matches(aDoc.getId(), aSet, aUpdateBegin, aUpdateEnd)) //
+                .forEach(e -> sendUpdate(e.getKey(), e.getValue(), aDoc, aUpdateBegin, aUpdateEnd));
     }
 
-    private void sendUpdate(ViewportDefinition vpd, ViewportState vps, long aProjectId,
-            long aDocumentId, String aUser, int aUpdateBegin, int aUpdateEnd)
+    private void sendUpdate(ViewportDefinition vpd, ViewportState vps, SourceDocument aDoc,
+            int aUpdateBegin, int aUpdateEnd)
     {
+        if (vps.getJson() == null) {
+            LOG.trace("Not sending update for document {} - viewport not initialized yet", aDoc);
+            return;
+        }
+
         // MDC.put(KEY_REPOSITORY_PATH, repositoryProperties.getPath().toString());
 
         try (var session = CasStorageSession.openNested()) {
             var project = projectService.getProject(vpd.getProjectId());
-            var newJson = render(project, vpd.getDocumentId(), vpd.getUser(), vpd.getBegin(),
-                    vpd.getEnd(), vpd.getFormat());
+            var newJson = render(project, vpd);
+
+            if (newJson.equals(vps.getJson())) {
+                LOG.trace("Not sending update for document {} - no changes", aDoc);
+                return;
+            }
+
+            LOG.trace("Sending update for document {} - {}", aDoc, vpd);
 
             var diff = Jackson3JsonDiff.asJson(vps.getJson(), newJson);
 
             vps.setJson(newJson);
 
+            var sha = SimpMessageHeaderAccessor.create(MESSAGE);
+            sha.setHeader(X_DIAM_FORMAT, vpd.getFormat());
+            sha.setHeader(X_DIAM_EXTENSIONS,
+                    toJsonString(vpd.getEnabledExtensions().stream().sorted().toList()));
+            sha.setLeaveMutable(true);
+
             msgTemplate.convertAndSend("/topic" + vpd.getTopic(),
-                    new MViewportUpdate(aUpdateBegin, aUpdateEnd, diff));
+                    new MViewportUpdate(aUpdateBegin, aUpdateEnd, diff), sha.getMessageHeaders());
         }
         catch (Exception ex) {
-            log.error("Unable to render update", ex);
+            LOG.error("Unable to render update", ex);
         }
 
         // finally {

--- a/inception/inception-diam/src/main/ts/src/diam/DiamWebsocketImpl.test.ts
+++ b/inception/inception-diam/src/main/ts/src/diam/DiamWebsocketImpl.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { makeHeaders, buildSelectorHeader } from './DiamWebsocketImpl';
+
+describe('makeHeaders', () => {
+    it('includes empty array values as JSON string "[]"', () => {
+        const selectorMap = { 'X-DIAM-EXTENSIONS': [] as string[] };
+        const headers = makeHeaders(selectorMap);
+        expect(headers).toHaveProperty('X-DIAM-EXTENSIONS', '[]');
+    });
+
+    it('includes non-empty array as JSON string', () => {
+        const selectorMap = { 'X-DIAM-EXTENSIONS': ['spell', 'cur'] };
+        const headers = makeHeaders(selectorMap);
+        expect(headers['X-DIAM-EXTENSIONS']).toBe(JSON.stringify(['cur', 'spell']));
+    });
+});
+
+describe('buildSelectorHeader', () => {
+    it('returns equality selector for empty arrays', () => {
+        const selectorMap = { 'X-DIAM-EXTENSIONS': [] as string[] };
+        const selector = buildSelectorHeader(selectorMap);
+        expect(selector).toBe("headers['X-DIAM-EXTENSIONS'] == '[]'");
+    });
+
+    it('returns equality selector for non-empty arrays (sorted)', () => {
+        const selectorMap = { 'X-DIAM-EXTENSIONS': ['b', 'a'] };
+        const selector = buildSelectorHeader(selectorMap);
+        expect(selector).toBe("headers['X-DIAM-EXTENSIONS'] == '[\"a\",\"b\"]'");
+    });
+
+    it('returns undefined for empty map', () => {
+        const selector = buildSelectorHeader({});
+        expect(selector).toBeUndefined();
+    });
+
+    it('builds combined selector for format and extensions', () => {
+        const selector = buildSelectorHeader({ 'X-DIAM-FORMAT': 'compact', 'X-DIAM-EXTENSIONS': [] });
+        expect(selector).toBe("headers['X-DIAM-FORMAT'] == 'compact' and headers['X-DIAM-EXTENSIONS'] == '[]'");
+    });
+});

--- a/inception/inception-diam/src/main/ts/src/diam/DiamWebsocketImpl.ts
+++ b/inception/inception-diam/src/main/ts/src/diam/DiamWebsocketImpl.ts
@@ -15,8 +15,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Client, Stomp, StompSubscription, IFrame, frameCallbackType } from '@stomp/stompjs';
-import { DiamWebsocket, DiamWebsocketConnectOptions } from '@inception-project/inception-js-api';
+import { Client, Stomp, type StompSubscription, type IFrame, type frameCallbackType, type IMessage } from '@stomp/stompjs';
+import { type DiamWebsocket, type DiamWebsocketConnectOptions, type DiamWebsocketSubscribeOptions } from '@inception-project/inception-js-api';
 import * as jsonpatch from 'fast-json-patch';
 
 /**
@@ -25,19 +25,17 @@ import * as jsonpatch from 'fast-json-patch';
 export declare type dataCallback = (data: any) => void;
 
 export class DiamWebsocketImpl implements DiamWebsocket {
-    private stompClient: Client;
-    private webSocket: WebSocket;
-    private initSubscription: StompSubscription;
-    private updateSubscription: StompSubscription;
-    private diff: any;
+    private stompClient?: Client;
+    private initSubscription!: StompSubscription;
+    private updateSubscription!: StompSubscription;
 
     private data: any;
 
-    public onConnect: frameCallbackType;
+    public onConnect!: frameCallbackType;
 
     connect(options: string | DiamWebsocketConnectOptions) {
         if (this.stompClient) {
-            console.log('Already connected');
+            console.debug('Already connected');
             return;
         }
 
@@ -60,6 +58,7 @@ export class DiamWebsocketImpl implements DiamWebsocket {
         }
 
         this.stompClient.onConnect = (frame) => {
+            if (!this.stompClient) return
             this.stompClient.subscribe('/user/queue/errors', this.handleProtocolError);
             if (this.onConnect) {
                 this.onConnect(frame);
@@ -72,8 +71,11 @@ export class DiamWebsocketImpl implements DiamWebsocket {
     }
 
     disconnect() {
-        this.stompClient.deactivate();
-        this.stompClient.webSocket?.close();
+        if (this.stompClient) {
+            this.stompClient.deactivate();
+            this.stompClient.webSocket?.close();
+            this.stompClient = undefined;
+        }
     }
 
     private handleBrokerError(receipt: IFrame) {
@@ -81,23 +83,54 @@ export class DiamWebsocketImpl implements DiamWebsocket {
         console.log('Additional details: ' + receipt.body);
     }
 
-    private handleProtocolError(msg) {
+    private handleProtocolError(msg: IMessage) {
         console.log(msg);
     }
 
-    subscribeToViewport(aViewportTopic: string, callback: dataCallback) {
+    subscribeToViewport(aViewportTopic: string, callback: dataCallback, options?: DiamWebsocketSubscribeOptions) {
+        if (!this.stompClient) return
+
+        let selectorMap: Record<string, string|string[]> = {
+            'X-DIAM-FORMAT': 'compact_v2',
+            'X-DIAM-EXTENSIONS': []
+        };
+
+        if (options) {
+            if (options.enableExtensions) {
+                // Validate that extensions is an array of allowed names (lowercase letters and hyphens)
+                if (!Array.isArray(options.enableExtensions)) {
+                    throw new Error('options.enableExtensions must be an array of extension names');
+                }
+                for (const e of options.enableExtensions) {
+                    if (typeof e !== 'string' || !/^[a-z-]+$/.test(e)) {
+                        throw new Error(`Invalid extension name: ${e}. Must match /^[a-z-]+$/`);
+                    }
+                }
+                selectorMap['X-DIAM-EXTENSIONS'] = options.enableExtensions || [];
+            }
+            if (options.format) {
+                selectorMap['X-DIAM-FORMAT'] = options.format;
+            }
+        }
+
+        let headers = makeHeaders(selectorMap);
+        let selector = buildSelectorHeader(selectorMap);
+        if (selector) {
+            headers['selector'] = selector;
+        }
+
         this.unsubscribeFromViewport();
+
         this.initSubscription = this.stompClient.subscribe('/app' + aViewportTopic, (msg) => {
             this.data = JSON.parse(msg.body);
-            this.diff = null;
             callback(this.data);
-        });
+        }, headers);
+
         this.updateSubscription = this.stompClient.subscribe('/topic' + aViewportTopic, (msg) => {
             const update = JSON.parse(msg.body);
             this.data = jsonpatch.applyPatch(this.data, update.diff).newDocument;
-            this.diff = update.diff;
             callback(this.data);
-        });
+        }, headers);
     }
 
     unsubscribeFromViewport() {
@@ -108,4 +141,53 @@ export class DiamWebsocketImpl implements DiamWebsocket {
             this.updateSubscription.unsubscribe();
         }
     }
+}
+
+export function makeHeaders(selectorMap: Record<string, string | string[]>): Record<string, string> {
+    let headers: Record<string, string> = {}
+    for (const [key, value] of Object.entries(selectorMap)) {
+        if (value === null || value === undefined || value === '') {
+            continue;
+        }
+
+        if (Array.isArray(value)) {
+            // Arrays: Sort and deduplicate then perform equality check against
+            // the canonical JSON representation
+            const sortedValues = Array.from(new Set([...value].map(String).sort()));
+            headers[key] = JSON.stringify(sortedValues);
+        } else {
+            headers[key] = value;
+        }
+    }
+    return headers;
+}
+
+/**
+ * Converts a map of header requirements into a Spring SpEL selector string.
+ * @param selectorMap - A dictionary where keys are header names and values are 
+ * either a single string (exact match) or an array of strings (all must match).
+ * @returns The formatted SpEL selector string, or undefined if no valid selectors were provided.
+ */
+export function buildSelectorHeader(selectorMap: Record<string, string | string[]>): string | undefined {
+    const selectorConditions: string[] = [];
+
+    for (const [key, value] of Object.entries(selectorMap)) {
+        // Skip null, undefined, or empty strings
+        if (value === null || value === undefined || value === '') {
+            continue; 
+        }
+
+        if (Array.isArray(value)) {
+            // Arrays: Sort and deduplicate then perform equality check against
+            // the canonical JSON representation
+            const sortedValues = Array.from(new Set([...value].map(String).sort()));
+            selectorConditions.push(`headers['${key}'] == '${JSON.stringify(sortedValues)}'`);
+        } else {
+            // Strings: Enforce an exact match
+            selectorConditions.push(`headers['${key}'] == '${value}'`);
+        }
+    }
+
+    // Join all conditions with 'and', or return undefined if empty
+    return selectorConditions.length > 0 ? selectorConditions.join(' and ') : undefined;
 }

--- a/inception/inception-diam/src/test/java/de/tudarmstadt/ukp/inception/diam/service/DiamWebsocketController_ViewportRoutingTest.java
+++ b/inception/inception-diam/src/test/java/de/tudarmstadt/ukp/inception/diam/service/DiamWebsocketController_ViewportRoutingTest.java
@@ -20,17 +20,23 @@ package de.tudarmstadt.ukp.inception.diam.service;
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.ANNOTATOR;
 import static de.tudarmstadt.ukp.clarin.webanno.security.model.Role.ROLE_USER;
 import static de.tudarmstadt.ukp.inception.diam.service.DiamWebsocketController.FORMAT_LEGACY;
+import static de.tudarmstadt.ukp.inception.diam.service.DiamWebsocketController.X_DIAM_FORMAT;
+import static de.tudarmstadt.ukp.inception.support.json.JSONUtil.fromJsonString;
 import static de.tudarmstadt.ukp.inception.websocket.config.WebsocketConfig.WS_ENDPOINT;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.emptyMap;
 import static org.apache.commons.io.IOUtils.toInputStream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.springframework.messaging.simp.SimpMessageHeaderAccessor.DESTINATION_HEADER;
+import static org.springframework.messaging.simp.SimpMessageHeaderAccessor.SUBSCRIPTION_ID_HEADER;
 import static org.springframework.security.config.Customizer.withDefaults;
 import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
 
 import java.io.File;
 import java.lang.invoke.MethodHandles;
+import java.util.Map;
+import java.util.function.BiConsumer;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -101,7 +107,6 @@ import de.tudarmstadt.ukp.inception.websocket.config.WebsocketAutoConfiguration;
 import de.tudarmstadt.ukp.inception.websocket.config.WebsocketSecurityConfig;
 import de.tudarmstadt.ukp.inception.workload.config.WorkloadManagementAutoConfiguration;
 import jakarta.persistence.EntityManager;
-import tools.jackson.databind.node.JsonNodeFactory;
 
 @SpringBootTest( //
         webEnvironment = RANDOM_PORT, //
@@ -152,11 +157,13 @@ public class DiamWebsocketController_ViewportRoutingTest
     private @Autowired RepositoryProperties repositoryProperties;
     private @Autowired EntityManager entityManager;
     private @Autowired UserDao userService;
+    private @Autowired TestPreRenderer testPreRenderer;
 
     private static @TempDir File repositoryDir;
 
     private static User user;
     private static Project testProject;
+    private static AnnotationLayer testLayer;
     private static SourceDocument testDoc;
     private static AnnotationDocument testAnnotationDocument;
 
@@ -185,6 +192,10 @@ public class DiamWebsocketController_ViewportRoutingTest
         projectService.createProject(testProject);
         projectService.assignRole(testProject, user, ANNOTATOR);
 
+        testLayer = new AnnotationLayer();
+        testLayer.setProject(testProject);
+        testLayer.setId(1L);
+
         testDoc = new SourceDocument("testDoc", testProject, "text");
         documentService.createSourceDocument(testDoc);
 
@@ -208,38 +219,147 @@ public class DiamWebsocketController_ViewportRoutingTest
     @Test
     public void thatViewportBasedMessageRoutingWorks() throws Exception
     {
-        var emptyListNode = JsonNodeFactory.instance.arrayNode();
+        var vpd1 = ViewportDefinition.builder() //
+                .withDocument(testAnnotationDocument) //
+                .withRange(10, 20) //
+                .withFormat(FORMAT_LEGACY) //
+                .build();
+        var vpd2 = ViewportDefinition.builder() //
+                .withDocument(testAnnotationDocument) //
+                .withRange(30, 40) //
+                .withFormat(FORMAT_LEGACY) //
+                .build();
 
-        var vpd1 = new ViewportDefinition(testAnnotationDocument, 10, 20, FORMAT_LEGACY);
-        var vpd2 = new ViewportDefinition(testAnnotationDocument, 30, 40, FORMAT_LEGACY);
+        testPreRenderer.setRenderFunc((aResponse, aRequest) -> {
+            aResponse.add(new VSpan(testLayer, new VID(1),
+                    new VRange(aRequest.getWindowBeginOffset(), aRequest.getWindowEndOffset()),
+                    emptyMap()));
+        });
 
         try (var client1 = new WebSocketStompTestClient(USER, PASS);
                 var client2 = new WebSocketStompTestClient(USER, PASS)) {
-            client1.expectSuccessfulConnection().connect(websocketUrl);
-            client1.subscribe("/topic" + vpd1.getTopic());
-            client1.expect(MViewportInit.class, msg -> {
+            var connection1 = client1.expectSuccessfulConnection().connect(websocketUrl);
+            var queueSub1 = client1.subscribe("/topic" + vpd1.getTopic(), Map.of( //
+                    X_DIAM_FORMAT, vpd1.getFormat(), //
+                    "selector", "headers['" + X_DIAM_FORMAT + "']=='" + vpd1.getFormat() + "'"));
+            client1.expectWithHeaders(MViewportInit.class, (message, msg) -> {
                 assertThat(msg.getText()).contains("test. This");
+                assertThat(message.getHeaders().get(DESTINATION_HEADER))
+                        .isEqualTo("/app" + vpd1.getTopic());
             });
-            client1.subscribe("/app" + vpd1.getTopic());
+            var appSub1 = client1.subscribe("/app" + vpd1.getTopic(), Map.of( //
+                    X_DIAM_FORMAT, vpd1.getFormat(), //
+                    "selector", "headers['" + X_DIAM_FORMAT + "']=='" + vpd1.getFormat() + "'"));
 
-            client2.expectSuccessfulConnection().connect(websocketUrl);
-            client2.subscribe("/topic" + vpd2.getTopic());
-            client2.expect(MViewportInit.class, msg -> {
+            var connection2 = client2.expectSuccessfulConnection().connect(websocketUrl);
+            var queueSub2 = client2.subscribe("/topic" + vpd2.getTopic(), Map.of( //
+                    X_DIAM_FORMAT, vpd2.getFormat(), //
+                    "selector", "headers['" + X_DIAM_FORMAT + "']=='" + vpd2.getFormat() + "'"));
+            client2.expectWithHeaders(MViewportInit.class, (message, msg) -> {
                 assertThat(msg.getText()).contains(". This is ");
+                assertThat(message.getHeaders().get(DESTINATION_HEADER))
+                        .isEqualTo("/app" + vpd2.getTopic());
             });
-            client2.subscribe("/app" + vpd2.getTopic());
+            var appSub2 = client2.subscribe("/app" + vpd2.getTopic(), Map.of( //
+                    X_DIAM_FORMAT, vpd2.getFormat(), //
+                    "selector", "headers['" + X_DIAM_FORMAT + "']=='" + vpd2.getFormat() + "'"));
 
-            client1.expect(new MViewportUpdate(12, 15, emptyListNode))
-                    .expect(new MViewportUpdate(15, 35, emptyListNode));
-            client2.expect(new MViewportUpdate(31, 33, emptyListNode))
-                    .expect(new MViewportUpdate(15, 35, emptyListNode));
+            assertThat(connection1.getSessionId()).isNotEqualTo(connection2.getSessionId());
 
+            // Verify that the queue and app subscriptions have distinct ids
+            assertThat(queueSub1.getSubscriptionId()).isNotNull();
+            assertThat(appSub1.getSubscriptionId()).isNotNull();
+            assertThat(queueSub1.getSubscriptionId()).isNotEqualTo(appSub1.getSubscriptionId());
+
+            assertThat(queueSub2.getSubscriptionId()).isNotNull();
+            assertThat(appSub2.getSubscriptionId()).isNotNull();
+            assertThat(queueSub2.getSubscriptionId()).isNotEqualTo(appSub2.getSubscriptionId());
+
+            var expected1 = new MViewportUpdate(12, 15, fromJsonString(
+                    "[{\"op\":\"replace\",\"path\":\"/spans/0/vid\",\"value\":\"2\"}]"));
+            var expected2 = new MViewportUpdate(15, 35, fromJsonString(
+                    "[{\"op\":\"replace\",\"path\":\"/spans/0/vid\",\"value\":\"4\"}]"));
+            client1.expectWithHeaders(MViewportUpdate.class, (message, update) -> {
+                assertThat(update).isEqualTo(expected1);
+                assertThat(message.getHeaders().get(DESTINATION_HEADER))
+                        .isEqualTo("/topic" + vpd1.getTopic());
+                assertThat(message.getHeaders().get(SUBSCRIPTION_ID_HEADER))
+                        .isEqualTo(queueSub1.getSubscriptionId());
+            }).expectWithHeaders(MViewportUpdate.class, (message, update) -> {
+                assertThat(update).isEqualTo(expected2);
+                assertThat(message.getHeaders().get(DESTINATION_HEADER))
+                        .isEqualTo("/topic" + vpd1.getTopic());
+                assertThat(message.getHeaders().get(SUBSCRIPTION_ID_HEADER))
+                        .isEqualTo(queueSub1.getSubscriptionId());
+            });
+
+            var expected3 = new MViewportUpdate(31, 33, fromJsonString(
+                    "[{\"op\":\"replace\",\"path\":\"/spans/0/vid\",\"value\":\"3\"}]"));
+            var expected4 = new MViewportUpdate(15, 35, fromJsonString(
+                    "[{\"op\":\"replace\",\"path\":\"/spans/0/vid\",\"value\":\"4\"}]"));
+            client2.expectWithHeaders(MViewportUpdate.class, (message, update) -> {
+                assertThat(update).isEqualTo(expected3);
+                assertThat(message.getHeaders().get(DESTINATION_HEADER))
+                        .isEqualTo("/topic" + vpd2.getTopic());
+                assertThat(message.getHeaders().get(SUBSCRIPTION_ID_HEADER))
+                        .isEqualTo(queueSub2.getSubscriptionId());
+            }).expectWithHeaders(MViewportUpdate.class, (message, update) -> {
+                assertThat(update).isEqualTo(expected4);
+                assertThat(message.getHeaders().get(DESTINATION_HEADER))
+                        .isEqualTo("/topic" + vpd2.getTopic());
+                assertThat(message.getHeaders().get(SUBSCRIPTION_ID_HEADER))
+                        .isEqualTo(queueSub2.getSubscriptionId());
+            });
+
+            testPreRenderer.setRenderFunc((aResponse, aRequest) -> {
+                aResponse.add(new VSpan(testLayer, new VID(2),
+                        new VRange(aRequest.getWindowBeginOffset(), aRequest.getWindowEndOffset()),
+                        emptyMap()));
+            });
             sut.sendUpdate(testAnnotationDocument, 12, 15);
+
+            testPreRenderer.setRenderFunc((aResponse, aRequest) -> {
+                aResponse.add(new VSpan(testLayer, new VID(3),
+                        new VRange(aRequest.getWindowBeginOffset(), aRequest.getWindowEndOffset()),
+                        emptyMap()));
+            });
             sut.sendUpdate(testAnnotationDocument, 31, 33);
+
+            testPreRenderer.setRenderFunc((aResponse, aRequest) -> {
+                aResponse.add(new VSpan(testLayer, new VID(4),
+                        new VRange(aRequest.getWindowBeginOffset(), aRequest.getWindowEndOffset()),
+                        emptyMap()));
+            });
             sut.sendUpdate(testAnnotationDocument, 15, 35);
 
             client1.assertExpectations();
             client2.assertExpectations();
+        }
+    }
+
+    static private class TestPreRenderer
+        implements PreRenderer
+    {
+        private BiConsumer<VDocument, RenderRequest> renderFunc;
+
+        @Override
+        public String getId()
+        {
+            return "TestPreRenderer";
+        }
+
+        @Override
+        public void render(VDocument aResponse, RenderRequest aRequest)
+        {
+            if (renderFunc == null) {
+                throw new IllegalStateException("renderFunc not set");
+            }
+            renderFunc.accept(aResponse, aRequest);
+        }
+
+        public void setRenderFunc(BiConsumer<VDocument, RenderRequest> aRenderFunc)
+        {
+            renderFunc = aRenderFunc;
         }
     }
 
@@ -293,26 +413,9 @@ public class DiamWebsocketController_ViewportRoutingTest
 
         @Primary
         @Bean
-        public PreRenderer testPreRenderer()
+        public TestPreRenderer testPreRenderer()
         {
-            return new PreRenderer()
-            {
-                @Override
-                public String getId()
-                {
-                    return "TestPreRenderer";
-                }
-
-                @Override
-                public void render(VDocument aResponse, RenderRequest aRequest)
-                {
-                    var layer = new AnnotationLayer();
-                    layer.setId(1l);
-                    aResponse.add(
-                            new VSpan(layer, new VID(1), new VRange(aRequest.getWindowBeginOffset(),
-                                    aRequest.getWindowEndOffset()), emptyMap()));
-                }
-            };
+            return new TestPreRenderer();
         }
     }
 }

--- a/inception/inception-diam/src/test/resources/log4j2-test.xml
+++ b/inception/inception-diam/src/test/resources/log4j2-test.xml
@@ -7,19 +7,17 @@
   </Appenders>
 
   <Loggers>
+<!--     <Logger name="de.tudarmstadt.ukp.inception.support.test.websocket" level="TRACE" /> -->
 <!--     <Logger name="de.tudarmstadt.ukp.inception.diam" level="TRACE"/> -->
 <!--     <Logger name="org.springframework.messaging" level="TRACE"/>  -->
+<!--     <Logger name="org.springframework.web.socket" level="TRACE"/> -->
 <!--     <Logger name="org.springframework.web.socket.messaging" level="TRACE"/>  -->
 <!--     If there are exceptions during authorization, increase the StompSubProtocolHandler log level! -->
 <!--     <Logger name="org.springframework.web.socket.messaging.StompSubProtocolHandler" level="DEBUG"/> -->
-<!--     <Logger name="de.tudarmstadt.ukp.clarin.webanno.security.ExtensiblePermissionEvaluator" level="TRACE"/> -->
 <!--     <Logger name="org.springframework.security" level="TRACE" /> -->
 <!--     <Logger name="org.springframework.security.authorization" level="TRACE" /> -->
-<!--     <Logger name="de.tudarmstadt.ukp.inception.support.test.websocket" level="TRACE" /> -->
-<!--     <Logger name="de.tudarmstadt.ukp.inception.support.test.websocket" level="TRACE"/> -->
-<!--     <Logger name="org.springframework.web.socket" level="TRACE"/> -->
 <!--     <Logger name="org.springframework.security.messaging" level="TRACE"/> -->
-<!--     <Logger name="org.springframework.messaging" level="TRACE"/> -->
+<!--     <Logger name="de.tudarmstadt.ukp.clarin.webanno.security.ExtensiblePermissionEvaluator" level="TRACE"/> -->
 
     <Root level="WARN">
       <AppenderRef ref="ConsoleAppender" />

--- a/inception/inception-imls-ollama/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/ollama/client/OllamaClientImpl.java
+++ b/inception/inception-imls-ollama/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/ollama/client/OllamaClientImpl.java
@@ -192,7 +192,7 @@ public class OllamaClientImpl
             var theIs = is;
             if (LOG.isTraceEnabled() && aRequest.isStream() == false) {
                 var responseBytes = is.readAllBytes();
-                LOG.trace("Recieved chat response: {}", new String(responseBytes, UTF_8));
+                LOG.trace("Received chat response: {}", new String(responseBytes, UTF_8));
                 theIs = new ByteArrayInputStream(responseBytes);
             }
 

--- a/inception/inception-js-api/src/main/ts/src/diam/DiamWebsocket.ts
+++ b/inception/inception-js-api/src/main/ts/src/diam/DiamWebsocket.ts
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { frameCallbackType } from '@stomp/stompjs';
+import { type frameCallbackType } from '@stomp/stompjs';
 
 /**
  * This callback will accept the annotation data.
@@ -27,6 +27,14 @@ export interface DiamWebsocketConnectOptions {
     csrfToken: string;
 }
 
+export interface DiamWebsocketSubscribeOptions {
+    /**
+     * List of additional extensions that should be enabled for this subscription.
+     */
+    enableExtensions?: string[];
+    format?: string;
+}
+
 export interface DiamWebsocket {
     connect(options: string | DiamWebsocketConnectOptions): void;
 
@@ -34,7 +42,7 @@ export interface DiamWebsocket {
 
     disconnect(): void;
 
-    subscribeToViewport(viewportTopic: string, callback: dataCallback): void;
+    subscribeToViewport(viewportTopic: string, callback: dataCallback, options?: DiamWebsocketSubscribeOptions): void;
 
     unsubscribeFromViewport(): void;
 }

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/json/JSONUtil.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/json/JSONUtil.java
@@ -135,6 +135,15 @@ public class JSONUtil
         return aMapper.writeValueAsString(aObject);
     }
 
+    public static JsonNode fromJsonString(String aJSON) throws IOException
+    {
+        if (aJSON == null) {
+            return null;
+        }
+
+        return getObjectMapper().readTree(aJSON);
+    }
+
     public static <T> T fromJsonString(Class<T> aClass, String aJSON) throws IOException
     {
         if (aJSON == null) {
@@ -142,6 +151,20 @@ public class JSONUtil
         }
 
         return getObjectMapper().readValue(aJSON, aClass);
+    }
+
+    public static <T> T fromJsonString(Class<T> aClass, String aJSON, T aDefaultValue)
+    {
+        if (aJSON == null) {
+            return aDefaultValue;
+        }
+
+        try {
+            return getObjectMapper().readValue(aJSON, aClass);
+        }
+        catch (Exception e) {
+            return aDefaultValue;
+        }
     }
 
     public static <T> T fromValidatedJsonString(Class<T> aClass, String aJSON, Schema aSchema)

--- a/inception/inception-telemetry/src/test/java/de/tudarmstadt/ukp/clarin/webanno/telemetry/matomo/MatomoTelemetrySupportImplTest.java
+++ b/inception/inception-telemetry/src/test/java/de/tudarmstadt/ukp/clarin/webanno/telemetry/matomo/MatomoTelemetrySupportImplTest.java
@@ -105,7 +105,7 @@ class MatomoTelemetrySupportImplTest
     }
 
     @Test
-    void thatAliveIsRecieved() throws Exception
+    void thatAliveIsReceived() throws Exception
     {
         assertThat(sut.isEnabled()).isTrue();
 
@@ -135,7 +135,7 @@ class MatomoTelemetrySupportImplTest
     }
 
     @Test
-    void thatPingIsRecieved() throws Exception
+    void thatPingIsReceived() throws Exception
     {
         assertThat(sut.isEnabled()).isTrue();
 

--- a/inception/inception-testing/src/main/java/de/tudarmstadt/ukp/inception/support/test/websocket/WebSocketSessionTestHandler.java
+++ b/inception/inception-testing/src/main/java/de/tudarmstadt/ukp/inception/support/test/websocket/WebSocketSessionTestHandler.java
@@ -44,7 +44,7 @@ public class WebSocketSessionTestHandler
 {
     private static final Logger LOG = getLogger(lookup().lookupClass());
 
-    private final AtomicBoolean errorRecieved = new AtomicBoolean(false);
+    private final AtomicBoolean errorReceived = new AtomicBoolean(false);
 
     private final FailableRunnable<Throwable> afterConnectedAction;
     private final String destination;
@@ -85,7 +85,7 @@ public class WebSocketSessionTestHandler
     {
         LOG.error("Error: {}", aHeaders.get("message"));
         errorMsg = aHeaders.getFirst("message");
-        errorRecieved.set(true);
+        errorReceived.set(true);
     }
 
     @Override
@@ -94,7 +94,7 @@ public class WebSocketSessionTestHandler
     {
         LOG.error("Exception: {}", aException.getMessage(), aException);
         errorMsg = aException.getMessage();
-        errorRecieved.set(true);
+        errorReceived.set(true);
     }
 
     @Override
@@ -102,19 +102,19 @@ public class WebSocketSessionTestHandler
     {
         LOG.error("Transport error: {}", aException.getMessage());
         // errorMsg = aException.getMessage();
-        // errorRecieved.set(true);
-        // responseRecievedLatch.countDown();
+        // errorReceived.set(true);
+        // responseReceivedLatch.countDown();
     }
 
     public boolean messagesProcessed()
     {
-        return expectedMessages.isEmpty() || errorRecieved.get();
+        return expectedMessages.isEmpty() || errorReceived.get();
     }
 
     public void assertSuccess()
     {
         assertThat(errorMsg).isNull();
-        assertThat(errorRecieved).isFalse();
+        assertThat(errorReceived).isFalse();
     }
 
     public static Builder builder()
@@ -124,7 +124,7 @@ public class WebSocketSessionTestHandler
 
     public void assertError(Consumer<String> aErrorConsumer)
     {
-        assertThat(errorRecieved).as("error was detected").isTrue();
+        assertThat(errorReceived).as("error was detected").isTrue();
         aErrorConsumer.accept(errorMsg);
     }
 
@@ -145,7 +145,7 @@ public class WebSocketSessionTestHandler
         public void handleFrame(StompHeaders aHeaders, Object aPayload)
         {
             if (expectedMessages.isEmpty()) {
-                Assertions.fail("Recieved unexpected message: {}", aPayload);
+                Assertions.fail("Received unexpected message: {}", aPayload);
             }
 
             expectedMessages.peek().handler.accept(aHeaders, aPayload);

--- a/inception/inception-testing/src/main/java/de/tudarmstadt/ukp/inception/support/test/websocket/WebSocketStompTestClient.java
+++ b/inception/inception-testing/src/main/java/de/tudarmstadt/ukp/inception/support/test/websocket/WebSocketStompTestClient.java
@@ -39,6 +39,7 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
+import java.util.function.BiConsumer;
 
 import org.apache.commons.lang3.function.FailableConsumer;
 import org.apache.commons.lang3.function.FailableRunnable;
@@ -81,7 +82,7 @@ public class WebSocketStompTestClient
     private CapturingSessionHandler sessionHandler;
     private StompSession session;
 
-    private Queue<Object> recieved;
+    private Queue<Object> received;
     private Queue<Expectation<?>> expectations;
 
     public WebSocketStompTestClient(String aUsername, String aPassword)
@@ -89,7 +90,7 @@ public class WebSocketStompTestClient
         username = aUsername;
         password = aPassword;
 
-        recieved = new ConcurrentLinkedQueue<>();
+        received = new ConcurrentLinkedQueue<>();
         expectations = new ConcurrentLinkedDeque<>();
         messageConverter = new JacksonJsonMessageConverter(JsonMapper.builder() //
                 .disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES) //
@@ -110,14 +111,14 @@ public class WebSocketStompTestClient
         assertThat(expectations).as("expectations").isNotEmpty();
         assertThat(session).as("already connected").isNull();
 
-        sessionHandler = new CapturingSessionHandler(recieved);
+        sessionHandler = new CapturingSessionHandler(received);
         session = stompClient //
                 .connectAsync(aUrl, getHeaders(), sessionHandler) //
                 .get(connectTimeout.getSeconds(), SECONDS);
 
-        await("all expected responses recieved") //
+        await("all expected responses received") //
                 .atMost(connectTimeout) //
-                .until(() -> recieved.size() >= expectations.size());
+                .until(() -> received.size() >= expectations.size());
 
         await("extra time") //
                 .pollDelay(Duration.ofSeconds(1)) //
@@ -178,6 +179,23 @@ public class WebSocketStompTestClient
         return this;
     }
 
+    public <T> WebSocketStompTestClient expectWithHeaders(Class<T> aClass,
+            BiConsumer<Message<?>, T> aMatcher)
+    {
+        expectations.add(new Expectation<>(Message.class, false, msg -> {
+            try {
+                @SuppressWarnings("unchecked")
+                var obj = (T) messageConverter.fromMessage(msg, aClass);
+                aMatcher.accept((Message<?>) msg, obj);
+            }
+            catch (MessageConversionException e) {
+                fail("Unable to convert message: " + msg + " with payload "
+                        + new String((byte[]) msg.getPayload(), UTF_8), e);
+            }
+        }));
+        return this;
+    }
+
     /**
      * Subscribes to a topic. Requires expected messages to be queued before.
      * 
@@ -187,8 +205,29 @@ public class WebSocketStompTestClient
      */
     public Subscription subscribe(String aTopic)
     {
-        var handler = new CapturingFrameHandler<>(Message.class, recieved);
-        var sub = session.subscribe(aTopic, handler);
+        return subscribe(aTopic, null);
+    }
+
+    /**
+     * Subscribes to a topic. Requires expected messages to be queued before.
+     * 
+     * @param aTopic
+     *            topic to subscribe to
+     * @param aHeaders
+     *            extra headers
+     * @return subscription.
+     */
+    public Subscription subscribe(String aTopic, Map<String, String> aHeaders)
+    {
+        var headers = new StompHeaders();
+        headers.setDestination(aTopic);
+
+        if (aHeaders != null) {
+            headers.setAll(aHeaders);
+        }
+
+        var handler = new CapturingFrameHandler<>(Message.class, received);
+        var sub = session.subscribe(headers, handler);
 
         waitForMessages();
 
@@ -222,9 +261,9 @@ public class WebSocketStompTestClient
 
     private void waitForMessages()
     {
-        await("all expected messages recieved") //
+        await("all expected messages received") //
                 .atMost(messageTimeout) //
-                .until(() -> recieved.size() >= expectations.size());
+                .until(() -> received.size() >= expectations.size());
 
         await("extra time") //
                 .pollDelay(Duration.ofSeconds(1)) //
@@ -233,11 +272,11 @@ public class WebSocketStompTestClient
 
     private void handleExpectations()
     {
-        var r = new LinkedList<>(recieved);
+        var r = new LinkedList<>(received);
         var e = new LinkedList<>(expectations);
 
         expectations.clear();
-        recieved.clear();
+        received.clear();
 
         var consuming = false;
         while (!r.isEmpty() && !e.isEmpty()) {
@@ -252,7 +291,7 @@ public class WebSocketStompTestClient
 
         if (!consuming) {
             LOG.trace("Remaining: {} messages  {} expectation", r.size(), e.size());
-            assertThat(r).as("remaining recieved messages").isEmpty();
+            assertThat(r).as("remaining received messages").isEmpty();
             assertThat(e).as("remaining expectations messages").isEmpty();
         }
         else {
@@ -326,40 +365,40 @@ public class WebSocketStompTestClient
     private static class CapturingSessionHandler
         extends StompSessionHandlerAdapter
     {
-        private final Queue<Object> recieved;
+        private final Queue<Object> received;
 
         CapturingSessionHandler(Queue<Object> aQueue)
         {
-            recieved = aQueue;
+            received = aQueue;
         }
 
         @Override
         public void afterConnected(StompSession aSession, StompHeaders aConnectedHeaders)
         {
-            LOG.trace("Recieved: connection: {}", aConnectedHeaders);
-            recieved.add(new ConnectionResponse(aConnectedHeaders, null));
+            LOG.trace("Received: connection: {}", aConnectedHeaders);
+            received.add(new ConnectionResponse(aConnectedHeaders, null));
         }
 
         @Override
         public void handleFrame(StompHeaders aHeaders, Object aPayload)
         {
-            LOG.trace("Recieved: frame: {}", aPayload);
-            recieved.add(new NoPayloadResponse(aHeaders, aPayload));
+            LOG.trace("Received: frame: {}", aPayload);
+            received.add(new NoPayloadResponse(aHeaders, aPayload));
         }
 
         @Override
         public void handleException(StompSession aSession, StompCommand aCommand,
                 StompHeaders aHeaders, byte[] aPayload, Throwable aException)
         {
-            LOG.trace("Recieved: exception", aException);
-            recieved.add(new ExceptionResponse(aSession, aCommand, aHeaders, aPayload, aException));
+            LOG.trace("Received: exception", aException);
+            received.add(new ExceptionResponse(aSession, aCommand, aHeaders, aPayload, aException));
         }
 
         @Override
         public void handleTransportError(StompSession aSession, Throwable aException)
         {
-            LOG.trace("Recieved: transport error", aException);
-            recieved.add(new TransportErrorResponse(aSession, aException));
+            LOG.trace("Received: transport error", aException);
+            received.add(new TransportErrorResponse(aSession, aException));
         }
     }
 
@@ -382,6 +421,7 @@ public class WebSocketStompTestClient
             return type;
         }
 
+        @SuppressWarnings("unchecked")
         public void accept(Object aObject)
         {
             try {
@@ -405,12 +445,12 @@ public class WebSocketStompTestClient
                 .getLogger(MethodHandles.lookup().lookupClass());
 
         private final Class<T> type;
-        private final Queue<Object> recieved;
+        private final Queue<Object> received;
 
         CapturingFrameHandler(Class<T> aType, Queue<Object> aQueue)
         {
             type = aType;
-            recieved = aQueue;
+            received = aQueue;
         }
 
         @Override
@@ -424,8 +464,8 @@ public class WebSocketStompTestClient
         public void handleFrame(StompHeaders aHeaders, Object aPayload)
         {
             if (type.isAssignableFrom(aPayload.getClass())) {
-                LOG.trace("Recieved: {}", aPayload);
-                recieved.add((T) aPayload);
+                LOG.trace("Received: {}", aPayload);
+                received.add((T) aPayload);
                 return;
             }
 

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/page/CurationPage.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/page/CurationPage.java
@@ -34,6 +34,7 @@ import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.AnnotationPageBase2;
 import de.tudarmstadt.ukp.inception.curation.api.CurationSessionService;
 import de.tudarmstadt.ukp.inception.curation.service.CurationDocumentService;
+import de.tudarmstadt.ukp.inception.ui.curation.sidebar.CurationEditorExtension;
 import de.tudarmstadt.ukp.inception.ui.curation.sidebar.CurationSidebarBehavior;
 import de.tudarmstadt.ukp.inception.workload.model.WorkloadManagementService;
 
@@ -56,6 +57,7 @@ public class CurationPage
 
         var sessionOwner = userRepository.getCurrentUsername();
         var state = getModelObject();
+        state.enableExtension(CurationEditorExtension.EXTENSION_ID);
 
         curationSessionService.startSession(sessionOwner, state.getProject(), false);
     }
@@ -73,11 +75,10 @@ public class CurationPage
     @Override
     public List<SourceDocument> getListOfDocs()
     {
-        var state = getModelObject();
         // Since the curatable documents depend on the document state, let's make sure the document
         // state is up-to-date
-        workloadManagementService.getWorkloadManagerExtension(state.getProject())
-                .freshenStatus(state.getProject());
-        return curationDocumentService.listCuratableSourceDocuments(state.getProject());
+        var project = getModelObject().getProject();
+        workloadManagementService.getWorkloadManagerExtension(project).freshenStatus(project);
+        return curationDocumentService.listCuratableSourceDocuments(project);
     }
 }

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/render/CurationSidebarRenderer.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/render/CurationSidebarRenderer.java
@@ -60,6 +60,7 @@ import de.tudarmstadt.ukp.inception.rendering.vmodel.VObject;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VSpan;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.api.layer.LayerSupportRegistry;
+import de.tudarmstadt.ukp.inception.ui.curation.sidebar.CurationEditorExtension;
 import de.tudarmstadt.ukp.inception.ui.curation.sidebar.CurationSidebarService;
 import de.tudarmstadt.ukp.inception.ui.curation.sidebar.config.CurationSidebarAutoConfiguration;
 
@@ -113,8 +114,11 @@ public class CurationSidebarRenderer
         var project = aRequest.getProject();
         var state = aRequest.getState();
 
-        // do not show predictions on the decicated curation page
         if (state != null && state.getMode() != ANNOTATION) {
+            return false;
+        }
+
+        if (!aRequest.getEnabledExtensions().contains(CurationEditorExtension.EXTENSION_ID)) {
             return false;
         }
 

--- a/inception/inception-websocket/pom.xml
+++ b/inception/inception-websocket/pom.xml
@@ -15,7 +15,9 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>de.tudarmstadt.ukp.inception.app</groupId>
@@ -82,10 +84,16 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot</artifactId>
     </dependency>
-    
+
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/inception/inception-websocket/src/main/java/de/tudarmstadt/ukp/inception/websocket/config/WebsocketConfig.java
+++ b/inception/inception-websocket/src/main/java/de/tudarmstadt/ukp/inception/websocket/config/WebsocketConfig.java
@@ -64,7 +64,7 @@ public class WebsocketConfig
         // broker will send to destinations with this prefix, queue is custom for user-specific
         // channels. client will subscribe to /queue/{subtopic} where subtopic is a specific topic
         // that controller or service will address messages to
-        aRegistry.enableSimpleBroker("/queue/", "/topic/");
+        aRegistry.enableSimpleBroker("/queue/", "/topic/").setSelectorHeaderName("selector");
         // clients should send messages to channels pre-fixed with this
         aRegistry.setApplicationDestinationPrefixes("/app/");
         aRegistry.setUserDestinationPrefix("/user/");

--- a/inception/inception-websocket/src/test/java/de/tudarmstadt/ukp/inception/websocket/StompSelectorTest.java
+++ b/inception/inception-websocket/src/test/java/de/tudarmstadt/ukp/inception/websocket/StompSelectorTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.websocket;
+
+import static org.apache.commons.lang3.reflect.MethodUtils.invokeMethod;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.simp.broker.DefaultSubscriptionRegistry;
+import org.springframework.messaging.support.GenericMessage;
+
+public class StompSelectorTest
+{
+    private DefaultSubscriptionRegistry sut;
+
+    @BeforeEach
+    void setup()
+    {
+        sut = new DefaultSubscriptionRegistry();
+    }
+
+    @Test
+    void test() throws Exception
+    {
+        var msg = new GenericMessage<>("", Map.of( //
+                "format", "compact", //
+                "extensions", "cur,other"));
+
+        assertThat(matches("headers['format'] == 'compact'", msg)).isTrue();
+        assertThat(matches("headers['format'] == 'legacy'", msg)).isFalse();
+        assertThat(matches("headers['extensions'] matches '.*\\bcur\\b.*'", msg)).isTrue();
+        assertThat(matches("headers['extensions'] matches '.*\\brec\\b.*'", msg)).isFalse();
+    }
+
+    private boolean matches(String aExpression, Message<String> aMessage)
+        throws NoSuchMethodException, IllegalAccessException, InvocationTargetException
+    {
+        var parser = new SpelExpressionParser();
+        var ex = parser.parseExpression(aExpression);
+        var result = (boolean) invokeMethod( //
+                sut, // The object instance
+                true, // forceAccess: MUST be true for private methods
+                "evaluateExpression", // The exact method name as a String
+                ex, // Parameter 1
+                aMessage // Parameter 2
+        );
+        return result;
+    }
+}


### PR DESCRIPTION
**What's in the PR**
- Add per-subscription extension support for DIAM rendering and websockets:
- Introduce `enabledExtensions` plumbing across backend and frontend (AnnotatorState, RenderRequest, ViewportDefinition builder, rendering pipeline).
- Parse `X-DIAM-EXTENSIONS` and `X-DIAM-FORMAT` headers in `DiamWebsocketController` and pass them into rendering.
- Switch websocket routing to use STOMP selectors
- Frontend API & client updates:
- Add `DiamWebsocketSubscribeOptions` to the JS API and accept `options` in `subscribeToViewport`.
- Send `X-DIAM-EXTENSIONS`/`X-DIAM-FORMAT` and `selector` from `DiamAnnotationBrowser.svelte` to `DiamWebsocketImpl`.
- Subscription management refactor:
- Replace Pair-based tracking with a `Subscription` record and a `subscriptions` set in `ViewportState`.
- Store username per subscription and publish updates individually using per-subscriber headers.
- Utility & config improvements:
- Add `JSONUtil.fromJsonString` helper for safe header parsing with defaults.
- Update `DiamAutoConfig` websocket destination matchers/security to `/app`, `/topic`
- Tests & callers:
- Update tests to use `ViewportDefinition.builder()` and adjust callers to the new API.
- Miscellaneous fixes:
- Typo fix in `Visualizer.ts` ("Recieved" -> "Received").
- Improve logging and debug messages, replace some `console.log` with `console.debug`.
- Enable curation UI extension guarding/initialization changes in curation pages and sidebar.

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
