### PR TITLE
#5954 - Cannot enter a concept by IRI when no KB exists in the project

### DIFF
--- a/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/service/ConceptLinkingServiceImpl.java
+++ b/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/service/ConceptLinkingServiceImpl.java
@@ -408,8 +408,7 @@ public class ConceptLinkingServiceImpl
         var iriMatches = new LinkedHashSet<KBHandle>();
         if (aKB.isReadOnly() && !suffixSearch) {
             // We do not want to cache all kinds of almost empty results while the user is typing,
-            // so
-            // we do not enter this branch if we are in suffixSearch mode.
+            // so we do not enter this branch if we are in suffixSearch mode.
             iriMatches.addAll(kbService.listHandlesCaching(aKB, iriMatchBuilder, true));
         }
         else {
@@ -569,6 +568,20 @@ public class ConceptLinkingServiceImpl
         }
         else {
             knowledgeBases.addAll(kbService.getEnabledKnowledgeBases(aProject));
+        }
+
+        // If there are no knowledge bases at all but the user has entered a valid IRI
+        // then we still want to be able to accept it
+        if (knowledgeBases.isEmpty()) {
+            try {
+                var iri = new ParsedIRI(aQuery);
+                return asList(KBHandle.builder() //
+                        .withIdentifier(iri.toString()) //
+                        .build());
+            }
+            catch (URISyntaxException | NullPointerException e) {
+                // Ignore
+            }
         }
 
         // Query the knowledge bases for candidates

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseService.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseService.java
@@ -128,6 +128,8 @@ public interface KnowledgeBaseService
      */
     List<KnowledgeBase> getEnabledKnowledgeBases(Project aProject);
 
+    boolean hasEnabledKnowledgeBases(Project aProject);
+
     boolean hasMoreThanOneEnabledKnowledgeBases(Project aProject);
 
     RepositoryImplConfig getNativeConfig();

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
@@ -509,6 +509,17 @@ public class KnowledgeBaseServiceImpl
         return countQuery.getSingleResult() > 1;
     }
 
+    @Override
+    @Transactional(readOnly = true)
+    public boolean hasEnabledKnowledgeBases(Project aProject)
+    {
+        var countQuery = entityManager.createQuery(
+                "SELECT COUNT(kb) FROM KnowledgeBase kb WHERE kb.project = :project AND kb.enabled = true",
+                Long.class);
+        countQuery.setParameter("project", aProject);
+        return countQuery.getSingleResult() > 0;
+    }
+
     @Transactional
     @Override
     public void removeKnowledgeBase(KnowledgeBase aKB)

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureEditor.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureEditor.java
@@ -67,7 +67,6 @@ import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureSupportRegistry;
 import de.tudarmstadt.ukp.inception.schema.api.feature.SuggestionStatePanel;
 import de.tudarmstadt.ukp.inception.support.kendo.KendoChoiceDescriptionScriptReference;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxLink;
-import de.tudarmstadt.ukp.inception.support.lambda.LambdaBehavior;
 import de.tudarmstadt.ukp.inception.ui.kb.IriInfoBadge;
 import de.tudarmstadt.ukp.inception.ui.kb.event.AjaxConceptSelectionEvent;
 import de.tudarmstadt.ukp.inception.ui.kb.event.AjaxInstanceSelectionEvent;
@@ -141,7 +140,7 @@ public class ConceptFeatureEditor
         queue(dialog);
 
         queue(new LambdaAjaxLink("openBrowseDialog", this::actionOpenBrowseDialog)
-                .add(LambdaBehavior.visibleWhen(this::isBrowsingAllowed)));
+                .add(visibleWhen(this::isBrowsingAllowed)));
     }
 
     private boolean isBrowsingAllowed()
@@ -151,8 +150,13 @@ public class ConceptFeatureEditor
 
         // There is now KB selector in the browser yet, so we do not show it unless either the
         // feature is bound to a specific KB or there is only a single KB in the project.
-        if (traits.getRepositoryId() == null && knowledgeBaseService
-                .hasMoreThanOneEnabledKnowledgeBases(getModelObject().feature.getProject())) {
+        var project = getModelObject().feature.getProject();
+        if (traits.getRepositoryId() == null
+                && knowledgeBaseService.hasMoreThanOneEnabledKnowledgeBases(project)) {
+            return false;
+        }
+
+        if (!knowledgeBaseService.hasEnabledKnowledgeBases(project)) {
             return false;
         }
 

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureEditor_ImplBase.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptFeatureEditor_ImplBase.java
@@ -26,7 +26,6 @@ import static org.apache.commons.lang3.StringUtils.substringAfter;
 import static org.apache.commons.lang3.StringUtils.substringBefore;
 import static org.apache.wicket.markup.head.JavaScriptHeaderItem.forReference;
 
-import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
@@ -132,7 +131,7 @@ public abstract class ConceptFeatureEditor_ImplBase
             var repoId = traits.getRepositoryId();
             // Check if kb is actually enabled
             if (!(repoId == null || kbService.isKnowledgeBaseEnabled(feat.getProject(), repoId))) {
-                return Collections.emptyList();
+                return emptyList();
             }
 
             // If there is a selection, we try obtaining its text from the CAS and use it as an

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptLabelCache.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptLabelCache.java
@@ -82,11 +82,13 @@ public class ConceptLabelCache
                         aKey.getLabel());
 
             }
+
             return kbHandle.orElseThrow(NoSuchElementException::new);
         }
         catch (NoSuchElementException e) {
-            LOG.error("No label for feature value [{}]", aKey.getLabel());
-            return new KBErrorHandle("NO LABEL (" + aKey.getLabel() + ")", e);
+            return KBHandle.builder() //
+                    .withIdentifier(aKey.getLabel()) //
+                    .build();
         }
         catch (Exception e) {
             LOG.error("Unable to obtain label value for feature value [{}]", aKey.getLabel(), e);


### PR DESCRIPTION
**What's in the PR**
- Accept raw IRIs as valid candidates when no knowledge bases are configured (ConceptLinkingServiceImpl).
- Add `hasEnabledKnowledgeBases(Project)` to `KnowledgeBaseService` and implement it to check for any enabled KBs.
- Adjust concept feature UI logic to use the new enabled-KB check and refine browsing visibility/behavior; cleanup related imports and helpers (ConceptFeatureEditor & ImplBase).
- When a concept label is missing, return a `KBHandle` with the label as identifier instead of an error handle; simplify error handling in `ConceptLabelCache`.
- Minor refactors and formatting: consolidate comments/line-wrapping, replace `Collections.emptyList()` with `emptyList()`, and remove an unused import.

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
