### PR TITLE
#5972 - Support obfuscated export

### DIFF
--- a/inception/inception-annotation-storage-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/casstorage/CasStorageService.java
+++ b/inception/inception-annotation-storage-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/casstorage/CasStorageService.java
@@ -51,6 +51,9 @@ public interface CasStorageService
     void writeCas(SourceDocument aDocument, CAS aCas, AnnotationSet aSet)
         throws IOException, CasSessionException;
 
+    void serializeCas(SourceDocument aDocument, AnnotationSet aSet, CAS aCas, OutputStream aOs)
+        throws IOException;
+
     /**
      * Retrieve the annotation CAS of a given user for a given {@link SourceDocument}. By default
      * applies the CAS doctor. This uses {@link CasAccessMode#EXCLUSIVE_WRITE_ACCESS} and

--- a/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/CasStorageServiceImpl.java
+++ b/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/CasStorageServiceImpl.java
@@ -236,8 +236,7 @@ public class CasStorageServiceImpl
             // have broken their promise to not make any modifications to a CAS that was loaded in
             // read-only mode.
             // ... however, if the CAS has been obtained bypassing the session and caches, then no
-            // such
-            // promise has been made. So we can then try to get exclusive access and save it.
+            // such promise has been made. So we can then try to get exclusive access and save it.
             if (session.contains(aCas)) {
                 if (!session.isWritingPermitted(aCas)) {
                     throw new IOException("Session does not permit the CAS for set [" + aSet
@@ -290,6 +289,14 @@ public class CasStorageServiceImpl
 
             session.getManagedState(aCas).ifPresent(SessionManagedCas::incrementWriteCount);
         }
+    }
+
+    @Override
+    public void serializeCas(SourceDocument aDocument, AnnotationSet aSet, CAS aCas,
+            OutputStream aOs)
+        throws IOException
+    {
+        driver.writeCas(aDocument, aSet, aCas, aOs);
     }
 
     @Override

--- a/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/driver/CasStorageDriver.java
+++ b/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/driver/CasStorageDriver.java
@@ -35,6 +35,9 @@ public interface CasStorageDriver
 
     void writeCas(SourceDocument aDocument, AnnotationSet aSet, CAS aCas) throws IOException;
 
+    void writeCas(SourceDocument aDocument, AnnotationSet aSet, CAS aCas, OutputStream aOS)
+        throws IOException;
+
     void exportCas(SourceDocument aDocument, AnnotationSet aSet, OutputStream aStream)
         throws IOException;
 

--- a/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/driver/filesystem/CasPersistenceUtils.java
+++ b/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/driver/filesystem/CasPersistenceUtils.java
@@ -137,7 +137,7 @@ public final class CasPersistenceUtils
         }
     }
 
-    private static void write(OutputStream aOut, CAS aCas) throws IOException, FileNotFoundException
+    static void write(OutputStream aOut, CAS aCas) throws IOException, FileNotFoundException
     {
         var serializer = serializeCASComplete((CASImpl) getRealCas(aCas));
         write(aOut, serializer);

--- a/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/driver/filesystem/FileSystemCasStorageDriver.java
+++ b/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/driver/filesystem/FileSystemCasStorageDriver.java
@@ -24,6 +24,7 @@ import static de.tudarmstadt.ukp.inception.support.logging.BaseLoggers.BOOT_LOG;
 import static de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil.setDocumentId;
 import static java.lang.System.currentTimeMillis;
 import static java.nio.file.Files.move;
+import static java.nio.file.Files.newInputStream;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static java.util.regex.Pattern.compile;
 import static java.util.regex.Pattern.quote;
@@ -164,6 +165,23 @@ public class FileSystemCasStorageDriver
         }
 
         return cas;
+    }
+
+    @Override
+    public void writeCas(SourceDocument aDocument, AnnotationSet aSet, CAS aCas, OutputStream aOS)
+        throws IOException
+    {
+        // Now write the new version to "<username>.ser" or CURATION_USER.ser
+        setDocumentId(aCas, aSet.id());
+        if (casStorageProperties.isParanoidCasSerialization()) {
+            CasPersistenceUtils.write(aOS, aCas);
+        }
+        else if (casStorageProperties.isCompressedCasSerialization()) {
+            CasPersistenceUtils.writeSnappyCompressed(aOS, aCas);
+        }
+        else {
+            CasPersistenceUtils.write(aOS, aCas);
+        }
     }
 
     @Override
@@ -402,7 +420,7 @@ public class FileSystemCasStorageDriver
         Validate.notNull(aDocument, "Source document must be specified");
         Validate.notNull(aSet, "Set must be specified");
 
-        try (var is = Files.newInputStream(getCasFile(aDocument, aSet).toPath())) {
+        try (var is = newInputStream(getCasFile(aDocument, aSet).toPath())) {
             IOUtils.copyLarge(is, aStream);
         }
     }

--- a/inception/inception-api-formats/pom.xml
+++ b/inception/inception-api-formats/pom.xml
@@ -42,12 +42,21 @@
       <artifactId>inception-support-xml</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-annotation-storage-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>org.dkpro.core</groupId>
       <artifactId>dkpro-core-api-io-asl</artifactId>
     </dependency>
-    
+    <dependency>
+      <groupId>org.dkpro.core</groupId>
+      <artifactId>dkpro-core-api-metadata-asl</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>org.apache.uima</groupId>
       <artifactId>uimaj-core</artifactId>

--- a/inception/inception-api-formats/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/format/FormatSupport.java
+++ b/inception/inception-api-formats/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/format/FormatSupport.java
@@ -17,47 +17,39 @@
  */
 package de.tudarmstadt.ukp.clarin.webanno.api.format;
 
-import static de.tudarmstadt.ukp.inception.support.io.ZipUtils.zipFolder;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet.INITIAL_SET;
 import static java.io.File.createTempFile;
+import static java.nio.file.Files.copy;
+import static java.nio.file.Files.createTempDirectory;
+import static java.nio.file.Files.readAllBytes;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.unmodifiableSet;
 import static java.util.Optional.empty;
-import static org.apache.commons.io.FileUtils.copyFile;
-import static org.apache.commons.io.FilenameUtils.getBaseName;
+import static org.apache.commons.io.FileUtils.deleteQuietly;
 import static org.apache.commons.io.FilenameUtils.getExtension;
-import static org.apache.commons.lang3.StringUtils.rightPad;
-import static org.apache.uima.fit.factory.AnalysisEngineFactory.createEngine;
-import static org.apache.uima.fit.factory.CollectionReaderFactory.createReader;
-import static org.apache.uima.fit.factory.ConfigurationParameterFactory.addConfigurationParameters;
-import static org.apache.uima.fit.util.LifeCycleUtil.collectionProcessComplete;
-import static org.apache.uima.fit.util.LifeCycleUtil.destroy;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.MalformedURLException;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
-import org.apache.uima.analysis_engine.AnalysisEngine;
-import org.apache.uima.analysis_engine.AnalysisEngineDescription;
-import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
+import org.apache.uima.UIMAException;
 import org.apache.uima.cas.CAS;
-import org.apache.uima.collection.CollectionException;
-import org.apache.uima.collection.CollectionReader;
-import org.apache.uima.collection.CollectionReaderDescription;
-import org.apache.uima.fit.util.LifeCycleUtil;
-import org.apache.uima.resource.ResourceInitializationException;
-import org.apache.uima.resource.metadata.TypeSystemDescription;
+import org.apache.uima.cas.CASException;
+import org.apache.uima.fit.factory.JCasFactory;
 import org.apache.wicket.request.resource.ResourceReference;
-import org.dkpro.core.api.io.JCasFileWriter_ImplBase;
-import org.dkpro.core.api.io.ResourceCollectionReaderBase;
 
-import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData;
 import de.tudarmstadt.ukp.inception.support.io.ZipUtils;
+import de.tudarmstadt.ukp.inception.support.uima.CasObfuscationUtils;
 import de.tudarmstadt.ukp.inception.support.xml.sanitizer.PolicyCollection;
 
 public interface FormatSupport
@@ -150,114 +142,78 @@ public interface FormatSupport
         return empty();
     }
 
-    /**
-     * @param aProject
-     *            the project into which to import the document(s).
-     * @param aTSD
-     *            the project's type system
-     * @return a UIMA reader description.
-     * @throws ResourceInitializationException
-     *             if the reader could not be initialized
-     */
-    default CollectionReaderDescription getReaderDescription(Project aProject,
-            TypeSystemDescription aTSD)
-        throws ResourceInitializationException
+    default InputStream obfuscate(SourceDocument aDocument, InputStream aSource) throws IOException
     {
-        throw new UnsupportedOperationException("The format [" + getName() + "] cannot be read");
-    }
+        if (!(isReadable() && isWritable())) {
+            throw new UnsupportedOperationException(
+                    "The format [" + getName() + "] cannot be obfuscated");
+        }
 
-    /**
-     * @param aProject
-     *            the project
-     * @param aTSD
-     *            the project's type system
-     * @param aCAS
-     *            the CAS to be exported
-     * @return a UIMA reader description.
-     * @throws ResourceInitializationException
-     *             if the writer could not be initialized
-     */
-    default AnalysisEngineDescription getWriterDescription(Project aProject,
-            TypeSystemDescription aTSD, CAS aCAS)
-        throws ResourceInitializationException
-    {
-        throw new UnsupportedOperationException("The format [" + getName() + "] cannot be written");
-    }
+        if (aSource == null) {
+            return null;
+        }
 
-    default InputStream obfuscate(InputStream aSource) throws IOException
-    {
-        throw new UnsupportedOperationException(
-                "The format [" + getName() + "] cannot be obfuscated");
-    }
+        File srcFile = null;
+        File targetFolder = null;
 
-    default void read(Project aProject, CAS cas, File aFile)
-        throws ResourceInitializationException, IOException, CollectionException
-    {
-        var readerDescription = getReaderDescription(aProject, null);
-        addConfigurationParameters(readerDescription,
-                ResourceCollectionReaderBase.PARAM_SOURCE_LOCATION,
-                aFile.getParentFile().getAbsolutePath(),
-                ResourceCollectionReaderBase.PARAM_PATTERNS, "[+]" + aFile.getName());
-
-        CollectionReader reader = null;
         try {
-            reader = createReader(readerDescription);
+            srcFile = createTempFile("inception-format-src", ".tmp");
+            copy(aSource, srcFile.toPath(), REPLACE_EXISTING);
 
-            if (!reader.hasNext()) {
-                throw new FileNotFoundException("Source file [" + aFile.getName()
-                        + "] not found in [" + aFile.getPath() + "]");
+            try (var session = CasStorageSession.openNested()) {
+                var jcas = JCasFactory.createJCas();
+                read(aDocument, jcas.getCas(), srcFile);
+
+                // Some exporters need access to the original source document in order
+                // to merge their data with the original data.
+                addOrUpdateDocumentMetadata(jcas.getCas(), aDocument, INITIAL_SET.id());
+
+                var obfCas = CasObfuscationUtils.obfuscate(jcas.getCas());
+
+                targetFolder = createTempDirectory("inception-format-obf").toFile();
+                var exportFile = write(aDocument, obfCas, targetFolder, false);
+
+                return new ByteArrayInputStream(readAllBytes(exportFile.toPath()));
             }
-            reader.getNext(cas);
+            catch (UIMAException e) {
+                throw new IOException(e);
+            }
         }
         finally {
-            LifeCycleUtil.close(reader);
-            LifeCycleUtil.destroy(reader);
+            deleteQuietly(srcFile);
+            deleteQuietly(targetFolder);
         }
     }
 
-    default File write(SourceDocument aDocument, CAS aCas, File aTargetFolder,
-            boolean aStripExtension)
-        throws ResourceInitializationException, AnalysisEngineProcessException, IOException
-    {
-        var writer = getWriterDescription(aDocument.getProject(), null, aCas);
-        addConfigurationParameters(writer, //
-                JCasFileWriter_ImplBase.PARAM_USE_DOCUMENT_ID, true,
-                JCasFileWriter_ImplBase.PARAM_ESCAPE_FILENAME, false,
-                JCasFileWriter_ImplBase.PARAM_TARGET_LOCATION, aTargetFolder,
-                JCasFileWriter_ImplBase.PARAM_STRIP_EXTENSION, aStripExtension);
+    void read(SourceDocument aDocument, CAS cas, File aFile) throws UIMAException, IOException;
 
-        // Not using SimplePipeline.runPipeline here now because it internally works
-        // with an aggregate engine which is slow due to
-        // https://issues.apache.org/jira/browse/UIMA-6200
-        AnalysisEngine engine = null;
-        try {
-            engine = createEngine(writer);
-            engine.process(aCas);
-            collectionProcessComplete(engine);
-        }
-        finally {
-            destroy(engine);
-        }
+    File write(SourceDocument aDocument, CAS aCas, File aTargetFolder, boolean aStripExtension)
+        throws UIMAException, IOException;
 
-        // If the writer produced more than one file, we package it up as a ZIP file
-        if (aTargetFolder.listFiles().length > 1) {
-            var exportFile = createTempFile("inception-document", ".zip");
-            zipFolder(aTargetFolder, exportFile);
-            return exportFile;
-        }
-
-        // If the writer produced only a single file, then that is the result
-        var exportedFile = aTargetFolder.listFiles()[0];
-        // temp-file prefix must be at least 3 chars
-        var baseName = rightPad(getBaseName(exportedFile.getName()), 3, "_");
-        var extension = getExtension(exportedFile.getName());
-        var exportFile = createTempFile(baseName, "." + extension);
-        copyFile(exportedFile, exportFile);
-        return exportFile;
-    }
-
-    default void prepareAnnotationCas(CAS aInitialCas, SourceDocument aDocument)
+    /**
+     * Apply to an initial CAS created from a source document in order to prepare it for being an
+     * annotation CAS for an annotator. It will modify the provided CAS in place, so make sure it is
+     * already the copy that will be given to the annotator!
+     * 
+     * @param aCas
+     *            the annotators CAS copied from the initial CAS.
+     * @param aDocument
+     *            the source document this CAS belongs to
+     */
+    default void prepareAnnotationCas(CAS aCas, SourceDocument aDocument)
     {
         // Do nothing by default
+    }
+
+    static void addOrUpdateDocumentMetadata(CAS aCas, SourceDocument aDocument, String aDataOwner)
+        throws MalformedURLException, CASException
+    {
+        var slug = aDocument.getProject().getSlug();
+        var documentMetadata = DocumentMetaData.get(aCas.getJCas());
+        documentMetadata.setDocumentTitle(aDocument.getName());
+        documentMetadata.setCollectionId(slug);
+        documentMetadata.setDocumentId(aDataOwner);
+        documentMetadata.setDocumentBaseUri(slug);
+        documentMetadata.setDocumentUri(slug + "/" + aDocument.getName());
     }
 }

--- a/inception/inception-api-formats/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/format/FormatSupportDescription.java
+++ b/inception/inception-api-formats/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/format/FormatSupportDescription.java
@@ -31,7 +31,7 @@ import org.apache.uima.resource.metadata.TypeSystemDescription;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 
 public class FormatSupportDescription
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     private final String id;
     private final String name;

--- a/inception/inception-api-formats/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/format/UimaReaderWriterFormatSupport_ImplBase.java
+++ b/inception/inception-api-formats/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/format/UimaReaderWriterFormatSupport_ImplBase.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.api.format;
+
+import static java.io.File.createTempFile;
+import static org.apache.commons.io.FileUtils.copyFile;
+import static org.apache.commons.io.FilenameUtils.getBaseName;
+import static org.apache.commons.io.FilenameUtils.getExtension;
+import static org.apache.commons.lang3.StringUtils.rightPad;
+import static org.apache.uima.fit.factory.AnalysisEngineFactory.createEngine;
+import static org.apache.uima.fit.factory.CollectionReaderFactory.createReader;
+import static org.apache.uima.fit.factory.ConfigurationParameterFactory.addConfigurationParameters;
+import static org.apache.uima.fit.util.LifeCycleUtil.collectionProcessComplete;
+import static org.apache.uima.fit.util.LifeCycleUtil.destroy;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import org.apache.uima.UIMAException;
+import org.apache.uima.analysis_engine.AnalysisEngine;
+import org.apache.uima.analysis_engine.AnalysisEngineDescription;
+import org.apache.uima.cas.CAS;
+import org.apache.uima.collection.CollectionException;
+import org.apache.uima.collection.CollectionReader;
+import org.apache.uima.collection.CollectionReaderDescription;
+import org.apache.uima.fit.util.LifeCycleUtil;
+import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
+import org.dkpro.core.api.io.JCasFileWriter_ImplBase;
+import org.dkpro.core.api.io.ResourceCollectionReaderBase;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+
+public abstract class UimaReaderWriterFormatSupport_ImplBase
+    implements FormatSupport
+{
+    /**
+     * @param aProject
+     *            the project into which to import the document(s).
+     * @param aTSD
+     *            the project's type system
+     * @return a UIMA reader description.
+     * @throws ResourceInitializationException
+     *             if the reader could not be initialized
+     */
+    public CollectionReaderDescription getReaderDescription(Project aProject,
+            TypeSystemDescription aTSD)
+        throws ResourceInitializationException
+    {
+        throw new UnsupportedOperationException("The format [" + getName() + "] cannot be read");
+    }
+
+    /**
+     * @param aProject
+     *            the project
+     * @param aTSD
+     *            the project's type system
+     * @param aCAS
+     *            the CAS to be exported
+     * @return a UIMA reader description.
+     * @throws ResourceInitializationException
+     *             if the writer could not be initialized
+     */
+    public AnalysisEngineDescription getWriterDescription(Project aProject,
+            TypeSystemDescription aTSD, CAS aCAS)
+        throws ResourceInitializationException
+    {
+        throw new UnsupportedOperationException("The format [" + getName() + "] cannot be written");
+    }
+
+    @Override
+    public void read(SourceDocument aDocument, CAS cas, File aFile)
+        throws ResourceInitializationException, IOException, CollectionException
+    {
+        var readerDescription = getReaderDescription(aDocument.getProject(), null);
+        addConfigurationParameters(readerDescription,
+                ResourceCollectionReaderBase.PARAM_SOURCE_LOCATION,
+                aFile.getParentFile().getAbsolutePath(),
+                ResourceCollectionReaderBase.PARAM_PATTERNS, "[+]" + aFile.getName());
+
+        CollectionReader reader = null;
+        try {
+            reader = createReader(readerDescription);
+
+            if (!reader.hasNext()) {
+                throw new FileNotFoundException("Source file [" + aFile.getName()
+                        + "] not found in [" + aFile.getPath() + "]");
+            }
+            reader.getNext(cas);
+        }
+        finally {
+            LifeCycleUtil.close(reader);
+            LifeCycleUtil.destroy(reader);
+        }
+    }
+
+    @Override
+    public File write(SourceDocument aDocument, CAS aCas, File aTargetFolder,
+            boolean aStripExtension)
+        throws UIMAException, IOException
+    {
+        var writer = getWriterDescription(aDocument.getProject(), null, aCas);
+        addConfigurationParameters(writer, //
+                JCasFileWriter_ImplBase.PARAM_USE_DOCUMENT_ID, true,
+                JCasFileWriter_ImplBase.PARAM_ESCAPE_FILENAME, false,
+                JCasFileWriter_ImplBase.PARAM_TARGET_LOCATION, aTargetFolder,
+                JCasFileWriter_ImplBase.PARAM_STRIP_EXTENSION, aStripExtension);
+
+        // Not using SimplePipeline.runPipeline here now because it internally works
+        // with an aggregate engine which is slow due to
+        // https://issues.apache.org/jira/browse/UIMA-6200
+        AnalysisEngine engine = null;
+        try {
+            engine = createEngine(writer);
+            engine.process(aCas);
+            collectionProcessComplete(engine);
+        }
+        finally {
+            destroy(engine);
+        }
+
+        if (aTargetFolder.listFiles().length > 1) {
+            throw new IOException("Writer are only allowed to produce exactly one output file. "
+                    + "Writers producing mutiple files need to override write() with a suitable implementation.");
+        }
+
+        // If the writer produced only a single file, then that is the result
+        var exportedFile = aTargetFolder.listFiles()[0];
+        // temp-file prefix must be at least 3 chars
+        var baseName = rightPad(getBaseName(exportedFile.getName()), 3, "_");
+        var extension = getExtension(exportedFile.getName());
+        var exportFile = createTempFile(baseName, "." + extension);
+        copyFile(exportedFile, exportFile);
+        return exportFile;
+    }
+}

--- a/inception/inception-api-formats/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/format/FormatSupportTest.java
+++ b/inception/inception-api-formats/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/format/FormatSupportTest.java
@@ -15,9 +15,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package de.tudarmstadt.ukp.inception.export;
+package de.tudarmstadt.ukp.clarin.webanno.api.format;
 
-import static de.tudarmstadt.ukp.inception.export.DocumentImportExportServiceImpl.addOrUpdateDocumentMetadata;
+import static de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport.addOrUpdateDocumentMetadata;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.uima.fit.factory.JCasFactory;
@@ -27,7 +27,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData;
 
-public class DocumentImportExportSerivceImplStaticsTest
+public class FormatSupportTest
 {
     @Test
     void thatDocumentMetadataIsSetCorrectly() throws Exception
@@ -55,7 +55,5 @@ public class DocumentImportExportSerivceImplStaticsTest
         assertThat(dmd.getDocumentBaseUri()).as("documentBaseUri").isEqualTo(slug);
         assertThat(dmd.getCollectionId()).as("collectionId").isEqualTo(slug);
         assertThat(dmd.getDocumentId()).as("documentId").isEqualTo(username);
-
     }
-
 }

--- a/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/config/DocumentServiceAutoConfiguration.java
+++ b/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/config/DocumentServiceAutoConfiguration.java
@@ -79,10 +79,11 @@ public class DocumentServiceAutoConfiguration
     @Bean
     public SourceDocumentExporter sourceDocumentExporter(DocumentService aDocumentService,
             RepositoryProperties aRepositoryProperties,
-            DocumentStorageService aDocumentStorageService)
+            DocumentStorageService aDocumentStorageService,
+            DocumentImportExportService aDocumentImportExportService)
     {
         return new SourceDocumentExporter(aDocumentService, aDocumentStorageService,
-                aRepositoryProperties);
+                aRepositoryProperties, aDocumentImportExportService);
     }
 
     @Bean

--- a/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/exporters/SourceDocumentExporter.java
+++ b/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/exporters/SourceDocumentExporter.java
@@ -22,14 +22,15 @@ import static de.tudarmstadt.ukp.inception.project.api.ProjectService.PROJECT_FO
 import static de.tudarmstadt.ukp.inception.project.api.ProjectService.SOURCE_FOLDER;
 import static java.lang.System.currentTimeMillis;
 import static java.nio.file.Files.createDirectories;
+import static java.nio.file.Files.newInputStream;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
 import static org.apache.commons.lang3.time.DurationFormatUtils.formatDurationWords;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.lang.invoke.MethodHandles;
-import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.zip.ZipFile;
@@ -40,6 +41,7 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import de.tudarmstadt.ukp.clarin.webanno.api.export.DocumentImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.FullProjectExportRequest;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExportException;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExportTaskMonitor;
@@ -70,14 +72,17 @@ public class SourceDocumentExporter
     private final DocumentService documentService;
     private final DocumentStorageService documentStorageService;
     private final RepositoryProperties repositoryProperties;
+    private final DocumentImportExportService documentImportExportService;
 
     public SourceDocumentExporter(DocumentService aDocumentService,
             DocumentStorageService aDocumentStorageService,
-            RepositoryProperties aRepositoryProperties)
+            RepositoryProperties aRepositoryProperties,
+            DocumentImportExportService aDocumentImportExportService)
     {
         documentService = aDocumentService;
         repositoryProperties = aRepositoryProperties;
         documentStorageService = aDocumentStorageService;
+        documentImportExportService = aDocumentImportExportService;
     }
 
     @Override
@@ -128,8 +133,7 @@ public class SourceDocumentExporter
             try {
                 ProjectExporter.writeEntry(aStage, SOURCE_FOLDER + "/" + sourceDocument.getName(),
                         os -> {
-                            try (var is = Files.newInputStream(documentStorageService
-                                    .getSourceDocumentFile(sourceDocument).toPath())) {
+                            try (var is = getSourceDocumentInputStream(aRequest, sourceDocument)) {
                                 is.transferTo(os);
                             }
                         });
@@ -149,6 +153,25 @@ public class SourceDocumentExporter
                         "Couldn't find some source file(s) related to project");
             }
         }
+    }
+
+    private InputStream getSourceDocumentInputStream(FullProjectExportRequest aRequest,
+            SourceDocument aDoc)
+        throws IOException
+    {
+        var is = newInputStream(documentStorageService.getSourceDocumentFile(aDoc).toPath());
+
+        if (aRequest.isObfuscate()) {
+            var maybeFS = documentImportExportService.getFormatById(aDoc.getFormat());
+            if (maybeFS.isEmpty()) {
+                throw new IOException(
+                        "Obfuscation failed. Unsupported format:[" + aDoc.getFormat() + "]");
+            }
+
+            is = maybeFS.get().obfuscate(aDoc, is);
+        }
+
+        return is;
     }
 
     @Override

--- a/inception/inception-documents/src/test/java/de/tudarmstadt/ukp/inception/documents/exporters/SourceDocumentExporterTest.java
+++ b/inception/inception-documents/src/test/java/de/tudarmstadt/ukp/inception/documents/exporters/SourceDocumentExporterTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import de.tudarmstadt.ukp.clarin.webanno.api.export.DocumentImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.FullProjectExportRequest;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExportTaskMonitor;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectImportRequest;
@@ -57,6 +58,7 @@ public class SourceDocumentExporterTest
     private RepositoryProperties repositoryProperties;
 
     private @Mock DocumentService documentService;
+    private @Mock DocumentImportExportService documentImportExportService;
     private DocumentStorageService documentStorageService;
 
     private Project project;
@@ -79,7 +81,7 @@ public class SourceDocumentExporterTest
         });
 
         sut = new SourceDocumentExporter(documentService, documentStorageService,
-                repositoryProperties);
+                repositoryProperties, documentImportExportService);
     }
 
     @Test

--- a/inception/inception-export-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/export/FullProjectExportRequest.java
+++ b/inception/inception-export-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/export/FullProjectExportRequest.java
@@ -28,6 +28,7 @@ public class FullProjectExportRequest
     private static final String FILENAME_PREFIX = "project";
     public static final String FORMAT_AUTO = "AUTO";
 
+    private String title;
     private String format;
     private boolean includeInProgress;
     private boolean obfuscate;
@@ -35,6 +36,7 @@ public class FullProjectExportRequest
     private FullProjectExportRequest(Builder aBuilder)
     {
         super(aBuilder.project);
+        title = aBuilder.title;
         format = aBuilder.format;
         includeInProgress = aBuilder.includeInProgress;
         obfuscate = aBuilder.obfuscate;
@@ -80,7 +82,7 @@ public class FullProjectExportRequest
     @Override
     public String getTitle()
     {
-        var sb = new StringBuilder("Project backup");
+        var sb = new StringBuilder(title);
         if (format != null) {
             sb.append(" (" + format + ")");
         }
@@ -95,6 +97,7 @@ public class FullProjectExportRequest
     public static final class Builder
     {
         private Project project;
+        private String title = "Project export";
         private String format;
         private boolean includeInProgress;
         private boolean obfuscate;
@@ -106,6 +109,12 @@ public class FullProjectExportRequest
         public Builder withProject(Project aProject)
         {
             project = aProject;
+            return this;
+        }
+
+        public Builder withTitle(String aTitle)
+        {
+            title = aTitle;
             return this;
         }
 

--- a/inception/inception-export/pom.xml
+++ b/inception/inception-export/pom.xml
@@ -132,10 +132,6 @@
 
     <dependency>
       <groupId>org.dkpro.core</groupId>
-      <artifactId>dkpro-core-api-metadata-asl</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.dkpro.core</groupId>
       <artifactId>dkpro-core-api-segmentation-asl</artifactId>
     </dependency>
     <dependency>
@@ -155,6 +151,11 @@
 
 
     <!-- TEST DEPENDENCIES -->
+    <dependency>
+      <groupId>org.dkpro.core</groupId>
+      <artifactId>dkpro-core-api-metadata-asl</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>jakarta.persistence</groupId>
       <artifactId>jakarta.persistence-api</artifactId>

--- a/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/DocumentImportExportServiceImpl.java
+++ b/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/DocumentImportExportServiceImpl.java
@@ -19,10 +19,12 @@ package de.tudarmstadt.ukp.inception.export;
 
 import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode.EXCLUSIVE_WRITE_ACCESS;
 import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode.UNMANAGED_ACCESS;
+import static de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport.addOrUpdateDocumentMetadata;
 import static de.tudarmstadt.ukp.inception.project.api.ProjectService.withProjectLogger;
 import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.INITIAL_CAS_PSEUDO_USER;
 import static de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil.exists;
 import static de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil.getRealCas;
+import static java.nio.file.Files.createTempDirectory;
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
@@ -34,8 +36,6 @@ import static org.apache.uima.util.CasCreationUtils.mergeTypeSystems;
 import java.io.File;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
-import java.net.MalformedURLException;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -46,7 +46,6 @@ import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.uima.UIMAException;
 import org.apache.uima.cas.CAS;
-import org.apache.uima.cas.CASException;
 import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.slf4j.Logger;
@@ -70,7 +69,6 @@ import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Mode;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
-import de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
 import de.tudarmstadt.ukp.inception.export.config.DocumentImportExportServiceAutoConfiguration;
@@ -318,7 +316,7 @@ public class DocumentImportExportServiceImpl
 
         // Prepare a CAS with the project type system
         var cas = WebAnnoCasUtil.createCas(tsd);
-        format.read(aDocument.getProject(), WebAnnoCasUtil.getRealCas(cas), aFile);
+        format.read(aDocument, getRealCas(cas), aFile);
 
         // Create sentence / token annotations if they are missing - sentences first because
         // tokens are then generated inside the sentences
@@ -452,13 +450,15 @@ public class DocumentImportExportServiceImpl
 
                 // Update the source file name in case it is changed for some reason. This is
                 // necessary for the writers to create the files under the correct names.
+                // NOTE: add metadata to the export CAS (not the source CAS) so writers
+                // receive the metadata when serializing the export CAS.
                 addOrUpdateDocumentMetadata(exportCas, aDocument, aDataOwner);
 
                 var features = listSupportedFeatures(project, aBulkOperationContext);
                 annotationService.addLayerAndFeatureDefinitionAnnotations(exportCas, features);
                 annotationService.addTagsetDefinitionAnnotations(exportCas, features);
 
-                var exportTempDir = Files.createTempDirectory("inception-export").toFile();
+                var exportTempDir = createTempDirectory("inception-export").toFile();
                 try {
                     return aFormat.write(aDocument, getRealCas(exportCas), exportTempDir,
                             aStripExtension);
@@ -539,17 +539,5 @@ public class DocumentImportExportServiceImpl
         }
 
         return features;
-    }
-
-    static void addOrUpdateDocumentMetadata(CAS aCas, SourceDocument aDocument, String aDataOwner)
-        throws MalformedURLException, CASException
-    {
-        var slug = aDocument.getProject().getSlug();
-        var documentMetadata = DocumentMetaData.get(aCas.getJCas());
-        documentMetadata.setDocumentTitle(aDocument.getName());
-        documentMetadata.setCollectionId(slug);
-        documentMetadata.setDocumentId(aDataOwner);
-        documentMetadata.setDocumentBaseUri(slug);
-        documentMetadata.setDocumentUri(slug + "/" + aDocument.getName());
     }
 }

--- a/inception/inception-external-search-pubannotation/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/pubannotation/format/PubAnnotationSectionsFormatSupport.java
+++ b/inception/inception-external-search-pubannotation/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/pubannotation/format/PubAnnotationSectionsFormatSupport.java
@@ -23,7 +23,7 @@ import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.inception.externalsearch.pubannotation.config.PubAnnotationDocumentRepositoryAutoConfiguration;
 
@@ -35,7 +35,7 @@ import de.tudarmstadt.ukp.inception.externalsearch.pubannotation.config.PubAnnot
  * </p>
  */
 public class PubAnnotationSectionsFormatSupport
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     public static final String ID = "pubannotation-sections";
     public static final String NAME = "PubAnnotation Document with Sections (JSON)";

--- a/inception/inception-io-bioc/src/main/java/de/tudarmstadt/ukp/inception/io/bioc/BioCFormatSupport.java
+++ b/inception/inception-io-bioc/src/main/java/de/tudarmstadt/ukp/inception/io/bioc/BioCFormatSupport.java
@@ -26,7 +26,7 @@ import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.inception.io.bioc.config.BioCAutoConfiguration;
 
@@ -37,7 +37,7 @@ import de.tudarmstadt.ukp.inception.io.bioc.config.BioCAutoConfiguration;
  * </p>
  */
 public class BioCFormatSupport
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     public static final String ID = "bioc";
     public static final String NAME = "BioC XML (experimental)";

--- a/inception/inception-io-bioc/src/main/java/de/tudarmstadt/ukp/inception/io/bioc/BioCXmlDocumentFormatSupport.java
+++ b/inception/inception-io-bioc/src/main/java/de/tudarmstadt/ukp/inception/io/bioc/BioCXmlDocumentFormatSupport.java
@@ -26,7 +26,7 @@ import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.io.bioc.config.BioCAutoConfiguration;
@@ -43,35 +43,42 @@ import de.tudarmstadt.ukp.inception.io.xml.dkprocore.XmlNodeUtils;
  */
 @Deprecated
 public class BioCXmlDocumentFormatSupport
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
+    @Deprecated
     public static final String ID = "bioc-xml";
+    @Deprecated
     public static final String NAME = "BioC XML Document (experimental)";
 
+    @Deprecated
     @Override
     public String getId()
     {
         return ID;
     }
 
+    @Deprecated
     @Override
     public String getName()
     {
         return NAME;
     }
 
+    @Deprecated
     @Override
     public boolean isReadable()
     {
         return true;
     }
 
+    @Deprecated
     @Override
     public boolean isWritable()
     {
         return true;
     }
 
+    @Deprecated
     @Override
     public CollectionReaderDescription getReaderDescription(Project aProject,
             TypeSystemDescription aTSD)
@@ -80,6 +87,7 @@ public class BioCXmlDocumentFormatSupport
         return createReaderDescription(BioCXmlDocumentReader.class, aTSD);
     }
 
+    @Deprecated
     @Override
     public AnalysisEngineDescription getWriterDescription(Project aProject,
             TypeSystemDescription aTSD, CAS aCAS)
@@ -88,6 +96,7 @@ public class BioCXmlDocumentFormatSupport
         return createEngineDescription(BioCXmlDocumentWriter.class, aTSD);
     }
 
+    @Deprecated
     @Override
     public void prepareAnnotationCas(CAS aInitialCas, SourceDocument aDocument)
     {

--- a/inception/inception-io-brat/src/main/java/de/tudarmstadt/ukp/inception/io/brat/BratBasicFormatSupport.java
+++ b/inception/inception-io-brat/src/main/java/de/tudarmstadt/ukp/inception/io/brat/BratBasicFormatSupport.java
@@ -23,7 +23,7 @@ import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.inception.io.brat.config.BratAutoConfiguration;
 import de.tudarmstadt.ukp.inception.io.brat.dkprocore.BratReader;
@@ -36,7 +36,7 @@ import de.tudarmstadt.ukp.inception.io.brat.dkprocore.BratReader;
  * </p>
  */
 public class BratBasicFormatSupport
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     public static final String ID = "bratBasic";
     public static final String NAME = "brat basic (experimental)";

--- a/inception/inception-io-brat/src/main/java/de/tudarmstadt/ukp/inception/io/brat/BratCustomFormatSupport.java
+++ b/inception/inception-io-brat/src/main/java/de/tudarmstadt/ukp/inception/io/brat/BratCustomFormatSupport.java
@@ -28,7 +28,7 @@ import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.inception.annotation.layer.relation.api.RelationLayerSupport;
 import de.tudarmstadt.ukp.inception.io.brat.config.BratAutoConfiguration;
@@ -44,7 +44,7 @@ import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
  * </p>
  */
 public class BratCustomFormatSupport
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     public static final String ID = "bratCustom";
     public static final String NAME = "brat custom (experimental)";

--- a/inception/inception-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/Conll2000FormatSupport.java
+++ b/inception/inception-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/Conll2000FormatSupport.java
@@ -28,7 +28,7 @@ import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.conll.Conll2000Reader;
 import org.dkpro.core.io.conll.Conll2000Writer;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.conll.config.ConllFormatsAutoConfiguration;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 
@@ -39,7 +39,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.Project;
  * </p>
  */
 public class Conll2000FormatSupport
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     public static final String ID = "conll2000";
     public static final String NAME = "CoNLL 2000";

--- a/inception/inception-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/Conll2002FormatSupport.java
+++ b/inception/inception-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/Conll2002FormatSupport.java
@@ -28,7 +28,7 @@ import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.conll.Conll2002Reader;
 import org.dkpro.core.io.conll.Conll2002Writer;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.conll.config.ConllFormatsAutoConfiguration;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 
@@ -39,7 +39,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.Project;
  * </p>
  */
 public class Conll2002FormatSupport
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     public static final String ID = "conll2002";
     public static final String NAME = "CoNLL 2002";

--- a/inception/inception-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/Conll2003FormatSupport.java
+++ b/inception/inception-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/Conll2003FormatSupport.java
@@ -28,7 +28,7 @@ import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.conll.Conll2003Reader;
 import org.dkpro.core.io.conll.Conll2003Writer;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.conll.config.ConllFormatsAutoConfiguration;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 
@@ -39,7 +39,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.Project;
  * </p>
  */
 public class Conll2003FormatSupport
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     public static final String ID = "conll2003";
     public static final String NAME = "CoNLL 2003";

--- a/inception/inception-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/Conll2006FormatSupport.java
+++ b/inception/inception-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/Conll2006FormatSupport.java
@@ -28,7 +28,7 @@ import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.conll.Conll2006Reader;
 import org.dkpro.core.io.conll.Conll2006Writer;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.conll.config.ConllFormatsAutoConfiguration;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 
@@ -39,7 +39,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.Project;
  * </p>
  */
 public class Conll2006FormatSupport
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     public static final String ID = "conll2006";
     public static final String NAME = "CoNLL 2006";

--- a/inception/inception-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/Conll2009FormatSupport.java
+++ b/inception/inception-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/Conll2009FormatSupport.java
@@ -28,7 +28,7 @@ import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.conll.Conll2009Reader;
 import org.dkpro.core.io.conll.Conll2009Writer;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.conll.config.ConllFormatsAutoConfiguration;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 
@@ -39,7 +39,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.Project;
  * </p>
  */
 public class Conll2009FormatSupport
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     public static final String ID = "conll2009";
     public static final String NAME = "CoNLL 2009";

--- a/inception/inception-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/Conll2012FormatSupport.java
+++ b/inception/inception-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/Conll2012FormatSupport.java
@@ -28,7 +28,7 @@ import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.conll.Conll2012Reader;
 import org.dkpro.core.io.conll.Conll2012Writer;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.conll.config.ConllFormatsAutoConfiguration;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 
@@ -39,7 +39,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.Project;
  * </p>
  */
 public class Conll2012FormatSupport
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     public static final String ID = "conll2012";
     public static final String NAME = "CoNLL 2012";

--- a/inception/inception-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/ConllCoreNlpFormatSupport.java
+++ b/inception/inception-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/ConllCoreNlpFormatSupport.java
@@ -28,7 +28,7 @@ import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.conll.ConllCoreNlpReader;
 import org.dkpro.core.io.conll.ConllCoreNlpWriter;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.conll.config.ConllFormatsAutoConfiguration;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 
@@ -39,7 +39,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.Project;
  * </p>
  */
 public class ConllCoreNlpFormatSupport
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     public static final String ID = "conllcorenlp";
     public static final String NAME = "CoNLL CoreNLP";

--- a/inception/inception-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/ConllUFormatSupport.java
+++ b/inception/inception-io-conll/src/main/java/de/tudarmstadt/ukp/clarin/webanno/conll/ConllUFormatSupport.java
@@ -28,7 +28,7 @@ import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.conll.ConllUReader;
 import org.dkpro.core.io.conll.ConllUWriter;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.conll.config.ConllFormatsAutoConfiguration;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 
@@ -39,7 +39,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.Project;
  * </p>
  */
 public class ConllUFormatSupport
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     public static final String ID = "conllu";
     public static final String NAME = "CoNLL-U";

--- a/inception/inception-io-docx/src/main/java/de/tudarmstadt/ukp/inception/io/docx/DocxFormatSupport.java
+++ b/inception/inception-io-docx/src/main/java/de/tudarmstadt/ukp/inception/io/docx/DocxFormatSupport.java
@@ -30,7 +30,7 @@ import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.apache.wicket.request.resource.ResourceReference;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.io.xml.dkprocore.XmlNodeUtils;
@@ -39,7 +39,7 @@ import de.tudarmstadt.ukp.inception.support.xml.sanitizer.PolicyCollection;
 import de.tudarmstadt.ukp.inception.support.xml.sanitizer.PolicyCollectionIOUtils;
 
 public class DocxFormatSupport
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     public static final String ID = "docx";
     public static final String NAME = "DOCX";

--- a/inception/inception-io-html/src/main/java/de/tudarmstadt/ukp/inception/io/html/HtmlFormatSupportImplBase.java
+++ b/inception/inception-io-html/src/main/java/de/tudarmstadt/ukp/inception/io/html/HtmlFormatSupportImplBase.java
@@ -23,14 +23,14 @@ import java.util.Set;
 
 import org.apache.uima.cas.CAS;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.externaleditor.policy.DefaultHtmlDocumentPolicy;
 import de.tudarmstadt.ukp.inception.io.xml.dkprocore.XmlNodeUtils;
 import de.tudarmstadt.ukp.inception.support.xml.sanitizer.PolicyCollection;
 
 public abstract class HtmlFormatSupportImplBase
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     private static final Set<String> HTML_SECTION_ELEMENTS = Set.of("p");
     private static final Set<String> HTML_PROTECTED_ELEMENTS = Set.of( //

--- a/inception/inception-io-html/src/main/java/de/tudarmstadt/ukp/inception/io/html/LegacyHtmlFormatSupport.java
+++ b/inception/inception-io-html/src/main/java/de/tudarmstadt/ukp/inception/io/html/LegacyHtmlFormatSupport.java
@@ -24,7 +24,7 @@ import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.html.HtmlReader;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 
 /**
@@ -35,7 +35,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.Project;
  * </p>
  */
 public class LegacyHtmlFormatSupport
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     public static final String ID = "html";
     public static final String NAME = "HTML (legacy)";

--- a/inception/inception-io-imscwb/src/main/java/de/tudarmstadt/ukp/inception/io/imscwb/ImsCwbFormatSupport.java
+++ b/inception/inception-io-imscwb/src/main/java/de/tudarmstadt/ukp/inception/io/imscwb/ImsCwbFormatSupport.java
@@ -24,7 +24,7 @@ import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.imscwb.ImsCwbReader;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.inception.io.imscwb.config.ImsCwbFormatSupportAutoConfiguration;
 
@@ -35,7 +35,7 @@ import de.tudarmstadt.ukp.inception.io.imscwb.config.ImsCwbFormatSupportAutoConf
  * </p>
  */
 public class ImsCwbFormatSupport
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     public static final String ID = "imscwb";
     public static final String NAME = "Corpus Workbench Format (aka VRT)";

--- a/inception/inception-io-intertext/src/main/java/de/tudarmstadt/ukp/inception/io/intertext/IntertextFormatSupport.java
+++ b/inception/inception-io-intertext/src/main/java/de/tudarmstadt/ukp/inception/io/intertext/IntertextFormatSupport.java
@@ -27,7 +27,7 @@ import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.apache.wicket.request.resource.ResourceReference;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.inception.io.intertext.config.IntertextAutoConfiguration;
 
@@ -38,7 +38,7 @@ import de.tudarmstadt.ukp.inception.io.intertext.config.IntertextAutoConfigurati
  * </p>
  */
 public class IntertextFormatSupport
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     public static final String ID = "intertext";
     public static final String NAME = "Intertext XML (experimental)";

--- a/inception/inception-io-json/src/main/java/de/tudarmstadt/ukp/inception/io/jsoncas/LegacyUimaJsonFormatSupport.java
+++ b/inception/inception-io-json/src/main/java/de/tudarmstadt/ukp/inception/io/jsoncas/LegacyUimaJsonFormatSupport.java
@@ -25,12 +25,12 @@ import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.json.JsonWriter;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.inception.io.jsoncas.config.LegacyUimaJsonCasFormatProperties;
 
 public class LegacyUimaJsonFormatSupport
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     public static final String ID = "json";
     public static final String NAME = "UIMA CAS JSON (legacy)";

--- a/inception/inception-io-json/src/main/java/de/tudarmstadt/ukp/inception/io/jsoncas/UimaJsonCasFormatSupport.java
+++ b/inception/inception-io-json/src/main/java/de/tudarmstadt/ukp/inception/io/jsoncas/UimaJsonCasFormatSupport.java
@@ -34,7 +34,7 @@ import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.apache.uima.util.TypeSystemUtil;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.export.DocumentImportExportService;
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.io.pdf.visual.PdfVModelUtils;
@@ -42,7 +42,7 @@ import de.tudarmstadt.ukp.inception.io.xml.dkprocore.XmlNodeUtils;
 import de.tudarmstadt.ukp.inception.schema.service.AnnotationSchemaServiceImpl;
 
 public class UimaJsonCasFormatSupport
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     public static final String ID = "jsoncas";
     public static final String NAME = "UIMA CAS JSON 0.4.0";
@@ -93,7 +93,7 @@ public class UimaJsonCasFormatSupport
     }
 
     @Override
-    public void read(Project aProject, CAS aCas, File aFile)
+    public void read(SourceDocument aDocument, CAS aCas, File aFile)
         throws ResourceInitializationException, IOException, CollectionException
     {
         // We need to perform a little hack here because the JSON CAS IO does not support lenient
@@ -105,7 +105,7 @@ public class UimaJsonCasFormatSupport
 
         upgradeCas(aCas, tsd);
 
-        FormatSupport.super.read(aProject, aCas, aFile);
+        super.read(aDocument, aCas, aFile);
 
         // No need to go back to the original CAS TS because another upgrade happens after
         // project import anyway.

--- a/inception/inception-io-json/src/main/java/de/tudarmstadt/ukp/inception/io/jsoncas/UimaJsonCasStructureFormatSupport.java
+++ b/inception/inception-io-json/src/main/java/de/tudarmstadt/ukp/inception/io/jsoncas/UimaJsonCasStructureFormatSupport.java
@@ -31,18 +31,17 @@ import java.io.IOException;
 
 import org.apache.uima.UIMAException;
 import org.apache.uima.analysis_engine.AnalysisEngineDescription;
-import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 
 public class UimaJsonCasStructureFormatSupport
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     public static final String ID = "jsoncas-struct";
     public static final String NAME = "UIMA CAS JSON 0.4.0 (XML/PDF structure)";
@@ -81,27 +80,19 @@ public class UimaJsonCasStructureFormatSupport
     @Override
     public File write(SourceDocument aDocument, CAS aCas, File aTargetFolder,
             boolean aStripExtension)
-        throws ResourceInitializationException, AnalysisEngineProcessException, IOException
+        throws UIMAException, IOException
     {
         var cas = aCas;
 
         if (!containsXmlDocumentStructure(aCas) || !containsPdfDocumentStructure(aCas)) {
-            try {
-                cas = createCasCopy(aCas);
-                var initialCas = documentService.createOrReadInitialCas(aDocument, AUTO_CAS_UPGRADE,
-                        SHARED_READ_ONLY_ACCESS);
-                transferPdfDocumentStructure(cas, initialCas);
-                transferXmlDocumentStructure(cas, initialCas);
-            }
-            catch (ResourceInitializationException | AnalysisEngineProcessException e) {
-                throw e;
-            }
-            catch (UIMAException e) {
-                throw new ResourceInitializationException(e);
-            }
+            cas = createCasCopy(aCas);
+            var initialCas = documentService.createOrReadInitialCas(aDocument, AUTO_CAS_UPGRADE,
+                    SHARED_READ_ONLY_ACCESS);
+            transferPdfDocumentStructure(cas, initialCas);
+            transferXmlDocumentStructure(cas, initialCas);
         }
 
-        return FormatSupport.super.write(aDocument, cas, aTargetFolder, aStripExtension);
+        return super.write(aDocument, cas, aTargetFolder, aStripExtension);
     }
 
     @Override

--- a/inception/inception-io-lif/src/main/java/de/tudarmstadt/ukp/inception/io/lif/LifFormatSupport.java
+++ b/inception/inception-io-lif/src/main/java/de/tudarmstadt/ukp/inception/io/lif/LifFormatSupport.java
@@ -28,7 +28,7 @@ import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.lif.LifReader;
 import org.dkpro.core.io.lif.LifWriter;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.inception.io.lif.config.LifFormatSupportAutoConfiguration;
 
@@ -40,7 +40,7 @@ import de.tudarmstadt.ukp.inception.io.lif.config.LifFormatSupportAutoConfigurat
  * </p>
  */
 public class LifFormatSupport
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     public static final String ID = "lif";
     public static final String NAME = "LAPPS Interchange Format";

--- a/inception/inception-io-nif/src/main/java/de/tudarmstadt/ukp/inception/io/nif/NifFormatSupport.java
+++ b/inception/inception-io-nif/src/main/java/de/tudarmstadt/ukp/inception/io/nif/NifFormatSupport.java
@@ -28,7 +28,7 @@ import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.nif.NifReader;
 import org.dkpro.core.io.nif.NifWriter;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.inception.io.nif.config.NifFormatSupportAutoConfiguration;
 
@@ -40,7 +40,7 @@ import de.tudarmstadt.ukp.inception.io.nif.config.NifFormatSupportAutoConfigurat
  * </p>
  */
 public class NifFormatSupport
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     public static final String ID = "nif";
     public static final String NAME = "NLP Interchange Format (NIF)";

--- a/inception/inception-io-pdf/src/main/java/de/tudarmstadt/ukp/inception/io/pdf/PdfFormatSupport.java
+++ b/inception/inception-io-pdf/src/main/java/de/tudarmstadt/ukp/inception/io/pdf/PdfFormatSupport.java
@@ -26,7 +26,7 @@ import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.io.pdf.config.PdfFormatAutoConfiguration;
@@ -41,7 +41,7 @@ import de.tudarmstadt.ukp.inception.io.pdf.visual.PdfVModelUtils;
  * </p>
  */
 public class PdfFormatSupport
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     public static final String ID = "pdf2";
     public static final String NAME = "PDF";

--- a/inception/inception-io-pdf/src/main/java/de/tudarmstadt/ukp/inception/io/pdf/PdfJsonCasFormatSupport.java
+++ b/inception/inception-io-pdf/src/main/java/de/tudarmstadt/ukp/inception/io/pdf/PdfJsonCasFormatSupport.java
@@ -25,7 +25,7 @@ import org.apache.uima.cas.CAS;
 import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.inception.io.pdf.config.PdfFormatAutoConfiguration;
 
@@ -37,7 +37,7 @@ import de.tudarmstadt.ukp.inception.io.pdf.config.PdfFormatAutoConfiguration;
  * </p>
  */
 public class PdfJsonCasFormatSupport
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     public static final String ID = "pdf2JsonCas";
     public static final String NAME = "PDF (with embedded JSON CAS)";

--- a/inception/inception-io-pdf/src/main/java/de/tudarmstadt/ukp/inception/io/pdf/PdfXmiCasFormatSupport.java
+++ b/inception/inception-io-pdf/src/main/java/de/tudarmstadt/ukp/inception/io/pdf/PdfXmiCasFormatSupport.java
@@ -25,7 +25,7 @@ import org.apache.uima.cas.CAS;
 import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.inception.io.pdf.config.PdfFormatAutoConfiguration;
 
@@ -37,7 +37,7 @@ import de.tudarmstadt.ukp.inception.io.pdf.config.PdfFormatAutoConfiguration;
  * </p>
  */
 public class PdfXmiCasFormatSupport
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     public static final String ID = "pdf2XmiCas";
     public static final String NAME = "PDF (with embedded XMI CAS)";

--- a/inception/inception-io-perseus/src/main/java/de/tudarmstadt/ukp/inception/io/perseus/PerseusFormatSupport.java
+++ b/inception/inception-io-perseus/src/main/java/de/tudarmstadt/ukp/inception/io/perseus/PerseusFormatSupport.java
@@ -24,7 +24,7 @@ import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.perseus.PerseusReader;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.inception.io.perseus.config.PerseusFormatAutoConfiguration;
 
@@ -35,7 +35,7 @@ import de.tudarmstadt.ukp.inception.io.perseus.config.PerseusFormatAutoConfigura
  * </p>
  */
 public class PerseusFormatSupport
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     public static final String ID = "perseus_2.1";
     public static final String NAME = "Perseus treebank XML (2.1)";

--- a/inception/inception-io-rdf/src/main/java/de/tudarmstadt/ukp/inception/io/rdf/UimaRdfCasFormatSupport.java
+++ b/inception/inception-io-rdf/src/main/java/de/tudarmstadt/ukp/inception/io/rdf/UimaRdfCasFormatSupport.java
@@ -27,7 +27,7 @@ import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.inception.io.rdf.config.RdfFormatAutoConfiguration;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
@@ -40,7 +40,7 @@ import de.tudarmstadt.ukp.inception.ui.kb.feature.ConceptFeatureSupport;
  * </p>
  */
 public class UimaRdfCasFormatSupport
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     public static final String ID = "rdfcas";
     public static final String NAME = "UIMA CAS RDF";

--- a/inception/inception-io-tcf/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tcf/TcfFormatSupport.java
+++ b/inception/inception-io-tcf/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tcf/TcfFormatSupport.java
@@ -28,7 +28,7 @@ import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.tcf.TcfReader;
 import org.dkpro.core.io.tcf.TcfWriter;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.tcf.config.TcfFormatsAutoConfiguration;
 
@@ -39,7 +39,7 @@ import de.tudarmstadt.ukp.clarin.webanno.tcf.config.TcfFormatsAutoConfiguration;
  * </p>
  */
 public class TcfFormatSupport
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     public static final String ID = "tcf";
     public static final String NAME = "WebLicht TCF";

--- a/inception/inception-io-tei/src/main/java/de/tudarmstadt/ukp/inception/io/tei/TeiFormatSupport.java
+++ b/inception/inception-io-tei/src/main/java/de/tudarmstadt/ukp/inception/io/tei/TeiFormatSupport.java
@@ -26,7 +26,7 @@ import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.inception.io.tei.config.TeiFormatsAutoConfiguration;
 import de.tudarmstadt.ukp.inception.io.tei.dkprobackport.TeiReader;
@@ -39,7 +39,7 @@ import de.tudarmstadt.ukp.inception.io.tei.dkprobackport.TeiWriter;
  * </p>
  */
 public class TeiFormatSupport
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     public static final String ID = "dkpro-core-tei";
     public static final String NAME = "TEI P5 XML (legacy)";

--- a/inception/inception-io-tei/src/main/java/de/tudarmstadt/ukp/inception/io/tei/TeiXmlDocumentFormatSupport.java
+++ b/inception/inception-io-tei/src/main/java/de/tudarmstadt/ukp/inception/io/tei/TeiXmlDocumentFormatSupport.java
@@ -31,7 +31,7 @@ import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.apache.wicket.request.resource.ResourceReference;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.io.xml.dkprocore.XmlNodeUtils;
@@ -40,7 +40,7 @@ import de.tudarmstadt.ukp.inception.support.xml.sanitizer.PolicyCollection;
 import de.tudarmstadt.ukp.inception.support.xml.sanitizer.PolicyCollectionIOUtils;
 
 public class TeiXmlDocumentFormatSupport
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     public static final String ID = "tei-xml-document";
     public static final String NAME = "TEI P5 XML (experimental)";

--- a/inception/inception-io-text/src/main/java/de/tudarmstadt/ukp/clarin/webanno/text/LineOrientedTextFormatSupport.java
+++ b/inception/inception-io-text/src/main/java/de/tudarmstadt/ukp/clarin/webanno/text/LineOrientedTextFormatSupport.java
@@ -28,8 +28,9 @@ import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.text.config.TextFormatsAutoConfiguration;
 import de.tudarmstadt.ukp.inception.support.text.TextUtils;
 
@@ -40,7 +41,7 @@ import de.tudarmstadt.ukp.inception.support.text.TextUtils;
  * </p>
  */
 public class LineOrientedTextFormatSupport
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     public static final String ID = "textlines";
     public static final String NAME = "Plain text (one sentence per line)";
@@ -64,7 +65,7 @@ public class LineOrientedTextFormatSupport
     }
 
     @Override
-    public InputStream obfuscate(InputStream aSource) throws IOException
+    public InputStream obfuscate(SourceDocument aDocument, InputStream aSource) throws IOException
     {
         if (aSource == null) {
             return null;

--- a/inception/inception-io-text/src/main/java/de/tudarmstadt/ukp/clarin/webanno/text/PretokenizedTextFormatSupport.java
+++ b/inception/inception-io-text/src/main/java/de/tudarmstadt/ukp/clarin/webanno/text/PretokenizedTextFormatSupport.java
@@ -28,8 +28,9 @@ import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.text.config.TextFormatsAutoConfiguration;
 import de.tudarmstadt.ukp.inception.support.text.TextUtils;
 
@@ -40,7 +41,7 @@ import de.tudarmstadt.ukp.inception.support.text.TextUtils;
  * </p>
  */
 public class PretokenizedTextFormatSupport
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     public static final String ID = "pretokenized-textlines";
     public static final String NAME = "Plain text (space-separated tokens, one sentence per line)";
@@ -64,7 +65,7 @@ public class PretokenizedTextFormatSupport
     }
 
     @Override
-    public InputStream obfuscate(InputStream aSource) throws IOException
+    public InputStream obfuscate(SourceDocument aDocument, InputStream aSource) throws IOException
     {
         if (aSource == null) {
             return null;

--- a/inception/inception-io-text/src/main/java/de/tudarmstadt/ukp/clarin/webanno/text/TextFormatSupport.java
+++ b/inception/inception-io-text/src/main/java/de/tudarmstadt/ukp/clarin/webanno/text/TextFormatSupport.java
@@ -32,8 +32,9 @@ import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.text.TextWriter;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.text.config.TextFormatsAutoConfiguration;
 import de.tudarmstadt.ukp.inception.support.text.TextUtils;
 
@@ -44,7 +45,7 @@ import de.tudarmstadt.ukp.inception.support.text.TextUtils;
  * </p>
  */
 public class TextFormatSupport
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     public static final String ID = "text";
     public static final String NAME = "Plain text";
@@ -74,7 +75,7 @@ public class TextFormatSupport
     }
 
     @Override
-    public InputStream obfuscate(InputStream aSource) throws IOException
+    public InputStream obfuscate(SourceDocument aDocument, InputStream aSource) throws IOException
     {
         if (aSource == null) {
             return null;

--- a/inception/inception-io-text/src/test/java/de/tudarmstadt/ukp/clarin/webanno/text/LineOrientedTextReaderTest.java
+++ b/inception/inception-io-text/src/test/java/de/tudarmstadt/ukp/clarin/webanno/text/LineOrientedTextReaderTest.java
@@ -29,6 +29,7 @@ import java.io.FileOutputStream;
 import org.apache.uima.fit.factory.JCasFactory;
 import org.junit.jupiter.api.Test;
 
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
 
@@ -58,7 +59,7 @@ class LineOrientedTextReaderTest
         var original = "My number is 555-1234.";
 
         try (var in = new ByteArrayInputStream(original.getBytes(UTF_8));
-                var ob = fs.obfuscate(in)) {
+                var ob = fs.obfuscate(null, in)) {
 
             var obBytes = ob.readAllBytes();
 
@@ -69,7 +70,7 @@ class LineOrientedTextReaderTest
             }
 
             var jcas = JCasFactory.createJCas();
-            fs.read(null, jcas.getCas(), tmp);
+            fs.read(new SourceDocument(), jcas.getCas(), tmp);
 
             var casText = jcas.getDocumentText();
             assertThat(casText).isEqualTo(new String(obBytes, UTF_8));

--- a/inception/inception-io-text/src/test/java/de/tudarmstadt/ukp/clarin/webanno/text/PretokenizedLineOrientedTextReaderTest.java
+++ b/inception/inception-io-text/src/test/java/de/tudarmstadt/ukp/clarin/webanno/text/PretokenizedLineOrientedTextReaderTest.java
@@ -29,6 +29,7 @@ import java.io.FileOutputStream;
 import org.apache.uima.fit.factory.JCasFactory;
 import org.junit.jupiter.api.Test;
 
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
 
@@ -96,7 +97,7 @@ class PretokenizedLineOrientedTextReaderTest
         var original = "My number is 555-1234.";
 
         try (var in = new ByteArrayInputStream(original.getBytes(UTF_8));
-                var ob = fs.obfuscate(in)) {
+                var ob = fs.obfuscate(null, in)) {
 
             var obBytes = ob.readAllBytes();
 
@@ -107,7 +108,7 @@ class PretokenizedLineOrientedTextReaderTest
             }
 
             var jcas = JCasFactory.createJCas();
-            fs.read(null, jcas.getCas(), tmp);
+            fs.read(new SourceDocument(), jcas.getCas(), tmp);
 
             var casText = jcas.getDocumentText();
             assertThat(casText).isEqualTo(new String(obBytes, UTF_8));

--- a/inception/inception-io-text/src/test/java/de/tudarmstadt/ukp/clarin/webanno/text/TextFormatSupportTest.java
+++ b/inception/inception-io-text/src/test/java/de/tudarmstadt/ukp/clarin/webanno/text/TextFormatSupportTest.java
@@ -27,6 +27,8 @@ import java.io.FileOutputStream;
 import org.apache.uima.fit.factory.JCasFactory;
 import org.junit.jupiter.api.Test;
 
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+
 class TextFormatSupportTest
 {
     @Test
@@ -37,7 +39,7 @@ class TextFormatSupportTest
         var original = "My number is 555-1234.";
 
         try (var in = new ByteArrayInputStream(original.getBytes(UTF_8));
-                var ob = fs.obfuscate(in)) {
+                var ob = fs.obfuscate(null, in)) {
 
             var obBytes = ob.readAllBytes();
 
@@ -48,7 +50,7 @@ class TextFormatSupportTest
             }
 
             var jcas = JCasFactory.createJCas();
-            fs.read(null, jcas.getCas(), tmp);
+            fs.read(new SourceDocument(), jcas.getCas(), tmp);
 
             var casText = jcas.getDocumentText();
             assertThat(casText).isEqualTo(new String(obBytes, UTF_8));

--- a/inception/inception-io-webanno-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebAnnoTsv1FormatSupport.java
+++ b/inception/inception-io-webanno-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebAnnoTsv1FormatSupport.java
@@ -23,7 +23,7 @@ import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.tsv.config.WebAnnoFormatsAutoConfiguration;
 
@@ -34,7 +34,7 @@ import de.tudarmstadt.ukp.clarin.webanno.tsv.config.WebAnnoFormatsAutoConfigurat
  * </p>
  */
 public class WebAnnoTsv1FormatSupport
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     public static final String ID = "tsv";
     public static final String NAME = "WebAnno TSV v1 (WebAnno v1.x)";

--- a/inception/inception-io-webanno-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebAnnoTsv2FormatSupport.java
+++ b/inception/inception-io-webanno-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebAnnoTsv2FormatSupport.java
@@ -23,7 +23,7 @@ import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.tsv.config.WebAnnoFormatsAutoConfiguration;
 
@@ -34,7 +34,7 @@ import de.tudarmstadt.ukp.clarin.webanno.tsv.config.WebAnnoFormatsAutoConfigurat
  * </p>
  */
 public class WebAnnoTsv2FormatSupport
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     public static final String ID = "ctsv";
     public static final String NAME = "WebAnno TSV v2 (WebAnno v2.x)";

--- a/inception/inception-io-webanno-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebAnnoTsv3FormatSupport.java
+++ b/inception/inception-io-webanno-tsv/src/main/java/de/tudarmstadt/ukp/clarin/webanno/tsv/WebAnnoTsv3FormatSupport.java
@@ -26,7 +26,7 @@ import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.tsv.config.WebAnnoFormatsAutoConfiguration;
 
@@ -37,7 +37,7 @@ import de.tudarmstadt.ukp.clarin.webanno.tsv.config.WebAnnoFormatsAutoConfigurat
  * </p>
  */
 public class WebAnnoTsv3FormatSupport
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     public static final String ID = "ctsv3";
     public static final String NAME = "WebAnno TSV v3.3 (WebAnno v3.x)";

--- a/inception/inception-io-xmi/src/main/java/de/tudarmstadt/ukp/inception/io/xmi/BinaryCasFormatSupport.java
+++ b/inception/inception-io-xmi/src/main/java/de/tudarmstadt/ukp/inception/io/xmi/BinaryCasFormatSupport.java
@@ -27,7 +27,7 @@ import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.bincas.BinaryCasWriter;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.io.pdf.visual.PdfVModelUtils;
@@ -42,7 +42,7 @@ import de.tudarmstadt.ukp.inception.io.xml.dkprocore.XmlNodeUtils;
  * </p>
  */
 public class BinaryCasFormatSupport
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     public static final String ID = "bin";
     public static final String NAME = "UIMA binary CAS";

--- a/inception/inception-io-xmi/src/main/java/de/tudarmstadt/ukp/inception/io/xmi/UimaInlineXmlFormatSupport.java
+++ b/inception/inception-io-xmi/src/main/java/de/tudarmstadt/ukp/inception/io/xmi/UimaInlineXmlFormatSupport.java
@@ -25,11 +25,11 @@ import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.xml.InlineXmlWriter;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 
 public class UimaInlineXmlFormatSupport
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     public static final String ID = "dkpro-core-uima-inline-xml";
     public static final String NAME = "Inline XML";

--- a/inception/inception-io-xmi/src/main/java/de/tudarmstadt/ukp/inception/io/xmi/XmiFormatSupport.java
+++ b/inception/inception-io-xmi/src/main/java/de/tudarmstadt/ukp/inception/io/xmi/XmiFormatSupport.java
@@ -28,7 +28,6 @@ import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.xmi.XmiReader;
 import org.dkpro.core.io.xmi.XmiWriter;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.io.pdf.visual.PdfVModelUtils;
@@ -43,7 +42,7 @@ import de.tudarmstadt.ukp.inception.io.xml.dkprocore.XmlNodeUtils;
  * </p>
  */
 public class XmiFormatSupport
-    implements FormatSupport
+    extends XmiFormatSupport_ImplBase
 {
     public static final String ID = "xmi";
     public static final String NAME = "UIMA CAS XMI (XML 1.0)";
@@ -75,12 +74,6 @@ public class XmiFormatSupport
 
     @Override
     public boolean isWritable()
-    {
-        return true;
-    }
-
-    @Override
-    public boolean isProneToInconsistencies()
     {
         return true;
     }

--- a/inception/inception-io-xmi/src/main/java/de/tudarmstadt/ukp/inception/io/xmi/XmiFormatSupport_ImplBase.java
+++ b/inception/inception-io-xmi/src/main/java/de/tudarmstadt/ukp/inception/io/xmi/XmiFormatSupport_ImplBase.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.io.xmi;
+
+import static de.tudarmstadt.ukp.inception.support.io.ZipUtils.zipFolder;
+import static java.io.File.createTempFile;
+import static org.apache.uima.fit.factory.AnalysisEngineFactory.createEngine;
+import static org.apache.uima.fit.factory.ConfigurationParameterFactory.addConfigurationParameters;
+import static org.apache.uima.fit.util.LifeCycleUtil.collectionProcessComplete;
+import static org.apache.uima.fit.util.LifeCycleUtil.destroy;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.uima.analysis_engine.AnalysisEngine;
+import org.apache.uima.analysis_engine.AnalysisEngineProcessException;
+import org.apache.uima.cas.CAS;
+import org.apache.uima.resource.ResourceInitializationException;
+import org.dkpro.core.api.io.JCasFileWriter_ImplBase;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+
+public abstract class XmiFormatSupport_ImplBase
+    extends UimaReaderWriterFormatSupport_ImplBase
+{
+    @Override
+    public final boolean isProneToInconsistencies()
+    {
+        return true;
+    }
+
+    @Override
+    public File write(SourceDocument aDocument, CAS aCas, File aTargetFolder,
+            boolean aStripExtension)
+        throws ResourceInitializationException, AnalysisEngineProcessException, IOException
+    {
+        var writer = getWriterDescription(aDocument.getProject(), null, aCas);
+        addConfigurationParameters(writer, //
+                JCasFileWriter_ImplBase.PARAM_USE_DOCUMENT_ID, true,
+                JCasFileWriter_ImplBase.PARAM_ESCAPE_FILENAME, false,
+                JCasFileWriter_ImplBase.PARAM_TARGET_LOCATION, aTargetFolder,
+                JCasFileWriter_ImplBase.PARAM_STRIP_EXTENSION, aStripExtension);
+
+        // Not using SimplePipeline.runPipeline here now because it internally works
+        // with an aggregate engine which is slow due to
+        // https://issues.apache.org/jira/browse/UIMA-6200
+        AnalysisEngine engine = null;
+        try {
+            engine = createEngine(writer);
+            engine.process(aCas);
+            collectionProcessComplete(engine);
+        }
+        finally {
+            destroy(engine);
+        }
+
+        // The DKPro XmiWriter produces not only the XMI file but also a typesystem.xml file.
+        // So we ZIP up the target folder and return that ZIP file as the export result.
+        var exportFile = createTempFile("inception-document", ".zip");
+        zipFolder(aTargetFolder, exportFile);
+        return exportFile;
+    }
+
+}

--- a/inception/inception-io-xmi/src/main/java/de/tudarmstadt/ukp/inception/io/xmi/XmiXml11FormatSupport.java
+++ b/inception/inception-io-xmi/src/main/java/de/tudarmstadt/ukp/inception/io/xmi/XmiXml11FormatSupport.java
@@ -28,7 +28,6 @@ import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.xmi.XmiReader;
 import org.dkpro.core.io.xmi.XmiWriter;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.io.pdf.visual.PdfVModelUtils;
@@ -43,7 +42,7 @@ import de.tudarmstadt.ukp.inception.io.xml.dkprocore.XmlNodeUtils;
  * </p>
  */
 public class XmiXml11FormatSupport
-    implements FormatSupport
+    extends XmiFormatSupport_ImplBase
 {
     public static final String ID = "xmi-xml1.1";
     public static final String NAME = "UIMA CAS XMI (XML 1.1)";
@@ -75,12 +74,6 @@ public class XmiXml11FormatSupport
 
     @Override
     public boolean isWritable()
-    {
-        return true;
-    }
-
-    @Override
-    public boolean isProneToInconsistencies()
     {
         return true;
     }

--- a/inception/inception-io-xmi/src/main/java/de/tudarmstadt/ukp/inception/io/xmi/XmiXmlStructureFormatSupport.java
+++ b/inception/inception-io-xmi/src/main/java/de/tudarmstadt/ukp/inception/io/xmi/XmiXmlStructureFormatSupport.java
@@ -37,7 +37,6 @@ import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 import org.dkpro.core.io.xmi.XmiWriter;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
@@ -51,7 +50,7 @@ import de.tudarmstadt.ukp.inception.io.xmi.config.UimaFormatsPropertiesImpl.XmiF
  * </p>
  */
 public class XmiXmlStructureFormatSupport
-    implements FormatSupport
+    extends XmiFormatSupport_ImplBase
 {
     public static final String ID = "xmi-struct";
     public static final String NAME = "UIMA CAS XMI (XML 1.0 + XML/PDF structure)";
@@ -85,12 +84,6 @@ public class XmiXmlStructureFormatSupport
     }
 
     @Override
-    public boolean isProneToInconsistencies()
-    {
-        return true;
-    }
-
-    @Override
     public File write(SourceDocument aDocument, CAS aCas, File aTargetFolder,
             boolean aStripExtension)
         throws ResourceInitializationException, AnalysisEngineProcessException, IOException
@@ -113,7 +106,7 @@ public class XmiXmlStructureFormatSupport
             }
         }
 
-        return FormatSupport.super.write(aDocument, cas, aTargetFolder, aStripExtension);
+        return super.write(aDocument, cas, aTargetFolder, aStripExtension);
     }
 
     @Override

--- a/inception/inception-io-xml/src/main/java/de/tudarmstadt/ukp/inception/io/xml/CustomXmlFormatFactory.java
+++ b/inception/inception-io-xml/src/main/java/de/tudarmstadt/ukp/inception/io/xml/CustomXmlFormatFactory.java
@@ -38,7 +38,7 @@ import org.apache.wicket.resource.FileSystemResourceReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.io.xml.dkprocore.XmlDocumentReader;
@@ -48,7 +48,7 @@ import de.tudarmstadt.ukp.inception.support.xml.sanitizer.PolicyCollection;
 import de.tudarmstadt.ukp.inception.support.xml.sanitizer.PolicyCollectionIOUtils;
 
 public class CustomXmlFormatFactory
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 

--- a/inception/inception-io-xml/src/main/java/de/tudarmstadt/ukp/inception/io/xml/XmlFormatSupport.java
+++ b/inception/inception-io-xml/src/main/java/de/tudarmstadt/ukp/inception/io/xml/XmlFormatSupport.java
@@ -26,7 +26,7 @@ import org.apache.uima.collection.CollectionReaderDescription;
 import org.apache.uima.resource.ResourceInitializationException;
 import org.apache.uima.resource.metadata.TypeSystemDescription;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.UimaReaderWriterFormatSupport_ImplBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.io.xml.dkprocore.XmlDocumentReader;
@@ -34,7 +34,7 @@ import de.tudarmstadt.ukp.inception.io.xml.dkprocore.XmlDocumentWriter;
 import de.tudarmstadt.ukp.inception.io.xml.dkprocore.XmlNodeUtils;
 
 public class XmlFormatSupport
-    implements FormatSupport
+    extends UimaReaderWriterFormatSupport_ImplBase
 {
     public static final String ID = "dkpro-core-xml-document";
     public static final String NAME = "XML (generic)";

--- a/inception/inception-project-export/src/main/java/de/tudarmstadt/ukp/inception/project/export/config/ProjectExportServiceAutoConfiguration.java
+++ b/inception/inception-project-export/src/main/java/de/tudarmstadt/ukp/inception/project/export/config/ProjectExportServiceAutoConfiguration.java
@@ -48,6 +48,7 @@ import de.tudarmstadt.ukp.inception.project.export.legacy.LegacyExportProjectSet
 import de.tudarmstadt.ukp.inception.project.export.settings.ExportProjectSettingsPanelFactory;
 import de.tudarmstadt.ukp.inception.project.export.task.backup.BackupProjectExportExtension;
 import de.tudarmstadt.ukp.inception.project.export.task.curated.CuratedDocumentsProjectExportExtension;
+import de.tudarmstadt.ukp.inception.project.export.task.export.TransformingProjectExportExtension;
 import de.tudarmstadt.ukp.inception.scheduling.SchedulingService;
 import de.tudarmstadt.ukp.inception.websocket.security.StompSecurityConfigurer;
 
@@ -98,6 +99,13 @@ public class ProjectExportServiceAutoConfiguration
     public BackupProjectExportExtension backupProjectExportExtension()
     {
         return new BackupProjectExportExtension();
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "dashboard.transforming-export.enabled", havingValue = "true", matchIfMissing = false)
+    public TransformingProjectExportExtension transformingProjectExportExtension()
+    {
+        return new TransformingProjectExportExtension();
     }
 
     @Bean

--- a/inception/inception-project-export/src/main/java/de/tudarmstadt/ukp/inception/project/export/legacy/LegacyProjectExportPanel.java
+++ b/inception/inception-project-export/src/main/java/de/tudarmstadt/ukp/inception/project/export/legacy/LegacyProjectExportPanel.java
@@ -88,6 +88,7 @@ public class LegacyProjectExportPanel
 
         add(form = new Form<>("exportForm",
                 new CompoundPropertyModel<>(FullProjectExportRequest.builder() //
+                        .withTitle("Project backup") //
                         .withFormat(FullProjectExportRequest.FORMAT_AUTO) //
                         .withIncludeInProgress(true) //
                         .build())));

--- a/inception/inception-project-export/src/main/java/de/tudarmstadt/ukp/inception/project/export/task/backup/BackupProjectExportExtension.java
+++ b/inception/inception-project-export/src/main/java/de/tudarmstadt/ukp/inception/project/export/task/backup/BackupProjectExportExtension.java
@@ -19,6 +19,7 @@ package de.tudarmstadt.ukp.inception.project.export.task.backup;
 
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
+import org.springframework.core.annotation.Order;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.inception.project.export.ProjectExportExtension;
@@ -30,6 +31,7 @@ import de.tudarmstadt.ukp.inception.project.export.config.ProjectExportServiceAu
  * {@link ProjectExportServiceAutoConfiguration#backupProjectExportExtension()}.
  * </p>
  */
+@Order(100)
 public class BackupProjectExportExtension
     implements ProjectExportExtension
 {

--- a/inception/inception-project-export/src/main/java/de/tudarmstadt/ukp/inception/project/export/task/backup/BackupProjectExporterPanel.java
+++ b/inception/inception-project-export/src/main/java/de/tudarmstadt/ukp/inception/project/export/task/backup/BackupProjectExporterPanel.java
@@ -47,6 +47,7 @@ public class BackupProjectExporterPanel
 
         var model = CompoundPropertyModel.of(FullProjectExportRequest.builder() //
                 .withProject(aModel.getObject()) //
+                .withTitle("Project backup") //
                 .withIncludeInProgress(true) //
                 .build());
 

--- a/inception/inception-project-export/src/main/java/de/tudarmstadt/ukp/inception/project/export/task/curated/CuratedDocumentsProjectExportExtension.java
+++ b/inception/inception-project-export/src/main/java/de/tudarmstadt/ukp/inception/project/export/task/curated/CuratedDocumentsProjectExportExtension.java
@@ -20,6 +20,7 @@ package de.tudarmstadt.ukp.inception.project.export.task.curated;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
+import org.springframework.core.annotation.Order;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
@@ -32,6 +33,7 @@ import de.tudarmstadt.ukp.inception.project.export.config.ProjectExportServiceAu
  * {@link ProjectExportServiceAutoConfiguration#curatedDocumentsProjectExportExtension}.
  * </p>
  */
+@Order(300)
 public class CuratedDocumentsProjectExportExtension
     implements ProjectExportExtension
 {

--- a/inception/inception-project-export/src/main/java/de/tudarmstadt/ukp/inception/project/export/task/export/TransformingProjectExportExtension.java
+++ b/inception/inception-project-export/src/main/java/de/tudarmstadt/ukp/inception/project/export/task/export/TransformingProjectExportExtension.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.project.export.task.export;
+
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.model.IModel;
+import org.springframework.core.annotation.Order;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.inception.project.export.ProjectExportExtension;
+import de.tudarmstadt.ukp.inception.project.export.config.ProjectExportServiceAutoConfiguration;
+
+/**
+ * <p>
+ * This class is exposed as a Spring Component via
+ * {@link ProjectExportServiceAutoConfiguration#transformingProjectExportExtension()}.
+ * </p>
+ */
+@Order(200)
+public class TransformingProjectExportExtension
+    implements ProjectExportExtension
+{
+    public static final String ID = "transformingExport";
+
+    @Override
+    public String getId()
+    {
+        return ID;
+    }
+
+    @Override
+    public boolean accepts(Project aContext)
+    {
+        return true;
+    }
+
+    @Override
+    public Panel createExporterPanel(String aId, IModel<Project> aProject)
+    {
+        return new TransformingProjectExporterPanel(aId, aProject);
+    }
+}

--- a/inception/inception-project-export/src/main/java/de/tudarmstadt/ukp/inception/project/export/task/export/TransformingProjectExportTask.java
+++ b/inception/inception-project-export/src/main/java/de/tudarmstadt/ukp/inception/project/export/task/export/TransformingProjectExportTask.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.project.export.task.export;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.export.FullProjectExportRequest;
+import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExportException;
+import de.tudarmstadt.ukp.clarin.webanno.api.export.ProjectExportTaskMonitor;
+import de.tudarmstadt.ukp.inception.project.export.ProjectExportService;
+import de.tudarmstadt.ukp.inception.project.export.task.ProjectExportTask_ImplBase;
+
+public class TransformingProjectExportTask
+    extends ProjectExportTask_ImplBase<FullProjectExportRequest>
+{
+    private @Autowired ProjectExportService exportService;
+
+    public TransformingProjectExportTask(FullProjectExportRequest aRequest, String aUsername)
+    {
+        super(aRequest.getProject(), aRequest, aUsername);
+    }
+
+    @Override
+    public File export(FullProjectExportRequest aRequest, ProjectExportTaskMonitor aMonitor)
+        throws ProjectExportException, IOException, InterruptedException
+    {
+        return exportService.exportProject(aRequest, aMonitor);
+    }
+}

--- a/inception/inception-project-export/src/main/java/de/tudarmstadt/ukp/inception/project/export/task/export/TransformingProjectExporterPanel.html
+++ b/inception/inception-project-export/src/main/java/de/tudarmstadt/ukp/inception/project/export/task/export/TransformingProjectExporterPanel.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<!--
+  Licensed to the Technische Universität Darmstadt under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The Technische Universität Darmstadt 
+  licenses this file to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.
+   
+  http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<html xmlns:wicket="http://wicket.apache.org">
+<body>
+  <wicket:extend>
+    <h2>Export transformed archive</h2>
+    
+    <p class="small">
+      Exports an archive containing the entire project.
+      This exporter offers options to modify the exported project, e.g. to obfuscate document contents.
+      While the exported project can be imported again, this export is <b>NOT A BACKUP</b>.
+    </p>
+
+    <div class="container">
+      <div class="row form-row">
+        <div class="form-check form-switch">
+          <input wicket:id="obfuscate" class="form-check-input" type="checkbox"> 
+          <label wicket:for="obfuscate" class="form-check-label" >
+            <wicket:label key="obfuscate"/>
+          </label>
+          <div class="form-text">
+            Best-effort replacement of document text with blind text. May not work for all types of documents.
+          </div>
+        </div>
+      </div>
+    </div>
+    
+    <div class="text-end">
+      <button wicket:id="startExport" type="button" class="btn btn-primary text-nowrap">
+        <i class="fas fa-play"></i>&nbsp;
+        <wicket:message key="export"/>
+      </button>
+    </div>
+  </wicket:extend>
+</body>
+</html>

--- a/inception/inception-project-export/src/main/java/de/tudarmstadt/ukp/inception/project/export/task/export/TransformingProjectExporterPanel.java
+++ b/inception/inception-project-export/src/main/java/de/tudarmstadt/ukp/inception/project/export/task/export/TransformingProjectExporterPanel.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.project.export.task.export;
+
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.markup.html.form.CheckBox;
+import org.apache.wicket.model.CompoundPropertyModel;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.spring.injection.annot.SpringBean;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.export.DocumentImportExportService;
+import de.tudarmstadt.ukp.clarin.webanno.api.export.FullProjectExportRequest;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.inception.project.export.ProjectExportService;
+import de.tudarmstadt.ukp.inception.project.export.settings.ProjectExporterPanelImplBase;
+import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxFormComponentUpdatingBehavior;
+import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxLink;
+
+public class TransformingProjectExporterPanel
+    extends ProjectExporterPanelImplBase
+{
+    private static final long serialVersionUID = 4106224145358319779L;
+
+    private @SpringBean ProjectExportService projectExportService;
+    private @SpringBean DocumentImportExportService importExportService;
+
+    public TransformingProjectExporterPanel(String aId, IModel<Project> aModel)
+    {
+        super(aId);
+
+        var model = CompoundPropertyModel.of(FullProjectExportRequest.builder() //
+                .withProject(aModel.getObject()) //
+                .withTitle("Transformed project export") //
+                .withIncludeInProgress(true) //
+                .build());
+
+        setDefaultModel(model);
+
+        var obfuscate = new CheckBox("obfuscate", model.bind("obfuscate"));
+        obfuscate.setOutputMarkupId(true);
+        obfuscate.add(new LambdaAjaxFormComponentUpdatingBehavior());
+        add(obfuscate);
+
+        add(new LambdaAjaxLink("startExport", this::actionStartExport));
+    }
+
+    @SuppressWarnings("unchecked")
+    public IModel<FullProjectExportRequest> getModel()
+    {
+        return (IModel<FullProjectExportRequest>) getDefaultModel();
+    }
+
+    public FullProjectExportRequest getModelObject()
+    {
+        return (FullProjectExportRequest) getDefaultModelObject();
+    }
+
+    private void actionStartExport(AjaxRequestTarget aTarget)
+    {
+        var authentication = SecurityContextHolder.getContext().getAuthentication();
+        var request = getModelObject();
+        var task = new TransformingProjectExportTask(request, authentication.getName());
+
+        projectExportService.startTask(task);
+    }
+}

--- a/inception/inception-project-export/src/main/java/de/tudarmstadt/ukp/inception/project/export/task/export/TransformingProjectExporterPanel.utf8.properties
+++ b/inception/inception-project-export/src/main/java/de/tudarmstadt/ukp/inception/project/export/task/export/TransformingProjectExporterPanel.utf8.properties
@@ -1,0 +1,19 @@
+# Licensed to the Technische Universität Darmstadt under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The Technische Universität Darmstadt 
+# licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.
+#  
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+format=Secondary format
+format.nullValid=No additional format
+export=Start export...
+obfuscate=Obfuscate

--- a/inception/inception-project-export/src/test/java/de/tudarmstadt/ukp/inception/project/export/AnnotationDocumentsExporterTest.java
+++ b/inception/inception-project-export/src/test/java/de/tudarmstadt/ukp/inception/project/export/AnnotationDocumentsExporterTest.java
@@ -118,8 +118,8 @@ public class AnnotationDocumentsExporterTest
                 casStorageService, schemaService, properties, checksRegistry, repairsRegistry,
                 xmiFormatSupport);
 
-        sut = new AnnotationDocumentExporter(documentService, userService, importExportSerivce,
-                repositoryProperties);
+        sut = new AnnotationDocumentExporter(documentService, casStorageService, userService,
+                importExportSerivce, repositoryProperties);
     }
 
     @Test

--- a/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/config/AnnotationSchemaServiceAutoConfiguration.java
+++ b/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/config/AnnotationSchemaServiceAutoConfiguration.java
@@ -26,6 +26,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 
+import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasStorageService;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.DocumentImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.inception.annotation.feature.bool.BooleanFeatureSupport;
@@ -130,10 +131,11 @@ public class AnnotationSchemaServiceAutoConfiguration
 
     @Bean
     public AnnotationDocumentExporter annotationDocumentExporter(DocumentService aDocumentService,
-            UserDao aUserRepository, DocumentImportExportService aImportExportService,
+            CasStorageService aCasStorageService, UserDao aUserRepository,
+            DocumentImportExportService aImportExportService,
             RepositoryProperties aRepositoryProperties)
     {
-        return new AnnotationDocumentExporter(aDocumentService, aUserRepository,
+        return new AnnotationDocumentExporter(aDocumentService, aCasStorageService, aUserRepository,
                 aImportExportService, aRepositoryProperties);
     }
 

--- a/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/exporters/AnnotationDocumentExporter.java
+++ b/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/exporters/AnnotationDocumentExporter.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.schema.exporters;
 
+import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode.UNMANAGED_NON_INITIALIZING_ACCESS;
 import static de.tudarmstadt.ukp.clarin.webanno.api.export.FullProjectExportRequest.FORMAT_AUTO;
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet.INITIAL_SET;
 import static de.tudarmstadt.ukp.clarin.webanno.model.Mode.ANNOTATION;
@@ -28,6 +29,7 @@ import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.INITIAL_CAS_PSEU
 import static de.tudarmstadt.ukp.inception.support.io.FastIOUtils.copy;
 import static java.lang.Math.ceil;
 import static java.lang.System.currentTimeMillis;
+import static java.nio.file.Files.newInputStream;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.function.Function.identity;
@@ -62,6 +64,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 
+import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasStorageService;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.DocumentImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.FullProjectExportRequest;
@@ -84,6 +87,7 @@ import de.tudarmstadt.ukp.inception.documents.api.RepositoryProperties;
 import de.tudarmstadt.ukp.inception.documents.exporters.SourceDocumentExporter;
 import de.tudarmstadt.ukp.inception.schema.config.AnnotationSchemaServiceAutoConfiguration;
 import de.tudarmstadt.ukp.inception.support.logging.LogMessage;
+import de.tudarmstadt.ukp.inception.support.uima.CasObfuscationUtils;
 
 /**
  * <p>
@@ -101,16 +105,19 @@ public class AnnotationDocumentExporter
     private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private final DocumentService documentService;
+    private final CasStorageService casStorageService;
     private final UserDao userRepository;
     private final DocumentImportExportService importExportService;
     private final RepositoryProperties repositoryProperties;
 
     @Autowired
-    public AnnotationDocumentExporter(DocumentService aDocumentService, UserDao aUserRepository,
+    public AnnotationDocumentExporter(DocumentService aDocumentService,
+            CasStorageService aCasStorageService, UserDao aUserRepository,
             DocumentImportExportService aImportExportService,
             RepositoryProperties aRepositoryProperties)
     {
         documentService = aDocumentService;
+        casStorageService = aCasStorageService;
         userRepository = aUserRepository;
         importExportService = aImportExportService;
         repositoryProperties = aRepositoryProperties;
@@ -223,10 +230,7 @@ public class AnnotationDocumentExporter
                     documentService.createOrReadInitialCas(srcDoc);
                 }
 
-                ProjectExporter.writeEntry(
-                        aStage, ANNOTATION_CAS_FOLDER + srcDoc.getName() + "/"
-                                + INITIAL_CAS_PSEUDO_USER + ".ser",
-                        os -> documentService.exportCas(srcDoc, INITIAL_SET, os));
+                exportCas(aRequest, aStage, bulkOperationContext, srcDoc, INITIAL_SET);
 
                 if (format != null) {
                     exportAdditionalFormat(aStage, bulkOperationContext, srcDoc, format,
@@ -250,11 +254,8 @@ public class AnnotationDocumentExporter
                             && !annDoc.getState().equals(AnnotationDocumentState.NEW)
                             && !annDoc.getState().equals(AnnotationDocumentState.IGNORE)) {
 
-                        ProjectExporter.writeEntry(aStage, ANNOTATION_CAS_FOLDER + srcDoc.getName()
-                                + "/" + annDoc.getUser() + ".ser", os -> {
-                                    documentService.exportCas(srcDoc,
-                                            AnnotationSet.forUser(annDoc.getUser()), os);
-                                });
+                        exportCas(aRequest, aStage, bulkOperationContext, srcDoc,
+                                annDoc.getAnnotationSet());
 
                         if (format != null) {
                             exportAdditionalFormat(aStage, bulkOperationContext, srcDoc, format,
@@ -271,6 +272,35 @@ public class AnnotationDocumentExporter
             aMonitor.setProgress(initProgress + (int) ceil(((double) i) / documents.size() * 80.0));
             i++;
         }
+    }
+
+    private void exportCas(FullProjectExportRequest aRequest, ZipOutputStream aStage,
+            Map<Pair<Project, String>, Object> bulkOperationContext, SourceDocument aSrcDoc,
+            AnnotationSet aSet)
+        throws IOException
+    {
+        if (aRequest.isObfuscate()) {
+            ProjectExporter.writeEntry(aStage,
+                    ANNOTATION_CAS_FOLDER + aSrcDoc.getName() + "/" + aSet.id() + ".ser", os -> {
+                        try (var session = CasStorageSession.openNested()) {
+                            var cas = casStorageService.readCas(aSrcDoc, aSet,
+                                    UNMANAGED_NON_INITIALIZING_ACCESS);
+                            try {
+                                cas = CasObfuscationUtils.obfuscate(cas);
+                            }
+                            catch (UIMAException e) {
+                                throw new IOException("Obfuscation failed", e);
+                            }
+                            casStorageService.serializeCas(aSrcDoc, aSet, cas, os);
+                        }
+                    });
+
+            return;
+        }
+
+        ProjectExporter.writeEntry(aStage,
+                ANNOTATION_CAS_FOLDER + aSrcDoc.getName() + "/" + aSet.id() + ".ser",
+                os -> documentService.exportCas(aSrcDoc, aSet, os));
     }
 
     private void exportAdditionalFormat(ZipOutputStream aStage,
@@ -290,7 +320,7 @@ public class AnnotationDocumentExporter
                 var filename = aUsername + "." + getExtension(annFile.getName());
                 ProjectExporter.writeEntry(aStage,
                         ANNOTATION_ORIGINAL_FOLDER + srcDoc.getName() + "/" + filename, os -> {
-                            try (var is = Files.newInputStream(finalAnnFile.toPath())) {
+                            try (var is = newInputStream(finalAnnFile.toPath())) {
                                 is.transferTo(os);
                             }
                         });
@@ -299,7 +329,7 @@ public class AnnotationDocumentExporter
                 ProjectExporter.writeEntry(aStage,
                         ANNOTATION_ORIGINAL_FOLDER + srcDoc.getName() + "/" + annFile.getName(),
                         os -> {
-                            try (var is = Files.newInputStream(finalAnnFile.toPath())) {
+                            try (var is = newInputStream(finalAnnFile.toPath())) {
                                 is.transferTo(os);
                             }
                         });

--- a/inception/inception-schema/src/test/java/de/tudarmstadt/ukp/inception/schema/service/AnnotationSchemaServiceImplTest.java
+++ b/inception/inception-schema/src/test/java/de/tudarmstadt/ukp/inception/schema/service/AnnotationSchemaServiceImplTest.java
@@ -43,6 +43,7 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasStorageService;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.DocumentImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.constraints.config.ConstraintsServiceAutoConfiguration;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
@@ -95,6 +96,7 @@ class AnnotationSchemaServiceImplTest
 
     private @MockitoBean DocumentService documentService;
     private @MockitoBean DocumentImportExportService documentImportExportService;
+    private @MockitoBean CasStorageService casStorageService;
 
     private @Autowired ProjectService projectService;
     private @Autowired UserDao userRepository;

--- a/inception/inception-support/pom.xml
+++ b/inception/inception-support/pom.xml
@@ -22,9 +22,17 @@
     <artifactId>inception-app</artifactId>
     <version>41.0-SNAPSHOT</version>
   </parent>
+
   <artifactId>inception-support</artifactId>
   <name>INCEpTION - Support library</name>
+
   <dependencies>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-support-xml</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  
     <dependency>
       <groupId>jakarta.annotation</groupId>
       <artifactId>jakarta.annotation-api</artifactId>

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/uima/CasObfuscationUtils.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/uima/CasObfuscationUtils.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.support.uima;
+
+import static de.tudarmstadt.ukp.inception.support.uima.ICasUtil.findAllFeatureStructures;
+import static org.apache.uima.cas.CAS.FEATURE_BASE_NAME_SOFA;
+import static org.apache.uima.cas.CAS.TYPE_NAME_STRING;
+import static org.apache.uima.cas.CAS.TYPE_NAME_STRING_ARRAY;
+
+import org.apache.uima.UIMAException;
+import org.apache.uima.cas.CAS;
+import org.apache.uima.cas.SofaFS;
+import org.apache.uima.cas.StringArrayFS;
+import org.apache.uima.cas.impl.CASImpl;
+import org.apache.uima.cas.impl.Serialization;
+import org.apache.uima.resource.ResourceInitializationException;
+import org.apache.uima.util.CasCopier;
+import org.apache.uima.util.CasCreationUtils;
+import org.dkpro.core.api.xml.type.XmlAttribute;
+import org.dkpro.core.api.xml.type.XmlDocument;
+import org.dkpro.core.api.xml.type.XmlNode;
+
+import de.tudarmstadt.ukp.inception.support.text.TextUtils;
+
+public class CasObfuscationUtils
+{
+    public static CAS obfuscate(CAS aCas) throws UIMAException
+    {
+        if (aCas == null) {
+            return null;
+        }
+
+        // Create a fresh CAS and initialize its CAS manager (type system, indexes,
+        // type priorities) from the source CAS manager.
+        var targetCas = createCasUsingTemplate(aCas);
+
+        // Set obfuscated document text on the target first so offsets remain valid
+        // while copying annotations.
+        targetCas.setDocumentText(obfuscateDocumentText(aCas));
+
+        // Copy all feature structures (annotations, metadata) into the target CAS.
+        CasCopier.copyCas(aCas, targetCas, false);
+
+        // Obfuscate any primitive string features (and string arrays) on copied FSes.
+        obfuscateStringFeatures(targetCas);
+
+        // Set obfuscated language after copying/obfuscating so it is not overwritten
+        // by the CasCopier.
+        targetCas.setDocumentLanguage(TextUtils.obfuscate(aCas.getDocumentLanguage()));
+
+        return targetCas;
+    }
+
+    private static CAS createCasUsingTemplate(CAS aCas) throws ResourceInitializationException
+    {
+        var sourceReal = WebAnnoCasUtil.getRealCas(aCas);
+        var sourceImpl = (CASImpl) sourceReal;
+        var casMgr = Serialization.serializeCASMgr(sourceImpl);
+
+        var targetCas = CasCreationUtils.createCas();
+        targetCas.getJCasImpl().getCasImpl().getBinaryCasSerDes()
+                .setupCasFromCasMgrSerializer(casMgr);
+        return targetCas;
+    }
+
+    private static String obfuscateDocumentText(CAS aCas)
+    {
+        var originalText = aCas.getDocumentText();
+        if (originalText == null) {
+            return null;
+        }
+
+        var obfuscatedText = TextUtils.obfuscate(originalText);
+        if (obfuscatedText.length() != originalText.length()) {
+            throw new IllegalStateException("Obfuscated text length differs from original");
+        }
+
+        return obfuscatedText;
+    }
+
+    static void obfuscateStringFeatures(CAS aCas)
+    {
+        var reachable = findAllFeatureStructures(aCas);
+
+        for (var fs : reachable) {
+            if (fs instanceof SofaFS) {
+                // Can't use standard set methods with SofaFS features.
+                continue;
+            }
+
+            if (fs instanceof XmlNode || fs instanceof XmlDocument || fs instanceof XmlAttribute) {
+                // We need to maintain this, otherwise document layout breaks e.g. for HTML files
+                continue;
+            }
+
+            // Note: DocumentMetaData is obfuscated like other string features so that
+            // exported copies do not leak identifying metadata.
+
+            for (var f : fs.getType().getFeatures()) {
+                // Skip sofa references and non-primitive features
+                if (FEATURE_BASE_NAME_SOFA.equals(f.getShortName())) {
+                    continue;
+                }
+
+                if (f.getRange().isPrimitive()) {
+                    if (TYPE_NAME_STRING.equals(f.getRange().getName())) {
+                        var val = fs.getFeatureValueAsString(f);
+                        if (val != null) {
+                            fs.setStringValue(f, TextUtils.obfuscate(val));
+                        }
+                    }
+                }
+                else {
+                    // Handle string arrays
+                    if (TYPE_NAME_STRING_ARRAY.equals(f.getRange().getName())) {
+                        var arrFs = (StringArrayFS) fs.getFeatureValue(f);
+                        if (arrFs != null) {
+                            for (int i = 0; i < arrFs.size(); i++) {
+                                var s = arrFs.get(i);
+                                if (s != null) {
+                                    arrFs.set(i, TextUtils.obfuscate(s));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/inception/inception-support/src/test/java/de/tudarmstadt/ukp/inception/support/uima/CasObfuscationUtilsTest.java
+++ b/inception/inception-support/src/test/java/de/tudarmstadt/ukp/inception/support/uima/CasObfuscationUtilsTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *  
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.support.uima;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.uima.fit.factory.JCasFactory;
+import org.apache.uima.jcas.tcas.Annotation;
+import org.junit.jupiter.api.Test;
+
+import de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData;
+
+public class CasObfuscationUtilsTest
+{
+    @Test
+    void thatObfuscationObfuscatesStrings() throws Exception
+    {
+        var jcas = JCasFactory.createJCas();
+        jcas.setDocumentText("Hello World 1234!");
+        jcas.setDocumentLanguage("en");
+
+        var dmd = DocumentMetaData.create(jcas);
+        dmd.setDocumentTitle("My Secret Title");
+        dmd.setDocumentId("ID-12345");
+
+        var ann = new Annotation(jcas, 0, 5);
+        ann.addToIndexes();
+
+        var obfCas = CasObfuscationUtils.obfuscate(jcas.getCas());
+
+        assertThat(obfCas).isNotNull();
+        assertThat(obfCas.getDocumentText()).isNotNull();
+        assertThat(obfCas.getDocumentText().length()).isEqualTo(jcas.getDocumentText().length());
+        assertThat(obfCas.getDocumentText()).isNotEqualTo(jcas.getDocumentText());
+        assertThat(obfCas.getDocumentLanguage()).isNotEqualTo(jcas.getDocumentLanguage());
+
+        var obfDmd = DocumentMetaData.get(obfCas);
+        assertThat(obfDmd).isNotNull();
+        assertThat(obfDmd.getDocumentTitle()).isNotEqualTo(dmd.getDocumentTitle());
+        assertThat(obfDmd.getDocumentId()).isNotEqualTo(dmd.getDocumentId());
+
+        var obfJCas = obfCas.getJCas();
+        var annIter = obfJCas.getAnnotationIndex(Annotation.class).iterator();
+        boolean found = false;
+        while (annIter.hasNext()) {
+            var a = annIter.next();
+            if (a.getBegin() == 0 && a.getEnd() == 5) {
+                found = true;
+                break;
+            }
+        }
+        assertThat(found).isTrue();
+    }
+
+}


### PR DESCRIPTION
**What's in the PR**
- Add TransformingProjectExportExtension, TransformingProjectExportTask and UI panel for transforming exports
- Refactor CAS storage service and filesystem driver; improve persistence utilities
- Update and extend format support APIs and tests (UimaReaderWriterFormatSupport_ImplBase, FormatSupportTest)
- Add CasObfuscationUtils and unit tests
- Misc fixes and test updates across document/export and IO modules

**How to test manually**
* Enable transforming exports and try an obfuscated export

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
