### PR TITLE
#5984 - Use docker maven plugin buildx support for multi-platform builds

### DIFF
--- a/inception/inception-docker/README.md
+++ b/inception/inception-docker/README.md
@@ -1,62 +1,94 @@
 # INCEpTION Docker
 
-You can use this module to build a Docker image either as part of the main build from the project
-root or individually by only building this module. If you only build this module, make sure that
-you have previously built the entire project so the Docker image can be created using the latest
-INCEpTION (`inception-app-webapp`) artifact. 
+This module builds the INCEpTION Docker image. It is excluded from a normal
+reactor build and only included when the `dist-docker` profile is active. If you
+build only this module, make sure that you have previously built the entire
+project so that the latest `inception-app-webapp` standalone artifact is
+available in your local Maven repository.
+
+Two profiles control the build:
+
+- `dist-docker` — adds the docker module to the reactor (declared in the parent
+  pom). Without this profile, the docker module is not built at all.
+- `release-docker` — switches to a multi-platform (`linux/amd64` + `linux/arm64`)
+  buildx build and pushes the resulting manifest list to the registry.
+
+Image name and tags are controlled by the `docker.image.name` property
+(defaults to `ghcr.io/inception-project/inception-snapshots`).
 
 ## SNAPSHOT builds
-To create a SNAPSHOT build:
 
-    mvn -Pdocker clean docker:build
-    mvn -Pdocker docker:push   (only if the build should be published)
+Build a single-architecture image into your local Docker daemon (no push):
 
-To run the latest SNAPSHOT build, use: 
+    mvn -Pdist-docker clean install
+
+Build and push a multi-architecture SNAPSHOT image to
+`ghcr.io/inception-project/inception-snapshots`:
+
+    mvn -Pdist-docker,release-docker clean deploy
+
+Run the latest published SNAPSHOT:
 
     docker run -p8080:8080 -v inception-data:/export -it ghcr.io/inception-project/inception-snapshots
 
-To run the latest SNAPSHOT build with Docker Compose, use:
+Run the latest SNAPSHOT via Docker Compose:
 
-    INCEPTION_IMAGE=ghcr.io/inception-project/inception-snapshots INCEPTION_VERSION=latest docker-compose -f ../inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/scripts/docker-compose.yml -p inception up
+    export INCEPTION_IMAGE=ghcr.io/inception-project/inception-snapshots
+    export INCEPTION_VERSION=latest
+    docker-compose -f ../inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/scripts/docker-compose.yml -p inception up
 
 ## Release builds
-   
-For a release build:
 
-    mvn -Pdocker clean docker:build -Ddocker.image.name="ghcr.io/inception-project/inception"
-    mvn -Pdocker docker:push -Ddocker.image.name="ghcr.io/inception-project/inception"
-        
+Build and push a multi-architecture release image to
+`ghcr.io/inception-project/inception`:
+
+    mvn -Pdist-docker,release-docker clean deploy -Ddocker.image.name=ghcr.io/inception-project/inception
+
+Run the released image:
+
     docker run -p8080:8080 -v inception-data:/export -it ghcr.io/inception-project/inception
 
-## Multi-platform build for ARM46 and AMD64
+## Building only the docker module
 
-To build a docker images which runs on AMD64 as well as ARM64 machines, use:
+When invoking Maven from inside the `inception-docker/` directory, the
+`dist-docker` profile is not needed (it only gates module inclusion in the
+parent reactor). The `release-docker` profile is still required to enable
+multi-arch + push:
 
-    docker buildx create --use          (need to do this only once!)
-    mvn -Pdocker-buildx clean package   (will be pushed immediately!)
+    cd inception-docker
+    mvn install                         # local single-arch build
+    mvn -Prelease-docker deploy         # multi-arch build + push
 
-Mind that you may have to log in to GitHub before being able to publish. This can be done e.g.
-via Docker Desktop or on the command line via `docker login`.
+## Authentication
+
+Pushing to GitHub Container Registry requires authentication. Log in via Docker
+Desktop or on the command line:
+
+    docker login ghcr.io
 
 ## Options
-If you want to keep the application data easily accessible in a folder on your host (e.g. if you
-want to use a custom settings.properties file), you can provide a path on the host to the `-v` 
-parameter.
+
+If you want to keep the application data easily accessible in a folder on your
+host (e.g. if you want to use a custom `settings.properties` file), provide a
+path on the host to the `-v` parameter:
 
     docker run -v /path/on/host/inception/repository:/export ...
 
 ## More on Docker Compose
-In order to use **docker-compose**, specify 
 
-export INCEPTION_HOME=/path/on/host/inception
-export INCEPTION_PORT=port-on-host
+To use **docker-compose**, specify:
 
-In the folder where the **inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/scripts/docker-compose.yml** is located, call
+    export INCEPTION_HOME=/path/on/host/inception
+    export INCEPTION_PORT=port-on-host
+
+In the folder where
+`inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/scripts/docker-compose.yml`
+is located, call:
 
     docker-compose -p inception up -d
-    
+
 This starts an INCEpTION instance together with a MariaDB database.
-    
-To stop, call
+
+To stop, call:
 
     docker-compose -p inception down

--- a/inception/inception-docker/pom.xml
+++ b/inception/inception-docker/pom.xml
@@ -140,20 +140,25 @@
           <plugin>
             <groupId>io.fabric8</groupId>
             <artifactId>docker-maven-plugin</artifactId>
-            <configuration>
-              <images>
-                <image>
-                  <build>
-                    <buildx>
-                      <platforms combine.children="override">
-                        <platform>linux/amd64</platform>
-                        <platform>linux/arm64</platform>
-                      </platforms>
-                    </buildx>
-                  </build>
-                </image>
-              </images>
-            </configuration>
+            <executions>
+              <execution>
+                <id>push</id>
+                <configuration>
+                  <images>
+                    <image>
+                      <build>
+                        <buildx>
+                          <platforms combine.children="override">
+                            <platform>linux/amd64</platform>
+                            <platform>linux/arm64</platform>
+                          </platforms>
+                        </buildx>
+                      </build>
+                    </image>
+                  </images>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>

--- a/inception/inception-docker/pom.xml
+++ b/inception/inception-docker/pom.xml
@@ -23,12 +23,27 @@
     <version>41.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
+
   <artifactId>inception-docker</artifactId>
   <name>INCEpTION - Docker Image</name>
   <packaging>pom</packaging>
+
   <properties>
     <docker.image.name>ghcr.io/inception-project/inception-snapshots</docker.image.name>
+    <docker.platform>linux/amd64</docker.platform>
+    <docker.skip.build>false</docker.skip.build>
+    <docker.skip.push>true</docker.skip.push>
+    <!-- Referenced in the Dockerfile. The 'maven/' prefix is the directory
+         where docker-maven-plugin stages the assembled dependencies. -->
+    <docker.jarfile>maven/inception-app-webapp-${project.version}-standalone.jar</docker.jarfile>
+    <!-- This module produces no Maven artifact; skip the regular install/deploy
+         steps so 'mvn install' / 'mvn deploy' do not try to publish the pom.
+         The docker image is built/pushed via docker-maven-plugin executions
+         bound to the install and deploy phases. -->
+    <maven.install.skip>true</maven.install.skip>
+    <maven.deploy.skip>true</maven.deploy.skip>
   </properties>
+
   <dependencies>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
@@ -37,90 +52,88 @@
       <classifier>standalone</classifier>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.fabric8</groupId>
+        <artifactId>docker-maven-plugin</artifactId>
+        <configuration>
+          <images>
+            <image>
+              <name>${docker.image.name}</name>
+              <build>
+                <tags>
+                  <tag>latest</tag>
+                  <tag>${project.version}</tag>
+                </tags>
+                <dockerFileDir>${project.basedir}/src/main/docker</dockerFileDir>
+                <filter>@</filter>
+                <buildx>
+                  <platforms>
+                    <platform>${docker.platform}</platform>
+                  </platforms>
+                </buildx>
+                <assembly>
+                  <inline>
+                    <dependencySets>
+                      <dependencySet>
+                        <includes>
+                          <include>de.tudarmstadt.ukp.inception.app:inception-app-webapp</include>
+                        </includes>
+                        <useTransitiveFiltering>false</useTransitiveFiltering>
+                        <outputDirectory>.</outputDirectory>
+                        <outputFileNameMapping>inception-app-webapp-${project.version}-standalone.jar</outputFileNameMapping>
+                      </dependencySet>
+                    </dependencySets>
+                  </inline>
+                </assembly>
+              </build>
+            </image>
+          </images>
+        </configuration>
+        <executions>
+          <execution>
+            <id>build</id>
+            <phase>install</phase>
+            <goals>
+              <goal>build</goal>
+            </goals>
+            <configuration>
+              <skipBuild>${docker.skip.build}</skipBuild>
+            </configuration>
+          </execution>
+          <execution>
+            <id>push</id>
+            <phase>deploy</phase>
+            <goals>
+              <goal>push</goal>
+            </goals>
+            <configuration>
+              <skipPush>${docker.skip.push}</skipPush>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
-      <id>docker-buildx</id>
-      <properties>
-        <!-- This property us referenced in the Dockerfile -->
-        <docker.jarfile>inception-app-webapp-${project.version}-standalone.jar</docker.jarfile>
-      </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-dependency-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>stage-jar</id>
-                <phase>generate-resources</phase>
-                <goals>
-                  <goal>copy-dependencies</goal>
-                </goals>
-                <configuration>
-                  <outputDirectory>${project.build.directory}/buildx</outputDirectory>
-                  <includeArtifactIds>inception-app-webapp</includeArtifactIds>
-                  <includeClassifiers>standalone</includeClassifiers>
-                  <excludeTransitive>true</excludeTransitive>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-resources-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>stage-dockerfile</id>
-                <phase>prepare-package</phase>
-                <goals>
-                  <goal>copy-resources</goal>
-                </goals>
-                <configuration>
-                  <outputDirectory>${project.build.directory}/buildx</outputDirectory>
-                  <delimiters>
-                    <delimiter>@</delimiter>
-                  </delimiters>
-                  <resources>
-                    <resource>
-                      <directory>src/main/docker</directory>
-                      <filtering>true</filtering>
-                    </resource>
-                  </resources>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>exec-maven-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>build-docker-image</id>
-                <phase>package</phase>
-                <goals>
-                  <goal>exec</goal>
-                </goals>
-                <configuration>
-                  <workingDirectory>${project.build.directory}/buildx</workingDirectory>
-                  <executable>docker</executable>
-                  <commandlineArgs>buildx build --push --platform=linux/amd64,linux/arm64 -t ${docker.image.name}:latest -t ${docker.image.name}:${project.version} .</commandlineArgs>
-                </configuration>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>docker</id>
+      <id>host-arch-arm64</id>
       <activation>
-        <property>
-          <name>enable-docker</name>
-        </property>
+        <os>
+          <arch>aarch64</arch>
+        </os>
       </activation>
       <properties>
-        <!-- This property us referenced in the Dockerfile -->
-        <docker.jarfile>maven/inception-app-webapp-${project.version}-standalone.jar</docker.jarfile>
+        <docker.platform>linux/arm64</docker.platform>
+      </properties>
+    </profile>
+    <profile>
+      <id>release-docker</id>
+      <properties>
+        <docker.skip.push>false</docker.skip.push>
       </properties>
       <build>
         <plugins>
@@ -130,28 +143,13 @@
             <configuration>
               <images>
                 <image>
-                  <name>${docker.image.name}</name>
                   <build>
-                    <tags>
-                      <tag>latest</tag>
-                      <tag>${project.version}</tag>
-                    </tags>
-                    <dockerFileDir>${project.basedir}/src/main/docker</dockerFileDir>
-                    <filter>@</filter>
-                    <assembly>
-                      <inline>
-                        <dependencySets>
-                          <dependencySet>
-                            <includes>
-                              <include>de.tudarmstadt.ukp.inception.app:inception-app-webapp</include>
-                            </includes>
-                            <useTransitiveFiltering>false</useTransitiveFiltering>
-                            <outputDirectory>.</outputDirectory>
-                            <outputFileNameMapping>inception-app-webapp-${project.version}-standalone.jar</outputFileNameMapping>
-                          </dependencySet>
-                        </dependencySets>
-                      </inline>
-                    </assembly>
+                    <buildx>
+                      <platforms combine.children="override">
+                        <platform>linux/amd64</platform>
+                        <platform>linux/arm64</platform>
+                      </platforms>
+                    </buildx>
                   </build>
                 </image>
               </images>

--- a/inception/pom.xml
+++ b/inception/pom.xml
@@ -309,8 +309,6 @@
     <!-- Examples -->
     <module>inception-example-imls-data-majority</module>
     <!--<module>inception-imls-dl4j</module>-->
-    <!-- Packaging -->
-    <module>inception-docker</module>
     <!-- Versioning -->
     <module>inception-versioning</module>
     <module>inception-websocket</module>
@@ -671,6 +669,12 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>dist-docker</id>
+      <modules>
+        <module>inception-docker</module>
+      </modules>
+    </profile>
     <profile>
       <id>m2e</id>
       <activation>


### PR DESCRIPTION
**What's in the PR**
- Consolidate the previous `docker` and `docker-buildx` profiles into a single fabric8 buildx-based configuration
- Make the Docker module opt-in via the parent's `dist-docker` profile so it is no longer part of the default reactor
- Add a `release-docker` profile that switches to multi-architecture (linux/amd64 + linux/arm64) and enables pushing
- Bind `docker:build` to the install phase so it loads a single-arch image into the local Docker daemon
- Bind `docker:push` to the deploy phase for multi-arch buildx push when `release-docker` is active
- Auto-activate a host-arch profile that selects linux/arm64 on aarch64 hosts so local builds produce native images on Apple Silicon
- Drop the manual `docker buildx create --use` step; fabric8 manages its own buildx builder
- Update the README to reflect the new profile names and lifecycle bindings

**How to test manually**
*  Try docker / release build

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
