### PR TITLE
Issue #5999: Upgrade dependencies

### DIFF
--- a/inception/inception-app-webapp/pom.xml
+++ b/inception/inception-app-webapp/pom.xml
@@ -870,27 +870,27 @@
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <artifactId>testcontainers-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>mariadb</artifactId>
+      <artifactId>testcontainers-mariadb</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>mysql</artifactId>
+      <artifactId>testcontainers-mysql</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>postgresql</artifactId>
+      <artifactId>testcontainers-postgresql</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>mssqlserver</artifactId>
+      <artifactId>testcontainers-mssqlserver</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/inception/inception-assistant/pom.xml
+++ b/inception/inception-assistant/pom.xml
@@ -315,6 +315,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-web-server</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
       <scope>test</scope>

--- a/inception/inception-assistant/src/test/java/de/tudarmstadt/ukp/inception/assistant/AssistantServiceImplTest.java
+++ b/inception/inception-assistant/src/test/java/de/tudarmstadt/ukp/inception/assistant/AssistantServiceImplTest.java
@@ -42,7 +42,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.boot.web.server.context.WebServerApplicationContext;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Lazy;
@@ -64,6 +64,7 @@ import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.security.config.SecurityAutoConfiguration;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.inception.annotation.storage.config.CasStorageServiceAutoConfiguration;
+import de.tudarmstadt.ukp.inception.assistant.config.AssistantAutoConfiguration;
 import de.tudarmstadt.ukp.inception.assistant.config.AssistantToolsAutoConfiguration;
 import de.tudarmstadt.ukp.inception.assistant.model.MTextMessage;
 import de.tudarmstadt.ukp.inception.documents.api.RepositoryAutoConfiguration;
@@ -94,6 +95,7 @@ import jakarta.persistence.EntityManager;
                 AssistantToolsAutoConfiguration.class, //
                 WorkloadManagementAutoConfiguration.class })
 @ImportAutoConfiguration({ //
+        AssistantAutoConfiguration.class, //
         EventLoggingAutoConfiguration.class, //
         SecurityAutoConfiguration.class, //
         WebsocketAutoConfiguration.class, //
@@ -115,14 +117,14 @@ class AssistantServiceImplTest
     private static final String USER = "user";
     private static final String PASS = "pass";
 
-    private @LocalServerPort int port;
     private String websocketUrl;
 
+    private @Autowired WebServerApplicationContext webServerAppCtxt;
     private @Autowired ProjectService projectService;
     private @Autowired RepositoryProperties repositoryProperties;
     private @Autowired EntityManager entityManager;
     private @Autowired UserDao userService;
-    private @Autowired AssistantServiceImpl assistantService;
+    private @Autowired AssistantService assistantService;
 
     private static @TempDir File repositoryDir;
 
@@ -132,7 +134,7 @@ class AssistantServiceImplTest
     @BeforeEach
     void setup() throws Exception
     {
-        websocketUrl = "ws://localhost:" + port + WS_ENDPOINT;
+        websocketUrl = "ws://localhost:" + webServerAppCtxt.getWebServer().getPort() + WS_ENDPOINT;
 
         setupOnce();
     }

--- a/inception/inception-dependencies/pom.xml
+++ b/inception/inception-dependencies/pom.xml
@@ -88,6 +88,30 @@
       </dependency>
 
       <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers-bom</artifactId>
+        <version>${testcontainers.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <!-- Jackson (has to come before OpenSAML/Spring Boot to avoid them picking an older Jackson) -->
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${jackson.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>tools.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>${jackson3.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+
+      <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-bom</artifactId>
         <version>${slf4j.version}</version>
@@ -246,13 +270,6 @@
         <groupId>org.mockito</groupId>
         <artifactId>mockito-bom</artifactId>
         <version>${mockito.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.testcontainers</groupId>
-        <artifactId>testcontainers-bom</artifactId>
-        <version>${testcontainers.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -907,22 +924,6 @@
         <groupId>org.springframework.data</groupId>
         <artifactId>spring-data-commons</artifactId>
         <version>${spring.data.version}</version>
-      </dependency>
-
-      <!-- Jackson (has to come before OpenSAML to avoid OpenSAML picking an older Jackson) -->
-      <dependency>
-        <groupId>com.fasterxml.jackson</groupId>
-        <artifactId>jackson-bom</artifactId>
-        <version>${jackson.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>tools.jackson</groupId>
-        <artifactId>jackson-bom</artifactId>
-        <version>${jackson3.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
       </dependency>
       
       <!-- httpcomponents needs to come before OpenSAML to avoid OpenSAML picking an older version -->

--- a/inception/inception-kb/pom.xml
+++ b/inception/inception-kb/pom.xml
@@ -367,7 +367,7 @@
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <artifactId>testcontainers-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/inception/inception-remote/pom.xml
+++ b/inception/inception-remote/pom.xml
@@ -446,12 +446,12 @@
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <artifactId>testcontainers-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>kafka</artifactId>
+      <artifactId>testcontainers-kafka</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/inception/inception-security/pom.xml
+++ b/inception/inception-security/pom.xml
@@ -192,7 +192,7 @@
 
     <dependency>
       <groupId>org.testcontainers</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <artifactId>testcontainers-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -75,10 +75,10 @@
     <build-groovy-version>5.0.4</build-groovy-version>
 
     <junit.version>6.0.3</junit.version>
-    <mockito.version>5.22.0</mockito.version>
+    <mockito.version>5.23.0</mockito.version>
     <assertj.version>3.27.7</assertj.version>
     <xmlunit.version>2.11.0</xmlunit.version>
-    <testcontainers.version>1.21.4</testcontainers.version>
+    <testcontainers.version>2.0.5</testcontainers.version>
     <keycloak-admin-client.version>26.0.8</keycloak-admin-client.version>
     <testcontainers-keycloak.version>4.1.1</testcontainers-keycloak.version>
 
@@ -90,27 +90,27 @@
 
     <pdfbox.version>3.0.6</pdfbox.version>
 
-    <spring.version>7.0.5</spring.version>
-    <spring.boot.version>4.0.3</spring.boot.version>
-    <spring.data.version>4.0.3</spring.data.version>
-    <spring.security.version>7.0.3</spring.security.version>
+    <spring.version>7.0.7</spring.version>
+    <spring.boot.version>4.0.6</spring.boot.version>
+    <spring.data.version>4.0.5</spring.data.version>
+    <spring.security.version>7.0.5</spring.security.version>
     <springdoc.version>3.0.2</springdoc.version>
-    <swagger.version>2.2.43</swagger.version>
+    <swagger.version>2.2.49</swagger.version>
     <jjwt.version>0.13.0</jjwt.version>
 
     <slf4j.version>2.0.17</slf4j.version>
-    <log4j2.version>2.25.3</log4j2.version>
-    <jboss.logging.version>3.6.2.Final</jboss.logging.version>
-    <sentry.version>8.33.0</sentry.version>
+    <log4j2.version>2.25.4</log4j2.version>
+    <jboss.logging.version>3.6.3.Final</jboss.logging.version>
+    <sentry.version>8.40.0</sentry.version>
 
-    <tomcat.version>11.0.20</tomcat.version>
-    <jetty.version>12.1.6</jetty.version>
+    <tomcat.version>11.0.21</tomcat.version>
+    <jetty.version>12.1.8</jetty.version>
     <servlet-api.version>6.1.0</servlet-api.version>
 
     <mariadb.driver.version>3.5.7</mariadb.driver.version>
     <mssql.driver.version>12.10.2.jre11</mssql.driver.version>
     <mysql.driver.version>9.6.0</mysql.driver.version>
-    <postgres.driver.version>42.7.10</postgres.driver.version>
+    <postgres.driver.version>42.7.11</postgres.driver.version>
     <hibernate.version>7.2.6.Final</hibernate.version>
     <hibernate.validator.version>8.0.3.Final</hibernate.validator.version>
 
@@ -139,12 +139,12 @@
 
     <ant-version>1.10.15</ant-version>
     <json.version>20240303</json.version>
-    <jackson.version>2.21.1</jackson.version>
-    <jackson3.version>3.1.0</jackson3.version>
+    <jackson.version>2.21.3</jackson.version>
+    <jackson3.version>3.1.3</jackson3.version>
     <snakeyaml.version>2.6</snakeyaml.version>
     <okhttp.version>5.3.2</okhttp.version>
-    <okio.version>3.16.4</okio.version>
-    <byte-buddy.version>1.18.5</byte-buddy.version>
+    <okio.version>3.17.0</okio.version>
+    <byte-buddy.version>1.18.8</byte-buddy.version>
     <caffeine.version>3.2.3</caffeine.version>
     <commons-beanutils.version>1.11.0</commons-beanutils.version>
     <commons-collections4.version>4.5.0</commons-collections4.version>
@@ -153,13 +153,13 @@
     <commons-pool2.version>2.13.1</commons-pool2.version>
     <commons-lang3.version>3.20.0</commons-lang3.version>
     <commons-dbcp2.version>2.14.0</commons-dbcp2.version>
-    <commons-codec.version>1.21.0</commons-codec.version>
+    <commons-codec.version>1.22.0</commons-codec.version>
     <commons-compress.version>1.28.0</commons-compress.version>
     <commons-math3.version>3.6.1</commons-math3.version>
     <commons-text.version>1.15.0</commons-text.version>
     <commons-validator.version>1.10.1</commons-validator.version>
-    <commons-io.version>2.21.0</commons-io.version>
-    <commons-logging.version>1.3.5</commons-logging.version>
+    <commons-io.version>2.22.0</commons-io.version>
+    <commons-logging.version>1.3.6</commons-logging.version>
     <commons-logging-api.version>1.1</commons-logging-api.version>
     <dom4j.version>2.2.0</dom4j.version>
     <flexmark.version>0.64.8</flexmark.version>
@@ -172,16 +172,16 @@
     <zjsonpatch.version>0.6.2</zjsonpatch.version>
     <picocli.version>4.7.7</picocli.version>
     <woodstox-core.version>6.7.0</woodstox-core.version>
-    <nimbus-jose-jwt.version>10.8</nimbus-jose-jwt.version>
-    <json-schema-validator.version>3.0.0</json-schema-validator.version>
+    <nimbus-jose-jwt.version>10.9</nimbus-jose-jwt.version>
+    <json-schema-validator.version>3.0.2</json-schema-validator.version>
     <json-schema-generator.version>4.38.0</json-schema-generator.version>
     <jgit.version>6.10.1.202505221210-r</jgit.version>
     <javax.activation-api-version>1.2.0</javax.activation-api-version>
-    <jaxb.version>4.0.6</jaxb.version>
+    <jaxb.version>4.0.7</jaxb.version>
     <jaxb-impl-version>2.3.9</jaxb-impl-version>
     <jaxb-core-version>2.3.0.1</jaxb-core-version>
     <jaxb-api-version>2.3.1</jaxb-api-version>
-    <jakarta.xml.bind-api-version>4.0.4</jakarta.xml.bind-api-version>
+    <jakarta.xml.bind-api-version>4.0.5</jakarta.xml.bind-api-version>
     <snappy.version>1.1.10.8</snappy.version>
     <jsonld-java.version>0.13.6</jsonld-java.version>
     <jna.version>5.18.1</jna.version>
@@ -191,7 +191,7 @@
     <hsqldb.version>2.7.4</hsqldb.version>
     <opensaml.version>5.2.1</opensaml.version>
     <oauth2-oidc-sdk.version>9.43.6</oauth2-oidc-sdk.version>
-    <javassist.version>3.30.2-GA</javassist.version>
+    <javassist.version>3.31.0-GA</javassist.version>
     <openjson.version>1.0.13</openjson.version>
 
     <node.version>24.14.1</node.version>


### PR DESCRIPTION
**What's in the PR**
- mockito 5.22.0 -> 5.23.0
- testcontainers 1.21.4 -> 2.0.5
- spring 7.0.5 -> 7.0.7
- spring.boot 4.0.3 -> 4.0.6
- spring.data 4.0.3 -> 4.0.6
- spring.security 7.0.3 -> 7.0.5
- swagger 2.2.43 -> 2.2.49
- log4j2 2.25.3 -> 2.25.4
- jboss.logging 3.6.2.Final -> 3.6.3.Final
- sentry 8.33.0 -> 8.40.0
- tomcat 11.0.20 -> 11.0.21
- jetty 12.1.6 -> 12.1.8
- postgres.driver 42.7.10 -> 42.7.11
- jackson 2.21.1 -> 2.21.3
- jackson3 3.1.0 -> 3.1.3
- okio 3.16.4 -> 3.17.0
- byte-buddy 1.18.5 -> 1.18.8
- commons-codec 1.21.0 -> 1.22.0
- commons-io 2.21.0 -> 2.22.0
- commons-logging 1.3.5 -> 1.3.6
- nimbus-jose-jwt 10.8 -> 10.9
- json-schema-validator 3.0.0 -> 3.0.2
- jaxb 4.0.6 -> 4.0.7
- jakarta.xml.bind-api 4.0.4 -> 4.0.5
- javassist 3.30.2-GA -> 3.31.0-GA

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
