### PR TITLE
#5991 - Ability for admin to see global settings

### DIFF
--- a/inception/inception-active-learning/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-active-learning/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "recommender.active-learning.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables the active learning sidebar for recommenders."
+    }
+  ]
+}

--- a/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/config/CasStorageBackupProperties.java
+++ b/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/config/CasStorageBackupProperties.java
@@ -29,7 +29,14 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties("backup")
 public class CasStorageBackupProperties
 {
+    /**
+     * Time between backups in seconds. Setting the interval to {@code 0} disables internal backups.
+     */
+    // Default value (86400 = 24 hours) is declared in
+    // META-INF/additional-spring-configuration-metadata.json because the metadata processor
+    // cannot extract values from method-call initializers.
     private long interval = Duration.ofHours(24).toSeconds();
+
     private final KeepOptions keep = new KeepOptions();
 
     public void setInterval(long aInterval)
@@ -49,7 +56,10 @@ public class CasStorageBackupProperties
 
     public static class KeepOptions
     {
+        /** Maximum age of backups to keep, in seconds. {@code 0} means unlimited. */
         private long time;
+
+        /** Maximum number of backups to keep. {@code 0} means unlimited. */
         private int number = 2;
 
         public long getTime()

--- a/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/config/CasStorageCachePropertiesImpl.java
+++ b/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/config/CasStorageCachePropertiesImpl.java
@@ -30,10 +30,32 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class CasStorageCachePropertiesImpl
     implements CasStorageCacheProperties
 {
+    /**
+     * Periodic interval in which the system should check if CASes can be removed from the memory
+     * cache.
+     */
     private Duration idleCasEvictionDelay = Duration.ofMinutes(5);
+
+    /** Time a CAS should at least remain cached in memory to avoid loading from disk. */
     private Duration minIdleCasTime = Duration.ofMinutes(5);
+
+    /** Time for an exclusive action to wait for another exclusive action to finish. */
     private Duration casBorrowWaitTimeout = Duration.ofMinutes(3);
+
+    /**
+     * Number of shared read-only CASes to keep in memory. Defaults between {@code 10} and
+     * {@code 5000} depending on the heap size.
+     */
+    // Default value is computed at runtime based on the heap size and is declared in
+    // META-INF/additional-spring-configuration-metadata.json because the metadata processor
+    // cannot extract values from method-call initializers.
     private long sharedCasCacheSize = getDefaultCasCacheSize();
+
+    /**
+     * Whether to capture and record the stack trace each time a CAS is checked out from the
+     * exclusive pool so it can be included in diagnostics when errors occur. Capturing a stack
+     * trace on every checkout adds noticeable overhead!
+     */
     private boolean traceAccess = false;
 
     @Override

--- a/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/config/CasStoragePropertiesImpl.java
+++ b/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/config/CasStoragePropertiesImpl.java
@@ -33,9 +33,33 @@ import org.springframework.jmx.export.annotation.ManagedResource;
 public class CasStoragePropertiesImpl
     implements CasStorageProperties
 {
+    /** Whether to compress annotation files. */
     private boolean compressedCasSerialization = true;
+
+    /**
+     * Verify CAS serializability before writing to disk. The serialized form is round-tripped into
+     * a dummy CAS first, and only written if the round-trip succeeds -- this guards against
+     * UIMA-6162-style breakage where an unreadable CAS would render the document broken in the
+     * project. Slower than the regular path; when enabled, the output is uncompressed regardless of
+     * {@code compressedCasSerialization}.
+     */
     private boolean paranoidCasSerialization = false;
+
+    /**
+     * Capture stack traces of the threads owning a CAS, and track per-file write attempts in an
+     * in-memory metadata cache. Useful for diagnosing concurrent-access or stuck-CAS-ownership
+     * issues; adds noticeable overhead per CAS borrow/release and per write, so leave disabled in
+     * production.
+     */
     private boolean traceAccess = false;
+
+    /**
+     * Leniency for file systems where timestamps are not exact. Use with extreme caution: if an
+     * editor accesses an annotation file out-of-sync with the editor, this can lead to unexpected
+     * behavior. However, when deploying on certain cloud storage facilities, file system timestamps
+     * may not be exact down to the millisecond, so configuring a slight leniency here may be
+     * helpful.
+     */
     private Duration fileSystemTimestampAccuracy = Duration.ofMillis(0);
 
     @ManagedAttribute

--- a/inception/inception-annotation-storage/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-annotation-storage/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,9 @@
+{
+  "properties": [
+    {
+      "name": "backup.interval",
+      "type": "java.lang.Long",
+      "defaultValue": 86400
+    }
+  ]
+}

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/config/KeyBindingsPropertiesImpl.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/config/KeyBindingsPropertiesImpl.java
@@ -76,13 +76,28 @@ public class KeyBindingsPropertiesImpl
     public static class NavigationShortcutsImpl
         implements NavigationShortcuts
     {
+        /** Keyboard shortcut to navigate to the next page. */
         private KeyCombo nextPage = new KeyCombo(Page_down);
+
+        /** Keyboard shortcut to navigate to the previous page. */
         private KeyCombo previousPage = new KeyCombo(Page_up);
+
+        /** Keyboard shortcut to navigate to the first page. */
         private KeyCombo firstPage = new KeyCombo(Home);
+
+        /** Keyboard shortcut to navigate to the last page. */
         private KeyCombo lastPage = new KeyCombo(End);
+
+        /** Keyboard shortcut to navigate to the next document. */
         private KeyCombo nextDocument = new KeyCombo(Shift, Page_down);
+
+        /** Keyboard shortcut to navigate to the previous document. */
         private KeyCombo previousDocument = new KeyCombo(Shift, Page_up);
+
+        /** Keyboard shortcut to jump to the next annotation. */
         private KeyCombo nextAnnotation = new KeyCombo(true, Shift, Right);
+
+        /** Keyboard shortcut to jump to the previous annotation. */
         private KeyCombo previousAnnotation = new KeyCombo(true, Shift, Left);
 
         @Override
@@ -177,10 +192,19 @@ public class KeyBindingsPropertiesImpl
     public static class EditingShortcutsImpl
         implements EditingShortcuts
     {
+        /** Keyboard shortcut to undo the last annotation action. */
         private KeyCombo undo = new KeyCombo(Ctrl, z);
+
+        /** Keyboard shortcut to redo an undone annotation action. */
         private KeyCombo redo = new KeyCombo(Shift, Ctrl, z);
+
+        /** Keyboard shortcut to delete the selected annotation. */
         private KeyCombo deleteAnnotation = new KeyCombo(Shift, Delete);
+
+        /** Keyboard shortcut to clear the annotation detail editor. */
         private KeyCombo clearSelection = new KeyCombo(Shift, Escape);
+
+        /** Keyboard shortcut to toggle selection mode. */
         private KeyCombo toggleSelection = new KeyCombo(Shift, Space);
 
         @Override
@@ -242,9 +266,16 @@ public class KeyBindingsPropertiesImpl
     public static class AnchoringModeShortcutsImpl
         implements AnchoringModeShortcuts
     {
+        /** Keyboard shortcut to switch to character-based selection mode. */
         private KeyCombo characters = new KeyCombo(true, Shift, one);
+
+        /** Keyboard shortcut to switch to single token selection mode. */
         private KeyCombo singleToken = new KeyCombo(true, Shift, two);
+
+        /** Keyboard shortcut to switch to multi-token selection mode. */
         private KeyCombo tokens = new KeyCombo(true, Shift, three);
+
+        /** Keyboard shortcut to switch to sentence selection mode. */
         private KeyCombo sentences = new KeyCombo(true, Shift, four);
 
         @Override
@@ -295,6 +326,7 @@ public class KeyBindingsPropertiesImpl
     public static class DialogShortcutsImpl
         implements DialogShortcuts
     {
+        /** Keyboard shortcut to close the currently open dialog. */
         private KeyCombo closeDialog = new KeyCombo(Escape);
 
         @Override

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/preferences/AnnotationEditorDefaultPreferencesPropertiesImpl.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/preferences/AnnotationEditorDefaultPreferencesPropertiesImpl.java
@@ -23,7 +23,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class AnnotationEditorDefaultPreferencesPropertiesImpl
     implements AnnotationEditorDefaultPreferencesProperties
 {
+    /** The number of sentences to display per page. */
     private int pageSize = 10;
+
+    /** Whether to scroll the annotation being edited into the center of the page. */
     private boolean autoScroll = false;
 
     @Override

--- a/inception/inception-app-webapp/src/main/resources/application.yml
+++ b/inception/inception-app-webapp/src/main/resources/application.yml
@@ -89,5 +89,11 @@ wicket:
         compressCss: false
 
 springdoc:
+  # Tie the OpenAPI/Swagger endpoints to the remote API: when remote-api is on,
+  # SpringDoc serves the docs; when it's off, both endpoints are disabled. Setting
+  # these explicitly also suppresses SpringDoc's "enabled by default" startup warning.
+  api-docs:
+    enabled: ${remote-api.enabled:${webanno.remote-api.enable:false}}
   swagger-ui:
+    enabled: ${remote-api.enabled:${webanno.remote-api.enable:false}}
     tagsSorter: alpha

--- a/inception/inception-assistant-ui/pom.xml
+++ b/inception/inception-assistant-ui/pom.xml
@@ -240,6 +240,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-web-server</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.hsqldb</groupId>
       <artifactId>hsqldb</artifactId>
       <scope>test</scope>

--- a/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/config/AssistantDocumentIndexPropertiesImpl.java
+++ b/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/config/AssistantDocumentIndexPropertiesImpl.java
@@ -27,12 +27,37 @@ import org.springframework.jmx.export.annotation.ManagedResource;
 public class AssistantDocumentIndexPropertiesImpl
     implements AssistantDocumentIndexProperties
 {
+    /** How often the index pool is checked for idle indexes. */
     private Duration idleEvictionDelay = Duration.ofMinutes(5);
+
+    /** How long an index may remain in the pool before being considered for eviction. */
     private Duration minIdleTime = Duration.ofMinutes(5);
+
+    /** How long to wait for access to an index before timing out. */
     private Duration borrowWaitTimeout = Duration.ofMinutes(3);
+
+    /** Maximum number of relevant chunks from the user guide to pass to the LLM service. */
     private int maxChunks = 10;
+
+    /**
+     * Size of a chunk in LLM tokens. Should not be higher than
+     * {@code assistant.embedding.context-length} to avoid truncation. It can be lower to create
+     * more topically focused chunks.
+     */
     private int chunkSize = 128;
+
+    /**
+     * Minimum relevance score for chunks to be considered. Should be a positive number not larger
+     * than {@code 1.0}.
+     */
     private double minScore = 0.6;
+
+    /**
+     * Overlap between indexed chunks. When overlapping chunks are retrieved, they are used to
+     * reconstruct a consecutive larger chunk of the document which is then passed on to the model.
+     * As a consequence, source attribution will link to a larger region of the document; however,
+     * the response from the LLM may be more coherent.
+     */
     private int unitOverlap = 0;
 
     @Override

--- a/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/config/AssistantPropertiesImpl.java
+++ b/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/config/AssistantPropertiesImpl.java
@@ -2,13 +2,13 @@
  * Licensed to the Technische Universität Darmstadt under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
- * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * regarding copyright ownership.  The Technische Universität Darmstadt
  * licenses this file to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.
- *  
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,21 +28,25 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class AssistantPropertiesImpl
     implements AssistantProperties
 {
+    /** URL of the Ollama service. */
     private String url = "http://localhost:11434";
+
+    /** The name by which the assistant identifies itself. */
     private String nickname = "INCEpTION";
+
+    /** API key sent to the Ollama service, when required. Empty by default. */
     private String apiKey = null;
+
+    /**
+     * Whether an extra LLM call should be made to generate a summary line for thinking sections.
+     */
     private boolean summarizeThoughts = false;
 
     private final AssistantChatPropertiesImpl chat = new AssistantChatPropertiesImpl();
     private final AssistantEmbeddingPropertiesImpl embedding = new AssistantEmbeddingPropertiesImpl();
-    private final AssitantUserGuidePropertiesImpl userGuide = new AssitantUserGuidePropertiesImpl();
-    private final AssistantDocumentIndexProperties documentIndex;
+    private final AssistantUserGuidePropertiesImpl userGuide = new AssistantUserGuidePropertiesImpl();
 
-    @Autowired
-    public AssistantPropertiesImpl(AssistantDocumentIndexProperties aDocumentIndex)
-    {
-        documentIndex = aDocumentIndex;
-    }
+    private @Autowired AssistantDocumentIndexProperties documentIndex;
 
     public void setApiKey(String aApiKey)
     {
@@ -101,9 +105,14 @@ public class AssistantPropertiesImpl
     }
 
     @Override
-    public AssitantUserGuidePropertiesImpl getUserGuide()
+    public AssistantUserGuidePropertiesImpl getUserGuide()
     {
         return userGuide;
+    }
+
+    public void setDocumentIndex(AssistantDocumentIndexProperties aDocumentIndex)
+    {
+        documentIndex = aDocumentIndex;
     }
 
     @Override
@@ -112,11 +121,21 @@ public class AssistantPropertiesImpl
         return documentIndex;
     }
 
-    public class AssitantUserGuidePropertiesImpl
+    public static class AssistantUserGuidePropertiesImpl
         implements AssitantUserGuideProperties
     {
+        /**
+         * Maximum number of relevant chunks from the user guide to pass to the LLM service.
+         */
         private int maxChunks = 3;
+
+        /**
+         * Minimum relevance score for chunks to be considered. Should be a positive number not
+         * larger than {@code 1.0}.
+         */
         private double minScore = 0.8;
+
+        /** Whether to re-build the user manual index when the application starts. */
         private boolean rebuildIndexOnBoot = false;
 
         @Override
@@ -156,13 +175,57 @@ public class AssistantPropertiesImpl
     public static class AssistantChatPropertiesImpl
         implements AssistantChatProperties
     {
+        /** The model used to drive the chat functionality of the assistant. */
         private String model = "llama3.2";
+
+        /**
+         * The capabilities of the model. Relevant values are {@code auto}, {@code completion} and
+         * {@code tools}. With {@code auto} the system queries the LLM service during startup to
+         * determine the model's capabilities; setting this manually overrides the detection and
+         * avoids the startup query.
+         */
+        // Default ([auto]) is declared in META-INF/additional-spring-configuration-metadata.json
+        // because the metadata processor cannot read instance initializer blocks.
         private final Set<String> capabilities = new HashSet<>();
+
+        /**
+         * The token encoding used by the model. Used to estimate token counts so that text can be
+         * chunked accurately. Leave at the default if in doubt.
+         */
         private String encoding = "cl100k_base";
+
+        /**
+         * The context length supported by the model. Controls how much chat history is preserved.
+         * With {@code 0} (the default), the LLM service is queried during startup to detect the
+         * value automatically. Setting it manually avoids the startup query.
+         */
         private int contextLength = AUTO_DETECT;
+
+        /**
+         * Diversity of output: tokens are sampled from the smallest set whose probabilities sum to
+         * this threshold. Tune the balance between diversity (high, 0.9) and coherence (low,
+         * 0.3-0.5).
+         */
         private double topP = 0.3;
+
+        /**
+         * Number of top-ranked tokens considered for sampling during text generation. Tune the
+         * balance between diversity (high &gt;= 50) and coherence (low, e.g. 5).
+         */
         private int topK = 25;
+
+        /**
+         * Discourages the model from repeating the same words or phrases by reducing the
+         * probability of already-generated tokens, promoting more varied and coherent output. Tune
+         * the balance between less repetition (high &gt;= 1.5) and more repetition (low, 1.0).
+         */
         private double repeatPenalty = 1.1;
+
+        /**
+         * Randomness of the model's output, by adjusting the probability distribution of the next
+         * word. Tune the balance between more randomness (high &gt;= 1.0) and less randomness (low,
+         * 0.5).
+         */
         private double temperature = 0.1;
 
         {
@@ -264,12 +327,38 @@ public class AssistantPropertiesImpl
     public static class AssistantEmbeddingPropertiesImpl
         implements AssistantEmbeddingProperties
     {
+        /** The model used to drive the search functionality of the assistant. */
         private String model = "granite-embedding";
 
+        /** Random number generator seed used to ensure repeatable retrieval results. */
         private int seed = 0xDEADBEEF;
+
+        /**
+         * Context length supported by the model in LLM tokens. Controls how much of a chunk is used
+         * to calculate the embedding. Should not be lower than
+         * {@code assistant.documents.chunk-size}.
+         */
         private int contextLength = 768;
+
+        /**
+         * Maximum number of chunks sent together to the LLM service when generating embeddings.
+         * Batching multiple chunks in a single request increases indexing speed.
+         */
         private int batchSize = 16;
+
+        /**
+         * The token encoding used by the model. Used to estimate token counts so that text can be
+         * chunked accurately. Leave at the default if in doubt.
+         */
         private String encoding = "cl100k_base";
+
+        /**
+         * Dimension of the embedding vectors created by the model. With {@code 0} (the default),
+         * the LLM service is queried during startup to auto-detect the vector size; setting this
+         * manually is helpful when the LLM service may be unavailable during startup. Changing the
+         * value requires indexes to be rebuilt. Dimensions higher than 1024 are not recommended due
+         * to memory usage and reduced performance.
+         */
         private int dimension = AUTO_DETECT_DIMENSION;
 
         @Override

--- a/inception/inception-assistant/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-assistant/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,14 @@
+{
+  "properties": [
+    {
+      "name": "assistant.chat.capabilities",
+      "defaultValue": [ "auto" ]
+    },
+    {
+      "name": "assistant.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Whether to enable the assistant."
+    }
+  ]
+}

--- a/inception/inception-assistant/src/main/resources/META-INF/asciidoc/admin-guide/settings_assistant.adoc
+++ b/inception/inception-assistant/src/main/resources/META-INF/asciidoc/admin-guide/settings_assistant.adoc
@@ -48,6 +48,11 @@ CAUTION: Experimental feature.
 | Whether an extra LLM call should be made to generate a summary line for thinking sections.
 | `false`
 | `true`
+
+| `assistant.api-key`
+| API key sent to the Ollama service (or compatible service) when the service requires authentication. Leave empty if no key is required.
+| _empty_
+| `sk-...`
 |===
 
 .Settings related to the assistant chat functionality

--- a/inception/inception-assistant/src/test/java/de/tudarmstadt/ukp/inception/assistant/AgentLoopTest.java
+++ b/inception/inception-assistant/src/test/java/de/tudarmstadt/ukp/inception/assistant/AgentLoopTest.java
@@ -66,7 +66,8 @@ class AgentLoopTest
     @BeforeEach
     void setUp()
     {
-        props = new AssistantPropertiesImpl(new AssistantDocumentIndexPropertiesImpl());
+        props = new AssistantPropertiesImpl();
+        props.setDocumentIndex(new AssistantDocumentIndexPropertiesImpl());
         props.setUrl(DEFAULT_OLLAMA_URL);
         props.getChat().setModel("gpt-oss:120b-cloud");
 

--- a/inception/inception-assistant/src/test/java/de/tudarmstadt/ukp/inception/assistant/userguide/UserGuideQueryServiceImplTest.java
+++ b/inception/inception-assistant/src/test/java/de/tudarmstadt/ukp/inception/assistant/userguide/UserGuideQueryServiceImplTest.java
@@ -37,7 +37,6 @@ import org.slf4j.LoggerFactory;
 
 import de.tudarmstadt.ukp.inception.assistant.config.AssistantDocumentIndexProperties;
 import de.tudarmstadt.ukp.inception.assistant.config.AssistantDocumentIndexPropertiesImpl;
-import de.tudarmstadt.ukp.inception.assistant.config.AssistantProperties;
 import de.tudarmstadt.ukp.inception.assistant.config.AssistantPropertiesImpl;
 import de.tudarmstadt.ukp.inception.assistant.embedding.EmbeddingServiceImpl;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaClient;
@@ -51,7 +50,7 @@ class UserGuideQueryServiceImplTest
     private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private @Mock SchedulingService schedulingService;
-    private AssistantProperties assistantProperties;
+    private AssistantPropertiesImpl assistantProperties;
     private AssistantDocumentIndexProperties assistantDocumentIndexProperties;
     private OllamaClient ollamaClient;
     private UserGuideQueryServiceImpl sut;
@@ -70,7 +69,8 @@ class UserGuideQueryServiceImplTest
     void setup()
     {
         assistantDocumentIndexProperties = new AssistantDocumentIndexPropertiesImpl();
-        assistantProperties = new AssistantPropertiesImpl(assistantDocumentIndexProperties);
+        assistantProperties = new AssistantPropertiesImpl();
+        assistantProperties.setDocumentIndex(assistantDocumentIndexProperties);
         ollamaClient = new OllamaClientImpl();
         embeddingService = new EmbeddingServiceImpl(assistantProperties, ollamaClient);
         sut = new UserGuideQueryServiceImpl(assistantProperties, schedulingService,

--- a/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/config/BratAnnotationEditorPropertiesImpl.java
+++ b/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/config/BratAnnotationEditorPropertiesImpl.java
@@ -26,6 +26,7 @@ import org.springframework.jmx.export.annotation.ManagedResource;
 public class BratAnnotationEditorPropertiesImpl
     implements BratAnnotationEditorProperties
 {
+    /** Whether to select annotations with a single click. */
     private boolean singleClickSelection = true;
     private boolean clientSideProfiling = false;
     private String whiteSpaceReplacementCharacter = REPLACEMENT_CHARACTER;

--- a/inception/inception-brat-editor/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-brat-editor/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "ui.brat.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables the brat annotation editor UI."
+    }
+  ]
+}

--- a/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/config/EntityLinkingPropertiesImpl.java
+++ b/inception/inception-concept-linking/src/main/java/de/tudarmstadt/ukp/inception/conceptlinking/config/EntityLinkingPropertiesImpl.java
@@ -2,13 +2,13 @@
  * Licensed to the Technische Universität Darmstadt under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
- * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * regarding copyright ownership.  The Technische Universität Darmstadt
  * licenses this file to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.
- *  
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,11 +29,37 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class EntityLinkingPropertiesImpl
     implements EntityLinkingProperties
 {
+    /**
+     * Size of the candidate cache, which stores a set of candidates for a mention. Increasing the
+     * cache size will reduce the number of queries that have to be made against the KB and
+     * therefore increase average retrieval time.
+     */
     private int cacheSize = 1024;
 
+    /**
+     * Size {@code k} of the mention context, where the context is defined as the words included in
+     * a window with {@code k} words to both left and right.
+     */
     private int mentionContextSize = 5;
+
+    /**
+     * Candidate retrieval limit. Defines how many concepts should be retrieved for the candidate
+     * retrieval step. Increasing this parameter will lead to a longer time to retrieve candidates
+     * from the KB.
+     */
     private int candidateQueryLimit = 2500;
+
+    /**
+     * Candidate display limit. Regulates how many candidates will be displayed for a mention in the
+     * concept selector UI.
+     */
     private int candidateDisplayLimit = 100;
+
+    /**
+     * Semantic signature query limit. Defines how many concepts should be retrieved for the
+     * semantic signature of a candidate. Increasing this parameter will lead to a longer time to
+     * retrieve concepts for constructing the semantic signature.
+     */
     private int signatureQueryLimit = Integer.MAX_VALUE;
 
     @Override

--- a/inception/inception-concept-linking/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-concept-linking/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,15 @@
+{
+  "properties": [
+    {
+      "name": "knowledge-base.entity-linking.signature-query-limit",
+      "type": "java.lang.Integer",
+      "defaultValue": 2147483647
+    },
+    {
+      "name": "knowledge-base.entity-linking.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables knowledge base entity linking support."
+    }
+  ]
+}

--- a/inception/inception-constraints/src/main/java/de/tudarmstadt/ukp/clarin/webanno/constraints/config/ConstraintsPropertiesImpl.java
+++ b/inception/inception-constraints/src/main/java/de/tudarmstadt/ukp/clarin/webanno/constraints/config/ConstraintsPropertiesImpl.java
@@ -27,6 +27,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class ConstraintsPropertiesImpl
     implements ConstraintsProperties
 {
+    /** Time after which entries in the constraints cache expire and are removed. */
     private Duration cacheExpireDelay = ofMinutes(30);
 
     @Override

--- a/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/config/CurationPropertiesImpl.java
+++ b/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/config/CurationPropertiesImpl.java
@@ -28,6 +28,11 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class CurationPropertiesImpl
     implements CurationProperties
 {
+    /**
+     * If enabled, a document is considered curatable when at least one annotator has finished
+     * working on it. Otherwise, a document is only considered curatable once it has reached the
+     * annotation-finished state at the document level.
+     */
     private boolean legacyCuratableDocumentsStrategy = false;
 
     @Override

--- a/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/sidebar/CurationSidebarPropertiesImpl.java
+++ b/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/sidebar/CurationSidebarPropertiesImpl.java
@@ -30,6 +30,10 @@ import de.tudarmstadt.ukp.inception.curation.config.CurationServiceAutoConfigura
 public class CurationSidebarPropertiesImpl
     implements CurationSidebarProperties
 {
+    /**
+     * If enabled, annotators can choose to write the curated annotations into their own user's
+     * annotation document instead of into the shared curation document.
+     */
     private boolean ownUserCurationTargetEnabled;
 
     @Override

--- a/inception/inception-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/config/CasDoctorPropertiesImpl.java
+++ b/inception/inception-diag/src/main/java/de/tudarmstadt/ukp/clarin/webanno/diag/config/CasDoctorPropertiesImpl.java
@@ -26,8 +26,15 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class CasDoctorPropertiesImpl
     implements CasDoctorProperties
 {
+    /**
+     * Extra checks to perform when a CAS is saved (also on load if any repairs are enabled).
+     */
     private List<String> checks = Collections.emptyList();
+
+    /** Repairs to be performed when a CAS is loaded - order matters! */
     private List<String> repairs = Collections.emptyList();
+
+    /** If the extra checks trigger an exception. */
     private boolean fatal = true;
     // private boolean forceReleaseBehavior = false;
 

--- a/inception/inception-documents-api/src/main/java/de/tudarmstadt/ukp/inception/documents/api/RepositoryAutoConfiguration.java
+++ b/inception/inception-documents-api/src/main/java/de/tudarmstadt/ukp/inception/documents/api/RepositoryAutoConfiguration.java
@@ -2,13 +2,13 @@
  * Licensed to the Technische Universität Darmstadt under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
- * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * regarding copyright ownership.  The Technische Universität Darmstadt
  * licenses this file to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.
- *  
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/inception/inception-documents/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-documents/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "monitoring.metrics.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Enables exposing application metrics for monitoring (e.g. via JMX)."
+    }
+  ]
+}

--- a/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/config/DocumentImportExportServicePropertiesImpl.java
+++ b/inception/inception-export/src/main/java/de/tudarmstadt/ukp/inception/export/config/DocumentImportExportServicePropertiesImpl.java
@@ -23,8 +23,18 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class DocumentImportExportServicePropertiesImpl
     implements DocumentImportExportServiceProperties
 {
+    /**
+     * Whether to run the CAS Doctor on every imported document. {@code AUTO} enables checks for
+     * formats that give the user a lot of flexibility but also have great potential for importing
+     * inconsistent data. {@code OFF} disables all checks on import; {@code ON} checks all formats,
+     * even the more rigid ones.
+     */
     private CasDoctorOnImportPolicy runCasDoctorOnImport = CasDoctorOnImportPolicy.AUTO;
+
+    /** Token-count limit for imported documents. {@code 0} means no limit. */
     private int maxTokens = 2_000_000;
+
+    /** Sentence-count limit for imported documents. {@code 0} means no limit. */
     private int maxSentences = 20_000;
 
     @Override

--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/config/ExternalEditorPropertiesImpl.java
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/config/ExternalEditorPropertiesImpl.java
@@ -25,11 +25,31 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class ExternalEditorPropertiesImpl
     implements ExternalEditorProperties
 {
+    /** Whether to remove HTML {@code <img>} tags during rendering. */
     private boolean blockImg = false;
+
+    /**
+     * Where to allow loading images from. Possible values are {@code NONE}, {@code LOCAL} and
+     * {@code ANY}.
+     */
     private Source allowImgSource = LOCAL;
+
+    /** Whether to remove HTML {@code <audio>} tags during rendering. */
     private boolean blockAudio = false;
+
+    /**
+     * Where to allow loading audio files from. Possible values are {@code NONE}, {@code LOCAL} and
+     * {@code ANY}.
+     */
     private Source allowAudioSource = LOCAL;
+
+    /** Whether to remove HTML {@code <video>} tags during rendering. */
     private boolean blockVideo = false;
+
+    /**
+     * Where to allow loading video files from. Possible values are {@code NONE}, {@code LOCAL} and
+     * {@code ANY}.
+     */
     private Source allowVideoSource = LOCAL;
 
     // Experimental / undocumented properties

--- a/inception/inception-external-editor/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-external-editor/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,16 @@
+{
+  "properties": [
+    {
+      "name": "ui.external.allow-img-source",
+      "defaultValue": "LOCAL"
+    },
+    {
+      "name": "ui.external.allow-audio-source",
+      "defaultValue": "LOCAL"
+    },
+    {
+      "name": "ui.external.allow-video-source",
+      "defaultValue": "LOCAL"
+    }
+  ]
+}

--- a/inception/inception-external-search-core/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/config/ExternalSearchAutoConfiguration.java
+++ b/inception/inception-external-search-core/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/config/ExternalSearchAutoConfiguration.java
@@ -36,7 +36,8 @@ import de.tudarmstadt.ukp.inception.externalsearch.exporter.DocumentRepositoryEx
  * Provides all back-end Spring beans for the external search functionality.
  */
 @Configuration
-@ConditionalOnProperty(prefix = "external-search", name = "enabled", havingValue = "true", matchIfMissing = true)
+@ConditionalOnProperty(prefix = "external-search", name = "enabled", havingValue = "true", //
+        matchIfMissing = ExternalSearchProperties.DEFAULT_ENABLED)
 public class ExternalSearchAutoConfiguration
 {
     @Bean

--- a/inception/inception-external-search-core/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/config/ExternalSearchProperties.java
+++ b/inception/inception-external-search-core/src/main/java/de/tudarmstadt/ukp/inception/externalsearch/config/ExternalSearchProperties.java
@@ -25,7 +25,10 @@ import org.springframework.stereotype.Component;
 @ConfigurationProperties("external-search")
 public class ExternalSearchProperties
 {
-    private boolean enabled = false;
+    public static final boolean DEFAULT_ENABLED = true;
+
+    /** Enable/disable document repository support. */
+    private boolean enabled = DEFAULT_ENABLED;
 
     public boolean isEnabled()
     {

--- a/inception/inception-external-search-opensearch/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-external-search-opensearch/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "external-search.open-search.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables the OpenSearch external document repository support."
+    }
+  ]
+}

--- a/inception/inception-external-search-pubannotation/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-external-search-pubannotation/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "external-search.pub-annotation.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables the PubAnnotation external document repository support."
+    }
+  ]
+}

--- a/inception/inception-external-search-pubmed/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-external-search-pubmed/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "external-search.pmc.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Enables the PubMed Central (PMC) external document repository support."
+    }
+  ]
+}

--- a/inception/inception-external-search-solr/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-external-search-solr/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "external-search.solr.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables the Solr external document repository support."
+    }
+  ]
+}

--- a/inception/inception-feature-link/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/link/LinkFeatureSupportPropertiesImpl.java
+++ b/inception/inception-feature-link/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/link/LinkFeatureSupportPropertiesImpl.java
@@ -28,8 +28,16 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class LinkFeatureSupportPropertiesImpl
     implements LinkFeatureSupportProperties
 {
+    /**
+     * If the tagset is larger than the threshold, an auto-complete field is used instead of a
+     * standard combobox.
+     */
     private int autoCompleteThreshold = 75;
 
+    /**
+     * When an auto-complete field is used, this determines the maximum number of items shown in the
+     * dropdown menu.
+     */
     private int autoCompleteMaxResults = 100;
 
     @Override

--- a/inception/inception-feature-lookup/src/main/java/de/tudarmstadt/ukp/inception/feature/lookup/config/LookupServicePropertiesImpl.java
+++ b/inception/inception-feature-lookup/src/main/java/de/tudarmstadt/ukp/inception/feature/lookup/config/LookupServicePropertiesImpl.java
@@ -34,18 +34,34 @@ public class LookupServicePropertiesImpl
     public static final int HARD_QUERY_CONTEXT_LENGTH = 200;
     public static final int HARD_MIN_RESULTS = 10;
 
+    /** Default maximum number of results returned by a lookup query. */
     private int defaultMaxResults = 1_000;
+
+    /** Hard upper bound on the maximum number of results returned by a lookup query. */
     private int hardMaxResults = 10_000;
 
+    /** Maximum number of entries kept in the lookup cache. */
     private long cacheSize = 100_000;
+
+    /** Time after which entries in the lookup cache expire and are removed. */
     private @DurationUnit(MINUTES) Duration cacheExpireDelay = ofMinutes(15);
+
+    /** Time after which entries in the lookup cache are refreshed in the background. */
     private @DurationUnit(MINUTES) Duration cacheRefreshDelay = ofMinutes(5);
 
+    /** Maximum number of entries kept in the render cache. */
     private long renderCacheSize = 10_000;
+
+    /** Time after which entries in the render cache expire and are removed. */
     private @DurationUnit(MINUTES) Duration renderCacheExpireDelay = ofMinutes(10);
+
+    /** Time after which entries in the render cache are refreshed in the background. */
     private @DurationUnit(MINUTES) Duration renderCacheRefreshDelay = ofMinutes(1);
 
+    /** Timeout for establishing a connection to the remote lookup service. */
     private Duration connectTimeout = Duration.of(10, SECONDS);
+
+    /** Timeout for reading a response from the remote lookup service. */
     private Duration readTimeout = Duration.of(10, SECONDS);
 
     @Override

--- a/inception/inception-feature-lookup/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-feature-lookup/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "annotation.feature-support.lookup.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Enables the lookup feature type for annotation features."
+    }
+  ]
+}

--- a/inception/inception-feature-string/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/StringFeatureSupportPropertiesImpl.java
+++ b/inception/inception-feature-string/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/StringFeatureSupportPropertiesImpl.java
@@ -28,10 +28,22 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class StringFeatureSupportPropertiesImpl
     implements StringFeatureSupportProperties
 {
+    /**
+     * If the tagset is larger than the threshold, an combo-box field is used instead of a
+     * radio-choice.
+     */
     private int comboBoxThreshold = 6;
 
+    /**
+     * If the tagset is larger than the threshold, an auto-complete field is used instead of a
+     * standard combobox.
+     */
     private int autoCompleteThreshold = 75;
 
+    /**
+     * When an auto-complete field is used, this determines the maximum number of items shown in the
+     * dropdown menu.
+     */
     private int autoCompleteMaxResults = 100;
 
     @Override

--- a/inception/inception-html-apache-annotator-editor/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-html-apache-annotator-editor/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "ui.html-apacheannotator.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables the Apache Annotator-based HTML annotation editor UI."
+    }
+  ]
+}

--- a/inception/inception-html-recogito-editor/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-html-recogito-editor/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "ui.html-recogitojs.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Enables the RecogitoJS-based HTML annotation editor UI."
+    }
+  ]
+}

--- a/inception/inception-imls-azureai-openai/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-imls-azureai-openai/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "recommender.azureai-openai.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Enables the Azure AI OpenAI recommender."
+    }
+  ]
+}

--- a/inception/inception-imls-chatgpt/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-imls-chatgpt/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "recommender.chatgpt.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Enables the ChatGPT recommender."
+    }
+  ]
+}

--- a/inception/inception-imls-elg/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-imls-elg/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "recommender.elg.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables the European Language Grid (ELG) recommender."
+    }
+  ]
+}

--- a/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/v1/config/ExternalRecommenderPropertiesImpl.java
+++ b/inception/inception-imls-external/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/external/v1/config/ExternalRecommenderPropertiesImpl.java
@@ -32,7 +32,14 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class ExternalRecommenderPropertiesImpl
     implements ExternalRecommenderProperties
 {
+    /** Duration of connect timeout. */
+    // Default (30s) is declared in META-INF/additional-spring-configuration-metadata.json
+    // because the metadata processor cannot read method-call initializers.
     private Duration connectTimeout = Duration.of(30, SECONDS);
+
+    /** Duration of read timeout. */
+    // Default (30s) is declared in META-INF/additional-spring-configuration-metadata.json
+    // because the metadata processor cannot read method-call initializers.
     private Duration readTimeout = Duration.of(30, SECONDS);
 
     @Override

--- a/inception/inception-imls-external/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-imls-external/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,20 @@
+{
+  "properties": [
+    {
+      "name": "recommender.external.connect-timeout",
+      "type": "java.time.Duration",
+      "defaultValue": "30s"
+    },
+    {
+      "name": "recommender.external.read-timeout",
+      "type": "java.time.Duration",
+      "defaultValue": "30s"
+    },
+    {
+      "name": "recommender.external.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables external recommender support."
+    }
+  ]
+}

--- a/inception/inception-imls-hf/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-imls-hf/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "recommender.hf.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Enables the HuggingFace recommender."
+    }
+  ]
+}

--- a/inception/inception-imls-ollama/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-imls-ollama/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "recommender.ollama.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Enables the Ollama recommender."
+    }
+  ]
+}

--- a/inception/inception-imls-stringmatch/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-imls-stringmatch/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "recommender.string-matching.relation.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Enables the string-matching relation recommender."
+    }
+  ]
+}

--- a/inception/inception-imls-weblicht/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-imls-weblicht/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "recommender.weblicht.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables the WebLicht recommender."
+    }
+  ]
+}

--- a/inception/inception-io-bioc/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-io-bioc/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,16 @@
+{
+  "properties": [
+    {
+      "name": "format.bioc-xml.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Enables BioC XML import/export support."
+    },
+    {
+      "name": "format.bioc.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Enables BioC import/export support."
+    }
+  ]
+}

--- a/inception/inception-io-brat/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-io-brat/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,16 @@
+{
+  "properties": [
+    {
+      "name": "format.brat-basic.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Enables basic brat format import/export support."
+    },
+    {
+      "name": "format.brat-custom.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Enables custom brat format import/export support."
+    }
+  ]
+}

--- a/inception/inception-io-conll/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-io-conll/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,52 @@
+{
+  "properties": [
+    {
+      "name": "format.conll2000.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables CoNLL 2000 format import/export support."
+    },
+    {
+      "name": "format.conll2002.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables CoNLL 2002 format import/export support."
+    },
+    {
+      "name": "format.conll2003.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables CoNLL 2003 format import/export support."
+    },
+    {
+      "name": "format.conll2006.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables CoNLL 2006 format import/export support."
+    },
+    {
+      "name": "format.conll2009.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables CoNLL 2009 format import/export support."
+    },
+    {
+      "name": "format.conll2012.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables CoNLL 2012 format import/export support."
+    },
+    {
+      "name": "format.conllcorenlp.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables CoNLL CoreNLP format import/export support."
+    },
+    {
+      "name": "format.conllu.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables CoNLL-U format import/export support."
+    }
+  ]
+}

--- a/inception/inception-io-docx/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-io-docx/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "format.docx.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Enables DOCX import/export support."
+    }
+  ]
+}

--- a/inception/inception-io-html/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-io-html/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,28 @@
+{
+  "properties": [
+    {
+      "name": "format.html-legacy.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Enables legacy HTML import/export support."
+    },
+    {
+      "name": "format.html-zip.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Enables HTML ZIP import/export support."
+    },
+    {
+      "name": "format.html.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables HTML import/export support."
+    },
+    {
+      "name": "format.mhtml.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Enables MHTML import/export support."
+    }
+  ]
+}

--- a/inception/inception-io-imscwb/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-io-imscwb/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "format.imscwb.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables IMS Open Corpus Workbench (CWB) format import/export support."
+    }
+  ]
+}

--- a/inception/inception-io-intertext/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-io-intertext/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "format.intertext.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Enables InterText format import/export support."
+    }
+  ]
+}

--- a/inception/inception-io-json/src/main/java/de/tudarmstadt/ukp/inception/io/jsoncas/config/LegacyUimaJsonCasFormatProperties.java
+++ b/inception/inception-io-json/src/main/java/de/tudarmstadt/ukp/inception/io/jsoncas/config/LegacyUimaJsonCasFormatProperties.java
@@ -22,6 +22,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties("format.json-cas-legacy")
 public class LegacyUimaJsonCasFormatProperties
 {
+    /**
+     * Whether to omit default values (e.g. {@code 0} for numbers or {@code false} for booleans)
+     * from the JSON output. By default, all values are written even when they equal the default.
+     */
     private boolean omitDefaultValues = false;
 
     public void setOmitDefaultValues(boolean aOmitDefaultValues)

--- a/inception/inception-io-json/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-io-json/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,22 @@
+{
+  "properties": [
+    {
+      "name": "format.json-cas-legacy.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Enables legacy JSON CAS format import/export support."
+    },
+    {
+      "name": "format.json-cas-struct.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables structured JSON CAS format import/export support."
+    },
+    {
+      "name": "format.json-cas.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables JSON CAS format import/export support."
+    }
+  ]
+}

--- a/inception/inception-io-lif/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-io-lif/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "format.lif.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables LAPPS Interchange Format (LIF) import/export support."
+    }
+  ]
+}

--- a/inception/inception-io-nif/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-io-nif/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "format.nif.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables NLP Interchange Format (NIF) import/export support."
+    }
+  ]
+}

--- a/inception/inception-io-pdf/src/main/java/de/tudarmstadt/ukp/inception/io/pdf/config/PdfFormatPropertiesImpl.java
+++ b/inception/inception-io-pdf/src/main/java/de/tudarmstadt/ukp/inception/io/pdf/config/PdfFormatPropertiesImpl.java
@@ -23,17 +23,53 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class PdfFormatPropertiesImpl
     implements PdfFormatProperties
 {
+    /**
+     * Try extracting a basic HTML structure (mainly paragraphs) to improve the rendering of the
+     * document in HTML-based editors.
+     */
     private boolean generateHtmlStructure = true;
 
+    /**
+     * Enable to order the text as it appears on screen. Disable to leave the text in the order it
+     * appears in the PDF file. In most cases, the order as it appears in the file is the correct
+     * order.
+     */
     private boolean sortByPosition = false;
+
+    /**
+     * Some PDFs overlap the same text multiple times to make it look bold. Keep the setting enabled
+     * to remove the duplicate text.
+     */
     private boolean suppressDuplicateOverlappingText = true;
+
+    /** Enable to respect the bead structures in the PDF file (if available). */
     private boolean shouldSeparateByBeads = true;
 
+    /**
+     * Enable to try preserving line breaks and using consecutive line breaks to identify
+     * paragraphs.
+     */
     private boolean addMoreFormatting = true;
+
+    /**
+     * Consider an indented line to be a new paragraph if the indentation is greater than this
+     * value.
+     */
     private float indentThreshold = 2.0f;
+
+    /** Lines further apart than this value are considered to be separate paragraphs. */
     private float dropThreshold = 2.5f;
 
+    /**
+     * Controls when spaces are introduced between characters. Increase to reduce the number of
+     * spaces. Reduce if spaces are missing between characters.
+     */
     private float averageCharTolerance = 0.3f;
+
+    /**
+     * Controls when spaces are introduced between characters. Increase to reduce the number of
+     * spaces. Reduce if spaces are missing between characters.
+     */
     private float spacingTolerance = 0.5f;
 
     @Override

--- a/inception/inception-io-pdf/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-io-pdf/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,22 @@
+{
+  "properties": [
+    {
+      "name": "format.pdf-json-cas.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Enables PDF JSON CAS format import/export support."
+    },
+    {
+      "name": "format.pdf-xmi-cas.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Enables PDF XMI CAS format import/export support."
+    },
+    {
+      "name": "format.pdf.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables PDF import/export support."
+    }
+  ]
+}

--- a/inception/inception-io-perseus/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-io-perseus/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "format.perseus.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables Perseus format import/export support."
+    }
+  ]
+}

--- a/inception/inception-io-rdf/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-io-rdf/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "format.rdf-cas.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Enables RDF CAS format import/export support."
+    }
+  ]
+}

--- a/inception/inception-io-tcf/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-io-tcf/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "format.tcf.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables Text Corpus Format (TCF) import/export support."
+    }
+  ]
+}

--- a/inception/inception-io-tei/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-io-tei/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,16 @@
+{
+  "properties": [
+    {
+      "name": "format.dkpro-core-tei.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables DKPro Core TEI format import/export support."
+    },
+    {
+      "name": "format.tei.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Enables TEI format import/export support."
+    }
+  ]
+}

--- a/inception/inception-io-text/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-io-text/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,22 @@
+{
+  "properties": [
+    {
+      "name": "format.text-line-oriented.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables line-oriented plain text format import/export support."
+    },
+    {
+      "name": "format.text-pretokenized.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables pre-tokenized plain text format import/export support."
+    },
+    {
+      "name": "format.text.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables plain text format import/export support."
+    }
+  ]
+}

--- a/inception/inception-io-webanno-tsv/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-io-webanno-tsv/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,22 @@
+{
+  "properties": [
+    {
+      "name": "format.webanno1.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables WebAnno TSV v1 format import/export support."
+    },
+    {
+      "name": "format.webanno2.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables WebAnno TSV v2 format import/export support."
+    },
+    {
+      "name": "format.webanno3.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables WebAnno TSV v3 format import/export support."
+    }
+  ]
+}

--- a/inception/inception-io-xmi/src/main/java/de/tudarmstadt/ukp/inception/io/xmi/config/UimaFormatsPropertiesImpl.java
+++ b/inception/inception-io-xmi/src/main/java/de/tudarmstadt/ukp/inception/io/xmi/config/UimaFormatsPropertiesImpl.java
@@ -55,6 +55,11 @@ public class UimaFormatsPropertiesImpl
 
     public static class XmiFormatProperties
     {
+        /**
+         * If enabled, characters that are not allowed in XML (e.g. most control characters) are
+         * replaced with a placeholder when writing XMI files. This avoids producing XMI documents
+         * that cannot be parsed back, at the cost of altering the original text.
+         */
         private boolean sanitizeIllegalCharacters = true;
 
         public void setSanitizeIllegalCharacters(boolean aSanitizeIllegalCharacters)

--- a/inception/inception-io-xmi/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-io-xmi/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,34 @@
+{
+  "properties": [
+    {
+      "name": "format.uima-binary-cas.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Enables UIMA binary CAS format import/export support."
+    },
+    {
+      "name": "format.uima-inline-xml.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables UIMA inline XML format import/export support."
+    },
+    {
+      "name": "format.uima-xmi-struct.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables structured UIMA XMI format import/export support."
+    },
+    {
+      "name": "format.uima-xmi-xml1_1.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables UIMA XMI (XML 1.1) format import/export support."
+    },
+    {
+      "name": "format.uima-xmi.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables UIMA XMI format import/export support."
+    }
+  ]
+}

--- a/inception/inception-io-xmi/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-io-xmi/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -19,7 +19,7 @@
       "description": "Enables structured UIMA XMI format import/export support."
     },
     {
-      "name": "format.uima-xmi-xml1_1.enabled",
+      "name": "format.uima-xmi-xml1-1.enabled",
       "type": "java.lang.Boolean",
       "defaultValue": true,
       "description": "Enables UIMA XMI (XML 1.1) format import/export support."

--- a/inception/inception-io-xml/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-io-xml/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,16 @@
+{
+  "properties": [
+    {
+      "name": "format.custom-xml.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Enables custom XML format import/export support."
+    },
+    {
+      "name": "format.generic-xml.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Enables generic XML format import/export support."
+    }
+  ]
+}

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/config/KnowledgeBasePropertiesImpl.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/config/KnowledgeBasePropertiesImpl.java
@@ -2,13 +2,13 @@
  * Licensed to the Technische Universität Darmstadt under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
- * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * regarding copyright ownership.  The Technische Universität Darmstadt
  * licenses this file to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.
- *  
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -38,19 +38,44 @@ public class KnowledgeBasePropertiesImpl
 {
     public static final int HARD_MIN_RESULTS = 10;
 
+    /**
+     * Multiplier applied to the per-KB maximum result count to determine how many candidates the
+     * internal full-text search (Lucene) backing the local KB indexes returns before secondary
+     * filtering and ranking are applied. Higher values improve recall at the cost of search
+     * performance. Clamped to the range [1.0, 10.0].
+     */
     private double ftsInternalMaxResultsFactor = 2.5;
 
+    /**
+     * Default result limit for SPARQL queries. Determines the default value for the maximum number
+     * of results that can be retrieved from a SPARQL query. The queries are used to retrieve
+     * concepts, statements, properties, etc. from the knowledge base. The maximum number of results
+     * can also be configured separately for each knowledge base in the project settings.
+     */
     private int defaultMaxResults = 1_000;
+
+    /** Hard limit for the maximum number of results from a query. */
     private int hardMaxResults = 10_000;
 
+    /** Whether to delete orphaned KBs on start. */
     private boolean removeOrphansOnStart = false;
 
+    /** Number of items (classes, instances and properties) to cache. */
     private long cacheSize = 100_000;
+
+    /** Time before items are expunged from the cache. */
     private @DurationUnit(MINUTES) Duration cacheExpireDelay = ofMinutes(15);
+
+    /** Time before items are asynchronously refreshed. */
     private @DurationUnit(MINUTES) Duration cacheRefreshDelay = ofMinutes(5);
 
+    /** Number of items (classes, instances and properties) to cache during rendering. */
     private long renderCacheSize = 10_000;
+
+    /** Time before items are expunged from the render cache. */
     private @DurationUnit(MINUTES) Duration renderCacheExpireDelay = ofMinutes(10);
+
+    /** Time before items are asynchronously refreshed when rendering. */
     private @DurationUnit(MINUTES) Duration renderCacheRefreshDelay = ofMinutes(1);
 
     private List<String> defaultFallbackLanguages = emptyList();

--- a/inception/inception-kb/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-kb/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "knowledge-base.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables knowledge base support."
+    }
+  ]
+}

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/document/config/DocumentMetadataLayerSupportPropertiesImpl.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/document/config/DocumentMetadataLayerSupportPropertiesImpl.java
@@ -23,6 +23,13 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class DocumentMetadataLayerSupportPropertiesImpl
     implements DocumentMetadataLayerSupportProperties
 {
+    /**
+     * Enable/disable document metadata layer support.
+     * <p>
+     * Disabling document metadata support prevents new document metadata layers from being created,
+     * but it does not prevent the use of existing document metadata layers in order not to break
+     * existing projects.
+     */
     private boolean enabled = true;
 
     @Override

--- a/inception/inception-layer-docmetadata/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-layer-docmetadata/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "documentmetadata.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables the document-metadata layer support: per-document metadata sidebar, undo support, and (when the recommendation service is present) metadata-suggestion support."
+    }
+  ]
+}

--- a/inception/inception-layer-span/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/config/SpanRecommenderPropertiesImpl.java
+++ b/inception/inception-layer-span/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/config/SpanRecommenderPropertiesImpl.java
@@ -28,6 +28,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class SpanRecommenderPropertiesImpl
     implements SpanRecommenderProperties
 {
+    /**
+     * If enabled, span recommendations rendered in the brat editor get hover-overlay Accept/Reject
+     * buttons in addition to the default click-to-accept / right-click-to-reject interaction.
+     */
     private boolean actionButtonsEnabled;
 
     @Override

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingAutoConfiguration.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingAutoConfiguration.java
@@ -41,7 +41,8 @@ import jakarta.persistence.EntityManager;
  * Provides support event logging.
  */
 @Configuration
-@ConditionalOnProperty(prefix = "event-logging", name = "enabled", havingValue = "true", matchIfMissing = true)
+@ConditionalOnProperty(prefix = "event-logging", name = "enabled", havingValue = "true", //
+        matchIfMissing = EventLoggingProperties.DEFAULT_ENABLED)
 @EnableConfigurationProperties(EventLoggingPropertiesImpl.class)
 public class EventLoggingAutoConfiguration
 {

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingProperties.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingProperties.java
@@ -21,6 +21,8 @@ import java.util.Set;
 
 public interface EventLoggingProperties
 {
+    boolean DEFAULT_ENABLED = true;
+
     void setEnabled(boolean aEnabled);
 
     boolean isEnabled();

--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingPropertiesImpl.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/config/EventLoggingPropertiesImpl.java
@@ -31,10 +31,22 @@ import de.tudarmstadt.ukp.inception.documents.event.AfterCasWrittenEvent;
 public class EventLoggingPropertiesImpl
     implements EventLoggingProperties
 {
-    private boolean enabled;
+    /**
+     * If enabled, application events are persisted to the event log so they can be reviewed later
+     * (e.g. for auditing or analytics).
+     */
+    private boolean enabled = EventLoggingProperties.DEFAULT_ENABLED;
 
+    /**
+     * Simple names of event classes to include in the event log. If empty, all events are included
+     * (subject to {@link #excludePatterns}).
+     */
     private Set<String> includePatterns = Collections.emptySet(); // Default include everything
 
+    /**
+     * Simple names of event classes to exclude from the event log. Applied after
+     * {@link #includePatterns} and used to suppress high-volume or uninteresting events.
+     */
     private Set<String> excludePatterns = Set.of( //
             AfterCasWrittenEvent.class.getSimpleName(), //
             AvailabilityChangeEvent.class.getSimpleName(), //

--- a/inception/inception-pdf-editor2/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-pdf-editor2/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "ui.pdf.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables the PDF annotation editor UI."
+    }
+  ]
+}

--- a/inception/inception-processing/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-processing/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,28 @@
+{
+  "properties": [
+    {
+      "name": "bulk-processing.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables the bulk processing page."
+    },
+    {
+      "name": "bulk-processing.process.apply-recommender.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Enables the bulk recommender (apply-recommender) process."
+    },
+    {
+      "name": "bulk-processing.process.auto-curation.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Enables the bulk auto-curation process."
+    },
+    {
+      "name": "bulk-processing.process.extract-tagset.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables the bulk tagset extraction process."
+    }
+  ]
+}

--- a/inception/inception-project-export/src/main/java/de/tudarmstadt/ukp/inception/project/export/config/ProjectExportServiceAutoConfiguration.java
+++ b/inception/inception-project-export/src/main/java/de/tudarmstadt/ukp/inception/project/export/config/ProjectExportServiceAutoConfiguration.java
@@ -70,7 +70,7 @@ public class ProjectExportServiceAutoConfiguration
                 aSchedulingService, aApplicationEventPublisher);
     }
 
-    @ConditionalOnProperty(name = "dashboard.legacy-export", havingValue = "false", matchIfMissing = true)
+    @ConditionalOnProperty(prefix = "dashboard.legacy-export", name = "enabled", havingValue = "false", matchIfMissing = true)
     @Bean
     public ExportProjectSettingsPanelFactory exportProjectSettingsPanelFactory()
     {
@@ -81,7 +81,7 @@ public class ProjectExportServiceAutoConfiguration
      * @deprecated Old export page code - to be removed in a future release.
      */
     @Deprecated
-    @ConditionalOnProperty(name = "dashboard.legacy-export", havingValue = "true", matchIfMissing = false)
+    @ConditionalOnProperty(prefix = "dashboard.legacy-export", name = "enabled", havingValue = "true", matchIfMissing = false)
     @Bean
     public LegacyExportProjectSettingsPanelFactory legacyExportProjectSettingsPanelFactory()
     {

--- a/inception/inception-project-export/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-project-export/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,16 @@
+{
+  "properties": [
+    {
+      "name": "dashboard.legacy-export.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Enables the legacy project export option on the project export page."
+    },
+    {
+      "name": "dashboard.transforming-export.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Enables the experimental transforming project export option, which allows applying transformations such as text obfuscation to source documents during export."
+    }
+  ]
+}

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/config/InteractiveRecommenderPropertiesImpl.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/config/InteractiveRecommenderPropertiesImpl.java
@@ -30,6 +30,11 @@ import de.tudarmstadt.ukp.inception.recommendation.api.config.InteractiveRecomme
 public class InteractiveRecommenderPropertiesImpl
     implements InteractiveRecommenderProperties
 {
+    /**
+     * If enabled, LLM-based recommenders expose the "interactive" trait, allowing them to be
+     * configured to run on demand from the annotation page rather than only through the regular
+     * recommendation cycle.
+     */
     private boolean enabled;
 
     @Override

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/config/RecommenderProperties.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/config/RecommenderProperties.java
@@ -21,8 +21,6 @@ import de.tudarmstadt.ukp.inception.recommendation.config.RecommenderPropertiesI
 
 public interface RecommenderProperties
 {
-    boolean isActionButtonsEnabled();
-
     boolean isEnabled();
 
     Messages getMessages();

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/config/RecommenderPropertiesImpl.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/config/RecommenderPropertiesImpl.java
@@ -28,8 +28,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class RecommenderPropertiesImpl
     implements RecommenderProperties
 {
-    private boolean enabled;
-    private boolean actionButtonsEnabled;
+    /** Enable/disable recommender support. */
+    private boolean enabled = true;
+
     private Messages messages = new Messages();
 
     @Override
@@ -44,28 +45,42 @@ public class RecommenderPropertiesImpl
     }
 
     @Override
-    public boolean isActionButtonsEnabled()
-    {
-        return actionButtonsEnabled;
-    }
-
-    public void setActionButtonsEnabled(boolean aActionButtonsEnabled)
-    {
-        actionButtonsEnabled = aActionButtonsEnabled;
-    }
-
-    @Override
     public Messages getMessages()
     {
         return messages;
     }
 
-    public class Messages
+    public static class Messages
     {
+        /**
+         * If enabled, an info message is posted to the recommendation log when a prediction run
+         * completes without producing any new suggestions.
+         */
         private boolean noNewPredictionsAvailable = false;
+
+        /**
+         * If enabled, an info message is posted to the recommendation log when a prediction run
+         * produces new suggestions, indicating how many became available.
+         */
         private boolean newPredictionsAvailable = false;
+
+        /**
+         * If enabled, an info message is posted to the recommendation log when a recommender's
+         * automatic evaluation completes successfully.
+         */
         private boolean evaluationSuccessful = false;
+
+        /**
+         * If enabled, an error message is posted to the recommendation log when a recommender's
+         * automatic evaluation fails.
+         */
         private boolean evaluationFailed = true;
+
+        /**
+         * If enabled, an info message is posted to the recommendation log when a non-trainable
+         * recommender is auto-activated (since these recommenders skip the regular
+         * train-and-evaluate cycle).
+         */
         private boolean nonTrainableRecommenderActivation = false;
 
         public boolean isNoNewPredictionsAvailable()

--- a/inception/inception-recommendation/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-recommendation/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "recommender.sidebar.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables the recommender sidebar on the annotation page."
+    }
+  ]
+}

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/config/RemoteApiProperties.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/config/RemoteApiProperties.java
@@ -22,7 +22,12 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties("remote-api")
 public class RemoteApiProperties
 {
+    /**
+     * Enable the remote API. When enabled, the role {@code ROLE_REMOTE} can be assigned to a user
+     * to grant access to the remote API. The remote API is disabled by default.
+     */
     private boolean enabled = false;
+
     private HttpBasicProperties httpBasic = new HttpBasicProperties();
     private OAuth2Properties oauth2 = null;
 
@@ -61,6 +66,9 @@ public class RemoteApiProperties
 
     public static class HttpBasicProperties
     {
+        /**
+         * Enable HTTP basic authentication for the remote API.
+         */
         private boolean enabled = true;
 
         public boolean isEnabled()
@@ -76,8 +84,19 @@ public class RemoteApiProperties
 
     public static class OAuth2Properties
     {
+        /**
+         * Enable OAuth2 authentication for the remote API.
+         */
         private boolean enabled = false;
+
+        /**
+         * Claim containing the username. Defaults to {@code sub}.
+         */
         private String userNameAttribute;
+
+        /**
+         * Client ID used by the OAuth2 IdP. Mandatory if OAuth2 is enabled.
+         */
         private String realm;
 
         public boolean isEnabled()

--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/webhooks/WebhooksConfiguration.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/webhooks/WebhooksConfiguration.java
@@ -38,12 +38,35 @@ public class WebhooksConfiguration
 {
     public static final String PROPERTY_PREFIX = "webhooks";
 
+    /**
+     * List of globally configured webhooks. Each webhook specifies an URL and a set of topics about
+     * which the remote service listening at the given URL is notified.
+     * <p>
+     * Supported topics:
+     * <ul>
+     * <li>{@code DOCUMENT_STATE} - events related to the change of a document state such as when
+     * any user starts annotating or curating the document.</li>
+     * <li>{@code ANNOTATION_STATE} - events related to the change of an annotation state such as
+     * when a user starts or completes the annotation of a document.</li>
+     * <li>{@code PROJECT_STATE} - events related to the change of an entire project such as when
+     * all documents have been curated.</li>
+     * </ul>
+     */
     private List<Webhook> globalHooks = new ArrayList<>();
 
+    /**
+     * Delay in milliseconds between retry attempts when delivering a webhook notification fails.
+     * Allowed range is {@code 10} to {@code 5000}.
+     */
     @Min(value = 10)
     @Max(value = 5000)
     private int retryDelay = 1000;
 
+    /**
+     * Number of additional delivery attempts to make when a webhook notification cannot be
+     * delivered. By default, only one delivery attempt is made ({@code 0} retries). Up to {@code 3}
+     * additional attempts can be configured.
+     */
     @Min(value = 0)
     @Max(value = 3)
     private int retryCount = 0;

--- a/inception/inception-remote/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-remote/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,33 @@
+{
+  "properties": [
+    {
+      "name": "remote-api.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Enables the AERO-style remote API (project, document, permission, curation endpoints). Leave disabled unless an external client needs programmatic access to the application."
+    },
+    {
+      "name": "remote-api.tasks.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Enables the asynchronous task management endpoints of the remote API. Requires remote-api.enabled=true."
+    },
+    {
+      "name": "remote-api.tasks.bulk-prediction.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Enables bulk prediction submission via the remote API task endpoints. Requires remote-api.tasks.enabled=true."
+    },
+    {
+      "name": "webanno.remote-api.enable",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Legacy alias for remote-api.enabled, retained for backwards compatibility with WebAnno-era configurations.",
+      "deprecation": {
+        "level": "warning",
+        "replacement": "remote-api.enabled",
+        "reason": "Renamed when WebAnno was rebranded as INCEpTION."
+      }
+    }
+  ]
+}

--- a/inception/inception-scheduling/src/main/java/de/tudarmstadt/ukp/inception/scheduling/config/SchedulingProperties.java
+++ b/inception/inception-scheduling/src/main/java/de/tudarmstadt/ukp/inception/scheduling/config/SchedulingProperties.java
@@ -22,7 +22,17 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties("inception.scheduling")
 public class SchedulingProperties
 {
+    /**
+     * Number of threads the scheduler uses to run tasks. Should be less than the number of hardware
+     * threads available on the machine that runs the application. The higher the number, the more
+     * tasks can be run in parallel.
+     */
     private int numberOfThreads = 4;
+
+    /**
+     * Maximum number of tasks that can be waiting in the scheduler queue. If the queue is full,
+     * then no new tasks can be scheduled until running tasks are completed.
+     */
     private int queueSize = 100;
 
     public int getNumberOfThreads()

--- a/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/config/AnnotationSchemaPropertiesImpl.java
+++ b/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/config/AnnotationSchemaPropertiesImpl.java
@@ -34,7 +34,21 @@ public class AnnotationSchemaPropertiesImpl
     implements AnnotationSchemaProperties
 {
     private boolean tokenLayerEditable;
+
+    /**
+     * Enable/disable editing sentences.
+     * <p>
+     * Highly experimental. Expect strange things to happen if you start adding/removing/changing
+     * segmentation annotations (i.e. sentences or tokens).
+     */
     private boolean sentenceLayerEditable;
+
+    /**
+     * Enable/disable cross-layer relations.
+     * <p>
+     * Experimental feature. While this feature introduces a new level of flexibility, it can also
+     * interact with existing features in unexpected and untested ways.
+     */
     private boolean crossLayerRelationsEnabled;
 
     @ManagedAttribute

--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/config/SearchPropertiesImpl.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/config/SearchPropertiesImpl.java
@@ -32,6 +32,10 @@ public class SearchPropertiesImpl
 {
     public static final String ALL = "all";
 
+    /**
+     * List of possible numbers of results per page for in-project search. Users can pick a value
+     * from this list in the search sidebar to determine how many results are displayed per page.
+     */
     long[] pagesSizes = { 10, 20, 50, 100, 500, 1000 };
 
     @Override

--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/config/SearchServiceAutoConfiguration.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/config/SearchServiceAutoConfiguration.java
@@ -44,7 +44,7 @@ import de.tudarmstadt.ukp.inception.search.log.SearchQueryEventAdapter;
 
 @Configuration
 @EnableConfigurationProperties(SearchServicePropertiesImpl.class)
-@ConditionalOnProperty(prefix = "search", name = "enabled", havingValue = "true", matchIfMissing = true)
+@ConditionalOnProperty(prefix = "search", name = "enabled", havingValue = "true", matchIfMissing = SearchServiceProperties.DEFAULT_ENABLED)
 public class SearchServiceAutoConfiguration
 {
     @Bean

--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/config/SearchServiceProperties.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/config/SearchServiceProperties.java
@@ -21,6 +21,8 @@ import java.time.Duration;
 
 public interface SearchServiceProperties
 {
+    boolean DEFAULT_ENABLED = true;
+
     boolean isEnabled();
 
     /**

--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/config/SearchServicePropertiesImpl.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/config/SearchServicePropertiesImpl.java
@@ -25,7 +25,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class SearchServicePropertiesImpl
     implements SearchServiceProperties
 {
-    private boolean enabled = false;
+    /** Enable/disable search. */
+    private boolean enabled = SearchServiceProperties.DEFAULT_ENABLED;
 
     private Duration indexKeepOpenTime = Duration.ofMinutes(10);
 

--- a/inception/inception-security/pom.xml
+++ b/inception/inception-security/pom.xml
@@ -181,6 +181,10 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-data-jpa-test</artifactId>
       <scope>test</scope>
     </dependency>

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/config/InceptionSecurityAutoConfiguration.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/config/InceptionSecurityAutoConfiguration.java
@@ -19,6 +19,7 @@ package de.tudarmstadt.ukp.clarin.webanno.security.config;
 
 import javax.sql.DataSource;
 
+import org.springframework.boot.actuate.endpoint.SanitizingFunction;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -91,5 +92,37 @@ public class InceptionSecurityAutoConfiguration
         var authProvider = new InceptionDaoAuthenticationProvider(aUserDetails);
         authProvider.setPasswordEncoder(aPasswordEncoder);
         return authProvider;
+    }
+
+    /**
+     * Default redaction rules applied wherever a
+     * {@link org.springframework.boot.actuate.endpoint.Sanitizer} collects
+     * {@link SanitizingFunction} beans &mdash; both Spring Boot's actuator endpoints (e.g.
+     * {@code /env}, {@code /configprops}) and our admin Settings page. Mirrors the credential-style
+     * key list the actuator used to apply by default before Boot 3 made all sanitization opt-in.
+     * Other modules can contribute their own {@link SanitizingFunction} beans to extend redaction.
+     */
+    @Bean
+    public SanitizingFunction credentialSanitizingFunction()
+    {
+        // ifLikelyCredential already covers keys ending in password/secret/key/token and
+        // keys containing "credentials". The extra ifKeyContains entries make api-key
+        // matching explicit (in any common spelling) and add bearer/authorization which
+        // the default chain does not cover.
+        return SanitizingFunction.sanitizeValue() //
+                .ifLikelyCredential() //
+                .ifKeyContains("apikey", "api-key", "api_key", "bearer", "authorization");
+    }
+
+    /**
+     * Mask {@code repository.path}: the on-disk INCEpTION data directory leaks deployment-specific
+     * filesystem layout, so we redact it from any externally visible surface (actuator endpoints,
+     * admin Settings page).
+     */
+    @Bean
+    public SanitizingFunction repositoryPathSanitizingFunction()
+    {
+        return SanitizingFunction.sanitizeValue() //
+                .ifKeyEquals("repository.path");
     }
 }

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/config/LoginPropertiesImpl.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/config/LoginPropertiesImpl.java
@@ -23,8 +23,22 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class LoginPropertiesImpl
     implements LoginProperties
 {
+    /**
+     * Auto-login using the given identity provider. Set this to the registration ID of a SAML or
+     * OAuth2 provider configured via {@code spring.security.saml2.relyingparty.registration.*} or
+     * {@code spring.security.oauth2.client.*} to bypass the login page and sign users in
+     * automatically. Useful for single-sign-on scenarios where only a single identity provider is
+     * used. To bypass auto-login (e.g. to sign in via credentials), navigate to
+     * {@code .../login.html?skipAutoLogin=true} in a fresh browser session.
+     */
     private String autoLogin;
+
     private long maxConcurrentSessions;
+
+    /**
+     * Custom message to appear on the login page, such as a project web-site or annotation
+     * guideline link. The message supports markdown syntax.
+     */
     private String message;
 
     public void setAutoLogin(String aAutoLogin)

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/config/PreauthenticationPropertiesImpl.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/config/PreauthenticationPropertiesImpl.java
@@ -43,12 +43,21 @@ public class PreauthenticationPropertiesImpl
     implements PreauthenticationProperties
 {
     private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    /**
+     * URL to call after logging out to also sign out of external authentication.
+     */
     private String logoutUrl;
 
     private NewUser newuser = new NewUser();
 
     public static class NewUser
     {
+        /**
+         * Default roles for new users (comma separated). The {@code ROLE_USER} role is always
+         * added, even if not specified explicitly. Adding {@code ROLE_PROJECT_CREATOR} allows all
+         * auto-created users to create their own projects.
+         */
         private List<String> roles = new ArrayList<>();
 
         public List<String> getRoles()

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/config/SecurityPropertiesImpl.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/config/SecurityPropertiesImpl.java
@@ -31,28 +31,41 @@ public class SecurityPropertiesImpl
     private String defaultAdminUsername;
     private String defaultAdminPassword;
     private boolean defaultAdminRemoteAccess = false;
+
+    /**
+     * Whether simple space characters are permitted in usernames. Enable this option only when
+     * necessary to restore access to existing accounts in certain scenarios such as when using
+     * external authentication. Usernames with spaces may lead to problems e.g. when
+     * exporting/importing projects or documents or when constructing certain URLs.
+     */
     private boolean spaceAllowedInUsername = false;
 
     public static final int HARD_MINIMUM_PASSWORD_LENGTH = 0;
     public static final int DEFAULT_MINIMUM_PASSWORD_LENGTH = 8;
+    /** Minimum number of characters a password can have (max {@code 128}). */
     private int minimumPasswordLength = DEFAULT_MINIMUM_PASSWORD_LENGTH;
 
     public static final int HARD_MAXIMUM_PASSWORD_LENGTH = 128;
     public static final int DEFAULT_MAXIMUM_PASSWORD_LENGTH = 32;
+    /** Maximum number of characters a password can have (max {@code 128}). */
     private int maximumPasswordLength = DEFAULT_MAXIMUM_PASSWORD_LENGTH;
 
     public static final int HARD_MINIMUM_USERNAME_LENGTH = 1;
     public static final int DEFAULT_MINIMUM_USERNAME_LENGTH = 4;
+    /** Minimum number of characters a username can have (max {@code 128}). */
     private int minimumUsernameLength = DEFAULT_MINIMUM_USERNAME_LENGTH;
 
     public static final int HARD_MAXIMUM_USERNAME_LENGTH = 128;
     public static final int DEFAULT_MAXIMUM_USERNAME_LENGTH = 64;
+    /** Maximum number of characters a username can have (max {@code 128}). */
     private int maximumUsernameLength = DEFAULT_MAXIMUM_USERNAME_LENGTH;
 
     public static final String DEFAULT_USERNAME_PATTERN = ".*";
+    /** Regular expression for valid usernames. */
     private Pattern usernamePattern = Pattern.compile(DEFAULT_USERNAME_PATTERN);
 
     public static final String DEFAULT_PASSWORD_PATTERN = ".*";
+    /** Regular expression for valid passwords. */
     private Pattern passwordPattern = Pattern.compile(DEFAULT_PASSWORD_PATTERN);
 
     @Override

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/config/UserProfilePropertiesImpl.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/config/UserProfilePropertiesImpl.java
@@ -23,6 +23,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class UserProfilePropertiesImpl
     implements UserProfileProperties
 {
+    /**
+     * Whether regular users can access their own profile to change their password and other profile
+     * information. This setting has no effect when running in pre-authentication mode.
+     */
     private boolean accessible = true;
 
     public void setAccessible(boolean aAccessible)

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/config/CspPropertiesImpl.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/config/CspPropertiesImpl.java
@@ -27,9 +27,13 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class CspPropertiesImpl
     implements CspProperties
 {
+    /** URLs from which images can be loaded. */
     private List<String> allowedImageSources;
+
+    /** URLs from which media (audio/video) can be loaded. */
     private List<String> allowedMediaSources;
 
+    /** URLs which can embed the application in IFrames. */
     private List<String> allowedFrameAncestors;
 
     @Override

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/config/SecurityOAuthRolesPropertiesImpl.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/inception/security/config/SecurityOAuthRolesPropertiesImpl.java
@@ -23,11 +23,29 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class SecurityOAuthRolesPropertiesImpl
     implements SecurityOAuthRolesProperties
 {
+    /**
+     * Set to {@code true} to activate group-to-role mapping. When disabled, all authenticated users
+     * receive {@code ROLE_USER} regardless of their group memberships.
+     */
     private boolean enabled = false;
+
+    /** Name of the OIDC token claim that contains the user's group memberships. */
     private String claim = "groups";
+
+    /**
+     * Group name (or path) that grants {@code ROLE_ADMIN}. Note that {@code ROLE_ADMIN} does
+     * <b>not</b> imply {@code ROLE_USER}. An admin who also needs to use the application as a
+     * regular user must be placed in both the admin group and the user group.
+     */
     private String admin;
+
+    /** Group name (or path) that grants {@code ROLE_USER}. */
     private String user;
+
+    /** Group name (or path) that grants {@code ROLE_PROJECT_CREATOR}. */
     private String projectCreator;
+
+    /** Group name (or path) that grants {@code ROLE_REMOTE}. */
     private String remote;
 
     @Override

--- a/inception/inception-security/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-security/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,12 @@
+{
+  "properties": [
+    { "name": "security.username-pattern", "defaultValue": ".*" },
+    { "name": "security.password-pattern", "defaultValue": ".*" },
+    {
+      "name": "restoreDefaultAdminAccount",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Recovery flag: when set to a non-'false' value at startup, INCEpTION enters admin account recovery mode and re-creates the default admin account. Intended for emergency recovery only; leave unset in normal operation."
+    }
+  ]
+}

--- a/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/config/InviteServicePropertiesImpl.java
+++ b/inception/inception-sharing/src/main/java/de/tudarmstadt/ukp/inception/sharing/config/InviteServicePropertiesImpl.java
@@ -23,7 +23,17 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class InviteServicePropertiesImpl
     implements InviteServiceProperties
 {
+    /**
+     * Whether to enable guest annotators. When enabled, users can be invited via a password-less
+     * login. The user logging in chooses a login name and a project-bound password-less account is
+     * created for this user. The user can only log in to this account via the invite link. When the
+     * project is deleted, all the project-bound accounts are deleted as well.
+     */
     private boolean guestsEnabled;
+
+    /**
+     * Base URL used to generate invite links, e.g. when running behind a reverse proxy.
+     */
     private String inviteBaseUrl;
 
     @Override

--- a/inception/inception-sharing/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-sharing/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "sharing.invites.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Enables the project sharing / invite-link feature. When disabled, the InviteService and its associated UI components are not registered."
+    }
+  ]
+}

--- a/inception/inception-support/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-support/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "profiling.bean-initialization-timing",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Enables profiling and logging of Spring bean initialization timings."
+    }
+  ]
+}

--- a/inception/inception-telemetry/src/main/java/de/tudarmstadt/ukp/clarin/webanno/telemetry/config/TelemetryServicePropertiesImpl.java
+++ b/inception/inception-telemetry/src/main/java/de/tudarmstadt/ukp/clarin/webanno/telemetry/config/TelemetryServicePropertiesImpl.java
@@ -26,6 +26,11 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class TelemetryServicePropertiesImpl
     implements TelemetryServiceProperties
 {
+    /**
+     * Pre-configured response to telemetry submission requests. Setting this avoids the
+     * {@code admin} user being asked about telemetry submission on the first login. Valid values
+     * are {@code ACCEPT} and {@code REJECT}.
+     */
     private AutoResponse autoRespond;
 
     @Override

--- a/inception/inception-telemetry/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-telemetry/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "telemetry.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables anonymous usage telemetry collection."
+    }
+  ]
+}

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/config/DashboardPropertiesImpl.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/config/DashboardPropertiesImpl.java
@@ -32,6 +32,15 @@ import de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel;
 public class DashboardPropertiesImpl
     implements DashboardProperties
 {
+    /**
+     * System roles able to access project dashboards.
+     * <p>
+     * Project managers can always access the project dashboard, even if they are not included in
+     * this setting.
+     */
+    // Default ([ANNOTATOR, CURATOR]) is declared in
+    // META-INF/additional-spring-configuration-metadata.json because the metadata
+    // processor cannot read constructor calls used as field initializers.
     private Set<PermissionLevel> accessibleByRoles = new HashSet<>(asList(ANNOTATOR, CURATOR));
 
     @Override

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/config/DebugPropertiesImpl.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/config/DebugPropertiesImpl.java
@@ -23,6 +23,11 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class DebugPropertiesImpl
     implements DebugProperties
 {
+    /**
+     * If enabled, server-side request processing timings are measured and reported back to the
+     * browser via the {@code Server-Timing} HTTP response header so they show up in the browser
+     * developer tools. Intended for development and performance debugging.
+     */
     private boolean sendServerSideTimings = false;
 
     @Override

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/config/ErrorPagePropertiesImpl.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/config/ErrorPagePropertiesImpl.java
@@ -23,6 +23,12 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class ErrorPagePropertiesImpl
     implements ErrorPageProperties
 {
+    /**
+     * Disable display of information about operating system, Java version, etc. on the error page.
+     * While this information is useful for local users when reporting bugs, security-conscious
+     * administrators running {product-name} as a service may want to enable hiding the details to
+     * avoid information about their system being exposed.
+     */
     private boolean hideDetails;
 
     @Override

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/config/HeaderLinkPropertiesImpl.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/config/HeaderLinkPropertiesImpl.java
@@ -26,6 +26,14 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class HeaderLinkPropertiesImpl
     implements HeaderLinkSettings
 {
+    /**
+     * Icons/links to display in the page header. Each entry is keyed by an identifier and contains
+     * a {@code linkUrl} (target page) and an {@code imageUrl} (icon image). Images are
+     * automatically resized via CSS; point to a reasonably small image to keep loading times low.
+     * The order of the icons is controlled by the ID, not by the order in the configuration file.
+     * {@code imageUrl} values may use a special {@code file:} prefix to refer to an image file
+     * placed under the {@code ${inception.home}/public} directory.
+     */
     private Map<String, HeaderLink> icon = new HashMap<>();
 
     @Override

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/config/ProjectUiPropertiesImpl.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/config/ProjectUiPropertiesImpl.java
@@ -69,7 +69,15 @@ public class ProjectUiPropertiesImpl
 
     public static class Action
     {
+        /** Whether the bulk action is enabled. */
         private boolean enabled;
+
+        /**
+         * User roles allowed to perform the bulk action.
+         */
+        // Default ([ROLE_ADMIN]) is declared in
+        // META-INF/additional-spring-configuration-metadata.json because the metadata
+        // processor cannot read constructor calls used as field initializers.
         private Set<Role> roles = new HashSet<>(asList(ROLE_ADMIN));
 
         public Action(boolean aEnabled)

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/config/WarningsPropertiesImpl.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/config/WarningsPropertiesImpl.java
@@ -24,12 +24,12 @@ public class WarningsPropertiesImpl
     implements WarningsProperties
 {
     /**
-     * If true the embedded database warning is shown. Default true to preserve current behavior.
+     * If {@code true}, the embedded database warning is shown.
      */
     private boolean embeddedDatabase = true;
 
     /**
-     * If true the unsupported browser warning is shown. Default true to preserve current behavior.
+     * Whether to warn about unsupported browsers.
      */
     private boolean unsupportedBrowser = true;
 

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/darkmode/DarkModePropertiesImpl.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/inception/ui/core/darkmode/DarkModePropertiesImpl.java
@@ -23,6 +23,9 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class DarkModePropertiesImpl
     implements DarkModeProperties
 {
+    /**
+     * Whether to enable the ability to switch between light and dark mode (experimental).
+     */
     private boolean enabled;
 
     @Override

--- a/inception/inception-ui-core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-ui-core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,27 @@
+{
+  "properties": [
+    {
+      "name": "ui.dashboard.accessible-by-roles",
+      "defaultValue": [
+        "ANNOTATOR",
+        "CURATOR"
+      ]
+    },
+    {
+      "name": "ui.project.bulk-actions.delete.enabled",
+      "defaultValue": false
+    },
+    {
+      "name": "ui.project.bulk-actions.delete.roles",
+      "defaultValue": [
+        "ROLE_ADMIN"
+      ]
+    },
+    {
+      "name": "ui.dark-mode.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Enables the dark-mode toggle in the menu bar."
+    }
+  ]
+}

--- a/inception/inception-ui-dashboard/pom.xml
+++ b/inception/inception-ui-dashboard/pom.xml
@@ -183,6 +183,10 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-tomcat</artifactId>
     </dependency>
     <dependency>

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/ConfigurationProperty.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/ConfigurationProperty.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.core.dashboard.admin.settings;
+
+import java.io.Serializable;
+
+/**
+ * One row of the admin Settings page: a Spring configuration property enriched with its effective
+ * runtime value (already passed through the configured {@code Sanitizer}) and the property source
+ * it came from.
+ */
+public class ConfigurationProperty
+    implements Serializable
+{
+    private static final long serialVersionUID = 1L;
+
+    private final String name;
+    private final String type;
+    private final String description;
+    private final String sourceType;
+    private final String defaultValue;
+    private final String effectiveValue;
+    private final String effectiveSource;
+    private final boolean deprecated;
+    private final String deprecationNote;
+
+    public ConfigurationProperty(String aName, String aType, String aDescription,
+            String aSourceType, String aDefaultValue, String aEffectiveValue,
+            String aEffectiveSource, boolean aDeprecated, String aDeprecationNote)
+    {
+        name = aName;
+        type = aType;
+        description = aDescription;
+        sourceType = aSourceType;
+        defaultValue = aDefaultValue;
+        effectiveValue = aEffectiveValue;
+        effectiveSource = aEffectiveSource;
+        deprecated = aDeprecated;
+        deprecationNote = aDeprecationNote;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public String getType()
+    {
+        return type;
+    }
+
+    public String getDescription()
+    {
+        return description;
+    }
+
+    public String getSourceType()
+    {
+        return sourceType;
+    }
+
+    public String getDefaultValue()
+    {
+        return defaultValue;
+    }
+
+    public String getEffectiveValue()
+    {
+        return effectiveValue;
+    }
+
+    public String getEffectiveSource()
+    {
+        return effectiveSource;
+    }
+
+    public boolean isDeprecated()
+    {
+        return deprecated;
+    }
+
+    public String getDeprecationNote()
+    {
+        return deprecationNote;
+    }
+}

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/JavadocToMarkdownConverter.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/JavadocToMarkdownConverter.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.core.dashboard.admin.settings;
+
+final class JavadocToMarkdownConverter
+{
+    private JavadocToMarkdownConverter()
+    {
+        // utility class
+    }
+
+    /**
+     * Best-effort conversion of common Javadoc constructs in Spring configuration descriptions to
+     * Markdown.
+     */
+    static String descriptionToMarkdown(String aText)
+    {
+        if (aText == null || aText.isEmpty()) {
+            return aText;
+        }
+        var s = aText;
+        // Inline Javadoc tags (balanced-brace aware so {@code {a}b} works)
+        s = replaceInlineTag(s, "code", "`", "`");
+        s = replaceInlineTag(s, "linkplain", "`", "`");
+        s = replaceInlineTag(s, "link", "`", "`");
+        s = replaceInlineTag(s, "literal", "", "");
+        // Block-level HTML
+        s = s.replaceAll("(?i)<br\\s*/?>", "\n");
+        s = s.replaceAll("(?i)<p>\\s*", "\n\n");
+        s = s.replaceAll("(?i)</p>", "");
+        // Lists: turn each <li>...</li> into "- ..." lines
+        s = s.replaceAll("(?i)<li>\\s*", "\n- ");
+        s = s.replaceAll("(?i)</li>", "");
+        s = s.replaceAll("(?is)</?[uo]l>\\s*", "\n");
+        // Strip any remaining tags defensively
+        s = s.replaceAll("<[^>]+>", "");
+        // Decode common HTML entities (decode &amp; last to avoid double-decoding)
+        s = s.replace("&lt;", "<") //
+                .replace("&gt;", ">") //
+                .replace("&quot;", "\"") //
+                .replace("&apos;", "'") //
+                .replace("&amp;", "&");
+        return s;
+    }
+
+    static String replaceInlineTag(String aText, String aTag, String aPrefix, String aSuffix)
+    {
+        var prefix = "{@" + aTag;
+        var out = new StringBuilder(aText.length());
+        var i = 0;
+        while (i < aText.length()) {
+            var start = aText.indexOf(prefix, i);
+            if (start < 0) {
+                out.append(aText, i, aText.length());
+                break;
+            }
+            // Ensure the next character ends the tag name (whitespace or closing brace)
+            var afterTag = start + prefix.length();
+            if (afterTag >= aText.length() || (!Character.isWhitespace(aText.charAt(afterTag))
+                    && aText.charAt(afterTag) != '}')) {
+                out.append(aText, i, afterTag);
+                i = afterTag;
+                continue;
+            }
+            // Find matching closing brace, accounting for nested braces
+            var depth = 1;
+            var j = afterTag;
+            while (j < aText.length() && depth > 0) {
+                var c = aText.charAt(j);
+                if (c == '{') {
+                    depth++;
+                }
+                else if (c == '}') {
+                    depth--;
+                    if (depth == 0) {
+                        break;
+                    }
+                }
+                j++;
+            }
+            if (depth != 0) {
+                // Unbalanced - emit verbatim and stop
+                out.append(aText, i, aText.length());
+                break;
+            }
+            // Skip leading whitespace after the tag name
+            var contentStart = afterTag;
+            while (contentStart < j && Character.isWhitespace(aText.charAt(contentStart))) {
+                contentStart++;
+            }
+            out.append(aText, i, start);
+            out.append(aPrefix);
+            // Escape so the content survives the later HTML stripping. The final
+            // entity-decoding pass restores the original characters.
+            for (var k = contentStart; k < j; k++) {
+                var c = aText.charAt(k);
+                switch (c) {
+                case '<':
+                    out.append("&lt;");
+                    break;
+                case '>':
+                    out.append("&gt;");
+                    break;
+                case '&':
+                    out.append("&amp;");
+                    break;
+                default:
+                    out.append(c);
+                }
+            }
+            out.append(aSuffix);
+            i = j + 1;
+        }
+        return out.toString();
+    }
+}

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/SettingsNode.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/SettingsNode.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.core.dashboard.admin.settings;
+
+import static java.util.Comparator.comparing;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * One node in the namespace tree of {@link ConfigurationProperty configuration properties}. The
+ * root node has an empty path; every other node represents a dot-segment of the property hierarchy.
+ * Properties are attached to the node corresponding to their parent namespace; pure namespace nodes
+ * (no own properties) have only children.
+ */
+public class SettingsNode
+    implements Serializable
+{
+    private static final long serialVersionUID = 1L;
+
+    private final String path;
+    private final String name;
+    private final List<SettingsNode> children = new ArrayList<>();
+    private final List<ConfigurationProperty> properties = new ArrayList<>();
+
+    private SettingsNode(String aPath, String aName)
+    {
+        path = aPath;
+        name = aName;
+    }
+
+    public String getPath()
+    {
+        return path;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public List<SettingsNode> getChildren()
+    {
+        return children;
+    }
+
+    public List<ConfigurationProperty> getProperties()
+    {
+        return properties;
+    }
+
+    @Override
+    public boolean equals(Object aOther)
+    {
+        if (this == aOther) {
+            return true;
+        }
+        if (!(aOther instanceof SettingsNode other)) {
+            return false;
+        }
+        return Objects.equals(path, other.path);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hashCode(path);
+    }
+
+    /**
+     * Build a tree from the flat list of properties. Returns the synthetic root node whose path is
+     * empty and whose children are the top-level namespaces.
+     */
+    public static SettingsNode buildTree(List<ConfigurationProperty> aProperties)
+    {
+        var root = new SettingsNode("", "");
+        // Build with mutable maps so we can merge as we go, then snapshot to lists.
+        var byPath = new LinkedHashMap<String, NodeBuilder>();
+        byPath.put("", new NodeBuilder(root));
+
+        for (var property : aProperties) {
+            var name = property.getName();
+            if (name == null || name.isEmpty()) {
+                continue;
+            }
+            var segments = name.split("\\.");
+            // Walk/create nodes for every prefix except the last segment, which is the
+            // property's own name and should not become a tree node.
+            var parentBuilder = byPath.get("");
+            var pathSoFar = new StringBuilder();
+            for (var i = 0; i < segments.length - 1; i++) {
+                if (i > 0) {
+                    pathSoFar.append('.');
+                }
+                pathSoFar.append(segments[i]);
+                var path = pathSoFar.toString();
+                var child = byPath.get(path);
+                if (child == null) {
+                    var node = new SettingsNode(path, segments[i]);
+                    child = new NodeBuilder(node);
+                    byPath.put(path, child);
+                    parentBuilder.children.put(segments[i], child);
+                }
+                parentBuilder = child;
+            }
+            parentBuilder.node.properties.add(property);
+        }
+
+        // Materialize: copy sorted child lists onto each node, sort properties by name.
+        for (var builder : byPath.values()) {
+            var sortedChildren = new ArrayList<>(builder.children.values());
+            sortedChildren.sort(comparing(b -> b.node.name));
+            for (var child : sortedChildren) {
+                builder.node.children.add(child.node);
+            }
+            builder.node.properties.sort(comparing(ConfigurationProperty::getName));
+        }
+
+        return root;
+    }
+
+    private static final class NodeBuilder
+    {
+        final SettingsNode node;
+        final Map<String, NodeBuilder> children = new LinkedHashMap<>();
+
+        NodeBuilder(SettingsNode aNode)
+        {
+            node = aNode;
+        }
+    }
+}

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/SettingsPage.html
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/SettingsPage.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<!--
+  Licensed to the Technische Universität Darmstadt under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The Technische Universität Darmstadt
+  licenses this file to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<html xmlns:wicket="http://wicket.apache.org">
+<wicket:head>
+  <style>
+    .settings-list .property-name  { font-family: var(--bs-font-monospace); font-weight: 600; }
+    .settings-list .property-value { font-family: var(--bs-font-monospace); word-break: break-all; white-space: pre-line; }
+    .settings-list .property-meta  { color: var(--bs-secondary-color); font-size: 0.85em; }
+    .settings-list .property-desc  { color: var(--bs-secondary-color); font-size: 0.9em; }
+    .settings-list .deprecated .property-name { text-decoration: line-through; }
+  </style>
+</wicket:head>
+<body>
+  <wicket:extend>
+    <div class="flex-content flex-v-container flex-gutter">
+      <div class="text-muted text-center mx-3" role="alert">
+        <wicket:message key="read-only-note"/>
+      </div>
+      <div class="flex-content flex-h-container flex-gutter">
+        <div class="flex-v-container flex-gutter min-content-height flex-sidebar">
+          <div class="flex-content card">
+            <div class="card-header">
+              <wicket:message key="namespaces"/>
+            </div>
+            <div class="card-body scrolling">
+              <div wicket:id="tree"></div>
+            </div>
+          </div>
+        </div>
+        <div class="flex-content flex-v-container flex-gutter">
+          <div class="flex-content card">
+            <div class="card-header">
+              <span wicket:id="selectedPath"></span>
+            </div>
+            <div wicket:id="detail" class="card-body scrolling">
+              <div wicket:id="emptyState"
+                   class="d-flex flex-column justify-content-center align-items-center text-body-secondary h-100" style="white-space: pre-line;">
+                <wicket:message key="no-properties"/>
+              </div>
+              <div wicket:id="propertiesContainer" class="list-group settings-list">
+                <div wicket:id="properties" class="list-group-item">
+                  <div class="d-flex flex-row align-items-baseline justify-content-between">
+                    <span wicket:id="name" class="property-name"></span>
+                    <span wicket:id="type" class="badge text-bg-light property-meta ms-2"></span>
+                  </div>
+                  <div class="d-flex flex-row mt-1">
+                    <span wicket:id="effectiveValue" class="property-value flex-grow-1"></span>
+                    <span wicket:id="source" class="badge text-bg-secondary ms-2 align-self-center"></span>
+                  </div>
+                  <div class="property-meta mt-1" wicket:enclosure="defaultValue">
+                    default: <span wicket:id="defaultValue" class="property-value"></span>
+                  </div>
+                  <div class="property-desc mt-1" wicket:enclosure="description">
+                    <span wicket:id="description"></span>
+                  </div>
+                  <div class="text-warning property-meta mt-1" wicket:enclosure="deprecationNote">
+                    <i class="fas fa-exclamation-triangle me-1"></i>
+                    <span wicket:id="deprecationNote"></span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </wicket:extend>
+</body>
+</html>

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/SettingsPage.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/SettingsPage.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.inception.ui.core.dashboard.admin.settings;
 
 import static de.tudarmstadt.ukp.inception.support.lambda.LambdaBehavior.visibleWhen;
+import static de.tudarmstadt.ukp.inception.ui.core.dashboard.admin.settings.JavadocToMarkdownConverter.descriptionToMarkdown;
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 
@@ -234,39 +235,6 @@ public class SettingsPage
         }
         var dot = aName.lastIndexOf('.');
         return dot >= 0 ? aName.substring(dot + 1) : aName;
-    }
-
-    /**
-     * Best-effort conversion of common Javadoc constructs in Spring configuration descriptions to
-     * Markdown so they render nicely in {@link MarkdownLabel}.
-     */
-    private static String descriptionToMarkdown(String aText)
-    {
-        if (aText == null || aText.isEmpty()) {
-            return aText;
-        }
-        var s = aText;
-        // Inline Javadoc tags
-        s = s.replaceAll("\\{@code\\s+([^}]+)\\}", "`$1`");
-        s = s.replaceAll("\\{@link(?:plain)?\\s+([^}]+)\\}", "`$1`");
-        s = s.replaceAll("\\{@literal\\s+([^}]+)\\}", "$1");
-        // Block-level HTML
-        s = s.replaceAll("(?i)<br\\s*/?>", "\n");
-        s = s.replaceAll("(?i)<p>\\s*", "\n\n");
-        s = s.replaceAll("(?i)</p>", "");
-        // Lists: turn each <li>...</li> into "- ..." lines
-        s = s.replaceAll("(?i)<li>\\s*", "\n- ");
-        s = s.replaceAll("(?i)</li>", "");
-        s = s.replaceAll("(?is)</?[uo]l>\\s*", "\n");
-        // Strip any remaining tags defensively
-        s = s.replaceAll("<[^>]+>", "");
-        // Decode common HTML entities (decode &amp; last to avoid double-decoding)
-        s = s.replace("&lt;", "<") //
-                .replace("&gt;", ">") //
-                .replace("&quot;", "\"") //
-                .replace("&apos;", "'") //
-                .replace("&amp;", "&");
-        return s;
     }
 
     private void denyAccess()

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/SettingsPage.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/SettingsPage.java
@@ -1,0 +1,277 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.core.dashboard.admin.settings;
+
+import static de.tudarmstadt.ukp.inception.support.lambda.LambdaBehavior.visibleWhen;
+import static java.lang.String.format;
+import static java.util.Collections.emptyList;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import org.apache.wicket.AttributeModifier;
+import org.apache.wicket.Component;
+import org.apache.wicket.RestartResponseException;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.extensions.markup.html.repeater.tree.AbstractTree;
+import org.apache.wicket.extensions.markup.html.repeater.tree.DefaultNestedTree;
+import org.apache.wicket.extensions.markup.html.repeater.tree.content.Folder;
+import org.apache.wicket.markup.html.WebMarkupContainer;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.list.ListItem;
+import org.apache.wicket.markup.html.list.ListView;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.LoadableDetachableModel;
+import org.apache.wicket.model.Model;
+import org.apache.wicket.request.mapper.parameter.PageParameters;
+import org.apache.wicket.spring.injection.annot.SpringBean;
+import org.wicketstuff.annotation.mount.MountPath;
+
+import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
+import de.tudarmstadt.ukp.inception.support.markdown.MarkdownLabel;
+import de.tudarmstadt.ukp.inception.ui.core.dashboard.admin.AdminSettingsDashboardPageBase;
+
+@MountPath("/admin/settings")
+public class SettingsPage
+    extends AdminSettingsDashboardPageBase
+{
+    private static final long serialVersionUID = 1L;
+
+    // Two-step type shortener:
+    // 1. PACKAGE_PREFIX strips lowercase-led, dotted package prefixes
+    // (java.util.List<de.foo.Bar> -> List<Bar>).
+    // 2. OUTER_CLASS_PREFIX strips outer-class chains in nested types
+    // (Outer$Inner -> Inner, Outer$Inner$Deep -> Deep, Map$Entry -> Entry).
+    // Both run inside generics safely because the patterns require a capitalized
+    // identifier immediately after the prefix.
+    private static final Pattern PACKAGE_PREFIX = Pattern.compile("(?:[a-z_][\\w]*\\.)+(?=[A-Z])");
+    private static final Pattern OUTER_CLASS_PREFIX = Pattern
+            .compile("(?:[A-Z]\\w*[\\.$])+(?=[A-Z])");
+
+    private @SpringBean UserDao userService;
+    private @SpringBean SpringConfigurationMetadataService metadataService;
+
+    private final IModel<SettingsNode> rootModel;
+    private final IModel<SettingsNode> selectedModel;
+    private AbstractTree<SettingsNode> tree;
+    private WebMarkupContainer detailContainer;
+    private Label selectedPathLabel;
+
+    public SettingsPage(final PageParameters aParameters)
+    {
+        super(aParameters);
+
+        if (!userService.isCurrentUserAdmin()) {
+            denyAccess();
+        }
+
+        rootModel = LoadableDetachableModel
+                .of(() -> SettingsNode.buildTree(metadataService.listProperties()));
+        var rootChildren = rootModel.getObject().getChildren();
+        selectedModel = Model.of(rootChildren.isEmpty() ? null : rootChildren.get(0));
+
+        tree = createTree();
+        queue(tree);
+
+        detailContainer = new WebMarkupContainer("detail");
+        detailContainer.setOutputMarkupId(true);
+        queue(detailContainer);
+
+        selectedPathLabel = new Label("selectedPath",
+                LoadableDetachableModel.of(() -> selectedModel.getObject() != null
+                        ? selectedModel.getObject().getPath()
+                        : ""));
+        selectedPathLabel.setOutputMarkupId(true);
+        queue(selectedPathLabel);
+
+        var emptyState = new WebMarkupContainer("emptyState");
+        emptyState.add(visibleWhen(() -> propertiesForSelection().isEmpty()));
+        queue(emptyState);
+
+        var propertiesContainer = new WebMarkupContainer("propertiesContainer");
+        propertiesContainer.add(visibleWhen(() -> !propertiesForSelection().isEmpty()));
+        queue(propertiesContainer);
+
+        queue(new ListView<ConfigurationProperty>("properties",
+                LoadableDetachableModel.of(this::propertiesForSelection))
+        {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            protected void populateItem(ListItem<ConfigurationProperty> aItem)
+            {
+                populateProperty(aItem);
+            }
+        });
+    }
+
+    private List<ConfigurationProperty> propertiesForSelection()
+    {
+        var selected = selectedModel.getObject();
+        return selected != null ? selected.getProperties() : emptyList();
+    }
+
+    private DefaultNestedTree<SettingsNode> createTree()
+    {
+        return new DefaultNestedTree<SettingsNode>("tree", new SettingsTreeProvider(rootModel),
+                Model.ofSet(new HashSet<>()))
+        {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            protected Component newContentComponent(String aId, IModel<SettingsNode> aNode)
+            {
+                return new Folder<SettingsNode>(aId, this, aNode)
+                {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    protected IModel<String> newLabelModel(IModel<SettingsNode> aModel)
+                    {
+                        var node = aModel.getObject();
+                        var ownCount = node.getProperties().size();
+                        return Model.of(ownCount > 0 ? node.getName() + " (" + ownCount + ")"
+                                : node.getName());
+                    }
+
+                    @Override
+                    protected boolean isClickable()
+                    {
+                        return true;
+                    }
+
+                    @Override
+                    protected void onClick(Optional<AjaxRequestTarget> aTarget)
+                    {
+                        var previous = selectedModel.getObject();
+                        selectedModel.setObject(getModelObject());
+                        aTarget.ifPresent(target -> {
+                            if (previous != null) {
+                                updateNode(previous, target);
+                            }
+                            updateNode(getModelObject(), target);
+                            target.add(detailContainer, selectedPathLabel);
+                        });
+                    }
+
+                    @Override
+                    protected boolean isSelected()
+                    {
+                        return Objects.equals(getModelObject(), selectedModel.getObject());
+                    }
+                };
+            }
+        };
+    }
+
+    private void populateProperty(ListItem<ConfigurationProperty> aItem)
+    {
+        var view = aItem.getModelObject();
+
+        if (view.isDeprecated()) {
+            aItem.add(AttributeModifier.append("class", "deprecated"));
+        }
+
+        aItem.add(new Label("name", lastSegment(view.getName())));
+        aItem.add(new Label("type", shortenType(view.getType())));
+
+        var overridden = view.getEffectiveValue() != null;
+        var displayedValue = overridden ? view.getEffectiveValue()
+                : view.getDefaultValue() != null ? view.getDefaultValue() : "<unset>";
+        var valueLabel = new Label("effectiveValue", displayedValue);
+        if (!overridden) {
+            // Fallback to the default value: render muted so it reads as "not explicitly set"
+            valueLabel.add(AttributeModifier.append("class", "text-body-secondary"));
+        }
+        aItem.add(valueLabel);
+
+        aItem.add(new Label("source",
+                view.getEffectiveSource() != null ? view.getEffectiveSource() : "default"));
+
+        // Only show the separate "default: X" row when an actual PropertySource overrode
+        // the value (i.e. the source label is not "default") AND a default is known. Without
+        // an override the displayed value already IS the default, so a comparison row would
+        // be noise.
+        aItem.add(new Label("defaultValue", view.getDefaultValue()) //
+                .setVisible(view.getEffectiveSource() != null && view.getDefaultValue() != null));
+        aItem.add(new MarkdownLabel("description", descriptionToMarkdown(view.getDescription()))
+                .setVisible(view.getDescription() != null));
+        aItem.add(new Label("deprecationNote", view.getDeprecationNote())
+                .setVisible(view.getDeprecationNote() != null));
+    }
+
+    private static String shortenType(String aType)
+    {
+        if (aType == null) {
+            return "";
+        }
+        var s = PACKAGE_PREFIX.matcher(aType).replaceAll("");
+        return OUTER_CLASS_PREFIX.matcher(s).replaceAll("");
+    }
+
+    private static String lastSegment(String aName)
+    {
+        if (aName == null) {
+            return "";
+        }
+        var dot = aName.lastIndexOf('.');
+        return dot >= 0 ? aName.substring(dot + 1) : aName;
+    }
+
+    /**
+     * Best-effort conversion of common Javadoc constructs in Spring configuration descriptions to
+     * Markdown so they render nicely in {@link MarkdownLabel}.
+     */
+    private static String descriptionToMarkdown(String aText)
+    {
+        if (aText == null || aText.isEmpty()) {
+            return aText;
+        }
+        var s = aText;
+        // Inline Javadoc tags
+        s = s.replaceAll("\\{@code\\s+([^}]+)\\}", "`$1`");
+        s = s.replaceAll("\\{@link(?:plain)?\\s+([^}]+)\\}", "`$1`");
+        s = s.replaceAll("\\{@literal\\s+([^}]+)\\}", "$1");
+        // Block-level HTML
+        s = s.replaceAll("(?i)<br\\s*/?>", "\n");
+        s = s.replaceAll("(?i)<p>\\s*", "\n\n");
+        s = s.replaceAll("(?i)</p>", "");
+        // Lists: turn each <li>...</li> into "- ..." lines
+        s = s.replaceAll("(?i)<li>\\s*", "\n- ");
+        s = s.replaceAll("(?i)</li>", "");
+        s = s.replaceAll("(?is)</?[uo]l>\\s*", "\n");
+        // Strip any remaining tags defensively
+        s = s.replaceAll("<[^>]+>", "");
+        // Decode common HTML entities (decode &amp; last to avoid double-decoding)
+        s = s.replace("&lt;", "<") //
+                .replace("&gt;", ">") //
+                .replace("&quot;", "\"") //
+                .replace("&apos;", "'") //
+                .replace("&amp;", "&");
+        return s;
+    }
+
+    private void denyAccess()
+    {
+        getSession().error(format("Access to [%s] denied.", getClass().getSimpleName()));
+        throw new RestartResponseException(getApplication().getHomePage());
+    }
+}

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/SettingsPage.utf8.properties
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/SettingsPage.utf8.properties
@@ -1,0 +1,20 @@
+# Licensed to the Technische Universität Darmstadt under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The Technische Universität Darmstadt
+# licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+page.title=Settings
+page.icon=
+namespaces=Namespaces
+no-properties=No properties at this namespace level.\n\nSelect a child node to see its properties.
+read-only-note=This page shows the effective application settings for inspection only. Settings cannot be changed here. To modify configuration, edit the active settings.properties or settings.yml file, or pass the corresponding command-line parameters when starting the application, and then restart.

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/SettingsPageMenuItem.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/SettingsPageMenuItem.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.core.dashboard.admin.settings;
+
+import org.apache.wicket.Component;
+import org.apache.wicket.Page;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.annotation.Order;
+
+import de.agilecoders.wicket.core.markup.html.bootstrap.image.Icon;
+import de.agilecoders.wicket.extensions.markup.html.bootstrap.icon.FontAwesome5IconType;
+import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
+import de.tudarmstadt.ukp.clarin.webanno.ui.core.menu.MenuItem;
+import wicket.contrib.input.events.key.KeyType;
+
+@Order(400)
+public class SettingsPageMenuItem
+    implements MenuItem
+{
+    private @Autowired UserDao userService;
+
+    @Override
+    public String getPath()
+    {
+        return "/admin/settings";
+    }
+
+    @Override
+    public Component getIcon(String aId)
+    {
+        return new Icon(aId, FontAwesome5IconType.sliders_h_s);
+    }
+
+    @Override
+    public String getLabel()
+    {
+        return "Settings";
+    }
+
+    @Override
+    public boolean applies()
+    {
+        return userService.isAdministrator(userService.getCurrentUser());
+    }
+
+    @Override
+    public Class<? extends Page> getPageClass()
+    {
+        return SettingsPage.class;
+    }
+
+    @Override
+    public KeyType[] shortcut()
+    {
+        return new KeyType[] { KeyType.Alt, KeyType.s };
+    }
+}

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/SettingsPageProperties.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/SettingsPageProperties.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.core.dashboard.admin.settings;
+
+import java.util.Set;
+
+public interface SettingsPageProperties
+{
+    Set<String> getHiddenNamespaces();
+}

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/SettingsPagePropertiesImpl.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/SettingsPagePropertiesImpl.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.core.dashboard.admin.settings;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("dashboard.admin-settings")
+public class SettingsPagePropertiesImpl
+    implements SettingsPageProperties
+{
+    /**
+     * Namespaces hidden from the admin Settings page tree. Useful for suppressing properties that
+     * are framework- or infrastructure-related rather than application configuration. An entry can
+     * be a single segment (e.g. {@code "spring"}) to hide everything below it, or a dotted
+     * multi-segment prefix (e.g. {@code "telemetry.matomo"}) to hide only that subtree. A property
+     * is hidden when its name equals an entry, or starts with an entry followed by a dot. Matching
+     * is case-sensitive.
+     */
+    // Default declared in META-INF/additional-spring-configuration-metadata.json
+    // because the metadata processor cannot evaluate the LinkedHashSet/List.of expression.
+    private Set<String> hiddenNamespaces = new LinkedHashSet<>(List.of( //
+            "spring", //
+            "springdoc", //
+            "wicket", //
+            "sentry", //
+            "management", //
+            "server", //
+            "endpoints", //
+            "logging", //
+            "telemetry.matomo"));
+
+    @Override
+    public Set<String> getHiddenNamespaces()
+    {
+        return hiddenNamespaces;
+    }
+
+    public void setHiddenNamespaces(Set<String> aHiddenNamespaces)
+    {
+        hiddenNamespaces = aHiddenNamespaces != null ? aHiddenNamespaces : new LinkedHashSet<>();
+    }
+}

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/SettingsTreeProvider.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/SettingsTreeProvider.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.core.dashboard.admin.settings;
+
+import java.util.Iterator;
+
+import org.apache.wicket.extensions.markup.html.repeater.tree.ITreeProvider;
+import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.Model;
+
+public class SettingsTreeProvider
+    implements ITreeProvider<SettingsNode>
+{
+    private static final long serialVersionUID = 1L;
+
+    private final IModel<SettingsNode> rootModel;
+
+    public SettingsTreeProvider(IModel<SettingsNode> aRootModel)
+    {
+        rootModel = aRootModel;
+    }
+
+    @Override
+    public Iterator<? extends SettingsNode> getRoots()
+    {
+        return rootModel.getObject().getChildren().iterator();
+    }
+
+    @Override
+    public boolean hasChildren(SettingsNode aNode)
+    {
+        return !aNode.getChildren().isEmpty();
+    }
+
+    @Override
+    public Iterator<? extends SettingsNode> getChildren(SettingsNode aNode)
+    {
+        return aNode.getChildren().iterator();
+    }
+
+    @Override
+    public IModel<SettingsNode> model(SettingsNode aNode)
+    {
+        return Model.of(aNode);
+    }
+
+    @Override
+    public void detach()
+    {
+        rootModel.detach();
+    }
+}

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/SpringConfigurationMetadataService.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/SpringConfigurationMetadataService.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.core.dashboard.admin.settings;
+
+import java.util.List;
+
+public interface SpringConfigurationMetadataService
+{
+    /**
+     * @return all known configuration properties (declared via {@code @ConfigurationProperties} and
+     *         discovered via {@code META-INF/spring-configuration-metadata.json} on the classpath),
+     *         enriched with their effective runtime values. Sorted by property name.
+     */
+    List<ConfigurationProperty> listProperties();
+}

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/SpringConfigurationMetadataServiceImpl.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/SpringConfigurationMetadataServiceImpl.java
@@ -1,0 +1,611 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.core.dashboard.admin.settings;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Comparator.comparing;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.boot.actuate.endpoint.SanitizableData;
+import org.springframework.boot.actuate.endpoint.Sanitizer;
+import org.springframework.boot.actuate.endpoint.SanitizingFunction;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.origin.OriginLookup;
+import org.springframework.boot.origin.TextResourceOrigin;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.EnumerablePropertySource;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.PropertySource;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+
+import de.tudarmstadt.ukp.inception.support.json.JSONUtil;
+import de.tudarmstadt.ukp.inception.ui.core.dashboard.admin.settings.model.ConfigurationMetadata;
+import de.tudarmstadt.ukp.inception.ui.core.dashboard.admin.settings.model.ConfigurationMetadataProperty;
+
+public class SpringConfigurationMetadataServiceImpl
+    implements SpringConfigurationMetadataService
+{
+    private static final Logger LOG = LoggerFactory
+            .getLogger(SpringConfigurationMetadataServiceImpl.class);
+
+    private static final String METADATA_PATTERN = //
+            "classpath*:META-INF/spring-configuration-metadata.json";
+
+    // Name of the ConfigurationPropertySourcesPropertySource that Spring Boot
+    // attaches at index 0 to wrap all other sources for fast binder lookups.
+    // Mirrors ConfigurationPropertySources.ATTACHED_PROPERTY_SOURCE_NAME, which
+    // is package-private in Spring Boot 4 and not part of the public API.
+    private static final String ATTACHED_PROPERTY_SOURCE_NAME = "configurationProperties";
+
+    private final Environment environment;
+    private final Sanitizer sanitizer;
+    private final SettingsPageProperties settingsProperties;
+    private final ListableBeanFactory beanFactory;
+
+    private volatile List<ConfigurationMetadataProperty> cachedMetadata;
+    // Multiple @ConfigurationProperties beans may share the same prefix (each binding the
+    // subset of properties it has accessors for, e.g. recommender + spanRecommender both
+    // declare prefix "recommender"). Keep all of them so the live-lookup can fall through
+    // to whichever bean actually owns the requested sub-path.
+    private volatile Map<String, List<Object>> cachedConfigPropertyBeans;
+
+    public SpringConfigurationMetadataServiceImpl(Environment aEnvironment,
+            Iterable<SanitizingFunction> aSanitizingFunctions,
+            SettingsPageProperties aSettingsProperties, ListableBeanFactory aBeanFactory)
+    {
+        environment = aEnvironment;
+        sanitizer = new Sanitizer(aSanitizingFunctions);
+        settingsProperties = aSettingsProperties;
+        beanFactory = aBeanFactory;
+    }
+
+    @Override
+    public List<ConfigurationProperty> listProperties()
+    {
+        var metadata = getMetadata();
+        var hidden = settingsProperties.getHiddenNamespaces();
+        // Snapshot every PropertySource's property names once -- without this we'd rescan
+        // every enumerable source for every metadata property, giving O(properties x sources
+        // x keys) behavior on a page with thousands of keys across dozens of sources.
+        var sources = snapshotSources();
+
+        var views = new ArrayList<ConfigurationProperty>(metadata.size());
+        for (var property : metadata) {
+            if (isHidden(property.getName(), hidden)) {
+                continue;
+            }
+            views.add(toView(property, sources));
+        }
+        views.sort(comparing(ConfigurationProperty::getName));
+        return views;
+    }
+
+    private static boolean isHidden(String aName, Set<String> aHidden)
+    {
+        if (aName == null || aHidden == null || aHidden.isEmpty()) {
+            return false;
+        }
+        for (var hidden : aHidden) {
+            if (aName.equals(hidden) || aName.startsWith(hidden + ".")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private ConfigurationProperty toView(ConfigurationMetadataProperty aProperty,
+            List<SourceSnapshot> aSources)
+    {
+        var name = aProperty.getName();
+
+        var defaultValue = sanitizeAsString(null, name, aProperty.getDefaultValue());
+
+        String effectiveValue = null;
+        String effectiveSource = null;
+        var match = findSource(name, aSources);
+        if (match != null) {
+            var source = match.source;
+            var raw = source.getProperty(name);
+            if (raw != null) {
+                effectiveValue = sanitizeAsString(source, name, raw);
+            }
+            else {
+                // The source contains sub-keys under "<name>." but not "<name>" itself --
+                // e.g. a Map/Collection-typed property bound from YAML, where Spring flattens
+                // the hierarchy into leaf keys. Render the value from the source's leaf keys
+                // so the displayed form mirrors what's in settings.yml/properties, and
+                // attribute it to that source.
+                effectiveValue = renderFromLeafKeys(match, name);
+                if (effectiveValue == null) {
+                    effectiveValue = sanitizeAsString(source, name, readLiveValue(name));
+                }
+            }
+            effectiveSource = resolveSourceName(match, name);
+        }
+        else if (environment.containsProperty(name)) {
+            // Resolved through the environment but not directly attributable to one source
+            // (e.g. a placeholder-resolved value). Sanitize without a source attribution.
+            effectiveValue = sanitizeAsString(null, name, environment.getProperty(name));
+        }
+        else if (defaultValue == null) {
+            // No PropertySource override and the metadata processor did not record a default
+            // (e.g. method-call field initializers, constructor-set fields, or values computed
+            // at runtime by getters). Walk the matching @ConfigurationProperties bean tree to
+            // surface the live value as the effective default, since no source overrides it.
+            var live = readLiveValue(name);
+            if (live != null) {
+                defaultValue = sanitizeAsString(null, name, live);
+            }
+            else {
+                LOG.trace("Property [{}] comes out unset: no PropertySource override, no "
+                        + "metadata default, and live-lookup returned null", name);
+            }
+        }
+
+        var deprecationNote = describeDeprecation(aProperty);
+
+        return new ConfigurationProperty( //
+                name, //
+                aProperty.getType(), //
+                aProperty.getDescription(), //
+                aProperty.getSourceType(), //
+                defaultValue, //
+                effectiveValue, //
+                effectiveSource, //
+                aProperty.isDeprecated(), //
+                deprecationNote);
+    }
+
+    private String sanitizeAsString(PropertySource<?> aSource, String aName, Object aValue)
+    {
+        if (aValue == null) {
+            return null;
+        }
+        var sanitized = sanitizer.sanitize(new SanitizableData(aSource, aName, aValue), true);
+        return sanitized == null ? null : String.valueOf(sanitized);
+    }
+
+    /**
+     * Read the live value of a property by walking the matching {@code @ConfigurationProperties}
+     * bean tree via getter reflection. Returns {@code null} if no bean owns this property, the walk
+     * hits a null intermediate value, or any reflection step fails.
+     */
+    private Object readLiveValue(String aName)
+    {
+        var beans = getConfigPropertyBeans();
+
+        // Find the longest prefix that matches this property name. Multiple beans may share
+        // it (e.g. RecommenderPropertiesImpl and SpanRecommenderPropertiesImpl both declare
+        // prefix "recommender") -- each binds the subset of properties for which it has
+        // accessors, so we have to try them all and return the first non-null result.
+        List<Object> candidates = null;
+        String matchedPrefix = null;
+        for (var entry : beans.entrySet()) {
+            var prefix = entry.getKey();
+            if (aName.equals(prefix) || aName.startsWith(prefix + ".")) {
+                if (matchedPrefix == null || prefix.length() > matchedPrefix.length()) {
+                    matchedPrefix = prefix;
+                    candidates = entry.getValue();
+                }
+            }
+        }
+        if (candidates == null || matchedPrefix == null) {
+            LOG.trace("Live-lookup for [{}] failed: no @ConfigurationProperties bean owns a "
+                    + "matching prefix", aName);
+            return null;
+        }
+
+        var remaining = aName.equals(matchedPrefix) //
+                ? "" //
+                : aName.substring(matchedPrefix.length() + 1);
+
+        for (var bean : candidates) {
+            var value = walkBean(aName, bean, remaining);
+            if (value != null) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    private static Object walkBean(String aName, Object aBean, String aRemaining)
+    {
+        if (aRemaining.isEmpty()) {
+            return aBean;
+        }
+
+        Object current = aBean;
+        var segments = aRemaining.split("\\.");
+        for (int i = 0; i < segments.length; i++) {
+            if (current == null) {
+                LOG.trace(
+                        "Live-lookup for [{}] hit a null intermediate value at segment [{}] "
+                                + "(after walking [{}]) on bean [{}]",
+                        aName, segments[i], String.join(".", Arrays.copyOfRange(segments, 0, i)),
+                        aBean.getClass().getName());
+                return null;
+            }
+            var next = invokeGetter(current, segments[i]);
+            if (next == null) {
+                LOG.trace("Live-lookup for [{}] returned null from getter for segment [{}] on "
+                        + "[{}] (no JavaBean accessor matched, or the getter returned null)", aName,
+                        segments[i], current.getClass().getName());
+            }
+            current = next;
+        }
+        return current;
+    }
+
+    private static Object invokeGetter(Object aTarget, String aKebabSegment)
+    {
+        var camel = kebabToCamel(aKebabSegment);
+        var capitalised = Character.toUpperCase(camel.charAt(0)) + camel.substring(1);
+        for (var prefix : new String[] { "get", "is" }) {
+            try {
+                var method = aTarget.getClass().getMethod(prefix + capitalised);
+                return method.invoke(aTarget);
+            }
+            catch (NoSuchMethodException e) {
+                // try next prefix
+            }
+            catch (ReflectiveOperationException e) {
+                LOG.debug("Live-value getter [{}{}] on {} threw", prefix, capitalised,
+                        aTarget.getClass().getName(), e);
+                return null;
+            }
+        }
+        return null;
+    }
+
+    private static String kebabToCamel(String aKebab)
+    {
+        var sb = new StringBuilder(aKebab.length());
+        var capitalize = false;
+        for (int i = 0; i < aKebab.length(); i++) {
+            var c = aKebab.charAt(i);
+            if (c == '-') {
+                capitalize = true;
+            }
+            else if (capitalize) {
+                sb.append(Character.toUpperCase(c));
+                capitalize = false;
+            }
+            else {
+                sb.append(c);
+            }
+        }
+        return sb.toString();
+    }
+
+    private Map<String, List<Object>> getConfigPropertyBeans()
+    {
+        var cached = cachedConfigPropertyBeans;
+        if (cached != null) {
+            return cached;
+        }
+        synchronized (this) {
+            if (cachedConfigPropertyBeans != null) {
+                return cachedConfigPropertyBeans;
+            }
+            var byPrefix = new HashMap<String, List<Object>>();
+            for (var bean : beanFactory.getBeansWithAnnotation(ConfigurationProperties.class)
+                    .values()) {
+                var ann = AnnotationUtils.findAnnotation(bean.getClass(),
+                        ConfigurationProperties.class);
+                if (ann == null) {
+                    continue;
+                }
+                var prefix = !ann.prefix().isEmpty() ? ann.prefix() : ann.value();
+                if (!prefix.isEmpty()) {
+                    byPrefix.computeIfAbsent(prefix, k -> new ArrayList<>()).add(bean);
+                }
+            }
+            cachedConfigPropertyBeans = byPrefix;
+            return cachedConfigPropertyBeans;
+        }
+    }
+
+    private List<ConfigurationMetadataProperty> getMetadata()
+    {
+        var cached = cachedMetadata;
+        if (cached != null) {
+            return cached;
+        }
+        synchronized (this) {
+            if (cachedMetadata != null) {
+                return cachedMetadata;
+            }
+            cachedMetadata = loadMetadata();
+            return cachedMetadata;
+        }
+    }
+
+    private List<ConfigurationMetadataProperty> loadMetadata()
+    {
+        var resolver = new PathMatchingResourcePatternResolver();
+        Resource[] resources;
+        try {
+            resources = resolver.getResources(METADATA_PATTERN);
+        }
+        catch (IOException e) {
+            LOG.warn("Unable to scan classpath for [{}]", METADATA_PATTERN, e);
+            return List.of();
+        }
+
+        // Properties may be declared in multiple jars (e.g. an interface in -api and the
+        // impl in the impl module both contribute the same property names). Deduplicate
+        // by name, keeping the first occurrence with a non-null description if available.
+        var byName = new LinkedHashMap<String, ConfigurationMetadataProperty>();
+        var seenResources = new HashSet<String>();
+        for (var resource : resources) {
+            var key = describeResource(resource);
+            if (!seenResources.add(key)) {
+                continue;
+            }
+            try (InputStream in = resource.getInputStream()) {
+                var metadata = JSONUtil.fromJsonStream(ConfigurationMetadata.class, in);
+                for (var property : metadata.getProperties()) {
+                    if (property.getName() == null) {
+                        continue;
+                    }
+                    byName.merge(property.getName(), property,
+                            SpringConfigurationMetadataServiceImpl::pickBetter);
+                }
+            }
+            catch (IOException e) {
+                LOG.warn("Unable to read configuration metadata from [{}]", resource, e);
+            }
+        }
+
+        LOG.debug("Loaded {} configuration metadata properties from {} resource(s)", byName.size(),
+                resources.length);
+
+        return List.copyOf(byName.values());
+    }
+
+    private static ConfigurationMetadataProperty pickBetter(ConfigurationMetadataProperty aFirst,
+            ConfigurationMetadataProperty aSecond)
+    {
+        if (aFirst.getDescription() == null && aSecond.getDescription() != null) {
+            return aSecond;
+        }
+        if (aFirst.getDefaultValue() == null && aSecond.getDefaultValue() != null) {
+            return aSecond;
+        }
+        return aFirst;
+    }
+
+    /**
+     * For property sources backed by a config file, return the file's basename (e.g.
+     * {@code application.properties}, {@code settings.yml}) using Spring Boot's per-property origin
+     * tracking. For other sources (system properties, environment variables, command-line args,
+     * ...) fall back to the source's own name.
+     */
+    private static String resolveSourceName(SourceSnapshot aSnapshot, String aName)
+    {
+        var source = aSnapshot.source;
+        if (source instanceof OriginLookup<?> rawLookup) {
+            @SuppressWarnings("unchecked")
+            var lookup = (OriginLookup<String>) rawLookup;
+            var fileName = filenameFromOrigin(lookup, aName);
+            if (fileName != null) {
+                return fileName;
+            }
+            // Map/Collection-typed properties have no Origin under the literal prefix --
+            // only the leaf keys do. Look up the origin of any leaf to discover the file.
+            for (var key : aSnapshot.leafKeys(aName + ".")) {
+                fileName = filenameFromOrigin(lookup, key);
+                if (fileName != null) {
+                    return fileName;
+                }
+            }
+        }
+        return source.getName();
+    }
+
+    private static String filenameFromOrigin(OriginLookup<String> aLookup, String aKey)
+    {
+        for (var origin = aLookup.getOrigin(aKey); origin != null; origin = origin.getParent()) {
+            if (origin instanceof TextResourceOrigin textOrigin) {
+                var resource = textOrigin.getResource();
+                if (resource != null && resource.getFilename() != null) {
+                    return resource.getFilename();
+                }
+            }
+        }
+        return null;
+    }
+
+    private static String describeResource(Resource aResource)
+    {
+        try {
+            return aResource.getURI().toString();
+        }
+        catch (IOException e) {
+            return aResource.getDescription();
+        }
+    }
+
+    private List<SourceSnapshot> snapshotSources()
+    {
+        if (!(environment instanceof ConfigurableEnvironment configurable)) {
+            return emptyList();
+        }
+        var snapshots = new ArrayList<SourceSnapshot>();
+        for (PropertySource<?> source : configurable.getPropertySources()) {
+            // Skip the ConfigurationPropertySourcesPropertySource that Spring Boot
+            // installs at index 0 to wrap all other sources for fast binder lookups.
+            // It contains essentially every property and would mask the real origin.
+            if (ATTACHED_PROPERTY_SOURCE_NAME.equals(source.getName())) {
+                continue;
+            }
+            snapshots.add(new SourceSnapshot(source));
+        }
+        return snapshots;
+    }
+
+    private static SourceSnapshot findSource(String aName, List<SourceSnapshot> aSnapshots)
+    {
+        SourceSnapshot prefixMatch = null;
+        var prefix = aName + ".";
+        for (var snapshot : aSnapshots) {
+            if (snapshot.sortedNames != null) {
+                if (snapshot.names.contains(aName)) {
+                    return snapshot;
+                }
+                if (prefixMatch == null && snapshot.hasLeafKey(prefix)) {
+                    // Map/Collection-typed properties never appear under their literal name --
+                    // Spring flattens YAML/properties hierarchies into leaf keys (e.g.
+                    // "style.header.icon.inception.link-url"). Remember this source as a
+                    // candidate but keep scanning in case a higher-priority source has the
+                    // exact name.
+                    prefixMatch = snapshot;
+                }
+            }
+            else if (snapshot.source.getProperty(aName) != null) {
+                return snapshot;
+            }
+        }
+        return prefixMatch;
+    }
+
+    /**
+     * One-shot snapshot of a {@link PropertySource}'s property names. For enumerable sources we
+     * cache a {@link Set} for O(1) exact lookups and a sorted array for binary-search prefix scans,
+     * so per-property work stays bounded across thousands of metadata entries.
+     */
+    private static final class SourceSnapshot
+    {
+        final PropertySource<?> source;
+        final Set<String> names;
+        final String[] sortedNames;
+
+        SourceSnapshot(PropertySource<?> aSource)
+        {
+            source = aSource;
+            if (aSource instanceof EnumerablePropertySource<?> enumerable) {
+                var raw = enumerable.getPropertyNames();
+                names = new HashSet<>(asList(raw));
+                sortedNames = raw.clone();
+                Arrays.sort(sortedNames);
+            }
+            else {
+                names = null;
+                sortedNames = null;
+            }
+        }
+
+        boolean hasLeafKey(String aPrefix)
+        {
+            var idx = firstIndexAtOrAfter(aPrefix);
+            return idx < sortedNames.length && sortedNames[idx].startsWith(aPrefix);
+        }
+
+        List<String> leafKeys(String aPrefix)
+        {
+            if (sortedNames == null) {
+                return emptyList();
+            }
+            var result = new ArrayList<String>();
+            for (var i = firstIndexAtOrAfter(aPrefix); i < sortedNames.length; i++) {
+                if (!sortedNames[i].startsWith(aPrefix)) {
+                    break;
+                }
+                result.add(sortedNames[i]);
+            }
+            return result;
+        }
+
+        private int firstIndexAtOrAfter(String aKey)
+        {
+            var idx = Arrays.binarySearch(sortedNames, aKey);
+            return idx >= 0 ? idx : -idx - 1;
+        }
+    }
+
+    /**
+     * Render the value of a Map/Collection-typed property by collecting its leaf keys from
+     * {@code aSource} (e.g. for {@code style.header.icon} bound from YAML, the leaves are
+     * {@code style.header.icon.inception.link-url}, {@code style.header.icon.inception.image-url}
+     * and so on). The output is a multi-line {@code <suffix>=<value>} block that closely mirrors
+     * what was actually written in {@code settings.yml}/{@code .properties}, instead of the
+     * {@code Map.toString()} form with object hashes.
+     *
+     * Returns {@code null} if the source has no leaf keys for {@code aName}, in which case callers
+     * should fall back to the live value.
+     */
+    private String renderFromLeafKeys(SourceSnapshot aSnapshot, String aName)
+    {
+        var prefix = aName + ".";
+        var leafKeys = aSnapshot.leafKeys(prefix);
+        if (leafKeys.isEmpty()) {
+            return null;
+        }
+        var source = aSnapshot.source;
+        var sb = new StringBuilder();
+        for (var key : leafKeys) {
+            if (sb.length() > 0) {
+                sb.append('\n');
+            }
+            var raw = source.getProperty(key);
+            var sanitized = sanitizeAsString(source, key, raw);
+            sb.append(key.substring(prefix.length())).append('=')
+                    .append(sanitized != null ? sanitized : "");
+        }
+        return sb.toString();
+    }
+
+    private static String describeDeprecation(ConfigurationMetadataProperty aProperty)
+    {
+        var deprecation = aProperty.getDeprecation();
+        if (deprecation == null) {
+            return aProperty.isDeprecated() ? "Deprecated." : null;
+        }
+        var sb = new StringBuilder();
+        if (deprecation.getLevel() != null) {
+            sb.append('(').append(deprecation.getLevel()).append(") ");
+        }
+        if (deprecation.getReason() != null) {
+            sb.append(deprecation.getReason()).append(' ');
+        }
+        if (deprecation.getReplacement() != null) {
+            sb.append("Use ").append(deprecation.getReplacement()).append(" instead. ");
+        }
+        if (deprecation.getSince() != null) {
+            sb.append("Since ").append(deprecation.getSince()).append('.');
+        }
+        var note = sb.toString().trim();
+        return note.isEmpty() ? "Deprecated." : note;
+    }
+}

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/model/ConfigurationMetadata.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/model/ConfigurationMetadata.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.core.dashboard.admin.settings.model;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Root structure of a Spring Boot {@code META-INF/spring-configuration-metadata.json} file.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ConfigurationMetadata
+{
+    private List<ConfigurationMetadataGroup> groups = List.of();
+    private List<ConfigurationMetadataProperty> properties = List.of();
+
+    public List<ConfigurationMetadataGroup> getGroups()
+    {
+        return groups;
+    }
+
+    public void setGroups(List<ConfigurationMetadataGroup> aGroups)
+    {
+        groups = aGroups != null ? aGroups : List.of();
+    }
+
+    public List<ConfigurationMetadataProperty> getProperties()
+    {
+        return properties;
+    }
+
+    public void setProperties(List<ConfigurationMetadataProperty> aProperties)
+    {
+        properties = aProperties != null ? aProperties : List.of();
+    }
+}

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/model/ConfigurationMetadataGroup.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/model/ConfigurationMetadataGroup.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.core.dashboard.admin.settings.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ConfigurationMetadataGroup
+{
+    private String name;
+    private String type;
+    private String sourceType;
+    private String description;
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public void setName(String aName)
+    {
+        name = aName;
+    }
+
+    public String getType()
+    {
+        return type;
+    }
+
+    public void setType(String aType)
+    {
+        type = aType;
+    }
+
+    public String getSourceType()
+    {
+        return sourceType;
+    }
+
+    public void setSourceType(String aSourceType)
+    {
+        sourceType = aSourceType;
+    }
+
+    public String getDescription()
+    {
+        return description;
+    }
+
+    public void setDescription(String aDescription)
+    {
+        description = aDescription;
+    }
+}

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/model/ConfigurationMetadataProperty.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/model/ConfigurationMetadataProperty.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.core.dashboard.admin.settings.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ConfigurationMetadataProperty
+{
+    private String name;
+    private String type;
+    private String description;
+    private String sourceType;
+    private Object defaultValue;
+    private boolean deprecated;
+    private Deprecation deprecation;
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public void setName(String aName)
+    {
+        name = aName;
+    }
+
+    public String getType()
+    {
+        return type;
+    }
+
+    public void setType(String aType)
+    {
+        type = aType;
+    }
+
+    public String getDescription()
+    {
+        return description;
+    }
+
+    public void setDescription(String aDescription)
+    {
+        description = aDescription;
+    }
+
+    public String getSourceType()
+    {
+        return sourceType;
+    }
+
+    public void setSourceType(String aSourceType)
+    {
+        sourceType = aSourceType;
+    }
+
+    public Object getDefaultValue()
+    {
+        return defaultValue;
+    }
+
+    public void setDefaultValue(Object aDefaultValue)
+    {
+        defaultValue = aDefaultValue;
+    }
+
+    public boolean isDeprecated()
+    {
+        return deprecated || deprecation != null;
+    }
+
+    public void setDeprecated(boolean aDeprecated)
+    {
+        deprecated = aDeprecated;
+    }
+
+    public Deprecation getDeprecation()
+    {
+        return deprecation;
+    }
+
+    public void setDeprecation(Deprecation aDeprecation)
+    {
+        deprecation = aDeprecation;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Deprecation
+    {
+        private String level;
+        private String reason;
+        private String replacement;
+        private String since;
+
+        public String getLevel()
+        {
+            return level;
+        }
+
+        public void setLevel(String aLevel)
+        {
+            level = aLevel;
+        }
+
+        public String getReason()
+        {
+            return reason;
+        }
+
+        public void setReason(String aReason)
+        {
+            reason = aReason;
+        }
+
+        public String getReplacement()
+        {
+            return replacement;
+        }
+
+        public void setReplacement(String aReplacement)
+        {
+            replacement = aReplacement;
+        }
+
+        public String getSince()
+        {
+            return since;
+        }
+
+        public void setSince(String aSince)
+        {
+            since = aSince;
+        }
+    }
+}

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/users/RemoteApiPropertiesImpl.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/users/RemoteApiPropertiesImpl.java
@@ -25,6 +25,9 @@ import org.springframework.stereotype.Component;
 public class RemoteApiPropertiesImpl
     implements RemoteApiProperties
 {
+    /**
+     * Whether to enable the remote API.
+     */
     private boolean enabled = false;
 
     @Override

--- a/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/config/DashboardAutoConfiguration.java
+++ b/inception/inception-ui-dashboard/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/config/DashboardAutoConfiguration.java
@@ -20,12 +20,14 @@ package de.tudarmstadt.ukp.inception.ui.core.dashboard.config;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.endpoint.SanitizingFunction;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.core.env.Environment;
 
 import com.giffing.wicket.spring.boot.starter.configuration.extensions.core.csrf.CsrfAttacksPreventionProperties;
 
@@ -36,6 +38,11 @@ import de.tudarmstadt.ukp.inception.ui.core.dashboard.admin.dashlet.NetworkAdmin
 import de.tudarmstadt.ukp.inception.ui.core.dashboard.admin.dashlet.SystemStatusService;
 import de.tudarmstadt.ukp.inception.ui.core.dashboard.admin.dashlet.SystemStatusServiceImpl;
 import de.tudarmstadt.ukp.inception.ui.core.dashboard.admin.log.LogPageMenuItem;
+import de.tudarmstadt.ukp.inception.ui.core.dashboard.admin.settings.SettingsPageMenuItem;
+import de.tudarmstadt.ukp.inception.ui.core.dashboard.admin.settings.SettingsPageProperties;
+import de.tudarmstadt.ukp.inception.ui.core.dashboard.admin.settings.SettingsPagePropertiesImpl;
+import de.tudarmstadt.ukp.inception.ui.core.dashboard.admin.settings.SpringConfigurationMetadataService;
+import de.tudarmstadt.ukp.inception.ui.core.dashboard.admin.settings.SpringConfigurationMetadataServiceImpl;
 import de.tudarmstadt.ukp.inception.ui.core.dashboard.admin.users.ManageUsersPageMenuItem;
 import de.tudarmstadt.ukp.inception.ui.core.dashboard.dashlet.ProjectDashboardDashletExtension;
 import de.tudarmstadt.ukp.inception.ui.core.dashboard.dashlet.ProjectDashboardDashletExtensionPoint;
@@ -56,7 +63,8 @@ import de.tudarmstadt.ukp.inception.ui.core.dashboard.settings.users.ProjectUser
 
 @ConditionalOnWebApplication
 @Configuration
-@EnableConfigurationProperties({ DashboardPropertiesImpl.class, ProjectUiPropertiesImpl.class })
+@EnableConfigurationProperties({ DashboardPropertiesImpl.class, ProjectUiPropertiesImpl.class,
+        SettingsPagePropertiesImpl.class })
 public class DashboardAutoConfiguration
 {
     @Bean
@@ -176,5 +184,21 @@ public class DashboardAutoConfiguration
     public ManageUsersPageMenuItem manageUsersPageMenuItem()
     {
         return new ManageUsersPageMenuItem();
+    }
+
+    @Bean
+    public SettingsPageMenuItem settingsPageMenuItem()
+    {
+        return new SettingsPageMenuItem();
+    }
+
+    @Bean
+    public SpringConfigurationMetadataService springConfigurationMetadataService(
+            Environment aEnvironment, List<SanitizingFunction> aSanitizingFunctions,
+            SettingsPageProperties aSettingsProperties,
+            org.springframework.beans.factory.ListableBeanFactory aBeanFactory)
+    {
+        return new SpringConfigurationMetadataServiceImpl(aEnvironment, aSanitizingFunctions,
+                aSettingsProperties, aBeanFactory);
     }
 }

--- a/inception/inception-ui-dashboard/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-ui-dashboard/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,18 @@
+{
+  "properties": [
+    {
+      "name": "dashboard.admin-settings.hidden-namespaces",
+      "defaultValue": [
+        "spring",
+        "springdoc",
+        "wicket",
+        "sentry",
+        "management",
+        "server",
+        "endpoints",
+        "logging",
+        "telemetry.matomo"
+      ]
+    }
+  ]
+}

--- a/inception/inception-ui-dashboard/src/test/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/JavadocToMarkdownConverterTest.java
+++ b/inception/inception-ui-dashboard/src/test/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/JavadocToMarkdownConverterTest.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.core.dashboard.admin.settings;
+
+import static de.tudarmstadt.ukp.inception.ui.core.dashboard.admin.settings.JavadocToMarkdownConverter.descriptionToMarkdown;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class JavadocToMarkdownConverterTest
+{
+    @Test
+    void thatNullAndEmptyArePassedThrough()
+    {
+        assertThat(descriptionToMarkdown(null)).isNull();
+        assertThat(descriptionToMarkdown("")).isEmpty();
+    }
+
+    @Test
+    void thatPlainTextIsUnchanged()
+    {
+        assertThat(descriptionToMarkdown("Just some text.")).isEqualTo("Just some text.");
+    }
+
+    @Test
+    void thatCodeTagBecomesBackticks()
+    {
+        assertThat(descriptionToMarkdown("Use {@code foo} here.")).isEqualTo("Use `foo` here.");
+    }
+
+    @Test
+    void thatCodeTagWithNestedBracesIsHandled()
+    {
+        assertThat(
+                descriptionToMarkdown("QName {@code {http://www.w3.org/1998/Math/MathML}math} ok."))
+                        .isEqualTo("QName `{http://www.w3.org/1998/Math/MathML}math` ok.");
+    }
+
+    @Test
+    void thatMultipleNestedBracesAreHandled()
+    {
+        assertThat(descriptionToMarkdown("{@code a{b{c}d}e}")).isEqualTo("`a{b{c}d}e`");
+    }
+
+    @Test
+    void thatLinkTagBecomesBackticks()
+    {
+        assertThat(descriptionToMarkdown("See {@link Foo#bar}.")).isEqualTo("See `Foo#bar`.");
+    }
+
+    @Test
+    void thatLinkplainTagBecomesBackticks()
+    {
+        assertThat(descriptionToMarkdown("See {@linkplain Foo bar baz}."))
+                .isEqualTo("See `Foo bar baz`.");
+    }
+
+    @Test
+    void thatLiteralTagStripsBraces()
+    {
+        assertThat(descriptionToMarkdown("Value is {@literal hello}."))
+                .isEqualTo("Value is hello.");
+    }
+
+    @Test
+    void thatMultipleTagsOnSameLineAreReplaced()
+    {
+        assertThat(descriptionToMarkdown("{@code a} and {@code b}")).isEqualTo("`a` and `b`");
+    }
+
+    @Test
+    void thatUnbalancedTagIsLeftAlone()
+    {
+        // No closing brace - the original text is preserved as-is.
+        assertThat(descriptionToMarkdown("Stray {@code never closed"))
+                .isEqualTo("Stray {@code never closed");
+    }
+
+    @Test
+    void thatBrIsConvertedToNewline()
+    {
+        assertThat(descriptionToMarkdown("a<br>b<br/>c<BR />d")).isEqualTo("a\nb\nc\nd");
+    }
+
+    @Test
+    void thatParagraphIsConvertedToBlankLine()
+    {
+        assertThat(descriptionToMarkdown("a<p>b</p>")).isEqualTo("a\n\nb");
+    }
+
+    @Test
+    void thatListItemsAreConvertedToBullets()
+    {
+        assertThat(descriptionToMarkdown("Items:<ul><li>one</li><li>two</li></ul>"))
+                .isEqualTo("Items:\n- one\n- two\n");
+    }
+
+    @Test
+    void thatCodeContentSurvivesHtmlStripping()
+    {
+        assertThat(descriptionToMarkdown("Use {@code List<String>} here."))
+                .isEqualTo("Use `List<String>` here.");
+    }
+
+    @Test
+    void thatLiteralContentSurvivesHtmlStripping()
+    {
+        assertThat(descriptionToMarkdown("Value is {@literal <foo>&<bar>}."))
+                .isEqualTo("Value is <foo>&<bar>.");
+    }
+
+    @Test
+    void thatRemainingTagsAreStripped()
+    {
+        assertThat(descriptionToMarkdown("Hello <b>world</b>!")).isEqualTo("Hello world!");
+    }
+
+    @Test
+    void thatHtmlEntitiesAreDecoded()
+    {
+        assertThat(descriptionToMarkdown("&lt;a&gt; &amp; &quot;b&quot; &apos;c&apos;"))
+                .isEqualTo("<a> & \"b\" 'c'");
+    }
+
+    @Test
+    void thatAmpEntityIsDecodedLast()
+    {
+        // &amp;lt; should decode to &lt; (not <), since &amp; is processed last
+        assertThat(descriptionToMarkdown("&amp;lt;")).isEqualTo("&lt;");
+    }
+
+    @Test
+    void thatTagPrefixDoesNotMatchLongerTagName()
+    {
+        // Ensure {@codex ...} is not matched as {@code ...}
+        assertThat(descriptionToMarkdown("{@codex foo}")).isEqualTo("{@codex foo}");
+    }
+}

--- a/inception/inception-ui-dashboard/src/test/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/SpringConfigurationMetadataServiceIntegrationTest.java
+++ b/inception/inception-ui-dashboard/src/test/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/admin/settings/SpringConfigurationMetadataServiceIntegrationTest.java
@@ -1,0 +1,611 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.core.dashboard.admin.settings;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+
+import de.tudarmstadt.ukp.inception.support.json.JSONUtil;
+import de.tudarmstadt.ukp.inception.ui.core.dashboard.admin.settings.model.ConfigurationMetadata;
+
+/**
+ * Verifies what {@link SpringConfigurationMetadataService} reports for nested-property holders
+ * declared with different field shapes on the outer {@code @ConfigurationProperties} class.
+ *
+ * <p>
+ * Findings the test pins down (each case is a static nested holder; the differentiator is the outer
+ * field's declaration):
+ * <ul>
+ * <li><b>SETTER</b>: non-{@code final} field with a setter on the outer class. The
+ * {@code spring-boot-configuration-processor} extracts {@code defaultValue} from the holder's field
+ * initialisers.</li>
+ * <li><b>FINAL</b>: {@code final} field, no setter (matches the {@code AssistantPropertiesImpl}
+ * convention). Processor extracts {@code defaultValue}.</li>
+ * <li><b>BARE</b>: non-{@code final}, no setter. Processor still extracts {@code defaultValue} --
+ * the static-ness of the holder is the actual prerequisite, not the outer field's shape.</li>
+ * <li><b>METHOD_INIT</b>: static holder, but the holder's field is initialised via a method call.
+ * The processor cannot evaluate the initialiser, so no {@code defaultValue} is emitted. The
+ * service's live-lookup fallback (walking the {@code @ConfigurationProperties} bean tree via
+ * getters) must then surface the runtime value so the property is never reported as "unset".</li>
+ * </ul>
+ *
+ * Regression guard for the {@code RecommenderPropertiesImpl.Messages} situation we hit on the
+ * {@code feature/5991-Ability-for-admin-to-see-global-settings} branch.
+ */
+@SpringBootTest( //
+        classes = SpringConfigurationMetadataServiceIntegrationTest.TestContext.class, //
+        properties = { //
+                "spring.main.banner-mode=off", //
+                // Load a real classpath file so the property source has TextResourceOrigin
+                // tracking -- exercises the OriginLookup-based filename extraction in the
+                // service. Inline "properties=" entries don't carry a file origin and would
+                // not exercise that path.
+                "spring.config.import=classpath:test-map-case.properties" })
+public class SpringConfigurationMetadataServiceIntegrationTest
+{
+    enum FieldShape
+    {
+        SETTER("test-setter-case", true), FINAL("test-final-case", true),
+        BARE("test-bare-case", true),
+        // METHOD_INIT exercises the gap that the service's live-lookup fallback fills:
+        // the processor can't extract a literal default from a method-call initialiser.
+        METHOD_INIT("test-method-init-case", false);
+
+        final String prefix;
+        /**
+         * Whether the {@code spring-boot-configuration-processor} is expected to write a
+         * {@code defaultValue} into {@code spring-configuration-metadata.json} for this shape.
+         */
+        final boolean processorEmitsDefault;
+
+        FieldShape(String aPrefix, boolean aProcessorEmitsDefault)
+        {
+            prefix = aPrefix;
+            processorEmitsDefault = aProcessorEmitsDefault;
+        }
+
+        String propertyName()
+        {
+            return prefix + ".holder.flag";
+        }
+    }
+
+    /**
+     * Runtime value of {@code holder.flag} on every fixture below. Kept identical so the observable
+     * result is the same string regardless of which path supplies it.
+     */
+    private static final String EXPECTED_VALUE = "true";
+
+    private @Autowired Environment environment;
+    private @Autowired ListableBeanFactory beanFactory;
+
+    /**
+     * Public-API guarantee for every shape: the property is listed and not unset (defaultValue or
+     * effectiveValue is non-null). This is the regression guard against the
+     * {@code Messages}-was-non-static problem and against any future regression where a
+     * runtime-only initialiser would otherwise come out blank.
+     */
+    @ParameterizedTest
+    @EnumSource(FieldShape.class)
+    void propertyIsReportedNotUnset(FieldShape aShape)
+    {
+        var property = findProperty(newService().listProperties(), aShape.propertyName());
+
+        assertThat(property.getDefaultValue() != null || property.getEffectiveValue() != null) //
+                .as("property %s should not be unset (default=%s, effective=%s)",
+                        aShape.propertyName(), property.getDefaultValue(),
+                        property.getEffectiveValue()) //
+                .isTrue();
+    }
+
+    /**
+     * Whichever path supplies the value (metadata default or live-lookup fallback), it must equal
+     * the holder's runtime field value.
+     */
+    @ParameterizedTest
+    @EnumSource(FieldShape.class)
+    void reportedValueMatchesRuntimeState(FieldShape aShape)
+    {
+        var property = findProperty(newService().listProperties(), aShape.propertyName());
+
+        var observed = property.getEffectiveValue() != null //
+                ? property.getEffectiveValue() //
+                : property.getDefaultValue();
+
+        assertThat(observed) //
+                .as("reported value for %s", aShape.propertyName()) //
+                .isEqualTo(EXPECTED_VALUE);
+    }
+
+    /**
+     * Pins down the {@code spring-boot-configuration-processor}'s behaviour for each shape. If a
+     * Spring Boot upgrade ever changes this (e.g. METHOD_INIT starts getting a default, making the
+     * live-lookup fallback unnecessary for that case), this assertion will flag it.
+     */
+    @ParameterizedTest
+    @EnumSource(FieldShape.class)
+    void processorMetadataDefaultMatchesShapeExpectation(FieldShape aShape) throws IOException
+    {
+        var metadataDefault = readProcessorDefault(aShape.propertyName());
+
+        if (aShape.processorEmitsDefault) {
+            assertThat(metadataDefault) //
+                    .as("processor should emit defaultValue for %s shape", aShape) //
+                    .isNotNull() //
+                    .isEqualTo(EXPECTED_VALUE);
+        }
+        else {
+            assertThat(metadataDefault) //
+                    .as("processor should NOT emit defaultValue for %s shape", aShape) //
+                    .isNull();
+        }
+    }
+
+    private SpringConfigurationMetadataServiceImpl newService()
+    {
+        return new SpringConfigurationMetadataServiceImpl(environment, emptyList(),
+                () -> emptySet(), beanFactory);
+    }
+
+    private static ConfigurationProperty findProperty(List<ConfigurationProperty> aProperties,
+            String aName)
+    {
+        return aProperties.stream() //
+                .filter(p -> aName.equals(p.getName())) //
+                .findFirst() //
+                .orElseThrow(() -> new AssertionError("Property [" + aName + "] not listed"));
+    }
+
+    /**
+     * Reads {@code defaultValue} for {@code aName} directly from
+     * {@code META-INF/spring-configuration-metadata.json} on the classpath -- i.e. exactly what the
+     * {@code spring-boot-configuration-processor} wrote at compile time, bypassing any live-lookup
+     * fallback the service applies.
+     */
+    private static String readProcessorDefault(String aName) throws IOException
+    {
+        var resolver = new PathMatchingResourcePatternResolver();
+        var resources = resolver
+                .getResources("classpath*:META-INF/spring-configuration-metadata.json");
+        for (var resource : resources) {
+            try (InputStream in = resource.getInputStream()) {
+                var metadata = JSONUtil.fromJsonStream(ConfigurationMetadata.class, in);
+                for (var property : metadata.getProperties()) {
+                    if (aName.equals(property.getName()) && property.getDefaultValue() != null) {
+                        return String.valueOf(property.getDefaultValue());
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Reproduces the multi-bean-per-prefix collision we observed at runtime:
+     * {@code RecommenderPropertiesImpl} and {@code SpanRecommenderPropertiesImpl} both declare
+     * {@code @ConfigurationProperties("recommender")}, and the live-lookup must fall through to the
+     * bean that actually owns the requested sub-path.
+     */
+    @Test
+    void liveLookupFallsThroughWhenMultipleBeansSharePrefix()
+    {
+        var properties = newService().listProperties();
+
+        var owned = findProperty(properties, "test-shared-prefix.deep.flag");
+        var observed = owned.getEffectiveValue() != null //
+                ? owned.getEffectiveValue() //
+                : owned.getDefaultValue();
+
+        assertThat(observed) //
+                .as("property only owned by SharedPrefixOwnerProperties should be resolved "
+                        + "even though SharedPrefixOtherProperties shares the prefix and does "
+                        + "not declare it") //
+                .isEqualTo(EXPECTED_VALUE);
+    }
+
+    /**
+     * Hidden namespaces support multi-segment prefixes, not just top-level segments. So adding
+     * {@code "telemetry.matomo"} to the hidden set hides exactly the matomo subtree while leaving
+     * other {@code telemetry.*} properties visible. A bare top-level entry (e.g.
+     * {@code "telemetry"}) still hides everything below it as before.
+     */
+    @Test
+    void multiSegmentHiddenPrefixHidesOnlyMatchingSubtree()
+    {
+        var sut = new SpringConfigurationMetadataServiceImpl(environment, emptyList(),
+                () -> Set.of("test-hidden.matomo"), beanFactory);
+
+        var names = sut.listProperties().stream() //
+                .map(ConfigurationProperty::getName) //
+                .filter(n -> n.startsWith("test-hidden.")) //
+                .toList();
+
+        assertThat(names) //
+                .as("multi-segment prefix hides exactly the matomo subtree") //
+                .doesNotContain("test-hidden.matomo.flag") //
+                .contains("test-hidden.kept.flag");
+    }
+
+    @Test
+    void topLevelHiddenPrefixHidesEntireSubtree()
+    {
+        var sut = new SpringConfigurationMetadataServiceImpl(environment, emptyList(),
+                () -> Set.of("test-hidden"), beanFactory);
+
+        var names = sut.listProperties().stream() //
+                .map(ConfigurationProperty::getName) //
+                .filter(n -> n.startsWith("test-hidden.")) //
+                .toList();
+
+        assertThat(names) //
+                .as("top-level prefix hides the entire subtree") //
+                .isEmpty();
+    }
+
+    /**
+     * Map-typed properties (e.g. {@code style.header.icon} as a {@code Map<String, HeaderLink>})
+     * are flattened by Spring into leaf keys in the property source -- there is no literal
+     * {@code style.header.icon} key. The service must:
+     * <ul>
+     * <li>still attribute the property to the source that supplied the leaves (not "default"),
+     * and</li>
+     * <li>render the value in a form that mirrors what was actually written, instead of
+     * {@code Map.toString()} with object hashes.</li>
+     * </ul>
+     */
+    @Test
+    void mapTypedPropertyAttributesSourceAndRendersLeafKeys()
+    {
+        var property = findProperty(newService().listProperties(), "test-map-case.icon");
+
+        assertThat(property.getEffectiveSource()) //
+                .as("source must be attributed to the .properties filename via the leaf "
+                        + "keys' Origin tracking, not to the verbose 'Config resource ... "
+                        + "via location ...' form, and not to 'default'") //
+                .isEqualTo("test-map-case.properties");
+
+        assertThat(property.getEffectiveValue()) //
+                .as("value should be rendered as flattened leaf key=value lines, not as "
+                        + "Map.toString() with object hashes") //
+                .isNotNull() //
+                .doesNotContain("@") //
+                .contains("inception.link-url=https://inception-project.github.io/") //
+                .contains("inception.image-url=images/inception.png") //
+                .contains("docs.link-url=https://example.org/docs") //
+                .contains("docs.image-url=images/docs.png");
+
+        // Lines should be sorted so the output is stable.
+        var lines = property.getEffectiveValue().split("\n");
+        var sorted = lines.clone();
+        java.util.Arrays.sort(sorted);
+        assertThat(lines) //
+                .as("rendered lines should be sorted for stable output") //
+                .containsExactly(sorted);
+    }
+
+    @Configuration
+    @EnableConfigurationProperties({ //
+            SetterCaseProperties.class, //
+            FinalCaseProperties.class, //
+            BareCaseProperties.class, //
+            MethodInitCaseProperties.class, //
+            SharedPrefixOwnerProperties.class, //
+            SharedPrefixOtherProperties.class, //
+            MapCaseProperties.class, //
+            HiddenCaseProperties.class })
+    public static class TestContext
+    {
+        // Beans enabled via @EnableConfigurationProperties above.
+    }
+
+    /** Non-final field, with setter. */
+    @ConfigurationProperties("test-setter-case")
+    public static class SetterCaseProperties
+    {
+        private Holder holder = new Holder();
+
+        public Holder getHolder()
+        {
+            return holder;
+        }
+
+        public void setHolder(Holder aHolder)
+        {
+            holder = aHolder;
+        }
+
+        public static class Holder
+        {
+            private boolean flag = true;
+
+            public boolean isFlag()
+            {
+                return flag;
+            }
+
+            public void setFlag(boolean aFlag)
+            {
+                flag = aFlag;
+            }
+        }
+    }
+
+    /** Final field, no setter. */
+    @ConfigurationProperties("test-final-case")
+    public static class FinalCaseProperties
+    {
+        private final Holder holder = new Holder();
+
+        public Holder getHolder()
+        {
+            return holder;
+        }
+
+        public static class Holder
+        {
+            private boolean flag = true;
+
+            public boolean isFlag()
+            {
+                return flag;
+            }
+
+            public void setFlag(boolean aFlag)
+            {
+                flag = aFlag;
+            }
+        }
+    }
+
+    /**
+     * Non-final field, no setter -- the original {@code RecommenderPropertiesImpl.messages} shape
+     * after {@code Messages} was made static.
+     */
+    @ConfigurationProperties("test-bare-case")
+    public static class BareCaseProperties
+    {
+        private Holder holder = new Holder();
+
+        public Holder getHolder()
+        {
+            return holder;
+        }
+
+        public static class Holder
+        {
+            private boolean flag = true;
+
+            public boolean isFlag()
+            {
+                return flag;
+            }
+
+            public void setFlag(boolean aFlag)
+            {
+                flag = aFlag;
+            }
+        }
+    }
+
+    /**
+     * Holder field initialised via a method call. The {@code spring-boot-configuration-processor}
+     * only extracts literal default values; method-call initialisers are opaque to it, so no
+     * {@code defaultValue} is emitted. The service must surface the runtime value via its
+     * live-lookup fallback.
+     */
+    @ConfigurationProperties("test-method-init-case")
+    public static class MethodInitCaseProperties
+    {
+        private final Holder holder = new Holder();
+
+        public Holder getHolder()
+        {
+            return holder;
+        }
+
+        public static class Holder
+        {
+            private boolean flag = computeDefault();
+
+            private static boolean computeDefault()
+            {
+                return true;
+            }
+
+            public boolean isFlag()
+            {
+                return flag;
+            }
+
+            public void setFlag(boolean aFlag)
+            {
+                flag = aFlag;
+            }
+        }
+    }
+
+    /**
+     * Owns {@code test-shared-prefix.deep.flag}. Shares the {@code test-shared-prefix} prefix with
+     * {@link SharedPrefixOtherProperties}, which does not declare {@code deep.flag}.
+     */
+    @ConfigurationProperties("test-shared-prefix")
+    public static class SharedPrefixOwnerProperties
+    {
+        private final Deep deep = new Deep();
+
+        public Deep getDeep()
+        {
+            return deep;
+        }
+
+        public static class Deep
+        {
+            private boolean flag = true;
+
+            public boolean isFlag()
+            {
+                return flag;
+            }
+
+            public void setFlag(boolean aFlag)
+            {
+                flag = aFlag;
+            }
+        }
+    }
+
+    /**
+     * Shares the {@code test-shared-prefix} prefix with {@link SharedPrefixOwnerProperties} but
+     * declares a different sub-path. The live-lookup must not stop at this bean when resolving
+     * {@code test-shared-prefix.deep.flag}.
+     */
+    @ConfigurationProperties("test-shared-prefix")
+    public static class SharedPrefixOtherProperties
+    {
+        private boolean unrelated;
+
+        public boolean isUnrelated()
+        {
+            return unrelated;
+        }
+
+        public void setUnrelated(boolean aUnrelated)
+        {
+            unrelated = aUnrelated;
+        }
+    }
+
+    /**
+     * Two static nested holders so we can verify multi-segment hidden-namespace matching:
+     * {@code test-hidden.matomo.*} (intended to be hidden) and {@code test-hidden.kept.*} (intended
+     * to remain visible).
+     */
+    @ConfigurationProperties("test-hidden")
+    public static class HiddenCaseProperties
+    {
+        private final Matomo matomo = new Matomo();
+        private final Kept kept = new Kept();
+
+        public Matomo getMatomo()
+        {
+            return matomo;
+        }
+
+        public Kept getKept()
+        {
+            return kept;
+        }
+
+        public static class Matomo
+        {
+            private boolean flag = false;
+
+            public boolean isFlag()
+            {
+                return flag;
+            }
+
+            public void setFlag(boolean aFlag)
+            {
+                flag = aFlag;
+            }
+        }
+
+        public static class Kept
+        {
+            private boolean flag = false;
+
+            public boolean isFlag()
+            {
+                return flag;
+            }
+
+            public void setFlag(boolean aFlag)
+            {
+                flag = aFlag;
+            }
+        }
+    }
+
+    /**
+     * Mirrors {@code HeaderLinkPropertiesImpl}: a {@code Map<String, Entry>} bound from leaf keys
+     * in YAML/properties. The metadata processor records a single entry for the {@code icon}
+     * prefix; the actual values are spread across leaf keys in the property source.
+     */
+    @ConfigurationProperties("test-map-case")
+    public static class MapCaseProperties
+    {
+        private Map<String, Entry> icon = new HashMap<>();
+
+        public Map<String, Entry> getIcon()
+        {
+            return icon;
+        }
+
+        public void setIcon(Map<String, Entry> aIcon)
+        {
+            icon = aIcon;
+        }
+
+        public static class Entry
+        {
+            private String linkUrl;
+            private String imageUrl;
+
+            public String getLinkUrl()
+            {
+                return linkUrl;
+            }
+
+            public void setLinkUrl(String aLinkUrl)
+            {
+                linkUrl = aLinkUrl;
+            }
+
+            public String getImageUrl()
+            {
+                return imageUrl;
+            }
+
+            public void setImageUrl(String aImageUrl)
+            {
+                imageUrl = aImageUrl;
+            }
+        }
+    }
+}

--- a/inception/inception-ui-dashboard/src/test/resources/test-map-case.properties
+++ b/inception/inception-ui-dashboard/src/test/resources/test-map-case.properties
@@ -1,0 +1,4 @@
+test-map-case.icon.inception.link-url=https://inception-project.github.io/
+test-map-case.icon.inception.image-url=images/inception.png
+test-map-case.icon.docs.link-url=https://example.org/docs
+test-map-case.icon.docs.image-url=images/docs.png

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/UserSelectionPanelConfigurationImpl.java
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/users/UserSelectionPanelConfigurationImpl.java
@@ -27,6 +27,12 @@ public class UserSelectionPanelConfigurationImpl
 {
     public static final String PROPERTY_PREFIX = "user-selection";
 
+    /**
+     * Whether the list of users shown in the users tab of the project settings is restricted. If
+     * enabled, the full name of a user has to be entered into the input field before the user can
+     * be added. If disabled, it is possible to see all enabled users and to add any of them to the
+     * project.
+     */
     private boolean hideUsers;
 
     @Override

--- a/inception/inception-ui-search/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-ui-search/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "search.statistics-sidebar.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables the statistics sidebar on the annotation page."
+    }
+  ]
+}

--- a/inception/inception-versioning/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-versioning/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "versioning.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": false,
+      "description": "Enables project versioning support."
+    }
+  ]
+}

--- a/inception/inception-websocket/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-websocket/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,16 @@
+{
+  "properties": [
+    {
+      "name": "websocket.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables WebSocket support and endpoint."
+    },
+    {
+      "name": "websocket.recommender-events.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables push messages for recommender events over WebSocket."
+    }
+  ]
+}

--- a/inception/inception-workload-dynamic/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-workload-dynamic/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "workload.dynamic.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables the dynamic workload management strategy."
+    }
+  ]
+}

--- a/inception/inception-workload-matrix/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/inception/inception-workload-matrix/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "workload.matrix.enabled",
+      "type": "java.lang.Boolean",
+      "defaultValue": true,
+      "description": "Enables the matrix workload management strategy."
+    }
+  ]
+}

--- a/inception/pom.xml
+++ b/inception/pom.xml
@@ -95,13 +95,6 @@
       <scope>provided</scope>
     </dependency>
 
-    <!-- Generation of Spring Property Metadata files -->
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-configuration-processor</artifactId>
-      <optional>true</optional>
-    </dependency>
-    
     <!-- JAXB is no longer included with Java 9+ by default -->
     <!-- Old javax JAXB -->
     <dependency>
@@ -378,6 +371,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
+          <compilerArgs>
+            <arg>-Aorg.springframework.boot.configurationprocessor.additionalMetadataLocations=${project.basedir}/src/main/resources</arg>
+          </compilerArgs>
           <annotationProcessorPaths>
             <path>
               <groupId>org.hibernate.orm</groupId>
@@ -388,6 +384,11 @@
               <groupId>org.apache.logging.log4j</groupId>
               <artifactId>log4j-core</artifactId>
               <version>${log4j2.version}</version>
+            </path>
+            <path>
+              <groupId>org.springframework.boot</groupId>
+              <artifactId>spring-boot-configuration-processor</artifactId>
+              <version>${spring.boot.version}</version>
             </path>
           </annotationProcessorPaths>
         </configuration>
@@ -500,11 +501,7 @@
               - Dev aids 
               -->
             <dependency>com.google.code.findbugs:jsr305</dependency>
-            <!-- 
-              - Generation of Spring Property Metadata files 
-              -->
-            <dependency>org.springframework.boot:spring-boot-configuration-processor</dependency>
-            <!-- 
+            <!--
               - Generation of constants for I18N properties files
               -->
             <dependency>com.github.kklisura.java.processing:props-to-constants-generator</dependency>


### PR DESCRIPTION
**What's in the PR**
- Fix generation of spring property metadata
- Read only settings page for admins
- Configure global sanitizer for potential password/credential properties
- Ability to exclude namespaces from the settings page
- Add descriptions to properties in property classes

**How to test manually**
* Check the new settings page in the admin section

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
