### PR TITLE
#5960 - Upgrade dependencies

### DIFF
--- a/inception/inception-app-webapp/src/main/webapp/.gitignore
+++ b/inception/inception-app-webapp/src/main/webapp/.gitignore
@@ -1,2 +1,17 @@
+# Licensed to the Technische Universität Darmstadt under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The Technische Universität Darmstadt
+# licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 *
 !.gitignore

--- a/inception/inception-bom/pom.xml
+++ b/inception/inception-bom/pom.xml
@@ -33,7 +33,7 @@
       <plugin>
         <groupId>eu.maveniverse.maven.plugins</groupId>
         <artifactId>bom-builder3</artifactId>
-        <version>1.3.1</version>
+        <version>1.3.3</version>
         <executions>
           <execution>
             <id>build-bom</id>

--- a/inception/inception-kb-lucene-sail/pom.xml
+++ b/inception/inception-kb-lucene-sail/pom.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Licensed to the Apache Software Foundation (ASF) under one
+   or more contributor license agreements.  See the NOTICE file
+   distributed with this work for additional information
+   regarding copyright ownership.  The ASF licenses this file
+   to you under the Apache License, Version 2.0 (the
+   "License"); you may not use this file except in compliance
+   with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing,
+   software distributed under the License is distributed on an
+   "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+   KIND, either express or implied.  See the License for the
+   specific language governing permissions and limitations
+   under the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
@@ -145,29 +163,4 @@
       </plugins>
     </pluginManagement>
   </build>
-  <profiles>
-    <profile>
-      <id>rat-check</id>
-      <activation>
-        <file>
-          <exists>src/main/java</exists>
-        </file>
-      </activation>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>org.apache.rat</groupId>
-              <artifactId>apache-rat-plugin</artifactId>
-              <configuration>
-                <excludes combine.children="append">
-                  <exclude>**/*</exclude>
-                </excludes>
-              </configuration>
-            </plugin>
-          </plugins>
-        </pluginManagement>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/inception/inception-kb/pom.xml
+++ b/inception/inception-kb/pom.xml
@@ -421,9 +421,9 @@
               <groupId>org.apache.rat</groupId>
               <artifactId>apache-rat-plugin</artifactId>
               <configuration>
-                <excludes combine.children="append">
-                  <exclude>**/de/tudarmstadt/ukp/inception/kb/querybuilder/backport/Bind.java</exclude>
-                </excludes>
+                <inputExcludes combine.children="append">
+                  <inputExclude>**/de/tudarmstadt/ukp/inception/kb/querybuilder/backport/Bind.java</inputExclude>
+                </inputExcludes>
               </configuration>
             </plugin>
           </plugins>

--- a/inception/inception-pdf-editor2/pom.xml
+++ b/inception/inception-pdf-editor2/pom.xml
@@ -160,10 +160,10 @@
             <execution>
               <id>default</id>
               <configuration>
-                <excludes combine.children="append">
-                  <exclude>src/main/ts/**/*</exclude>
-                  <exclude>src/main/pdfjs/**/*</exclude>
-                </excludes>
+                <inputExcludes combine.children="append">
+                  <inputExclude>src/main/ts/**/*</inputExclude>
+                  <inputExclude>src/main/pdfjs/**/*</inputExclude>
+                </inputExcludes>
               </configuration>
             </execution>
           </executions>

--- a/inception/inception-search-mtas-upstream/pom.xml
+++ b/inception/inception-search-mtas-upstream/pom.xml
@@ -49,11 +49,11 @@
             <execution>
               <id>default</id>
               <configuration>
-                <excludes combine.children="append">
-                  <exclude>src/main/java/**</exclude>
-                  <exclude>src/test/java/**</exclude>
-                  <exclude>docker/**</exclude>
-                </excludes>
+                <inputExcludes combine.children="append">
+                  <inputExclude>src/main/java/**</inputExclude>
+                  <inputExclude>src/test/java/**</inputExclude>
+                  <inputExclude>docker/**</inputExclude>
+                </inputExcludes>
               </configuration>
             </execution>
           </executions>

--- a/inception/inception-support/pom.xml
+++ b/inception/inception-support/pom.xml
@@ -236,10 +236,10 @@
             <execution>
               <id>default</id>
               <configuration>
-                <excludes combine.children="append">
+                <inputExcludes combine.children="append">
                   <!-- Trivial template file which a license header would bloat too much-->
-                  <exclude>**/remove-input-behavior.js</exclude>
-                </excludes>
+                  <inputExclude>**/remove-input-behavior.js</inputExclude>
+                </inputExcludes>
               </configuration>
             </execution>
           </executions>

--- a/inception/pom.xml
+++ b/inception/pom.xml
@@ -600,17 +600,17 @@
         <plugin>
           <groupId>org.apache.rat</groupId>
           <artifactId>apache-rat-plugin</artifactId>
-          <version>0.16.1</version>
+          <version>0.18</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
-          <version>3.5.0</version>
+          <version>3.6.3</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.8.1</version>
+          <version>3.10.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.gmaven</groupId>
@@ -620,7 +620,7 @@
         <plugin>
           <groupId>com.github.eirslett</groupId>
           <artifactId>frontend-maven-plugin</artifactId>
-          <version>1.15.1</version>
+          <version>2.0.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -648,7 +648,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-war-plugin</artifactId>
-          <version>3.4.0</version>
+          <version>3.5.1</version>
         </plugin>
         <plugin>
           <groupId>io.fabric8</groupId>
@@ -658,7 +658,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>versions-maven-plugin</artifactId>
-          <version>2.18.0</version>
+          <version>2.21.0</version>
           <configuration>
             <rulesUri>file:${maven.multiModuleProjectDirectory}/inception/inception-build/src/main/resources/inception/rules.xml</rulesUri>
             <!--
@@ -770,41 +770,42 @@
                 </goals>
                 <configuration>
                   <consoleOutput>true</consoleOutput>
-                  <excludes combine.children="append">
-                    <exclude>.mvn/jvm.config</exclude>
-                    <exclude>.oracle_jre_usage/*.timestamp</exclude>
-                    <exclude>.factorypath</exclude>
-                    <exclude>.gitignore</exclude>
-                    <exclude>.checkstyle</exclude>
-                    <exclude>**/.asciidoctorconfig.adoc</exclude>
-                    <exclude>**/.vscode/**/*</exclude>
-                    <exclude>suppressions.xml</exclude>
-                    <exclude>marker-*</exclude>
+                  <inputExcludes combine.children="append">
+                    <inputExclude>/.mvn/jvm.config</inputExclude>
+                    <inputExclude>/.oracle_jre_usage/*.timestamp</inputExclude>
+                    <inputExclude>/.factorypath</inputExclude>
+                    <inputExclude>/.gitignore</inputExclude>
+                    <inputExclude>/**/.gitignore</inputExclude>
+                    <inputExclude>/.checkstyle</inputExclude>
+                    <inputExclude>/**/.asciidoctorconfig.adoc</inputExclude>
+                    <inputExclude>/**/.vscode/**</inputExclude>
+                    <inputExclude>/suppressions.xml</inputExclude>
+                    <inputExclude>/marker-*</inputExclude>
                     <!-- maven config files -->
-                    <exclude>src/main/filter/**/*</exclude>
+                    <inputExclude>/src/main/filter/**</inputExclude>
                     <!-- release generated artifact -->
-                    <exclude>release.properties</exclude>
+                    <inputExclude>/release.properties</inputExclude>
                     <!-- generated JCas wrappers -->
-                    <exclude>src/main/java/**/type/**/*</exclude>
+                    <inputExclude>/src/main/java/**/type/**</inputExclude>
                     <!-- other -->
-                    <exclude>CONTRIBUTORS.txt</exclude>
-                    <exclude>CHANGES</exclude>
-                    <exclude>CHANGES.txt</exclude>
-                    <exclude>NOTICE</exclude>
-                    <exclude>NOTICE.txt</exclude>
-                    <exclude>README</exclude>
-                    <exclude>README.txt</exclude>
-                    <exclude>README.md</exclude>
-                    <exclude>src/main/docker/**/*</exclude>
-                    <exclude>src/main/resources/**/*</exclude>
-                    <exclude>src/test/resources/**/*</exclude>
-                    <exclude>**/cache/**/*</exclude>
-                    <exclude>**/*.example</exclude>
-                    <exclude>doc/*.json</exclude>
-                    <exclude>licenses/**/*</exclude>
-                    <exclude>**/mocha-test-report.xml</exclude>
-                    <exclude>**/src/main/ts/node_modules/**/*</exclude>
-                  </excludes>
+                    <inputExclude>/CONTRIBUTORS.txt</inputExclude>
+                    <inputExclude>/CHANGES</inputExclude>
+                    <inputExclude>/CHANGES.txt</inputExclude>
+                    <inputExclude>/NOTICE</inputExclude>
+                    <inputExclude>/NOTICE.txt</inputExclude>
+                    <inputExclude>/README</inputExclude>
+                    <inputExclude>/README.txt</inputExclude>
+                    <inputExclude>/README.md</inputExclude>
+                    <inputExclude>/src/main/docker/**</inputExclude>
+                    <inputExclude>/src/main/resources/**</inputExclude>
+                    <inputExclude>/src/test/resources/**</inputExclude>
+                    <inputExclude>/**/cache/**</inputExclude>
+                    <inputExclude>/**/*.example</inputExclude>
+                    <inputExclude>/doc/*.json</inputExclude>
+                    <inputExclude>/licenses/**</inputExclude>
+                    <inputExclude>/**/mocha-test-report.xml</inputExclude>
+                    <inputExclude>/**/src/main/ts/node_modules/**</inputExclude>
+                  </inputExcludes>
                 </configuration>
               </execution>
             </executions>
@@ -1151,15 +1152,15 @@
               <groupId>org.apache.rat</groupId>
               <artifactId>apache-rat-plugin</artifactId>
               <configuration>
-                <excludes combine.children="append">
-                  <exclude>src/main/ts/.sass-cache/**</exclude>
-                  <exclude>src/main/ts/.eslintrc.yml</exclude>
-                  <exclude>src/main/ts/*.json</exclude>
-                  <exclude>src/main/ts_template/*.json</exclude>
-                  <exclude>src/main/ts/node_modules/**/*</exclude>
-                  <exclude>**/mocha-test-report.xml</exclude>
-                  <exclude>**/vite.config.js.timestamp*</exclude>
-                </excludes>
+                <inputExcludes combine.children="append">
+                  <inputExclude>src/main/ts/.sass-cache/**</inputExclude>
+                  <inputExclude>src/main/ts/.eslintrc.yml</inputExclude>
+                  <inputExclude>src/main/ts/*.json</inputExclude>
+                  <inputExclude>src/main/ts_template/*.json</inputExclude>
+                  <inputExclude>src/main/ts/node_modules/**/*</inputExclude>
+                  <inputExclude>**/mocha-test-report.xml</inputExclude>
+                  <inputExclude>**/vite.config.js.timestamp*</inputExclude>
+                </inputExcludes>
               </configuration>
             </plugin>
           </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -278,10 +278,9 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <!-- https://github.com/eclipse-m2e/m2e-core/issues/2091 -->
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.4.2</version>
+          <version>3.5.0</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
**What's in the PR**
- Upgrade `apache-rat-plugin` and migrate `excludes`/`exclude` configuration to the new `inputExcludes`/`inputExclude` element names
- Drop obsolete `rat-check` profile from `inception-kb-lucene-sail`
- Add Apache license header to `inception-app-webapp` webapp `.gitignore` and `inception-kb-lucene-sail/pom.xml`
- Tighten root RAT exclude patterns with leading-slash anchoring and add `/**/.gitignore`
- apache-rat-plugin 0.16.1 -> 0.18
- bom-builder3 1.3.1 -> 1.3.3
- exec-maven-plugin 3.5.0 -> 3.6.3
- maven-dependency-plugin 3.8.1 -> 3.10.0
- frontend-maven-plugin 1.15.1 -> 2.0.0
- maven-war-plugin 3.4.0 -> 3.5.1
- versions-maven-plugin 2.18.0 -> 2.21.0
- maven-jar-plugin 3.4.2 -> 3.5.0

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
