### PR TITLE
#4121 - Annotations are missing when exporting in NIF

### DIFF
--- a/inception/inception-io-nif/pom.xml
+++ b/inception/inception-io-nif/pom.xml
@@ -45,6 +45,10 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
     </dependency>
 

--- a/inception/inception-io-nif/src/main/java/de/tudarmstadt/ukp/inception/io/nif/NifFormatSupport.java
+++ b/inception/inception-io-nif/src/main/java/de/tudarmstadt/ukp/inception/io/nif/NifFormatSupport.java
@@ -30,6 +30,7 @@ import org.dkpro.core.io.nif.NifWriter;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.inception.io.nif.config.NifFormatProperties;
 import de.tudarmstadt.ukp.inception.io.nif.config.NifFormatSupportAutoConfiguration;
 
 /**
@@ -44,6 +45,13 @@ public class NifFormatSupport
 {
     public static final String ID = "nif";
     public static final String NAME = "NLP Interchange Format (NIF)";
+
+    private final NifFormatProperties properties;
+
+    public NifFormatSupport(NifFormatProperties aProperties)
+    {
+        properties = aProperties;
+    }
 
     @Override
     public String getId()
@@ -74,7 +82,9 @@ public class NifFormatSupport
             TypeSystemDescription aTSD)
         throws ResourceInitializationException
     {
-        return createReaderDescription(NifReader.class, aTSD);
+        return createReaderDescription(NifReader.class, aTSD, //
+                NifReader.PARAM_STRIP_CLASS_IRI, properties.getStripClassIri(), //
+                NifReader.PARAM_STRIP_IDENTIFIER_IRI, properties.getStripIdentifierIri());
     }
 
     @Override
@@ -82,6 +92,8 @@ public class NifFormatSupport
             TypeSystemDescription aTSD, CAS aCAS)
         throws ResourceInitializationException
     {
-        return createEngineDescription(NifWriter.class, aTSD);
+        return createEngineDescription(NifWriter.class, aTSD, //
+                NifWriter.PARAM_DEFAULT_CLASS_IRI, properties.getDefaultClassIri(), //
+                NifWriter.PARAM_DEFAULT_IDENTIFIER_IRI, properties.getDefaultIdentifierIri());
     }
 }

--- a/inception/inception-io-nif/src/main/java/de/tudarmstadt/ukp/inception/io/nif/config/NifFormatProperties.java
+++ b/inception/inception-io-nif/src/main/java/de/tudarmstadt/ukp/inception/io/nif/config/NifFormatProperties.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.io.nif.config;
+
+public interface NifFormatProperties
+{
+    /**
+     * @return IRI prefix used by the writer to mint a {@code taClassRef} target when the named
+     *         entity {@code value} is not a valid IRI. Non-IRI values are URL-encoded and appended
+     *         to this prefix. If {@code null} or empty, non-IRI values are skipped on export.
+     */
+    String getDefaultClassIri();
+
+    /**
+     * @return IRI prefix used by the writer to mint a {@code taIdentRef} target when the named
+     *         entity {@code identifier} is not a valid IRI. Non-IRI values are URL-encoded and
+     *         appended to this prefix. If {@code null} or empty, non-IRI values are skipped on
+     *         export.
+     */
+    String getDefaultIdentifierIri();
+
+    /**
+     * @return IRI prefix the reader strips from {@code taClassRef} values before storing them as
+     *         the named entity {@code value}. The remainder is URL-decoded. Enables a clean
+     *         round-trip with the corresponding writer prefix.
+     */
+    String getStripClassIri();
+
+    /**
+     * @return IRI prefix the reader strips from {@code taIdentRef} values before storing them as
+     *         the named entity {@code identifier}. The remainder is URL-decoded. Enables a clean
+     *         round-trip with the corresponding writer prefix.
+     */
+    String getStripIdentifierIri();
+}

--- a/inception/inception-io-nif/src/main/java/de/tudarmstadt/ukp/inception/io/nif/config/NifFormatPropertiesImpl.java
+++ b/inception/inception-io-nif/src/main/java/de/tudarmstadt/ukp/inception/io/nif/config/NifFormatPropertiesImpl.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.io.nif.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("format.nif")
+public class NifFormatPropertiesImpl
+    implements NifFormatProperties
+{
+    private static final String DEFAULT_PREFIX = "urn:inception:";
+
+    private String defaultClassIri = DEFAULT_PREFIX;
+    private String defaultIdentifierIri = DEFAULT_PREFIX;
+    private String stripClassIri = DEFAULT_PREFIX;
+    private String stripIdentifierIri = DEFAULT_PREFIX;
+
+    @Override
+    public String getDefaultClassIri()
+    {
+        return defaultClassIri;
+    }
+
+    public void setDefaultClassIri(String aDefaultClassIri)
+    {
+        defaultClassIri = aDefaultClassIri;
+    }
+
+    @Override
+    public String getDefaultIdentifierIri()
+    {
+        return defaultIdentifierIri;
+    }
+
+    public void setDefaultIdentifierIri(String aDefaultIdentifierIri)
+    {
+        defaultIdentifierIri = aDefaultIdentifierIri;
+    }
+
+    @Override
+    public String getStripClassIri()
+    {
+        return stripClassIri;
+    }
+
+    public void setStripClassIri(String aStripClassIri)
+    {
+        stripClassIri = aStripClassIri;
+    }
+
+    @Override
+    public String getStripIdentifierIri()
+    {
+        return stripIdentifierIri;
+    }
+
+    public void setStripIdentifierIri(String aStripIdentifierIri)
+    {
+        stripIdentifierIri = aStripIdentifierIri;
+    }
+}

--- a/inception/inception-io-nif/src/main/java/de/tudarmstadt/ukp/inception/io/nif/config/NifFormatSupportAutoConfiguration.java
+++ b/inception/inception-io-nif/src/main/java/de/tudarmstadt/ukp/inception/io/nif/config/NifFormatSupportAutoConfiguration.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.inception.io.nif.config;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -25,11 +26,12 @@ import de.tudarmstadt.ukp.inception.io.nif.NifFormatSupport;
 
 @Configuration
 @ConditionalOnProperty(prefix = "format.nif", name = "enabled", havingValue = "true", matchIfMissing = true)
+@EnableConfigurationProperties(NifFormatPropertiesImpl.class)
 public class NifFormatSupportAutoConfiguration
 {
     @Bean
-    public NifFormatSupport nifFormatSupport()
+    public NifFormatSupport nifFormatSupport(NifFormatProperties aProperties)
     {
-        return new NifFormatSupport();
+        return new NifFormatSupport(aProperties);
     }
 }

--- a/inception/inception-io-nif/src/main/java/org/dkpro/core/io/nif/NifReader.java
+++ b/inception/inception-io-nif/src/main/java/org/dkpro/core/io/nif/NifReader.java
@@ -92,6 +92,26 @@ public class NifReader
     @ConfigurationParameter(name = PARAM_POS_MAPPING_LOCATION, mandatory = false)
     private String posMappingLocation;
 
+    /**
+     * If set, IRIs read from {@code taClassRef} starting with this prefix will have the prefix
+     * stripped (and the remainder URL-decoded) before being stored as the named entity
+     * {@code value}. This is the read-side counterpart of
+     * {@link NifWriter#PARAM_DEFAULT_CLASS_IRI}.
+     */
+    public static final String PARAM_STRIP_CLASS_IRI = "stripClassIri";
+    @ConfigurationParameter(name = PARAM_STRIP_CLASS_IRI, mandatory = false)
+    private String stripClassIri;
+
+    /**
+     * If set, IRIs read from {@code taIdentRef} starting with this prefix will have the prefix
+     * stripped (and the remainder URL-decoded) before being stored as the named entity
+     * {@code identifier}. This is the read-side counterpart of
+     * {@link NifWriter#PARAM_DEFAULT_IDENTIFIER_IRI}.
+     */
+    public static final String PARAM_STRIP_IDENTIFIER_IRI = "stripIdentifierIri";
+    @ConfigurationParameter(name = PARAM_STRIP_IDENTIFIER_IRI, mandatory = false)
+    private String stripIdentifierIri;
+
     private MappingProvider posMappingProvider;
 
     private Resource res;
@@ -137,6 +157,8 @@ public class NifReader
 
         Nif2DKPro converter = new Nif2DKPro();
         converter.setPosMappingProvider(posMappingProvider);
+        converter.setStripClassIri(stripClassIri);
+        converter.setStripIdentifierIri(stripIdentifierIri);
         converter.convert(context, aJCas);
 
         inFileCount++;

--- a/inception/inception-io-nif/src/main/java/org/dkpro/core/io/nif/NifWriter.java
+++ b/inception/inception-io-nif/src/main/java/org/dkpro/core/io/nif/NifWriter.java
@@ -69,6 +69,24 @@ public class NifWriter
     @ConfigurationParameter(name = PARAM_FILENAME_EXTENSION, mandatory = true, defaultValue = ".ttl")
     private String filenameSuffix;
 
+    /**
+     * IRI prefix used to mint a {@code taClassRef} target when the named entity {@code value} is
+     * not itself a valid IRI. The non-IRI value is URL-encoded and appended to this prefix. If
+     * unset, non-IRI values are skipped (legacy behavior).
+     */
+    public static final String PARAM_DEFAULT_CLASS_IRI = "defaultClassIri";
+    @ConfigurationParameter(name = PARAM_DEFAULT_CLASS_IRI, mandatory = false)
+    private String defaultClassIri;
+
+    /**
+     * IRI prefix used to mint a {@code taIdentRef} target when the named entity {@code identifier}
+     * is not itself a valid IRI. The non-IRI value is URL-encoded and appended to this prefix. If
+     * unset, non-IRI values are skipped (legacy behavior).
+     */
+    public static final String PARAM_DEFAULT_IDENTIFIER_IRI = "defaultIdentifierIri";
+    @ConfigurationParameter(name = PARAM_DEFAULT_IDENTIFIER_IRI, mandatory = false)
+    private String defaultIdentifierIri;
+
     @Override
     public void process(JCas aJCas) throws AnalysisEngineProcessException
     {
@@ -76,7 +94,7 @@ public class NifWriter
         model.setNsPrefix(NIF.PREFIX_NIF, NIF.NS_NIF);
         model.setNsPrefix(ITS.PREFIX_ITS, ITS.NS_ITS);
 
-        DKPro2Nif.convert(aJCas, model);
+        DKPro2Nif.convert(aJCas, model, defaultClassIri, defaultIdentifierIri);
 
         try (OutputStream docOS = getOutputStream(aJCas, filenameSuffix)) {
             RDFDataMgr.write(docOS, model.getBaseModel(),

--- a/inception/inception-io-nif/src/main/java/org/dkpro/core/io/nif/internal/DKPro2Nif.java
+++ b/inception/inception-io-nif/src/main/java/org/dkpro/core/io/nif/internal/DKPro2Nif.java
@@ -22,6 +22,9 @@ import static org.apache.jena.datatypes.xsd.XSDDatatype.XSDstring;
 import static org.apache.uima.fit.util.JCasUtil.select;
 import static org.apache.uima.fit.util.JCasUtil.selectCovered;
 
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
 import org.apache.jena.irix.IRIs;
 import org.apache.jena.ontology.Individual;
 import org.apache.jena.ontology.OntModel;
@@ -39,6 +42,12 @@ import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
 public class DKPro2Nif
 {
     public static void convert(JCas aJCas, OntModel aTarget)
+    {
+        convert(aJCas, aTarget, null, null);
+    }
+
+    public static void convert(JCas aJCas, OntModel aTarget, String aDefaultClassIri,
+            String aDefaultIdentifierIri)
     {
         // Shorten down variable name for model
         OntModel m = aTarget;
@@ -194,10 +203,10 @@ public class DKPro2Nif
             String neClass = uimaNamedEntity.getValue();
             String neIdentifier = uimaNamedEntity.getIdentifier();
 
-            boolean neClassIsUri = neClass != null && IRIs.check(neClass);
-            boolean neIdentifierIsUri = neIdentifier != null && IRIs.check(neIdentifier);
+            String neClassIri = toIri(neClass, aDefaultClassIri);
+            String neIdentifierIri = toIri(neIdentifier, aDefaultIdentifierIri);
 
-            if (!neClassIsUri && !neIdentifierIsUri) {
+            if (neClassIri == null && neIdentifierIri == null) {
                 continue;
             }
 
@@ -212,13 +221,28 @@ public class DKPro2Nif
             nifNamedEntity.addLiteral(pEndIndex,
                     m.createTypedLiteral(uimaNamedEntity.getEnd(), XSDnonNegativeInteger));
 
-            if (neClassIsUri) {
-                nifNamedEntity.addProperty(pTaClassRef, m.createResource(neClass));
+            if (neClassIri != null) {
+                nifNamedEntity.addProperty(pTaClassRef, m.createResource(neClassIri));
             }
 
-            if (neIdentifierIsUri) {
-                nifNamedEntity.addProperty(pTaIdentRef, m.createResource(neIdentifier));
+            if (neIdentifierIri != null) {
+                nifNamedEntity.addProperty(pTaIdentRef, m.createResource(neIdentifierIri));
             }
         }
+    }
+
+    private static String toIri(String aValue, String aDefaultPrefix)
+    {
+        if (aValue == null || aValue.isEmpty()) {
+            return null;
+        }
+        if (IRIs.check(aValue)) {
+            return aValue;
+        }
+        if (aDefaultPrefix == null || aDefaultPrefix.isEmpty()) {
+            return null;
+        }
+        String candidate = aDefaultPrefix + URLEncoder.encode(aValue, StandardCharsets.UTF_8);
+        return IRIs.check(candidate) ? candidate : null;
     }
 }

--- a/inception/inception-io-nif/src/main/java/org/dkpro/core/io/nif/internal/Nif2DKPro.java
+++ b/inception/inception-io-nif/src/main/java/org/dkpro/core/io/nif/internal/Nif2DKPro.java
@@ -17,6 +17,8 @@
  */
 package org.dkpro.core.io.nif.internal;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -46,10 +48,22 @@ import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
 public class Nif2DKPro
 {
     private MappingProvider posMappingProvider;
+    private String stripClassIri;
+    private String stripIdentifierIri;
 
     public void setPosMappingProvider(MappingProvider aPosMappingProvider)
     {
         posMappingProvider = aPosMappingProvider;
+    }
+
+    public void setStripClassIri(String aStripClassIri)
+    {
+        stripClassIri = aStripClassIri;
+    }
+
+    public void setStripIdentifierIri(String aStripIdentifierIri)
+    {
+        stripIdentifierIri = aStripIdentifierIri;
     }
 
     public void convert(Statement aContext, JCas aJCas)
@@ -201,24 +215,35 @@ public class Nif2DKPro
 
             // If there is a most-specific class, then we use that
             if (nifNamedEntity.hasProperty(pTaMsClassRef)) {
-                uimaNamedEntity
-                        .setValue(nifNamedEntity.getProperty(pTaMsClassRef).getResource().getURI());
+                uimaNamedEntity.setValue(stripPrefix(
+                        nifNamedEntity.getProperty(pTaMsClassRef).getResource().getURI(),
+                        stripClassIri));
             }
             // ... else, we use some class
             else if (nifNamedEntity.hasProperty(pTaClassRef)) {
-                uimaNamedEntity
-                        .setValue(nifNamedEntity.getProperty(pTaClassRef).getResource().getURI());
+                uimaNamedEntity.setValue(
+                        stripPrefix(nifNamedEntity.getProperty(pTaClassRef).getResource().getURI(),
+                                stripClassIri));
             }
 
             // If the entity is linked, then we keep the identifier
             if (nifNamedEntity.hasProperty(pTaIdentRef)) {
                 uimaNamedEntity.setIdentifier(
-                        nifNamedEntity.getProperty(pTaIdentRef).getResource().getURI());
+                        stripPrefix(nifNamedEntity.getProperty(pTaIdentRef).getResource().getURI(),
+                                stripIdentifierIri));
             }
             uimaNamedEntity.addToIndexes();
 
             assert assertSanity(nifNamedEntity, uimaNamedEntity);
         }
+    }
+
+    private static String stripPrefix(String aValue, String aPrefix)
+    {
+        if (aValue == null || aPrefix == null || aPrefix.isEmpty() || !aValue.startsWith(aPrefix)) {
+            return aValue;
+        }
+        return URLDecoder.decode(aValue.substring(aPrefix.length()), StandardCharsets.UTF_8);
     }
 
     private static boolean assertSanity(Resource aNif, Annotation aUima)

--- a/inception/inception-io-nif/src/main/resources/META-INF/asciidoc/user-guide/formats-nif.adoc
+++ b/inception/inception-io-nif/src/main/resources/META-INF/asciidoc/user-guide/formats-nif.adoc
@@ -69,3 +69,45 @@ The link:https://persistence.uni-leipzig.org/nlp2rdf/[NLP Interchange Format] (N
         a                  nif:Annotation ;
         itsrdf:taIdentRef  <http://example.org/Geography> .
 ----
+
+The `itsrdf:taClassRef` and `itsrdf:taIdentRef` properties require their values to be valid IRIs. INCEpTION normally uses plain string tags (e.g. `LOC`, `PER`) for the named entity `value` and `identifier`, which are not valid IRIs and would otherwise be skipped on export. To support this case, INCEpTION mints IRIs for non-IRI values on export by URL-encoding them and prepending a configurable prefix (default: `urn:inception:`). On import, IRIs starting with the same prefix are stripped back to plain values, allowing a clean round-trip. Values that are already valid IRIs are written and read verbatim.
+
+To restore the strict legacy behavior of skipping non-IRI values on export, set the corresponding prefix to an empty string.
+
+.NIF export settings
+[cols="4*", options="header"]
+|===
+| Setting
+| Description
+| Default
+| Example
+
+| `format.nif.default-class-iri`
+| IRI prefix used to mint a `taClassRef` target when the named entity `value` is not a valid IRI. The non-IRI value is URL-encoded and appended to this prefix. If set to an empty string, non-IRI values are skipped on export.
+| `urn:inception:`
+| `http://example.org/ne/class/`
+
+| `format.nif.default-identifier-iri`
+| IRI prefix used to mint a `taIdentRef` target when the named entity `identifier` is not a valid IRI. The non-IRI value is URL-encoded and appended to this prefix. If set to an empty string, non-IRI values are skipped on export.
+| `urn:inception:`
+| `http://example.org/ne/instance/`
+|===
+
+.NIF import settings
+[cols="4*", options="header"]
+|===
+| Setting
+| Description
+| Default
+| Example
+
+| `format.nif.strip-class-iri`
+| If set, IRIs read from `taClassRef` starting with this prefix have the prefix stripped (and the remainder URL-decoded) before being stored as the named entity `value`. Enables a clean round-trip with `format.nif.default-class-iri`.
+| `urn:inception:`
+| `http://example.org/ne/class/`
+
+| `format.nif.strip-identifier-iri`
+| If set, IRIs read from `taIdentRef` starting with this prefix have the prefix stripped (and the remainder URL-decoded) before being stored as the named entity `identifier`. Enables a clean round-trip with `format.nif.default-identifier-iri`.
+| `urn:inception:`
+| `http://example.org/ne/instance/`
+|===

--- a/inception/inception-io-nif/src/test/java/de/tudarmstadt/ukp/inception/io/nif/NifReaderWriterTest.java
+++ b/inception/inception-io-nif/src/test/java/de/tudarmstadt/ukp/inception/io/nif/NifReaderWriterTest.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.io.nif;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.uima.fit.factory.AnalysisEngineFactory.createEngine;
+import static org.apache.uima.fit.factory.CollectionReaderFactory.createReader;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.contentOf;
+import static org.assertj.core.api.Assertions.tuple;
+
+import java.io.File;
+
+import org.apache.uima.fit.factory.JCasFactory;
+import org.dkpro.core.io.nif.NifReader;
+import org.dkpro.core.io.nif.NifWriter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData;
+import de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity;
+
+class NifReaderWriterTest
+{
+    private static final String PREFIX = "urn:inception:";
+
+    @Test
+    void nonIriValueIsSkippedWhenNoDefaultPrefix(@TempDir File aTemp) throws Exception
+    {
+        var cas = createCasWithNamedEntity("LOC", null);
+
+        var writer = createEngine(NifWriter.class, //
+                NifWriter.PARAM_TARGET_LOCATION, aTemp);
+        writer.process(cas);
+
+        var ttl = contentOf(new File(aTemp, "test.txt.ttl"), UTF_8);
+        // No taClassRef / taIdentRef triple because "LOC" is not a valid IRI and no prefix is set.
+        assertThat(ttl).doesNotContain("taClassRef").doesNotContain("taIdentRef");
+    }
+
+    @Test
+    void nonIriValueIsPrefixedWhenDefaultPrefixSet(@TempDir File aTemp) throws Exception
+    {
+        var cas = createCasWithNamedEntity("LOC", "linked");
+
+        var writer = createEngine(NifWriter.class, //
+                NifWriter.PARAM_TARGET_LOCATION, aTemp, //
+                NifWriter.PARAM_DEFAULT_CLASS_IRI, PREFIX, //
+                NifWriter.PARAM_DEFAULT_IDENTIFIER_IRI, PREFIX);
+        writer.process(cas);
+
+        var ttl = contentOf(new File(aTemp, "test.txt.ttl"), UTF_8);
+        assertThat(ttl).contains("<" + PREFIX + "LOC>");
+        assertThat(ttl).contains("<" + PREFIX + "linked>");
+    }
+
+    @Test
+    void existingIriValueIsKeptVerbatim(@TempDir File aTemp) throws Exception
+    {
+        var cas = createCasWithNamedEntity("http://example.org/LOC", "http://example.org/e/1");
+
+        var writer = createEngine(NifWriter.class, //
+                NifWriter.PARAM_TARGET_LOCATION, aTemp, //
+                NifWriter.PARAM_DEFAULT_CLASS_IRI, PREFIX, //
+                NifWriter.PARAM_DEFAULT_IDENTIFIER_IRI, PREFIX);
+        writer.process(cas);
+
+        var ttl = contentOf(new File(aTemp, "test.txt.ttl"), UTF_8);
+        assertThat(ttl).contains("<http://example.org/LOC>");
+        assertThat(ttl).contains("<http://example.org/e/1>");
+        assertThat(ttl).doesNotContain(PREFIX);
+    }
+
+    @Test
+    void readerStripsConfiguredPrefix(@TempDir File aTemp) throws Exception
+    {
+        var written = createCasWithNamedEntity("LOC", "linked");
+        var writer = createEngine(NifWriter.class, //
+                NifWriter.PARAM_TARGET_LOCATION, aTemp, //
+                NifWriter.PARAM_DEFAULT_CLASS_IRI, PREFIX, //
+                NifWriter.PARAM_DEFAULT_IDENTIFIER_IRI, PREFIX);
+        writer.process(written);
+
+        var roundTripped = JCasFactory.createJCas();
+        var reader = createReader(NifReader.class, //
+                NifReader.PARAM_SOURCE_LOCATION, new File(aTemp, "test.txt.ttl"), //
+                NifReader.PARAM_STRIP_CLASS_IRI, PREFIX, //
+                NifReader.PARAM_STRIP_IDENTIFIER_IRI, PREFIX);
+        reader.getNext(roundTripped.getCas());
+
+        assertThat(roundTripped.select(NamedEntity.class).asList()) //
+                .extracting(NamedEntity::getValue, NamedEntity::getIdentifier) //
+                .containsExactly(tuple("LOC", "linked"));
+    }
+
+    @Test
+    void readerKeepsIriWhenPrefixDoesNotMatch(@TempDir File aTemp) throws Exception
+    {
+        var written = createCasWithNamedEntity("LOC", null);
+        var writer = createEngine(NifWriter.class, //
+                NifWriter.PARAM_TARGET_LOCATION, aTemp, //
+                NifWriter.PARAM_DEFAULT_CLASS_IRI, PREFIX);
+        writer.process(written);
+
+        var roundTripped = JCasFactory.createJCas();
+        var reader = createReader(NifReader.class, //
+                NifReader.PARAM_SOURCE_LOCATION, new File(aTemp, "test.txt.ttl"), //
+                NifReader.PARAM_STRIP_CLASS_IRI, "urn:somethingelse:");
+        reader.getNext(roundTripped.getCas());
+
+        assertThat(roundTripped.select(NamedEntity.class).asList()) //
+                .extracting(NamedEntity::getValue) //
+                .containsExactly(PREFIX + "LOC");
+    }
+
+    @Test
+    void roundTripPreservesPlainTagValues(@TempDir File aTemp) throws Exception
+    {
+        var original = createCasWithNamedEntity("PER", "alice");
+        var writer = createEngine(NifWriter.class, //
+                NifWriter.PARAM_TARGET_LOCATION, aTemp, //
+                NifWriter.PARAM_DEFAULT_CLASS_IRI, PREFIX, //
+                NifWriter.PARAM_DEFAULT_IDENTIFIER_IRI, PREFIX);
+        writer.process(original);
+
+        var roundTripped = JCasFactory.createJCas();
+        var reader = createReader(NifReader.class, //
+                NifReader.PARAM_SOURCE_LOCATION, new File(aTemp, "test.txt.ttl"), //
+                NifReader.PARAM_STRIP_CLASS_IRI, PREFIX, //
+                NifReader.PARAM_STRIP_IDENTIFIER_IRI, PREFIX);
+        reader.getNext(roundTripped.getCas());
+
+        assertThat(roundTripped.select(NamedEntity.class).asList()) //
+                .extracting(NamedEntity::getValue, NamedEntity::getIdentifier) //
+                .containsExactly(tuple("PER", "alice"));
+    }
+
+    private static org.apache.uima.jcas.JCas createCasWithNamedEntity(String aValue,
+            String aIdentifier)
+        throws Exception
+    {
+        var cas = JCasFactory.createJCas();
+        cas.setDocumentText("John lives in Berlin.");
+
+        var dmd = DocumentMetaData.create(cas);
+        dmd.setDocumentId("test.txt");
+        dmd.setDocumentUri("urn:test.txt");
+
+        var ne = new NamedEntity(cas, 14, 20);
+        ne.setValue(aValue);
+        if (aIdentifier != null) {
+            ne.setIdentifier(aIdentifier);
+        }
+        ne.addToIndexes();
+        return cas;
+    }
+}


### PR DESCRIPTION
**What's in the PR**
- Add NIF default IRI prefix support for non-IRI named entity values
- NifWriter: new PARAM_DEFAULT_CLASS_IRI / PARAM_DEFAULT_IDENTIFIER_IRI; non-IRI value/identifier values are URL-encoded and prefixed instead of being silently dropped
- NifReader: symmetric PARAM_STRIP_CLASS_IRI / PARAM_STRIP_IDENTIFIER_IRI to round-trip cleanly back to plain tagset values
- Introduce NifFormatProperties / NifFormatPropertiesImpl (format.nif.* configuration properties) defaulting all four prefixes to "urn:inception:" for out-of-the-box behavior
- Wire properties through NifFormatSupport and auto-configuration
- Add NifReaderWriterTest covering: legacy skip when no prefix set, prefix minting, IRI passthrough, reader strip, non-matching strip, and full round-trip of plain tag values

**How to test manually**
* See issue description

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
