### PR TITLE
#3769 - Out of tagset tag cannot be merged in curation

### DIFF
--- a/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/render/BratSerializerImpl.java
+++ b/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/render/BratSerializerImpl.java
@@ -20,6 +20,7 @@ package de.tudarmstadt.ukp.clarin.webanno.brat.render;
 import static de.tudarmstadt.ukp.clarin.webanno.brat.schema.BratSchemaGeneratorImpl.getBratTypeName;
 import static de.tudarmstadt.ukp.clarin.webanno.model.ScriptDirection.RTL;
 import static de.tudarmstadt.ukp.inception.support.text.TrimUtils.trim;
+import static de.tudarmstadt.ukp.inception.support.uima.ICasUtil.selectAnnotationByAddr;
 import static java.lang.Character.isWhitespace;
 import static java.lang.Character.toTitleCase;
 import static java.util.Arrays.asList;
@@ -41,7 +42,6 @@ import java.util.Locale;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.text.AnnotationFS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,7 +68,6 @@ import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VSentenceMarker;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VTextMarker;
 import de.tudarmstadt.ukp.inception.support.text.TextUtils;
-import de.tudarmstadt.ukp.inception.support.uima.ICasUtil;
 
 /**
  * Render documents using brat. This class converts a UIMA annotation representation into the object
@@ -176,15 +175,7 @@ public class BratSerializerImpl
     private void renderComments(GetDocumentResponse aResponse, VDocument aVDoc,
             RenderRequest aRequest)
     {
-        CAS cas = aRequest.getCas();
-
-        if (cas == null) {
-            // FIXME: In curation, rendering happens at a different time than serializing and
-            // we can not keep the CAS around all the time - for the moment, we also do not need
-            // the sentence comments on the annotators views in curation, so we ignore this.
-            // Eventually, it should be changed so that we do not need the CAS here.
-            return;
-        }
+        var cas = aRequest.getCas();
 
         Map<AnnotationFS, Integer> sentenceIndexes = null;
         for (var vcomment : aVDoc.comments()) {
@@ -194,10 +185,13 @@ public class BratSerializerImpl
             default -> AnnotationComment.ANNOTATOR_NOTES;
             };
 
+            // In curation, rendering happens at a different time than serializing and
+            // the CAS is not kept around. Without it we cannot resolve sentence-attached
+            // comments, but we can still emit annotation comments.
             AnnotationFS fs;
-            if (!vcomment.getVid().isSynthetic() && ((fs = ICasUtil.selectAnnotationByAddr(cas,
-                    vcomment.getVid().getId())) != null
-                    && fs.getType().getName().equals(Sentence.class.getName()))) {
+            if (cas != null && !vcomment.getVid().isSynthetic()
+                    && ((fs = selectAnnotationByAddr(cas, vcomment.getVid().getId())) != null
+                            && fs.getType().getName().equals(Sentence.class.getName()))) {
                 // Lazily fetching the sentences because we only need them for the comments
                 if (sentenceIndexes == null) {
                     sentenceIndexes = new HashMap<>();

--- a/inception/inception-brat-editor/src/main/ts/src/visualizer/Visualizer.ts
+++ b/inception/inception-brat-editor/src/main/ts/src/visualizer/Visualizer.ts
@@ -250,9 +250,9 @@ export class Visualizer {
     commentPrioLevels: string[] = [
         'Unconfirmed',
         'Incomplete',
+        'AnnotatorNotes',
         'Warning',
         'Error',
-        'AnnotatorNotes',
         'AddedAnnotation',
         'MissingAnnotation',
         'ChangedAnnotation',

--- a/inception/inception-feature-string/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiValueStringFeatureSupport.java
+++ b/inception/inception-feature-string/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiValueStringFeatureSupport.java
@@ -32,6 +32,7 @@ import java.io.Serializable;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 
@@ -285,9 +286,27 @@ public class MultiValueStringFeatureSupport
     @Override
     public boolean isFeatureValueValid(AnnotationFeature aFeature, FeatureStructure aFS)
     {
-        if (aFeature.isRequired()) {
-            var value = FSUtil.getFeature(aFS, aFeature.getName(), List.class);
-            return isNotEmpty(value);
+        var value = FSUtil.getFeature(aFS, aFeature.getName(), List.class);
+
+        if (aFeature.isRequired() && !isNotEmpty(value)) {
+            return false;
+        }
+
+        var tagset = aFeature.getTagset();
+        if (schemaService != null && tagset != null && !tagset.isCreateTag() && isNotEmpty(value)) {
+            var tags = schemaService.listTagsImmutable(tagset);
+            var tagNames = new HashSet<String>();
+            for (var tag : tags) {
+                tagNames.add(tag.getName());
+            }
+            for (var v : value) {
+                if (v == null) {
+                    continue;
+                }
+                if (!tagNames.contains(v)) {
+                    return false;
+                }
+            }
         }
 
         return true;

--- a/inception/inception-feature-string/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/StringFeatureSupport.java
+++ b/inception/inception-feature-string/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/string/StringFeatureSupport.java
@@ -130,8 +130,20 @@ public class StringFeatureSupport
     @Override
     public boolean isFeatureValueValid(AnnotationFeature aFeature, FeatureStructure aFS)
     {
-        if (aFeature.isRequired()) {
-            return isNotBlank(FSUtil.getFeature(aFS, aFeature.getName(), String.class));
+        var value = FSUtil.getFeature(aFS, aFeature.getName(), String.class);
+
+        if (aFeature.isRequired() && !isNotBlank(value)) {
+            return false;
+        }
+
+        var tagset = aFeature.getTagset();
+        if (schemaService != null && tagset != null && !tagset.isCreateTag() && value != null) {
+            for (var tag : schemaService.listTagsImmutable(tagset)) {
+                if (tag.getName().equals(value)) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         return true;

--- a/inception/inception-feature-string/src/test/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiValueStringFeatureSupportTest.java
+++ b/inception/inception-feature-string/src/test/java/de/tudarmstadt/ukp/inception/annotation/feature/multistring/MultiValueStringFeatureSupportTest.java
@@ -21,6 +21,7 @@ import static java.util.Arrays.asList;
 import static org.apache.uima.fit.factory.JCasFactory.createJCasFromPath;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.List;
 
@@ -36,6 +37,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.ImmutableTag;
 import de.tudarmstadt.ukp.clarin.webanno.model.LinkMode;
 import de.tudarmstadt.ukp.clarin.webanno.model.MultiValueMode;
 import de.tudarmstadt.ukp.clarin.webanno.model.TagSet;
@@ -122,5 +124,73 @@ public class MultiValueStringFeatureSupportTest
 
         assertThat(FSUtil.getFeature(spanFS, valueFeature.getName(), String[].class)) //
                 .isNull();
+    }
+
+    @Test
+    public void thatRequiredFeatureWithEmptyValueIsInvalid()
+    {
+        valueFeature.setRequired(true);
+
+        FSUtil.setFeature(spanFS, valueFeature.getName(), new String[0]);
+
+        assertThat(sut.isFeatureValueValid(valueFeature, spanFS)).isFalse();
+    }
+
+    @Test
+    public void thatRequiredFeatureWithNullValueIsInvalid()
+    {
+        valueFeature.setRequired(true);
+
+        assertThat(sut.isFeatureValueValid(valueFeature, spanFS)).isFalse();
+    }
+
+    @Test
+    public void thatOptionalFeatureWithEmptyValueIsValid()
+    {
+        valueFeature.setRequired(false);
+
+        FSUtil.setFeature(spanFS, valueFeature.getName(), new String[0]);
+
+        assertThat(sut.isFeatureValueValid(valueFeature, spanFS)).isTrue();
+    }
+
+    @Test
+    public void thatClosedTagsetWithOutOfTagsetEntryIsInvalid()
+    {
+        valueTagset.setCreateTag(false);
+        valueFeature.setTagset(valueTagset);
+
+        when(schemaService.listTagsImmutable(valueTagset))
+                .thenReturn(asList(new ImmutableTag("known", "")));
+
+        FSUtil.setFeature(spanFS, valueFeature.getName(),
+                new String[] { "known", "out-of-tagset" });
+
+        assertThat(sut.isFeatureValueValid(valueFeature, spanFS)).isFalse();
+    }
+
+    @Test
+    public void thatClosedTagsetWithAllInTagsetEntriesIsValid()
+    {
+        valueTagset.setCreateTag(false);
+        valueFeature.setTagset(valueTagset);
+
+        when(schemaService.listTagsImmutable(valueTagset))
+                .thenReturn(asList(new ImmutableTag("known1", ""), new ImmutableTag("known2", "")));
+
+        FSUtil.setFeature(spanFS, valueFeature.getName(), new String[] { "known1", "known2" });
+
+        assertThat(sut.isFeatureValueValid(valueFeature, spanFS)).isTrue();
+    }
+
+    @Test
+    public void thatOpenTagsetWithOutOfTagsetEntryIsValid()
+    {
+        valueTagset.setCreateTag(true);
+        valueFeature.setTagset(valueTagset);
+
+        FSUtil.setFeature(spanFS, valueFeature.getName(), new String[] { "out-of-tagset" });
+
+        assertThat(sut.isFeatureValueValid(valueFeature, spanFS)).isTrue();
     }
 }

--- a/inception/inception-feature-string/src/test/java/de/tudarmstadt/ukp/inception/annotation/feature/string/StringFeatureSupportTest.java
+++ b/inception/inception-feature-string/src/test/java/de/tudarmstadt/ukp/inception/annotation/feature/string/StringFeatureSupportTest.java
@@ -17,9 +17,11 @@
  */
 package de.tudarmstadt.ukp.inception.annotation.feature.string;
 
+import static java.util.Arrays.asList;
 import static org.apache.uima.fit.factory.JCasFactory.createJCasFromPath;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.Type;
@@ -33,6 +35,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.ImmutableTag;
 import de.tudarmstadt.ukp.clarin.webanno.model.TagSet;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.support.uima.ICasUtil;
@@ -92,5 +95,72 @@ public class StringFeatureSupportTest
 
         assertThat((String) sut.getFeatureValue(valueFeature, spanFS)) //
                 .isEqualTo(value);
+    }
+
+    @Test
+    public void thatRequiredFeatureWithBlankValueIsInvalid()
+    {
+        valueFeature.setRequired(true);
+
+        FSUtil.setFeature(spanFS, valueFeature.getName(), "");
+
+        assertThat(sut.isFeatureValueValid(valueFeature, spanFS)).isFalse();
+    }
+
+    @Test
+    public void thatRequiredFeatureWithNullValueIsInvalid()
+    {
+        valueFeature.setRequired(true);
+
+        assertThat(sut.isFeatureValueValid(valueFeature, spanFS)).isFalse();
+    }
+
+    @Test
+    public void thatOptionalFeatureWithBlankValueIsValid()
+    {
+        valueFeature.setRequired(false);
+
+        FSUtil.setFeature(spanFS, valueFeature.getName(), "");
+
+        assertThat(sut.isFeatureValueValid(valueFeature, spanFS)).isTrue();
+    }
+
+    @Test
+    public void thatClosedTagsetWithOutOfTagsetValueIsInvalid()
+    {
+        valueTagset.setCreateTag(false);
+        valueFeature.setTagset(valueTagset);
+
+        when(schemaService.listTagsImmutable(valueTagset))
+                .thenReturn(asList(new ImmutableTag("known", "")));
+
+        FSUtil.setFeature(spanFS, valueFeature.getName(), "out-of-tagset");
+
+        assertThat(sut.isFeatureValueValid(valueFeature, spanFS)).isFalse();
+    }
+
+    @Test
+    public void thatClosedTagsetWithInTagsetValueIsValid()
+    {
+        valueTagset.setCreateTag(false);
+        valueFeature.setTagset(valueTagset);
+
+        when(schemaService.listTagsImmutable(valueTagset))
+                .thenReturn(asList(new ImmutableTag("known", "")));
+
+        FSUtil.setFeature(spanFS, valueFeature.getName(), "known");
+
+        assertThat(sut.isFeatureValueValid(valueFeature, spanFS)).isTrue();
+    }
+
+    @Test
+    public void thatOpenTagsetWithOutOfTagsetValueIsValid()
+    {
+        valueTagset.setCreateTag(true);
+        valueFeature.setTagset(valueTagset);
+
+        FSUtil.setFeature(spanFS, valueFeature.getName(), "out-of-tagset");
+
+        assertThat(sut.isFeatureValueValid(valueFeature, spanFS)).isTrue();
     }
 }

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorEditor.scss
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorEditor.scss
@@ -216,7 +216,7 @@ html > body {
     }
 }
 
-.iaa-error-marker {
+.iaa-marker-error {
     filter: drop-shadow(0 0 clamp(3px, 0.3em, 10px) var(--i7n-error-color))
         brightness(var(--hover-brightness));
 }

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionAnnotationVisualizer.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionAnnotationVisualizer.ts
@@ -375,6 +375,9 @@ export class SectionAnnotationVisualizer {
         if (selectedAnnotationVids.includes(ann.vid)) {
             e.classList.add('iaa-focussed');
         }
+        if (ann.comments?.find((c) => c.type === 'error')) {
+            e.classList.add('iaa-marker-error');
+        }
         e.textContent = ann.label || `[${ann.layer.name}]` || 'No label';
         if (ann.score && !ann.hideScore) {
             e.textContent += ` [${ann.score.toFixed(2)}]`;

--- a/inception/inception-js-api/src/main/ts/src/util/ViewportTracker.test.ts
+++ b/inception/inception-js-api/src/main/ts/src/util/ViewportTracker.test.ts
@@ -187,6 +187,76 @@ describe('ViewportTracker (pause/resume)', () => {
         tracker.disconnect();
     });
 
+    it('prunes stale visibleElements after DOM replacement on re-initialization', () => {
+        const container = document.createElement('div');
+        const childA = document.createElement('div');
+        childA.style.display = 'block';
+        childA.textContent = 'A';
+        container.appendChild(childA);
+        document.body.appendChild(container);
+
+        const cb = vi.fn();
+        const tracker = new ViewportTracker(container, cb);
+        const obs1 = MockIntersectionObserver.lastInstance!;
+
+        // Mark childA visible
+        obs1.simulate([{ isIntersecting: true, target: childA }]);
+        vi.advanceTimersByTime(300);
+        expect(tracker.visibleElements.has(childA)).toBe(true);
+
+        // Replace childA with childB to mimic a render replacing DOM nodes
+        container.removeChild(childA);
+        const childB = document.createElement('div');
+        childB.style.display = 'block';
+        childB.textContent = 'B';
+        container.appendChild(childB);
+
+        // Trigger re-initialization via pause/resume
+        tracker.pause();
+        tracker.resume();
+
+        // Stale ref to detached childA must be dropped
+        expect(tracker.visibleElements.has(childA)).toBe(false);
+
+        // The new element must now be observed
+        const obs2 = MockIntersectionObserver.lastInstance!;
+        expect(obs2.observed).toContain(childB);
+        expect(obs2.observed).not.toContain(childA);
+
+        tracker.disconnect();
+    });
+
+    it('does not schedule another callback when entries change but range stays the same', () => {
+        const container = document.createElement('div');
+        const child = document.createElement('div');
+        child.style.display = 'block';
+        child.textContent = 'abc';
+        container.appendChild(child);
+        document.body.appendChild(container);
+
+        const cb = vi.fn();
+        const tracker = new ViewportTracker(container, cb);
+        const obs = MockIntersectionObserver.lastInstance!;
+
+        // First intersection — initial callback fires regardless of range change
+        obs.simulate([{ isIntersecting: true, target: child }]);
+        vi.advanceTimersByTime(300);
+        expect(cb).toHaveBeenCalledTimes(1);
+
+        // Element leaves the viewport: no add → no callback scheduled
+        obs.simulate([{ isIntersecting: false, target: child }]);
+        vi.advanceTimersByTime(300);
+        expect(cb).toHaveBeenCalledTimes(1);
+
+        // Element re-enters: this counts as an add, but the computed range is identical
+        // to the current range, so no additional callback should be scheduled.
+        obs.simulate([{ isIntersecting: true, target: child }]);
+        vi.advanceTimersByTime(300);
+        expect(cb).toHaveBeenCalledTimes(1);
+
+        tracker.disconnect();
+    });
+
     it('forceRefresh does nothing while paused and resume triggers immediate callback', () => {
         const container = document.createElement('div');
         const child = document.createElement('div');

--- a/inception/inception-js-api/src/main/ts/src/util/ViewportTracker.ts
+++ b/inception/inception-js-api/src/main/ts/src/util/ViewportTracker.ts
@@ -283,6 +283,16 @@ export class ViewportTracker {
 
         this.trackedElements = Array.from(leafTrackingCandidates);
 
+        // Drop any element refs that are no longer tracked. Without this, the set grows
+        // unbounded as renders replace DOM nodes, and stale refs prevent the "added" count
+        // from reflecting reality. Prune in place so external references obtained via the
+        // public getter continue to observe updates.
+        this._visibleElements.forEach((e) => {
+            if (!leafTrackingCandidates.has(e)) {
+                this._visibleElements.delete(e)
+            }
+        })
+
         // If paused we do not create an observer now
         if (this.paused) {
             console.debug('ViewportTracker is paused; skipping observer creation');
@@ -323,11 +333,18 @@ export class ViewportTracker {
             console.debug(
                 `Visible elements changed: ${visibleElementsAdded} added, ${this._visibleElements.size} visible elements in total`
             );
-            // the first time the callback is called, we want to make sure that the annotations are
-            // loaded at least once
-            this.initialized = true;
-            this._currentRange = this.calculateWindowRange();
-            this.initiateAction();
+            const newRange = this.calculateWindowRange();
+            const rangeChanged =
+                newRange[0] !== this._currentRange[0] || newRange[1] !== this._currentRange[1];
+            this._currentRange = newRange;
+            // The first time the callback is called, we want to make sure that the annotations are
+            // loaded at least once. Subsequent fires only invoke the callback if the visible range
+            // actually changed - otherwise re-observed elements after a render pass can spuriously
+            // re-trigger a load even though there is nothing new to fetch.
+            if (!this.initialized || rangeChanged) {
+                this.initialized = true;
+                this.initiateAction();
+            }
         }
     }
 

--- a/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/rendering/Renderer.java
+++ b/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/rendering/Renderer.java
@@ -175,7 +175,7 @@ public interface Renderer
 
             if (!adapter.isFeatureValueValid(feature, aFS)) {
                 aResponse.add(new VComment(VID.of(aFS), ERROR,
-                        "Required feature [" + feature.getUiName() + "] not set."));
+                        "Feature [" + feature.getUiName() + "] has no valid value."));
             }
         }
     }

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/render/CurationSidebarRenderer.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/render/CurationSidebarRenderer.java
@@ -26,6 +26,7 @@ import static org.apache.uima.cas.text.AnnotationPredicates.colocated;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -36,6 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.annotation.Order;
 
+import de.tudarmstadt.ukp.clarin.webanno.constraints.evaluator.ConstraintsEvaluator;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.CasDiff;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.Configuration;
 import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.DiffResult;
@@ -169,6 +171,8 @@ public class CurationSidebarRenderer
         var generatedCurationVids = new HashSet<VID>();
         var showAll = curationService.isShowAll(sessionOwner, project.getId());
         var showScore = curationService.isShowScore(sessionOwner, project.getId());
+        var constraintsEvaluator = new ConstraintsEvaluator();
+        var constraints = aRequest.getConstraints();
         for (var cfgSet : diff.getConfigurationSets()) {
             LOG.trace("Processing set: {}", cfgSet);
 
@@ -214,6 +218,21 @@ public class CurationSidebarRenderer
 
                 var objects = renderer.render(aRequest, layerSupportedFeatures, aVdoc, ann);
 
+                var adapter = renderer.getTypeAdapter();
+                var invalidFeatures = new ArrayList<String>();
+                for (var feature : layerSupportedFeatures) {
+                    if (!feature.isEnabled()) {
+                        continue;
+                    }
+                    if (constraintsEvaluator.isHiddenConditionalFeature(constraints, ann,
+                            feature)) {
+                        continue;
+                    }
+                    if (!adapter.isFeatureValueValid(feature, ann)) {
+                        invalidFeatures.add(feature.getUiName());
+                    }
+                }
+
                 for (var object : objects) {
                     if (!showAll && shouldBeHidden(aRequest, diff, cfg, layer, ann, object,
                             targetUser)) {
@@ -241,6 +260,11 @@ public class CurationSidebarRenderer
                     aVdoc.add(object);
 
                     aVdoc.add(new VComment(object.getVid(), VCommentType.INFO, "Curation item"));
+
+                    for (var name : invalidFeatures) {
+                        aVdoc.add(new VComment(object.getVid(), VCommentType.ERROR,
+                                "Feature [" + name + "] has no valid value."));
+                    }
 
                     if (object instanceof VArc arc) {
                         resolveArcEndpoints(targetUser, diff, showAll, cfg, arc);

--- a/inception/inception-ui-curation/src/test/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/render/CurationSidebarRendererTest.java
+++ b/inception/inception-ui-curation/src/test/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/render/CurationSidebarRendererTest.java
@@ -24,7 +24,9 @@ import static java.util.Arrays.asList;
 import static org.apache.uima.fit.factory.TypeSystemDescriptionFactory.createTypeSystemDescription;
 import static org.apache.uima.util.CasCreationUtils.mergeTypeSystems;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -35,8 +37,10 @@ import java.util.List;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.text.AnnotationFS;
 import org.apache.uima.fit.factory.CasFactory;
+import org.apache.uima.fit.util.FSUtil;
 import org.apache.uima.resource.metadata.impl.TypeSystemDescription_impl;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -52,9 +56,11 @@ import de.tudarmstadt.ukp.clarin.webanno.curation.casdiff.DiffSupportRegistryImp
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
+import de.tudarmstadt.ukp.clarin.webanno.model.ImmutableTag;
 import de.tudarmstadt.ukp.clarin.webanno.model.OverlapMode;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.clarin.webanno.model.TagSet;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.inception.annotation.feature.bool.BooleanFeatureSupport;
@@ -63,6 +69,7 @@ import de.tudarmstadt.ukp.inception.annotation.feature.link.LinkFeatureSupport;
 import de.tudarmstadt.ukp.inception.annotation.feature.link.LinkFeatureTraits;
 import de.tudarmstadt.ukp.inception.annotation.feature.number.NumberFeatureSupport;
 import de.tudarmstadt.ukp.inception.annotation.feature.string.StringFeatureSupport;
+import de.tudarmstadt.ukp.inception.annotation.feature.string.StringFeatureSupportPropertiesImpl;
 import de.tudarmstadt.ukp.inception.annotation.layer.behaviors.LayerBehaviorRegistryImpl;
 import de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationLayerSupportImpl;
 import de.tudarmstadt.ukp.inception.annotation.layer.relation.api.RelationLayerSupport;
@@ -76,6 +83,7 @@ import de.tudarmstadt.ukp.inception.curation.api.CurationVID;
 import de.tudarmstadt.ukp.inception.curation.api.DiffAdapterRegistry;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.rendering.request.RenderRequest;
+import de.tudarmstadt.ukp.inception.rendering.vmodel.VCommentType;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VDocument;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
@@ -119,6 +127,8 @@ class CurationSidebarRendererTest
     private AnnotationLayer spanLayer;
     private AnnotationLayer relationLayer;
     private AnnotationFeature spanLayerLinkFeature;
+    private AnnotationFeature spanLayerValueFeature;
+    private TagSet closedValueTagset;
     private SpanAdapter spanLayerAdapter;
     private DiffSupportRegistryImpl diffSupportRegistry;
     private DiffAdapterRegistry diffAdapterRegistry;
@@ -127,7 +137,7 @@ class CurationSidebarRendererTest
     void setup() throws Exception
     {
         featureSupportRegistry = new FeatureSupportRegistryImpl(asList( //
-                new StringFeatureSupport(), //
+                new StringFeatureSupport(new StringFeatureSupportPropertiesImpl(), schemaService), //
                 new BooleanFeatureSupport(), //
                 new NumberFeatureSupport(), //
                 new LinkFeatureSupport(schemaService)));
@@ -197,6 +207,21 @@ class CurationSidebarRendererTest
                 .withMultiValueMode(ARRAY) //
                 .build();
 
+        closedValueTagset = new TagSet();
+        closedValueTagset.setName("values");
+        closedValueTagset.setProject(project);
+        closedValueTagset.setCreateTag(false);
+
+        spanLayerValueFeature = AnnotationFeature.builder() //
+                .withId(2l) //
+                .withProject(project) //
+                .withLayer(spanLayer) //
+                .withName("value") //
+                .withUiName("value") //
+                .withType(CAS.TYPE_NAME_STRING) //
+                .build();
+        spanLayerValueFeature.setTagset(closedValueTagset);
+
         relationLayer = AnnotationLayer.builder() //
                 .withId(2l) //
                 .withProject(project) //
@@ -209,7 +234,10 @@ class CurationSidebarRendererTest
         when(curationSessionService.listUsersReadyForCuration(curator.getUsername(), project, doc))
                 .thenReturn(asList(anno1, anno2));
 
-        var allFeaturesInProject = asList(spanLayerLinkFeature);
+        var allFeaturesInProject = asList(spanLayerLinkFeature, spanLayerValueFeature);
+
+        lenient().when(schemaService.listTagsImmutable(any()))
+                .thenReturn(asList(new ImmutableTag("known", "")));
         when(schemaService.getAdapter(any())).thenAnswer(call -> {
             var layer = call.getArgument(0, AnnotationLayer.class);
             var support = layerSupportRegistry.findExtension(layer).get();
@@ -584,6 +612,75 @@ class CurationSidebarRendererTest
 
         assertThat(vdoc.spans()).isEmpty();
         assertThat(vdoc.arcs()).isEmpty();
+    }
+
+    /**
+     * A closed-tagset feature value that is not part of the tagset must produce an ERROR comment on
+     * the rendered curation span.
+     */
+    @Test
+    void thatOutOfTagsetValueProducesErrorComment() throws Exception
+    {
+        spanLayer.setOverlapMode(OverlapMode.ANY_OVERLAP);
+        var request = renderRequest("anchor");
+
+        var anchorA = spanLayerAdapter.add(doc, anno1.getUsername(), anno1Cas, 0, 6);
+        FSUtil.setFeature(anchorA, spanLayerValueFeature.getName(), "out-of-tagset");
+        var anchorB = spanLayerAdapter.add(doc, anno2.getUsername(), anno2Cas, 0, 6);
+        FSUtil.setFeature(anchorB, spanLayerValueFeature.getName(), "out-of-tagset");
+
+        sut.render(vdoc, request);
+
+        assertThat(vdoc.comments()) //
+                .extracting(comment -> comment.getCommentType(), comment -> comment.getComment()) //
+                .contains( //
+                        tuple(VCommentType.INFO, "Curation item"), //
+                        tuple(VCommentType.ERROR, "Feature [value] has no valid value."));
+    }
+
+    /**
+     * A closed-tagset feature value that is part of the tagset must not produce an ERROR comment.
+     */
+    @Test
+    void thatInTagsetValueProducesNoErrorComment() throws Exception
+    {
+        spanLayer.setOverlapMode(OverlapMode.ANY_OVERLAP);
+        var request = renderRequest("anchor");
+
+        var anchorA = spanLayerAdapter.add(doc, anno1.getUsername(), anno1Cas, 0, 6);
+        FSUtil.setFeature(anchorA, spanLayerValueFeature.getName(), "known");
+        var anchorB = spanLayerAdapter.add(doc, anno2.getUsername(), anno2Cas, 0, 6);
+        FSUtil.setFeature(anchorB, spanLayerValueFeature.getName(), "known");
+
+        sut.render(vdoc, request);
+
+        assertThat(vdoc.comments()) //
+                .extracting(comment -> comment.getCommentType()) //
+                .doesNotContain(VCommentType.ERROR);
+    }
+
+    /**
+     * A disabled feature must not be validated and therefore not produce an ERROR comment, even if
+     * its value is not part of the closed tagset. Disabled features can be used to model
+     * conditionally hidden features whose values are intentionally ignored.
+     */
+    @Test
+    void thatDisabledFeatureWithInvalidValueProducesNoErrorComment() throws Exception
+    {
+        spanLayer.setOverlapMode(OverlapMode.ANY_OVERLAP);
+        spanLayerValueFeature.setEnabled(false);
+        var request = renderRequest("anchor");
+
+        var anchorA = spanLayerAdapter.add(doc, anno1.getUsername(), anno1Cas, 0, 6);
+        FSUtil.setFeature(anchorA, spanLayerValueFeature.getName(), "out-of-tagset");
+        var anchorB = spanLayerAdapter.add(doc, anno2.getUsername(), anno2Cas, 0, 6);
+        FSUtil.setFeature(anchorB, spanLayerValueFeature.getName(), "out-of-tagset");
+
+        sut.render(vdoc, request);
+
+        assertThat(vdoc.comments()) //
+                .extracting(comment -> comment.getCommentType()) //
+                .doesNotContain(VCommentType.ERROR);
     }
 
     private CurationVID curationVid(User aUser, AnnotationFS anchorA)

--- a/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchAnnotationSidebar.java
+++ b/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchAnnotationSidebar.java
@@ -870,8 +870,8 @@ public class SearchAnnotationSidebar
             AnnotatorState state, AnnotationFS annoFS)
         throws AnnotationException
     {
-        try (var ctx = aAdapter.updateFeatureValues(aDocument, state.getUser().getUsername(),
-                aCas, ICasUtil.getAddr(annoFS))) {
+        try (var ctx = aAdapter.updateFeatureValues(aDocument, state.getUser().getUsername(), aCas,
+                ICasUtil.getAddr(annoFS))) {
             for (var featureState : state.getFeatureStates()) {
                 var featureValue = featureState.value;
                 var feature = featureState.feature;


### PR DESCRIPTION
**What's in the PR**
- Validate string and multi-value string feature values against closed tagsets, flagging out-of-tagset values as invalid
- Surface invalid-feature errors in the curation sidebar so out-of-tagset values are visible during curation
- Update validation comment wording from "Required feature not set" to "Feature has no valid value"
- Render sentence comments in brat only when a CAS is available instead of skipping all comment rendering
- Reorder brat comment priority levels so AnnotatorNotes outranks Warning/Error
- Add iaa-marker-error styling to section annotations carrying error comments and rename .iaa-error-marker to .iaa-marker-error
- Fix ViewportTracker to prune stale visible-element refs and only re-trigger loads when the visible range actually changes

**How to test manually**
* See issue description
* Then check if the errors render properly

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
