### PR TITLE
#1084 - Stacking relations in PDF editor

### DIFF
--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/model/RelationAnnotation.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/model/RelationAnnotation.ts
@@ -14,6 +14,8 @@ export default class RelationAnnotation extends AbstractAnnotation {
     x2: number;
     y2: number;
     zIndex: number;
+    stackIndex = 0;
+    stackSize = 1;
     _rel1Annotation: SpanAnnotation | null = null;
     _rel2Annotation: SpanAnnotation | null = null;
 

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/render/renderRelation.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/render/renderRelation.ts
@@ -19,10 +19,10 @@ export function renderRelation(a: RelationAnnotation): HTMLDivElement {
     // if difference of x and difference of y is both 0 use 0 for atan
     const theta = Math.atan(xDiff === 0 && yDiff === 0 ? 0 : yDiff / xDiff);
     const sign = a.x1 < a.x2 ? 1 : -1;
-    a.x1 += DEFAULT_RADIUS * Math.cos(theta) * sign;
-    a.x2 -= DEFAULT_RADIUS * Math.cos(theta) * sign;
-    a.y1 += DEFAULT_RADIUS * Math.sin(theta) * sign;
-    a.y2 -= DEFAULT_RADIUS * Math.sin(theta) * sign;
+    a.x1 += (DEFAULT_RADIUS / 2) * Math.cos(theta) * sign;
+    a.x2 -= (DEFAULT_RADIUS / 2) * Math.cos(theta) * sign;
+    a.y1 += (DEFAULT_RADIUS / 2) * Math.sin(theta) * sign;
+    a.y2 -= (DEFAULT_RADIUS / 2) * Math.sin(theta) * sign;
 
     const top = Math.min(a.y1, a.y2);
     const left = Math.min(a.x1, a.x2);
@@ -79,8 +79,14 @@ export function renderRelation(a: RelationAnnotation): HTMLDivElement {
         marker.appendChild(polygon);
     }
 
-    // Find Control points.
-    const control = findBezierControlPoint(a.x1, a.y1, a.x2, a.y2);
+    // Find Control points. Fan stacked relations (same endpoint pair) by varying
+    // the perpendicular distance of the Bezier control point so each arc is
+    // independently visible and hoverable.
+    const BASE_DISTANCE = 30;
+    const STACK_SPACING = 12;
+    const distance =
+        BASE_DISTANCE + STACK_SPACING * (a.stackIndex - (a.stackSize - 1) / 2);
+    const control = findBezierControlPoint(a.x1, a.y1, a.x2, a.y2, distance);
 
     // Create Outline.
     const outline = document.createElementNS('http://www.w3.org/2000/svg', 'path');

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/utils/relation.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/core/src/utils/relation.ts
@@ -15,9 +15,10 @@ export function findBezierControlPoint(
     x1: number,
     y1: number,
     x2: number,
-    y2: number
+    y2: number,
+    distance = 30
 ): { x: number; y: number } {
-    const DISTANCE = 30;
+    const DISTANCE = distance;
 
     // vertical line.
     if (x1 === x2) {

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/pdfanno.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/pdfanno.ts
@@ -383,7 +383,23 @@ function renderAnnotations(doc: AnnotatedText): void {
 
     if (doc.relations) {
         console.log(`Loaded ${doc.relations.size} relations annotations`);
-        doc.relations.forEach((relation) => renderRelation(doc, relation));
+        const stackBuckets = new Map<string, Relation[]>();
+        doc.relations.forEach((relation) => {
+            const a = relation.arguments[0].targetId;
+            const b = relation.arguments[1].targetId;
+            const key = String(a) < String(b) ? `${a}|${b}` : `${b}|${a}`;
+            const bucket = stackBuckets.get(key);
+            if (bucket) {
+                bucket.push(relation);
+            } else {
+                stackBuckets.set(key, [relation]);
+            }
+        });
+        stackBuckets.forEach((bucket) => {
+            bucket.forEach((relation, index) =>
+                renderRelation(doc, relation, index, bucket.length)
+            );
+        });
     }
 
     if (doc.textMarkers) {
@@ -427,7 +443,7 @@ function renderSpan(doc: AnnotatedText, span: Span) {
     spanAnnotation.save();
 }
 
-function renderRelation(doc: AnnotatedText, relation: Relation) {
+function renderRelation(doc: AnnotatedText, relation: Relation, stackIndex = 0, stackSize = 1) {
     const source = annotationContainer.findById(relation.arguments[0].targetId);
     const target = annotationContainer.findById(relation.arguments[1].targetId);
 
@@ -443,6 +459,8 @@ function renderRelation(doc: AnnotatedText, relation: Relation) {
     relationAnnotation.rel2Annotation = target as SpanAnnotation;
     relationAnnotation.color = relation.color || '#FFF';
     relationAnnotation.text = relation.label || '';
+    relationAnnotation.stackIndex = stackIndex;
+    relationAnnotation.stackSize = stackSize;
 
     const ms = doc.annotationMarkers.get(relationAnnotation.vid) || [];
     ms.forEach((m) => relationAnnotation.classList.push(`i7n-marker-${m.type}`));


### PR DESCRIPTION
**What's in the PR**
- Fan out stacked relations (same endpoint pair) by varying the Bezier control point's perpendicular distance so each arc is individually visible and hoverable
- Track `stackIndex` / `stackSize` on `RelationAnnotation` and group relations by unordered endpoint pair before rendering
- Make `findBezierControlPoint` accept a configurable `distance` parameter
- Halve the endpoint inset (`DEFAULT_RADIUS / 2`) so stacked arcs remain anchored close to their span endpoints

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
