### PR TITLE
#5114 - Relation suggestions hidden even when stacking is enabled

### DIFF
--- a/inception/inception-layer-docmetadata/src/test/java/de/tudarmstadt/ukp/inception/annotation/layer/document/recommender/MetadataSuggestionSupportTest.java
+++ b/inception/inception-layer-docmetadata/src/test/java/de/tudarmstadt/ukp/inception/annotation/layer/document/recommender/MetadataSuggestionSupportTest.java
@@ -1,0 +1,239 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.annotation.layer.document.recommender;
+
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.SINGLE_TOKEN;
+import static de.tudarmstadt.ukp.clarin.webanno.model.OverlapMode.OVERLAP_ONLY;
+import static de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordChangeLocation.MAIN_EDITOR;
+import static de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordUserAction.ACCEPTED;
+import static de.tudarmstadt.ukp.inception.support.uima.ICasUtil.selectFsByAddr;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.lenient;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.uima.cas.CAS;
+import org.apache.uima.cas.FeatureStructure;
+import org.apache.uima.fit.factory.JCasFactory;
+import org.apache.uima.fit.factory.TypeSystemDescriptionFactory;
+import org.apache.uima.jcas.JCas;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import de.tudarmstadt.ukp.clarin.webanno.constraints.ConstraintsService;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.inception.annotation.layer.document.DocumentMetadataLayerAdapterImpl;
+import de.tudarmstadt.ukp.inception.annotation.layer.document.DocumentMetadataLayerBehavior;
+import de.tudarmstadt.ukp.inception.annotation.layer.document.api.DocumentMetadataLayerSupport;
+import de.tudarmstadt.ukp.inception.annotation.layer.document.api.DocumentMetadataLayerTraits;
+import de.tudarmstadt.ukp.inception.recommendation.api.LearningRecordService;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.MetadataSuggestion;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
+import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
+import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureSupport;
+import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureSupportRegistry;
+import de.tudarmstadt.ukp.inception.schema.api.layer.LayerSupport;
+import de.tudarmstadt.ukp.inception.schema.api.layer.LayerSupportRegistry;
+
+/**
+ * Locks in {@code MetadataSuggestionSupport.acceptSuggestion} branching: empty-label fill,
+ * stacked-create when the layer is not a singleton, and overwrite-existing when it is.
+ */
+@ExtendWith(MockitoExtension.class)
+public class MetadataSuggestionSupportTest
+{
+    private static final String META_TYPE = "test.MetaTag";
+    private static final String FEATURE = "value";
+
+    private @Mock ConstraintsService constraintsService;
+    private @Mock LearningRecordService learningRecordService;
+    private @Mock AnnotationSchemaService schemaService;
+    private @Mock FeatureSupportRegistry featureSupportRegistry;
+    private @Mock LayerSupportRegistry layerSupportRegistry;
+    private @Mock(name = "primitiveFeatureSupport") FeatureSupport<Void> featureSupport;
+    private @Mock DocumentMetadataLayerSupport layerSupport;
+
+    private Project project;
+    private SourceDocument document;
+    private String username;
+    private AnnotationLayer metaLayer;
+    private AnnotationFeature valueFeature;
+    private DocumentMetadataLayerTraits layerTraits;
+    private List<DocumentMetadataLayerBehavior> behaviors;
+    private JCas jcas;
+    private DocumentMetadataLayerAdapterImpl adapter;
+    private MetadataSuggestionSupport sut;
+    private Recommender recommender;
+
+    @BeforeEach
+    public void setup() throws Exception
+    {
+        username = "user";
+
+        project = new Project();
+        project.setId(1L);
+
+        document = new SourceDocument();
+        document.setId(1L);
+        document.setProject(project);
+
+        var tsd = TypeSystemDescriptionFactory.createTypeSystemDescription();
+        var td = tsd.addType(META_TYPE, "", CAS.TYPE_NAME_ANNOTATION_BASE);
+        td.addFeature(FEATURE, "", CAS.TYPE_NAME_STRING);
+        td.addFeature("i7n_uiOrder", "", CAS.TYPE_NAME_INTEGER);
+        jcas = JCasFactory.createJCas(tsd);
+        jcas.setDocumentText("This is a test .");
+
+        metaLayer = new AnnotationLayer(META_TYPE, "Meta", DocumentMetadataLayerSupport.TYPE,
+                project, true, SINGLE_TOKEN, OVERLAP_ONLY);
+        metaLayer.setId(1L);
+
+        valueFeature = new AnnotationFeature(2L, metaLayer, FEATURE, CAS.TYPE_NAME_STRING);
+
+        recommender = new Recommender("test-recommender", metaLayer);
+        recommender.setId(99L);
+        recommender.setFeature(valueFeature);
+
+        layerTraits = new DocumentMetadataLayerTraits();
+
+        // Adapter delegates getTraits → layerSupportRegistry.getLayerSupport(layer).readTraits(...)
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        var layerSupportWild = (LayerSupport) layerSupport;
+        lenient().when(layerSupportRegistry.getLayerSupport(any(AnnotationLayer.class)))
+                .thenReturn(layerSupportWild);
+        lenient().when(layerSupport.readTraits(any(AnnotationLayer.class)))
+                .thenAnswer(inv -> layerTraits);
+
+        behaviors = emptyList();
+
+        lenient().when(featureSupport.accepts(any())).thenReturn(true);
+        lenient().doAnswer(inv -> {
+            CAS cas = inv.getArgument(0);
+            AnnotationFeature feat = inv.getArgument(1);
+            int addr = inv.getArgument(2);
+            Object val = inv.getArgument(3);
+            var fs = selectFsByAddr(cas, addr);
+            fs.setStringValue(fs.getType().getFeatureByBaseName(feat.getName()), (String) val);
+            return null;
+        }).when(featureSupport).pushFeatureValue(any(), any(), anyInt(), any());
+        lenient().when(featureSupport.getFeatureValue(any(), any())).thenAnswer(inv -> {
+            AnnotationFeature feat = inv.getArgument(0);
+            FeatureStructure fs = inv.getArgument(1);
+            var f = fs.getType().getFeatureByBaseName(feat.getName());
+            return f == null ? null : fs.getStringValue(f);
+        });
+
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        var asWild = (Optional) Optional.of(featureSupport);
+        lenient().when(featureSupportRegistry.findExtension(any(AnnotationFeature.class)))
+                .thenReturn(asWild);
+
+        adapter = new DocumentMetadataLayerAdapterImpl(layerSupportRegistry, featureSupportRegistry,
+                null, metaLayer, () -> asList(valueFeature), constraintsService, behaviors);
+
+        sut = new MetadataSuggestionSupport(null, learningRecordService, null, schemaService);
+    }
+
+    @Test
+    public void thatAcceptingSuggestionWithoutExisting_createsNewAnnotation() throws Exception
+    {
+        sut.acceptSuggestion("session", document, username, jcas.getCas(), adapter, valueFeature,
+                null, suggestion("topicA"), MAIN_EDITOR, ACCEPTED);
+
+        assertThat(metaValues()).containsExactly("topicA");
+    }
+
+    @Test
+    public void thatAcceptingSuggestionFillsEmptyLabelOnExistingAnnotation() throws Exception
+    {
+        addMeta(null);
+
+        sut.acceptSuggestion("session", document, username, jcas.getCas(), adapter, valueFeature,
+                null, suggestion("topicA"), MAIN_EDITOR, ACCEPTED);
+
+        assertThat(metaValues()).containsExactly("topicA");
+    }
+
+    @Test
+    public void thatAcceptingSuggestion_nonSingleton_createsAdditionalAnnotation() throws Exception
+    {
+        layerTraits.setSingleton(false);
+        addMeta("topicA");
+
+        sut.acceptSuggestion("session", document, username, jcas.getCas(), adapter, valueFeature,
+                null, suggestion("topicB"), MAIN_EDITOR, ACCEPTED);
+
+        assertThat(metaValues()).containsExactlyInAnyOrder("topicA", "topicB");
+    }
+
+    @Test
+    public void thatAcceptingSuggestion_singleton_overwritesExistingAnnotation() throws Exception
+    {
+        layerTraits.setSingleton(true);
+        addMeta("topicA");
+
+        sut.acceptSuggestion("session", document, username, jcas.getCas(), adapter, valueFeature,
+                null, suggestion("topicB"), MAIN_EDITOR, ACCEPTED);
+
+        assertThat(metaValues()).containsExactly("topicB");
+    }
+
+    private void addMeta(String value)
+    {
+        var type = jcas.getCas().getTypeSystem().getType(META_TYPE);
+        var fs = jcas.getCas().createFS(type);
+        if (value != null) {
+            fs.setStringValue(type.getFeatureByBaseName(FEATURE), value);
+        }
+        fs.setIntValue(type.getFeatureByBaseName("i7n_uiOrder"), 1);
+        jcas.getCas().addFsToIndexes(fs);
+    }
+
+    private List<String> metaValues()
+    {
+        var type = jcas.getCas().getTypeSystem().getType(META_TYPE);
+        return jcas.getCas().select(type) //
+                .map(fs -> fs.getStringValue(type.getFeatureByBaseName(FEATURE))) //
+                .toList();
+    }
+
+    private MetadataSuggestion suggestion(String label)
+    {
+        return MetadataSuggestion.builder() //
+                .withId(1) //
+                .withRecommender(recommender) //
+                .withDocument(document) //
+                .withLayer(metaLayer) //
+                .withFeature(valueFeature) //
+                .withLabel(label) //
+                .withUiLabel(label) //
+                .withScore(0.9) //
+                .build();
+    }
+}

--- a/inception/inception-layer-relation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/recommender/ArcSuggestionSupport_ImplBase.java
+++ b/inception/inception-layer-relation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/recommender/ArcSuggestionSupport_ImplBase.java
@@ -138,21 +138,38 @@ public abstract class ArcSuggestionSupport_ImplBase
                 group.showAll(AnnotationSuggestion.FLAG_ALL);
 
                 var position = group.getPosition();
+                var stackingEnabled = aLayer.isAllowStacking();
 
-                // FIXME: Looks like we need to implement not hiding relations if stacking is
-                // enabled.
-
-                // If any annotation at this position has a non-null label for this feature,
-                // then we hide the suggestion group
+                // For each existing relation at the same (source, target) position decide whether
+                // each suggestion should still be visible. Relations that share a position are by
+                // definition co-located, so no extra geometry check is needed (unlike spans).
                 for (var annotationFS : groupedAnnotations.get(position)) {
                     var label = annotationFS.getFeatureValueAsString(feat);
-                    if (annotationFS.getFeatureValueAsString(feat) != null) {
-                        for (var suggestion : group) {
-                            if (suggestion.isCorrection() && !suggestion.labelEquals(label)) {
-                                continue;
-                            }
+                    for (var suggestion : group) {
+                        // Correction suggestions are only relevant when they would change the
+                        // label of an existing annotation; identical labels are not corrections.
+                        if (suggestion.isCorrection() && !suggestion.labelEquals(label)) {
+                            continue;
+                        }
 
+                        // A suggestion that would just create an annotation without setting a
+                        // feature value duplicates the existing relation - hide it.
+                        if (suggestion.getLabel() == null) {
                             suggestion.hide(FLAG_OVERLAP);
+                            continue;
+                        }
+
+                        // Suggestion duplicates an existing labeled relation - hide it.
+                        if (label != null && suggestion.labelEquals(label)) {
+                            suggestion.hide(FLAG_OVERLAP);
+                            continue;
+                        }
+
+                        // Suggestion would create a new relation at an already-occupied position.
+                        // Only allow this when stacking is enabled on the layer.
+                        if (label != null && !stackingEnabled) {
+                            suggestion.hide(FLAG_OVERLAP);
+                            continue;
                         }
                     }
                 }

--- a/inception/inception-layer-relation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/recommender/RelationSuggestionSupport.java
+++ b/inception/inception-layer-relation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/recommender/RelationSuggestionSupport.java
@@ -168,7 +168,7 @@ public class RelationSuggestionSupport
 
         // The begin and end feature of a relation in the CAS are of the dependent/target
         // annotation. See also RelationAdapter::createRelationAnnotation.
-        // We use that fact to search for existing relations for this relation suggestion
+        // We use that fact to search for existing relations for this relation suggestion.
         var candidates = new ArrayList<AnnotationFS>();
         for (var relationCandidate : selectAt(aCas, type, targetBegin, targetEnd)) {
             var source = (AnnotationFS) relationCandidate.getFeatureValue(sourceFeature);
@@ -184,26 +184,34 @@ public class RelationSuggestionSupport
             }
         }
 
+        var stackingEnabled = aAdapter.getLayer().isAllowStacking();
+        var candidateWithEmptyLabel = candidates.stream() //
+                .filter(c -> aAdapter.getFeatureValue(aFeature, c) == null) //
+                .findFirst();
+
         try (var eventBatch = aAdapter.batchEvents()) {
             var annotationCreated = false;
-            AnnotationFS annotation = null;
-            if (candidates.size() == 1) {
-                // One candidate, we just return it
-                annotation = candidates.get(0);
+            AnnotationFS annotation;
+            if (candidateWithEmptyLabel.isPresent()) {
+                // If there is a relation where the predicted feature is unset, use it ...
+                annotation = candidateWithEmptyLabel.get();
             }
-            else if (candidates.size() > 1) {
-                LOG.warn(
-                        "Found multiple candidates for upserting relation from suggestion, using first one");
+            else if (candidates.isEmpty() || (stackingEnabled && !suggestion.isCorrection())) {
+                // ... otherwise, if stacking is allowed and this is not a correction, create a
+                // new (stacked) relation
+                annotation = null;
+            }
+            else {
+                // ... otherwise update the feature on the existing relation
+                if (candidates.size() > 1) {
+                    LOG.warn(
+                            "Found multiple candidates for upserting relation from suggestion, using first one");
+                }
                 annotation = candidates.get(0);
             }
 
             // We did not find a relation for this suggestion, so we create a new one
             if (annotation == null) {
-                // FIXME: We get the first match for the (begin, end) span. With stacking, there can
-                // be more than one and we need to get the right one then which does not need to be
-                // the first. We wait for #2135 to fix this. When stacking is enabled, then also
-                // consider creating a new relation instead of upserting an existing one.
-
                 var source = selectAt(aCas, attachType, sourceBegin, sourceEnd).stream().findFirst()
                         .orElse(null);
                 var target = selectAt(aCas, attachType, targetBegin, targetEnd).stream().findFirst()

--- a/inception/inception-layer-relation/src/test/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/recommender/RelationSuggestionSupportTest.java
+++ b/inception/inception-layer-relation/src/test/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/recommender/RelationSuggestionSupportTest.java
@@ -1,0 +1,287 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.annotation.layer.relation.recommender;
+
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.SINGLE_TOKEN;
+import static de.tudarmstadt.ukp.clarin.webanno.model.OverlapMode.NO_OVERLAP;
+import static de.tudarmstadt.ukp.clarin.webanno.model.OverlapMode.OVERLAP_ONLY;
+import static de.tudarmstadt.ukp.clarin.webanno.model.OverlapMode.STACKING_ONLY;
+import static de.tudarmstadt.ukp.inception.annotation.layer.relation.api.RelationLayerSupport.FEAT_REL_SOURCE;
+import static de.tudarmstadt.ukp.inception.annotation.layer.relation.api.RelationLayerSupport.FEAT_REL_TARGET;
+import static de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordChangeLocation.MAIN_EDITOR;
+import static de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordUserAction.ACCEPTED;
+import static de.tudarmstadt.ukp.inception.support.uima.ICasUtil.selectFsByAddr;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.apache.uima.fit.util.JCasUtil.select;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.lenient;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.uima.cas.CAS;
+import org.apache.uima.fit.factory.JCasFactory;
+import org.apache.uima.fit.testing.factory.TokenBuilder;
+import org.apache.uima.jcas.JCas;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import de.tudarmstadt.ukp.clarin.webanno.constraints.ConstraintsService;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.dkpro.core.api.lexmorph.type.pos.POS;
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
+import de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.Dependency;
+import de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationAdapterImpl;
+import de.tudarmstadt.ukp.inception.annotation.layer.relation.RelationAttachmentBehavior;
+import de.tudarmstadt.ukp.inception.annotation.layer.relation.api.RelationLayerSupport;
+import de.tudarmstadt.ukp.inception.annotation.layer.relation.behavior.RelationCrossSentenceBehavior;
+import de.tudarmstadt.ukp.inception.annotation.layer.relation.behavior.RelationLayerBehavior;
+import de.tudarmstadt.ukp.inception.annotation.layer.relation.behavior.RelationOverlapBehavior;
+import de.tudarmstadt.ukp.inception.annotation.layer.span.api.SpanLayerSupport;
+import de.tudarmstadt.ukp.inception.recommendation.api.LearningRecordService;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.RelationPosition;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.RelationSuggestion;
+import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
+import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureSupport;
+import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureSupportRegistry;
+import de.tudarmstadt.ukp.inception.schema.api.layer.LayerSupportRegistry;
+import de.tudarmstadt.ukp.inception.schema.api.layer.LayerSupportRegistryImpl;
+
+/**
+ * Verifies that {@code RelationSuggestionSupport.acceptSuggestion} does not silently overwrite an
+ * existing relation when stacking is enabled and the suggestion proposes a different label.
+ */
+@ExtendWith(MockitoExtension.class)
+public class RelationSuggestionSupportTest
+{
+    private @Mock ConstraintsService constraintsService;
+    private @Mock LearningRecordService learningRecordService;
+    private @Mock AnnotationSchemaService schemaService;
+    private @Mock FeatureSupportRegistry featureSupportRegistry;
+    private @Mock(name = "primitiveFeatureSupport") FeatureSupport<Void> featureSupport;
+
+    private LayerSupportRegistry layerSupportRegistry;
+    private Project project;
+    private SourceDocument document;
+    private String username;
+    private AnnotationLayer depLayer;
+    private AnnotationFeature dependencyTypeFeature;
+    private Recommender recommender;
+    private List<RelationLayerBehavior> behaviors;
+    private JCas jcas;
+    private RelationAdapterImpl adapter;
+    private RelationSuggestionSupport sut;
+
+    @BeforeEach
+    public void setup() throws Exception
+    {
+        jcas = JCasFactory.createJCas();
+        username = "user";
+
+        project = new Project();
+        project.setId(1L);
+
+        document = new SourceDocument();
+        document.setId(1L);
+        document.setProject(project);
+
+        var tokenLayer = new AnnotationLayer(Token.class.getName(), "Token", SpanLayerSupport.TYPE,
+                project, true, SINGLE_TOKEN, NO_OVERLAP);
+        tokenLayer.setId(1L);
+        var tokenLayerPos = new AnnotationFeature(1L, tokenLayer, "pos", POS.class.getName());
+
+        depLayer = new AnnotationLayer(Dependency.class.getName(), "Dependency",
+                RelationLayerSupport.TYPE, project, true, SINGLE_TOKEN, OVERLAP_ONLY);
+        depLayer.setId(3L);
+        depLayer.setAttachType(tokenLayer);
+        depLayer.setAttachFeature(tokenLayerPos);
+
+        var govFeature = new AnnotationFeature(2L, depLayer, "Governor", Token.class.getName());
+        var depFeature = new AnnotationFeature(3L, depLayer, "Dependent", Token.class.getName());
+        dependencyTypeFeature = new AnnotationFeature(4L, depLayer, "DependencyType",
+                CAS.TYPE_NAME_STRING);
+
+        recommender = new Recommender("test-recommender", depLayer);
+        recommender.setId(99L);
+        recommender.setFeature(dependencyTypeFeature);
+
+        layerSupportRegistry = new LayerSupportRegistryImpl(emptyList());
+
+        behaviors = asList(new RelationAttachmentBehavior(), new RelationOverlapBehavior(),
+                new RelationCrossSentenceBehavior());
+
+        // Make pushFeatureValue actually mutate the CAS so commitLabel sees the new label.
+        // Mockito interface mocks do not invoke `default` methods, so we stub it explicitly.
+        lenient().when(featureSupport.accepts(any())).thenReturn(true);
+        lenient().doAnswer(inv -> {
+            CAS cas = inv.getArgument(0);
+            AnnotationFeature feat = inv.getArgument(1);
+            int addr = inv.getArgument(2);
+            Object val = inv.getArgument(3);
+            var fs = selectFsByAddr(cas, addr);
+            fs.setStringValue(fs.getType().getFeatureByBaseName(feat.getName()), (String) val);
+            return null;
+        }).when(featureSupport).pushFeatureValue(any(), any(), anyInt(), any());
+        lenient().doAnswer(inv -> {
+            AnnotationFeature feat = inv.getArgument(0);
+            var fs = (org.apache.uima.cas.FeatureStructure) inv.getArgument(1);
+            return fs.getStringValue(fs.getType().getFeatureByBaseName(feat.getName()));
+        }).when(featureSupport).getFeatureValue(any(), any());
+
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        var asWild = (Optional) Optional.of(featureSupport);
+        lenient().when(featureSupportRegistry.findExtension(any(AnnotationFeature.class)))
+                .thenReturn(asWild);
+
+        // Pass null for the event publisher: TypeAdapter#isSilenced is then true and the
+        // recommendation-acceptance event + learning record are skipped.
+        adapter = new RelationAdapterImpl(layerSupportRegistry, featureSupportRegistry, null,
+                depLayer, FEAT_REL_TARGET, FEAT_REL_SOURCE,
+                () -> asList(govFeature, depFeature, dependencyTypeFeature), behaviors,
+                constraintsService);
+
+        sut = new RelationSuggestionSupport(null, learningRecordService, null, schemaService,
+                featureSupportRegistry);
+    }
+
+    @Test
+    public void thatAcceptingSuggestionAtUnoccupiedPosition_createsNewRelation() throws Exception
+    {
+        var tokens = createTokensAndPos();
+
+        sut.acceptSuggestion("session", document, username, jcas.getCas(), adapter,
+                dependencyTypeFeature, null,
+                relationSuggestion(tokens.get(0), tokens.get(1), "subj", false), MAIN_EDITOR,
+                ACCEPTED);
+
+        assertThat(select(jcas, Dependency.class)) //
+                .extracting(Dependency::getDependencyType) //
+                .containsExactly("subj");
+    }
+
+    @Test
+    public void thatAcceptingSuggestionAtOccupiedPosition_withoutStacking_updatesExistingLabel()
+        throws Exception
+    {
+        depLayer.setOverlapMode(OVERLAP_ONLY);
+
+        var tokens = createTokensAndPos();
+        addRelation(tokens.get(0), tokens.get(1), "obj");
+
+        sut.acceptSuggestion("session", document, username, jcas.getCas(), adapter,
+                dependencyTypeFeature, null,
+                relationSuggestion(tokens.get(0), tokens.get(1), "subj", false), MAIN_EDITOR,
+                ACCEPTED);
+
+        assertThat(select(jcas, Dependency.class)) //
+                .extracting(Dependency::getDependencyType) //
+                .containsExactly("subj");
+    }
+
+    @Test
+    public void thatAcceptingSuggestionAtOccupiedPosition_withStacking_createsNewRelation()
+        throws Exception
+    {
+        depLayer.setOverlapMode(STACKING_ONLY);
+
+        var tokens = createTokensAndPos();
+        addRelation(tokens.get(0), tokens.get(1), "obj");
+
+        sut.acceptSuggestion("session", document, username, jcas.getCas(), adapter,
+                dependencyTypeFeature, null,
+                relationSuggestion(tokens.get(0), tokens.get(1), "subj", false), MAIN_EDITOR,
+                ACCEPTED);
+
+        assertThat(select(jcas, Dependency.class)) //
+                .extracting(Dependency::getDependencyType) //
+                .containsExactlyInAnyOrder("obj", "subj");
+    }
+
+    @Test
+    public void thatAcceptingCorrectionSuggestion_withStacking_updatesExistingRelation()
+        throws Exception
+    {
+        depLayer.setOverlapMode(STACKING_ONLY);
+
+        var tokens = createTokensAndPos();
+        addRelation(tokens.get(0), tokens.get(1), "obj");
+
+        sut.acceptSuggestion("session", document, username, jcas.getCas(), adapter,
+                dependencyTypeFeature, null,
+                relationSuggestion(tokens.get(0), tokens.get(1), "subj", true), MAIN_EDITOR,
+                ACCEPTED);
+
+        assertThat(select(jcas, Dependency.class)) //
+                .extracting(Dependency::getDependencyType) //
+                .containsExactly("subj");
+    }
+
+    private List<Token> createTokensAndPos() throws Exception
+    {
+        var builder = new TokenBuilder<>(Token.class, Sentence.class);
+        builder.buildTokens(jcas, "This is a test .");
+
+        for (var t : select(jcas, Token.class)) {
+            var pos = new POS(jcas, t.getBegin(), t.getEnd());
+            t.setPos(pos);
+            pos.addToIndexes();
+        }
+
+        return new ArrayList<>(select(jcas, Token.class));
+    }
+
+    private Dependency addRelation(Token source, Token target, String label) throws Exception
+    {
+        var fs = new Dependency(jcas, target.getBegin(), target.getEnd());
+        fs.setGovernor(source);
+        fs.setDependent(target);
+        fs.setDependencyType(label);
+        fs.addToIndexes();
+        return fs;
+    }
+
+    private RelationSuggestion relationSuggestion(Token source, Token target, String label,
+            boolean correction)
+    {
+        return RelationSuggestion.builder() //
+                .withId(1) //
+                .withRecommender(recommender) //
+                .withDocument(document) //
+                .withLayer(depLayer) //
+                .withFeature(dependencyTypeFeature) //
+                .withPosition(new RelationPosition(source.getBegin(), source.getEnd(),
+                        target.getBegin(), target.getEnd())) //
+                .withLabel(label) //
+                .withUiLabel(label) //
+                .withScore(0.9) //
+                .withCorrection(correction) //
+                .build();
+    }
+}

--- a/inception/inception-layer-span/src/test/java/de/tudarmstadt/ukp/inception/annotation/layer/span/recommender/SpanSuggestionSupportTest.java
+++ b/inception/inception-layer-span/src/test/java/de/tudarmstadt/ukp/inception/annotation/layer/span/recommender/SpanSuggestionSupportTest.java
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.annotation.layer.span.recommender;
+
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnchoringMode.TOKENS;
+import static de.tudarmstadt.ukp.clarin.webanno.model.OverlapMode.OVERLAP_ONLY;
+import static de.tudarmstadt.ukp.clarin.webanno.model.OverlapMode.STACKING_ONLY;
+import static de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordChangeLocation.MAIN_EDITOR;
+import static de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordUserAction.ACCEPTED;
+import static de.tudarmstadt.ukp.inception.support.uima.ICasUtil.selectFsByAddr;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.apache.uima.fit.util.JCasUtil.select;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.lenient;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.uima.cas.CAS;
+import org.apache.uima.fit.factory.JCasFactory;
+import org.apache.uima.fit.testing.factory.TokenBuilder;
+import org.apache.uima.jcas.JCas;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import de.tudarmstadt.ukp.clarin.webanno.constraints.ConstraintsService;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity;
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
+import de.tudarmstadt.ukp.inception.annotation.layer.behavior.SpanAnchoringModeBehavior;
+import de.tudarmstadt.ukp.inception.annotation.layer.behavior.SpanCrossSentenceBehavior;
+import de.tudarmstadt.ukp.inception.annotation.layer.behavior.SpanOverlapBehavior;
+import de.tudarmstadt.ukp.inception.annotation.layer.span.SpanAdapterImpl;
+import de.tudarmstadt.ukp.inception.annotation.layer.span.api.SpanLayerBehavior;
+import de.tudarmstadt.ukp.inception.annotation.layer.span.api.SpanLayerSupport;
+import de.tudarmstadt.ukp.inception.recommendation.api.LearningRecordService;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.SpanSuggestion;
+import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
+import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureSupport;
+import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureSupportRegistry;
+import de.tudarmstadt.ukp.inception.schema.api.layer.LayerSupportRegistry;
+import de.tudarmstadt.ukp.inception.schema.api.layer.LayerSupportRegistryImpl;
+
+/**
+ * Characterizes {@code SpanSuggestionSupport.acceptSuggestion} so the existing branching
+ * (create-new vs. upsert vs. fill-empty) is locked in against future regressions — particularly the
+ * rule that, with stacking enabled, accepting a different-label suggestion creates a new stacked
+ * annotation rather than overwriting an existing one.
+ */
+@ExtendWith(MockitoExtension.class)
+public class SpanSuggestionSupportTest
+{
+    private @Mock ConstraintsService constraintsService;
+    private @Mock LearningRecordService learningRecordService;
+    private @Mock AnnotationSchemaService schemaService;
+    private @Mock FeatureSupportRegistry featureSupportRegistry;
+    private @Mock(name = "primitiveFeatureSupport") FeatureSupport<Void> featureSupport;
+
+    private LayerSupportRegistry layerSupportRegistry;
+    private Project project;
+    private SourceDocument document;
+    private String username;
+    private AnnotationLayer neLayer;
+    private AnnotationFeature valueFeature;
+    private List<SpanLayerBehavior> behaviors;
+    private JCas jcas;
+    private SpanAdapterImpl adapter;
+    private SpanSuggestionSupport sut;
+    private Recommender recommender;
+
+    @BeforeEach
+    public void setup() throws Exception
+    {
+        jcas = JCasFactory.createJCas();
+        username = "user";
+
+        project = new Project();
+        project.setId(1L);
+
+        document = new SourceDocument();
+        document.setId(1L);
+        document.setProject(project);
+
+        neLayer = new AnnotationLayer(NamedEntity.class.getName(), "NE", SpanLayerSupport.TYPE,
+                project, true, TOKENS, OVERLAP_ONLY);
+        neLayer.setId(1L);
+
+        valueFeature = new AnnotationFeature(2L, neLayer, "value", CAS.TYPE_NAME_STRING);
+
+        recommender = new Recommender("test-recommender", neLayer);
+        recommender.setId(99L);
+        recommender.setFeature(valueFeature);
+
+        layerSupportRegistry = new LayerSupportRegistryImpl(emptyList());
+
+        behaviors = asList(new SpanOverlapBehavior(), new SpanCrossSentenceBehavior(),
+                new SpanAnchoringModeBehavior());
+
+        lenient().when(featureSupport.accepts(any())).thenReturn(true);
+        lenient().doAnswer(inv -> {
+            CAS cas = inv.getArgument(0);
+            AnnotationFeature feat = inv.getArgument(1);
+            int addr = inv.getArgument(2);
+            Object val = inv.getArgument(3);
+            var fs = selectFsByAddr(cas, addr);
+            fs.setStringValue(fs.getType().getFeatureByBaseName(feat.getName()), (String) val);
+            return null;
+        }).when(featureSupport).pushFeatureValue(any(), any(), anyInt(), any());
+        // SpanSuggestionSupport reads via aAdapter.getFeatureValue to detect empty-label
+        // candidates, so the mock must reflect what's actually in the CAS.
+        lenient().when(featureSupport.getFeatureValue(any(), any())).thenAnswer(inv -> {
+            AnnotationFeature feat = inv.getArgument(0);
+            org.apache.uima.cas.FeatureStructure fs = inv.getArgument(1);
+            var f = fs.getType().getFeatureByBaseName(feat.getName());
+            return f == null ? null : fs.getStringValue(f);
+        });
+
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        var asWild = (Optional) Optional.of(featureSupport);
+        lenient().when(featureSupportRegistry.findExtension(any(AnnotationFeature.class)))
+                .thenReturn(asWild);
+
+        // Pass null event publisher → adapter is silenced → recommendation event + learning
+        // record are skipped.
+        adapter = new SpanAdapterImpl(layerSupportRegistry, featureSupportRegistry, null, neLayer,
+                () -> asList(valueFeature), behaviors, constraintsService);
+
+        sut = new SpanSuggestionSupport(null, learningRecordService, null, schemaService,
+                featureSupportRegistry, () -> false);
+
+        var builder = new TokenBuilder<>(Token.class, Sentence.class);
+        builder.buildTokens(jcas, "This is a test .");
+    }
+
+    @Test
+    public void thatAcceptingSuggestionAtUnoccupiedPosition_createsNewSpan() throws Exception
+    {
+        sut.acceptSuggestion("session", document, username, jcas.getCas(), adapter, valueFeature,
+                null, spanSuggestion(0, 4, "PER", false), MAIN_EDITOR, ACCEPTED);
+
+        assertThat(select(jcas, NamedEntity.class)) //
+                .extracting(NamedEntity::getValue) //
+                .containsExactly("PER");
+    }
+
+    @Test
+    public void thatAcceptingSuggestionFillsEmptyLabelOnExistingSpan() throws Exception
+    {
+        addNamedEntity(0, 4, null);
+
+        sut.acceptSuggestion("session", document, username, jcas.getCas(), adapter, valueFeature,
+                null, spanSuggestion(0, 4, "PER", false), MAIN_EDITOR, ACCEPTED);
+
+        assertThat(select(jcas, NamedEntity.class)) //
+                .extracting(NamedEntity::getValue) //
+                .containsExactly("PER");
+    }
+
+    @Test
+    public void thatAcceptingSuggestionAtOccupiedPosition_withoutStacking_updatesExistingLabel()
+        throws Exception
+    {
+        neLayer.setOverlapMode(OVERLAP_ONLY);
+        addNamedEntity(0, 4, "ORG");
+
+        sut.acceptSuggestion("session", document, username, jcas.getCas(), adapter, valueFeature,
+                null, spanSuggestion(0, 4, "PER", false), MAIN_EDITOR, ACCEPTED);
+
+        assertThat(select(jcas, NamedEntity.class)) //
+                .extracting(NamedEntity::getValue) //
+                .containsExactly("PER");
+    }
+
+    @Test
+    public void thatAcceptingSuggestionAtOccupiedPosition_withStacking_createsNewSpan()
+        throws Exception
+    {
+        neLayer.setOverlapMode(STACKING_ONLY);
+        addNamedEntity(0, 4, "ORG");
+
+        sut.acceptSuggestion("session", document, username, jcas.getCas(), adapter, valueFeature,
+                null, spanSuggestion(0, 4, "PER", false), MAIN_EDITOR, ACCEPTED);
+
+        assertThat(select(jcas, NamedEntity.class)) //
+                .extracting(NamedEntity::getValue) //
+                .containsExactlyInAnyOrder("ORG", "PER");
+    }
+
+    private NamedEntity addNamedEntity(int begin, int end, String value)
+    {
+        var ne = new NamedEntity(jcas, begin, end);
+        if (value != null) {
+            ne.setValue(value);
+        }
+        ne.addToIndexes();
+        return ne;
+    }
+
+    private SpanSuggestion spanSuggestion(int begin, int end, String label, boolean correction)
+    {
+        return SpanSuggestion.builder() //
+                .withId(1) //
+                .withRecommender(recommender) //
+                .withDocument(document) //
+                .withLayer(neLayer) //
+                .withFeature(valueFeature) //
+                .withPosition(begin, end) //
+                .withCoveredText("text") //
+                .withLabel(label) //
+                .withUiLabel(label) //
+                .withScore(0.9) //
+                .withCorrection(correction) //
+                .build();
+    }
+}

--- a/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/relation/RelationSuggestionVisibilityCalculationTest.java
+++ b/inception/inception-recommendation/src/test/java/de/tudarmstadt/ukp/inception/recommendation/relation/RelationSuggestionVisibilityCalculationTest.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.recommendation.relation;
 
+import static de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordUserAction.REJECTED;
 import static de.tudarmstadt.ukp.inception.recommendation.service.Fixtures.getInvisibleSuggestions;
 import static de.tudarmstadt.ukp.inception.recommendation.service.Fixtures.getVisibleSuggestions;
 import static java.util.Arrays.asList;
@@ -40,6 +41,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import de.tudarmstadt.ukp.clarin.webanno.constraints.ConstraintsService;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.OverlapMode;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
@@ -51,6 +53,7 @@ import de.tudarmstadt.ukp.inception.annotation.layer.relation.recommender.Relati
 import de.tudarmstadt.ukp.inception.annotation.layer.span.SpanLayerSupportImpl;
 import de.tudarmstadt.ukp.inception.recommendation.api.LearningRecordService;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.AnnotationSuggestion;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecord;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.RelationPosition;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.RelationSuggestion;
@@ -209,20 +212,209 @@ public class RelationSuggestionVisibilityCalculationTest
     static SuggestionDocumentGroup<RelationSuggestion> makeRelationSuggestionGroup(
             SourceDocument doc, AnnotationFeature aFeat, int[][] vals)
     {
+        return makeRelationSuggestionGroup(doc, aFeat, vals, null);
+    }
+
+    static SuggestionDocumentGroup<RelationSuggestion> makeRelationSuggestionGroup(
+            SourceDocument doc, AnnotationFeature aFeat, int[][] vals, String[] labels)
+    {
         var rec = Recommender.builder().withId(RECOMMENDER_ID).withName(RECOMMENDER_NAME)
                 .withLayer(aFeat.getLayer()).withFeature(aFeat).build();
 
         var suggestions = new ArrayList<RelationSuggestion>();
-        for (int[] val : vals) {
-            var suggestion = RelationSuggestion.builder() //
+        for (int i = 0; i < vals.length; i++) {
+            var val = vals[i];
+            var builder = RelationSuggestion.builder() //
                     .withId(val[0]) //
                     .withRecommender(rec) //
                     .withDocument(doc) //
                     .withPosition(new RelationPosition(val[1], val[2], val[3], val[4]))
-                    .withScore(CONFIDENCE).withScoreExplanation(CONFIDENCE_EXPLANATION).build();
-            suggestions.add(suggestion);
+                    .withScore(CONFIDENCE).withScoreExplanation(CONFIDENCE_EXPLANATION);
+            if (labels != null && labels[i] != null) {
+                builder.withLabel(labels[i]);
+            }
+            suggestions.add(builder.build());
         }
 
         return SuggestionDocumentGroup.groupsOfType(RelationSuggestion.class, suggestions);
+    }
+
+    @Test
+    public void thatSuggestionAtFreePositionIsVisible() throws Exception
+    {
+        doReturn(emptyList()).when(learningRecordService).listLearningRecords(TEST_USER, TEST_USER,
+                layer);
+
+        // Existing relation in CAS spans (0,3) -> (13,20). Suggestion endpoints differ.
+        var cas = getTestCas();
+        var suggestions = makeRelationSuggestionGroup(doc, feature,
+                new int[][] { { 1, 26, 30, 36, 41 } }, new String[] { "DEP" });
+
+        sut.calculateSuggestionVisibility(TEST_USER, doc, cas, TEST_USER, layer, suggestions, 0,
+                100);
+
+        assertThat(getVisibleSuggestions(suggestions)) //
+                .as("Suggestion at a free position should be visible") //
+                .hasSize(1);
+        assertThat(getInvisibleSuggestions(suggestions)) //
+                .as("No suggestions hidden when no overlap exists") //
+                .isEmpty();
+    }
+
+    @Test
+    public void thatSuggestionWithSameLabelAsExistingRelationIsHidden() throws Exception
+    {
+        doReturn(emptyList()).when(learningRecordService).listLearningRecords(TEST_USER, TEST_USER,
+                layer);
+
+        // Existing relation has label "DEP". Suggestion duplicates it.
+        var cas = getTestCas();
+        var suggestions = makeRelationSuggestionGroup(doc, feature,
+                new int[][] { { 1, 0, 3, 13, 20 } }, new String[] { "DEP" });
+
+        sut.calculateSuggestionVisibility(TEST_USER, doc, cas, TEST_USER, layer, suggestions, 0,
+                25);
+
+        assertThat(getVisibleSuggestions(suggestions)) //
+                .as("Duplicate suggestion should be hidden") //
+                .isEmpty();
+        assertThat(getInvisibleSuggestions(suggestions)) //
+                .extracting(AnnotationSuggestion::getReasonForHiding) //
+                .extracting(String::trim) //
+                .containsExactly("overlapping");
+    }
+
+    @Test
+    public void thatSuggestionWithDifferentLabelHiddenWhenStackingDisabled() throws Exception
+    {
+        layer.setOverlapMode(OverlapMode.NO_OVERLAP);
+        doReturn(emptyList()).when(learningRecordService).listLearningRecords(TEST_USER, TEST_USER,
+                layer);
+
+        // Existing relation has label "DEP". Suggestion has different label, but stacking off.
+        var cas = getTestCas();
+        var suggestions = makeRelationSuggestionGroup(doc, feature,
+                new int[][] { { 1, 0, 3, 13, 20 } }, new String[] { "OTHER" });
+
+        sut.calculateSuggestionVisibility(TEST_USER, doc, cas, TEST_USER, layer, suggestions, 0,
+                25);
+
+        assertThat(getVisibleSuggestions(suggestions)) //
+                .as("Different-label suggestion must be hidden when stacking is disabled") //
+                .isEmpty();
+        assertThat(getInvisibleSuggestions(suggestions)) //
+                .as("Hidden because no stacking is allowed") //
+                .isNotEmpty();
+    }
+
+    @Test
+    public void thatSuggestionWithDifferentLabelVisibleWhenStackingEnabled() throws Exception
+    {
+        layer.setOverlapMode(OverlapMode.ANY_OVERLAP);
+        doReturn(emptyList()).when(learningRecordService).listLearningRecords(TEST_USER, TEST_USER,
+                layer);
+
+        // Existing relation has label "DEP". Suggestion has different label, stacking on.
+        var cas = getTestCas();
+        var suggestions = makeRelationSuggestionGroup(doc, feature,
+                new int[][] { { 1, 0, 3, 13, 20 } }, new String[] { "OTHER" });
+
+        sut.calculateSuggestionVisibility(TEST_USER, doc, cas, TEST_USER, layer, suggestions, 0,
+                25);
+
+        assertThat(getVisibleSuggestions(suggestions)) //
+                .as("Different-label suggestion must remain visible when stacking is enabled") //
+                .hasSize(1);
+        assertThat(getInvisibleSuggestions(suggestions)) //
+                .as("Nothing should be hidden when stacking permits a new differently-labeled "
+                        + "relation at the same endpoints") //
+                .isEmpty();
+    }
+
+    @Test
+    public void thatSuggestionWithSameLabelHiddenEvenWhenStackingEnabled() throws Exception
+    {
+        layer.setOverlapMode(OverlapMode.ANY_OVERLAP);
+        doReturn(emptyList()).when(learningRecordService).listLearningRecords(TEST_USER, TEST_USER,
+                layer);
+
+        var cas = getTestCas();
+        var suggestions = makeRelationSuggestionGroup(doc, feature,
+                new int[][] { { 1, 0, 3, 13, 20 } }, new String[] { "DEP" });
+
+        sut.calculateSuggestionVisibility(TEST_USER, doc, cas, TEST_USER, layer, suggestions, 0,
+                25);
+
+        assertThat(getVisibleSuggestions(suggestions)) //
+                .as("Duplicate-label suggestion must be hidden even with stacking enabled") //
+                .isEmpty();
+    }
+
+    @Test
+    public void thatRejectedSuggestionWithMatchingLabelIsHidden() throws Exception
+    {
+        var rejected = LearningRecord.builder() //
+                .withSourceDocument(doc) //
+                .withLayer(layer) //
+                .withAnnotationFeature(feature) //
+                .withOffsetBegin(0).withOffsetEnd(3) // source
+                .withOffsetBegin2(13).withOffsetEnd2(20) // target
+                .withAnnotation("DEP") //
+                .withUserAction(REJECTED) //
+                .build();
+        doReturn(asList(rejected)).when(learningRecordService).listLearningRecords(TEST_USER,
+                TEST_USER, layer);
+
+        // Use endpoints with no existing relation in the CAS so the only reason to hide is the
+        // learning record.
+        var cas = getEmptyCasWithTokens();
+        var suggestions = makeRelationSuggestionGroup(doc, feature,
+                new int[][] { { 1, 0, 3, 13, 20 } }, new String[] { "DEP" });
+
+        sut.calculateSuggestionVisibility(TEST_USER, doc, cas, TEST_USER, layer, suggestions, 0,
+                25);
+
+        assertThat(getVisibleSuggestions(suggestions)) //
+                .as("Suggestion matching a rejected learning record must be hidden") //
+                .isEmpty();
+        assertThat(getInvisibleSuggestions(suggestions)).isNotEmpty();
+    }
+
+    @Test
+    public void thatRejectedSuggestionWithDifferentLabelStaysVisible() throws Exception
+    {
+        var rejected = LearningRecord.builder() //
+                .withSourceDocument(doc) //
+                .withLayer(layer) //
+                .withAnnotationFeature(feature) //
+                .withOffsetBegin(0).withOffsetEnd(3) //
+                .withOffsetBegin2(13).withOffsetEnd2(20) //
+                .withAnnotation("OTHER") //
+                .withUserAction(REJECTED) //
+                .build();
+        doReturn(asList(rejected)).when(learningRecordService).listLearningRecords(TEST_USER,
+                TEST_USER, layer);
+
+        var cas = getEmptyCasWithTokens();
+        var suggestions = makeRelationSuggestionGroup(doc, feature,
+                new int[][] { { 1, 0, 3, 13, 20 } }, new String[] { "DEP" });
+
+        sut.calculateSuggestionVisibility(TEST_USER, doc, cas, TEST_USER, layer, suggestions, 0,
+                25);
+
+        assertThat(getVisibleSuggestions(suggestions)) //
+                .as("Suggestion with different label than rejected record must remain visible") //
+                .hasSize(1);
+    }
+
+    private CAS getEmptyCasWithTokens() throws Exception
+    {
+        var jcas = JCasFactory.createText("Dies ist ein Testtext, ach ist der schoen, "
+                + "der schoenste von allen Testtexten.", "de");
+        new Token(jcas, 0, 3).addToIndexes();
+        new Token(jcas, 13, 20).addToIndexes();
+        new Token(jcas, 26, 30).addToIndexes();
+        new Token(jcas, 36, 41).addToIndexes();
+        return jcas.getCas();
     }
 }


### PR DESCRIPTION
**What's in the PR**
- Relation suggestion visibility now compares the suggested label against existing relations at the same (source, target) position instead of hiding the whole group as soon as any labeled relation exists there
- Suggestions whose label differs from existing relations stay visible when the layer's overlap mode allows stacking (`ANY_OVERLAP` / `STACKING_ONLY`)
- Duplicate-label suggestions and label-less suggestions are still hidden, and different-label suggestions remain hidden when stacking is disabled
- Added test coverage in `RelationSuggestionVisibilityCalculationTest` for: free position, duplicate label, different label without stacking, different label with stacking (the bug case), duplicate label with stacking, and rejected-learning-record matching/non-matching labels

**How to test manually**
* See issue description

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
