### PR TITLE
#5113 - Recommendations for multi-value features on document-level annotations broken

### DIFF
--- a/inception/inception-layer-docmetadata/pom.xml
+++ b/inception/inception-layer-docmetadata/pom.xml
@@ -219,6 +219,12 @@
     </dependency>
     
     <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-feature-string</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.dkpro.core</groupId>
       <artifactId>dkpro-core-api-segmentation-asl</artifactId>
       <scope>test</scope>

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/document/config/DocumentMetadataLayerSupportAutoConfiguration.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/document/config/DocumentMetadataLayerSupportAutoConfiguration.java
@@ -121,9 +121,10 @@ public class DocumentMetadataLayerSupportAutoConfiguration
             RecommendationService aRecommendationService,
             LearningRecordService aLearningRecordService,
             ApplicationEventPublisher aApplicationEventPublisher,
-            AnnotationSchemaService aSchemaService)
+            AnnotationSchemaService aSchemaService,
+            FeatureSupportRegistry aFeatureSupportRegistry)
     {
         return new MetadataSuggestionSupport(aRecommendationService, aLearningRecordService,
-                aApplicationEventPublisher, aSchemaService);
+                aApplicationEventPublisher, aSchemaService, aFeatureSupportRegistry);
     }
 }

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/document/recommender/MetadataSuggestionSupport.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/document/recommender/MetadataSuggestionSupport.java
@@ -19,7 +19,9 @@ package de.tudarmstadt.ukp.inception.annotation.layer.document.recommender;
 
 import static de.tudarmstadt.ukp.inception.recommendation.api.model.AnnotationSuggestion.FLAG_ALL;
 import static de.tudarmstadt.ukp.inception.recommendation.api.model.AnnotationSuggestion.FLAG_OVERLAP;
+import static java.util.Arrays.asList;
 import static org.apache.uima.cas.CAS.TYPE_NAME_STRING;
+import static org.apache.uima.cas.CAS.TYPE_NAME_STRING_ARRAY;
 
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
@@ -30,7 +32,6 @@ import java.util.Optional;
 
 import org.apache.uima.cas.AnnotationBaseFS;
 import org.apache.uima.cas.CAS;
-import org.apache.uima.cas.Feature;
 import org.apache.uima.jcas.cas.AnnotationBase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,6 +60,7 @@ import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.AnnotationException;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.TypeAdapter;
+import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureSupportRegistry;
 
 public class MetadataSuggestionSupport
     extends SuggestionSupport_ImplBase
@@ -68,13 +70,17 @@ public class MetadataSuggestionSupport
 
     public static final String TYPE = "META";
 
+    private final FeatureSupportRegistry featureSupportRegistry;
+
     public MetadataSuggestionSupport(RecommendationService aRecommendationService,
             LearningRecordService aLearningRecordService,
             ApplicationEventPublisher aApplicationEventPublisher,
-            AnnotationSchemaService aSchemaService)
+            AnnotationSchemaService aSchemaService,
+            FeatureSupportRegistry aFeatureSupportRegistry)
     {
         super(aRecommendationService, aLearningRecordService, aApplicationEventPublisher,
                 aSchemaService);
+        featureSupportRegistry = aFeatureSupportRegistry;
     }
 
     @Override
@@ -85,7 +91,9 @@ public class MetadataSuggestionSupport
         }
 
         var feature = aContext.feature();
-        if (TYPE_NAME_STRING.equals(feature.getType()) || feature.isVirtualFeature()) {
+        if (TYPE_NAME_STRING.equals(feature.getType())
+                || TYPE_NAME_STRING_ARRAY.equals(feature.getType())
+                || feature.isVirtualFeature()) {
             return true;
         }
 
@@ -210,7 +218,7 @@ public class MetadataSuggestionSupport
                     .toList();
 
             hideSpanSuggestionsThatMatchAnnotations(traits.isSingleton(), annotations, feature,
-                    feat, suggestionsForFeature);
+                    suggestionsForFeature);
 
             // Anything that was not hidden so far might still have been rejected
             suggestionsForFeature.stream() //
@@ -222,26 +230,32 @@ public class MetadataSuggestionSupport
     }
 
     private void hideSpanSuggestionsThatMatchAnnotations(boolean singleton,
-            List<AnnotationBase> aAnnotations, AnnotationFeature aFeature, Feature aFeat,
+            List<AnnotationBase> aAnnotations, AnnotationFeature aFeature,
             List<SuggestionGroup<MetadataSuggestion>> aSuggestionsForFeature)
     {
+        var featureSupport = featureSupportRegistry.findExtension(aFeature).get();
 
         for (var annotation : aAnnotations) {
-            // FIXME: This will not work for multi-valued features
-            var label = annotation.getFeatureValueAsString(aFeat);
+            var wrappedValue = featureSupport.getFeatureValue(aFeature, annotation);
+            var value = featureSupport.unwrapFeatureValue(aFeature, wrappedValue);
+            var labelObjects = value instanceof Iterable values ? values : asList(value);
 
-            if (label == null) {
-                continue;
-            }
+            for (var labelObject : labelObjects) {
+                var label = Objects.toString(labelObject, null);
 
-            for (var sugGroup : aSuggestionsForFeature) {
-                if (singleton) {
-                    sugGroup.hideAll(FLAG_OVERLAP);
+                if (label == null) {
+                    continue;
                 }
-                else {
-                    for (var suggestion : sugGroup) {
-                        if (label.equals(suggestion.getLabel())) {
-                            suggestion.hide(FLAG_OVERLAP);
+
+                for (var sugGroup : aSuggestionsForFeature) {
+                    if (singleton) {
+                        sugGroup.hideAll(FLAG_OVERLAP);
+                    }
+                    else {
+                        for (var suggestion : sugGroup) {
+                            if (label.equals(suggestion.getLabel())) {
+                                suggestion.hide(FLAG_OVERLAP);
+                            }
                         }
                     }
                 }

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/document/recommender/MetadataSuggestionSupport.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/document/recommender/MetadataSuggestionSupport.java
@@ -233,6 +233,17 @@ public class MetadataSuggestionSupport
             List<AnnotationBase> aAnnotations, AnnotationFeature aFeature,
             List<SuggestionGroup<MetadataSuggestion>> aSuggestionsForFeature)
     {
+        if (aSuggestionsForFeature.isEmpty() || aAnnotations.isEmpty()) {
+            return;
+        }
+
+        if (singleton) {
+            for (var sugGroup : aSuggestionsForFeature) {
+                sugGroup.hideAll(FLAG_OVERLAP);
+            }
+            return;
+        }
+
         var featureSupport = featureSupportRegistry.findExtension(aFeature).get();
 
         for (var annotation : aAnnotations) {
@@ -248,14 +259,9 @@ public class MetadataSuggestionSupport
                 }
 
                 for (var sugGroup : aSuggestionsForFeature) {
-                    if (singleton) {
-                        sugGroup.hideAll(FLAG_OVERLAP);
-                    }
-                    else {
-                        for (var suggestion : sugGroup) {
-                            if (label.equals(suggestion.getLabel())) {
-                                suggestion.hide(FLAG_OVERLAP);
-                            }
+                    for (var suggestion : sugGroup) {
+                        if (label.equals(suggestion.getLabel())) {
+                            suggestion.hide(FLAG_OVERLAP);
                         }
                     }
                 }

--- a/inception/inception-layer-docmetadata/src/test/java/de/tudarmstadt/ukp/inception/annotation/layer/document/recommender/MetadataSuggestionExtractionTest.java
+++ b/inception/inception-layer-docmetadata/src/test/java/de/tudarmstadt/ukp/inception/annotation/layer/document/recommender/MetadataSuggestionExtractionTest.java
@@ -47,6 +47,7 @@ import de.tudarmstadt.ukp.inception.recommendation.api.model.MetadataSuggestion;
 import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
 import de.tudarmstadt.ukp.inception.recommendation.api.recommender.ExtractionContext;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
+import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureSupportRegistry;
 import de.tudarmstadt.ukp.inception.support.uima.SegmentationUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -56,6 +57,7 @@ class MetadataSuggestionExtractionTest
     private @Mock LearningRecordService learningRecordService;
     private @Mock ApplicationEventPublisher applicationEventPublisher;
     private @Mock AnnotationSchemaService schemaService;
+    private @Mock FeatureSupportRegistry featureSupportRegistry;
 
     private Project project;
     private SourceDocument document;
@@ -91,7 +93,7 @@ class MetadataSuggestionExtractionTest
         SegmentationUtils.tokenize(originalCas);
 
         sut = new MetadataSuggestionSupport(recommendationService, learningRecordService,
-                applicationEventPublisher, schemaService);
+                applicationEventPublisher, schemaService, featureSupportRegistry);
     }
 
     @Test

--- a/inception/inception-layer-docmetadata/src/test/java/de/tudarmstadt/ukp/inception/annotation/layer/document/recommender/MetadataSuggestionVisibilityCalculationTest.java
+++ b/inception/inception-layer-docmetadata/src/test/java/de/tudarmstadt/ukp/inception/annotation/layer/document/recommender/MetadataSuggestionVisibilityCalculationTest.java
@@ -1,0 +1,307 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.annotation.layer.document.recommender;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+import org.apache.uima.cas.CAS;
+import org.apache.uima.fit.factory.CasFactory;
+import org.apache.uima.fit.util.FSUtil;
+import org.apache.uima.resource.metadata.FeatureDescription;
+import org.apache.uima.resource.metadata.TypeDescription;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
+import org.apache.uima.resource.metadata.impl.TypeSystemDescription_impl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.MultiValueMode;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.inception.annotation.feature.multistring.MultiValueStringFeatureSupport;
+import de.tudarmstadt.ukp.inception.annotation.feature.string.StringFeatureSupport;
+import de.tudarmstadt.ukp.inception.annotation.layer.document.api.DocumentMetadataLayerAdapter;
+import de.tudarmstadt.ukp.inception.annotation.layer.document.api.DocumentMetadataLayerTraits;
+import de.tudarmstadt.ukp.inception.recommendation.api.LearningRecordService;
+import de.tudarmstadt.ukp.inception.recommendation.api.RecommendationService;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.AnnotationSuggestion;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecord;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.LearningRecordUserAction;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.MetadataSuggestion;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.Recommender;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.SuggestionDocumentGroup;
+import de.tudarmstadt.ukp.inception.recommendation.api.model.SuggestionGroup;
+import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
+import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureSupportRegistryImpl;
+
+@ExtendWith(MockitoExtension.class)
+class MetadataSuggestionVisibilityCalculationTest
+{
+    private static final String TEST_USER = "Testuser";
+
+    private @Mock RecommendationService recommendationService;
+    private @Mock LearningRecordService learningRecordService;
+    private @Mock ApplicationEventPublisher applicationEventPublisher;
+    private @Mock AnnotationSchemaService schemaService;
+    private @Mock DocumentMetadataLayerAdapter adapter;
+
+    private Project project;
+    private SourceDocument doc;
+    private TypeSystemDescription tsd;
+    private TypeDescription typeDesc;
+    private AnnotationLayer layer;
+    private AnnotationFeature singleValueFeature;
+    private AnnotationFeature multiValueFeature;
+    private Recommender singleValueRecommender;
+    private Recommender multiValueRecommender;
+    private DocumentMetadataLayerTraits traits;
+    private CAS cas;
+
+    private MetadataSuggestionSupport sut;
+
+    @BeforeEach
+    void setUp() throws Exception
+    {
+        project = Project.builder().withId(1l).withName("Test").build();
+        doc = SourceDocument.builder().withId(12l).withName("doc").withProject(project).build();
+
+        tsd = new TypeSystemDescription_impl();
+        typeDesc = tsd.addType("custom.Metadata", "", CAS.TYPE_NAME_ANNOTATION_BASE);
+        FeatureDescription singleFeatDesc = typeDesc.addFeature("value", "", CAS.TYPE_NAME_STRING);
+        FeatureDescription multiFeatDesc = typeDesc.addFeature("values", "",
+                CAS.TYPE_NAME_STRING_ARRAY, CAS.TYPE_NAME_STRING, false);
+
+        layer = AnnotationLayer.builder().withId(44l).withName(typeDesc.getName()).build();
+
+        singleValueFeature = AnnotationFeature.builder().withId(1l) //
+                .withLayer(layer) //
+                .withName(singleFeatDesc.getName()) //
+                .withType(CAS.TYPE_NAME_STRING) //
+                .withMultiValueMode(MultiValueMode.NONE) //
+                .build();
+
+        multiValueFeature = AnnotationFeature.builder().withId(2l) //
+                .withLayer(layer) //
+                .withName(multiFeatDesc.getName()) //
+                .withType(CAS.TYPE_NAME_STRING_ARRAY) //
+                .withMultiValueMode(MultiValueMode.ARRAY) //
+                .build();
+
+        singleValueRecommender = Recommender.builder().withId(101l).withName("rec-single") //
+                .withProject(project).withLayer(layer).withFeature(singleValueFeature).build();
+        multiValueRecommender = Recommender.builder().withId(102l).withName("rec-multi") //
+                .withProject(project).withLayer(layer).withFeature(multiValueFeature).build();
+
+        traits = new DocumentMetadataLayerTraits();
+
+        cas = CasFactory.createCas(tsd);
+
+        when(schemaService.getAdapter(layer)).thenReturn(adapter);
+        when(adapter.getTraits(DocumentMetadataLayerTraits.class))
+                .thenReturn(Optional.of(traits));
+
+        var featureSupportRegistry = new FeatureSupportRegistryImpl(
+                asList(new StringFeatureSupport(), new MultiValueStringFeatureSupport()));
+        featureSupportRegistry.init();
+
+        sut = new MetadataSuggestionSupport(recommendationService, learningRecordService,
+                applicationEventPublisher, schemaService, featureSupportRegistry);
+    }
+
+    @Test
+    void testWithoutExistingAnnotationSuggestionStaysVisible() throws Exception
+    {
+        when(schemaService.listSupportedFeatures(layer)).thenReturn(asList(singleValueFeature));
+        doReturn(emptyList()).when(learningRecordService).listLearningRecords(TEST_USER, TEST_USER,
+                layer);
+
+        var suggestion = newSuggestion(singleValueRecommender, "happy", 1);
+        var groups = groups(suggestion);
+
+        sut.calculateSuggestionVisibility(TEST_USER, doc, cas, TEST_USER, layer, groups, 0,
+                cas.getDocumentText() == null ? 0 : cas.getDocumentText().length());
+
+        assertThat(visible(groups)).containsExactly(suggestion);
+    }
+
+    @Test
+    void testSingleValuedFeatureWithMatchingLabelHidesSuggestion() throws Exception
+    {
+        when(schemaService.listSupportedFeatures(layer)).thenReturn(asList(singleValueFeature));
+        doReturn(emptyList()).when(learningRecordService).listLearningRecords(TEST_USER, TEST_USER,
+                layer);
+
+        var ann = cas.createFS(cas.getTypeSystem().getType(typeDesc.getName()));
+        FSUtil.setFeature(ann, "value", "happy");
+        cas.addFsToIndexes(ann);
+
+        var suggestion = newSuggestion(singleValueRecommender, "happy", 1);
+        var groups = groups(suggestion);
+
+        sut.calculateSuggestionVisibility(TEST_USER, doc, cas, TEST_USER, layer, groups, 0, 0);
+
+        assertThat(invisible(groups)).containsExactly(suggestion);
+    }
+
+    @Test
+    void testSingleValuedFeatureWithDifferentLabelKeepsSuggestionVisible() throws Exception
+    {
+        when(schemaService.listSupportedFeatures(layer)).thenReturn(asList(singleValueFeature));
+        doReturn(emptyList()).when(learningRecordService).listLearningRecords(TEST_USER, TEST_USER,
+                layer);
+
+        var ann = cas.createFS(cas.getTypeSystem().getType(typeDesc.getName()));
+        FSUtil.setFeature(ann, "value", "sad");
+        cas.addFsToIndexes(ann);
+
+        var suggestion = newSuggestion(singleValueRecommender, "happy", 1);
+        var groups = groups(suggestion);
+
+        sut.calculateSuggestionVisibility(TEST_USER, doc, cas, TEST_USER, layer, groups, 0, 0);
+
+        assertThat(visible(groups)).containsExactly(suggestion);
+    }
+
+    @Test
+    void testSingletonLayerHidesAllSuggestionsWhenAnnotationExists() throws Exception
+    {
+        traits.setSingleton(true);
+        when(schemaService.listSupportedFeatures(layer)).thenReturn(asList(singleValueFeature));
+        doReturn(emptyList()).when(learningRecordService).listLearningRecords(TEST_USER, TEST_USER,
+                layer);
+
+        var ann = cas.createFS(cas.getTypeSystem().getType(typeDesc.getName()));
+        FSUtil.setFeature(ann, "value", "anything");
+        cas.addFsToIndexes(ann);
+
+        var suggestionA = newSuggestion(singleValueRecommender, "happy", 1);
+        var suggestionB = newSuggestion(singleValueRecommender, "sad", 2);
+        var groups = groups(suggestionA, suggestionB);
+
+        sut.calculateSuggestionVisibility(TEST_USER, doc, cas, TEST_USER, layer, groups, 0, 0);
+
+        assertThat(invisible(groups)).containsExactlyInAnyOrder(suggestionA, suggestionB);
+    }
+
+    @Test
+    void testRejectedSuggestionIsHidden() throws Exception
+    {
+        when(schemaService.listSupportedFeatures(layer)).thenReturn(asList(singleValueFeature));
+
+        var record = new LearningRecord();
+        record.setUser(TEST_USER);
+        record.setSourceDocument(doc);
+        record.setLayer(layer);
+        record.setAnnotationFeature(singleValueFeature);
+        record.setAnnotation("happy");
+        record.setUserAction(LearningRecordUserAction.REJECTED);
+        doReturn(asList(record)).when(learningRecordService).listLearningRecords(TEST_USER,
+                TEST_USER, layer);
+
+        var suggestion = newSuggestion(singleValueRecommender, "happy", 1);
+        var groups = groups(suggestion);
+
+        sut.calculateSuggestionVisibility(TEST_USER, doc, cas, TEST_USER, layer, groups, 0, 0);
+
+        assertThat(invisible(groups)).containsExactly(suggestion);
+    }
+
+    @Test
+    void testMultiValuedFeatureWithMatchingLabelHidesSuggestion() throws Exception
+    {
+        when(schemaService.listSupportedFeatures(layer)).thenReturn(asList(multiValueFeature));
+        doReturn(emptyList()).when(learningRecordService).listLearningRecords(TEST_USER, TEST_USER,
+                layer);
+
+        var ann = cas.createFS(cas.getTypeSystem().getType(typeDesc.getName()));
+        FSUtil.setFeature(ann, "values", asList("happy", "calm"));
+        cas.addFsToIndexes(ann);
+
+        var suggestion = newSuggestion(multiValueRecommender, "happy", 1);
+        var groups = groups(suggestion);
+
+        sut.calculateSuggestionVisibility(TEST_USER, doc, cas, TEST_USER, layer, groups, 0, 0);
+
+        assertThat(invisible(groups)).containsExactly(suggestion);
+    }
+
+    @Test
+    void testMultiValuedFeatureWithDifferentLabelsKeepsSuggestionVisible() throws Exception
+    {
+        when(schemaService.listSupportedFeatures(layer)).thenReturn(asList(multiValueFeature));
+        doReturn(emptyList()).when(learningRecordService).listLearningRecords(TEST_USER, TEST_USER,
+                layer);
+
+        var ann = cas.createFS(cas.getTypeSystem().getType(typeDesc.getName()));
+        FSUtil.setFeature(ann, "values", asList("sad", "angry"));
+        cas.addFsToIndexes(ann);
+
+        var suggestion = newSuggestion(multiValueRecommender, "happy", 1);
+        var groups = groups(suggestion);
+
+        sut.calculateSuggestionVisibility(TEST_USER, doc, cas, TEST_USER, layer, groups, 0, 0);
+
+        assertThat(visible(groups)).containsExactly(suggestion);
+    }
+
+    private MetadataSuggestion newSuggestion(Recommender aRecommender, String aLabel, int aId)
+    {
+        return MetadataSuggestion.builder() //
+                .withId(aId) //
+                .withRecommender(aRecommender) //
+                .withDocument(doc) //
+                .withLabel(aLabel) //
+                .build();
+    }
+
+    private SuggestionDocumentGroup<MetadataSuggestion> groups(MetadataSuggestion... aSuggestions)
+    {
+        return SuggestionDocumentGroup.groupsOfType(MetadataSuggestion.class, asList(aSuggestions));
+    }
+
+    private static List<MetadataSuggestion> visible(
+            Collection<SuggestionGroup<MetadataSuggestion>> aGroups)
+    {
+        return aGroups.stream() //
+                .flatMap(SuggestionGroup::stream) //
+                .filter(AnnotationSuggestion::isVisible) //
+                .toList();
+    }
+
+    private static List<MetadataSuggestion> invisible(
+            Collection<SuggestionGroup<MetadataSuggestion>> aGroups)
+    {
+        return aGroups.stream() //
+                .flatMap(SuggestionGroup::stream) //
+                .filter(s -> !s.isVisible()) //
+                .toList();
+    }
+}


### PR DESCRIPTION
**What's in the PR**
- Rewrote `MetadataSuggestionSupport.hideSpanSuggestionsThatMatchAnnotations` to read existing feature values via `FeatureSupportRegistry` and iterate over `Iterable` values, so multi-valued features (e.g. `StringArray`) are properly compared against suggestion labels instead of falling through `getFeatureValueAsString` and never matching.
- Injected `FeatureSupportRegistry` into `MetadataSuggestionSupport` and wired it through `DocumentMetadataLayerSupportAutoConfiguration`.
- Added `MetadataSuggestionVisibilityCalculationTest` covering single-value match/no-match, singleton hide-all, learning-record rejection, and the previously broken multi-value match/no-match cases.
- Updated `MetadataSuggestionExtractionTest` and added `inception-feature-string` test dependency for the new visibility test.

**How to test manually**
* See issue description

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
