### PR TITLE
Issue #6014: Document goes not scroll to last position if a feature was updated

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/TypeAdapter_ImplBase.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/TypeAdapter_ImplBase.java
@@ -36,6 +36,7 @@ import java.util.function.Supplier;
 
 import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.FeatureStructure;
+import org.apache.uima.jcas.tcas.Annotation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationEvent;
@@ -169,10 +170,10 @@ public abstract class TypeAdapter_ImplBase
         if (candidates.isEmpty()) {
 
             // Heuristic: let's assume that annotation with the highest address is the latest one
-            org.apache.uima.jcas.tcas.Annotation latest = null;
-            for (var ann : aCAS.select(org.apache.uima.jcas.tcas.Annotation.class)) {
+            Annotation latest = null;
+            for (var ann : aCAS.select(Annotation.class)) {
                 var addr = ICasUtil.getAddr(ann);
-                if (latest == null || addr < ICasUtil.getAddr(latest)) {
+                if (latest == null || addr > ICasUtil.getAddr(latest)) {
                     latest = ann;
                 }
             }
@@ -253,6 +254,10 @@ public abstract class TypeAdapter_ImplBase
         featureSupport.setFeatureValue(aCas, aFeature, aAddress, aValue);
 
         publishFeatureValueUpdated(aDocument, aUsername, fs, aFeature, featureSupport, oldValue);
+
+        if (fs instanceof Annotation ann) {
+            setResumptionLocation(aCas, ann.getBegin());
+        }
 
         clearHiddenFeatures(aDocument, aUsername, fs);
     }
@@ -508,6 +513,10 @@ public abstract class TypeAdapter_ImplBase
             featureSupport.setFeatureValue(fs.getCAS(), aFeature, getAddr(fs), aValue);
 
             publishFeatureValueUpdated(document, username, fs, aFeature, featureSupport, oldValue);
+
+            if (fs instanceof Annotation ann) {
+                setResumptionLocation(fs.getCAS(), ann.getBegin());
+            }
 
             featureUpdated = true;
         }

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorVisualizer.svelte.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorVisualizer.svelte.ts
@@ -46,6 +46,11 @@ export const INFO_LABEL = 'ℹ️';
 export const WARN_LABEL = '⚠️';
 
 const SCROLL_ITERATION_MS = 100;
+// After scroll position stabilises we wait this long for any late DOM mutations
+// (e.g. async section-summary spacers from a render that runs after the scroll
+// has reached its target) before declaring the scroll complete. The MutationObserver
+// installed during scrolling cancels the deferred completion if a mutation arrives.
+const SCROLL_QUIET_PERIOD_MS = 400;
 const RESIZE_DEBOUNCE_MS = 500;
 const LOAD_ANNOTATIONS_DEBOUNCE_MS = 150;
 const PING_MARKER_REMOVAL_DELAY_MS = 2000;
@@ -72,6 +77,8 @@ export class ApacheAnnotatorVisualizer {
 
     private scrolling = false;
     private lastScrollTop: number | undefined = undefined;
+    private lastMarkerTop: number | undefined = undefined;
+    private scrollMutationObserver: MutationObserver | undefined = undefined;
     private removeScrollMarkers: (() => void)[] = [];
     private removeScrollMarkersTimeout: number | undefined = undefined;
     private removePingMarkers: (() => void)[] = [];
@@ -349,6 +356,16 @@ export class ApacheAnnotatorVisualizer {
         }
 
         const loader = () => {
+            // Defer loading while a scroll is in progress — re-rendering during
+            // every scroll iteration would generate a lot of useless ajax/DOM work
+            // for intermediate viewport ranges nobody will look at.
+            //
+            // The scrollTo loop releases the deferral (sets `scrolling = false`) at
+            // the moment it believes the scroll has reached its target, then waits
+            // through a quiet period during which the loader is allowed to run. If
+            // the resulting render mutates the layout, the scroll MutationObserver
+            // re-suspends scrolling and starts another iteration; otherwise the
+            // quiet period elapses and the scroll completes.
             if (this.scrolling) {
                 this.loadAnnotationsTimeout = this.schedule(LOAD_ANNOTATIONS_DEBOUNCE_MS, loader);
                 return;
@@ -699,9 +716,15 @@ export class ApacheAnnotatorVisualizer {
     }
 
     private clearScrollMarkers() {
+        if (this.scrollMutationObserver) {
+            this.scrollMutationObserver.disconnect();
+            this.scrollMutationObserver = undefined;
+        }
         if (this.removeScrollMarkersTimeout) {
             this.scrolling = false;
-            this.cancelScheduled(this.removeScrollMarkersTimeout);
+            // Scroll-loop timers are real setTimeouts (not idle callbacks), so use
+            // clearTimeout directly rather than going through cancelScheduled.
+            window.clearTimeout(this.removeScrollMarkersTimeout);
             this.removeScrollMarkersTimeout = undefined;
             this.removeScrollMarkers.forEach((remove) => remove());
             this.removeScrollMarkers = [];
@@ -745,8 +768,13 @@ export class ApacheAnnotatorVisualizer {
     }
 
     scrollTo(args: { offset: number; position?: string; pingRanges?: Offsets[] }): void {
+        console.debug('Scrolling to offset ' + args.offset);
+
         const range = offsetToRange(this.root, args.offset, args.offset);
-        if (!range) return;
+        if (!range) {
+            console.debug('Could not determine scroll target range for offset ' + args.offset);
+            return;
+        }
 
         this.clearScrollMarkers();
         this.clearPingMarkers();
@@ -787,28 +815,37 @@ export class ApacheAnnotatorVisualizer {
             // are set on our scroll root element. For such a case, we schedule a new scroll action
             // which would then take the new padding into account. We do this as long as the transient
             // markers are still there.
+            // Use real setTimeout (not the schedule()/requestIdleCallback abstraction)
+            // for scroll-loop timing: requestIdleCallback fires as soon as the browser
+            // is idle, treating its `timeout` argument as a max wait — useless for
+            // implementing real delays between scroll iterations or a quiet period.
             var scrollIntoViewFunc = () => {
+                this.removeScrollMarkersTimeout = undefined;
                 finalScrollTarget.scrollIntoView({
                     behavior: 'auto',
                     block: 'center',
                     inline: 'nearest',
                 });
-                if (this.removeScrollMarkers.length > 0) {
-                    this.removeScrollMarkersTimeout = this.schedule(
-                        SCROLL_ITERATION_MS,
-                        scrollIntoViewFunc
-                    );
-                }
 
                 const wrapper = this.root.closest('.i7n-wrapper');
                 const scrollTop = wrapper?.scrollTop || this.root.scrollTop || 0;
+                this.lastMarkerTop = finalScrollTarget.getBoundingClientRect().top;
                 if (scrollTop === this.lastScrollTop) {
-                    this.scrollToComplete(args.pingRanges);
+                    // Scroll position is stable. Release the loader-deferral so any
+                    // pending annotation render can run, then wait through a quiet
+                    // period. If the render mutates the layout the MutationObserver
+                    // will re-suspend scrolling and reschedule another iteration; if
+                    // nothing mutates we complete.
+                    this.scrolling = false;
+                    this.removeScrollMarkersTimeout = window.setTimeout(() => {
+                        this.removeScrollMarkersTimeout = undefined;
+                        this.scrollToComplete(args.pingRanges);
+                    }, SCROLL_QUIET_PERIOD_MS);
                 } else {
                     this.lastScrollTop = scrollTop;
-                    this.removeScrollMarkersTimeout = this.schedule(
-                        SCROLL_ITERATION_MS,
-                        scrollIntoViewFunc
+                    this.removeScrollMarkersTimeout = window.setTimeout(
+                        scrollIntoViewFunc,
+                        SCROLL_ITERATION_MS
                     );
                 }
             };
@@ -816,9 +853,47 @@ export class ApacheAnnotatorVisualizer {
             this.scrolling = true;
             this.sectionAnnotationVisualizer.suspend();
             this.sectionAnnotationCreator.suspend();
-            this.removeScrollMarkersTimeout = this.schedule(
-                SCROLL_ITERATION_MS,
-                scrollIntoViewFunc
+
+            // Watch the scroll container for DOM mutations during scrolling. Async
+            // renders (e.g. section summary spacers) can shift content above the
+            // marker and push it out of the viewport. On any mutation we invalidate
+            // the stability tracker and reschedule another iteration so the loop
+            // re-scrolls to the marker's new position.
+            const scrollContainer = this.root.closest('.i7n-wrapper') || this.root;
+            this.scrollMutationObserver?.disconnect();
+            this.scrollMutationObserver = new MutationObserver(() => {
+                if (this.removeScrollMarkers.length === 0) return;
+                // Filter out mutations that don't actually move the marker — e.g. a
+                // re-render that clears and re-inserts the same section spacers in
+                // the same positions, or a `root.normalize()` reshuffling text nodes
+                // by sub-pixel amounts. Only react when the marker's viewport
+                // position has shifted by at least one pixel.
+                const markerTop = finalScrollTarget.getBoundingClientRect().top;
+                if (
+                    this.lastMarkerTop !== undefined &&
+                    Math.abs(markerTop - this.lastMarkerTop) < 1
+                ) {
+                    return;
+                }
+
+                this.lastScrollTop = undefined;
+                this.scrolling = true;
+                if (this.removeScrollMarkersTimeout) {
+                    window.clearTimeout(this.removeScrollMarkersTimeout);
+                }
+                this.removeScrollMarkersTimeout = window.setTimeout(
+                    scrollIntoViewFunc,
+                    SCROLL_ITERATION_MS
+                );
+            });
+            this.scrollMutationObserver.observe(scrollContainer, {
+                childList: true,
+                subtree: true,
+            });
+
+            this.removeScrollMarkersTimeout = window.setTimeout(
+                scrollIntoViewFunc,
+                SCROLL_ITERATION_MS
             );
         }
     }
@@ -850,6 +925,7 @@ export class ApacheAnnotatorVisualizer {
         this.sectionAnnotationCreator.resume();
         this.sectionAnnotationVisualizer.resume();
         this.lastScrollTop = undefined;
+        this.lastMarkerTop = undefined;
 
         // Workaround for Firefox somehow scrolling the page body a bit when we scroll
         // inside the iframe during page loading

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorVisualizer.svelte.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorVisualizer.svelte.ts
@@ -98,8 +98,9 @@ export class ApacheAnnotatorVisualizer {
 
         this.tracker = new ViewportTracker(
                 this.root, () => {
-                    this.loadAnnotations()
-                }, 
+                    // We can optimize scrolling by deferring rendering during the scroll
+                    this.doLoadAnnotations({ allowRenderSkip: true });
+                },
                 {
                     ignoreSelector: '.iaa-section-control, .iaa-vertical-marker-focus, .iaa-ping-marker, iaa-visible-annotations-panel, iaa-visible-annotations-panel-spacer'
                 });
@@ -350,6 +351,11 @@ export class ApacheAnnotatorVisualizer {
     }
 
     loadAnnotations(): void {
+        this.doLoadAnnotations({ allowRenderSkip: false });
+    }
+
+    private doLoadAnnotations(opts: { allowRenderSkip: boolean }): void {
+        const allowSkip = opts.allowRenderSkip;
         if (this.loadAnnotationsTimeout) {
             this.cancelScheduled(this.loadAnnotationsTimeout);
             this.loadAnnotationsTimeout = undefined;
@@ -388,14 +394,14 @@ export class ApacheAnnotatorVisualizer {
                 const endTime = performance.now();
                 console.log(`Loading annotations took ${endTime - startTime}ms`);
 
-                this.renderAnnotations(this.data);
+                this.renderAnnotations(this.data, { allowSkip });
             });
         };
 
         this.loadAnnotationsTimeout = this.schedule(LOAD_ANNOTATIONS_DEBOUNCE_MS, loader);
     }
 
-    private renderAnnotations(doc: AnnotatedText): void {
+    private renderAnnotations(doc: AnnotatedText, opts?: { allowSkip?: boolean }): void {
         // Pause tracker while performing DOM writes to avoid visibility feedback loops.
         this.tracker?.pause();
 
@@ -419,7 +425,7 @@ export class ApacheAnnotatorVisualizer {
             }
 
             if (annotatorState.showAggregatedLabels) {
-                this.sectionAnnotationVisualizer.render(doc);
+                this.sectionAnnotationVisualizer.render(doc, opts);
             } else {
                 this.sectionAnnotationVisualizer.clear();
             }

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorVisualizer.svelte.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorVisualizer.svelte.ts
@@ -926,14 +926,6 @@ export class ApacheAnnotatorVisualizer {
         this.sectionAnnotationVisualizer.resume();
         this.lastScrollTop = undefined;
         this.lastMarkerTop = undefined;
-
-        // Workaround for Firefox somehow scrolling the page body a bit when we scroll
-        // inside the iframe during page loading
-        if (navigator.userAgent.includes('Firefox')) {
-            if (window?.parent?.document?.body?.scrollTop) {
-                window.parent.document.body.scrollTop = 0;
-            }
-        }
     }
 
     private clearHighlights(): void {

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionAnnotationVisualizer.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionAnnotationVisualizer.ts
@@ -29,6 +29,7 @@ export class SectionAnnotationVisualizer {
     private ajax: DiamAjax;
     private root: Element;
     private suspended = false;
+    private lastFingerprint: string | undefined = undefined;
 
     public constructor(root: Element, ajax: DiamAjax, sectionSelector: string) {
         this.root = root;
@@ -60,15 +61,29 @@ export class SectionAnnotationVisualizer {
     }
 
     render(doc: AnnotatedText) {
-        if (this.sectionSelector) {
-            this.clear();
-            this.renderSectionGroups(doc);
-            this.ensurePanelVisibility('render');
+        if (!this.sectionSelector) return;
+
+        // Skip rerendering if the visible section headers did not change.
+        const fingerprint = this.computeFingerprint(doc);
+        if (fingerprint === this.lastFingerprint) {
+            this.ensurePanelVisibility('render-skipped');
+            return;
         }
+
+        this.clear();
+        this.renderSectionGroups(doc);
+        this.ensurePanelVisibility('render');
+        this.lastFingerprint = fingerprint;
+    }
+
+    private computeFingerprint(doc: AnnotatedText): string {
+        if (!doc.spans) return '';
+        return Array.from(doc.spans.keys()).sort().join(',');
     }
 
     clear() {
         if (this.sectionSelector) {
+            this.lastFingerprint = undefined;
             this.root.parentElement
                 ?.querySelectorAll('.iaa-visible-annotations-panel')
                 .forEach((e) => e.remove());

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionAnnotationVisualizer.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionAnnotationVisualizer.ts
@@ -60,12 +60,15 @@ export class SectionAnnotationVisualizer {
         this.clear();
     }
 
-    render(doc: AnnotatedText) {
+    render(doc: AnnotatedText, opts?: { allowSkip?: boolean }) {
         if (!this.sectionSelector) return;
 
-        // Skip rerendering if the visible section headers did not change.
+        // Default behaviour is always rebuild — safe for any caller that may
+        // have changed annotation properties (label, color, score, …) without
+        // changing the VID set. The tracker callback opts in to `allowSkip`
+        // because during scrolling only the VID set can change.
         const fingerprint = this.computeFingerprint(doc);
-        if (fingerprint === this.lastFingerprint) {
+        if (opts?.allowSkip && fingerprint === this.lastFingerprint) {
             this.ensurePanelVisibility('render-skipped');
             return;
         }

--- a/inception/inception-support-bootstrap/src/main/ts/bootstrap/inception-custom.scss
+++ b/inception/inception-support-bootstrap/src/main/ts/bootstrap/inception-custom.scss
@@ -25,7 +25,11 @@ body {
     width: 100%;
     display: flex;
     flex-direction: column;
-    overflow: hidden;
+    // `clip` rather than `hidden` so html/body are not scroll containers — this
+    // prevents Firefox's focus/anchor auto-scroll from shifting the page by a
+    // few pixels during initial load (which we used to undo with a workaround
+    // in the editor's scrollToComplete).
+    overflow: clip;
 }
 
 .page-header {
@@ -308,6 +312,7 @@ span.form-control {
 .dev-warnings {
     .alert {
         padding: 0px 5px 0px 5px;
+        margin: 0;
         border: none;
         color: yellow;
         background-color: red;


### PR DESCRIPTION
**What's in the PR**
* Record scroll-to position when a feature is edited, not only when an annotation is added
* Fix scrolling issue when section headers are enabled
* Remove Firefox-specific workaround

**How to test manually**
* Try with and without section headers on different documents

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
