### PR TITLE
#3614 - Float features round really aggressively

### DIFF
--- a/inception/inception-api-annotation/src/main/resources/META-INF/asciidoc/user-guide/projects_layers_feature_number.adoc
+++ b/inception/inception-api-annotation/src/main/resources/META-INF/asciidoc/user-guide/projects_layers_feature_number.adoc
@@ -33,4 +33,7 @@
 
 | Editor Type
 | Select which editor should be used for modifying this features value.
+
+| Decimals
+| Only visible for float features. Determines the number of decimal places displayed in the editor (0–10, default: 3).
 |====

--- a/inception/inception-feature-number/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/number/NumberFeatureEditor.java
+++ b/inception/inception-feature-number/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/number/NumberFeatureEditor.java
@@ -57,7 +57,9 @@ public class NumberFeatureEditor<T extends Number>
             break;
         }
         case CAS.TYPE_NAME_FLOAT: {
-            field = new NumberTextField<>("value", Float.class);
+            var options = NumberFeatureTraitsEditor.buildNumericOptions(Float.class,
+                    aTraits.getDecimals());
+            field = new NumberTextField<>("value", Float.class, options);
             if (aTraits.isLimited()) {
                 field.setMinimum(aTraits.getMinimum().floatValue());
                 field.setMaximum(aTraits.getMaximum().floatValue());

--- a/inception/inception-feature-number/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/number/NumberFeatureTraits.java
+++ b/inception/inception-feature-number/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/number/NumberFeatureTraits.java
@@ -34,6 +34,8 @@ public class NumberFeatureTraits
 {
     private static final long serialVersionUID = -2395185084802071593L;
 
+    public static final int MAX_DECIMALS = 10;
+
     public enum EditorType
     {
         @JsonEnumDefaultValue
@@ -58,6 +60,7 @@ public class NumberFeatureTraits
     private Number minimum = 0;
     private Number maximum = 0;
     private EditorType editorType = SPINNER;
+    private int decimals = 3;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private Number defaultValue;
@@ -105,6 +108,16 @@ public class NumberFeatureTraits
     public void setEditorType(EditorType aEditorType)
     {
         editorType = aEditorType;
+    }
+
+    public int getDecimals()
+    {
+        return decimals;
+    }
+
+    public void setDecimals(int aDecimals)
+    {
+        decimals = Math.max(0, Math.min(MAX_DECIMALS, aDecimals));
     }
 
     public Number getDefaultValue()

--- a/inception/inception-feature-number/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/number/NumberFeatureTraitsEditor.html
+++ b/inception/inception-feature-number/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/number/NumberFeatureTraitsEditor.html
@@ -34,7 +34,7 @@
         Minimum
       </label>
       <div class="col-sm-8">
-        <input type="number" style="width:100%;" wicket:id="minimum" data-container="body"></input>
+        <input type="number" class="form-control" wicket:id="minimum" data-container="body"></input>
       </div>
     </div>
     <div class="row form-row" wicket:enclosure="maximum">
@@ -42,7 +42,7 @@
         Maximum
       </label>
       <div class="col-sm-8">
-        <input type="number" style="width:100%;"  wicket:id="maximum" data-container="body"></input>
+        <input type="number" class="form-control" wicket:id="maximum" data-container="body"></input>
       </div>
     </div>
     <div class="row form-row" wicket:enclosure="editorType">
@@ -53,12 +53,20 @@
         <select class="form-select flex-content" wicket:id="editorType"/>
       </div>
     </div>
+    <div class="row form-row" wicket:enclosure="decimals">
+      <label wicket:for="decimals" class="col-sm-4 col-form-label">
+        Decimals
+      </label>
+      <div class="col-sm-8">
+        <input type="number" class="form-control" wicket:id="decimals" data-container="body"></input>
+      </div>
+    </div>
     <div class="row form-row" wicket:enclosure="defaultValue">
       <label wicket:for="defaultValue" class="col-sm-4 col-form-label">
         Default value
       </label>
       <div class="col-sm-8">
-        <input type="number" style="width:100%;" wicket:id="defaultValue" data-container="body"></input>
+        <input type="number" class="form-control" wicket:id="defaultValue" data-container="body"></input>
       </div>
     </div>
   </form>

--- a/inception/inception-feature-number/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/number/NumberFeatureTraitsEditor.java
+++ b/inception/inception-feature-number/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/number/NumberFeatureTraitsEditor.java
@@ -85,19 +85,15 @@ public class NumberFeatureTraitsEditor
         form.setOutputMarkupPlaceholderTag(true);
         add(form);
 
-        Class clazz = Integer.class;
-        Options options = new Options();
-
+        final Class clazz;
         switch (feature.getObject().getType()) {
-        case CAS.TYPE_NAME_INTEGER: {
-            clazz = Integer.class;
-            options.set("format", "'n0'");
-            break;
-        }
-        case CAS.TYPE_NAME_FLOAT: {
+        case CAS.TYPE_NAME_FLOAT:
             clazz = Float.class;
             break;
-        }
+        case CAS.TYPE_NAME_INTEGER:
+        default:
+            clazz = Integer.class;
+            break;
         }
 
         var limited = new CheckBox("limited");
@@ -113,35 +109,77 @@ public class NumberFeatureTraitsEditor
                 () -> traits.getObject().isLimited() && isEditorTypeSelectionPossible()));
         form.add(editorType);
 
-        var minimum = new NumberTextField<>("minimum", clazz, options);
-        minimum.add(visibleWhen(() -> traits.getObject().isLimited()));
-        form.add(minimum);
+        form.add(createMinimumField(form, clazz));
+        form.add(createMaximumField(form, clazz));
+        form.add(createDefaultValueField(clazz));
 
-        var maximum = new NumberTextField<>("maximum", clazz, options);
-        maximum.add(visibleWhen(() -> traits.getObject().isLimited()));
-        form.add(maximum);
+        var decimals = new NumberTextField<>("decimals", Integer.class,
+                new Options().set("format", "'n0'"));
+        decimals.setMinimum(0);
+        decimals.setMaximum(NumberFeatureTraits.MAX_DECIMALS);
+        decimals.add(visibleWhen(() -> clazz == Float.class));
+        decimals.add(new LambdaAjaxFormComponentUpdatingBehavior("change", target -> {
+            form.replace(createMinimumField(form, clazz));
+            form.replace(createMaximumField(form, clazz));
+            form.replace(createDefaultValueField(clazz));
+            target.add(form);
+        }));
+        form.add(decimals);
+    }
 
-        var defaultValue = new NumberTextField<>("defaultValue", clazz, options);
-        defaultValue.add(new LambdaAjaxFormComponentUpdatingBehavior("change"));
-        form.add(defaultValue);
+    static Options buildNumericOptions(Class<?> aClazz, int aDecimals)
+    {
+        var d = Math.max(0, Math.min(NumberFeatureTraits.MAX_DECIMALS, aDecimals));
+        var options = new Options();
+        if (aClazz == Float.class) {
+            options.set("format", d == 0 ? "'#'" : "'#." + "#".repeat(d) + "'");
+            options.set("decimals", d);
+            options.set("step", Math.pow(10, -d));
+        }
+        else {
+            options.set("format", "'n0'");
+        }
+        return options;
+    }
 
-        minimum.add(new LambdaAjaxFormComponentUpdatingBehavior("change", target -> {
+    private NumberTextField<?> createMinimumField(Form<Traits> aForm, Class aClazz)
+    {
+        var field = new NumberTextField<>("minimum", aClazz,
+                buildNumericOptions(aClazz, traits.getObject().getDecimals()));
+        field.add(visibleWhen(() -> traits.getObject().isLimited()));
+        field.add(new LambdaAjaxFormComponentUpdatingBehavior("change", target -> {
             var min = new BigDecimal(traits.getObject().getMinimum().toString());
             var max = new BigDecimal(traits.getObject().getMaximum().toString());
             if (min.compareTo(max) > 0) {
                 traits.getObject().setMaximum(traits.getObject().getMinimum());
             }
-            target.add(form);
+            target.add(aForm);
         }));
+        return field;
+    }
 
-        maximum.add(new LambdaAjaxFormComponentUpdatingBehavior("change", target -> {
+    private NumberTextField<?> createMaximumField(Form<Traits> aForm, Class aClazz)
+    {
+        var field = new NumberTextField<>("maximum", aClazz,
+                buildNumericOptions(aClazz, traits.getObject().getDecimals()));
+        field.add(visibleWhen(() -> traits.getObject().isLimited()));
+        field.add(new LambdaAjaxFormComponentUpdatingBehavior("change", target -> {
             var min = new BigDecimal(traits.getObject().getMinimum().toString());
             var max = new BigDecimal(traits.getObject().getMaximum().toString());
             if (min.compareTo(max) > 0) {
                 traits.getObject().setMinimum(traits.getObject().getMaximum());
             }
-            target.add(form);
+            target.add(aForm);
         }));
+        return field;
+    }
+
+    private NumberTextField<?> createDefaultValueField(Class aClazz)
+    {
+        var field = new NumberTextField<>("defaultValue", aClazz,
+                buildNumericOptions(aClazz, traits.getObject().getDecimals()));
+        field.add(new LambdaAjaxFormComponentUpdatingBehavior("change"));
+        return field;
     }
 
     /**
@@ -179,6 +217,7 @@ public class NumberFeatureTraitsEditor
         result.setMaximum(t.getMaximum());
         result.setEditorType(t.getEditorType());
         result.setDefaultValue(t.getDefaultValue());
+        result.setDecimals(t.getDecimals());
 
         return result;
     }
@@ -197,6 +236,7 @@ public class NumberFeatureTraitsEditor
         t.setEditorType(
                 isEditorTypeSelectionPossible() ? traits.getObject().getEditorType() : SPINNER);
         t.setDefaultValue(traits.getObject().getDefaultValue());
+        t.setDecimals(traits.getObject().getDecimals());
 
         getFeatureSupport().writeTraits(feature.getObject(), t);
     }
@@ -215,6 +255,17 @@ public class NumberFeatureTraitsEditor
         private Number maximum;
         private NumberFeatureTraits.EditorType editorType;
         private Number defaultValue;
+        private int decimals;
+
+        public int getDecimals()
+        {
+            return decimals;
+        }
+
+        public void setDecimals(int aDecimals)
+        {
+            decimals = aDecimals;
+        }
 
         public boolean isLimited()
         {


### PR DESCRIPTION
**What's in the PR**
- Add configurable decimal places for float number features (default: 3)
- Add decimals property to NumberFeatureTraits and wire it through the traits editor
- Configure Kendo NumberTextField with format, decimals, and step options based on the configured precision
- Add "Decimals" field to the traits editor UI, visible only for float features (range 0–10)
- Replace inline style="width:100%;" with form-control CSS class on number inputs in the traits editor HTML
- Fix switch statement in NumberFeatureTraitsEditor to use a proper default case

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [x] PR updates documentation
