### PR TITLE
#2401 - Per-project log should be removed when project is deleted

### DIFF
--- a/inception/inception-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
+++ b/inception/inception-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
@@ -783,6 +783,7 @@ public class ProjectServiceImpl
     @Transactional
     public void removeProject(Project aProject) throws IOException
     {
+        File logFile = null;
         try (var logCtx = withProjectLogger(aProject)) {
             var start = System.currentTimeMillis();
 
@@ -810,10 +811,19 @@ public class ProjectServiceImpl
                 LOG.info("Project directory to be deleted was not found: [{}]. Ignoring.", path);
             }
 
+            logFile = getProjectLogFile(project);
+
             applicationEventPublisher.publishEvent(new AfterProjectRemovedEvent(this, project));
 
             LOG.info("Removed project {} ({})", project,
                     formatDurationWords(System.currentTimeMillis() - start, true, true));
+        }
+
+        // Delete the per-project log file after the logger MDC context has been closed so no
+        // further log lines get routed to it. Best-effort: log appenders may still hold the
+        // handle briefly on some platforms.
+        if (logFile != null && logFile.exists() && !FileUtils.deleteQuietly(logFile)) {
+            LOG.warn("Could not delete project log file: [{}]", logFile);
         }
     }
 

--- a/inception/inception-project/src/test/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImplTest.java
+++ b/inception/inception-project/src/test/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImplTest.java
@@ -290,6 +290,19 @@ public class ProjectServiceImplTest
         assertThat(sut.listRoles(testProject, beate)).isEmpty();
     }
 
+    @Test
+    public void thatRemovingProjectAlsoDeletesProjectLogFile() throws Exception
+    {
+        var logFile = sut.getProjectLogFile(testProject);
+        logFile.getParentFile().mkdirs();
+        assertThat(logFile.createNewFile()).isTrue();
+        assertThat(logFile).exists();
+
+        sut.removeProject(testProject);
+
+        assertThat(logFile).doesNotExist();
+    }
+
     @SpringBootConfiguration
     public static class SpringConfig
     {


### PR DESCRIPTION
**What's in the PR**
- Delete per-project log file when removing a project
- Move log file deletion after the logger MDC context is closed to avoid writing to a deleted file
- Add best-effort deletion with a warning if the file cannot be removed (e.g. due to platform file handle retention)
- Add test to verify that removing a project also deletes its log file

**How to test manually**
* Delete a project
* Check if its log file is gone

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
