### PR TITLE
#1911 - Log out user when revoking roles and indicate when manual re-login is necessary

### DIFF
--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/UserDao.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/UserDao.java
@@ -155,6 +155,13 @@ public interface UserDao
     Set<String> getRoles(User aUser);
 
     /**
+     * @return the roles of the given user as currently committed to the database, ignoring any
+     *         not-yet-flushed in-memory changes. Useful for diffing pre/post state of an
+     *         in-progress update.
+     */
+    Set<Role> getCommittedRoles(String aUsername);
+
+    /**
      * @return the number of enabled users
      */
     long countEnabledUsers();

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/UserDaoImpl.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/UserDaoImpl.java
@@ -28,6 +28,7 @@ import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.INITIAL_CAS_PSEU
 import static de.tudarmstadt.ukp.inception.support.text.TextUtils.containsAnyCharacterMatching;
 import static de.tudarmstadt.ukp.inception.support.text.TextUtils.sortAndRemoveDuplicateCharacters;
 import static de.tudarmstadt.ukp.inception.support.text.TextUtils.startsWithMatching;
+import static jakarta.persistence.FlushModeType.COMMIT;
 import static java.lang.String.join;
 import static org.apache.commons.lang3.StringUtils.contains;
 import static org.apache.commons.lang3.StringUtils.containsAny;
@@ -52,6 +53,7 @@ import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.session.SessionInformation;
 import org.springframework.security.core.session.SessionRegistry;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
@@ -223,17 +225,61 @@ public class UserDaoImpl
     @Transactional
     public User update(User aUser)
     {
-        return entityManager.merge(aUser);
+        // Read previous roles directly from DB so we can detect role removal regardless of
+        // whether aUser is detached or already in the persistence context.
+        var oldRoles = getCommittedRoles(aUser.getUsername());
+        var merged = entityManager.merge(aUser);
+
+        // If any role was *removed*, kick the affected user out of all their sessions so the
+        // revocation takes effect immediately. Pure role grants don't trigger this — the user
+        // can keep working and only needs to re-login to start exercising the new role.
+        // Don't kick the admin doing the change out of their own session.
+        var removed = EnumSet.copyOf(oldRoles);
+        removed.removeAll(merged.getRoles());
+        if (!removed.isEmpty() && !Objects.equals(getCurrentUsername(), merged.getUsername())) {
+            expireAllSessionsFor(merged.getUsername());
+        }
+
+        return merged;
+    }
+
+    /**
+     * Expire all active sessions for the given username so any pending authentication-derived state
+     * (roles, account validity) takes effect on the next request. Sessions are looked up by
+     * username because {@code SpringAuthenticatedWebSession} registers sessions with
+     * {@code Authentication.getName()} regardless of the authentication mechanism (form,
+     * OAuth2/OIDC, SAML2, pre-auth) — so a username-keyed lookup covers all login methods.
+     */
+    private void expireAllSessionsFor(String aUsername)
+    {
+        if (sessionRegistry == null) {
+            return;
+        }
+        sessionRegistry.getAllSessions(aUsername, false).forEach(SessionInformation::expireNow);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Set<Role> getCommittedRoles(String aUsername)
+    {
+        // FlushModeType.COMMIT: do not auto-flush the persistence context before this query.
+        // The caller may have already mutated the managed user entity in memory; we want the
+        // DB-committed roles, not the about-to-be-flushed in-memory ones, so we can detect a
+        // role removal by comparing the pre-update DB state to the post-merge entity state.
+        var rows = entityManager
+                .createQuery("SELECT r FROM User u JOIN u.roles r WHERE u.username = :u",
+                        Role.class)
+                .setParameter("u", aUsername) //
+                .setFlushMode(COMMIT) //
+                .getResultList();
+        return rows.isEmpty() ? EnumSet.noneOf(Role.class) : EnumSet.copyOf(rows);
     }
 
     @Override
     @Transactional
     public int delete(String aUsername)
     {
-        if (sessionRegistry != null) {
-            sessionRegistry.getAllSessions(aUsername, false)
-                    .forEach(_session -> _session.expireNow());
-        }
+        expireAllSessionsFor(aUsername);
 
         var toDelete = get(aUsername);
         if (toDelete == null) {
@@ -249,10 +295,7 @@ public class UserDaoImpl
     @Transactional
     public void delete(User aUser)
     {
-        if (sessionRegistry != null) {
-            sessionRegistry.getAllSessions(aUser.getUsername(), false)
-                    .forEach(_session -> _session.expireNow());
-        }
+        expireAllSessionsFor(aUser.getUsername());
 
         entityManager.remove(entityManager.merge(aUser));
     }
@@ -285,8 +328,7 @@ public class UserDaoImpl
             List<User> usersInRealm = listAllUsersFromRealm(aRealm);
 
             for (User user : usersInRealm) {
-                sessionRegistry.getAllSessions(user.getUsername(), false)
-                        .forEach(_session -> _session.expireNow());
+                expireAllSessionsFor(user.getUsername());
                 entityManager.remove(user);
             }
 

--- a/inception/inception-security/src/test/java/de/tudarmstadt/ukp/clarin/webanno/security/UserDaoImplTest.java
+++ b/inception/inception-security/src/test/java/de/tudarmstadt/ukp/clarin/webanno/security/UserDaoImplTest.java
@@ -22,12 +22,16 @@ import static de.tudarmstadt.ukp.clarin.webanno.security.config.SecurityProperti
 import static de.tudarmstadt.ukp.clarin.webanno.security.config.SecurityPropertiesImpl.DEFAULT_MINIMUM_USERNAME_LENGTH;
 import static de.tudarmstadt.ukp.clarin.webanno.security.config.SecurityPropertiesImpl.DEFAULT_PASSWORD_PATTERN;
 import static de.tudarmstadt.ukp.clarin.webanno.security.config.SecurityPropertiesImpl.DEFAULT_USERNAME_PATTERN;
+import static de.tudarmstadt.ukp.clarin.webanno.security.model.Role.ROLE_REMOTE;
+import static de.tudarmstadt.ukp.clarin.webanno.security.model.Role.ROLE_USER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
+import java.util.EnumSet;
 import java.util.regex.Pattern;
 
 import org.apache.wicket.validation.ValidationError;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,6 +40,10 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.boot.persistence.autoconfigure.EntityScan;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.session.SessionRegistry;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
@@ -63,6 +71,9 @@ class UserDaoImplTest
 
     @Autowired
     UserDaoImpl userDao;
+
+    @Autowired
+    SessionRegistry sessionRegistry;
 
     @BeforeEach
     void setup()
@@ -282,6 +293,66 @@ class UserDaoImplTest
 
         assertThat(userDao.get(username)).isNull();
         assertThat(userDao.get("admin")).isNull();
+    }
+
+    @AfterEach
+    void clearSecurityContext()
+    {
+        SecurityContextHolder.clearContext();
+    }
+
+    private void setCurrentUser(String aUsername)
+    {
+        var auth = UsernamePasswordAuthenticationToken.authenticated(aUsername, "x",
+                AuthorityUtils.NO_AUTHORITIES);
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    @Test
+    void thatRevokingRoleExpiresSessionsOfTheAffectedUser()
+    {
+        var bob = User.builder().withUsername("bob").withRoles(ROLE_USER, ROLE_REMOTE).build();
+        userDao.create(bob);
+        sessionRegistry.registerNewSession("bob-session-1", "bob");
+
+        setCurrentUser("admin"); // a different user is doing the change
+
+        bob.setRoles(EnumSet.of(ROLE_USER)); // revoke ROLE_REMOTE
+        userDao.update(bob);
+
+        assertThat(sessionRegistry.getSessionInformation("bob-session-1").isExpired()).isTrue();
+    }
+
+    @Test
+    void thatGrantingRoleDoesNotExpireSessions()
+    {
+        var bob = User.builder().withUsername("bob").withRoles(ROLE_USER).build();
+        userDao.create(bob);
+        sessionRegistry.registerNewSession("bob-session-1", "bob");
+
+        setCurrentUser("admin");
+
+        bob.setRoles(EnumSet.of(ROLE_USER, ROLE_REMOTE)); // grant ROLE_REMOTE
+        userDao.update(bob);
+
+        assertThat(sessionRegistry.getSessionInformation("bob-session-1").isExpired()).isFalse();
+    }
+
+    @Test
+    void thatRevokingOwnRoleDoesNotExpireOwnSession()
+    {
+        var alice = User.builder().withUsername("alice").withRoles(ROLE_USER, ROLE_REMOTE).build();
+        userDao.create(alice);
+        sessionRegistry.registerNewSession("alice-session-1", "alice");
+
+        setCurrentUser("alice"); // alice is editing herself
+
+        alice.setRoles(EnumSet.of(ROLE_USER));
+        userDao.update(alice);
+
+        assertThat(sessionRegistry.getSessionInformation("alice-session-1").isExpired())
+                .as("Admin must not lock themselves out by adjusting their own roles") //
+                .isFalse();
     }
 
     @Test

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/users/UserDetailPanel.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/users/UserDetailPanel.java
@@ -30,6 +30,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 
 import org.apache.wicket.AttributeModifier;
@@ -372,8 +373,37 @@ public class UserDetailPanel
                 success("User [" + user.getUsername() + "] has been created.");
             }
             else {
+                // Snapshot DB-committed roles before merging so we can detect newly granted
+                // roles and warn that the user must re-login for them to take effect.
+                var committedRoles = userService.getCommittedRoles(user.getUsername());
                 userService.update(user);
                 success("Details for user " + user + " have been updated.");
+
+                var isSelfEdit = user.getUsername().equals(userService.getCurrentUsername());
+
+                var revokedRoles = new HashSet<>(committedRoles);
+                revokedRoles.removeAll(user.getRoles());
+                if (!revokedRoles.isEmpty()) {
+                    if (isSelfEdit) {
+                        info("Revoked permissions will only take effect after you sign out and back in.");
+                    }
+                    else {
+                        info("User [" + user.getUsername()
+                                + "] has been signed out because permissions were revoked.");
+                    }
+                }
+
+                var grantedRoles = new HashSet<>(user.getRoles());
+                grantedRoles.removeAll(committedRoles);
+                if (!grantedRoles.isEmpty()) {
+                    if (isSelfEdit) {
+                        info("Newly granted permissions will only take effect after you sign out and back in.");
+                    }
+                    else {
+                        info("User [" + user.getUsername()
+                                + "] must sign out and back in before newly granted permissions take effect.");
+                    }
+                }
             }
 
             aTarget.addChildren(getPage(), IFeedback.class);


### PR DESCRIPTION
**What's in the PR**
- Add getCommittedRoles() to UserDao to read DB-committed roles bypassing the persistence context auto-flush
- Expire user sessions on role revocation so permission changes take effect immediately
- Skip session expiry when the admin edits their own roles to avoid self-lockout
- Show info message in UserDetailPanel when roles are granted, advising the user to re-login
- Add tests for role revocation session expiry, grant-no-expiry, and self-edit-no-expiry scenarios

**How to test manually**
* Revoke remote API role from your own user - you should retain the role until you re-login and a flash message should tell you so
* Revoke role from another user - user should be logged out
* Grant role to another user - role should only be active when the re-login, but you should get a flash message saying so

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
