### PR TITLE
#6032 - Scrolling to annotation no longer works

### DIFF
--- a/inception/inception-assistant/src/main/ts/build.mjs
+++ b/inception/inception-assistant/src/main/ts/build.mjs
@@ -54,7 +54,9 @@ const defaults = {
 }
 
 fs.mkdirsSync(`${outbase}`)
-fs.emptyDirSync(outbase)
+if (!argv.live) {
+  fs.emptyDirSync(outbase)
+}
 
 if (argv.live) {
   const context = await esbuild.context(defaults)

--- a/inception/inception-brat-editor/src/main/ts/build.mjs
+++ b/inception/inception-brat-editor/src/main/ts/build.mjs
@@ -62,7 +62,9 @@ const defaults = {
 }
 
 fs.mkdirsSync(`${outbase}`)
-fs.emptyDirSync(outbase)
+if (!argv.live) {
+  fs.emptyDirSync(outbase)
+}
 
 if (argv.live) {
   const context1 = await esbuild.context(Object.assign({

--- a/inception/inception-diam-editor/src/main/ts/build.mjs
+++ b/inception/inception-diam-editor/src/main/ts/build.mjs
@@ -63,7 +63,9 @@ const defaults = {
 }
 
 fs.mkdirsSync(`${outbase}`)
-fs.emptyDirSync(outbase)
+if (!argv.live) {
+  fs.emptyDirSync(outbase)
+}
 
 if (argv.live) {
   const context = await esbuild.context(defaults)

--- a/inception/inception-diam/src/main/ts/build.mjs
+++ b/inception/inception-diam/src/main/ts/build.mjs
@@ -42,7 +42,9 @@ const defaults = {
 }
 
 fs.mkdirsSync(`${outbase}`)
-fs.emptyDirSync(outbase)
+if (!argv.live) {
+  fs.emptyDirSync(outbase)
+}
 
 if (argv.live) {
   const context = await esbuild.context(defaults)

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/build.mjs
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/build.mjs
@@ -67,7 +67,9 @@ const defaults = {
 }
 
 fs.mkdirsSync(`${outbase}`)
-fs.emptyDirSync(outbase)
+if (!argv.live) {
+  fs.emptyDirSync(outbase)
+}
 
 if (argv.live) {
   const context = await esbuild.context({

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorVisualizer.svelte.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorVisualizer.svelte.ts
@@ -732,9 +732,16 @@ export class ApacheAnnotatorVisualizer {
             // clearTimeout directly rather than going through cancelScheduled.
             window.clearTimeout(this.removeScrollMarkersTimeout);
             this.removeScrollMarkersTimeout = undefined;
-            this.removeScrollMarkers.forEach((remove) => remove());
-            this.removeScrollMarkers = [];
         }
+        // Always remove existing markers. Gating this on removeScrollMarkersTimeout
+        // means the markers stick around after a scroll completes naturally (the
+        // quiet-period timer clears itself just before calling scrollToComplete,
+        // so the gate is false by the time we get here). The next scrollTo then
+        // creates a second <mark id="iaa-scroll-marker"> alongside the stale one,
+        // and the id-based lookup returns the first/stale match -- which is
+        // already in view -- so no scroll occurs.
+        this.removeScrollMarkers.forEach((remove) => remove());
+        this.removeScrollMarkers = [];
     }
 
     private renderPingMarkers(pingRanges?: Offsets[]) {

--- a/inception/inception-html-recogito-editor/src/main/ts/build.mjs
+++ b/inception/inception-html-recogito-editor/src/main/ts/build.mjs
@@ -66,7 +66,9 @@ const defaults = {
 }
 
 fs.mkdirsSync(`${outbase}`)
-fs.emptyDirSync(outbase)
+if (!argv.live) {
+  fs.emptyDirSync(outbase)
+}
 
 if (argv.live) {
   const context = await esbuild.context({

--- a/inception/inception-io-tei/src/main/ts/build.mjs
+++ b/inception/inception-io-tei/src/main/ts/build.mjs
@@ -43,7 +43,9 @@ const defaults = {
 }
 
 fs.mkdirsSync(`${outbase}`)
-fs.emptyDirSync(outbase)
+if (!argv.live) {
+  fs.emptyDirSync(outbase)
+}
 
 if (argv.live) {
   const context = await esbuild.context(defaults)

--- a/inception/inception-js-api/src/main/ts/build.mjs
+++ b/inception/inception-js-api/src/main/ts/build.mjs
@@ -60,7 +60,9 @@ const defaults = {
 }
 
 fs.mkdirsSync(`${outbase}`)
-fs.emptyDirSync(outbase)
+if (!argv.live) {
+  fs.emptyDirSync(outbase)
+}
 
 if (argv.live) {
   const context = await esbuild.context(defaults)

--- a/inception/inception-pdf-editor2/src/main/ts/build.mjs
+++ b/inception/inception-pdf-editor2/src/main/ts/build.mjs
@@ -66,7 +66,9 @@ const defaults = {
 }
 
 fs.mkdirsSync(`${outbase}`)
-fs.emptyDirSync(outbase)
+if (!argv.live) {
+  fs.emptyDirSync(outbase)
+}
 fs.copySync('pdfjs-web', `${outbase}`)
 fs.copySync('node_modules/pdfjs-dist/build', `${outbase}`)
 fs.copySync('node_modules/pdfjs-dist/cmaps', `${outbase}/cmaps`)

--- a/inception/inception-project-export/src/main/ts/build.mjs
+++ b/inception/inception-project-export/src/main/ts/build.mjs
@@ -55,7 +55,9 @@ const defaults = {
 }
 
 fs.mkdirsSync(`${outbase}`)
-fs.emptyDirSync(outbase)
+if (!argv.live) {
+  fs.emptyDirSync(outbase)
+}
 
 if (argv.live) {
   const context = await esbuild.context(defaults)

--- a/inception/inception-recommendation/src/main/ts/build.mjs
+++ b/inception/inception-recommendation/src/main/ts/build.mjs
@@ -52,7 +52,9 @@ const defaults = {
 }
 
 fs.mkdirsSync(`${outbase}`)
-fs.emptyDirSync(outbase)
+if (!argv.live) {
+  fs.emptyDirSync(outbase)
+}
 
 if (argv.live) {
   const context = await esbuild.context(defaults)

--- a/inception/inception-ui-dashboard-activity/src/main/ts/build.mjs
+++ b/inception/inception-ui-dashboard-activity/src/main/ts/build.mjs
@@ -59,7 +59,9 @@ const defaults = {
 }
 
 fs.mkdirsSync(`${outbase}`)
-fs.emptyDirSync(outbase)
+if (!argv.live) {
+  fs.emptyDirSync(outbase)
+}
 
 if (argv.live) {
   const context1 = await esbuild.context(Object.assign({

--- a/inception/inception-ui-scheduling/src/main/ts/build.mjs
+++ b/inception/inception-ui-scheduling/src/main/ts/build.mjs
@@ -51,7 +51,9 @@ const defaults = {
 }
 
 fs.mkdirsSync(`${outbase}`)
-fs.emptyDirSync(outbase)
+if (!argv.live) {
+  fs.emptyDirSync(outbase)
+}
 
 if (argv.live) {
   const context = await esbuild.context(defaults)


### PR DESCRIPTION
**What's in the PR**
- Fix scroll-to-annotation from sidebar breaking after the first click: `clearScrollMarkers()` in `ApacheAnnotatorVisualizer` was gated on `removeScrollMarkersTimeout` being truthy, but the quiet-period timer clears that field before calling `scrollToComplete` → `clearScrollMarkers`, so stale `<mark id="iaa-scroll-marker">` elements accumulated and `querySelector` returned the first/stale one
- Unrelated: Stop wiping the live-build output directory: across all `build.mjs` files, gate `fs.emptyDirSync(outbase)` on `!argv.live` so live builds no longer delete Java-side outputs that Maven writes into the same `target/classes/...` tree

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
