### PR TITLE
#6056 - Opening project progress chart on fresh project generates error

### DIFF
--- a/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/EventRepositoryImpl.java
+++ b/inception/inception-log/src/main/java/de/tudarmstadt/ukp/inception/log/EventRepositoryImpl.java
@@ -300,7 +300,9 @@ public class EventRepositoryImpl
     {
         var from = aFrom;
         if (from == null) {
-            from = Instant.MIN;
+            // Use EPOCH as a safe lower bound. Instant.MIN cannot be bound as a JDBC
+            // Timestamp because Timestamp.from() overflows on such an extreme value.
+            from = Instant.EPOCH;
         }
 
         // Initialize running counts from current state
@@ -353,7 +355,7 @@ public class EventRepositoryImpl
         }
 
         // Add boundary snapshot at aTo
-        if (!result.isEmpty() && !from.equals(Instant.MIN)) {
+        if (!result.isEmpty() && aFrom != null) {
             var lastSnapshot = result.get(result.size() - 1);
             if (!toDay(lastSnapshot.day()).equals(toDay(from))) {
                 result.add(createSnapshot(from, counts));

--- a/inception/inception-log/src/test/java/de/tudarmstadt/ukp/inception/log/EventRepositoryImplIntegrationTest.java
+++ b/inception/inception-log/src/test/java/de/tudarmstadt/ukp/inception/log/EventRepositoryImplIntegrationTest.java
@@ -209,6 +209,20 @@ public class EventRepositoryImplIntegrationTest
     }
 
     @Test
+    void calculateHistoricalDocumentStates_nullFrom_doesNotOverflowTimestamp()
+    {
+        // Regression test: previously a null `aFrom` was substituted with Instant.MIN,
+        // which overflows when Hibernate binds it as a JDBC Timestamp, producing a 500.
+        var currentStats = new HashMap<SourceDocumentState, Long>();
+        for (var state : SourceDocumentState.values()) {
+            currentStats.put(state, 0L);
+        }
+
+        assertThat(sut.calculateHistoricalDocumentStates(project, currentStats, null)) //
+                .isNotNull();
+    }
+
+    @Test
     void listRecentActivity_limitAndOrdering()
     {
         var base = Instant.now();

--- a/inception/inception-workload/src/main/java/de/tudarmstadt/ukp/inception/workload/ui/ProjectProgressPanelControllerImpl.java
+++ b/inception/inception-workload/src/main/java/de/tudarmstadt/ukp/inception/workload/ui/ProjectProgressPanelControllerImpl.java
@@ -89,6 +89,10 @@ public class ProjectProgressPanelControllerImpl
         }
 
         var stats = documentService.getSourceDocumentStats(project);
+        if (stats.getTotal() == 0) {
+            return emptyList();
+        }
+
         var history = eventRepository.calculateHistoricalDocumentStates(project, stats.toMap(),
                 aFrom.orElse(null));
 


### PR DESCRIPTION
**What's in the PR**
- Fix 500 error when opening the progress chart with no `from` parameter — `Instant.MIN` overflowed `Timestamp.from()` during Hibernate JDBC binding; use `Instant.EPOCH` as the safe lower bound instead.
- Adjust boundary-snapshot guard in `calculateHistoricalDocumentStates` to test `aFrom != null` directly, since the `Instant.MIN` sentinel is no longer used.
- Return an empty progress list when the project has no documents, so the chart shows its existing "No progress data" overlay instead of a flat zero line.
- Add regression test `calculateHistoricalDocumentStates_nullFrom_doesNotOverflowTimestamp` covering the null-`aFrom` path that previously triggered the Timestamp overflow.

**How to test manually**
* See issue description

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
