### PR TITLE
#6060 - Schema-version marker on project search indexes for lazy upgrades

### DIFF
--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/ReindexTask.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/ReindexTask.java
@@ -233,9 +233,10 @@ public class ReindexTask
                     }
                 }
 
-                // After re-indexing, reset the invalid flag
+                // After re-indexing, reset the invalid flag and stamp the schema version
                 if (!getMonitor().isCancelled()) {
                     index.setInvalid(false);
+                    index.setSchemaVersion(index.getPhysicalIndex().getCurrentSchemaVersion());
                 }
 
                 searchService.writeIndex(pooledIndex);

--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchServiceImpl.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchServiceImpl.java
@@ -800,6 +800,16 @@ public class SearchServiceImpl
             throw (new ExecutionException("Index still building. Try again later."));
         }
 
+        // Is the on-disk data shape current? Checked after isInvalid so that an in-flight
+        // rebuild (which only stamps schemaVersion on success) is not duplicated here.
+        var currentSchemaVersion = aIndex.getPhysicalIndex().getCurrentSchemaVersion();
+        if (aIndex.getSchemaVersion() != currentSchemaVersion) {
+            invalidateIndexAndForceIndexRebuild(aProject, aIndex,
+                    "ensureIndexIsCreatedAndValid[schemaMismatch:" + aIndex.getSchemaVersion()
+                            + "!=" + currentSchemaVersion + "]");
+            throw (new ExecutionException("Index still building. Try again later."));
+        }
+
         // Is the index usable - it might be corrupt and needs rebuilding
         try {
             aIndex.getPhysicalIndex().open();
@@ -823,7 +833,7 @@ public class SearchServiceImpl
             entityManager.merge(aIndex);
         }
 
-        enqueueReindexTask(aProject, "ensureIndexIsCreatedAndValid[doesNotExist]");
+        enqueueReindexTask(aProject, aReason);
     }
 
     private void enqueueReindexTask(Project aProject, String aTrigger)

--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/index/PhysicalIndex.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/index/PhysicalIndex.java
@@ -36,6 +36,17 @@ import de.tudarmstadt.ukp.inception.search.model.AnnotationSearchState;
 public interface PhysicalIndex
 {
     /**
+     * Schema version of the data shape this physical index implementation currently produces.
+     * Compared at index-open time against the value stamped on the {@code Index} entity by the last
+     * successful (re)build; a mismatch triggers a lazy rebuild. The numbering is private to each
+     * physical provider, so different providers may reuse the same numbers without conflict.
+     *
+     * @return the current schema version (must be a non-negative integer; bump when the on-disk
+     *         data shape changes in a way that requires a rebuild).
+     */
+    int getCurrentSchemaVersion();
+
+    /**
      * @return if whether the index has data that can be deleted, e.g. index files on disk.
      */
     boolean isCreated();

--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/model/Index.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/model/Index.java
@@ -58,6 +58,9 @@ public class Index
 
     private String physicalProvider;
 
+    @Column(nullable = false)
+    private int schemaVersion;
+
     @Transient
     private PhysicalIndex physicalIndex;
 
@@ -109,6 +112,16 @@ public class Index
     public void setPhysicalProvider(String physicalProvider)
     {
         this.physicalProvider = physicalProvider;
+    }
+
+    public int getSchemaVersion()
+    {
+        return schemaVersion;
+    }
+
+    public void setSchemaVersion(int aSchemaVersion)
+    {
+        schemaVersion = aSchemaVersion;
     }
 
     public PhysicalIndex getPhysicalIndex()

--- a/inception/inception-search-core/src/main/resources/de/tudarmstadt/ukp/inception/search/model/db-changelog.xml
+++ b/inception/inception-search-core/src/main/resources/de/tudarmstadt/ukp/inception/search/model/db-changelog.xml
@@ -37,4 +37,17 @@
       constraintName="FK_index_project" deferrable="false" initiallyDeferred="false"
       onDelete="CASCADE" onUpdate="NO ACTION" referencedColumnNames="id" referencedTableName="project" />
   </changeSet>
+
+  <changeSet author="INCEpTION Team" id="20260522-search-01">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <columnExists tableName="inception_index" columnName="schemaVersion"/>
+      </not>
+    </preConditions>
+    <addColumn tableName="inception_index">
+      <column name="schemaVersion" type="INT" defaultValueNumeric="0">
+        <constraints nullable="false" />
+      </column>
+    </addColumn>
+  </changeSet>
 </databaseChangeLog>

--- a/inception/inception-search-mtas/src/main/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndex.java
+++ b/inception/inception-search-mtas/src/main/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndex.java
@@ -145,6 +145,8 @@ import mtas.search.spans.util.MtasSpanQuery;
 public class MtasDocumentIndex
     implements PhysicalIndex
 {
+    static final int CURRENT_SCHEMA_VERSION = 1;
+
     /**
      * Constant for the field which carries the unique identifier for the index document consisting:
      * {@code [sourceDocumentId]/[annotationDocumentId]}
@@ -339,6 +341,12 @@ public class MtasDocumentIndex
                         project.getName(), project.getId());
             }
         }
+    }
+
+    @Override
+    public int getCurrentSchemaVersion()
+    {
+        return CURRENT_SCHEMA_VERSION;
     }
 
     @Override

--- a/inception/inception-search-mtas/src/test/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndexTest.java
+++ b/inception/inception-search-mtas/src/test/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndexTest.java
@@ -26,6 +26,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.uima.fit.factory.TypeSystemDescriptionFactory.createTypeSystemDescription;
 import static org.apache.uima.util.CasCreationUtils.mergeTypeSystems;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.awaitility.Awaitility.await;
 
 import java.io.ByteArrayInputStream;
@@ -67,6 +68,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.util.AopTestUtils;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -102,11 +104,13 @@ import de.tudarmstadt.ukp.inception.preferences.config.PreferencesServiceAutoCon
 import de.tudarmstadt.ukp.inception.project.api.ProjectService;
 import de.tudarmstadt.ukp.inception.scheduling.config.SchedulingServiceAutoConfiguration;
 import de.tudarmstadt.ukp.inception.schema.config.AnnotationSchemaServiceAutoConfiguration;
+import de.tudarmstadt.ukp.inception.search.ExecutionException;
 import de.tudarmstadt.ukp.inception.search.LayerStatistics;
 import de.tudarmstadt.ukp.inception.search.SearchResult;
 import de.tudarmstadt.ukp.inception.search.SearchServiceImpl;
 import de.tudarmstadt.ukp.inception.search.config.SearchServiceAutoConfiguration;
 import de.tudarmstadt.ukp.inception.search.index.mtas.config.MtasDocumentIndexAutoConfiguration;
+import de.tudarmstadt.ukp.inception.search.model.Index;
 import de.tudarmstadt.ukp.inception.support.spring.ApplicationContextProvider;
 import de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil;
 
@@ -837,6 +841,47 @@ class MtasDocumentIndexTest
         assertThat(countLiveRowsByFieldId(project, fieldId)) //
                 .as("Annotator row is duplicated when consecutive writes share a millisecond timestamp")
                 .isEqualTo(1);
+    }
+
+    @Test
+    void thatStaleSchemaVersionTriggersLazyReindex() throws Exception
+    {
+        var project = new Project("schema-lazy-upgrade");
+        createProject(project);
+
+        var doc = new SourceDocument("doc", project, "text");
+        uploadAndIndexDocument(Pair.of(doc, "Goodbye moon. Hello World."));
+
+        // Mutate the cached entity directly: the lazy upgrade check reads from PooledIndex, not DB
+        var indexEntity = lookupCachedIndex(project);
+        assertThat(indexEntity.getSchemaVersion())
+                .isEqualTo(MtasDocumentIndex.CURRENT_SCHEMA_VERSION);
+        indexEntity.setSchemaVersion(0);
+
+        assertThatExceptionOfType(ExecutionException.class) //
+                .isThrownBy(() -> searchService.query(user, project, "Goodbye"));
+
+        await("Lazy upgrade reindex to complete") //
+                .atMost(60, SECONDS) //
+                .pollInterval(200, MILLISECONDS) //
+                .until(() -> searchService.isIndexValid(project)
+                        && searchService.getIndexProgress(project).isEmpty());
+
+        assertThat(indexEntity.getSchemaVersion())
+                .isEqualTo(MtasDocumentIndex.CURRENT_SCHEMA_VERSION);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Index lookupCachedIndex(Project aProject) throws Exception
+    {
+        SearchServiceImpl target = AopTestUtils.getTargetObject(searchService);
+        var indexesField = SearchServiceImpl.class.getDeclaredField("indexes");
+        indexesField.setAccessible(true);
+        var indexes = (Map<Long, Object>) indexesField.get(target);
+        var pooledIndex = indexes.get(aProject.getId());
+        var getMethod = pooledIndex.getClass().getDeclaredMethod("get");
+        getMethod.setAccessible(true);
+        return (Index) getMethod.invoke(pooledIndex);
     }
 
     private static CAS buildSentenceCas(int aSentenceCount, int aTokensPerSentence) throws Exception


### PR DESCRIPTION
**What's in the PR**
- Add `schemaVersion` column to `inception_index` (Liquibase changeset, default 0 on existing rows).
- Add `int getCurrentSchemaVersion()` to `PhysicalIndex`; each provider declares its own sequence. `MtasDocumentIndex` starts at 1 so pre-#6054 indexes (implicit 0) are below current.
- `ReindexTask` stamps the current version on successful completion, alongside the existing `setInvalid(false)`, under the same `!isCancelled()` guard.
- `SearchServiceImpl#ensureIndexIsCreatedAndValid`: after the existing `isInvalid` branch, treat `schemaVersion != currentSchemaVersion` the same as `invalid=true` — invalidate and enqueue a rebuild. Ordering matters: a CLI `ReindexTask` sets `invalid=true` first and stamps the version only on success, so a query racing against a running rebuild hits the `isInvalid` branch and doesn't enqueue a duplicate.
- Add `MtasDocumentIndexTest#thatStaleSchemaVersionTriggersLazyReindex` covering the stamp and the lazy-upgrade trigger end-to-end.

**How to test manually**
* No specific test procedure

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
