### PR TITLE
#6054 - Annotation counts may be double the expected count

### DIFF
--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchServiceImpl.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchServiceImpl.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.search;
 
+import static de.tudarmstadt.ukp.inception.scheduling.TaskState.NOT_STARTED;
 import static de.tudarmstadt.ukp.inception.scheduling.TaskState.RUNNING;
 import static de.tudarmstadt.ukp.inception.search.model.AnnotationSearchState.KEY_SEARCH_STATE;
 import static java.lang.Integer.MAX_VALUE;
@@ -718,7 +719,12 @@ public class SearchServiceImpl
                 .map(task -> (IndexingTask_ImplBase) task)
                 .filter(task -> aProject.equals(task.getProject())) //
                 .filter(task -> task.getMonitor() != null) //
-                .filter(task -> task.getMonitor().getState() == RUNNING) //
+                // Include NOT_STARTED so that work which has been enqueued but not yet picked up
+                // by a worker thread is also visible. Without this, callers (tests waiting for
+                // indexing to settle, the UI progress indicator, ensureIndexIsCreatedAndValid)
+                // can miss the window between enqueue and the worker transitioning to RUNNING.
+                .filter(task -> task.getMonitor().getState() == NOT_STARTED
+                        || task.getMonitor().getState() == RUNNING) //
                 .toList();
 
         if (tasks.isEmpty()) {

--- a/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchAnnotationSidebar.java
+++ b/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchAnnotationSidebar.java
@@ -561,8 +561,13 @@ public class SearchAnnotationSidebar
         var maybeProgress = searchService.getIndexProgress(project);
         if (maybeProgress.isPresent()) {
             var p = maybeProgress.get();
-            info("Indexing in progress... cannot perform query at this time. " + p.percent() + "% ("
-                    + p.progress() + "/" + p.maxProgress() + ")");
+            if (p.maxProgress() > 0) {
+                info("Indexing in progress... cannot perform query at this time. " + p.percent()
+                        + "% (" + p.progress() + "/" + p.maxProgress() + ")");
+            }
+            else {
+                info("Index update pending... cannot perform query at this time.");
+            }
             aTarget.addChildren(getPage(), IFeedback.class);
             return;
         }


### PR DESCRIPTION
**What's in the PR**
- Make `SearchServiceImpl.getIndexProgress` also count `NOT_STARTED` indexing tasks so callers don't miss the window between enqueue and a worker picking the task up
- Distinguish queued from running indexing in the search sidebar: show "Index update pending..." when no task has started yet, keep the percentage message once one has

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
