### PR TITLE
#6064 - Show Lucene version of KB full-text index and offer one-click upgrade

### DIFF
--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseService.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseService.java
@@ -641,5 +641,11 @@ public interface KnowledgeBaseService
 
     long getIndexSize(KnowledgeBase aKB);
 
+    Optional<String> getIndexVersion(KnowledgeBase aKB);
+
+    boolean isIndexUpgradeAvailable(KnowledgeBase aKB);
+
+    void upgradeIndex(KnowledgeBase aKB) throws Exception;
+
     void configure(KnowledgeBase aKb, KnowledgeBaseProfile aWikidataProfile);
 }

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
@@ -71,6 +71,12 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.lucene.index.IndexFormatTooNewException;
+import org.apache.lucene.index.IndexFormatTooOldException;
+import org.apache.lucene.index.IndexNotFoundException;
+import org.apache.lucene.index.IndexUpgrader;
+import org.apache.lucene.index.SegmentInfos;
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.util.Version;
 import org.eclipse.rdf4j.common.transaction.IsolationLevels;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
@@ -334,6 +340,71 @@ public class KnowledgeBaseServiceImpl
     {
         var indexDir = new File(kbRepositoriesRoot, "indexes/" + aKB.getRepositoryId());
         return FileUtils.sizeOfDirectory(indexDir);
+    }
+
+    @Override
+    public Optional<String> getIndexVersion(KnowledgeBase aKB)
+    {
+        return readIndexCommitVersion(aKB).map(Object::toString);
+    }
+
+    @Override
+    public boolean isIndexUpgradeAvailable(KnowledgeBase aKB)
+    {
+        if (LOCAL != aKB.getType()) {
+            return false;
+        }
+        return readIndexCommitVersion(aKB) //
+                .map(v -> v.major < Version.LATEST.major) //
+                .orElse(false);
+    }
+
+    private Optional<Version> readIndexCommitVersion(KnowledgeBase aKB)
+    {
+        var indexDir = new File(kbRepositoriesRoot, "indexes/" + aKB.getRepositoryId());
+        if (!indexDir.isDirectory()) {
+            return Optional.empty();
+        }
+
+        try (var dir = FSDirectory.open(indexDir.toPath())) {
+            var segmentInfos = SegmentInfos.readLatestCommit(dir);
+            return Optional.ofNullable(segmentInfos.getCommitLuceneVersion());
+        }
+        catch (IndexNotFoundException e) {
+            return Optional.empty();
+        }
+        catch (IOException e) {
+            LOG.debug("Unable to read Lucene index version for KB [{}]", aKB.getRepositoryId(), e);
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public void upgradeIndex(KnowledgeBase aKB) throws Exception
+    {
+        if (LOCAL != aKB.getType()) {
+            throw new IllegalArgumentException("Index upgrade is only supported on local KBs");
+        }
+
+        var repo = repoManager.getRepository(aKB.getRepositoryId());
+        if (!(repo instanceof SailRepository sailRepo)) {
+            throw new IllegalArgumentException(
+                    "Index upgrade is not supported on [" + repo.getClass() + "] repositories");
+        }
+
+        var sail = sailRepo.getSail();
+        if (!(sail instanceof LuceneSail luceneSail)) {
+            throw new IllegalArgumentException(
+                    "Index upgrade is not supported on [" + sail.getClass() + "] repositories");
+        }
+
+        var luceneDir = luceneSail.getParameter(LuceneSail.LUCENE_DIR_KEY);
+        // Shut down the whole repository to release the index files. The repository
+        // manager will create a fresh repository on the next access.
+        sailRepo.shutDown();
+        try (var dir = FSDirectory.open(new File(luceneDir).toPath())) {
+            new IndexUpgrader(dir).upgrade();
+        }
     }
 
     @Override
@@ -1652,21 +1723,28 @@ public class KnowledgeBaseServiceImpl
             conn.commit();
         }
         catch (SailException e) {
-            if (ExceptionUtils.hasCause(e, IndexFormatTooNewException.class)) {
-                LOG.warn("Unable to access index: {}", e.getMessage());
-                LOG.info("Downgrade detected - trying to rebuild index from scratch...");
+            if (ExceptionUtils.indexOfThrowable(e, IndexFormatTooNewException.class) == -1
+                    && ExceptionUtils.indexOfThrowable(e, IndexFormatTooOldException.class) == -1) {
+                throw e;
+            }
 
-                var luceneDir = luceneSail.getParameter(LuceneSail.LUCENE_DIR_KEY);
-                luceneSail.shutDown();
-                FileUtils.deleteQuietly(new File(luceneDir));
-                luceneSail.init();
+            LOG.warn("Unable to access index: {}", e.getMessage());
+            LOG.info("Index format mismatch detected - trying to rebuild index from scratch...");
 
-                // Only try to rebuild once - so no recursion here!
-                try (var conn = getConnection(aKB)) {
-                    ReindexingUtils.reindex(luceneSail);
-                    // luceneSail.reindex();
-                    conn.commit();
-                }
+            var luceneDir = luceneSail.getParameter(LuceneSail.LUCENE_DIR_KEY);
+            // Shut down the whole repository so the manager will create a fresh one on
+            // next access. See upgradeIndex() for why we cannot shutDown/init the
+            // LuceneSail directly.
+            ((SailRepository) repo).shutDown();
+            FileUtils.deleteQuietly(new File(luceneDir));
+
+            var freshSail = (LuceneSail) ((SailRepository) repoManager
+                    .getRepository(aKB.getRepositoryId())).getSail();
+
+            // Only try to rebuild once - so no recursion here!
+            try (var conn = getConnection(aKB)) {
+                ReindexingUtils.reindex(freshSail);
+                conn.commit();
             }
         }
     }

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/FullTextIndexUpgradeTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/FullTextIndexUpgradeTest.java
@@ -27,6 +27,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.lucene.util.Version;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
 import org.junit.jupiter.api.AfterEach;
@@ -180,6 +181,73 @@ public class FullTextIndexUpgradeTest
                         "http://www.ukp.informatik.tu-darmstadt.de/inception/1.0#example",
                         "http://www.ukp.informatik.tu-darmstadt.de/inception/1.0#green-goblin",
                         "http://www.ukp.informatik.tu-darmstadt.de/inception/1.0#lucky-green");
+    }
+
+    @Test
+    void thatIndexCanBeUpgradedInPlace() throws Exception
+    {
+        copyDirectory(new File(REF_DIR, "lucene-8.11.3"), temp);
+
+        sut = new KnowledgeBaseServiceImpl(repoProperties, kbProperties, entityManager);
+
+        kb.setRepositoryId("pid-1-kbid-");
+        sut.reconfigureLocalKnowledgeBase(kb);
+
+        assertThat(sut.getIndexVersion(kb))
+                .hasValueSatisfying(v -> assertThat(v).startsWith("8.11.3"));
+        assertThat(sut.isIndexUpgradeAvailable(kb)).isTrue();
+
+        sut.upgradeIndex(kb);
+
+        assertThat(sut.getIndexVersion(kb))
+                .hasValueSatisfying(v -> assertThat(v).startsWith(Version.LATEST.major + "."));
+        assertThat(sut.isIndexUpgradeAvailable(kb)).isFalse();
+
+        List<KBHandle> results;
+        try (var conn = sut.getConnection(kb)) {
+            var prefLabels = SPARQLQueryBuilder.forItems(kb).resolvePrefLabelProperties(conn);
+            var builder = SPARQLQueryBuilder //
+                    .forItems(kb) //
+                    .withPrefLabelProperties(prefLabels) //
+                    .withLabelStartingWith("Green Go");
+            results = builder.asHandles(conn, true);
+        }
+
+        assertThat(results) //
+                .extracting(KBHandle::getIdentifier) //
+                .containsExactly(
+                        "http://www.ukp.informatik.tu-darmstadt.de/inception/1.0#green-goblin");
+    }
+
+    @Test
+    void thatRebuildRecoversFromIndexFormatTooOld() throws Exception
+    {
+        copyDirectory(new File(REF_DIR, "lucene-7.7.3"), temp);
+
+        sut = new KnowledgeBaseServiceImpl(repoProperties, kbProperties, entityManager);
+
+        kb.setRepositoryId("pid-1-kbid-");
+        sut.reconfigureLocalKnowledgeBase(kb);
+
+        sut.rebuildFullTextIndex(kb);
+
+        assertThat(sut.getIndexVersion(kb))
+                .hasValueSatisfying(v -> assertThat(v).startsWith(Version.LATEST.major + "."));
+
+        List<KBHandle> results;
+        try (var conn = sut.getConnection(kb)) {
+            var prefLabels = SPARQLQueryBuilder.forItems(kb).resolvePrefLabelProperties(conn);
+            var builder = SPARQLQueryBuilder //
+                    .forItems(kb) //
+                    .withPrefLabelProperties(prefLabels) //
+                    .withLabelStartingWith("Green Go");
+            results = builder.asHandles(conn, true);
+        }
+
+        assertThat(results) //
+                .extracting(KBHandle::getIdentifier) //
+                .containsExactly(
+                        "http://www.ukp.informatik.tu-darmstadt.de/inception/1.0#green-goblin");
     }
 
     @SpringBootConfiguration

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/AccessSettingsPanel.html
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/AccessSettingsPanel.html
@@ -30,13 +30,9 @@
       <label wicket:for="type" class="col-form-label col-sm-3">
         <wicket:message key="kb.wizard.steps.type.type"/>
       </label>
-      <div class="col-sm-9">
-        <select wicket:id="type" class="form-select" data-size="5"/>
-      </div>
-    </div>
-    <div class="row form-row" wicket:enclosure="writeprotection">
-      <div class="offset-sm-3 col-sm-9">
-        <div class="form-check">
+      <div class="col-sm-9 d-flex align-items-center gap-3">
+        <select wicket:id="type" class="form-select flex-grow-1" data-size="5"/>
+        <div class="form-check flex-shrink-0 mb-0 text-nowrap" wicket:enclosure="writeprotection">
           <input wicket:id="writeprotection" class="form-check-input" type="checkbox">
           <label wicket:for="writeprotection" class="form-check-label">
             <wicket:label key="kb.details.contents.permissions"/>

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/local/LocalRepositorySettingsPanel.html
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/local/LocalRepositorySettingsPanel.html
@@ -24,7 +24,7 @@
     <div class="row form-row" wicket:enclosure="repositorySize">
       <div class="offset-sm-3 col-sm-9 d-flex flex-row text-muted">
         <div class="me-5"><i class="fas fa-hdd me-1"></i> Repository: <span wicket:id="repositorySize"/> (<span wicket:id="statementCount"/> statements)</div>
-        <div><i class="fas fa-search me-1"></i> Full-text index: <span wicket:id="indexSize"/></div>
+        <div><i class="fas fa-search me-1"></i> Full-text index: <span wicket:id="indexSize"/><wicket:enclosure child="indexVersion"> (Lucene <span wicket:id="indexVersion"/><span wicket:id="upgradeAction"> &mdash; <a wicket:id="upgradeIndex" href="#">upgrade</a></span>)</wicket:enclosure></div>
       </div>
     </div>
 

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/local/LocalRepositorySettingsPanel.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/local/LocalRepositorySettingsPanel.java
@@ -35,6 +35,8 @@ import java.util.Map;
 import java.util.zip.GZIPOutputStream;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.feedback.IFeedback;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.form.Form;
@@ -60,6 +62,7 @@ import de.tudarmstadt.ukp.inception.kb.KnowledgeBaseService;
 import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBaseProperties;
 import de.tudarmstadt.ukp.inception.kb.yaml.KnowledgeBaseProfile;
 import de.tudarmstadt.ukp.inception.support.io.FileUploadDownloadHelper;
+import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxLink;
 import de.tudarmstadt.ukp.inception.support.wicket.AjaxDownloadLink;
 import de.tudarmstadt.ukp.inception.support.wicket.PipedStreamResource;
 import de.tudarmstadt.ukp.inception.ui.kb.project.KnowledgeBaseWrapper;
@@ -96,6 +99,7 @@ public class LocalRepositorySettingsPanel
 
     private final Label repositorySize;
     private final Label indexSize;
+    private final Label indexVersion;
     private final Label statementCount;
 
     private FileUploadField fileUpload;
@@ -128,6 +132,20 @@ public class LocalRepositorySettingsPanel
         indexSize.add(visibleWhen(getModel().map(KnowledgeBaseWrapper::isKbSaved)));
         queue(indexSize);
 
+        indexVersion = new Label("indexVersion", LoadableDetachableModel.of(() -> kbModel
+                .map(kbService::getIndexVersion).map(v -> v.orElse(null)).getObject()));
+        indexVersion.add(visibleWhen(() -> getModel().getObject().isKbSaved()
+                && indexVersion.getDefaultModelObject() != null));
+        queue(indexVersion);
+
+        var upgradeAction = new WebMarkupContainer("upgradeAction");
+        upgradeAction.setOutputMarkupPlaceholderTag(true);
+        upgradeAction.add(visibleWhen(() -> getModel().getObject().isKbSaved()
+                && kbService.isIndexUpgradeAvailable(getModel().getObject().getKb())));
+        queue(upgradeAction);
+
+        queue(new LambdaAjaxLink("upgradeIndex", this::actionUpgradeIndex));
+
         statementCount = new Label("statementCount", LoadableDetachableModel.of(() -> {
             var repoSize = repoSizeModel.getObject();
             if (repoSize > 25_000_000) {
@@ -141,6 +159,25 @@ public class LocalRepositorySettingsPanel
         }));
         statementCount.add(visibleWhen(getModel().map(KnowledgeBaseWrapper::isKbSaved)));
         queue(statementCount);
+    }
+
+    private void actionUpgradeIndex(AjaxRequestTarget aTarget)
+    {
+        aTarget.addChildren(getPage(), IFeedback.class);
+        var kb = getModel().getObject().getKb();
+        try {
+            LOG.info("Upgrading full-text index of {} ...", kb);
+            kbService.upgradeIndex(kb);
+            LOG.info("Completed upgrading full-text index of {}", kb);
+            success("Full-text index upgraded.");
+        }
+        catch (Exception e) {
+            error("Unable to upgrade full-text index: " + e.getLocalizedMessage());
+            LOG.error("Unable to upgrade full-text index for KB [{}]({}) in project [{}]({})",
+                    kb.getName(), kb.getRepositoryId(), kb.getProject().getName(),
+                    kb.getProject().getId(), e);
+        }
+        aTarget.add(this);
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
**What's in the PR**
- Show the Lucene version of a local KB's full-text index next to the index size in the KB settings
- Add an inline "upgrade" link that appears when the on-disk index major version is older than the running Lucene, runs `IndexUpgrader` in place, and disappears once versions match
- Extend the reindex auto-fallback in `rebuildFullTextIndex` to also recover from `IndexFormatTooOldException`, not just `IndexFormatTooNewException`
- Move the "read-only" checkbox onto the same row as the repository type dropdown to save vertical space in the access settings

**How to test manually**
* Open an old KB and hit the upgrade button

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
