### PR TITLE
#6069 - Improve SPARQL queries against RDF4J

### DIFF
--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseService.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseService.java
@@ -20,7 +20,9 @@ package de.tudarmstadt.ukp.inception.kb;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.eclipse.rdf4j.model.Statement;
@@ -512,6 +514,24 @@ public interface KnowledgeBaseService
      */
     @SuppressWarnings("javadoc")
     Optional<KBHandle> readHandle(Project aProject, String aIdentifier);
+
+    /**
+     * Batch-resolve handles for a collection of identifiers in a single SPARQL request. The
+     * returned map contains an entry for every requested identifier; identifiers not present in the
+     * knowledge base are mapped to a stub {@link KBHandle} carrying only the identifier (mirroring
+     * the always-returns-something semantics of {@link #readHandle(KnowledgeBase, String)}). This
+     * method bypasses the service-level query cache because batches don't share cache keys well;
+     * callers are expected to maintain their own per-id cache (e.g. ConceptLabelCache) on top.
+     */
+    @SuppressWarnings("javadoc")
+    Map<String, KBHandle> readHandles(KnowledgeBase aKB, Collection<String> aIdentifiers);
+
+    /**
+     * Project-level variant of {@link #readHandles(KnowledgeBase, Collection)}: queries enabled
+     * knowledge bases in order, keeping the first labeled handle encountered for each identifier.
+     */
+    @SuppressWarnings("javadoc")
+    Map<String, KBHandle> readHandles(Project aProject, Collection<String> aIdentifiers);
 
     /**
      * Retrieves the distinct parent concepts till the root element for an identifier regardless of

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
@@ -1611,19 +1611,22 @@ public class KnowledgeBaseServiceImpl
             var result = new LinkedHashMap<String, KBHandle>();
 
             // Chunk large inputs so that no single VALUES clause grows unbounded and the planner's
-            // intermediate result set stays manageable. Chunks run sequentially on the same KB
-            // connection — same transactional consistency as one big query.
-            for (var start = 0; start < distinctIds.size(); start += batchSize) {
-                var chunk = distinctIds.subList(start,
-                        Math.min(start + batchSize, distinctIds.size()));
-                readHandlesChunk(aKB, chunk, result);
-            }
+            // intermediate result set stays manageable. All chunks share one RepositoryConnection
+            // so we get a single transactional snapshot and avoid per-chunk connection overhead.
+            read(aKB, conn -> {
+                for (var start = 0; start < distinctIds.size(); start += batchSize) {
+                    var chunk = distinctIds.subList(start,
+                            Math.min(start + batchSize, distinctIds.size()));
+                    readHandlesChunk(aKB, conn, chunk, result);
+                }
+                return null;
+            });
 
             return result;
         }
     }
 
-    private void readHandlesChunk(KnowledgeBase aKB, List<String> aIds,
+    private void readHandlesChunk(KnowledgeBase aKB, RepositoryConnection aConn, List<String> aIds,
             Map<String, KBHandle> aResult)
     {
         var query = SPARQLQueryBuilder.forItems(aKB) //
@@ -1632,10 +1635,10 @@ public class KnowledgeBaseServiceImpl
                 .retrieveDescription() //
                 .retrieveDeprecation();
 
-        // Always direct read — bypasses queryCache by construction. Batch queries don't share
-        // cache keys well with single-id readHandle calls, and callers of this method are
-        // expected to maintain their own per-id cache.
-        var rows = read(aKB, conn -> query.asHandles(conn, true));
+        // Direct read on the caller-provided connection — bypasses queryCache by construction.
+        // Batch queries don't share cache keys well with single-id readHandle calls, and callers
+        // of this method are expected to maintain their own per-id cache.
+        var rows = query.asHandles(aConn, true);
         for (var row : rows) {
             aResult.putIfAbsent(row.getIdentifier(), row);
         }

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
@@ -1604,6 +1604,9 @@ public class KnowledgeBaseServiceImpl
         if (aKB == null) {
             throw new IllegalArgumentException("KnowledgeBase must not be null");
         }
+        if (aIdentifiers == null) {
+            throw new IllegalArgumentException("Identifiers must not be null");
+        }
         if (aIdentifiers.isEmpty()) {
             return emptyMap();
         }
@@ -1658,6 +1661,9 @@ public class KnowledgeBaseServiceImpl
     {
         if (aProject == null) {
             throw new IllegalArgumentException("Project must not be null");
+        }
+        if (aIdentifiers == null) {
+            throw new IllegalArgumentException("Identifiers must not be null");
         }
         if (aIdentifiers.isEmpty()) {
             return emptyMap();

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
@@ -1628,11 +1628,14 @@ public class KnowledgeBaseServiceImpl
     private void readHandlesChunk(KnowledgeBase aKB, RepositoryConnection aConn, List<String> aIds,
             Map<String, KBHandle> aResult)
     {
+        // Size the LIMIT to the batch so a low kb.getMaxResults() doesn't silently truncate
+        // results and turn existing IDs into stubs.
         var query = SPARQLQueryBuilder.forItems(aKB) //
                 .withIdentifier(aIds.toArray(String[]::new)) //
                 .retrieveLabel() //
                 .retrieveDescription() //
-                .retrieveDeprecation();
+                .retrieveDeprecation() //
+                .limit(aIds.size());
 
         // Bypasses queryCache: batch keys don't share well with single-id readHandle calls;
         // callers are expected to maintain their own per-id cache.

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
@@ -34,9 +34,7 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static java.util.Locale.ROOT;
-import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toMap;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.apache.commons.lang3.StringUtils.substringAfter;
@@ -1608,28 +1606,43 @@ public class KnowledgeBaseServiceImpl
         }
 
         try (var watch = new StopWatch(LOG, "readHandles(%d)", aIdentifiers.size())) {
-            var ids = aIdentifiers.stream().distinct().toArray(String[]::new);
-            var query = SPARQLQueryBuilder.forItems(aKB) //
-                    .withIdentifier(ids) //
-                    .retrieveLabel() //
-                    .retrieveDescription() //
-                    .retrieveDeprecation();
+            var distinctIds = aIdentifiers.stream().distinct().toList();
+            var batchSize = Math.max(1, properties.getReadBatchSize());
+            var result = new LinkedHashMap<String, KBHandle>();
 
-            // Always direct read — bypasses queryCache by construction. Batch queries don't share
-            // cache keys well with single-id readHandle calls, and callers of this method are
-            // expected to maintain their own per-id cache.
-            var rows = read(aKB, conn -> query.asHandles(conn, true));
-
-            var result = rows.stream() //
-                    .collect(toMap(KBObject::getIdentifier, identity(), (a, b) -> a,
-                            LinkedHashMap::new));
-
-            // Preserve the "always returns something per requested id" semantics of readHandle.
-            for (var id : ids) {
-                result.computeIfAbsent(id, KBHandle::new);
+            // Chunk large inputs so that no single VALUES clause grows unbounded and the planner's
+            // intermediate result set stays manageable. Chunks run sequentially on the same KB
+            // connection — same transactional consistency as one big query.
+            for (var start = 0; start < distinctIds.size(); start += batchSize) {
+                var chunk = distinctIds.subList(start,
+                        Math.min(start + batchSize, distinctIds.size()));
+                readHandlesChunk(aKB, chunk, result);
             }
 
             return result;
+        }
+    }
+
+    private void readHandlesChunk(KnowledgeBase aKB, List<String> aIds,
+            Map<String, KBHandle> aResult)
+    {
+        var query = SPARQLQueryBuilder.forItems(aKB) //
+                .withIdentifier(aIds.toArray(String[]::new)) //
+                .retrieveLabel() //
+                .retrieveDescription() //
+                .retrieveDeprecation();
+
+        // Always direct read — bypasses queryCache by construction. Batch queries don't share
+        // cache keys well with single-id readHandle calls, and callers of this method are
+        // expected to maintain their own per-id cache.
+        var rows = read(aKB, conn -> query.asHandles(conn, true));
+        for (var row : rows) {
+            aResult.putIfAbsent(row.getIdentifier(), row);
+        }
+
+        // Preserve the "always returns something per requested id" semantics of readHandle.
+        for (var id : aIds) {
+            aResult.computeIfAbsent(id, KBHandle::new);
         }
     }
 

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
@@ -1601,6 +1601,9 @@ public class KnowledgeBaseServiceImpl
     @Override
     public Map<String, KBHandle> readHandles(KnowledgeBase aKB, Collection<String> aIdentifiers)
     {
+        if (aKB == null) {
+            throw new IllegalArgumentException("KnowledgeBase must not be null");
+        }
         if (aIdentifiers.isEmpty()) {
             return emptyMap();
         }
@@ -1628,14 +1631,14 @@ public class KnowledgeBaseServiceImpl
     private void readHandlesChunk(KnowledgeBase aKB, RepositoryConnection aConn, List<String> aIds,
             Map<String, KBHandle> aResult)
     {
-        // Size the LIMIT to the batch so a low kb.getMaxResults() doesn't silently truncate
-        // results and turn existing IDs into stubs.
+        // Result is already bounded by the VALUES clause from withIdentifier; a SPARQL LIMIT
+        // would risk truncating legitimate multi-row-per-id output (languages × OPTIONALs).
         var query = SPARQLQueryBuilder.forItems(aKB) //
                 .withIdentifier(aIds.toArray(String[]::new)) //
                 .retrieveLabel() //
                 .retrieveDescription() //
                 .retrieveDeprecation() //
-                .limit(aIds.size());
+                .noLimit();
 
         // Bypasses queryCache: batch keys don't share well with single-id readHandle calls;
         // callers are expected to maintain their own per-id cache.
@@ -1653,6 +1656,9 @@ public class KnowledgeBaseServiceImpl
     @Override
     public Map<String, KBHandle> readHandles(Project aProject, Collection<String> aIdentifiers)
     {
+        if (aProject == null) {
+            throw new IllegalArgumentException("Project must not be null");
+        }
         if (aIdentifiers.isEmpty()) {
             return emptyMap();
         }

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
@@ -31,9 +31,12 @@ import static java.lang.Math.round;
 import static java.nio.file.Files.createDirectories;
 import static java.nio.file.Files.move;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static java.util.Locale.ROOT;
+import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 import static org.apache.commons.lang3.StringUtils.substringAfter;
@@ -53,6 +56,7 @@ import java.io.OutputStream;
 import java.lang.invoke.MethodHandles;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -1594,6 +1598,74 @@ public class KnowledgeBaseServiceImpl
         }
 
         return someResult;
+    }
+
+    @Override
+    public Map<String, KBHandle> readHandles(KnowledgeBase aKB, Collection<String> aIdentifiers)
+    {
+        if (aIdentifiers.isEmpty()) {
+            return emptyMap();
+        }
+
+        try (var watch = new StopWatch(LOG, "readHandles(%d)", aIdentifiers.size())) {
+            var ids = aIdentifiers.stream().distinct().toArray(String[]::new);
+            var query = SPARQLQueryBuilder.forItems(aKB) //
+                    .withIdentifier(ids) //
+                    .retrieveLabel() //
+                    .retrieveDescription() //
+                    .retrieveDeprecation();
+
+            // Always direct read — bypasses queryCache by construction. Batch queries don't share
+            // cache keys well with single-id readHandle calls, and callers of this method are
+            // expected to maintain their own per-id cache.
+            var rows = read(aKB, conn -> query.asHandles(conn, true));
+
+            var result = rows.stream() //
+                    .collect(toMap(KBObject::getIdentifier, identity(), (a, b) -> a,
+                            LinkedHashMap::new));
+
+            // Preserve the "always returns something per requested id" semantics of readHandle.
+            for (var id : ids) {
+                result.computeIfAbsent(id, KBHandle::new);
+            }
+
+            return result;
+        }
+    }
+
+    @Override
+    public Map<String, KBHandle> readHandles(Project aProject, Collection<String> aIdentifiers)
+    {
+        if (aIdentifiers.isEmpty()) {
+            return emptyMap();
+        }
+
+        var result = new LinkedHashMap<String, KBHandle>();
+        for (var id : aIdentifiers) {
+            result.put(id, new KBHandle(id));
+        }
+
+        for (var kb : getEnabledKnowledgeBases(aProject)) {
+            // Only re-query identifiers we haven't yet resolved to a labeled handle. Mirrors the
+            // single-id readHandle(Project, ...) loop, which stops at the first KB providing a
+            // name.
+            var unresolved = result.entrySet().stream() //
+                    .filter(e -> e.getValue().getName() == null) //
+                    .map(Map.Entry::getKey) //
+                    .toList();
+            if (unresolved.isEmpty()) {
+                break;
+            }
+
+            var kbResults = readHandles(kb, unresolved);
+            for (var entry : kbResults.entrySet()) {
+                if (entry.getValue().getName() != null) {
+                    result.put(entry.getKey(), entry.getValue());
+                }
+            }
+        }
+
+        return result;
     }
 
     /**

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
@@ -1610,9 +1610,8 @@ public class KnowledgeBaseServiceImpl
             var batchSize = Math.max(1, properties.getReadBatchSize());
             var result = new LinkedHashMap<String, KBHandle>();
 
-            // Chunk large inputs so that no single VALUES clause grows unbounded and the planner's
-            // intermediate result set stays manageable. All chunks share one RepositoryConnection
-            // so we get a single transactional snapshot and avoid per-chunk connection overhead.
+            // Chunk so no single VALUES clause grows unbounded. Shared connection so all chunks
+            // see one transactional snapshot.
             read(aKB, conn -> {
                 for (var start = 0; start < distinctIds.size(); start += batchSize) {
                     var chunk = distinctIds.subList(start,
@@ -1635,9 +1634,8 @@ public class KnowledgeBaseServiceImpl
                 .retrieveDescription() //
                 .retrieveDeprecation();
 
-        // Direct read on the caller-provided connection — bypasses queryCache by construction.
-        // Batch queries don't share cache keys well with single-id readHandle calls, and callers
-        // of this method are expected to maintain their own per-id cache.
+        // Bypasses queryCache: batch keys don't share well with single-id readHandle calls;
+        // callers are expected to maintain their own per-id cache.
         var rows = query.asHandles(aConn, true);
         for (var row : rows) {
             aResult.putIfAbsent(row.getIdentifier(), row);

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/config/KnowledgeBaseProperties.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/config/KnowledgeBaseProperties.java
@@ -56,5 +56,12 @@ public interface KnowledgeBaseProperties
 
     long getRenderCacheSize();
 
+    /**
+     * @return the maximum number of identifiers fitted into a single batch SPARQL request (e.g. by
+     *         {@code readHandles}). Larger collections are chunked so that no single VALUES clause
+     *         grows unbounded.
+     */
+    int getReadBatchSize();
+
     List<String> getDefaultFallbackLanguages();
 }

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/config/KnowledgeBasePropertiesImpl.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/config/KnowledgeBasePropertiesImpl.java
@@ -78,6 +78,13 @@ public class KnowledgeBasePropertiesImpl
     /** Time before items are asynchronously refreshed when rendering. */
     private @DurationUnit(MINUTES) Duration renderCacheRefreshDelay = ofMinutes(1);
 
+    /**
+     * Maximum number of identifiers fitted into a single batch SPARQL request. Collections larger
+     * than this are split into sequential chunks to keep VALUES clauses and intermediate result
+     * sets bounded.
+     */
+    private int readBatchSize = 250;
+
     private List<String> defaultFallbackLanguages = emptyList();
 
     public void setFtsInternalMaxResultsFactor(double aFtsMaxResultsFactor)
@@ -188,6 +195,17 @@ public class KnowledgeBasePropertiesImpl
     public void setRenderCacheRefreshDelay(Duration aRenderCacheRefreshDelay)
     {
         renderCacheRefreshDelay = aRenderCacheRefreshDelay;
+    }
+
+    @Override
+    public int getReadBatchSize()
+    {
+        return readBatchSize;
+    }
+
+    public void setReadBatchSize(int aReadBatchSize)
+    {
+        readBatchSize = aReadBatchSize;
     }
 
     @Override

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapter.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapter.java
@@ -27,4 +27,16 @@ public interface FtsAdapter
     void withLabelMatchingAnyOf(String... values);
 
     void withLabelStartingWith(String prefix);
+
+    /**
+     * Called once at query assembly time, after all {@code withLabel*} and {@code retrieve*}
+     * methods have run, but before the final SPARQL is rendered. Adapters can use this to defer
+     * pattern assembly until they have visibility into what optional lookups (label, description,
+     * deprecation) need to happen — e.g. to push those into UNION branches for query planners that
+     * otherwise produce poor join orders.
+     */
+    default void finalizeQuery(SPARQLQueryBuilder builder)
+    {
+        // No-op by default.
+    }
 }

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterAllegroGraph.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterAllegroGraph.java
@@ -68,8 +68,7 @@ public class FtsAdapterAllegroGraph
 
             valuePatterns.add(new AllegroGraphFtsQuery(VAR_SUBJECT, VAR_SCORE, VAR_MATCH_TERM,
                     VAR_MATCH_TERM_PROPERTY, sanitizedValue) //
-                            .filter(builder.equalsPattern(VAR_MATCH_TERM, value,
-                                    builder.getKnowledgeBase())));
+                            .filter(builder.equalsPattern(VAR_MATCH_TERM, value)));
         }
 
         if (valuePatterns.isEmpty()) {

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterBlazegraph.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterBlazegraph.java
@@ -51,8 +51,6 @@ public class FtsAdapterBlazegraph
     @Override
     public void withLabelMatchingExactlyAnyOf(String... aValues)
     {
-        var kb = builder.getKnowledgeBase();
-
         var valuePatterns = new ArrayList<GraphPattern>();
         for (var value : aValues) {
             var sanitizedValue = builder.sanitizeQueryString_FTS(value);
@@ -67,8 +65,8 @@ public class FtsAdapterBlazegraph
                     SPARQLQueryBuilder.VAR_SCORE, SPARQLQueryBuilder.VAR_MATCH_TERM,
                     SPARQLQueryBuilder.VAR_MATCH_TERM_PROPERTY, sanitizedValue) //
                             .withLimit(builder.getLimit()) //
-                            .filter(builder.equalsPattern(SPARQLQueryBuilder.VAR_MATCH_TERM, value,
-                                    kb)));
+                            .filter(builder.equalsPattern(SPARQLQueryBuilder.VAR_MATCH_TERM,
+                                    value)));
         }
 
         if (valuePatterns.isEmpty()) {

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterFuseki.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterFuseki.java
@@ -67,8 +67,7 @@ public class FtsAdapterFuseki
             valuePatterns.add(new FusekiFtsQuery(VAR_SUBJECT, VAR_SCORE, VAR_MATCH_TERM,
                     VAR_MATCH_TERM_PROPERTY, sanitizedValue) //
                             .withLimit(builder.getLimit()) //
-                            .filter(builder.equalsPattern(VAR_MATCH_TERM, value,
-                                    builder.getKnowledgeBase())));
+                            .filter(builder.equalsPattern(VAR_MATCH_TERM, value)));
         }
 
         if (valuePatterns.isEmpty()) {

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterGraphDb.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterGraphDb.java
@@ -51,8 +51,6 @@ public class FtsAdapterGraphDb
     @Override
     public void withLabelMatchingExactlyAnyOf(String... aValues)
     {
-        var kb = builder.getKnowledgeBase();
-
         var valuePatterns = new ArrayList<GraphPattern>();
         for (var value : aValues) {
             var sanitizedValue = builder.sanitizeQueryString_FTS(value);
@@ -63,7 +61,7 @@ public class FtsAdapterGraphDb
 
             builder.addProjection(VAR_SCORE);
 
-            var filter = builder.equalsPattern(VAR_MATCH_TERM, value, kb);
+            var filter = builder.equalsPattern(VAR_MATCH_TERM, value);
             valuePatterns.addAll(buildLanguageUnionPatterns(sanitizedValue, filter));
         }
 

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterRdf4J.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterRdf4J.java
@@ -131,7 +131,7 @@ public class FtsAdapterRdf4J
                             .andHas(LUCENE_PROPERTY, VAR_MATCH_TERM_PROPERTY) //
                             .andHas(LUCENE_SCORE, VAR_SCORE))
                     .andHas(VAR_MATCH_TERM_PROPERTY, VAR_MATCH_TERM);
-            var filters = builder.equalsFilters(VAR_MATCH_TERM, value, builder.getKnowledgeBase());
+            var filters = builder.equalsFilters(VAR_MATCH_TERM, value);
             pendingFtsBranches.add(new PendingFtsBranch(triple, filters, true));
         }
 

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterRdf4J.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterRdf4J.java
@@ -307,7 +307,13 @@ public class FtsAdapterRdf4J
         // a correctness fix.
         aBuilder.drainLabelPropertyBindings();
         var optionalLookups = aBuilder.drainOptionalLookupPatterns();
-        var prefLabelValuesBinding = aBuilder.bindPrefLabelPropertiesPlain(VAR_PREF_LABEL_PROPERTY);
+        // Fall back to the property-path OPTIONAL when no pref-label properties are pre-resolved.
+        // Without this, OPTIONAL lookups inside the branches that use ?pPrefLabel would match
+        // any predicate (#5444).
+        var plainBinding = aBuilder.bindPrefLabelPropertiesPlain(VAR_PREF_LABEL_PROPERTY);
+        var prefLabelValuesBinding = plainBinding != null //
+                ? plainBinding //
+                : aBuilder.bindPrefLabelProperties(VAR_PREF_LABEL_PROPERTY);
         var matchTermBinding = aBuilder.bindMatchTermProperties(VAR_MATCH_TERM_PROPERTY);
 
         // The sub-SELECT wrap is only safe when there are 2+ branches: with a single branch the

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterRdf4J.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterRdf4J.java
@@ -2,13 +2,13 @@
  * Licensed to the Technische Universität Darmstadt under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
- * regarding copyright ownership.  The Technische Universität Darmstadt 
+ * regarding copyright ownership.  The Technische Universität Darmstadt
  * licenses this file to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.
- *  
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -36,6 +36,7 @@ import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.literalOf;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expression;
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions;
@@ -67,6 +68,15 @@ public class FtsAdapterRdf4J
 
     private final SPARQLQueryBuilder builder;
 
+    // Branches are accumulated by withLabel* methods and only assembled into a UNION + PRIMARY
+    // pattern in finalizeQuery() — that way the adapter has a chance to push the
+    // retrieveLabel/retrieveDescription/retrieveDeprecation OPTIONAL lookups INTO each branch.
+    // RDF4J 5.1.4+ (see GH-4872) otherwise plans the trailing OPTIONALs as cartesian-product
+    // BadlyDesignedLeftJoinIterators that re-scan large fractions of the store per FTS hit,
+    // turning sub-second queries into multi-minute ones on large KBs like SNOMED (#5444).
+    private final List<GraphPattern> pendingFtsBranches = new ArrayList<>();
+    private boolean ftsActive = false;
+
     public FtsAdapterRdf4J(SPARQLQueryBuilder aBuilder)
     {
         builder = aBuilder;
@@ -76,8 +86,8 @@ public class FtsAdapterRdf4J
     public void withLabelMatchingExactlyAnyOf(String... aValues)
     {
         builder.addPrefix(PREFIX_RDF4J_LUCENE_SEARCH);
+        ftsActive = true;
 
-        var valuePatterns = new ArrayList<GraphPattern>();
         for (var value : aValues) {
             var sanitizedValue = builder.sanitizeQueryString_FTS(value);
 
@@ -87,7 +97,7 @@ public class FtsAdapterRdf4J
 
             builder.addProjection(VAR_SCORE);
 
-            valuePatterns.add(VAR_SUBJECT
+            pendingFtsBranches.add(VAR_SUBJECT
                     .has(FTS_RDF4J_LUCENE, bNode(LUCENE_QUERY, literalOf(sanitizedValue)) //
                             .andHas(LUCENE_PROPERTY, VAR_MATCH_TERM_PROPERTY) //
                             .andHas(LUCENE_SCORE, VAR_SCORE))
@@ -95,21 +105,17 @@ public class FtsAdapterRdf4J
                             .equalsPattern(VAR_MATCH_TERM, value, builder.getKnowledgeBase())));
         }
 
-        if (valuePatterns.isEmpty()) {
+        if (pendingFtsBranches.isEmpty()) {
             builder.noResult();
         }
-
-        builder.addPattern(PRIMARY, and( //
-                builder.bindMatchTermProperties(VAR_MATCH_TERM_PROPERTY), //
-                union(valuePatterns.toArray(GraphPattern[]::new))));
     }
 
     @Override
     public void withLabelContainingAnyOf(String... aValues)
     {
         builder.addPrefix(PREFIX_RDF4J_LUCENE_SEARCH);
+        ftsActive = true;
 
-        var valuePatterns = new ArrayList<GraphPattern>();
         for (var value : aValues) {
             // Strip single quotes and asterisks because they have special semantics
             var sanitizedValue = builder.sanitizeQueryString_FTS(value);
@@ -133,7 +139,7 @@ public class FtsAdapterRdf4J
             // returned). RDF4J only provides access to the matched term in a "highlighted" form
             // where "<B>" and "</B>" match the search term. So we have to strip these markers
             // out as part of the query.
-            valuePatterns.add(VAR_SUBJECT //
+            pendingFtsBranches.add(VAR_SUBJECT //
                     .has(FTS_RDF4J_LUCENE, bNode(LUCENE_QUERY, literalOf(query)) //
                             .andHas(LUCENE_PROPERTY, VAR_MATCH_TERM_PROPERTY) //
                             .andHas(LUCENE_SCORE, VAR_SCORE) //
@@ -148,25 +154,23 @@ public class FtsAdapterRdf4J
                     .filter(and(labelFilterExpressions.toArray(Expression[]::new))));
         }
 
-        if (valuePatterns.isEmpty()) {
+        if (pendingFtsBranches.isEmpty()) {
             builder.noResult();
         }
-
-        builder.addPattern(PRIMARY, and( //
-                builder.bindMatchTermProperties(VAR_MATCH_TERM_PROPERTY),
-                union(valuePatterns.toArray(GraphPattern[]::new))));
     }
 
     @Override
     public void withLabelStartingWith(String aPrefixQuery)
     {
         builder.addPrefix(PREFIX_RDF4J_LUCENE_SEARCH);
+        ftsActive = true;
 
         // Strip single quotes and asterisks because they have special semantics
         var queryString = builder.sanitizeQueryString_FTS(aPrefixQuery);
 
         if (isBlank(queryString)) {
             builder.noResult();
+            return;
         }
 
         // If the query string entered by the user does not end with a space character, then
@@ -180,21 +184,20 @@ public class FtsAdapterRdf4J
 
         // Locate all entries where the label contains the prefix (using the FTS) and then
         // filter them by those which actually start with the prefix.
-        builder.addPattern(PRIMARY, and( //
-                builder.bindMatchTermProperties(VAR_MATCH_TERM_PROPERTY), //
-                VAR_SUBJECT.has(FTS_RDF4J_LUCENE, bNode(LUCENE_QUERY, literalOf(queryString)) //
+        pendingFtsBranches.add(VAR_SUBJECT
+                .has(FTS_RDF4J_LUCENE, bNode(LUCENE_QUERY, literalOf(queryString)) //
                         .andHas(LUCENE_SCORE, VAR_SCORE)
                         .andHas(LUCENE_PROPERTY, VAR_MATCH_TERM_PROPERTY))
-                        .andHas(VAR_MATCH_TERM_PROPERTY, VAR_MATCH_TERM)
-                        .filter(builder.startsWithPattern(VAR_MATCH_TERM, aPrefixQuery))));
+                .andHas(VAR_MATCH_TERM_PROPERTY, VAR_MATCH_TERM)
+                .filter(builder.startsWithPattern(VAR_MATCH_TERM, aPrefixQuery)));
     }
 
     @Override
     public void withLabelMatchingAnyOf(String... aValues)
     {
         builder.addPrefix(PREFIX_RDF4J_LUCENE_SEARCH);
+        ftsActive = true;
 
-        var valuePatterns = new ArrayList<GraphPattern>();
         for (var value : aValues) {
             // Strip single quotes and asterisks because they have special semantics
             var sanitizedValue = builder.sanitizeQueryString_FTS(value);
@@ -217,7 +220,7 @@ public class FtsAdapterRdf4J
             // returned). RDF4J only provides access to the matched term in a "highlighted" form
             // where "<B>" and "</B>" match the search term. So we have to strip these markers
             // out as part of the query.
-            valuePatterns.add(VAR_SUBJECT //
+            pendingFtsBranches.add(VAR_SUBJECT //
                     .has(FTS_RDF4J_LUCENE, bNode(LUCENE_QUERY, literalOf(queryString)) //
                             .andHas(LUCENE_PROPERTY, VAR_MATCH_TERM_PROPERTY) //
                             .andHas(LUCENE_SCORE, VAR_SCORE) //
@@ -232,12 +235,54 @@ public class FtsAdapterRdf4J
                     .filter(and(labelFilterExpressions.toArray(Expression[]::new))));
         }
 
-        if (valuePatterns.isEmpty()) {
+        if (pendingFtsBranches.isEmpty()) {
             builder.noResult();
         }
+    }
 
-        builder.addPattern(PRIMARY, and( //
-                builder.bindMatchTermProperties(VAR_MATCH_TERM_PROPERTY),
-                union(valuePatterns.toArray(GraphPattern[]::new))));
+    @Override
+    public void finalizeQuery(SPARQLQueryBuilder aBuilder)
+    {
+        if (!ftsActive || pendingFtsBranches.isEmpty()) {
+            return;
+        }
+
+        // The inner OPTIONALs reference ?pPrefLabel, which is bound at top level by the
+        // SECONDARY pattern emitted by retrieveLabel — but as an OPTIONAL { VALUES ... } wrapper.
+        // RDF4J's optimizer reorders that OPTIONAL to AFTER the union, leaving ?pPrefLabel
+        // unbound when the inner OPTIONALs run; the inner StatementPattern then matches ANY
+        // property and we get back altLabel instead of prefLabel. Workaround: emit a hard
+        // (non-OPTIONAL) VALUES binding directly inside each UNION branch so ?pPrefLabel is
+        // bound before the inner OPTIONALs are evaluated.
+        // Drain the SECONDARY bindings (the OPTIONAL { VALUES ?pPrefLabel ... } / bindMatchTerm
+        // wrappers added by retrieveLabel). We re-emit equivalent hard bindings inside each
+        // branch below, so leaving them in SECONDARY would just be duplicates.
+        aBuilder.drainSecondaryPatterns();
+        var optionalLookups = aBuilder.drainOptionalLookupPatterns();
+        var prefLabelValuesBinding = aBuilder.bindPrefLabelPropertiesPlain(VAR_PREF_LABEL_PROPERTY);
+
+        var augmentedBranches = pendingFtsBranches.stream() //
+                .map(branch -> augmentBranch(branch, prefLabelValuesBinding, optionalLookups)) //
+                .toArray(GraphPattern[]::new);
+
+        aBuilder.addPattern(PRIMARY, and( //
+                aBuilder.bindMatchTermProperties(VAR_MATCH_TERM_PROPERTY), //
+                union(augmentedBranches)));
+    }
+
+    private static GraphPattern augmentBranch(GraphPattern aBranch, GraphPattern aPrefLabelBinding,
+            List<GraphPattern> aOptionalLookups)
+    {
+        if (aPrefLabelBinding == null && aOptionalLookups.isEmpty()) {
+            return aBranch;
+        }
+
+        var parts = new ArrayList<GraphPattern>();
+        if (aPrefLabelBinding != null) {
+            parts.add(aPrefLabelBinding);
+        }
+        parts.add(aBranch);
+        parts.addAll(aOptionalLookups);
+        return and(parts.toArray(GraphPattern[]::new));
     }
 }

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterRdf4J.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterRdf4J.java
@@ -96,6 +96,7 @@ public class FtsAdapterRdf4J
 
     private final List<PendingFtsBranch> pendingFtsBranches = new ArrayList<>();
     private boolean ftsActive = false;
+    private boolean finalized = false;
 
     public FtsAdapterRdf4J(SPARQLQueryBuilder aBuilder)
     {
@@ -277,6 +278,15 @@ public class FtsAdapterRdf4J
     @Override
     public void finalizeQuery(SPARQLQueryBuilder aBuilder)
     {
+        // Defense in depth against repeated invocation: draining secondary/optional lookup patterns
+        // and re-emitting the PRIMARY UNION is destructive, so a second pass would either drop
+        // OPTIONAL lookups or accumulate duplicate UNION patterns. The builder also guards this,
+        // but adapters should be self-contained.
+        if (finalized) {
+            return;
+        }
+        finalized = true;
+
         if (!ftsActive || pendingFtsBranches.isEmpty()) {
             return;
         }

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterRdf4J.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterRdf4J.java
@@ -97,12 +97,20 @@ public class FtsAdapterRdf4J
 
             builder.addProjection(VAR_SCORE);
 
-            pendingFtsBranches.add(VAR_SUBJECT
+            // Emit one FILTER per conjunct (REGEX, LANGMATCHES) instead of one combined
+            // FILTER ( REGEX(...) && LANGMATCHES(...) ). The combined form is opaque to the
+            // RDF4J cost estimator and triggers the #5444 pathology where the planner cannot
+            // push the cheap language check separately from the expensive anchored regex.
+            GraphPattern branch = VAR_SUBJECT
                     .has(FTS_RDF4J_LUCENE, bNode(LUCENE_QUERY, literalOf(sanitizedValue)) //
                             .andHas(LUCENE_PROPERTY, VAR_MATCH_TERM_PROPERTY) //
                             .andHas(LUCENE_SCORE, VAR_SCORE))
-                    .andHas(VAR_MATCH_TERM_PROPERTY, VAR_MATCH_TERM).filter(builder
-                            .equalsPattern(VAR_MATCH_TERM, value, builder.getKnowledgeBase())));
+                    .andHas(VAR_MATCH_TERM_PROPERTY, VAR_MATCH_TERM);
+            for (var filter : builder.equalsFilters(VAR_MATCH_TERM, value,
+                    builder.getKnowledgeBase())) {
+                branch = branch.filter(filter);
+            }
+            pendingFtsBranches.add(branch);
         }
 
         if (pendingFtsBranches.isEmpty()) {

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterRdf4J.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterRdf4J.java
@@ -278,10 +278,6 @@ public class FtsAdapterRdf4J
     @Override
     public void finalizeQuery(SPARQLQueryBuilder aBuilder)
     {
-        // Defense in depth against repeated invocation: draining secondary/optional lookup patterns
-        // and re-emitting the PRIMARY UNION is destructive, so a second pass would either drop
-        // OPTIONAL lookups or accumulate duplicate UNION patterns. The builder also guards this,
-        // but adapters should be self-contained.
         if (finalized) {
             return;
         }
@@ -309,7 +305,7 @@ public class FtsAdapterRdf4J
         // RDF4J QueryJoinOptimizer "rightArg must not be null" assertion on some
         // LuceneSail+small-data combinations, so keeping the OPTIONALs in-branch is also
         // a correctness fix.
-        aBuilder.drainSecondaryPatterns();
+        aBuilder.drainLabelPropertyBindings();
         var optionalLookups = aBuilder.drainOptionalLookupPatterns();
         var prefLabelValuesBinding = aBuilder.bindPrefLabelPropertiesPlain(VAR_PREF_LABEL_PROPERTY);
         var matchTermBinding = aBuilder.bindMatchTermProperties(VAR_MATCH_TERM_PROPERTY);
@@ -345,7 +341,8 @@ public class FtsAdapterRdf4J
         if (aBranch.filters().isEmpty()) {
             return aBranch.body();
         }
-        GraphPattern result = aBranch.body();
+        // and(...) first to keep filters in the same group as the body — see wrapBranchInSubSelect.
+        GraphPattern result = and(aBranch.body());
         for (var filter : aBranch.filters()) {
             result = result.filter(filter);
         }

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterRdf4J.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterRdf4J.java
@@ -30,6 +30,7 @@ import static org.eclipse.rdf4j.sparqlbuilder.constraint.SparqlFunction.REPLACE;
 import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.prefix;
 import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.var;
 import static org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns.and;
+import static org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns.select;
 import static org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns.union;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.bNode;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
@@ -74,7 +75,26 @@ public class FtsAdapterRdf4J
     // RDF4J 5.1.4+ (see GH-4872) otherwise plans the trailing OPTIONALs as cartesian-product
     // BadlyDesignedLeftJoinIterators that re-scan large fractions of the store per FTS hit,
     // turning sub-second queries into multi-minute ones on large KBs like SNOMED (#5444).
-    private final List<GraphPattern> pendingFtsBranches = new ArrayList<>();
+    /**
+     * @param body
+     *            the FTS body (search:matches + ?subj ?pMatch ?m for the exact-match case;
+     *            already-filtered GraphPattern for the other variants)
+     * @param filters
+     *            filters to apply outside {@code body} so they can be appended to a flat
+     *            {@code and(matchTermBinding, body)} group — only populated for the exact-match
+     *            path where the inner-StatementPattern cardinality estimate is catastrophic
+     * @param wrapInSubSelect
+     *            when {@code true}, finalizeQuery wraps the body in a sub-SELECT scope to force the
+     *            RDF4J planner away from a 5.5M-row HashJoinIteration. Only used for
+     *            {@link #withLabelMatchingExactlyAnyOf} — the other FTS shapes (startsWith,
+     *            containing, fuzzy) trigger an RDF4J QueryJoinOptimizer "rightArg must not be null"
+     *            assertion when wrapped, so they keep the legacy emission.
+     */
+    private record PendingFtsBranch(GraphPattern body, List<Expression<?>> filters,
+            boolean wrapInSubSelect)
+    {}
+
+    private final List<PendingFtsBranch> pendingFtsBranches = new ArrayList<>();
     private boolean ftsActive = false;
 
     public FtsAdapterRdf4J(SPARQLQueryBuilder aBuilder)
@@ -101,16 +121,17 @@ public class FtsAdapterRdf4J
             // FILTER ( REGEX(...) && LANGMATCHES(...) ). The combined form is opaque to the
             // RDF4J cost estimator and triggers the #5444 pathology where the planner cannot
             // push the cheap language check separately from the expensive anchored regex.
-            GraphPattern branch = VAR_SUBJECT
+            // Filters are stored separately so finalizeQuery can apply them inside a flat
+            // GroupGraphPattern (calling .filter() on a TriplePattern wraps it in an extra
+            // group, which the optimiser then treats as a "new scope" and falls back to a
+            // HashJoinIteration with a 5.5M-row estimate on `?subj ?pMatch ?m`).
+            var triple = VAR_SUBJECT
                     .has(FTS_RDF4J_LUCENE, bNode(LUCENE_QUERY, literalOf(sanitizedValue)) //
                             .andHas(LUCENE_PROPERTY, VAR_MATCH_TERM_PROPERTY) //
                             .andHas(LUCENE_SCORE, VAR_SCORE))
                     .andHas(VAR_MATCH_TERM_PROPERTY, VAR_MATCH_TERM);
-            for (var filter : builder.equalsFilters(VAR_MATCH_TERM, value,
-                    builder.getKnowledgeBase())) {
-                branch = branch.filter(filter);
-            }
-            pendingFtsBranches.add(branch);
+            var filters = builder.equalsFilters(VAR_MATCH_TERM, value, builder.getKnowledgeBase());
+            pendingFtsBranches.add(new PendingFtsBranch(triple, filters, true));
         }
 
         if (pendingFtsBranches.isEmpty()) {
@@ -147,7 +168,7 @@ public class FtsAdapterRdf4J
             // returned). RDF4J only provides access to the matched term in a "highlighted" form
             // where "<B>" and "</B>" match the search term. So we have to strip these markers
             // out as part of the query.
-            pendingFtsBranches.add(VAR_SUBJECT //
+            pendingFtsBranches.add(new PendingFtsBranch(VAR_SUBJECT //
                     .has(FTS_RDF4J_LUCENE, bNode(LUCENE_QUERY, literalOf(query)) //
                             .andHas(LUCENE_PROPERTY, VAR_MATCH_TERM_PROPERTY) //
                             .andHas(LUCENE_SCORE, VAR_SCORE) //
@@ -159,7 +180,8 @@ public class FtsAdapterRdf4J
                                     literalOf("<B>"), literalOf("")),
                             VAR_LABEL))
                     .and(VAR_SUBJECT.has(VAR_MATCH_TERM_PROPERTY, VAR_MATCH_TERM))
-                    .filter(and(labelFilterExpressions.toArray(Expression[]::new))));
+                    .filter(and(labelFilterExpressions.toArray(Expression[]::new))), List.of(),
+                    false));
         }
 
         if (pendingFtsBranches.isEmpty()) {
@@ -192,12 +214,15 @@ public class FtsAdapterRdf4J
 
         // Locate all entries where the label contains the prefix (using the FTS) and then
         // filter them by those which actually start with the prefix.
-        pendingFtsBranches.add(VAR_SUBJECT
-                .has(FTS_RDF4J_LUCENE, bNode(LUCENE_QUERY, literalOf(queryString)) //
-                        .andHas(LUCENE_SCORE, VAR_SCORE)
-                        .andHas(LUCENE_PROPERTY, VAR_MATCH_TERM_PROPERTY))
-                .andHas(VAR_MATCH_TERM_PROPERTY, VAR_MATCH_TERM)
-                .filter(builder.startsWithPattern(VAR_MATCH_TERM, aPrefixQuery)));
+        pendingFtsBranches
+                .add(new PendingFtsBranch(
+                        VAR_SUBJECT
+                                .has(FTS_RDF4J_LUCENE, bNode(LUCENE_QUERY, literalOf(queryString)) //
+                                        .andHas(LUCENE_SCORE, VAR_SCORE)
+                                        .andHas(LUCENE_PROPERTY, VAR_MATCH_TERM_PROPERTY))
+                                .andHas(VAR_MATCH_TERM_PROPERTY, VAR_MATCH_TERM)
+                                .filter(builder.startsWithPattern(VAR_MATCH_TERM, aPrefixQuery)),
+                        List.of(), false));
     }
 
     @Override
@@ -228,7 +253,7 @@ public class FtsAdapterRdf4J
             // returned). RDF4J only provides access to the matched term in a "highlighted" form
             // where "<B>" and "</B>" match the search term. So we have to strip these markers
             // out as part of the query.
-            pendingFtsBranches.add(VAR_SUBJECT //
+            pendingFtsBranches.add(new PendingFtsBranch(VAR_SUBJECT //
                     .has(FTS_RDF4J_LUCENE, bNode(LUCENE_QUERY, literalOf(queryString)) //
                             .andHas(LUCENE_PROPERTY, VAR_MATCH_TERM_PROPERTY) //
                             .andHas(LUCENE_SCORE, VAR_SCORE) //
@@ -240,7 +265,8 @@ public class FtsAdapterRdf4J
                                     literalOf("<B>"), literalOf("")),
                             VAR_LABEL))
                     .and(VAR_SUBJECT.has(VAR_MATCH_TERM_PROPERTY, VAR_MATCH_TERM))
-                    .filter(and(labelFilterExpressions.toArray(Expression[]::new))));
+                    .filter(and(labelFilterExpressions.toArray(Expression[]::new))), List.of(),
+                    false));
         }
 
         if (pendingFtsBranches.isEmpty()) {
@@ -255,27 +281,82 @@ public class FtsAdapterRdf4J
             return;
         }
 
-        // The inner OPTIONALs reference ?pPrefLabel, which is bound at top level by the
-        // SECONDARY pattern emitted by retrieveLabel — but as an OPTIONAL { VALUES ... } wrapper.
-        // RDF4J's optimizer reorders that OPTIONAL to AFTER the union, leaving ?pPrefLabel
-        // unbound when the inner OPTIONALs run; the inner StatementPattern then matches ANY
-        // property and we get back altLabel instead of prefLabel. Workaround: emit a hard
-        // (non-OPTIONAL) VALUES binding directly inside each UNION branch so ?pPrefLabel is
-        // bound before the inner OPTIONALs are evaluated.
-        // Drain the SECONDARY bindings (the OPTIONAL { VALUES ?pPrefLabel ... } / bindMatchTerm
-        // wrappers added by retrieveLabel). We re-emit equivalent hard bindings inside each
-        // branch below, so leaving them in SECONDARY would just be duplicates.
+        // Each FTS branch gets two transformations:
+        //
+        // 1. The FTS body (search:matches + ?subj ?pMatch ?m + post-filters) is wrapped in a
+        // sub-SELECT. The inner ?subj ?pMatch ?m StatementPattern is estimated by the
+        // planner at ~5.5M rows on real SNOMED (the planner can't statically see that
+        // search:matches will bind ?subj), so without a sub-SELECT boundary it picks a
+        // HashJoinIteration that materialises the whole ?subj?pMatch?m index — multi-second
+        // disk I/O. The sub-SELECT forces a nested-loop join with ?subj already bound by
+        // Lucene, which is essentially free.
+        //
+        // 2. The retrieve* OPTIONALs are pushed INSIDE each branch (rather than left at the
+        // outer level). RDF4J 5.1.4+ otherwise reorders the outer OPTIONAL { VALUES
+        // ?pPrefLabel … } past the union, leaving ?pPrefLabel unbound when the inner
+        // OPTIONALs evaluate — they then match against any predicate and we get altLabel
+        // back instead of prefLabel (#5444). A pure outer-OPTIONALs shape ALSO trips an
+        // RDF4J QueryJoinOptimizer "rightArg must not be null" assertion on some
+        // LuceneSail+small-data combinations, so keeping the OPTIONALs in-branch is also
+        // a correctness fix.
         aBuilder.drainSecondaryPatterns();
         var optionalLookups = aBuilder.drainOptionalLookupPatterns();
         var prefLabelValuesBinding = aBuilder.bindPrefLabelPropertiesPlain(VAR_PREF_LABEL_PROPERTY);
+        var matchTermBinding = aBuilder.bindMatchTermProperties(VAR_MATCH_TERM_PROPERTY);
+
+        // The sub-SELECT wrap is only safe when there are 2+ branches: with a single branch the
+        // sparqlbuilder collapses union(singleBranch) to just the branch, and a single sub-SELECT
+        // wrapped in an outer scope trips an RDF4J QueryJoinOptimizer "rightArg must not be null"
+        // assertion via LuceneSailConnection.evaluateInternal. Multi-branch sub-SELECTs work
+        // because the UNION node sits between the sub-SELECTs and the outer scope.
+        var useSubSelect = pendingFtsBranches.size() > 1
+                && pendingFtsBranches.stream().allMatch(PendingFtsBranch::wrapInSubSelect);
 
         var augmentedBranches = pendingFtsBranches.stream() //
-                .map(branch -> augmentBranch(branch, prefLabelValuesBinding, optionalLookups)) //
+                .map(branch -> augmentBranch(
+                        useSubSelect ? wrapBranchInSubSelect(branch, matchTermBinding)
+                                : applyFilters(branch),
+                        prefLabelValuesBinding, optionalLookups)) //
                 .toArray(GraphPattern[]::new);
 
-        aBuilder.addPattern(PRIMARY, and( //
-                aBuilder.bindMatchTermProperties(VAR_MATCH_TERM_PROPERTY), //
-                union(augmentedBranches)));
+        // With sub-SELECT branches the match-term VALUES is already inside each sub-SELECT, so
+        // the outer wrap is unnecessary. Otherwise it needs to live at the outer level so the
+        // branches' ?pMatch references resolve.
+        if (useSubSelect) {
+            aBuilder.addPattern(PRIMARY, union(augmentedBranches));
+        }
+        else {
+            aBuilder.addPattern(PRIMARY, and(matchTermBinding, union(augmentedBranches)));
+        }
+    }
+
+    private static GraphPattern applyFilters(PendingFtsBranch aBranch)
+    {
+        if (aBranch.filters().isEmpty()) {
+            return aBranch.body();
+        }
+        GraphPattern result = aBranch.body();
+        for (var filter : aBranch.filters()) {
+            result = result.filter(filter);
+        }
+        return result;
+    }
+
+    private static GraphPattern wrapBranchInSubSelect(PendingFtsBranch aBranch,
+            GraphPattern aMatchTermBinding)
+    {
+        // Build the sub-SELECT WHERE as a single flat GroupGraphPattern (matchTermBinding +
+        // triple) and then append the filters. and(...) wraps in a GraphPatternNotTriples
+        // whose .filter() appends to the inner GroupGraphPattern's filter list without adding
+        // a new group level — that flat shape is what lets the planner pick a JoinIterator
+        // instead of a HashJoinIteration.
+        var body = aMatchTermBinding != null //
+                ? and(aMatchTermBinding, aBranch.body()) //
+                : and(aBranch.body());
+        for (var filter : aBranch.filters()) {
+            body = body.filter(filter);
+        }
+        return select(VAR_SUBJECT, VAR_SCORE, VAR_MATCH_TERM).where(body);
     }
 
     private static GraphPattern augmentBranch(GraphPattern aBranch, GraphPattern aPrefLabelBinding,

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterStardog.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterStardog.java
@@ -62,8 +62,8 @@ public class FtsAdapterStardog
 
             valuePatterns.add(new StardogEntitySearchService(VAR_MATCH_TERM, sanitizedValue) //
                     .withLimit(builder.getLimit()) //
-                    .and(VAR_SUBJECT.has(VAR_MATCH_TERM_PROPERTY, VAR_MATCH_TERM).filter(builder
-                            .equalsPattern(VAR_MATCH_TERM, value, builder.getKnowledgeBase()))));
+                    .and(VAR_SUBJECT.has(VAR_MATCH_TERM_PROPERTY, VAR_MATCH_TERM)
+                            .filter(builder.equalsPattern(VAR_MATCH_TERM, value))));
         }
 
         if (valuePatterns.isEmpty()) {

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterVirtuoso.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterVirtuoso.java
@@ -53,8 +53,7 @@ public class FtsAdapterVirtuoso
             valuePatterns.add(VAR_SUBJECT.has(VAR_MATCH_TERM_PROPERTY, VAR_MATCH_TERM)
                     .and(VAR_MATCH_TERM.has(VIRTUOSO_QUERY,
                             literalOf("\"" + sanitizedValue + "\"")))
-                    .filter(builder.equalsPattern(VAR_MATCH_TERM, value,
-                            builder.getKnowledgeBase())));
+                    .filter(builder.equalsPattern(VAR_MATCH_TERM, value)));
         }
 
         if (valuePatterns.isEmpty()) {

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterWikidata.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterWikidata.java
@@ -57,7 +57,7 @@ public class FtsAdapterWikidata
 
             valuePatterns.add(new WikidataEntitySearchService(VAR_SUBJECT, query, language)
                     .and(VAR_SUBJECT.has(VAR_MATCH_TERM_PROPERTY, VAR_MATCH_TERM)
-                            .filter(builder.equalsPattern(VAR_MATCH_TERM, value, kb))));
+                            .filter(builder.equalsPattern(VAR_MATCH_TERM, value))));
         }
 
         if (valuePatterns.isEmpty()) {

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
@@ -182,6 +182,8 @@ public class SPARQLQueryBuilder
 
     private int limitOverride = DEFAULT_LIMIT;
 
+    private boolean unlimited = false;
+
     private boolean includeInferred = true;
 
     private Set<String> forceDisableFTS = new LinkedHashSet<>();
@@ -674,6 +676,13 @@ public class SPARQLQueryBuilder
     public SPARQLQueryOptionalElements limit(int aLimit)
     {
         limitOverride = aLimit;
+        return this;
+    }
+
+    @Override
+    public SPARQLQueryOptionalElements noLimit()
+    {
+        unlimited = true;
         return this;
     }
 
@@ -1452,14 +1461,16 @@ public class SPARQLQueryBuilder
             query.from(dataset(from(iri(kb.getDefaultDatasetIri()))));
         }
 
-        int actualLimit = getLimit();
+        if (!unlimited) {
+            int actualLimit = getLimit();
 
-        // If we do not do a server-side reduce, then we may get two results for every item
-        // from the server (one with and one without the language), so we need to double the
-        // query limit and cut down results locally later.
-        actualLimit = actualLimit * 2;
+            // If we do not do a server-side reduce, then we may get two results for every item
+            // from the server (one with and one without the language), so we need to double the
+            // query limit and cut down results locally later.
+            actualLimit = actualLimit * 2;
 
-        query.limit(actualLimit);
+            query.limit(actualLimit);
+        }
 
         return query;
     }

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
@@ -142,6 +142,7 @@ public class SPARQLQueryBuilder
 
     private final List<GraphPattern> primaryPatterns = new ArrayList<>();
     private final List<GraphPattern> primaryRestrictions = new ArrayList<>();
+    private final List<GraphPattern> labelPropertyBindings = new ArrayList<>();
     private final List<GraphPattern> secondaryPatterns = new ArrayList<>();
     private final List<GraphPattern> optionalLookupPatterns = new ArrayList<>();
 
@@ -573,16 +574,17 @@ public class SPARQLQueryBuilder
     }
 
     /**
-     * Returns the SECONDARY patterns (typically VALUES bindings for label-property variables like
-     * {@code ?pPrefLabel}) and clears them. Used by {@link FtsAdapter#finalizeQuery} when an
-     * adapter pushes OPTIONAL lookups into UNION branches — those inner OPTIONALs reference
-     * variables bound by the SECONDARY patterns, so the SECONDARY patterns have to move into the
-     * outer scope (above the UNION) for the variable scoping to still work.
+     * Returns the label-property bindings (VALUES wrappers for {@code ?pPrefLabel} /
+     * {@code ?pMatch} added by {@link #retrieveLabel()}) and clears them. Used by
+     * {@link FtsAdapter#finalizeQuery} when an adapter re-emits equivalent hard bindings INSIDE the
+     * FTS UNION branches and therefore wants the outer wrappers gone. Kept separate from
+     * {@link #secondaryPatterns} so unrelated SECONDARY patterns (e.g. {@code RDFS:RANGE} /
+     * {@code RDFS:DOMAIN} OPTIONALs added by {@link #retrieveDomainAndRange()}) survive the drain.
      */
-    List<GraphPattern> drainSecondaryPatterns()
+    List<GraphPattern> drainLabelPropertyBindings()
     {
-        var drained = new ArrayList<>(secondaryPatterns);
-        secondaryPatterns.clear();
+        var drained = new ArrayList<>(labelPropertyBindings);
+        labelPropertyBindings.clear();
         return drained;
     }
 
@@ -1334,7 +1336,7 @@ public class SPARQLQueryBuilder
     {
         if (!mode.getAdditionalMatchingProperties(kb).isEmpty()) {
             addPreferredLabelProjections(projections);
-            addPattern(SECONDARY, bindPrefLabelProperties(VAR_PREF_LABEL_PROPERTY));
+            labelPropertyBindings.add(bindPrefLabelProperties(VAR_PREF_LABEL_PROPERTY));
             retrieveOptionalWithLanguage(VAR_PREF_LABEL_PROPERTY, VAR_PREF_LABEL);
         }
 
@@ -1344,7 +1346,7 @@ public class SPARQLQueryBuilder
         }
 
         addMatchTermProjections(projections);
-        addPattern(SECONDARY, bindMatchTermProperties(VAR_MATCH_TERM_PROPERTY));
+        labelPropertyBindings.add(bindMatchTermProperties(VAR_MATCH_TERM_PROPERTY));
         retrieveOptionalWithLanguage(VAR_MATCH_TERM_PROPERTY, VAR_MATCH_TERM);
 
         return this;
@@ -1409,9 +1411,7 @@ public class SPARQLQueryBuilder
 
         // Give the FTS adapter a chance to assemble its deferred patterns now that all retrieve*
         // calls have run, e.g. to push OPTIONAL lookups into FTS UNION branches. Guarded because
-        // selectQuery() is invoked repeatedly via equals()/hashCode() for query-cache lookups, and
-        // finalizeQuery() drains pattern lists and adds new primary patterns — re-running it would
-        // drop OPTIONAL lookups or accumulate duplicate UNION patterns.
+        // equals()/hashCode() re-invoke selectQuery() and finalizeQuery() is destructive.
         if (!finalized) {
             getAdapter().finalizeQuery(this);
             finalized = true;
@@ -1444,6 +1444,7 @@ public class SPARQLQueryBuilder
                         .toArray(GraphPattern[]::new)).getQueryString()));
 
         // Then add the optional or lower-prio elements
+        labelPropertyBindings.stream().forEach(query::where);
         secondaryPatterns.stream().forEach(query::where);
         optionalLookupPatterns.stream().forEach(query::where);
 

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
@@ -676,6 +676,7 @@ public class SPARQLQueryBuilder
     public SPARQLQueryOptionalElements limit(int aLimit)
     {
         limitOverride = aLimit;
+        unlimited = false;
         return this;
     }
 

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
@@ -147,6 +147,8 @@ public class SPARQLQueryBuilder
 
     private FtsAdapter cachedFtsAdapter;
 
+    private boolean finalized = false;
+
     private boolean labelImplicitlyRetrieved = false;
 
     private boolean filterUsingRegex = true;
@@ -1406,8 +1408,14 @@ public class SPARQLQueryBuilder
         projections.add(VAR_SUBJECT);
 
         // Give the FTS adapter a chance to assemble its deferred patterns now that all retrieve*
-        // calls have run, e.g. to push OPTIONAL lookups into FTS UNION branches.
-        getAdapter().finalizeQuery(this);
+        // calls have run, e.g. to push OPTIONAL lookups into FTS UNION branches. Guarded because
+        // selectQuery() is invoked repeatedly via equals()/hashCode() for query-cache lookups, and
+        // finalizeQuery() drains pattern lists and adds new primary patterns — re-running it would
+        // drop OPTIONAL lookups or accumulate duplicate UNION patterns.
+        if (!finalized) {
+            getAdapter().finalizeQuery(this);
+            finalized = true;
+        }
 
         var query = Queries.SELECT().distinct();
         prefixes.forEach(query::prefix);

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
@@ -1107,9 +1107,9 @@ public class SPARQLQueryBuilder
         return value;
     }
 
-    Expression<?> equalsPattern(Variable aVariable, String aValue, KnowledgeBase aKB)
+    Expression<?> equalsPattern(Variable aVariable, String aValue)
     {
-        return and(equalsFilters(aVariable, aValue, aKB).toArray(Expression[]::new));
+        return and(equalsFilters(aVariable, aValue).toArray(Expression[]::new));
     }
 
     /**
@@ -1120,7 +1120,7 @@ public class SPARQLQueryBuilder
      * combined filter the cost-estimator treats the conjunction as one opaque expression and cannot
      * reorder/push the cheap LANGMATCHES separately from the expensive anchored REGEX.
      */
-    List<Expression<?>> equalsFilters(Variable aVariable, String aValue, KnowledgeBase aKB)
+    List<Expression<?>> equalsFilters(Variable aVariable, String aValue)
     {
         var regexFlags = "";
         if (caseInsensitive) {

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
@@ -1419,11 +1419,11 @@ public class SPARQLQueryBuilder
         // Must add it anyway because we group by it
         projections.add(VAR_SUBJECT);
 
-        // Give the FTS adapter a chance to assemble its deferred patterns now that all retrieve*
-        // calls have run, e.g. to push OPTIONAL lookups into FTS UNION branches. Guarded because
-        // equals()/hashCode() re-invoke selectQuery() and finalizeQuery() is destructive.
-        if (!finalized) {
-            getAdapter().finalizeQuery(this);
+        // Assemble FTS-adapter deferred patterns. Skipped when no FTS was used (otherwise
+        // identifier-only queries could trip an unknown-FTS-mode ISE) and run at most once
+        // (equals()/hashCode() re-invoke selectQuery() and finalizeQuery() is destructive).
+        if (!finalized && cachedFtsAdapter != null) {
+            cachedFtsAdapter.finalizeQuery(this);
             finalized = true;
         }
 

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
@@ -27,6 +27,7 @@ import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_STARDOG;
 import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_VIRTUOSO;
 import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_WIKIDATA;
 import static de.tudarmstadt.ukp.inception.kb.IriConstants.hasImplicitNamespace;
+import static de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilder.Priority.OPTIONAL_LOOKUP;
 import static de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilder.Priority.PRIMARY;
 import static de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilder.Priority.PRIMARY_RESTRICTIONS;
 import static de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilder.Priority.SECONDARY;
@@ -142,6 +143,9 @@ public class SPARQLQueryBuilder
     private final List<GraphPattern> primaryPatterns = new ArrayList<>();
     private final List<GraphPattern> primaryRestrictions = new ArrayList<>();
     private final List<GraphPattern> secondaryPatterns = new ArrayList<>();
+    private final List<GraphPattern> optionalLookupPatterns = new ArrayList<>();
+
+    private FtsAdapter cachedFtsAdapter;
 
     private boolean labelImplicitlyRetrieved = false;
 
@@ -149,7 +153,7 @@ public class SPARQLQueryBuilder
 
     enum Priority
     {
-        PRIMARY, PRIMARY_RESTRICTIONS, SECONDARY
+        PRIMARY, PRIMARY_RESTRICTIONS, SECONDARY, OPTIONAL_LOOKUP
     }
 
     /**
@@ -545,9 +549,39 @@ public class SPARQLQueryBuilder
         case SECONDARY:
             secondaryPatterns.add(aPattern);
             break;
+        case OPTIONAL_LOOKUP:
+            optionalLookupPatterns.add(aPattern);
+            break;
         default:
             throw new IllegalArgumentException("Unknown priority: [" + aPriority + "]");
         }
+    }
+
+    /**
+     * Returns the OPTIONAL lookup patterns (label/description/deprecation retrievals) collected so
+     * far, and clears them from the builder. Intended for use by an {@link FtsAdapter} in
+     * {@link FtsAdapter#finalizeQuery(SPARQLQueryBuilder)} that wants to push those patterns into
+     * FTS UNION branches instead of having them rendered as top-level OPTIONAL clauses.
+     */
+    List<GraphPattern> drainOptionalLookupPatterns()
+    {
+        var drained = new ArrayList<>(optionalLookupPatterns);
+        optionalLookupPatterns.clear();
+        return drained;
+    }
+
+    /**
+     * Returns the SECONDARY patterns (typically VALUES bindings for label-property variables like
+     * {@code ?pPrefLabel}) and clears them. Used by {@link FtsAdapter#finalizeQuery} when an
+     * adapter pushes OPTIONAL lookups into UNION branches — those inner OPTIONALs reference
+     * variables bound by the SECONDARY patterns, so the SECONDARY patterns have to move into the
+     * outer scope (above the UNION) for the variable scoping to still work.
+     */
+    List<GraphPattern> drainSecondaryPatterns()
+    {
+        var drained = new ArrayList<>(secondaryPatterns);
+        secondaryPatterns.clear();
+        return drained;
     }
 
     private void addMatchTermProjections(Collection<Projectable> aProjectables)
@@ -703,6 +737,23 @@ public class SPARQLQueryBuilder
     }
 
     /**
+     * Returns a hard-binding VALUES pattern for the pref-label properties, without the OPTIONAL
+     * wrapper used by {@link #bindPrefLabelProperties(Variable)}. Used by adapters that emit the
+     * binding inside a UNION branch where outer-scope OPTIONAL wrappers get reordered by the
+     * optimizer to after the inner patterns, leaving the variable unbound when those inner patterns
+     * reference it. Returns {@code null} when there is nothing to bind (no pre-resolved pref-label
+     * properties available — the caller should fall through to the OPTIONAL form).
+     */
+    GraphPattern bindPrefLabelPropertiesPlain(Variable aVariable)
+    {
+        if (preResolvedPrefLabelProperties.isEmpty()) {
+            return null;
+        }
+        return new ValuesPattern(aVariable,
+                preResolvedPrefLabelProperties.stream().map(Rdf::iri).toArray(RdfValue[]::new));
+    }
+
+    /**
      * Generates a pattern which binds all sub-properties of the label property to the given
      * variable.
      */
@@ -849,6 +900,14 @@ public class SPARQLQueryBuilder
     }
 
     private FtsAdapter getAdapter()
+    {
+        if (cachedFtsAdapter == null) {
+            cachedFtsAdapter = createAdapter();
+        }
+        return cachedFtsAdapter;
+    }
+
+    private FtsAdapter createAdapter()
     {
         var ftsMode = getFtsMode();
 
@@ -1312,7 +1371,7 @@ public class SPARQLQueryBuilder
         // Virtuoso has trouble with multiple OPTIONAL clauses causing results which would
         // normally match to be removed from the results set. Using a UNION seems to address this
         // labelPatterns.forEach(pattern -> addPattern(Priority.SECONDARY, optional(pattern)));
-        addPattern(SECONDARY, optional(union(pattern)));
+        addPattern(OPTIONAL_LOOKUP, optional(union(pattern)));
     }
 
     @Override
@@ -1336,6 +1395,10 @@ public class SPARQLQueryBuilder
     {
         // Must add it anyway because we group by it
         projections.add(VAR_SUBJECT);
+
+        // Give the FTS adapter a chance to assemble its deferred patterns now that all retrieve*
+        // calls have run, e.g. to push OPTIONAL lookups into FTS UNION branches.
+        getAdapter().finalizeQuery(this);
 
         var query = Queries.SELECT().distinct();
         prefixes.forEach(query::prefix);
@@ -1365,6 +1428,7 @@ public class SPARQLQueryBuilder
 
         // Then add the optional or lower-prio elements
         secondaryPatterns.stream().forEach(query::where);
+        optionalLookupPatterns.stream().forEach(query::where);
 
         if (kb.getDefaultDatasetIri() != null) {
             query.from(dataset(from(iri(kb.getDefaultDatasetIri()))));

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
@@ -180,9 +180,10 @@ public class SPARQLQueryBuilder
      */
     private boolean caseInsensitive = true;
 
-    private int limitOverride = DEFAULT_LIMIT;
+    /** Sentinel for "no LIMIT" — picked so {@code Stream.limit(getLimit())} is a no-op too. */
+    static final int UNLIMITED = Integer.MAX_VALUE;
 
-    private boolean unlimited = false;
+    private int limitOverride = DEFAULT_LIMIT;
 
     private boolean includeInferred = true;
 
@@ -676,14 +677,13 @@ public class SPARQLQueryBuilder
     public SPARQLQueryOptionalElements limit(int aLimit)
     {
         limitOverride = aLimit;
-        unlimited = false;
         return this;
     }
 
     @Override
     public SPARQLQueryOptionalElements noLimit()
     {
-        unlimited = true;
+        limitOverride = UNLIMITED;
         return this;
     }
 
@@ -1462,15 +1462,12 @@ public class SPARQLQueryBuilder
             query.from(dataset(from(iri(kb.getDefaultDatasetIri()))));
         }
 
-        if (!unlimited) {
-            int actualLimit = getLimit();
-
+        int actualLimit = getLimit();
+        if (actualLimit != UNLIMITED) {
             // If we do not do a server-side reduce, then we may get two results for every item
             // from the server (one with and one without the language), so we need to double the
             // query limit and cut down results locally later.
-            actualLimit = actualLimit * 2;
-
-            query.limit(actualLimit);
+            query.limit(actualLimit * 2);
         }
 
         return query;

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
@@ -1095,23 +1095,32 @@ public class SPARQLQueryBuilder
 
     Expression<?> equalsPattern(Variable aVariable, String aValue, KnowledgeBase aKB)
     {
-        var variable = aVariable;
+        return and(equalsFilters(aVariable, aValue, aKB).toArray(Expression[]::new));
+    }
 
+    /**
+     * Same conjuncts as {@link #equalsPattern}, but returned as separate expressions so the caller
+     * can emit each as its own SPARQL {@code FILTER} clause. Avoiding the combined
+     * {@code FILTER ( REGEX(...) && LANGMATCHES(...) )} shape helps the RDF4J planner — see
+     * <a href="https://github.com/eclipse-rdf4j/rdf4j/issues/5444">RDF4J #5444</a>: with a single
+     * combined filter the cost-estimator treats the conjunction as one opaque expression and cannot
+     * reorder/push the cheap LANGMATCHES separately from the expensive anchored REGEX.
+     */
+    List<Expression<?>> equalsFilters(Variable aVariable, String aValue, KnowledgeBase aKB)
+    {
         var regexFlags = "";
         if (caseInsensitive) {
             regexFlags += "i";
         }
 
-        // Match using REGEX to be resilient against extra whitespace
-        // Match exactly
+        // Match using REGEX to be resilient against extra whitespace, anchored for exact match.
         var value = "^" + asRegexp(aValue) + "$";
 
         var expressions = new ArrayList<Expression<?>>();
         expressions.add(
-                function(REGEX, function(STR, variable), literalOf(value), literalOf(regexFlags)));
+                function(REGEX, function(STR, aVariable), literalOf(value), literalOf(regexFlags)));
         expressions.add(matchKbLanguage(aVariable));
-
-        return and(expressions.toArray(Expression[]::new));
+        return expressions;
     }
 
     private Expression<?> matchString(SparqlFunction aFunction, Variable aVariable, String aValue)

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryOptionalElements.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryOptionalElements.java
@@ -42,6 +42,13 @@ public interface SPARQLQueryOptionalElements
 
     SPARQLQueryOptionalElements limit(int aLimit);
 
+    /**
+     * Skip the SPARQL LIMIT clause entirely. Use for identifier-based batch lookups where the
+     * result is naturally bounded by a VALUES clause and a hard LIMIT could truncate legitimate
+     * multi-row-per-identifier output (languages, OPTIONAL cartesian products).
+     */
+    SPARQLQueryOptionalElements noLimit();
+
     SPARQLQueryOptionalElements caseSensitive();
 
     SPARQLQueryOptionalElements caseSensitive(boolean aEnabled);

--- a/inception/inception-kb/src/main/resources/META-INF/asciidoc/admin-guide/settings_knowledgebase.adoc
+++ b/inception/inception-kb/src/main/resources/META-INF/asciidoc/admin-guide/settings_knowledgebase.adoc
@@ -83,6 +83,11 @@ The default value is shown as an example of how the parameter can be configured 
 | `1m`
 | `5m`
 
+| `knowledge-base.read-batch-size`
+| maximum number of identifiers fitted into a single batch SPARQL request (e.g. when resolving concept labels for annotation rendering). Larger collections are split into sequential chunks to keep `VALUES` clauses and intermediate result sets bounded. Tune higher for backends that handle large `VALUES` well, lower for constrained remote endpoints.
+| `250`
+| `1000`
+
 | `knowledge-base.remove-orphans-on-start`
 | whether to delete orphaned KBs on start
 | `false`

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplIntegrationTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplIntegrationTest.java
@@ -1996,6 +1996,107 @@ public class KnowledgeBaseServiceImplIntegrationTest
         assertThat(sut.getIndexSize(kb)).isGreaterThan(30000);
     }
 
+    @ParameterizedTest(name = "Reification = {0}")
+    @MethodSource("data")
+    public void readHandles_WithExistingConcepts_ShouldReturnHandlePerId(Reification reification)
+        throws Exception
+    {
+        setUp(reification);
+        sut.registerKnowledgeBase(kb, sut.getNativeConfig());
+
+        var c1 = buildConcept();
+        c1.setName("Alpha");
+        sut.createConcept(kb, c1);
+        var c2 = buildConcept();
+        c2.setName("Beta");
+        sut.createConcept(kb, c2);
+
+        var result = sut.readHandles(kb, asList(c1.getIdentifier(), c2.getIdentifier()));
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(c1.getIdentifier())).extracting(KBHandle::getName).isEqualTo("Alpha");
+        assertThat(result.get(c2.getIdentifier())).extracting(KBHandle::getName).isEqualTo("Beta");
+    }
+
+    @ParameterizedTest(name = "Reification = {0}")
+    @MethodSource("data")
+    public void readHandles_WithMissingIds_ShouldReturnStubHandles(Reification reification)
+        throws Exception
+    {
+        setUp(reification);
+        sut.registerKnowledgeBase(kb, sut.getNativeConfig());
+
+        var c1 = buildConcept();
+        c1.setName("Alpha");
+        sut.createConcept(kb, c1);
+
+        var missingId = "https://nonexistent.identifier.test/x";
+        var result = sut.readHandles(kb, asList(c1.getIdentifier(), missingId));
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(c1.getIdentifier())).extracting(KBHandle::getName).isEqualTo("Alpha");
+        assertThat(result.get(missingId)) //
+                .as("Missing IDs get stub handles with the requested identifier and no name")
+                .isNotNull() //
+                .extracting(KBHandle::getIdentifier, KBHandle::getName) //
+                .containsExactly(missingId, null);
+    }
+
+    @Test
+    public void readHandles_WithEmptyInput_ShouldReturnEmptyMap() throws Exception
+    {
+        setUp(Reification.NONE);
+        sut.registerKnowledgeBase(kb, sut.getNativeConfig());
+
+        assertThat(sut.readHandles(kb, List.of())).isEmpty();
+    }
+
+    @ParameterizedTest(name = "Reification = {0}")
+    @MethodSource("data")
+    public void readHandles_WithDuplicateIds_ShouldDeduplicate(Reification reification)
+        throws Exception
+    {
+        setUp(reification);
+        sut.registerKnowledgeBase(kb, sut.getNativeConfig());
+
+        var c1 = buildConcept();
+        c1.setName("Alpha");
+        sut.createConcept(kb, c1);
+
+        var result = sut.readHandles(kb,
+                asList(c1.getIdentifier(), c1.getIdentifier(), c1.getIdentifier()));
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(c1.getIdentifier())).extracting(KBHandle::getName).isEqualTo("Alpha");
+    }
+
+    @ParameterizedTest(name = "Reification = {0}")
+    @MethodSource("data")
+    public void readHandles_Project_ShouldResolveAcrossEnabledKBs(Reification reification)
+        throws Exception
+    {
+        setUp(reification);
+        sut.registerKnowledgeBase(kb, sut.getNativeConfig());
+        var kb2 = buildKnowledgeBase(project, "Second KB", reification);
+        sut.registerKnowledgeBase(kb2, sut.getNativeConfig());
+
+        var c1 = buildConcept();
+        c1.setName("InFirst");
+        sut.createConcept(kb, c1);
+
+        var c2 = buildConcept();
+        c2.setName("InSecond");
+        sut.createConcept(kb2, c2);
+
+        var result = sut.readHandles(project, asList(c1.getIdentifier(), c2.getIdentifier()));
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(c1.getIdentifier())).extracting(KBHandle::getName)
+                .isEqualTo("InFirst");
+        assertThat(result.get(c2.getIdentifier())).extracting(KBHandle::getName)
+                .isEqualTo("InSecond");
+    }
+
     // Helper
     private Project createProject(String name)
     {

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplIntegrationTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplIntegrationTest.java
@@ -107,12 +107,17 @@ public class KnowledgeBaseServiceImplIntegrationTest
 
     public void setUp(Reification reification) throws Exception
     {
+        setUp(reification, new KnowledgeBasePropertiesImpl());
+    }
+
+    public void setUp(Reification reification, KnowledgeBasePropertiesImpl aKbProperties)
+        throws Exception
+    {
         var repoProps = new RepositoryPropertiesImpl();
         repoProps.setPath(temporaryFolder);
-        var kbProperties = new KnowledgeBasePropertiesImpl();
         var entityManager = testEntityManager.getEntityManager();
         testFixtures = new TestFixtures(testEntityManager);
-        sut = new KnowledgeBaseServiceImpl(repoProps, kbProperties, entityManager);
+        sut = new KnowledgeBaseServiceImpl(repoProps, aKbProperties, entityManager);
         project = createProject(PROJECT_NAME);
         kb = buildKnowledgeBase(project, KB_NAME, reification);
     }
@@ -2068,6 +2073,37 @@ public class KnowledgeBaseServiceImplIntegrationTest
 
         assertThat(result).hasSize(1);
         assertThat(result.get(c1.getIdentifier())).extracting(KBHandle::getName).isEqualTo("Alpha");
+    }
+
+    @ParameterizedTest(name = "Reification = {0}")
+    @MethodSource("data")
+    public void readHandles_WithMoreIdsThanBatchSize_ShouldChunkAndMergeResults(
+            Reification reification)
+        throws Exception
+    {
+        var props = new KnowledgeBasePropertiesImpl();
+        props.setReadBatchSize(2);
+        setUp(reification, props);
+        sut.registerKnowledgeBase(kb, sut.getNativeConfig());
+
+        var concepts = new ArrayList<KBConcept>();
+        for (var i = 0; i < 5; i++) {
+            var c = buildConcept();
+            c.setName("Concept" + i);
+            sut.createConcept(kb, c);
+            concepts.add(c);
+        }
+
+        var ids = concepts.stream().map(KBConcept::getIdentifier).toList();
+        var result = sut.readHandles(kb, ids);
+
+        // 5 ids with batch size 2 => 3 chunks (2 + 2 + 1). All results must still be present.
+        assertThat(result).hasSize(5);
+        for (var i = 0; i < 5; i++) {
+            assertThat(result.get(concepts.get(i).getIdentifier())) //
+                    .extracting(KBHandle::getName) //
+                    .isEqualTo("Concept" + i);
+        }
     }
 
     @ParameterizedTest(name = "Reification = {0}")

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/config/KnowledgeBaseServiceUIAutoConfiguration.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/config/KnowledgeBaseServiceUIAutoConfiguration.java
@@ -37,6 +37,7 @@ import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureSupportRegistry;
 import de.tudarmstadt.ukp.inception.ui.kb.KnowledgeBasePageMenuItem;
 import de.tudarmstadt.ukp.inception.ui.kb.feature.ConceptFeatureSupport;
 import de.tudarmstadt.ukp.inception.ui.kb.feature.ConceptLabelCache;
+import de.tudarmstadt.ukp.inception.ui.kb.feature.KbLabelCachePrewarmStep;
 import de.tudarmstadt.ukp.inception.ui.kb.feature.MultiValueConceptFeatureSupport;
 import de.tudarmstadt.ukp.inception.ui.kb.initializers.NamedEntityIdentifierFeatureInitializer;
 import de.tudarmstadt.ukp.inception.ui.kb.project.KnowledgeBaseProjectSettingsPanelFactory;
@@ -95,6 +96,16 @@ public class KnowledgeBaseServiceUIAutoConfiguration
             KnowledgeBaseProperties aKBProperties)
     {
         return new ConceptLabelCache(aKbService, aKBProperties);
+    }
+
+    @Bean
+    public KbLabelCachePrewarmStep kbLabelCachePrewarmStep(ConceptLabelCache aLabelCache,
+            ConceptFeatureSupport aConceptFeatureSupport,
+            MultiValueConceptFeatureSupport aMultiValueConceptFeatureSupport,
+            AnnotationSchemaService aSchemaService)
+    {
+        return new KbLabelCachePrewarmStep(aLabelCache, aConceptFeatureSupport,
+                aMultiValueConceptFeatureSupport, aSchemaService);
     }
 
     @Bean

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptLabelCache.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptLabelCache.java
@@ -123,9 +123,14 @@ public class ConceptLabelCache
 
     /**
      * Bulk-load handles for the given keys via {@link KnowledgeBaseService#readHandles}, grouping
-     * by (project, repositoryId) so each group produces one batched SPARQL request. Falls back to
-     * single-key loading for any group that throws, preserving the per-key fault isolation of
-     * {@link #loadLabelValue}.
+     * by (projectId, repositoryId) so each group produces one batched SPARQL request. Falls back to
+     * single-key loading for any group whose batched request throws, preserving the per-key fault
+     * isolation of {@link #loadLabelValue}.
+     * <p>
+     * Throws {@link IllegalArgumentException} up-front if any key references an
+     * {@link AnnotationFeature} with no project, or a project that has not yet been persisted (null
+     * id) — those are programming errors, not data-level failures, so they are not caught and
+     * isolated per-key.
      */
     private Map<Key, KBHandle> bulkLoadLabelValues(Set<? extends Key> aKeys)
     {

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptLabelCache.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptLabelCache.java
@@ -146,28 +146,30 @@ public class ConceptLabelCache
             var keysInGroup = group.getValue();
 
             try {
-                // Map each key to its identifier (and back) for batch lookup.
-                var idsToKeys = keysInGroup.stream() //
-                        .collect(Collectors.groupingBy(Key::getLabel));
+                var distinctIds = keysInGroup.stream() //
+                        .map(Key::getLabel) //
+                        .collect(Collectors.toSet());
 
                 Map<String, KBHandle> handlesById;
                 if (repositoryId != null) {
                     var kbOpt = kbService.getKnowledgeBaseById(project, repositoryId) //
                             .filter(KnowledgeBase::isEnabled);
-                    handlesById = kbOpt.map(kb -> kbService.readHandles(kb, idsToKeys.keySet()))
+                    handlesById = kbOpt.map(kb -> kbService.readHandles(kb, distinctIds))
                             .orElse(Map.of());
                 }
                 else {
-                    handlesById = kbService.readHandles(project, idsToKeys.keySet());
+                    handlesById = kbService.readHandles(project, distinctIds);
                 }
 
                 for (var key : keysInGroup) {
+                    // readHandles guarantees one entry per requested id (stub when not found),
+                    // so we cache whatever it returned — mirrors loadLabelValue's behavior of
+                    // keeping handles with name=null but other metadata (description/deprecated).
                     var handle = handlesById.get(key.getLabel());
-                    if (handle != null && handle.getName() != null) {
+                    if (handle != null) {
                         result.put(key, handle);
                     }
                     else {
-                        // Mirror loadLabelValue's NoSuchElementException branch.
                         result.put(key, KBHandle.builder() //
                                 .withIdentifier(key.getLabel()) //
                                 .build());

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptLabelCache.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptLabelCache.java
@@ -140,6 +140,10 @@ public class ConceptLabelCache
                 throw new IllegalArgumentException("AnnotationFeature ["
                         + key.getAnnotationFeature().getName() + "] has no associated project");
             }
+            if (project.getId() == null) {
+                throw new IllegalArgumentException(
+                        "Project [" + project.getName() + "] has not been persisted (id is null)");
+            }
             var groupKey = new SimpleEntry<>(project.getId(), key.getRepositoryId());
             groups.computeIfAbsent(groupKey, k -> new java.util.ArrayList<>()).add(key);
         }

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptLabelCache.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptLabelCache.java
@@ -135,8 +135,12 @@ public class ConceptLabelCache
         // project still batch together. A null repositoryId means "any KB in the project".
         var groups = new LinkedHashMap<SimpleEntry<Long, String>, java.util.List<Key>>();
         for (var key : aKeys) {
-            var groupKey = new SimpleEntry<>(key.getAnnotationFeature().getProject().getId(),
-                    key.getRepositoryId());
+            var project = key.getAnnotationFeature().getProject();
+            if (project == null) {
+                throw new IllegalArgumentException("AnnotationFeature ["
+                        + key.getAnnotationFeature().getName() + "] has no associated project");
+            }
+            var groupKey = new SimpleEntry<>(project.getId(), key.getRepositoryId());
             groups.computeIfAbsent(groupKey, k -> new java.util.ArrayList<>()).add(key);
         }
 

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptLabelCache.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptLabelCache.java
@@ -35,7 +35,6 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
-import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.inception.kb.KnowledgeBaseService;
 import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBaseProperties;
 import de.tudarmstadt.ukp.inception.kb.graph.KBErrorHandle;
@@ -132,18 +131,20 @@ public class ConceptLabelCache
     {
         var result = new LinkedHashMap<Key, KBHandle>();
 
-        // Group keys by (project, repositoryId). A null repositoryId means "any KB in the project".
-        var groups = new LinkedHashMap<SimpleEntry<Project, String>, java.util.List<Key>>();
+        // Group by project ID (not Project reference) so distinct JPA instances of the same
+        // project still batch together. A null repositoryId means "any KB in the project".
+        var groups = new LinkedHashMap<SimpleEntry<Long, String>, java.util.List<Key>>();
         for (var key : aKeys) {
-            var groupKey = new SimpleEntry<>(key.getAnnotationFeature().getProject(),
+            var groupKey = new SimpleEntry<>(key.getAnnotationFeature().getProject().getId(),
                     key.getRepositoryId());
             groups.computeIfAbsent(groupKey, k -> new java.util.ArrayList<>()).add(key);
         }
 
         for (var group : groups.entrySet()) {
-            var project = group.getKey().getKey();
             var repositoryId = group.getKey().getValue();
             var keysInGroup = group.getValue();
+            // Any key works — all share the same project ID.
+            var project = keysInGroup.get(0).getAnnotationFeature().getProject();
 
             try {
                 var distinctIds = keysInGroup.stream() //
@@ -180,7 +181,7 @@ public class ConceptLabelCache
                 LOG.error(
                         "Bulk load failed for project [{}] repositoryId [{}]; "
                                 + "falling back to per-key loading",
-                        project != null ? project.getName() : null, repositoryId, e);
+                        project.getName(), repositoryId, e);
                 for (var key : keysInGroup) {
                     result.put(key, loadLabelValue(key));
                 }

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptLabelCache.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptLabelCache.java
@@ -17,17 +17,25 @@
  */
 package de.tudarmstadt.ukp.inception.ui.kb.feature;
 
+import java.util.AbstractMap.SimpleEntry;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.github.benmanes.caffeine.cache.CacheLoader;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.inception.kb.KnowledgeBaseService;
 import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBaseProperties;
 import de.tudarmstadt.ukp.inception.kb.graph.KBErrorHandle;
@@ -55,12 +63,30 @@ public class ConceptLabelCache
                 .maximumSize(aKBProperties.getRenderCacheSize()) //
                 .expireAfterWrite(aKBProperties.getRenderCacheExpireDelay()) //
                 .refreshAfterWrite(aKBProperties.getRenderCacheRefreshDelay()) //
-                .build(key -> loadLabelValue(key));
+                .build(new CacheLoader<Key, KBHandle>()
+                {
+                    @Override
+                    public KBHandle load(Key aKey)
+                    {
+                        return loadLabelValue(aKey);
+                    }
+
+                    @Override
+                    public Map<? extends Key, ? extends KBHandle> loadAll(Set<? extends Key> aKeys)
+                    {
+                        return bulkLoadLabelValues(aKeys);
+                    }
+                });
     }
 
     public KBHandle get(AnnotationFeature aFeature, String aRepositoryId, String aLabel)
     {
         return labelCache.get(new Key(aFeature, aRepositoryId, aLabel));
+    }
+
+    public Map<Key, KBHandle> getAll(Collection<Key> aKeys)
+    {
+        return labelCache.getAll(aKeys);
     }
 
     private KBHandle loadLabelValue(Key aKey)
@@ -96,7 +122,73 @@ public class ConceptLabelCache
         }
     }
 
-    private class Key
+    /**
+     * Bulk-load handles for the given keys via {@link KnowledgeBaseService#readHandles}, grouping
+     * by (project, repositoryId) so each group produces one batched SPARQL request. Falls back to
+     * single-key loading for any group that throws, preserving the per-key fault isolation of
+     * {@link #loadLabelValue}.
+     */
+    private Map<Key, KBHandle> bulkLoadLabelValues(Set<? extends Key> aKeys)
+    {
+        var result = new LinkedHashMap<Key, KBHandle>();
+
+        // Group keys by (project, repositoryId). A null repositoryId means "any KB in the project".
+        var groups = new LinkedHashMap<SimpleEntry<Project, String>, java.util.List<Key>>();
+        for (var key : aKeys) {
+            var groupKey = new SimpleEntry<>(key.getAnnotationFeature().getProject(),
+                    key.getRepositoryId());
+            groups.computeIfAbsent(groupKey, k -> new java.util.ArrayList<>()).add(key);
+        }
+
+        for (var group : groups.entrySet()) {
+            var project = group.getKey().getKey();
+            var repositoryId = group.getKey().getValue();
+            var keysInGroup = group.getValue();
+
+            try {
+                // Map each key to its identifier (and back) for batch lookup.
+                var idsToKeys = keysInGroup.stream() //
+                        .collect(Collectors.groupingBy(Key::getLabel));
+
+                Map<String, KBHandle> handlesById;
+                if (repositoryId != null) {
+                    var kbOpt = kbService.getKnowledgeBaseById(project, repositoryId) //
+                            .filter(KnowledgeBase::isEnabled);
+                    handlesById = kbOpt.map(kb -> kbService.readHandles(kb, idsToKeys.keySet()))
+                            .orElse(Map.of());
+                }
+                else {
+                    handlesById = kbService.readHandles(project, idsToKeys.keySet());
+                }
+
+                for (var key : keysInGroup) {
+                    var handle = handlesById.get(key.getLabel());
+                    if (handle != null && handle.getName() != null) {
+                        result.put(key, handle);
+                    }
+                    else {
+                        // Mirror loadLabelValue's NoSuchElementException branch.
+                        result.put(key, KBHandle.builder() //
+                                .withIdentifier(key.getLabel()) //
+                                .build());
+                    }
+                }
+            }
+            catch (Exception e) {
+                LOG.error(
+                        "Bulk load failed for project [{}] repositoryId [{}]; "
+                                + "falling back to per-key loading",
+                        project.getName(), repositoryId, e);
+                for (var key : keysInGroup) {
+                    result.put(key, loadLabelValue(key));
+                }
+            }
+        }
+
+        return result;
+    }
+
+    public static class Key
     {
         private final AnnotationFeature feature;
         private final String repositoryId;
@@ -107,6 +199,11 @@ public class ConceptLabelCache
             feature = aFeature;
             repositoryId = aRepositoryId;
             label = aLabel;
+        }
+
+        public static Key of(AnnotationFeature aFeature, String aRepositoryId, String aLabel)
+        {
+            return new Key(aFeature, aRepositoryId, aLabel);
         }
 
         public String getLabel()

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptLabelCache.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptLabelCache.java
@@ -180,7 +180,7 @@ public class ConceptLabelCache
                 LOG.error(
                         "Bulk load failed for project [{}] repositoryId [{}]; "
                                 + "falling back to per-key loading",
-                        project.getName(), repositoryId, e);
+                        project != null ? project.getName() : null, repositoryId, e);
                 for (var key : keysInGroup) {
                     result.put(key, loadLabelValue(key));
                 }

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/KbLabelCachePrewarmStep.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/KbLabelCachePrewarmStep.java
@@ -124,12 +124,14 @@ public class KbLabelCachePrewarmStep
     private void collectKeysForLayer(org.apache.uima.cas.CAS aCas, AnnotationLayer aLayer,
             int aWindowBegin, int aWindowEnd, RenderRequest aRequest, Set<Key> aOut)
     {
-        var features = schemaService.listSupportedFeatures(aLayer).stream() //
+        // Resolve repositoryId once per feature — readTraits deserializes JSON, so doing it per
+        // FS would scale with the document size.
+        var featureInfos = schemaService.listSupportedFeatures(aLayer).stream() //
                 .filter(f -> !aRequest.getHiddenFeatures().contains(f.getId())) //
-                .filter(f -> conceptFeatureSupport.accepts(f)
-                        || multiValueConceptFeatureSupport.accepts(f)) //
+                .map(this::toFeatureInfo) //
+                .filter(java.util.Objects::nonNull) //
                 .toList();
-        if (features.isEmpty()) {
+        if (featureInfos.isEmpty()) {
             return;
         }
 
@@ -142,35 +144,47 @@ public class KbLabelCachePrewarmStep
             if (!overlapping(fs, aWindowBegin, aWindowEnd)) {
                 continue;
             }
-            for (var feature : features) {
-                extractKeys(feature, fs, aOut);
+            for (var info : featureInfos) {
+                extractKeys(info, fs, aOut);
             }
         }
     }
 
-    private void extractKeys(AnnotationFeature aFeature, AnnotationFS aFs, Set<Key> aOut)
+    private FeatureInfo toFeatureInfo(AnnotationFeature aFeature)
     {
         if (conceptFeatureSupport.accepts(aFeature)) {
-            var id = FSUtil.getFeature(aFs, aFeature.getName(), String.class);
+            return new FeatureInfo(aFeature,
+                    conceptFeatureSupport.readTraits(aFeature).getRepositoryId(), false);
+        }
+        if (multiValueConceptFeatureSupport.accepts(aFeature)) {
+            return new FeatureInfo(aFeature,
+                    multiValueConceptFeatureSupport.readTraits(aFeature).getRepositoryId(), true);
+        }
+        return null;
+    }
+
+    private void extractKeys(FeatureInfo aInfo, AnnotationFS aFs, Set<Key> aOut)
+    {
+        var feature = aInfo.feature();
+        if (!aInfo.isMulti()) {
+            var id = FSUtil.getFeature(aFs, feature.getName(), String.class);
             if (isNotBlank(id)) {
-                var repoId = conceptFeatureSupport.readTraits(aFeature).getRepositoryId();
-                aOut.add(Key.of(aFeature, repoId, id));
+                aOut.add(Key.of(feature, aInfo.repositoryId(), id));
             }
             return;
         }
 
-        if (multiValueConceptFeatureSupport.accepts(aFeature)) {
-            @SuppressWarnings("unchecked")
-            var values = (List<String>) FSUtil.getFeature(aFs, aFeature.getName(), List.class);
-            if (values == null || values.isEmpty()) {
-                return;
-            }
-            var repoId = multiValueConceptFeatureSupport.readTraits(aFeature).getRepositoryId();
-            for (var id : values) {
-                if (isNotBlank(id)) {
-                    aOut.add(Key.of(aFeature, repoId, id));
-                }
+        @SuppressWarnings("unchecked")
+        var values = (List<String>) FSUtil.getFeature(aFs, feature.getName(), List.class);
+        if (values == null || values.isEmpty()) {
+            return;
+        }
+        for (var id : values) {
+            if (isNotBlank(id)) {
+                aOut.add(Key.of(feature, aInfo.repositoryId(), id));
             }
         }
     }
+
+    private record FeatureInfo(AnnotationFeature feature, String repositoryId, boolean isMulti) {}
 }

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/KbLabelCachePrewarmStep.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/feature/KbLabelCachePrewarmStep.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.kb.feature;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.apache.uima.cas.text.AnnotationPredicates.overlapping;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.uima.cas.text.AnnotationFS;
+import org.apache.uima.fit.util.FSUtil;
+import org.apache.uima.jcas.tcas.Annotation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.annotation.Order;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.inception.rendering.pipeline.RenderStep;
+import de.tudarmstadt.ukp.inception.rendering.request.RenderRequest;
+import de.tudarmstadt.ukp.inception.rendering.vmodel.VDocument;
+import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
+import de.tudarmstadt.ukp.inception.ui.kb.feature.ConceptLabelCache.Key;
+
+/**
+ * Pre-render step that walks the visible layers, collects every concept-feature value about to be
+ * rendered, and warms {@link ConceptLabelCache} via a single bulk load per (project, repositoryId)
+ * group. Runs immediately before {@link RenderStep#RENDER_STRUCTURE} so the per-annotation render
+ * loop downstream finds each label already cached.
+ *
+ * <p>
+ * Self-contained on purpose: no changes to the {@code FeatureSupport} SPI. If the warming misses
+ * (e.g. because of a logic drift vs. the actual renderer), the per-annotation
+ * {@code labelCache.get(...)} calls degrade gracefully to single-key loads — no correctness impact,
+ * only the perf benefit is reduced.
+ */
+@Order(KbLabelCachePrewarmStep.RENDER_PREWARM_KB_LABELS)
+public class KbLabelCachePrewarmStep
+    implements RenderStep
+{
+    public static final String ID = "KbLabelCachePrewarmer";
+
+    /**
+     * Ordered just before {@link RenderStep#RENDER_STRUCTURE} so the cache is warm when
+     * {@code PreRendererImpl} kicks off the per-annotation render loop.
+     */
+    public static final int RENDER_PREWARM_KB_LABELS = RenderStep.RENDER_STRUCTURE - 1;
+
+    private static final Logger LOG = LoggerFactory.getLogger(KbLabelCachePrewarmStep.class);
+
+    private final ConceptLabelCache labelCache;
+    private final ConceptFeatureSupport conceptFeatureSupport;
+    private final MultiValueConceptFeatureSupport multiValueConceptFeatureSupport;
+    private final AnnotationSchemaService schemaService;
+
+    public KbLabelCachePrewarmStep(ConceptLabelCache aLabelCache,
+            ConceptFeatureSupport aConceptFeatureSupport,
+            MultiValueConceptFeatureSupport aMultiValueConceptFeatureSupport,
+            AnnotationSchemaService aSchemaService)
+    {
+        labelCache = aLabelCache;
+        conceptFeatureSupport = aConceptFeatureSupport;
+        multiValueConceptFeatureSupport = aMultiValueConceptFeatureSupport;
+        schemaService = aSchemaService;
+    }
+
+    @Override
+    public String getId()
+    {
+        return ID;
+    }
+
+    @Override
+    public void render(VDocument aVdoc, RenderRequest aRequest)
+    {
+        var cas = aRequest.getCas();
+        if (cas == null) {
+            return;
+        }
+
+        var documentText = cas.getDocumentText();
+        if (documentText == null || documentText.isEmpty()) {
+            return;
+        }
+
+        var windowBegin = Math.max(0, aRequest.getWindowBeginOffset());
+        var windowEnd = Math.min(documentText.length(), aRequest.getWindowEndOffset());
+
+        var keys = new LinkedHashSet<Key>();
+
+        for (var layer : aRequest.getVisibleLayers()) {
+            collectKeysForLayer(cas, layer, windowBegin, windowEnd, aRequest, keys);
+        }
+
+        if (keys.isEmpty()) {
+            return;
+        }
+
+        var start = System.currentTimeMillis();
+        labelCache.getAll(keys);
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Prewarmed {} concept-label keys in {}ms", keys.size(),
+                    System.currentTimeMillis() - start);
+        }
+    }
+
+    private void collectKeysForLayer(org.apache.uima.cas.CAS aCas, AnnotationLayer aLayer,
+            int aWindowBegin, int aWindowEnd, RenderRequest aRequest, Set<Key> aOut)
+    {
+        var features = schemaService.listSupportedFeatures(aLayer).stream() //
+                .filter(f -> !aRequest.getHiddenFeatures().contains(f.getId())) //
+                .filter(f -> conceptFeatureSupport.accepts(f)
+                        || multiValueConceptFeatureSupport.accepts(f)) //
+                .toList();
+        if (features.isEmpty()) {
+            return;
+        }
+
+        var type = aCas.getTypeSystem().getType(aLayer.getName());
+        if (type == null) {
+            return;
+        }
+
+        for (var fs : aCas.<Annotation> select(type)) {
+            if (!overlapping(fs, aWindowBegin, aWindowEnd)) {
+                continue;
+            }
+            for (var feature : features) {
+                extractKeys(feature, fs, aOut);
+            }
+        }
+    }
+
+    private void extractKeys(AnnotationFeature aFeature, AnnotationFS aFs, Set<Key> aOut)
+    {
+        if (conceptFeatureSupport.accepts(aFeature)) {
+            var id = FSUtil.getFeature(aFs, aFeature.getName(), String.class);
+            if (isNotBlank(id)) {
+                var repoId = conceptFeatureSupport.readTraits(aFeature).getRepositoryId();
+                aOut.add(Key.of(aFeature, repoId, id));
+            }
+            return;
+        }
+
+        if (multiValueConceptFeatureSupport.accepts(aFeature)) {
+            @SuppressWarnings("unchecked")
+            var values = (List<String>) FSUtil.getFeature(aFs, aFeature.getName(), List.class);
+            if (values == null || values.isEmpty()) {
+                return;
+            }
+            var repoId = multiValueConceptFeatureSupport.readTraits(aFeature).getRepositoryId();
+            for (var id : values) {
+                if (isNotBlank(id)) {
+                    aOut.add(Key.of(aFeature, repoId, id));
+                }
+            }
+        }
+    }
+}

--- a/inception/inception-ui-kb/src/test/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptLabelCacheTest.java
+++ b/inception/inception-ui-kb/src/test/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptLabelCacheTest.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.kb.feature;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.inception.kb.KnowledgeBaseService;
+import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBasePropertiesImpl;
+import de.tudarmstadt.ukp.inception.kb.graph.KBHandle;
+import de.tudarmstadt.ukp.inception.ui.kb.feature.ConceptLabelCache.Key;
+
+@ExtendWith(MockitoExtension.class)
+public class ConceptLabelCacheTest
+{
+    private @Mock KnowledgeBaseService kbService;
+    private ConceptLabelCache sut;
+
+    private Project project;
+    private AnnotationFeature feature;
+
+    @BeforeEach
+    public void setUp()
+    {
+        sut = new ConceptLabelCache(kbService, new KnowledgeBasePropertiesImpl());
+
+        project = new Project();
+        project.setName("test-project");
+        feature = new AnnotationFeature();
+        feature.setProject(project);
+    }
+
+    @Test
+    public void getAll_resolvesViaBulkReadHandles_andReturnsHandlePerKey() throws Exception
+    {
+        var k1 = Key.of(feature, null, "id:1");
+        var k2 = Key.of(feature, null, "id:2");
+
+        when(kbService.readHandles(eq(project), any())).thenReturn(Map.of( //
+                "id:1", new KBHandle("id:1", "Alpha"), //
+                "id:2", new KBHandle("id:2", "Beta")));
+
+        var result = sut.getAll(asList(k1, k2));
+
+        assertThat(result.get(k1)).extracting(KBHandle::getName).isEqualTo("Alpha");
+        assertThat(result.get(k2)).extracting(KBHandle::getName).isEqualTo("Beta");
+        verify(kbService, times(1)).readHandles(eq(project), any());
+        verify(kbService, never()).readHandle(any(Project.class), anyString());
+    }
+
+    @Test
+    public void getAll_secondCallWithSameKeys_doesNotHitDB() throws Exception
+    {
+        var k1 = Key.of(feature, null, "id:1");
+
+        when(kbService.readHandles(eq(project), any())) //
+                .thenReturn(Map.of("id:1", new KBHandle("id:1", "Alpha")));
+
+        sut.getAll(asList(k1));
+        sut.getAll(asList(k1));
+
+        // Second getAll should hit the per-key cache, not re-query.
+        verify(kbService, times(1)).readHandles(eq(project), any());
+    }
+
+    @Test
+    public void getAll_followedByGet_servesFromCache() throws Exception
+    {
+        var k1 = Key.of(feature, null, "id:1");
+
+        when(kbService.readHandles(eq(project), any())) //
+                .thenReturn(Map.of("id:1", new KBHandle("id:1", "Alpha")));
+
+        sut.getAll(asList(k1));
+        var single = sut.get(feature, null, "id:1");
+
+        assertThat(single.getName()).isEqualTo("Alpha");
+        verify(kbService, times(1)).readHandles(eq(project), any());
+        verify(kbService, never()).readHandle(any(Project.class), anyString());
+    }
+
+    @Test
+    public void getAll_partialMisses_onlyBulkLoadsTheMissing() throws Exception
+    {
+        var k1 = Key.of(feature, null, "id:1");
+        var k2 = Key.of(feature, null, "id:2");
+        var k3 = Key.of(feature, null, "id:3");
+
+        when(kbService.readHandles(eq(project), any())) //
+                .thenReturn(Map.of( //
+                        "id:1", new KBHandle("id:1", "Alpha"), //
+                        "id:2", new KBHandle("id:2", "Beta")));
+        sut.getAll(asList(k1, k2));
+
+        when(kbService.readHandles(eq(project), any())) //
+                .thenReturn(Map.of("id:3", new KBHandle("id:3", "Gamma")));
+        sut.getAll(asList(k1, k2, k3));
+
+        // Two distinct bulk loads — first for {1,2}, second for {3} only.
+        verify(kbService, times(2)).readHandles(eq(project), any());
+    }
+
+    @Test
+    public void getAll_missingHandle_returnsStubWithIdentifier() throws Exception
+    {
+        var k1 = Key.of(feature, null, "id:missing");
+
+        // Mirror readHandles' "missing ids get a stub with no name" semantic.
+        when(kbService.readHandles(eq(project), any())) //
+                .thenReturn(Map.of("id:missing", new KBHandle("id:missing")));
+
+        var result = sut.getAll(asList(k1));
+
+        assertThat(result.get(k1)).isNotNull();
+        assertThat(result.get(k1).getIdentifier()).isEqualTo("id:missing");
+    }
+
+    @Test
+    public void getAll_groupsByRepositoryId_oneBatchPerGroup() throws Exception
+    {
+        var repoA = "kb-a";
+        var repoB = "kb-b";
+        var k1 = Key.of(feature, repoA, "id:1");
+        var k2 = Key.of(feature, repoA, "id:2");
+        var k3 = Key.of(feature, repoB, "id:3");
+
+        when(kbService.getKnowledgeBaseById(eq(project), anyString())) //
+                .thenReturn(java.util.Optional.empty());
+
+        sut.getAll(asList(k1, k2, k3));
+
+        // Two groups -> two getKnowledgeBaseById lookups (one per (project, repoId)).
+        verify(kbService, times(1)).getKnowledgeBaseById(eq(project), eq(repoA));
+        verify(kbService, times(1)).getKnowledgeBaseById(eq(project), eq(repoB));
+        verify(kbService, never()).readHandles(eq(project), any());
+    }
+}

--- a/inception/inception-ui-kb/src/test/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptLabelCacheTest.java
+++ b/inception/inception-ui-kb/src/test/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptLabelCacheTest.java
@@ -56,10 +56,13 @@ public class ConceptLabelCacheTest
     {
         sut = new ConceptLabelCache(kbService, new KnowledgeBasePropertiesImpl());
 
-        project = new Project();
-        project.setName("test-project");
-        feature = new AnnotationFeature();
-        feature.setProject(project);
+        project = Project.builder() //
+                .withId(1L) //
+                .withName("test-project") //
+                .build();
+        feature = AnnotationFeature.builder() //
+                .withProject(project) //
+                .build();
     }
 
     @Test

--- a/inception/inception-ui-kb/src/test/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptLabelCacheTest.java
+++ b/inception/inception-ui-kb/src/test/java/de/tudarmstadt/ukp/inception/ui/kb/feature/ConceptLabelCacheTest.java
@@ -148,6 +148,24 @@ public class ConceptLabelCacheTest
     }
 
     @Test
+    public void getAll_labellessHandleWithDescription_preservesDescription() throws Exception
+    {
+        var k1 = Key.of(feature, null, "id:1");
+
+        var labelless = KBHandle.builder() //
+                .withIdentifier("id:1") //
+                .withDescription("A described but unlabeled entity") //
+                .build();
+        when(kbService.readHandles(eq(project), any())) //
+                .thenReturn(Map.of("id:1", labelless));
+
+        var result = sut.getAll(asList(k1));
+
+        assertThat(result.get(k1).getName()).isNull();
+        assertThat(result.get(k1).getDescription()).isEqualTo("A described but unlabeled entity");
+    }
+
+    @Test
     public void getAll_groupsByRepositoryId_oneBatchPerGroup() throws Exception
     {
         var repoA = "kb-a";

--- a/inception/inception-ui-kb/src/test/java/de/tudarmstadt/ukp/inception/ui/kb/feature/KbLabelCachePrewarmStepTest.java
+++ b/inception/inception-ui-kb/src/test/java/de/tudarmstadt/ukp/inception/ui/kb/feature/KbLabelCachePrewarmStepTest.java
@@ -1,0 +1,256 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.kb.feature;
+
+import static java.util.Arrays.asList;
+import static org.apache.uima.fit.factory.JCasFactory.createJCasFromPath;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collection;
+import java.util.Map;
+
+import org.apache.uima.fit.util.FSUtil;
+import org.apache.uima.jcas.JCas;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.LinkMode;
+import de.tudarmstadt.ukp.clarin.webanno.model.MultiValueMode;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.inception.kb.KnowledgeBaseService;
+import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBasePropertiesImpl;
+import de.tudarmstadt.ukp.inception.kb.graph.KBHandle;
+import de.tudarmstadt.ukp.inception.rendering.request.RenderRequest;
+import de.tudarmstadt.ukp.inception.rendering.vmodel.VDocument;
+import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
+
+@ExtendWith(MockitoExtension.class)
+public class KbLabelCachePrewarmStepTest
+{
+    private @Mock KnowledgeBaseService kbService;
+    private @Mock AnnotationSchemaService schemaService;
+
+    private ConceptLabelCache labelCache;
+    private ConceptFeatureSupport conceptFeatureSupport;
+    private MultiValueConceptFeatureSupport multiValueConceptFeatureSupport;
+    private KbLabelCachePrewarmStep sut;
+
+    private Project project;
+    private JCas jcas;
+    private AnnotationLayer singleValueLayer;
+    private AnnotationLayer multiValueLayer;
+    private AnnotationFeature singleValueFeature;
+    private AnnotationFeature multiValueFeature;
+
+    @BeforeEach
+    public void setUp() throws Exception
+    {
+        labelCache = new ConceptLabelCache(kbService, new KnowledgeBasePropertiesImpl());
+        conceptFeatureSupport = new ConceptFeatureSupport(labelCache);
+        multiValueConceptFeatureSupport = new MultiValueConceptFeatureSupport(labelCache);
+
+        sut = new KbLabelCachePrewarmStep(labelCache, conceptFeatureSupport,
+                multiValueConceptFeatureSupport, schemaService);
+
+        project = new Project();
+        project.setName("test-project");
+
+        jcas = createJCasFromPath("src/test/resources/desc/type/webannoTestTypes.xml");
+        jcas.setDocumentText("0123456789");
+
+        singleValueLayer = new AnnotationLayer();
+        singleValueLayer.setName("webanno.custom.Span");
+        singleValueLayer.setProject(project);
+
+        multiValueLayer = new AnnotationLayer();
+        multiValueLayer.setName("webanno.custom.SpanMultiValue");
+        multiValueLayer.setProject(project);
+
+        singleValueFeature = new AnnotationFeature("value", ConceptFeatureSupport.TYPE_ANY_OBJECT);
+        singleValueFeature.setMode(MultiValueMode.NONE);
+        singleValueFeature.setLinkMode(LinkMode.NONE);
+        singleValueFeature.setLayer(singleValueLayer);
+        singleValueFeature.setProject(project);
+
+        multiValueFeature = new AnnotationFeature("values",
+                MultiValueConceptFeatureSupport.TYPE_ANY_OBJECT);
+        multiValueFeature.setMode(MultiValueMode.ARRAY);
+        multiValueFeature.setLinkMode(LinkMode.NONE);
+        multiValueFeature.setLayer(multiValueLayer);
+        multiValueFeature.setProject(project);
+    }
+
+    @Test
+    public void render_warmsSingleValueConceptIds() throws Exception
+    {
+        addSpan(jcas, "webanno.custom.Span", 0, 5, "value", "kb:id1");
+        addSpan(jcas, "webanno.custom.Span", 5, 10, "value", "kb:id2");
+
+        when(schemaService.listSupportedFeatures(singleValueLayer))
+                .thenReturn(asList(singleValueFeature));
+        when(kbService.readHandles(eq(project), any())) //
+                .thenReturn(Map.of( //
+                        "kb:id1", new KBHandle("kb:id1", "Alpha"), //
+                        "kb:id2", new KBHandle("kb:id2", "Beta")));
+
+        sut.render(new VDocument(), renderRequest(singleValueLayer));
+
+        verify(kbService, times(1)).readHandles(eq(project), any());
+        verify(kbService, never()).readHandle(any(Project.class), anyString());
+
+        // After warming, get(...) must hit the cache and not trigger another DB call.
+        labelCache.get(singleValueFeature, null, "kb:id1");
+        labelCache.get(singleValueFeature, null, "kb:id2");
+        verify(kbService, times(1)).readHandles(eq(project), any());
+        verify(kbService, never()).readHandle(any(Project.class), anyString());
+    }
+
+    @Test
+    public void render_warmsMultiValueConceptIds() throws Exception
+    {
+        var span = addSpan(jcas, "webanno.custom.SpanMultiValue", 0, 5, null, null);
+        FSUtil.setFeature(span, "values", asList("kb:a", "kb:b", "kb:c"));
+
+        when(schemaService.listSupportedFeatures(multiValueLayer))
+                .thenReturn(asList(multiValueFeature));
+        when(kbService.readHandles(eq(project), any())) //
+                .thenReturn(Map.of( //
+                        "kb:a", new KBHandle("kb:a", "A"), //
+                        "kb:b", new KBHandle("kb:b", "B"), //
+                        "kb:c", new KBHandle("kb:c", "C")));
+
+        sut.render(new VDocument(), renderRequest(multiValueLayer));
+
+        verify(kbService, times(1)).readHandles(eq(project), any());
+    }
+
+    @Test
+    public void render_skipsAnnotationsOutsideWindow() throws Exception
+    {
+        // Replace the default 10-char doc text with a 60-char one so we can place an annotation
+        // outside the rendering window.
+        jcas.reset();
+        jcas.setDocumentText("0123456789012345678901234567890123456789012345678901234567890");
+
+        addSpan(jcas, "webanno.custom.Span", 0, 5, "value", "kb:in-window");
+        addSpan(jcas, "webanno.custom.Span", 50, 55, "value", "kb:outside");
+
+        when(schemaService.listSupportedFeatures(singleValueLayer))
+                .thenReturn(asList(singleValueFeature));
+        when(kbService.readHandles(eq(project), any())) //
+                .thenReturn(Map.of("kb:in-window", new KBHandle("kb:in-window", "In")));
+
+        var request = RenderRequest.builder() //
+                .withCas(jcas.getCas()) //
+                .withWindow(0, 10) //
+                .withAllLayers(asList(singleValueLayer)) //
+                .withVisibleLayers(asList(singleValueLayer)) //
+                .build();
+
+        sut.render(new VDocument(), request);
+
+        @SuppressWarnings({ "unchecked", "rawtypes" })
+        var captor = org.mockito.ArgumentCaptor
+                .forClass((Class<Collection<String>>) (Class) Collection.class);
+        verify(kbService, times(1)).readHandles(eq(project), captor.capture());
+        assertThat(captor.getValue()).containsExactly("kb:in-window");
+    }
+
+    @Test
+    public void render_skipsHiddenFeatures() throws Exception
+    {
+        singleValueFeature.setId(42L);
+        addSpan(jcas, "webanno.custom.Span", 0, 5, "value", "kb:id1");
+
+        when(schemaService.listSupportedFeatures(singleValueLayer))
+                .thenReturn(asList(singleValueFeature));
+
+        var request = RenderRequest.builder() //
+                .withCas(jcas.getCas()) //
+                .withWindow(0, 10) //
+                .withAllLayers(asList(singleValueLayer)) //
+                .withVisibleLayers(asList(singleValueLayer)) //
+                .withHiddenFeatures(asList(42L)) //
+                .build();
+
+        sut.render(new VDocument(), request);
+
+        verify(kbService, never()).readHandles(any(Project.class), any());
+    }
+
+    @Test
+    public void render_doesNothingWhenNoConceptFeaturesPresent() throws Exception
+    {
+        addSpan(jcas, "webanno.custom.Span", 0, 5, "value", "kb:id1");
+
+        // Layer reports no features at all.
+        when(schemaService.listSupportedFeatures(singleValueLayer)).thenReturn(java.util.List.of());
+
+        sut.render(new VDocument(), renderRequest(singleValueLayer));
+
+        verify(kbService, never()).readHandles(any(Project.class), any());
+    }
+
+    @Test
+    public void render_doesNothingWhenAllIdentifiersAreBlank() throws Exception
+    {
+        addSpan(jcas, "webanno.custom.Span", 0, 5, "value", "");
+        addSpan(jcas, "webanno.custom.Span", 5, 10, "value", null);
+
+        when(schemaService.listSupportedFeatures(singleValueLayer))
+                .thenReturn(asList(singleValueFeature));
+
+        sut.render(new VDocument(), renderRequest(singleValueLayer));
+
+        verify(kbService, never()).readHandles(any(Project.class), any());
+    }
+
+    private org.apache.uima.cas.text.AnnotationFS addSpan(JCas aJCas, String aType, int aBegin,
+            int aEnd, String aFeatureName, String aValue)
+    {
+        var type = aJCas.getCas().getTypeSystem().getType(aType);
+        var fs = aJCas.getCas().createAnnotation(type, aBegin, aEnd);
+        if (aFeatureName != null && aValue != null) {
+            FSUtil.setFeature(fs, aFeatureName, aValue);
+        }
+        aJCas.getCas().addFsToIndexes(fs);
+        return fs;
+    }
+
+    private RenderRequest renderRequest(AnnotationLayer aLayer)
+    {
+        return RenderRequest.builder() //
+                .withCas(jcas.getCas()) //
+                .withWindow(0, jcas.getDocumentText().length()) //
+                .withAllLayers(asList(aLayer)) //
+                .withVisibleLayers(asList(aLayer)) //
+                .build();
+    }
+}

--- a/inception/inception-ui-kb/src/test/java/de/tudarmstadt/ukp/inception/ui/kb/feature/KbLabelCachePrewarmStepTest.java
+++ b/inception/inception-ui-kb/src/test/java/de/tudarmstadt/ukp/inception/ui/kb/feature/KbLabelCachePrewarmStepTest.java
@@ -79,32 +79,41 @@ public class KbLabelCachePrewarmStepTest
         sut = new KbLabelCachePrewarmStep(labelCache, conceptFeatureSupport,
                 multiValueConceptFeatureSupport, schemaService);
 
-        project = new Project();
-        project.setName("test-project");
+        project = Project.builder() //
+                .withId(1L) //
+                .withName("test-project") //
+                .build();
 
         jcas = createJCasFromPath("src/test/resources/desc/type/webannoTestTypes.xml");
         jcas.setDocumentText("0123456789");
 
-        singleValueLayer = new AnnotationLayer();
-        singleValueLayer.setName("webanno.custom.Span");
-        singleValueLayer.setProject(project);
+        singleValueLayer = AnnotationLayer.builder() //
+                .withName("webanno.custom.Span") //
+                .withProject(project) //
+                .build();
 
-        multiValueLayer = new AnnotationLayer();
-        multiValueLayer.setName("webanno.custom.SpanMultiValue");
-        multiValueLayer.setProject(project);
+        multiValueLayer = AnnotationLayer.builder() //
+                .withName("webanno.custom.SpanMultiValue") //
+                .withProject(project) //
+                .build();
 
-        singleValueFeature = new AnnotationFeature("value", ConceptFeatureSupport.TYPE_ANY_OBJECT);
-        singleValueFeature.setMode(MultiValueMode.NONE);
-        singleValueFeature.setLinkMode(LinkMode.NONE);
-        singleValueFeature.setLayer(singleValueLayer);
-        singleValueFeature.setProject(project);
+        singleValueFeature = AnnotationFeature.builder() //
+                .withName("value") //
+                .withType(ConceptFeatureSupport.TYPE_ANY_OBJECT) //
+                .withMultiValueMode(MultiValueMode.NONE) //
+                .withLinkMode(LinkMode.NONE) //
+                .withLayer(singleValueLayer) //
+                .withProject(project) //
+                .build();
 
-        multiValueFeature = new AnnotationFeature("values",
-                MultiValueConceptFeatureSupport.TYPE_ANY_OBJECT);
-        multiValueFeature.setMode(MultiValueMode.ARRAY);
-        multiValueFeature.setLinkMode(LinkMode.NONE);
-        multiValueFeature.setLayer(multiValueLayer);
-        multiValueFeature.setProject(project);
+        multiValueFeature = AnnotationFeature.builder() //
+                .withName("values") //
+                .withType(MultiValueConceptFeatureSupport.TYPE_ANY_OBJECT) //
+                .withMultiValueMode(MultiValueMode.ARRAY) //
+                .withLinkMode(LinkMode.NONE) //
+                .withLayer(multiValueLayer) //
+                .withProject(project) //
+                .build();
     }
 
     @Test


### PR DESCRIPTION
**What's in the PR**
- Enhanced `SPARQLQueryBuilder`/`FtsAdapter` to support deferred query finalization and better placement of OPTIONAL lookup patterns for RDF4J query planners.
- Added batched `KnowledgeBaseService.readHandles(...)` APIs plus chunking via a new `knowledge-base.read-batch-size` setting, and updated `ConceptLabelCache` to bulk-load via Caffeine `loadAll`.
- Introduced a UI render pre-step (`KbLabelCachePrewarmStep`) and accompanying tests to bulk-warm concept label cache entries for the visible rendering window.

**How to test manually**
* No specific test procedure

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [x] PR updates documentation
