### PR TITLE
#6076 - Display token and sentence count in the open document dialog

### DIFF
--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/DocumentStatistics.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/DocumentStatistics.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.search;
+
+import java.io.Serializable;
+
+public record DocumentStatistics(long tokenCount, long sentenceCount)
+    implements Serializable
+{}

--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchService.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchService.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.inception.search;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -26,6 +27,7 @@ import java.util.Set;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
@@ -199,5 +201,28 @@ public interface SearchService
      */
     Map<Long, Long> getAnnotationCountsPerSourceDocument(User aUser, Project aProject,
             AnnotationLayer aLayer)
+        throws IOException, ExecutionException;
+
+    /**
+     * Token and sentence counts per document for the given annotation set. For each requested
+     * document the row owned by {@code aSet} is preferred; if no such row is indexed, the
+     * {@link AnnotationSet#INITIAL_SET} row is used as fallback. Documents that have no row in
+     * either are omitted from the result map.
+     *
+     * @param aSet
+     *            which CAS the counts should reflect (a specific user's annotations, the curation
+     *            CAS, or the initial CAS)
+     * @param aProject
+     *            the project the documents belong to
+     * @param aDocuments
+     *            documents to compute counts for; if {@code null} or empty, the result is empty
+     * @return map from {@link SourceDocument} id to its {@link DocumentStatistics}
+     * @throws IOException
+     *             if there was an I/O-level problem
+     * @throws ExecutionException
+     *             if there was a search-level problem
+     */
+    Map<Long, DocumentStatistics> getAnnotationCountsPerDocument(AnnotationSet aSet,
+            Project aProject, Collection<SourceDocument> aDocuments)
         throws IOException, ExecutionException;
 }

--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchServiceImpl.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/SearchServiceImpl.java
@@ -22,12 +22,14 @@ import static de.tudarmstadt.ukp.inception.scheduling.TaskState.RUNNING;
 import static de.tudarmstadt.ukp.inception.search.model.AnnotationSearchState.KEY_SEARCH_STATE;
 import static java.lang.Integer.MAX_VALUE;
 import static java.lang.System.currentTimeMillis;
+import static java.util.Collections.emptyMap;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.springframework.transaction.annotation.Propagation.REQUIRES_NEW;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -50,6 +52,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
@@ -679,6 +682,24 @@ public class SearchServiceImpl
                     Integer.MAX_VALUE, null, null, prefs);
             return index.getPhysicalIndex().getAnnotationCountsPerSourceDocument(statRequest,
                     aLayer);
+        }
+    }
+
+    @Override
+    public Map<Long, DocumentStatistics> getAnnotationCountsPerDocument(AnnotationSet aSet,
+            Project aProject, Collection<SourceDocument> aDocuments)
+        throws IOException, ExecutionException
+    {
+        if (aDocuments == null || aDocuments.isEmpty()) {
+            return emptyMap();
+        }
+
+        try (var pooledIndex = acquireIndex(aProject.getId())) {
+            var index = pooledIndex.get();
+            ensureIndexIsCreatedAndValid(aProject, index);
+
+            var prefs = preferencesService.loadDefaultTraitsForProject(KEY_SEARCH_STATE, aProject);
+            return index.getPhysicalIndex().getAnnotationCountsPerDocument(aSet, aDocuments, prefs);
         }
     }
 

--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/index/PhysicalIndex.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/index/PhysicalIndex.java
@@ -18,13 +18,16 @@
 package de.tudarmstadt.ukp.inception.search.index;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.inception.search.DocumentStatistics;
 import de.tudarmstadt.ukp.inception.search.ExecutionException;
 import de.tudarmstadt.ukp.inception.search.LayerStatistics;
 import de.tudarmstadt.ukp.inception.search.SearchQueryRequest;
@@ -100,6 +103,26 @@ public interface PhysicalIndex
      */
     public Map<Long, Long> getAnnotationCountsPerSourceDocument(StatisticRequest aStatisticRequest,
             AnnotationLayer aLayer)
+        throws IOException, ExecutionException;
+
+    /**
+     * Token and sentence counts per source document for the given annotation set. For each
+     * requested source document the row owned by {@code aSet} is preferred; if no such row is
+     * indexed, the {@link AnnotationSet#INITIAL_SET} row is used as fallback. Source documents that
+     * have no row in either are omitted.
+     *
+     * @param aSet
+     *            which CAS the counts should reflect
+     * @param aDocuments
+     *            source documents to look up; if {@code null} or empty, the result is empty
+     * @return map from {@link SourceDocument} id to its {@link DocumentStatistics}
+     * @throws IOException
+     *             if there was an I/O-level problem
+     * @throws ExecutionException
+     *             if there was a search-level problem
+     */
+    public Map<Long, DocumentStatistics> getAnnotationCountsPerDocument(AnnotationSet aSet,
+            Collection<SourceDocument> aDocuments, AnnotationSearchState aSearchSettings)
         throws IOException, ExecutionException;
 
     void deindexDocument(SourceDocument aDocument) throws IOException;

--- a/inception/inception-search-mtas/src/main/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndex.java
+++ b/inception/inception-search-mtas/src/main/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndex.java
@@ -23,6 +23,7 @@ package de.tudarmstadt.ukp.inception.search.index.mtas;
 
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState.FINISHED;
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState.IGNORE;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet.INITIAL_SET;
 import static de.tudarmstadt.ukp.inception.search.Metrics.VIRTUAL_FEATURE_SENTENCE;
 import static de.tudarmstadt.ukp.inception.search.Metrics.VIRTUAL_FEATURE_TOKEN;
 import static de.tudarmstadt.ukp.inception.search.Metrics.VIRTUAL_LAYER_SEGMENTATION;
@@ -31,6 +32,7 @@ import static de.tudarmstadt.ukp.inception.search.index.mtas.MtasUimaParser.getI
 import static de.tudarmstadt.ukp.inception.search.index.mtas.MtasUtils.decodeFSAddress;
 import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.CURATION_USER;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 import static java.util.Comparator.comparing;
 import static java.util.Comparator.comparingLong;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -52,6 +54,7 @@ import java.lang.invoke.MethodHandles;
 import java.lang.reflect.InvocationTargetException;
 import java.text.BreakIterator;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -106,12 +109,14 @@ import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.schema.api.feature.FeatureSupportRegistry;
+import de.tudarmstadt.ukp.inception.search.DocumentStatistics;
 import de.tudarmstadt.ukp.inception.search.ExecutionException;
 import de.tudarmstadt.ukp.inception.search.FeatureIndexingSupport;
 import de.tudarmstadt.ukp.inception.search.FeatureIndexingSupportRegistry;
@@ -145,6 +150,10 @@ import mtas.search.spans.util.MtasSpanQuery;
 public class MtasDocumentIndex
     implements PhysicalIndex
 {
+    private static final String SENTENCE_QUERY = "<s=\"\"/>";
+
+    private static final String TOKEN_QUERY = "<Token=\"\"/>";
+
     static final int CURRENT_SCHEMA_VERSION = 1;
 
     /**
@@ -500,13 +509,13 @@ public class MtasDocumentIndex
         sentence.setUiName(VIRTUAL_FEATURE_SENTENCE);
         sentence.setLayer(rawText);
 
-        var results = getLayerStatistics(aStatisticRequest, "<Token=\"\"/>", fullDocSet);
+        var results = getLayerStatistics(aStatisticRequest, TOKEN_QUERY, fullDocSet);
 
         results.setFeature(token);
         allStats.put(VIRTUAL_LAYER_SEGMENTATION + "." + VIRTUAL_FEATURE_TOKEN, results);
         nonNullStats.put(VIRTUAL_LAYER_SEGMENTATION + "." + VIRTUAL_FEATURE_TOKEN, results);
 
-        results = getLayerStatistics(aStatisticRequest, "<s=\"\"/>", fullDocSet);
+        results = getLayerStatistics(aStatisticRequest, SENTENCE_QUERY, fullDocSet);
         results.setFeature(sentence);
         allStats.put(VIRTUAL_LAYER_SEGMENTATION + "." + VIRTUAL_FEATURE_SENTENCE, results);
         nonNullStats.put(VIRTUAL_LAYER_SEGMENTATION + "." + VIRTUAL_FEATURE_SENTENCE, results);
@@ -657,7 +666,7 @@ public class MtasDocumentIndex
             functionTypes[0] = LayerStatistics.STATS;
 
             // A query which counts sentences
-            var parsedSentQuery = parseQuery("<s=\"\"/>", aStatisticRequest.getSearchSettings());
+            var parsedSentQuery = parseQuery(SENTENCE_QUERY, aStatisticRequest.getSearchSettings());
             fieldStats.spanQueryList.add(parsedSentQuery);
 
             spanQuerys[1] = parsedSentQuery;
@@ -741,10 +750,10 @@ public class MtasDocumentIndex
 
         var type = aLayer.getName();
         if (Token._TypeName.equals(type)) {
-            return "<Token=\"\"/>";
+            return TOKEN_QUERY;
         }
         if (Sentence._TypeName.equals(type)) {
-            return "<s=\"\"/>";
+            return SENTENCE_QUERY;
         }
 
         return "<" + getIndexedName(aLayer.getUiName()) + "=\"\"/>";
@@ -860,6 +869,203 @@ public class MtasDocumentIndex
         }
 
         return counts;
+    }
+
+    @Override
+    public Map<Long, DocumentStatistics> getAnnotationCountsPerDocument(AnnotationSet aSet,
+            Collection<SourceDocument> aDocuments, AnnotationSearchState aSearchSettings)
+        throws IOException, ExecutionException
+    {
+        if (aDocuments == null || aDocuments.isEmpty()) {
+            return emptyMap();
+        }
+
+        // Same rationale as getAnnotationCountsPerSourceDocument: ensure pending writes are visible
+        // to the searcher so we don't fall back to a stale INITIAL_CAS row.
+        ensureAllIsCommitted();
+
+        var sourceDocIds = aDocuments.stream() //
+                .map(SourceDocument::getId) //
+                .collect(toSet());
+
+        var preferredUser = annotationSetToUserField(aSet);
+        var tokenQuery = parseQuery(TOKEN_QUERY, aSearchSettings);
+        var sentenceQuery = parseQuery(SENTENCE_QUERY, aSearchSettings);
+
+        IndexSearcher searcher = null;
+        try {
+            searcher = getSearcherManager().acquire();
+            var leaves = searcher.getIndexReader().leaves();
+
+            var srcDocByGlobalLuceneDocId = findCanonicalDocs(sourceDocIds, leaves, preferredUser);
+
+            if (srcDocByGlobalLuceneDocId.isEmpty()) {
+                return emptyMap();
+            }
+
+            // Pre-group the canonical doc ids by leaf segment once so each per-query sweep can
+            // advance() through positions instead of scanning every Lucene doc the query touches.
+            var preferredLocalIdsByLeafIndex = new HashMap<Integer, int[]>();
+            var globalIdsByLeafIndex = new HashMap<Integer, int[]>();
+            {
+                var leafBuckets = new HashMap<Integer, List<Integer>>();
+                for (var globalId : srcDocByGlobalLuceneDocId.keySet()) {
+                    var leafIdx = ReaderUtil.subIndex(globalId, leaves);
+                    leafBuckets.computeIfAbsent(leafIdx, $ -> new ArrayList<>()).add(globalId);
+                }
+                for (var e : leafBuckets.entrySet()) {
+                    var leafIdx = e.getKey();
+                    var globalIds = e.getValue();
+                    globalIds.sort(Integer::compare);
+                    var docBase = leaves.get(leafIdx).docBase;
+                    var localIds = new int[globalIds.size()];
+                    var globals = new int[globalIds.size()];
+                    for (var i = 0; i < globalIds.size(); i++) {
+                        globals[i] = globalIds.get(i);
+                        localIds[i] = globalIds.get(i) - docBase;
+                    }
+                    preferredLocalIdsByLeafIndex.put(leafIdx, localIds);
+                    globalIdsByLeafIndex.put(leafIdx, globals);
+                }
+            }
+
+            var tokenCounts = countSpansPerDoc(searcher, leaves, tokenQuery,
+                    preferredLocalIdsByLeafIndex, globalIdsByLeafIndex, srcDocByGlobalLuceneDocId);
+            var sentenceCounts = countSpansPerDoc(searcher, leaves, sentenceQuery,
+                    preferredLocalIdsByLeafIndex, globalIdsByLeafIndex, srcDocByGlobalLuceneDocId);
+
+            var result = new HashMap<Long, DocumentStatistics>();
+            for (var srcDocId : srcDocByGlobalLuceneDocId.values()) {
+                var tokens = tokenCounts.getOrDefault(srcDocId, 0L);
+                var sentences = sentenceCounts.getOrDefault(srcDocId, 0L);
+                result.put(srcDocId, new DocumentStatistics(tokens, sentences));
+            }
+            return result;
+        }
+        catch (Exception e) {
+            throw new ExecutionException("Unable to count tokens/sentences", e);
+        }
+        finally {
+            if (searcher != null) {
+                getSearcherManager().release(searcher);
+                searcher = null;
+            }
+        }
+    }
+
+    private static String annotationSetToUserField(AnnotationSet aSet)
+    {
+        // INITIAL_CAS rows are stored with FIELD_USER="" (see writeDocument for SourceDocument);
+        // every other annotation set maps 1:1 to its id (username, CURATION_USER, ...).
+        return INITIAL_SET.equals(aSet) ? "" : aSet.id();
+    }
+
+    private Map<Long, Long> countSpansPerDoc(IndexSearcher aSearcher,
+            List<LeafReaderContext> aLeaves, MtasSpanQuery aParsedQuery,
+            Map<Integer, int[]> aPreferredLocalIdsByLeafIndex,
+            Map<Integer, int[]> aGlobalIdsByLeafIndex,
+            Map<Integer, Long> aSrcDocByGlobalLuceneDocId)
+        throws IOException
+    {
+        var counts = new HashMap<Long, Long>();
+        var spanweight = aParsedQuery.rewrite(aSearcher).createWeight(aSearcher, COMPLETE_NO_SCORES,
+                0.0f);
+
+        for (var leafIdx = 0; leafIdx < aLeaves.size(); leafIdx++) {
+            var localIds = aPreferredLocalIdsByLeafIndex.get(leafIdx);
+            if (localIds == null) {
+                continue;
+            }
+
+            var leaf = aLeaves.get(leafIdx);
+            var spans = spanweight.getSpans(leaf, POSITIONS);
+            if (spans == null) {
+                continue;
+            }
+
+            var globals = aGlobalIdsByLeafIndex.get(leafIdx);
+
+            for (var i = 0; i < localIds.length; i++) {
+                var target = localIds[i];
+                if (spans.docID() < target) {
+                    if (spans.advance(target) == NO_MORE_DOCS) {
+                        break;
+                    }
+                }
+                if (spans.docID() != target) {
+                    continue;
+                }
+
+                var perDocCount = 0L;
+                while (spans.nextStartPosition() != Spans.NO_MORE_POSITIONS) {
+                    perDocCount++;
+                }
+                counts.merge(aSrcDocByGlobalLuceneDocId.get(globals[i]), perDocCount, Long::sum);
+            }
+        }
+
+        return counts;
+    }
+
+    /**
+     * Locate the canonical Lucene doc per source document, preferring rows owned by
+     * {@code aPreferredUser} and falling back to the INITIAL_CAS row (FIELD_USER="") when the
+     * preferred row is absent. When {@code aPreferredUser} is already the empty string, only the
+     * INITIAL_CAS pass runs.
+     */
+    private HashMap<Integer, Long> findCanonicalDocs(Set<Long> aSourceDocIds,
+            List<LeafReaderContext> aLeaves, String aPreferredUser)
+        throws IOException
+    {
+        var srcDocByGlobalLuceneDocId = new HashMap<Integer, Long>();
+        var hasPreferredRowBySourceDoc = new HashSet<Long>();
+        var preferIsInitial = aPreferredUser.isEmpty();
+
+        if (!preferIsInitial) {
+            for (var leafCtx : aLeaves) {
+                var leafReader = leafCtx.reader();
+                var storedFields = leafReader.storedFields();
+                var liveDocs = leafReader.getLiveDocs();
+                var docBase = leafCtx.docBase;
+
+                for (var localDocId : findLiveDocsByUser(leafReader, aPreferredUser, liveDocs)) {
+                    var rawSrcId = storedFields.document(localDocId).get(FIELD_SOURCE_DOCUMENT_ID);
+                    if (rawSrcId == null) {
+                        continue;
+                    }
+                    var srcDocId = Long.valueOf(rawSrcId);
+                    if (!aSourceDocIds.contains(srcDocId)) {
+                        continue;
+                    }
+                    srcDocByGlobalLuceneDocId.put(localDocId + docBase, srcDocId);
+                    hasPreferredRowBySourceDoc.add(srcDocId);
+                }
+            }
+        }
+
+        for (var leafCtx : aLeaves) {
+            var leafReader = leafCtx.reader();
+            var storedFields = leafReader.storedFields();
+            var liveDocs = leafReader.getLiveDocs();
+            var docBase = leafCtx.docBase;
+
+            for (var localDocId : findLiveDocsByUser(leafReader, "", liveDocs)) {
+                var rawSrcId = storedFields.document(localDocId).get(FIELD_SOURCE_DOCUMENT_ID);
+                if (rawSrcId == null) {
+                    continue;
+                }
+                var srcDocId = Long.valueOf(rawSrcId);
+                if (!aSourceDocIds.contains(srcDocId)) {
+                    continue;
+                }
+                if (hasPreferredRowBySourceDoc.contains(srcDocId)) {
+                    continue;
+                }
+                srcDocByGlobalLuceneDocId.put(localDocId + docBase, srcDocId);
+            }
+        }
+
+        return srcDocByGlobalLuceneDocId;
     }
 
     /**

--- a/inception/inception-ui-annotation/pom.xml
+++ b/inception/inception-ui-annotation/pom.xml
@@ -141,6 +141,11 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-search-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-feature-link</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/open/AnnotationDocumentTable.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/open/AnnotationDocumentTable.java
@@ -30,10 +30,14 @@ import static de.tudarmstadt.ukp.inception.support.lambda.KeyCodes.ENTER;
 import static java.time.Duration.ofMillis;
 import static org.apache.wicket.event.Broadcast.BUBBLE;
 
+import java.text.NumberFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
+import java.util.function.ToLongFunction;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.extensions.ajax.markup.html.repeater.data.table.AjaxFallbackHeadersToolbar;
@@ -47,11 +51,14 @@ import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.model.ResourceModel;
+import org.danekja.java.util.function.serializable.SerializableFunction;
 import org.wicketstuff.event.annotation.OnEvent;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.annotation.filters.AnnotationDocumentFilterStateChanged;
 import de.tudarmstadt.ukp.inception.annotation.filters.AnnotationDocumentStateFilterPanel;
+import de.tudarmstadt.ukp.inception.search.DocumentStatistics;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxFormComponentUpdatingBehavior;
 import de.tudarmstadt.ukp.inception.support.wicket.EmptyStateToolbar;
 import de.tudarmstadt.ukp.inception.support.wicket.SymbolLambdaColumn;
@@ -80,6 +87,10 @@ public class AnnotationDocumentTable
                 item -> item.getState()));
         columns.add(new AnnotationDocumentOpenActionColumn(this, new ResourceModel("DocumentName"),
                 NAME));
+        columns.add(new LambdaColumn<>(new ResourceModel("DocumentTokens"),
+                $ -> renderCount($.getDocument(), DocumentStatistics::tokenCount)));
+        columns.add(new LambdaColumn<>(new ResourceModel("DocumentSentences"),
+                $ -> renderCount($.getDocument(), DocumentStatistics::sentenceCount)));
         columns.add(new LambdaColumn<>(new ResourceModel("DocumentCreated"), CREATED,
                 $ -> renderDate($.getDocument().getCreated())));
         columns.add(new LambdaColumn<>(new ResourceModel("AnnotationsUpdated"), UPDATED,
@@ -133,6 +144,21 @@ public class AnnotationDocumentTable
         return dataProvider;
     }
 
+    public void setStatisticsLoader(
+            SerializableFunction<Collection<SourceDocument>, Map<Long, DocumentStatistics>> aLoader)
+    {
+        dataProvider.setStatisticsLoader(aLoader);
+    }
+
+    private String renderCount(SourceDocument aDoc, ToLongFunction<DocumentStatistics> aAccessor)
+    {
+        var stats = dataProvider.getPageStatistics().get(aDoc.getId());
+        if (stats == null) {
+            return "-";
+        }
+        return NumberFormat.getIntegerInstance(getLocale()).format(aAccessor.applyAsLong(stats));
+    }
+
     @OnEvent
     public void onAnnotationDocumentFilterStateChanged(AnnotationDocumentFilterStateChanged aEvent)
     {
@@ -145,7 +171,6 @@ public class AnnotationDocumentTable
             return "";
         }
 
-        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
-        return dateFormat.format(aDate);
+        return new SimpleDateFormat("yyyy-MM-dd").format(aDate);
     }
 }

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/open/AnnotationDocumentTable.utf8.properties
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/open/AnnotationDocumentTable.utf8.properties
@@ -1,7 +1,7 @@
-# Licensed to the Technische Universit‰t Darmstadt under one
+# Licensed to the Technische Universit√§t Darmstadt under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
-# regarding copyright ownership.  The Technische Universit‰t Darmstadt 
+# regarding copyright ownership.  The Technische Universit√§t Darmstadt 
 # licenses this file to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.
@@ -15,6 +15,8 @@
 # limitations under the License.
 DocumentState=State
 DocumentName=Name
+DocumentTokens=Tokens
+DocumentSentences=Sentences
 DocumentCreated=Created
 AnnotationsUpdated=Updated
 nameFilter.placeholder=Filter by name... (open with enter when one is left)

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/open/AnnotationDocumentTableDataProvider.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/open/AnnotationDocumentTableDataProvider.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.open;
 
 import static de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.open.AnnotationDocumentTableSortKeys.NAME;
+import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.apache.commons.lang3.ObjectUtils.compare;
@@ -25,16 +26,21 @@ import static org.apache.commons.lang3.StringUtils.containsIgnoreCase;
 import static org.apache.wicket.extensions.markup.html.repeater.data.sort.SortOrder.ASCENDING;
 
 import java.io.Serializable;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import org.apache.wicket.extensions.markup.html.repeater.data.table.filter.IFilterStateLocator;
 import org.apache.wicket.extensions.markup.html.repeater.util.SortableDataProvider;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
+import org.danekja.java.util.function.serializable.SerializableFunction;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.inception.search.DocumentStatistics;
 
 public class AnnotationDocumentTableDataProvider
     extends SortableDataProvider<AnnotationDocument, AnnotationDocumentTableSortKeys>
@@ -44,6 +50,9 @@ public class AnnotationDocumentTableDataProvider
 
     private AnnotationDocumentTableFilterState filterState;
     private IModel<List<AnnotationDocument>> data;
+    private SerializableFunction<Collection<SourceDocument>, //
+            Map<Long, DocumentStatistics>> statisticsLoader;
+    private transient Map<Long, DocumentStatistics> pageStatistics;
 
     public AnnotationDocumentTableDataProvider(IModel<List<AnnotationDocument>> aDocuments)
     {
@@ -56,14 +65,44 @@ public class AnnotationDocumentTableDataProvider
         setSort(NAME, ASCENDING);
     }
 
+    public void setStatisticsLoader(
+            SerializableFunction<Collection<SourceDocument>, Map<Long, DocumentStatistics>> aLoader)
+    {
+        statisticsLoader = aLoader;
+    }
+
+    /**
+     * Statistics for the current page as populated by the most recent {@link #iterator} call.
+     * Returns an empty map if no loader has been wired or before the table has been rendered.
+     */
+    public Map<Long, DocumentStatistics> getPageStatistics()
+    {
+        return pageStatistics != null ? pageStatistics : emptyMap();
+    }
+
     @Override
     public Iterator<? extends AnnotationDocument> iterator(long aFirst, long aCount)
     {
         var filteredData = filter(data.getObject());
         filteredData.sort(this::comparator);
-        return filteredData //
-                .subList((int) aFirst, (int) (aFirst + aCount)) //
-                .iterator();
+        var page = filteredData //
+                .subList((int) aFirst, (int) (aFirst + aCount));
+
+        if (statisticsLoader != null) {
+            var srcDocs = page.stream() //
+                    .map(AnnotationDocument::getDocument) //
+                    .collect(toList());
+            pageStatistics = statisticsLoader.apply(srcDocs);
+        }
+
+        return page.iterator();
+    }
+
+    @Override
+    public void detach()
+    {
+        super.detach();
+        pageStatistics = null;
     }
 
     private int comparator(AnnotationDocument o1, AnnotationDocument o2)

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/open/OpenDocumentDialogPanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/open/OpenDocumentDialogPanel.java
@@ -25,12 +25,15 @@ import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.MANAGER;
 import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.CURATION_USER;
 import static de.tudarmstadt.ukp.inception.support.lambda.HtmlElementEvents.CHANGE_EVENT;
 import static de.tudarmstadt.ukp.inception.support.lambda.LambdaBehavior.visibleWhen;
+import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
 import static wicket.contrib.input.events.EventType.click;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.wicket.RestartResponseException;
 import org.apache.wicket.ajax.AjaxRequestTarget;
@@ -51,8 +54,10 @@ import org.wicketstuff.event.annotation.OnEvent;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.config.KeyBindingsProperties;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Mode;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.clarin.webanno.ui.core.page.ProjectPageBase;
@@ -60,6 +65,8 @@ import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.preferences.PreferencesService;
 import de.tudarmstadt.ukp.inception.project.api.ProjectService;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
+import de.tudarmstadt.ukp.inception.search.DocumentStatistics;
+import de.tudarmstadt.ukp.inception.search.SearchService;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxFormComponentUpdatingBehavior;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxLink;
 import de.tudarmstadt.ukp.inception.support.wicket.DecoratedObject;
@@ -83,6 +90,7 @@ public class OpenDocumentDialogPanel
     private @SpringBean UserDao userRepository;
     private @SpringBean PreferencesService preferencesService;
     private @SpringBean KeyBindingsProperties keyBindings;
+    private @SpringBean SearchService searchService;
 
     private final DropDownChoice<DecoratedObject<User>> userListChoice;
     private final AnnotationDocumentTable table;
@@ -113,7 +121,28 @@ public class OpenDocumentDialogPanel
         table = new AnnotationDocumentTable(CID_TABLE,
                 LoadableDetachableModel.of(this::listDocuments));
         table.setOutputMarkupId(true);
+        table.setStatisticsLoader(this::loadStatistics);
         queue(table);
+    }
+
+    private Map<Long, DocumentStatistics> loadStatistics(Collection<SourceDocument> aDocuments)
+    {
+        var project = getModelObject().getProject();
+        var user = userListChoice.getModel().map(DecoratedObject::get).orElse(null).getObject();
+
+        if (project == null || user == null || aDocuments == null || aDocuments.isEmpty()) {
+            return emptyMap();
+        }
+
+        try {
+            return searchService.getAnnotationCountsPerDocument(AnnotationSet.forUser(user),
+                    project, aDocuments);
+        }
+        catch (Exception e) {
+            // Search index may be missing/invalid (e.g. still being built or never created on
+            // standalone install) — the dialog should still be usable without the count columns.
+            return emptyMap();
+        }
     }
 
     private boolean isFinishedDocumentsSkippedByNavigation()

--- a/inception/inception-ui-curation/pom.xml
+++ b/inception/inception-ui-curation/pom.xml
@@ -173,6 +173,11 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-search-core</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-layer-relation-api</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/actionbar/opendocument/CurationDocumentTable.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/actionbar/opendocument/CurationDocumentTable.java
@@ -31,10 +31,14 @@ import static de.tudarmstadt.ukp.inception.ui.curation.actionbar.opendocument.Cu
 import static java.time.Duration.ofMillis;
 import static org.apache.wicket.event.Broadcast.BUBBLE;
 
+import java.text.NumberFormat;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
+import java.util.function.ToLongFunction;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.extensions.ajax.markup.html.repeater.data.table.AjaxFallbackHeadersToolbar;
@@ -48,11 +52,13 @@ import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.PropertyModel;
 import org.apache.wicket.model.ResourceModel;
+import org.danekja.java.util.function.serializable.SerializableFunction;
 import org.wicketstuff.event.annotation.OnEvent;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.annotation.filters.SourceDocumentFilterStateChanged;
 import de.tudarmstadt.ukp.inception.annotation.filters.SourceDocumentStateFilterPanel;
+import de.tudarmstadt.ukp.inception.search.DocumentStatistics;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxFormComponentUpdatingBehavior;
 import de.tudarmstadt.ukp.inception.support.wicket.EmptyStateToolbar;
 import de.tudarmstadt.ukp.inception.support.wicket.SymbolLambdaColumn;
@@ -66,6 +72,7 @@ public class CurationDocumentTable
     private static final String CID_DATA_TABLE = "dataTable";
     private static final String CID_STATE_FILTERS = "stateFilters";
 
+    private final CurationDocumentTableDataProvider dataProvider;
     private final DataTable<SourceDocument, CurationDocumentTableSortKeys> table;
     private TextField<String> nameFilter;
 
@@ -74,13 +81,17 @@ public class CurationDocumentTable
         super(aId, aModel);
         setOutputMarkupId(true);
 
-        var dataProvider = new CurationDocumentTableDataProvider(aModel);
+        dataProvider = new CurationDocumentTableDataProvider(aModel);
 
         var columns = new ArrayList<IColumn<SourceDocument, CurationDocumentTableSortKeys>>();
         columns.add(new SymbolLambdaColumn<>(new ResourceModel("DocumentState"), STATE,
                 item -> item.getState()));
         columns.add(new CurationDocumentOpenActionColumn(this, new ResourceModel("DocumentName"),
                 NAME));
+        columns.add(new LambdaColumn<>(new ResourceModel("DocumentTokens"),
+                $ -> renderCount($, DocumentStatistics::tokenCount)));
+        columns.add(new LambdaColumn<>(new ResourceModel("DocumentSentences"),
+                $ -> renderCount($, DocumentStatistics::sentenceCount)));
         columns.add(new LambdaColumn<>(new ResourceModel("DocumentCreated"), CREATED,
                 $ -> renderDate($.getCreated())));
         columns.add(new LambdaColumn<>(new ResourceModel("DocumentUpdated"), UPDATED,
@@ -141,7 +152,21 @@ public class CurationDocumentTable
             return "";
         }
 
-        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
-        return dateFormat.format(aDate);
+        return new SimpleDateFormat("yyyy-MM-dd").format(aDate);
+    }
+
+    public void setStatisticsLoader(
+            SerializableFunction<Collection<SourceDocument>, Map<Long, DocumentStatistics>> aLoader)
+    {
+        dataProvider.setStatisticsLoader(aLoader);
+    }
+
+    private String renderCount(SourceDocument aDoc, ToLongFunction<DocumentStatistics> aAccessor)
+    {
+        var stats = dataProvider.getPageStatistics().get(aDoc.getId());
+        if (stats == null) {
+            return "-";
+        }
+        return NumberFormat.getIntegerInstance(getLocale()).format(aAccessor.applyAsLong(stats));
     }
 }

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/actionbar/opendocument/CurationDocumentTable.utf8.properties
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/actionbar/opendocument/CurationDocumentTable.utf8.properties
@@ -1,7 +1,7 @@
-# Licensed to the Technische Universit‰t Darmstadt under one
+# Licensed to the Technische Universit√§t Darmstadt under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
-# regarding copyright ownership.  The Technische Universit‰t Darmstadt 
+# regarding copyright ownership.  The Technische Universit√§t Darmstadt 
 # licenses this file to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.
@@ -15,6 +15,8 @@
 # limitations under the License.
 DocumentState=State
 DocumentName=Name
+DocumentTokens=Tokens
+DocumentSentences=Sentences
 DocumentCreated=Created
 DocumentUpdated=Updated
 nameFilter.placeholder=Filter by name... (open with enter when one is left)

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/actionbar/opendocument/CurationDocumentTableDataProvider.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/actionbar/opendocument/CurationDocumentTableDataProvider.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.inception.ui.curation.actionbar.opendocument;
 
 import static de.tudarmstadt.ukp.inception.ui.curation.actionbar.opendocument.CurationDocumentTableSortKeys.NAME;
+import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.apache.commons.lang3.ObjectUtils.compare;
@@ -25,16 +26,20 @@ import static org.apache.commons.lang3.StringUtils.containsIgnoreCase;
 import static org.apache.wicket.extensions.markup.html.repeater.data.sort.SortOrder.ASCENDING;
 
 import java.io.Serializable;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import org.apache.wicket.extensions.markup.html.repeater.data.table.filter.IFilterStateLocator;
 import org.apache.wicket.extensions.markup.html.repeater.util.SortableDataProvider;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
+import org.danekja.java.util.function.serializable.SerializableFunction;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.inception.search.DocumentStatistics;
 
 public class CurationDocumentTableDataProvider
     extends SortableDataProvider<SourceDocument, CurationDocumentTableSortKeys>
@@ -44,6 +49,9 @@ public class CurationDocumentTableDataProvider
 
     private CurationDocumentTableFilterState filterState;
     private List<SourceDocument> data;
+    private SerializableFunction<Collection<SourceDocument>, //
+            Map<Long, DocumentStatistics>> statisticsLoader;
+    private transient Map<Long, DocumentStatistics> pageStatistics;
 
     public CurationDocumentTableDataProvider(IModel<List<SourceDocument>> aDocuments)
     {
@@ -56,14 +64,37 @@ public class CurationDocumentTableDataProvider
         setSort(NAME, ASCENDING);
     }
 
+    public void setStatisticsLoader(
+            SerializableFunction<Collection<SourceDocument>, Map<Long, DocumentStatistics>> aLoader)
+    {
+        statisticsLoader = aLoader;
+    }
+
+    public Map<Long, DocumentStatistics> getPageStatistics()
+    {
+        return pageStatistics != null ? pageStatistics : emptyMap();
+    }
+
     @Override
     public Iterator<? extends SourceDocument> iterator(long aFirst, long aCount)
     {
         var filteredData = filter(data);
         filteredData.sort(this::comparator);
-        return filteredData //
-                .subList((int) aFirst, (int) (aFirst + aCount)) //
-                .iterator();
+        var page = filteredData //
+                .subList((int) aFirst, (int) (aFirst + aCount));
+
+        if (statisticsLoader != null) {
+            pageStatistics = statisticsLoader.apply(page);
+        }
+
+        return page.iterator();
+    }
+
+    @Override
+    public void detach()
+    {
+        super.detach();
+        pageStatistics = null;
     }
 
     private int comparator(SourceDocument o1, SourceDocument o2)

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/actionbar/opendocument/CurationOpenDocumentDialogPanel.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/actionbar/opendocument/CurationOpenDocumentDialogPanel.java
@@ -19,9 +19,12 @@ package de.tudarmstadt.ukp.inception.ui.curation.actionbar.opendocument;
 
 import static de.tudarmstadt.ukp.inception.curation.settings.CurationNavigationUserPrefs.KEY_CURATION_NAVIGATION_USER_PREFS;
 import static de.tudarmstadt.ukp.inception.support.lambda.HtmlElementEvents.CHANGE_EVENT;
+import static java.util.Collections.emptyMap;
 import static wicket.contrib.input.events.EventType.click;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.wicket.RestartResponseException;
 import org.apache.wicket.ajax.AjaxRequestTarget;
@@ -34,6 +37,7 @@ import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.wicketstuff.event.annotation.OnEvent;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.ui.core.page.ProjectPageBase;
@@ -41,6 +45,8 @@ import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.preferences.PreferencesService;
 import de.tudarmstadt.ukp.inception.project.api.ProjectService;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
+import de.tudarmstadt.ukp.inception.search.DocumentStatistics;
+import de.tudarmstadt.ukp.inception.search.SearchService;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxFormComponentUpdatingBehavior;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxLink;
 import de.tudarmstadt.ukp.inception.support.wicket.input.InputBehavior;
@@ -63,6 +69,7 @@ public class CurationOpenDocumentDialogPanel
     private @SpringBean DocumentService documentService;
     private @SpringBean UserDao userService;
     private @SpringBean PreferencesService preferencesService;
+    private @SpringBean SearchService searchService;
 
     private final CurationDocumentTable table;
 
@@ -80,6 +87,7 @@ public class CurationOpenDocumentDialogPanel
                 .add(new InputBehavior(new KeyType[] { KeyType.Escape }, click)));
 
         table = new CurationDocumentTable(CID_TABLE, documentList);
+        table.setStatisticsLoader(this::loadStatistics);
         queue(table);
 
         finishedDocumentsSkippedByNavigation = LambdaModel.of(
@@ -88,6 +96,23 @@ public class CurationOpenDocumentDialogPanel
         queue(new CheckBox(CID_FINISHED_DOCUMENTS_SKIPPED_BY_NAVIGATION,
                 finishedDocumentsSkippedByNavigation) //
                         .add(new LambdaAjaxFormComponentUpdatingBehavior(CHANGE_EVENT)));
+    }
+
+    private Map<Long, DocumentStatistics> loadStatistics(Collection<SourceDocument> aDocuments)
+    {
+        var project = getModelObject().getProject();
+
+        if (project == null || aDocuments == null || aDocuments.isEmpty()) {
+            return emptyMap();
+        }
+
+        try {
+            return searchService.getAnnotationCountsPerDocument(AnnotationSet.CURATION_SET, project,
+                    aDocuments);
+        }
+        catch (Exception e) {
+            return emptyMap();
+        }
     }
 
     private boolean isFinishedDocumentsSkippedByNavigation()


### PR DESCRIPTION
**What's in the PR**
- Add `DocumentStatistics` record (token + sentence counts) and `SearchService.getAnnotationCountsPerDocument(AnnotationSet, Project, Collection<SourceDocument>)` for per-document segmentation counts scoped to a given annotation set, with fallback to the initial CAS
- Wire the new method through `SearchServiceImpl` and `PhysicalIndex`
- Implement `MtasDocumentIndex.getAnnotationCountsPerDocument`: locate canonical Lucene docs preferring the requested annotation set's `FIELD_USER` (mapping `INITIAL_SET` to empty string) and falling back to the source-doc row, then sweep `<Token=""/>` and `<s=""/>` span queries across the resulting canonical doc set
- Add Tokens and Sentences columns to the open-document dialog in the annotation editor, populated per visible page so only the displayed rows hit MTAS
- `AnnotationDocumentTableDataProvider` now accepts a `SerializableFunction<Collection<SourceDocument>, Map<Long, DocumentStatistics>>` loader, invokes it in `iterator()` to refresh per-page statistics, and clears them on `detach()`
- `OpenDocumentDialogPanel` injects `SearchService` and supplies a loader using `AnnotationSet.forUser(selectedUser)`; failures (e.g. missing/invalid index) are swallowed so the dialog stays usable
- Mirror the same columns + loader plumbing in the curation open-document dialog using `AnnotationSet.CURATION_SET`
- Add an `inception-search-core` dependency to `inception-ui-annotation` (curation pulls it transitively)
- Add `DocumentTokens` and `DocumentSentences` i18n keys to both dialog property files

**How to test manually**
* Check open-document dialog on curation and annotation pages

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
