### PR TITLE
Issue #5960: Upgrade dependencies

### DIFF
--- a/inception/inception-dependencies/pom.xml
+++ b/inception/inception-dependencies/pom.xml
@@ -1347,12 +1347,6 @@
       </dependency>
 
       <dependency>
-        <groupId>org.cyberborean</groupId>
-        <artifactId>rdfbeans</artifactId>
-        <version>${rdfbeans.version}</version>
-      </dependency>
-
-      <dependency>
         <groupId>com.knuddels</groupId>
         <artifactId>jtokkit</artifactId>
         <version>${jtokkit.version}</version>

--- a/inception/inception-dependencies/pom.xml
+++ b/inception/inception-dependencies/pom.xml
@@ -782,7 +782,7 @@
       <dependency>
         <groupId>org.codehaus.woodstox</groupId>
         <artifactId>stax2-api</artifactId>
-        <version>4.2.2</version>
+        <version>4.3.0</version>
       </dependency>
 
       <dependency>

--- a/inception/inception-dependencies/pom.xml
+++ b/inception/inception-dependencies/pom.xml
@@ -79,12 +79,12 @@
       <dependency>
         <groupId>org.liquibase</groupId>
         <artifactId>liquibase-core</artifactId>
-        <version>4.33.0</version>
+        <version>${liquibase.version}</version>
       </dependency>
       <dependency>
         <groupId>com.mattbertolini</groupId>
         <artifactId>liquibase-slf4j</artifactId>
-        <version>5.1.0</version>
+        <version>${liquibase-slf4j.version}</version>
       </dependency>
 
       <dependency>
@@ -241,7 +241,7 @@
       <dependency>
         <groupId>jakarta.data</groupId>
         <artifactId>jakarta.data-api</artifactId>
-        <version>1.0.0</version>
+        <version>${jakarta.data.version}</version>
       </dependency>
 
       <!-- Testing -->
@@ -290,7 +290,7 @@
       <dependency>
         <groupId>no.nav.security</groupId>
         <artifactId>mock-oauth2-server</artifactId>
-        <version>0.5.10</version>
+        <version>${mock-oauth2-server.version}</version>
         <scope>test</scope>
         <exclusions>
           <exclusion>
@@ -500,7 +500,7 @@
       <dependency>
         <groupId>org.mozilla</groupId>
         <artifactId>rhino-runtime</artifactId>
-        <version>1.7.15</version>
+        <version>${rhino.version}</version>
       </dependency>
 
       <dependency>
@@ -522,12 +522,12 @@
       <dependency>
         <groupId>org.webjars.npm</groupId>
         <artifactId>webstomp-client</artifactId>
-        <version>1.2.6</version>
+        <version>${webstomp-client.version}</version>
       </dependency>
       <dependency>
         <groupId>org.sharegov</groupId>
         <artifactId>mjson</artifactId>
-        <version>1.4.2</version>
+        <version>${mjson.version}</version>
         <scope>provided</scope>
         <exclusions>
           <exclusion>
@@ -678,19 +678,19 @@
       <dependency>
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>jsr305</artifactId>
-        <version>3.0.2</version>
+        <version>${jsr305.version}</version>
       </dependency>
       
       <dependency>
         <groupId>com.ibm.icu</groupId>
         <artifactId>icu4j</artifactId>
-        <version>75.1</version>
+        <version>${icu4j.version}</version>
       </dependency>
 
       <dependency>
         <groupId>eu.openminted.share.annotations</groupId>
         <artifactId>omtd-share-annotations-api</artifactId>
-        <version>3.0.2.7</version>
+        <version>${omtd-share-annotations.version}</version>
       </dependency>
 
       <dependency>
@@ -782,7 +782,7 @@
       <dependency>
         <groupId>org.codehaus.woodstox</groupId>
         <artifactId>stax2-api</artifactId>
-        <version>4.3.0</version>
+        <version>${stax2-api.version}</version>
       </dependency>
 
       <dependency>
@@ -891,7 +891,7 @@
       <dependency>
         <groupId>javax.validation</groupId>
         <artifactId>validation-api</artifactId>
-        <version>2.0.1.Final</version>
+        <version>${javax.validation.version}</version>
       </dependency>
       <dependency>
         <groupId>org.javassist</groupId>
@@ -930,12 +930,12 @@
       <dependency>
         <groupId>org.apache.httpcomponents.core5</groupId>
         <artifactId>httpcore5</artifactId>
-        <version>5.3.6</version>
+        <version>${httpcore5.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents.client5</groupId>
         <artifactId>httpclient5</artifactId>
-        <version>5.5.1</version>
+        <version>${httpclient5.version}</version>
       </dependency>
 
       <dependency>
@@ -1014,7 +1014,7 @@
       <dependency>
         <groupId>org.dkpro.statistics</groupId>
         <artifactId>dkpro-statistics-agreement</artifactId>
-        <version>2.2.1</version>
+        <version>${dkpro-statistics.version}</version>
       </dependency>
 
       <!-- Snakeyaml -->
@@ -1029,7 +1029,7 @@
       <dependency>
         <groupId>eu.clarin.weblicht</groupId>
         <artifactId>wlfxb</artifactId>
-        <version>1.4.3</version>
+        <version>${wlfxb.version}</version>
         <exclusions>
           <!--
             - Looks like moxy isn't even used by wlfxb except for an annotation which again doesn't
@@ -1349,13 +1349,13 @@
       <dependency>
         <groupId>org.cyberborean</groupId>
         <artifactId>rdfbeans</artifactId>
-        <version>2.2</version>
+        <version>${rdfbeans.version}</version>
       </dependency>
 
       <dependency>
         <groupId>com.knuddels</groupId>
         <artifactId>jtokkit</artifactId>
-        <version>1.1.0</version>
+        <version>${jtokkit.version}</version>
       </dependency>
 
       <dependency>

--- a/inception/inception-imls-llm-support/pom.xml
+++ b/inception/inception-imls-llm-support/pom.xml
@@ -125,10 +125,6 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
     </dependency>
-   <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-    </dependency>
     <dependency>
       <groupId>tools.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>

--- a/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/support/response/SpanJsonSchemaAnnotationTaskCodec.java
+++ b/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/support/response/SpanJsonSchemaAnnotationTaskCodec.java
@@ -51,7 +51,6 @@ import org.apache.uima.jcas.tcas.Annotation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.github.victools.jsonschema.generator.Option;
 import com.github.victools.jsonschema.generator.SchemaGenerator;
 import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
@@ -259,7 +258,6 @@ public final class SpanJsonSchemaAnnotationTaskCodec
     @Override
     public void decode(RecommendationEngine aEngine, CAS aCas, PromptContext aContext,
             String aResponse)
-        throws JsonProcessingException
     {
         if (isBlank(aResponse)) {
             LOG.debug("Empty response. No mentions to extract.");

--- a/inception/inception-io-html/src/main/java/de/tudarmstadt/ukp/inception/io/html/dkprocore/internal/JSoupUtil.java
+++ b/inception/inception-io-html/src/main/java/de/tudarmstadt/ukp/inception/io/html/dkprocore/internal/JSoupUtil.java
@@ -29,21 +29,20 @@ import org.jsoup.nodes.Node;
 import org.jsoup.nodes.TextNode;
 
 /**
- * Methods in this class were copied from JSoup. They were private and could not be accessed.
+ * Methods in this class were copied from JSoup. They were private and could not be accessed. Last
+ * verified against jsoup 1.22.2.
  */
 public final class JSoupUtil
 {
-    /*
-     * org.jsoup.nodes.TextNode.lastCharIsWhitespace(StringBuilder)
-     */
+    // Source:
+    // https://github.com/jhy/jsoup/blob/jsoup-1.22.2/src/main/java/org/jsoup/nodes/TextNode.java#L117
     public static boolean lastCharIsWhitespace(CharSequence sb)
     {
         return sb.length() != 0 && sb.charAt(sb.length() - 1) == ' ';
     }
 
-    /*
-     * org.jsoup.nodes.Element.appendNormalisedText(StringBuilder, TextNode)
-     */
+    // Source:
+    // https://github.com/jhy/jsoup/blob/jsoup-1.22.2/src/main/java/org/jsoup/nodes/Element.java#L1686
     public static void appendNormalisedText(StringBuilder accum, TextNode textNode)
     {
         String text = textNode.getWholeText();
@@ -56,9 +55,8 @@ public final class JSoupUtil
         }
     }
 
-    /*
-     * org.jsoup.nodes.Element.preserveWhitespace(Node)
-     */
+    // Source:
+    // https://github.com/jhy/jsoup/blob/jsoup-1.22.2/src/main/java/org/jsoup/nodes/Element.java#L1694
     public static boolean preserveWhitespace(Node node)
     {
         // looks only at this element and five levels up, to prevent recursion & needless stack

--- a/inception/inception-io-pdf/src/main/java/de/tudarmstadt/ukp/inception/io/pdf/pdfbox/GlyphPositionUtils.java
+++ b/inception/inception-io-pdf/src/main/java/de/tudarmstadt/ukp/inception/io/pdf/pdfbox/GlyphPositionUtils.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.LineNumberReader;
 import java.lang.invoke.MethodHandles;
+import java.nio.charset.StandardCharsets;
 import java.text.Bidi;
 import java.text.Normalizer;
 import java.util.HashMap;
@@ -47,7 +48,7 @@ public class GlyphPositionUtils
     private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     // Source:
-    // https://github.com/apache/pdfbox/blob/10d1e91af4eb9a06af7e95460533bf3ebc1b1280/examples/src/main/java/org/apache/pdfbox/examples/util/DrawPrintTextLocations.java#L220
+    // https://github.com/apache/pdfbox/blob/3.0.7/examples/src/main/java/org/apache/pdfbox/examples/util/DrawPrintTextLocations.java#L202
     public static AffineTransform makeFlipAT(PDPage pdPage)
     {
         // flip y-axis
@@ -59,43 +60,32 @@ public class GlyphPositionUtils
     }
 
     // Source:
-    // https://github.com/apache/pdfbox/blob/10d1e91af4eb9a06af7e95460533bf3ebc1b1280/examples/src/main/java/org/apache/pdfbox/examples/util/DrawPrintTextLocations.java#L225
+    // https://github.com/apache/pdfbox/blob/3.0.7/examples/src/main/java/org/apache/pdfbox/examples/util/DrawPrintTextLocations.java#L207
     public static AffineTransform makeRotateAT(PDPage pdPage)
     {
         // page may be rotated
         AffineTransform rotateAT = new AffineTransform();
         int rotation = pdPage.getRotation();
-        if (rotation != 0) {
-            PDRectangle mediaBox = pdPage.getMediaBox();
-            switch (rotation) {
-            case 90:
-                rotateAT.translate(mediaBox.getHeight(), 0);
-                break;
-            case 270:
-                rotateAT.translate(0, mediaBox.getWidth());
-                break;
-            case 180:
-                rotateAT.translate(mediaBox.getWidth(), mediaBox.getHeight());
-                break;
-            default:
-                break;
-            }
-            rotateAT.rotate(Math.toRadians(rotation));
+        PDRectangle cropBox = pdPage.getCropBox();
+        switch (rotation) {
+        case 90:
+            rotateAT.translate(cropBox.getHeight(), 0);
+            break;
+        case 270:
+            rotateAT.translate(0, cropBox.getWidth());
+            break;
+        case 180:
+            rotateAT.translate(cropBox.getWidth(), cropBox.getHeight());
+            break;
+        default:
+            break;
         }
+        rotateAT.rotate(Math.toRadians(rotation));
         return rotateAT;
     }
 
     // Source:
-    // https://github.com/apache/pdfbox/blob/10d1e91af4eb9a06af7e95460533bf3ebc1b1280/examples/src/main/java/org/apache/pdfbox/examples/util/DrawPrintTextLocations.java#L248
-    public static AffineTransform makeTransAT(PDPage pdPage)
-    {
-        PDRectangle cropBox = pdPage.getCropBox();
-        return AffineTransform.getTranslateInstance(-cropBox.getLowerLeftX(),
-                cropBox.getLowerLeftY());
-    }
-
-    // Source:
-    // https://github.com/apache/pdfbox/blob/10d1e91af4eb9a06af7e95460533bf3ebc1b1280/examples/src/main/java/org/apache/pdfbox/examples/util/DrawPrintTextLocations.java#L290
+    // https://github.com/apache/pdfbox/blob/3.0.7/examples/src/main/java/org/apache/pdfbox/examples/util/DrawPrintTextLocations.java#L283
     public static Shape calculateFontBounds(TextPosition text, AffineTransform flipAT,
             AffineTransform rotateAT)
         throws IOException
@@ -156,7 +146,7 @@ public class GlyphPositionUtils
     }
 
     // source:
-    // https://github.com/apache/pdfbox/blob/2.0.28/pdfbox/src/main/java/org/apache/pdfbox/text/PDFTextStripper.java#L1911
+    // https://github.com/apache/pdfbox/blob/3.0.7/pdfbox/src/main/java/org/apache/pdfbox/text/PDFTextStripper.java#L2047
     // The support for extracting the glyph order was added for INCEpTION
     /**
      * Normalize certain Unicode characters. For example, convert the single "fi" ligature to "f"
@@ -221,7 +211,7 @@ public class GlyphPositionUtils
     }
 
     // source:
-    // https://github.com/apache/pdfbox/blob/10d1e91af4eb9a06af7e95460533bf3ebc1b1280/pdfbox/src/main/java/org/apache/pdfbox/text/PDFTextStripper.java#L1756
+    // https://github.com/apache/pdfbox/blob/3.0.7/pdfbox/src/main/java/org/apache/pdfbox/text/PDFTextStripper.java#L1903
     // The support for extracting the glyph order was added for INCEpTION
     /**
      * Handles the LTR and RTL direction of the given words. The whole implementation stands and
@@ -309,15 +299,15 @@ public class GlyphPositionUtils
     }
 
     // source:
-    // https://github.com/apache/pdfbox/blob/10d1e91af4eb9a06af7e95460533bf3ebc1b1280/pdfbox/src/main/java/org/apache/pdfbox/text/PDFTextStripper.java#L1822
-    private static Map<Character, Character> MIRRORING_CHAR_MAP = new HashMap<Character, Character>();
+    // https://github.com/apache/pdfbox/blob/3.0.7/pdfbox/src/main/java/org/apache/pdfbox/text/PDFTextStripper.java#L1958
+    private static final Map<Character, Character> MIRRORING_CHAR_MAP = new HashMap<>();
 
     // source:
-    // https://github.com/apache/pdfbox/blob/10d1e91af4eb9a06af7e95460533bf3ebc1b1280/pdfbox/src/main/java/org/apache/pdfbox/text/PDFTextStripper.java#L1824
+    // https://github.com/apache/pdfbox/blob/3.0.7/pdfbox/src/main/java/org/apache/pdfbox/text/PDFTextStripper.java#L1960
     static {
         String path = "/org/apache/pdfbox/resources/text/BidiMirroring.txt";
-        try (InputStream input = new BufferedInputStream(
-                PDFTextStripper.class.getResourceAsStream(path))) {
+        try (InputStream resourceAsStream = PDFTextStripper.class.getResourceAsStream(path);
+                InputStream input = new BufferedInputStream(resourceAsStream)) {
             parseBidiFile(input);
         }
         catch (IOException e) {
@@ -327,10 +317,10 @@ public class GlyphPositionUtils
     }
 
     // source:
-    // https://github.com/apache/pdfbox/blob/10d1e91af4eb9a06af7e95460533bf3ebc1b1280/pdfbox/src/main/java/org/apache/pdfbox/text/PDFTextStripper.java#L1856
+    // https://github.com/apache/pdfbox/blob/3.0.7/pdfbox/src/main/java/org/apache/pdfbox/text/PDFTextStripper.java#L1994
     /**
      * This method parses the bidi file provided as inputstream.
-     * 
+     *
      * @param inputStream
      *            - The bidi file as inputstream
      * @throws IOException
@@ -338,7 +328,8 @@ public class GlyphPositionUtils
      */
     private static void parseBidiFile(InputStream inputStream) throws IOException
     {
-        LineNumberReader rd = new LineNumberReader(new InputStreamReader(inputStream));
+        LineNumberReader rd = new LineNumberReader(
+                new InputStreamReader(inputStream, StandardCharsets.US_ASCII));
 
         do {
             String s = rd.readLine();

--- a/inception/inception-io-pdf/src/main/java/de/tudarmstadt/ukp/inception/io/pdf/visual/VisualPDFTextStripper.java
+++ b/inception/inception-io-pdf/src/main/java/de/tudarmstadt/ukp/inception/io/pdf/visual/VisualPDFTextStripper.java
@@ -50,6 +50,9 @@ import de.tudarmstadt.ukp.inception.io.pdf.visual.model.VGlyph;
 import de.tudarmstadt.ukp.inception.io.pdf.visual.model.VModel;
 import de.tudarmstadt.ukp.inception.io.pdf.visual.model.VPage;
 
+// Extends pdfbox PDFTextStripper. The set of overridden protected hooks and the relied-on
+// internals (output, charactersByArticle, TextPosition accessors) were last verified against:
+// https://github.com/apache/pdfbox/blob/3.0.7/pdfbox/src/main/java/org/apache/pdfbox/text/PDFTextStripper.java
 public class VisualPDFTextStripper
     extends PDFTextStripper
 {

--- a/inception/inception-kb/pom.xml
+++ b/inception/inception-kb/pom.xml
@@ -177,10 +177,6 @@
       <artifactId>rdf4j-common-transaction</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.cyberborean</groupId>
-      <artifactId>rdfbeans</artifactId>
-    </dependency>
-    <dependency>
       <groupId>net.sourceforge.owlapi</groupId>
       <artifactId>owlapi-api</artifactId>
     </dependency>

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/InceptionValueMapper.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/InceptionValueMapper.java
@@ -18,8 +18,6 @@
 package de.tudarmstadt.ukp.inception.kb;
 
 import org.apache.commons.lang3.Validate;
-import org.cyberborean.rdfbeans.datatype.DatatypeMapper;
-import org.cyberborean.rdfbeans.datatype.DefaultDatatypeMapper;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -63,8 +61,7 @@ public class InceptionValueMapper
             return vf.createLiteral((String) value, language);
         }
         else {
-            DatatypeMapper mapper = new DefaultDatatypeMapper();
-            return mapper.getRDFValue(value, vf);
+            return XsdDatatypes.toRdfValue(value, vf);
         }
     }
 }

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/XsdDatatypes.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/XsdDatatypes.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.kb;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.URI;
+import java.util.Date;
+import java.util.Map;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.util.Values;
+import org.eclipse.rdf4j.model.vocabulary.XSD;
+
+/**
+ * Java/RDF datatype conversion helpers — replaces the formerly-used
+ * {@code org.cyberborean.rdfbeans.datatype.DefaultDatatypeMapper}. Behavior is pinned by
+ * {@code InceptionValueMapperTest}, {@code KBStatementValueConversionTest} and
+ * {@code DatatypeUriLookupTest}.
+ */
+public final class XsdDatatypes
+{
+    private static final Map<Class<?>, IRI> JAVA_TO_XSD = Map.ofEntries(
+            Map.entry(String.class, XSD.STRING), Map.entry(Boolean.class, XSD.BOOLEAN),
+            Map.entry(BigDecimal.class, XSD.DECIMAL), Map.entry(Byte.class, XSD.BYTE),
+            Map.entry(Double.class, XSD.DOUBLE), Map.entry(Float.class, XSD.FLOAT),
+            Map.entry(Integer.class, XSD.INT), Map.entry(Long.class, XSD.LONG),
+            Map.entry(Short.class, XSD.SHORT), Map.entry(Date.class, XSD.DATETIME),
+            Map.entry(URI.class, XSD.ANYURI));
+
+    private XsdDatatypes()
+    {
+        // utility class
+    }
+
+    /**
+     * Map a Java class to its corresponding XSD datatype IRI, or {@code null} if the class is not
+     * one of the standard types.
+     */
+    public static IRI datatypeOf(Class<?> clazz)
+    {
+        return JAVA_TO_XSD.get(clazz);
+    }
+
+    /**
+     * Convert a Java value to an RDF {@link Value}. {@link URI} values are emitted as IRIs (not as
+     * {@code xsd:anyURI} literals); {@link BigDecimal} and {@link BigInteger} are mapped via the
+     * value factory's typed-literal constructors; all other types are routed through
+     * {@link Values#literal(ValueFactory, Object, boolean)} with {@code failOnUnknownType=true}.
+     */
+    public static Value toRdfValue(Object javaValue, ValueFactory vf)
+    {
+        if (javaValue instanceof URI) {
+            return vf.createIRI(javaValue.toString());
+        }
+        if (javaValue instanceof BigDecimal) {
+            return vf.createLiteral((BigDecimal) javaValue);
+        }
+        if (javaValue instanceof BigInteger) {
+            return vf.createLiteral((BigInteger) javaValue);
+        }
+        return Values.literal(vf, javaValue, true);
+    }
+
+    /**
+     * Convert an RDF {@link Literal} to a Java value of the natural type for its XSD datatype.
+     * Literals with an unrecognized datatype (including {@code xsd:integer} and language-tagged
+     * strings) are returned as their raw label.
+     */
+    public static Object toJavaObject(Literal lit)
+    {
+        IRI dt = lit.getDatatype();
+        if (XSD.STRING.equals(dt)) {
+            return lit.getLabel();
+        }
+        if (XSD.BOOLEAN.equals(dt)) {
+            return lit.booleanValue();
+        }
+        if (XSD.INT.equals(dt)) {
+            return lit.intValue();
+        }
+        if (XSD.LONG.equals(dt)) {
+            return lit.longValue();
+        }
+        if (XSD.SHORT.equals(dt)) {
+            return lit.shortValue();
+        }
+        if (XSD.BYTE.equals(dt)) {
+            return lit.byteValue();
+        }
+        if (XSD.FLOAT.equals(dt)) {
+            return lit.floatValue();
+        }
+        if (XSD.DOUBLE.equals(dt)) {
+            return lit.doubleValue();
+        }
+        if (XSD.DECIMAL.equals(dt)) {
+            return lit.decimalValue();
+        }
+        if (XSD.DATETIME.equals(dt)) {
+            return lit.calendarValue().toGregorianCalendar().getTime();
+        }
+        return lit.getLabel();
+    }
+}

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/KBQualifier.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/KBQualifier.java
@@ -23,12 +23,13 @@ import java.util.Set;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import org.cyberborean.rdfbeans.datatype.DefaultDatatypeMapper;
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
+
+import de.tudarmstadt.ukp.inception.kb.XsdDatatypes;
 
 public class KBQualifier
     implements Serializable
@@ -107,7 +108,7 @@ public class KBQualifier
                 Literal litValue = (Literal) aValue;
                 try {
                     language = litValue.getLanguage().orElse(null);
-                    value = new DefaultDatatypeMapper().getJavaObject(litValue);
+                    value = XsdDatatypes.toJavaObject(litValue);
                 }
                 catch (Exception e) {
                     value = "ERROR converting [" + litValue + "]: " + e.getMessage();

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/KBStatement.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/graph/KBStatement.java
@@ -26,14 +26,14 @@ import java.util.Set;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
-import org.cyberborean.rdfbeans.datatype.DatatypeMapper;
-import org.cyberborean.rdfbeans.datatype.DefaultDatatypeMapper;
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Literal;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+
+import de.tudarmstadt.ukp.inception.kb.XsdDatatypes;
 
 public class KBStatement
     implements Serializable
@@ -160,11 +160,10 @@ public class KBStatement
     public void setValue(Object aValue)
     {
         if (aValue instanceof Value) {
-            DatatypeMapper mapper = new DefaultDatatypeMapper();
             if (aValue instanceof Literal) {
                 Literal litValue = (Literal) aValue;
                 language = litValue.getLanguage().orElse(null);
-                value = mapper.getJavaObject(litValue);
+                value = XsdDatatypes.toJavaObject(litValue);
             }
             else if (aValue instanceof IRI) {
                 value = aValue;

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/DatatypeUriLookupTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/DatatypeUriLookupTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.kb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.net.URI;
+import java.util.Date;
+
+import org.eclipse.rdf4j.model.vocabulary.XSD;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the Java-class-to-XSD-IRI lookup behavior of {@link XsdDatatypes#datatypeOf(Class)}, used by
+ * the {@code *LiteralValueSupport} hierarchy and {@code ValueTypeSupportRegistryImpl}. Originated
+ * as a characterization of rdfbeans' {@code DefaultDatatypeMapper.getDatatypeURI}; the migration to
+ * {@code XsdDatatypes} must preserve these mappings.
+ */
+class DatatypeUriLookupTest
+{
+    @Test
+    void stringMapsToXsdString()
+    {
+        assertThat(XsdDatatypes.datatypeOf(String.class)).isEqualTo(XSD.STRING);
+    }
+
+    @Test
+    void integerMapsToXsdInt()
+    {
+        assertThat(XsdDatatypes.datatypeOf(Integer.class)).isEqualTo(XSD.INT);
+    }
+
+    @Test
+    void longMapsToXsdLong()
+    {
+        assertThat(XsdDatatypes.datatypeOf(Long.class)).isEqualTo(XSD.LONG);
+    }
+
+    @Test
+    void shortMapsToXsdShort()
+    {
+        assertThat(XsdDatatypes.datatypeOf(Short.class)).isEqualTo(XSD.SHORT);
+    }
+
+    @Test
+    void byteMapsToXsdByte()
+    {
+        assertThat(XsdDatatypes.datatypeOf(Byte.class)).isEqualTo(XSD.BYTE);
+    }
+
+    @Test
+    void floatMapsToXsdFloat()
+    {
+        assertThat(XsdDatatypes.datatypeOf(Float.class)).isEqualTo(XSD.FLOAT);
+    }
+
+    @Test
+    void doubleMapsToXsdDouble()
+    {
+        assertThat(XsdDatatypes.datatypeOf(Double.class)).isEqualTo(XSD.DOUBLE);
+    }
+
+    @Test
+    void bigDecimalMapsToXsdDecimal()
+    {
+        assertThat(XsdDatatypes.datatypeOf(BigDecimal.class)).isEqualTo(XSD.DECIMAL);
+    }
+
+    @Test
+    void booleanMapsToXsdBoolean()
+    {
+        assertThat(XsdDatatypes.datatypeOf(Boolean.class)).isEqualTo(XSD.BOOLEAN);
+    }
+
+    @Test
+    void dateMapsToXsdDateTime()
+    {
+        assertThat(XsdDatatypes.datatypeOf(Date.class)).isEqualTo(XSD.DATETIME);
+    }
+
+    @Test
+    void uriMapsToXsdAnyUri()
+    {
+        assertThat(XsdDatatypes.datatypeOf(URI.class)).isEqualTo(XSD.ANYURI);
+    }
+
+    @Test
+    void unknownClassReturnsNull()
+    {
+        assertThat(XsdDatatypes.datatypeOf(Object.class)).isNull();
+    }
+}

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/InceptionValueMapperTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/InceptionValueMapperTest.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.kb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.net.URI;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Literal;
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.XSD;
+import org.junit.jupiter.api.Test;
+
+import de.tudarmstadt.ukp.inception.kb.graph.KBHandle;
+import de.tudarmstadt.ukp.inception.kb.graph.KBStatement;
+
+/**
+ * Pins the Java-value-to-RDF-Value behavior of
+ * {@link InceptionValueMapper#mapStatementValue(KBStatement, ValueFactory)}. Originated as a
+ * characterization of the prior rdfbeans-based mapping; preserved through the migration to
+ * {@link de.tudarmstadt.ukp.inception.kb.XsdDatatypes}.
+ */
+class InceptionValueMapperTest
+{
+    private final ValueFactory vf = SimpleValueFactory.getInstance();
+    private final InceptionValueMapper sut = new InceptionValueMapper();
+
+    private KBStatement statement(Object value)
+    {
+        var stmt = new KBStatement(new KBHandle("http://example.org/subj"));
+        stmt.setValue(value);
+        return stmt;
+    }
+
+    private KBStatement statementWithLanguage(Object value, String language)
+    {
+        var stmt = statement(value);
+        stmt.setLanguage(language);
+        return stmt;
+    }
+
+    @Test
+    void iriPassthrough()
+    {
+        var iri = vf.createIRI("http://example.org/x");
+        var result = sut.mapStatementValue(statement(iri), vf);
+        assertThat(result).isEqualTo(iri);
+    }
+
+    @Test
+    void uriLikeStringBecomesIri()
+    {
+        var result = sut.mapStatementValue(statement("http://example.org/x"), vf);
+        assertThat(result).isInstanceOf(IRI.class);
+        assertThat(result.stringValue()).isEqualTo("http://example.org/x");
+    }
+
+    @Test
+    void plainStringBecomesXsdString()
+    {
+        var result = sut.mapStatementValue(statement("hello"), vf);
+        assertThat(result).isInstanceOf(Literal.class);
+        var lit = (Literal) result;
+        assertThat(lit.getLabel()).isEqualTo("hello");
+        assertThat(lit.getDatatype()).isEqualTo(XSD.STRING);
+    }
+
+    @Test
+    void stringWithLanguageBecomesLangString()
+    {
+        var result = sut.mapStatementValue(statementWithLanguage("hello", "en"), vf);
+        assertThat(result).isInstanceOf(Literal.class);
+        var lit = (Literal) result;
+        assertThat(lit.getLabel()).isEqualTo("hello");
+        assertThat(lit.getLanguage()).hasValue("en");
+    }
+
+    @Test
+    void integerBecomesXsdInt()
+    {
+        var result = sut.mapStatementValue(statement(42), vf);
+        assertThat(result).isInstanceOf(Literal.class);
+        var lit = (Literal) result;
+        assertThat(lit.getLabel()).isEqualTo("42");
+        assertThat(lit.getDatatype()).isEqualTo(XSD.INT);
+    }
+
+    @Test
+    void longBecomesXsdLong()
+    {
+        var result = sut.mapStatementValue(statement(9_999_999_999L), vf);
+        var lit = (Literal) result;
+        assertThat(lit.getLabel()).isEqualTo("9999999999");
+        assertThat(lit.getDatatype()).isEqualTo(XSD.LONG);
+    }
+
+    @Test
+    void shortBecomesXsdShort()
+    {
+        var result = sut.mapStatementValue(statement((short) 5), vf);
+        var lit = (Literal) result;
+        assertThat(lit.getLabel()).isEqualTo("5");
+        assertThat(lit.getDatatype()).isEqualTo(XSD.SHORT);
+    }
+
+    @Test
+    void byteBecomesXsdByte()
+    {
+        var result = sut.mapStatementValue(statement((byte) 7), vf);
+        var lit = (Literal) result;
+        assertThat(lit.getLabel()).isEqualTo("7");
+        assertThat(lit.getDatatype()).isEqualTo(XSD.BYTE);
+    }
+
+    @Test
+    void floatBecomesXsdFloat()
+    {
+        var result = sut.mapStatementValue(statement(1.5f), vf);
+        var lit = (Literal) result;
+        assertThat(lit.getLabel()).isEqualTo("1.5");
+        assertThat(lit.getDatatype()).isEqualTo(XSD.FLOAT);
+    }
+
+    @Test
+    void doubleBecomesXsdDouble()
+    {
+        var result = sut.mapStatementValue(statement(2.5d), vf);
+        var lit = (Literal) result;
+        assertThat(lit.getLabel()).isEqualTo("2.5");
+        assertThat(lit.getDatatype()).isEqualTo(XSD.DOUBLE);
+    }
+
+    @Test
+    void bigDecimalBecomesXsdDecimal()
+    {
+        var result = sut.mapStatementValue(statement(new BigDecimal("3.14")), vf);
+        var lit = (Literal) result;
+        assertThat(lit.getLabel()).isEqualTo("3.14");
+        assertThat(lit.getDatatype()).isEqualTo(XSD.DECIMAL);
+    }
+
+    @Test
+    void booleanBecomesXsdBoolean()
+    {
+        var result = sut.mapStatementValue(statement(Boolean.TRUE), vf);
+        var lit = (Literal) result;
+        assertThat(lit.getLabel()).isEqualTo("true");
+        assertThat(lit.getDatatype()).isEqualTo(XSD.BOOLEAN);
+    }
+
+    @Test
+    void dateBecomesXsdDateTime()
+    {
+        var cal = new GregorianCalendar(TimeZone.getTimeZone("UTC"));
+        cal.clear();
+        cal.set(2025, Calendar.MAY, 30, 12, 0, 0);
+        Date date = cal.getTime();
+
+        var result = sut.mapStatementValue(statement(date), vf);
+        var lit = (Literal) result;
+        assertThat(lit.getDatatype()).isEqualTo(XSD.DATETIME);
+        // Label is formatted in the local timezone, so we only check the date portion.
+        assertThat(lit.getLabel()).contains("2025-05-30T");
+    }
+
+    @Test
+    void uriBecomesIri() throws Exception
+    {
+        // rdfbeans handles java.net.URI by emitting an IRI (not a typed literal with xsd:anyURI).
+        var result = sut.mapStatementValue(statement(new URI("urn:example:abc")), vf);
+        assertThat(result).isInstanceOf(IRI.class);
+        assertThat(result.stringValue()).isEqualTo("urn:example:abc");
+    }
+}

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/graph/KBStatementValueConversionTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/graph/KBStatementValueConversionTest.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.kb.graph;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+
+import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.model.vocabulary.XSD;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the RDF-Literal-to-Java-Object behavior of {@link KBStatement#setValue(Object)} when the
+ * input is an RDF Literal. Originated as a characterization of the prior rdfbeans-based mapping;
+ * preserved through the migration to {@link de.tudarmstadt.ukp.inception.kb.XsdDatatypes}.
+ */
+class KBStatementValueConversionTest
+{
+    private final ValueFactory vf = SimpleValueFactory.getInstance();
+
+    private KBStatement statementWith(Object rdfValue)
+    {
+        var stmt = new KBStatement(new KBHandle("http://example.org/subj"));
+        stmt.setValue(rdfValue);
+        return stmt;
+    }
+
+    @Test
+    void xsdIntBecomesInteger()
+    {
+        var stmt = statementWith(vf.createLiteral("42", XSD.INT));
+        assertThat(stmt.getValue()).isInstanceOf(Integer.class).isEqualTo(42);
+    }
+
+    @Test
+    void xsdLongBecomesLong()
+    {
+        var stmt = statementWith(vf.createLiteral("9999999999", XSD.LONG));
+        assertThat(stmt.getValue()).isInstanceOf(Long.class).isEqualTo(9_999_999_999L);
+    }
+
+    @Test
+    void xsdShortBecomesShort()
+    {
+        var stmt = statementWith(vf.createLiteral("5", XSD.SHORT));
+        assertThat(stmt.getValue()).isInstanceOf(Short.class).isEqualTo((short) 5);
+    }
+
+    @Test
+    void xsdByteBecomesByte()
+    {
+        var stmt = statementWith(vf.createLiteral("7", XSD.BYTE));
+        assertThat(stmt.getValue()).isInstanceOf(Byte.class).isEqualTo((byte) 7);
+    }
+
+    @Test
+    void xsdIntegerKeepsStringLabel()
+    {
+        // rdfbeans does not include BigInteger in its type map, so xsd:integer literals are
+        // returned as their raw String label rather than a numeric type.
+        var stmt = statementWith(vf.createLiteral("123456789012345678901234567890", XSD.INTEGER));
+        assertThat(stmt.getValue()).isInstanceOf(String.class)
+                .isEqualTo("123456789012345678901234567890");
+    }
+
+    @Test
+    void xsdFloatBecomesFloat()
+    {
+        var stmt = statementWith(vf.createLiteral("1.5", XSD.FLOAT));
+        assertThat(stmt.getValue()).isInstanceOf(Float.class).isEqualTo(1.5f);
+    }
+
+    @Test
+    void xsdDoubleBecomesDouble()
+    {
+        var stmt = statementWith(vf.createLiteral("2.5", XSD.DOUBLE));
+        assertThat(stmt.getValue()).isInstanceOf(Double.class).isEqualTo(2.5d);
+    }
+
+    @Test
+    void xsdDecimalBecomesBigDecimal()
+    {
+        var stmt = statementWith(vf.createLiteral("3.14", XSD.DECIMAL));
+        assertThat(stmt.getValue()).isInstanceOf(BigDecimal.class)
+                .isEqualTo(new BigDecimal("3.14"));
+    }
+
+    @Test
+    void xsdBooleanBecomesBoolean()
+    {
+        var stmt = statementWith(vf.createLiteral("true", XSD.BOOLEAN));
+        assertThat(stmt.getValue()).isInstanceOf(Boolean.class).isEqualTo(Boolean.TRUE);
+    }
+
+    @Test
+    void xsdStringBecomesString()
+    {
+        var stmt = statementWith(vf.createLiteral("hello", XSD.STRING));
+        assertThat(stmt.getValue()).isInstanceOf(String.class).isEqualTo("hello");
+    }
+
+    @Test
+    void langStringPopulatesLanguageAndKeepsLabel()
+    {
+        var stmt = statementWith(vf.createLiteral("hallo", "de"));
+        assertThat(stmt.getValue()).isInstanceOf(String.class).isEqualTo("hallo");
+        assertThat(stmt.getLanguage()).isEqualTo("de");
+    }
+
+    @Test
+    void iriValueIsKeptAsIri()
+    {
+        var iri = vf.createIRI("http://example.org/x");
+        var stmt = statementWith(iri);
+        assertThat(stmt.getValue()).isEqualTo(iri);
+    }
+
+    @Test
+    void bnodeBecomesNull()
+    {
+        var stmt = statementWith(vf.createBNode("b1"));
+        assertThat(stmt.getValue()).isNull();
+    }
+}

--- a/inception/inception-ui-kb/pom.xml
+++ b/inception/inception-ui-kb/pom.xml
@@ -164,11 +164,6 @@
       <artifactId>rdf4j-common-exception</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.cyberborean</groupId>
-      <artifactId>rdfbeans</artifactId>
-    </dependency>
-    
-    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
     </dependency>

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/value/BooleanLiteralValueSupport.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/value/BooleanLiteralValueSupport.java
@@ -23,10 +23,10 @@ import java.util.List;
 import java.util.Optional;
 
 import org.apache.wicket.model.IModel;
-import org.cyberborean.rdfbeans.datatype.DefaultDatatypeMapper;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 
+import de.tudarmstadt.ukp.inception.kb.XsdDatatypes;
 import de.tudarmstadt.ukp.inception.kb.graph.KBObject;
 import de.tudarmstadt.ukp.inception.kb.graph.KBProperty;
 import de.tudarmstadt.ukp.inception.kb.graph.KBStatement;
@@ -73,7 +73,7 @@ public class BooleanLiteralValueSupport
             return false;
         }
 
-        IRI iri = DefaultDatatypeMapper.getDatatypeURI((aStatement.getValue()).getClass());
+        IRI iri = XsdDatatypes.datatypeOf((aStatement.getValue()).getClass());
 
         return iri != null && XSD.BOOLEAN.equals(iri);
     }

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/value/NumericLiteralValueSupport.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/value/NumericLiteralValueSupport.java
@@ -37,11 +37,11 @@ import java.util.List;
 import java.util.Optional;
 
 import org.apache.wicket.model.IModel;
-import org.cyberborean.rdfbeans.datatype.DefaultDatatypeMapper;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 
+import de.tudarmstadt.ukp.inception.kb.XsdDatatypes;
 import de.tudarmstadt.ukp.inception.kb.graph.KBObject;
 import de.tudarmstadt.ukp.inception.kb.graph.KBProperty;
 import de.tudarmstadt.ukp.inception.kb.graph.KBStatement;
@@ -91,7 +91,7 @@ public class NumericLiteralValueSupport
         if (aStatement.getValue() == null) {
             return false;
         }
-        IRI iri = DefaultDatatypeMapper.getDatatypeURI((aStatement.getValue()).getClass());
+        IRI iri = XsdDatatypes.datatypeOf((aStatement.getValue()).getClass());
         return NUMERIC_TYPES.contains(iri);
     }
 

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/value/StringLiteralValueSupport.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/value/StringLiteralValueSupport.java
@@ -23,10 +23,10 @@ import java.util.List;
 import java.util.Optional;
 
 import org.apache.wicket.model.IModel;
-import org.cyberborean.rdfbeans.datatype.DefaultDatatypeMapper;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 
+import de.tudarmstadt.ukp.inception.kb.XsdDatatypes;
 import de.tudarmstadt.ukp.inception.kb.graph.KBObject;
 import de.tudarmstadt.ukp.inception.kb.graph.KBProperty;
 import de.tudarmstadt.ukp.inception.kb.graph.KBStatement;
@@ -73,7 +73,7 @@ public class StringLiteralValueSupport
         if (aStatement.getValue() == null) {
             return false;
         }
-        IRI iri = DefaultDatatypeMapper.getDatatypeURI((aStatement.getValue()).getClass());
+        IRI iri = XsdDatatypes.datatypeOf((aStatement.getValue()).getClass());
         // Conditions for different datatype URI apart from String
         boolean accept = XSD.STRING.equals(iri);
 

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/value/ValueTypeSupportRegistryImpl.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/value/ValueTypeSupportRegistryImpl.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.ClassUtils;
-import org.cyberborean.rdfbeans.datatype.DefaultDatatypeMapper;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.vocabulary.XSD;
 import org.slf4j.Logger;
@@ -40,6 +39,7 @@ import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 
+import de.tudarmstadt.ukp.inception.kb.XsdDatatypes;
 import de.tudarmstadt.ukp.inception.kb.graph.KBProperty;
 import de.tudarmstadt.ukp.inception.kb.graph.KBStatement;
 import de.tudarmstadt.ukp.inception.support.logging.BaseLoggers;
@@ -117,7 +117,7 @@ public class ValueTypeSupportRegistryImpl
 
         if (aStatement.getValue() != null) {
             Class<?> clazz = aStatement.getValue().getClass();
-            IRI type = DefaultDatatypeMapper.getDatatypeURI(clazz);
+            IRI type = XsdDatatypes.datatypeOf(clazz);
 
             // Mapping fails for NaiveIRI class, so check manually
             // if the value is an instance of IRI

--- a/pom.xml
+++ b/pom.xml
@@ -81,10 +81,12 @@
     <testcontainers.version>2.0.5</testcontainers.version>
     <keycloak-admin-client.version>26.0.9</keycloak-admin-client.version>
     <testcontainers-keycloak.version>4.2.1</testcontainers-keycloak.version>
+    <mock-oauth2-server.version>0.5.10</mock-oauth2-server.version>
 
     <awaitility.version>4.3.0</awaitility.version>
 
     <dkpro.version>3.0.0-beta-1</dkpro.version>
+    <dkpro-statistics.version>2.2.1</dkpro-statistics.version>
     <uima.version>3.6.1</uima.version>
     <uima-json.version>0.5.0</uima-json.version>
 
@@ -113,6 +115,8 @@
     <postgres.driver.version>42.7.11</postgres.driver.version>
     <hibernate.version>7.4.0.Final</hibernate.version>
     <hibernate.validator.version>9.1.0.Final</hibernate.validator.version>
+    <liquibase.version>4.33.0</liquibase.version>
+    <liquibase-slf4j.version>5.1.0</liquibase-slf4j.version>
 
     <wicket.version>10.9.1</wicket.version>
     <wicketstuff.version>10.9.2</wicketstuff.version>
@@ -129,7 +133,8 @@
     <opensearch.version>3.6.0</opensearch.version>
     <jena.version>6.1.0</jena.version>
     <libthrift.version>0.23.0</libthrift.version>
-    <rdf4j.version>5.3.1</rdf4j.version> 
+    <rdf4j.version>5.3.1</rdf4j.version>
+    <rdfbeans.version>2.2</rdfbeans.version>
     <owlapi-version>5.5.1</owlapi-version>
 
     <asciidoctor.plugin.version>3.2.0</asciidoctor.plugin.version>
@@ -173,6 +178,7 @@
     <zjsonpatch.version>0.6.2</zjsonpatch.version>
     <picocli.version>4.7.7</picocli.version>
     <woodstox-core.version>7.2.0</woodstox-core.version>
+    <stax2-api.version>4.3.0</stax2-api.version>
     <nimbus-jose-jwt.version>10.9</nimbus-jose-jwt.version>
     <json-schema-validator.version>3.0.3</json-schema-validator.version>
     <json-schema-generator.version>5.0.0</json-schema-generator.version>
@@ -189,6 +195,9 @@
     <jaxb-core-version>2.3.0.1</jaxb-core-version>
     <jaxb-api-version>2.3.1</jaxb-api-version>
     <jakarta.xml.bind-api-version>4.0.5</jakarta.xml.bind-api-version>
+    <jakarta.data.version>1.0.0</jakarta.data.version>
+    <javax.validation.version>2.0.1.Final</javax.validation.version>
+    <wlfxb.version>1.4.3</wlfxb.version>
     <snappy.version>1.1.10.8</snappy.version>
     <jsonld-java.version>0.13.6</jsonld-java.version>
     <jna.version>5.18.1</jna.version>
@@ -200,6 +209,15 @@
     <oauth2-oidc-sdk.version>11.37.2</oauth2-oidc-sdk.version>
     <javassist.version>3.31.0-GA</javassist.version>
     <openjson.version>1.0.13</openjson.version>
+    <mjson.version>1.4.2</mjson.version>
+    <jsr305.version>3.0.2</jsr305.version>
+    <icu4j.version>75.1</icu4j.version>
+    <jtokkit.version>1.1.0</jtokkit.version>
+    <rhino.version>1.7.15</rhino.version>
+    <httpcore5.version>5.3.6</httpcore5.version>
+    <httpclient5.version>5.5.1</httpclient5.version>
+    <omtd-share-annotations.version>3.0.2.7</omtd-share-annotations.version>
+    <webstomp-client.version>1.2.6</webstomp-client.version>
 
     <node.version>24.14.1</node.version>
     <apache-annotator.version>^0.2.0</apache-annotator.version>

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,6 @@
     <jena.version>6.1.0</jena.version>
     <libthrift.version>0.23.0</libthrift.version>
     <rdf4j.version>5.3.1</rdf4j.version>
-    <rdfbeans.version>2.2</rdfbeans.version>
     <owlapi-version>5.5.1</owlapi-version>
 
     <asciidoctor.plugin.version>3.2.0</asciidoctor.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <uima.version>3.6.1</uima.version>
     <uima-json.version>0.5.0</uima-json.version>
 
-    <pdfbox.version>3.0.6</pdfbox.version>
+    <pdfbox.version>3.0.7</pdfbox.version>
 
     <spring.version>7.0.7</spring.version>
     <spring.boot.version>4.0.6</spring.boot.version>
@@ -101,21 +101,21 @@
     <slf4j.version>2.0.18</slf4j.version>
     <log4j2.version>2.26.0</log4j2.version>
     <jboss.logging.version>3.6.3.Final</jboss.logging.version>
-    <sentry.version>8.42.0</sentry.version>
+    <sentry.version>8.43.0</sentry.version>
 
     <tomcat.version>11.0.22</tomcat.version>
     <jetty.version>12.1.9</jetty.version>
     <servlet-api.version>6.1.0</servlet-api.version>
 
     <mariadb.driver.version>3.5.8</mariadb.driver.version>
-    <mssql.driver.version>12.10.2.jre11</mssql.driver.version>
+    <mssql.driver.version>13.4.0.jre11</mssql.driver.version>
     <mysql.driver.version>9.7.0</mysql.driver.version>
     <postgres.driver.version>42.7.11</postgres.driver.version>
-    <hibernate.version>7.3.5.Final</hibernate.version>
+    <hibernate.version>7.4.0.Final</hibernate.version>
     <hibernate.validator.version>9.1.0.Final</hibernate.validator.version>
 
     <wicket.version>10.9.1</wicket.version>
-    <wicketstuff.version>10.9.1</wicketstuff.version>
+    <wicketstuff.version>10.9.2</wicketstuff.version>
     <wicket-bootstrap.version>7.0.14</wicket-bootstrap.version>
     <wicket-jquery-selectors.version>4.0.14</wicket-jquery-selectors.version>
     <wicket-webjars.version>4.0.14</wicket-webjars.version>
@@ -139,8 +139,8 @@
 
     <ant-version>1.10.17</ant-version>
     <json.version>20240303</json.version>
-    <jackson.version>2.21.3</jackson.version>
-    <jackson3.version>3.1.3</jackson3.version>
+    <jackson.version>2.21.4</jackson.version>
+    <jackson3.version>3.1.4</jackson3.version>
     <snakeyaml.version>2.6</snakeyaml.version>
     <okhttp.version>5.3.2</okhttp.version>
     <okio.version>3.17.0</okio.version>
@@ -172,13 +172,13 @@
     <fastutil.version>8.5.18</fastutil.version>
     <zjsonpatch.version>0.6.2</zjsonpatch.version>
     <picocli.version>4.7.7</picocli.version>
-    <woodstox-core.version>6.7.0</woodstox-core.version>
+    <woodstox-core.version>7.2.0</woodstox-core.version>
     <nimbus-jose-jwt.version>10.9</nimbus-jose-jwt.version>
-    <json-schema-validator.version>3.0.2</json-schema-validator.version>
+    <json-schema-validator.version>3.0.3</json-schema-validator.version>
     <json-schema-generator.version>5.0.0</json-schema-generator.version>
     <jgit.version>7.6.0.202603022253-r</jgit.version>
     <javax.activation-api-version>1.2.0</javax.activation-api-version>
-    <jaxb.version>4.0.8</jaxb.version>
+    <jaxb.version>4.0.9</jaxb.version>
     <!--
       jaxb-impl-version / jaxb-core-version must remain on the 2.3.x line: it is the last
       release providing the legacy javax.xml.bind implementation. Newer 4.x releases
@@ -192,7 +192,7 @@
     <snappy.version>1.1.10.8</snappy.version>
     <jsonld-java.version>0.13.6</jsonld-java.version>
     <jna.version>5.18.1</jna.version>
-    <jsoup.version>1.18.3</jsoup.version>
+    <jsoup.version>1.22.2</jsoup.version>
     <matomo-java-tracker-core-version>3.4.0</matomo-java-tracker-core-version>
     <mime4j.version>0.8.14</mime4j.version>
     <hsqldb.version>2.7.4</hsqldb.version>


### PR DESCRIPTION
**What's in the PR**
- pdfbox 3.0.6 -> 3.0.7
- sentry 8.42.0 -> 8.43.0
- mssql-jdbc 12.10.2.jre11 -> 13.4.0.jre11
- hibernate 7.3.5.Final -> 7.4.0.Final
- wicketstuff 10.9.1 -> 10.9.2
- jackson 2.21.3 -> 2.21.4
- jackson3 3.1.3 -> 3.1.4
- woodstox-core 6.7.0 -> 7.2.0
- json-schema-validator 3.0.2 -> 3.0.3
- jaxb 4.0.8 -> 4.0.9
- jsoup 1.18.3 -> 1.22.2
- stax2-api 4.2.2 -> 4.3.0
- `GlyphPositionUtils`: adopt pdfbox 3.0.7 `cropBox`-based `makeRotateAT`; delete unused `makeTransAT`; null-safe try-with-resources for `BidiMirroring.txt` loader; pin `parseBidiFile` reader to `US_ASCII`; `final` + diamond on `MIRRORING_CHAR_MAP`
- `GlyphPositionUtils`: refresh all source-pin comments to pdfbox 3.0.7
- `VisualPDFTextStripper`: add class-level note recording last verification against pdfbox 3.0.7
- `JSoupUtil`: refresh source-pin comments to jsoup 1.22.2 with per-method URLs and class-level verification note
- Promote 18 hardcoded dependency-management versions to root-pom properties so they're picked up by `versions:display-property-updates`
- Drop rdfbeans dependency; replace its 3 method patterns with a small RDF4J-based utility `XsdDatatypes` co-located in the inception-kb module
- Migrate Java->RDF conversion (`InceptionValueMapper`) to `XsdDatatypes.toRdfValue` using RDF4J's `Values.literal` + explicit `BigDecimal`/`BigInteger` handlers (RDF4J built-ins don't cover those)
- Migrate RDF->Java conversion (`KBStatement.setValue`, `KBQualifier.setValue`) to `XsdDatatypes.toJavaObject` using RDF4J's typed `Literal` accessors
- Migrate `DefaultDatatypeMapper.getDatatypeURI` callsites (`BooleanLiteralValueSupport`, `NumericLiteralValueSupport`, `StringLiteralValueSupport`, `ValueTypeSupportRegistryImpl`) to `XsdDatatypes.datatypeOf`
- Add characterization tests pinning the converter behavior across the standard XSD types: `InceptionValueMapperTest` (14), `KBStatementValueConversionTest` (13), `DatatypeUriLookupTest` (12)
- Side effect: `BigDecimal` and `BigInteger` Java->RDF conversions now produce proper typed literals (previously returned null silently via rdfbeans)
- Remove `rdfbeans` dependency entries from `inception-kb` and `inception-ui-kb` poms, the dependency-management entry in `inception-dependencies`, and the `rdfbeans.version` property from the root pom

**How to test manually**
* No specific test procedure

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
