### PR TITLE
#6079 - Search match highlight remains lock at position when switching between documents

### DIFF
--- a/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchAnnotationSidebar.java
+++ b/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchAnnotationSidebar.java
@@ -630,7 +630,7 @@ public class SearchAnnotationSidebar
     {
         searchOptions.getObject().setQuery("");
         resultsProvider.emptyQuery();
-        searchOptions.getObject().setSelectedResult(null);
+        searchOptions.getObject().clearSelectedResult();
         aTarget.add(mainContainer);
 
         // Need to re-render because we want to highlight the match
@@ -641,7 +641,7 @@ public class SearchAnnotationSidebar
     {
         try {
             var opt = searchOptions.getObject();
-            opt.setSelectedResult(null);
+            opt.clearSelectedResult();
             resultsView.setItemsPerPage(opt.getItemsPerPage());
 
             resultsProvider.initializeQuery(aRequest);
@@ -973,7 +973,7 @@ public class SearchAnnotationSidebar
                 ? schemaService.getFeature(aItem.groupingFeature(), layer)
                 : null;
 
-        opt.setSelectedResult(null);
+        opt.clearSelectedResult();
         opt.setQuery(aItem.query());
         opt.setGroupingLayer(layer);
         opt.setGroupingFeature(feature);
@@ -1085,7 +1085,8 @@ public class SearchAnnotationSidebar
                     throws IOException
                 {
                     var selectedResult = aItem.getModelObject();
-                    searchOptions.getObject().setSelectedResult(selectedResult);
+                    searchOptions.getObject().setSelectedResult(selectedResult, AnnotationSet
+                            .forUser(SearchAnnotationSidebar.this.getModelObject().getUser()));
                     getAnnotationPage().actionShowSelectedDocument(t,
                             documentService.getSourceDocument(currentProject,
                                     selectedResult.getDocumentTitle()),

--- a/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchSidebarIcon.java
+++ b/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchSidebarIcon.java
@@ -35,6 +35,7 @@ import org.wicketstuff.event.annotation.OnEvent;
 
 import de.agilecoders.wicket.core.markup.html.bootstrap.image.Icon;
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.icon.FontAwesome5IconType;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.inception.app.ui.search.sidebar.options.SearchOptions;
 import de.tudarmstadt.ukp.inception.preferences.PreferencesService;
@@ -85,6 +86,8 @@ public class SearchSidebarIcon
 
         var query = searchOptions.map(SearchOptions::getQuery);
         var selectedResult = searchOptions.map(SearchOptions::getSelectedResult).getObject();
+        var selectedResultAnnotationSet = searchOptions
+                .map(SearchOptions::getSelectedResultAnnotationSet).getObject();
         if (query.map(StringUtils::isNotBlank).orElse(false).getObject()) {
             try {
                 var results = query(query.getObject());
@@ -111,7 +114,10 @@ public class SearchSidebarIcon
             }
         }
 
-        if (selectedResult != null) {
+        if (selectedResult != null
+                && selectedResult.getDocumentId() == getModelObject().getDocument().getId()
+                && AnnotationSet.forUser(getModelObject().getUser())
+                        .equals(selectedResultAnnotationSet)) {
             var range = VRange.clippedRange(aEvent.getVDocument(), selectedResult.getOffsetStart(),
                     selectedResult.getOffsetEnd());
 

--- a/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/options/SearchOptions.java
+++ b/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/options/SearchOptions.java
@@ -21,6 +21,7 @@ import java.io.Serializable;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.inception.search.SearchResult;
 
 public class SearchOptions
@@ -30,20 +31,32 @@ public class SearchOptions
 
     private String query;
     private SearchResult selectedResult;
+    private AnnotationSet selectedResultAnnotationSet;
     private boolean limitedToCurrentDocument = false;
     private AnnotationLayer groupingLayer;
     private AnnotationFeature groupingFeature;
     private long itemsPerPage;
     private boolean lowLevelPaging;
 
-    public void setSelectedResult(SearchResult aSelectedResult)
+    public void setSelectedResult(SearchResult aSelectedResult, AnnotationSet aAnnotationSet)
     {
         selectedResult = aSelectedResult;
+        selectedResultAnnotationSet = aAnnotationSet;
+    }
+
+    public void clearSelectedResult()
+    {
+        setSelectedResult(null, null);
     }
 
     public SearchResult getSelectedResult()
     {
         return selectedResult;
+    }
+
+    public AnnotationSet getSelectedResultAnnotationSet()
+    {
+        return selectedResultAnnotationSet;
     }
 
     public String getQuery()


### PR DESCRIPTION
**What's in the PR**
- Search sidebar focus highlight no longer leaks across documents or annotators
- Track the username of the annotator active when a search result was selected on `SearchOptions`
- Only render the `MATCH_FOCUS` marker when the current document id and current annotator match the selected result

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
