### PR TITLE
#6083 - Read document information from CASMetadata if possible

### DIFF
--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/AgreementServiceImpl.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/AgreementServiceImpl.java
@@ -51,7 +51,6 @@ import java.util.Set;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.io.output.CloseShieldOutputStream;
 import org.apache.uima.cas.CAS;
-import org.apache.uima.fit.util.FSUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -70,7 +69,6 @@ import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.inception.curation.api.DiffAdapterRegistry;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
-import de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil;
 
 public class AgreementServiceImpl
     implements AgreementService
@@ -216,12 +214,6 @@ public class AgreementServiceImpl
         var cas = documentService.readAnnotationCas(aDocument, aSet, AUTO_CAS_UPGRADE,
                 SHARED_READ_ONLY_ACCESS);
 
-        // Set the CAS name in the DocumentMetaData so that we can pick it
-        // up in the Diff position for the purpose of debugging / transparency.
-        var dmd = WebAnnoCasUtil.getDocumentMetadata(cas);
-        FSUtil.setFeature(dmd, "documentId", aDocument.getName());
-        FSUtil.setFeature(dmd, "collectionId", aDocument.getProject().getName());
-
         return Optional.of(cas);
     }
 
@@ -229,12 +221,6 @@ public class AgreementServiceImpl
     {
         var cas = documentService.createOrReadInitialCas(aDocument, AUTO_CAS_UPGRADE,
                 SHARED_READ_ONLY_ACCESS);
-
-        // Set the CAS name in the DocumentMetaData so that we can pick it
-        // up in the Diff position for the purpose of debugging / transparency.
-        var dmd = WebAnnoCasUtil.getDocumentMetadata(cas);
-        FSUtil.setFeature(dmd, "documentId", aDocument.getName());
-        FSUtil.setFeature(dmd, "collectionId", aDocument.getProject().getName());
 
         return cas;
     }

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/task/CalculatePairwiseAgreementTask.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/task/CalculatePairwiseAgreementTask.java
@@ -35,7 +35,6 @@ import java.util.Optional;
 
 import org.apache.commons.lang3.concurrent.LazyInitializer;
 import org.apache.uima.cas.CAS;
-import org.apache.uima.fit.util.FSUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -52,7 +51,6 @@ import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.scheduling.Task;
-import de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil;
 
 public class CalculatePairwiseAgreementTask
     extends Task
@@ -176,12 +174,6 @@ public class CalculatePairwiseAgreementTask
         var cas = documentService.createOrReadInitialCas(aDocument, AUTO_CAS_UPGRADE,
                 SHARED_READ_ONLY_ACCESS);
 
-        // Set the CAS name in the DocumentMetaData so that we can pick it
-        // up in the Diff position for the purpose of debugging / transparency.
-        var dmd = WebAnnoCasUtil.getDocumentMetadata(cas);
-        FSUtil.setFeature(dmd, "documentId", aDocument.getName());
-        FSUtil.setFeature(dmd, "collectionId", aDocument.getProject().getName());
-
         return cas;
     }
 
@@ -214,12 +206,6 @@ public class CalculatePairwiseAgreementTask
     {
         var cas = documentService.readAnnotationCas(aDocument, aSet, AUTO_CAS_UPGRADE,
                 SHARED_READ_ONLY_ACCESS);
-
-        // Set the CAS name in the DocumentMetaData so that we can pick it
-        // up in the Diff position for the purpose of debugging / transparency.
-        var dmd = WebAnnoCasUtil.getDocumentMetadata(cas);
-        FSUtil.setFeature(dmd, "documentId", aDocument.getName());
-        FSUtil.setFeature(dmd, "collectionId", aDocument.getProject().getName());
 
         return Optional.of(cas);
     }

--- a/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/task/CalculatePerDocumentAgreementTask.java
+++ b/inception/inception-agreement/src/main/java/de/tudarmstadt/ukp/clarin/webanno/agreement/task/CalculatePerDocumentAgreementTask.java
@@ -36,7 +36,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.uima.cas.CAS;
-import org.apache.uima.fit.util.FSUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -53,7 +52,6 @@ import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.scheduling.Task;
-import de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil;
 
 public class CalculatePerDocumentAgreementTask
     extends Task
@@ -133,12 +131,6 @@ public class CalculatePerDocumentAgreementTask
         var cas = documentService.createOrReadInitialCas(aDocument, AUTO_CAS_UPGRADE,
                 SHARED_READ_ONLY_ACCESS);
 
-        // Set the CAS name in the DocumentMetaData so that we can pick it
-        // up in the Diff position for the purpose of debugging / transparency.
-        var dmd = WebAnnoCasUtil.getDocumentMetadata(cas);
-        FSUtil.setFeature(dmd, "documentId", aDocument.getName());
-        FSUtil.setFeature(dmd, "collectionId", aDocument.getProject().getName());
-
         return cas;
     }
 
@@ -156,12 +148,6 @@ public class CalculatePerDocumentAgreementTask
 
         var cas = documentService.readAnnotationCas(aDocument, aDataOwner, AUTO_CAS_UPGRADE,
                 SHARED_READ_ONLY_ACCESS);
-
-        // Set the CAS name in the DocumentMetaData so that we can pick it
-        // up in the Diff position for the purpose of debugging / transparency.
-        var dmd = WebAnnoCasUtil.getDocumentMetadata(cas);
-        FSUtil.setFeature(dmd, "documentId", aDocument.getName());
-        FSUtil.setFeature(dmd, "collectionId", aDocument.getProject().getName());
 
         return cas;
     }

--- a/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/AgreementServiceImplTest.java
+++ b/inception/inception-agreement/src/test/java/de/tudarmstadt/ukp/clarin/webanno/agreement/AgreementServiceImplTest.java
@@ -33,8 +33,12 @@ import java.util.Set;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.fit.factory.CasFactory;
+import org.apache.uima.fit.factory.TypeSystemDescriptionFactory;
+import org.apache.uima.fit.util.FSUtil;
+import org.apache.uima.util.CasCreationUtils;
 import org.junit.jupiter.api.Test;
 
+import de.tudarmstadt.ukp.clarin.webanno.api.type.CASMetadata;
 import de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity;
 import de.tudarmstadt.ukp.inception.support.uima.AnnotationBuilder;
 
@@ -176,6 +180,48 @@ class AgreementServiceImplTest
         assertThat(generateReport(userCount, data).lines()).contains( //
                 "SpanPosition,,,de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity,"
                         + "value,8-12 [John],\"DIFFERENCE, COMPLETE, USED\",PER,LOC,<no label>");
+    }
+
+    @Test
+    void testReport_carriesDocumentIdentityFromCasMetadata() throws Exception
+    {
+        var type = NamedEntity._TypeName;
+        var feature = NamedEntity._FeatName_value;
+
+        var tsd = CasCreationUtils.mergeTypeSystems(
+                List.of(TypeSystemDescriptionFactory.createTypeSystemDescription(),
+                        TypeSystemDescriptionFactory.createTypeSystemDescription(
+                                "de/tudarmstadt/ukp/clarin/webanno/api/type/webanno-internal")));
+
+        var userCases = new HashMap<String, CAS>();
+        for (var user : List.of("user1", "user2")) {
+            var cas = CasFactory.createCas(tsd);
+            cas.setDocumentText("Joe");
+
+            var casMetadata = cas.createAnnotation(
+                    cas.getTypeSystem().getType(CASMetadata.class.getName()), 0, 0);
+            FSUtil.setFeature(casMetadata, "projectName", "proj1");
+            FSUtil.setFeature(casMetadata, "sourceDocumentName", "doc1");
+            cas.addFsToIndexes(casMetadata);
+
+            AnnotationBuilder.buildAnnotation(cas, type).at(0, 3).withFeature(feature, "PER")
+                    .buildAndAddToIndexes();
+
+            userCases.put(user, cas);
+        }
+
+        var diff = doDiff(asList(NER_DIFF_ADAPTER), userCases);
+        Set<String> tagSet = null;
+        var agreementResult = makeCodingStudy(diff, type, feature, tagSet, false, userCases);
+
+        var buffer = new StringBuilder();
+        try (var printer = new CSVPrinter(buffer, RFC4180)) {
+            AgreementServiceImpl.configurationSetsWithItemsToCsv(printer, agreementResult, true);
+        }
+
+        // The Collection/Document columns must be populated from the CASMetadata identity
+        assertThat(buffer.toString().lines())
+                .anyMatch(line -> line.startsWith("SpanPosition,proj1,doc1,"));
     }
 
     private String generateReport(int aUserCount, Row[] data) throws Exception, IOException

--- a/inception/inception-annotation-storage-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/type/CasMetadataSupport.java
+++ b/inception/inception-annotation-storage-api/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/type/CasMetadataSupport.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.api.type;
+
+import org.apache.uima.cas.CAS;
+
+/**
+ * Helpers for reading the document identity recorded in the INCEpTION-internal {@link CASMetadata}.
+ * <p>
+ * These tolerate older type systems where the {@code CASMetadata} type exists but does not (yet)
+ * declare all of its features - mirroring the feature-presence tolerance applied when the metadata
+ * is written. Reading the values via the generated accessors would instead throw if a feature is
+ * absent. The identity is only used for debugging/transparency, so a missing feature must never
+ * abort the operation that reads it.
+ */
+public final class CasMetadataSupport
+{
+    private CasMetadataSupport()
+    {
+        // No instances
+    }
+
+    /**
+     * @param aCas
+     *            a CAS.
+     * @return the project name recorded in the CAS' {@link CASMetadata}, or {@code null} if the CAS
+     *         has no {@code CASMetadata} type, no {@code CASMetadata} instance, or a
+     *         {@code CASMetadata} type that does not declare the {@code projectName} feature.
+     */
+    public static String getProjectName(CAS aCas)
+    {
+        return getIdentityFeature(aCas, CASMetadata._FeatName_projectName);
+    }
+
+    /**
+     * @param aCas
+     *            a CAS.
+     * @return the source document name recorded in the CAS' {@link CASMetadata}, or {@code null}
+     *         (see {@link #getProjectName(CAS)} for the cases in which {@code null} is returned).
+     */
+    public static String getSourceDocumentName(CAS aCas)
+    {
+        return getIdentityFeature(aCas, CASMetadata._FeatName_sourceDocumentName);
+    }
+
+    private static String getIdentityFeature(CAS aCas, String aFeatureName)
+    {
+        var type = aCas.getTypeSystem().getType(CASMetadata.class.getName());
+        if (type == null) {
+            return null;
+        }
+
+        var feature = type.getFeatureByBaseName(aFeatureName);
+        if (feature == null) {
+            // An older type system may declare the CASMetadata type without all of its features.
+            return null;
+        }
+
+        var instances = aCas.select(type).toList();
+        if (instances.isEmpty()) {
+            return null;
+        }
+
+        return instances.get(0).getStringValue(feature);
+    }
+}

--- a/inception/inception-annotation-storage-api/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/type/CasMetadataSupportTest.java
+++ b/inception/inception-annotation-storage-api/src/test/java/de/tudarmstadt/ukp/clarin/webanno/api/type/CasMetadataSupportTest.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.api.type;
+
+import static org.apache.uima.fit.factory.TypeSystemDescriptionFactory.createTypeSystemDescription;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import org.apache.uima.UIMAFramework;
+import org.apache.uima.cas.CAS;
+import org.apache.uima.resource.metadata.TypeSystemDescription;
+import org.apache.uima.util.CasCreationUtils;
+import org.junit.jupiter.api.Test;
+
+public class CasMetadataSupportTest
+{
+    @Test
+    public void thatIdentityIsReadFromFullCasMetadata() throws Exception
+    {
+        var tsd = createTypeSystemDescription(
+                "de/tudarmstadt/ukp/clarin/webanno/api/type/webanno-internal");
+        var cas = CasCreationUtils.createCas(tsd, null, null);
+
+        var cmd = new CASMetadata(cas.getJCas());
+        cmd.setProjectName("project");
+        cmd.setSourceDocumentName("document");
+        cmd.addToIndexes();
+
+        assertThat(CasMetadataSupport.getProjectName(cas)).isEqualTo("project");
+        assertThat(CasMetadataSupport.getSourceDocumentName(cas)).isEqualTo("document");
+    }
+
+    @Test
+    public void thatReadingToleratesOlderCasMetadataWithoutIdentityFeatures() throws Exception
+    {
+        // An older type system may declare the CASMetadata type without the identity features.
+        var tsd = UIMAFramework.getResourceSpecifierFactory().createTypeSystemDescription();
+        var type = tsd.addType(CASMetadata.class.getName(), "", CAS.TYPE_NAME_ANNOTATION);
+        type.addFeature("username", "", CAS.TYPE_NAME_STRING);
+
+        var cas = CasCreationUtils.createCas(tsd, null, null);
+        var casMetadataType = cas.getTypeSystem().getType(CASMetadata.class.getName());
+        var cmd = cas.createAnnotation(casMetadataType, 0, 0);
+        cas.addFsToIndexes(cmd);
+
+        // Reading via the generated accessor would throw because the feature is missing ...
+        assertThatExceptionOfType(Exception.class)
+                .isThrownBy(() -> cas.select(CASMetadata.class).get(0).getProjectName());
+
+        // ... but the support helper tolerates it and leaves the identity unset.
+        assertThat(CasMetadataSupport.getProjectName(cas)).isNull();
+        assertThat(CasMetadataSupport.getSourceDocumentName(cas)).isNull();
+    }
+
+    @Test
+    public void thatReadingToleratesMissingCasMetadataType() throws Exception
+    {
+        var cas = CasCreationUtils.createCas((TypeSystemDescription) null, null, null);
+
+        assertThat(CasMetadataSupport.getProjectName(cas)).isNull();
+        assertThat(CasMetadataSupport.getSourceDocumentName(cas)).isNull();
+    }
+}

--- a/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/CasMetadataUtils.java
+++ b/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/CasMetadataUtils.java
@@ -39,6 +39,22 @@ public class CasMetadataUtils
 {
     private final static Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
+    /**
+     * Sentinel {@code lastChangedOnDisk} value returned by {@link #getLastChanged(CAS)} when no
+     * timestamp is available - either because the CAS carries no {@link CASMetadata} instance or
+     * because its (older) CASMetadata type does not include the {@code lastChangedOnDisk} feature.
+     */
+    public static final long UNKNOWN_CAS_TIMESTAMP = -1l;
+
+    /**
+     * Sentinel {@code lastChangedOnDisk} value used to mark a CAS as <i>transient</i>: it was
+     * created on-the-fly (e.g. when reading under {@code SHARED_READ_ONLY_ACCESS} and no CAS exists
+     * on disk yet) and carries identity metadata for debugging/transparency only, but must never be
+     * persisted. This is deliberately distinct from {@link #UNKNOWN_CAS_TIMESTAMP}, so that a
+     * not-yet-stamped CAS on its legitimate first write is not mistaken for a transient one.
+     */
+    public static final long TRANSIENT_CAS_TIMESTAMP = -2l;
+
     public static TypeSystemDescription getInternalTypeSystem()
     {
         return createTypeSystemDescription(
@@ -124,8 +140,45 @@ public class CasMetadataUtils
     {
         var casMetadataType = getType(aCas, CASMetadata.class);
         var feature = casMetadataType.getFeatureByBaseName(CASMetadata._FeatName_lastChangedOnDisk);
+        if (feature == null) {
+            // An older type system may have a CASMetadata type that does not yet include the
+            // lastChangedOnDisk feature. We tolerate this here (just as addOrUpdateCasMetadata
+            // does when stamping) and treat it as "no timestamp available".
+            return UNKNOWN_CAS_TIMESTAMP;
+        }
         return aCas.select(casMetadataType).map(cmd -> cmd.getLongValue(feature)).findFirst()
-                .orElse(-1l);
+                .orElse(UNKNOWN_CAS_TIMESTAMP);
+    }
+
+    /**
+     * @return whether the type system of the given CAS supports {@link CASMetadata}.
+     */
+    public static boolean supportsCasMetadata(CAS aCas)
+    {
+        return aCas.getTypeSystem().getType(CASMetadata.class.getName()) != null;
+    }
+
+    /**
+     * @return whether the given CAS can be marked as transient - i.e. its type system declares the
+     *         {@link CASMetadata} type <em>including</em> the {@code lastChangedOnDisk} feature
+     *         that carries the {@link #TRANSIENT_CAS_TIMESTAMP} marker. Without that feature the
+     *         marker cannot be set, so the CAS could not later be recognized as transient.
+     */
+    public static boolean canMarkTransient(CAS aCas)
+    {
+        var type = aCas.getTypeSystem().getType(CASMetadata.class.getName());
+        return type != null
+                && type.getFeatureByBaseName(CASMetadata._FeatName_lastChangedOnDisk) != null;
+    }
+
+    /**
+     * @return whether the given CAS has been marked as transient (i.e. created on-the-fly and not
+     *         backed by a file on disk) and therefore must not be persisted.
+     * @see #TRANSIENT_CAS_TIMESTAMP
+     */
+    public static boolean isTransientCas(CAS aCas)
+    {
+        return supportsCasMetadata(aCas) && getLastChanged(aCas) == TRANSIENT_CAS_TIMESTAMP;
     }
 
     public static Optional<String> getUsername(CAS aCas)

--- a/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/CasStorageServiceImpl.java
+++ b/inception/inception-annotation-storage/src/main/java/de/tudarmstadt/ukp/inception/annotation/storage/CasStorageServiceImpl.java
@@ -846,6 +846,20 @@ public class CasStorageServiceImpl
 
                 addOrUpdateCasMetadata(aDocument, aSet, cas);
             }
+            else if (aAccessMode == SHARED_READ_ONLY_ACCESS
+                    && CasMetadataUtils.canMarkTransient(cas)) {
+                // The CAS was created on-the-fly for read-only access (the document has no CAS on
+                // disk yet) and is therefore never written back. We still stamp the document
+                // identity into the CASMetadata so that e.g. diff positions can pick it up for
+                // debugging / transparency, but mark it as transient so that it can never be
+                // accidentally persisted. We only do this when the transient marker feature is
+                // actually present - otherwise the CAS could not be recognized as transient later
+                // and we would create a stamped-but-unprotected CAS. We also deliberately do NOT do
+                // this for UNMANAGED_ACCESS, where the caller takes ownership of the CAS and may
+                // legitimately write it back (e.g. when resetting a document to its initial state).
+                CasMetadataUtils.addOrUpdateCasMetadata(cas,
+                        CasMetadataUtils.TRANSIENT_CAS_TIMESTAMP, aDocument, aSet.id());
+            }
         }
         // If no CAS provider is given, fail
         else {
@@ -1334,6 +1348,13 @@ public class CasStorageServiceImpl
     private void realWriteCas(SourceDocument aDocument, AnnotationSet aSet, CAS aCas)
         throws IOException
     {
+        if (CasMetadataUtils.isTransientCas(aCas)) {
+            throw new IOException("Refusing to persist CAS for set [" + aSet + "] on document "
+                    + aDocument + " in project " + aDocument.getProject() + ": this CAS was "
+                    + "created as a transient read-only CAS (not backed by a file on disk) and "
+                    + "must not be written back to disk.");
+        }
+
         analyze(aDocument, aSet, aCas);
 
         if (CasStorageSession.exists()) {

--- a/inception/inception-annotation-storage/src/test/java/de/tudarmstadt/ukp/inception/annotation/storage/CasStorageServiceImplTest.java
+++ b/inception/inception-annotation-storage/src/test/java/de/tudarmstadt/ukp/inception/annotation/storage/CasStorageServiceImplTest.java
@@ -58,6 +58,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.commons.pool2.impl.GenericKeyedObjectPool;
 import org.apache.commons.pool2.impl.GenericKeyedObjectPoolConfig;
+import org.apache.uima.UIMAFramework;
 import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.CASException;
 import org.apache.uima.fit.factory.TypeSystemDescriptionFactory;
@@ -207,6 +208,99 @@ public class CasStorageServiceImplTest
             sut.deleteCas(doc, set);
             assertThat(sut.existsCas(doc, set)).isFalse();
         }
+    }
+
+    @Test
+    public void testReadOnlyLazilyCreatedCasReceivesCasMetadata() throws Exception
+    {
+        try (var casStorageSession = openNested(true)) {
+            // Setup fixture - a document whose CAS does not exist on disk yet
+            var project = new Project();
+            project.setId(13l);
+            project.setName("project");
+            var doc = new SourceDocument();
+            doc.setProject(project);
+            doc.setId(13l);
+            doc.setName("document");
+            var set = AnnotationSet.forTest("test");
+
+            assertThat(sut.existsCas(doc, set)).isFalse();
+
+            // Actual test - load under read-only access, forcing the lazy-creation path
+            var cas = sut.readOrCreateCas(doc, set, AUTO_CAS_UPGRADE,
+                    () -> makeCas("This is a test"), SHARED_READ_ONLY_ACCESS).getJCas();
+
+            // A read-only access must not persist the lazily created CAS
+            assertThat(sut.existsCas(doc, set)) //
+                    .as("Read-only access must not write the CAS to disk") //
+                    .isFalse();
+
+            // ... but the CAS must still carry its identity in the CASMetadata so that e.g. diff
+            // positions can pick it up for debugging/transparency.
+            var cmds = new ArrayList<>(select(cas, CASMetadata.class));
+            assertThat(cmds).hasSize(1);
+            assertThat(cmds.get(0).getSourceDocumentName()).isEqualTo(doc.getName());
+            assertThat(cmds.get(0).getProjectName()).isEqualTo(doc.getProject().getName());
+        }
+    }
+
+    @Test
+    public void testThatTransientCasCannotBePersisted() throws Exception
+    {
+        try (var casStorageSession = openNested(true)) {
+            // Setup fixture - a CAS explicitly marked as transient (as a lazily created read-only
+            // CAS would be). It is deliberately NOT added to the session, so writeCas takes the
+            // exclusive-access path down to realWriteCas where the transient-guard sits. (A CAS
+            // held read-only within the session is already blocked one layer earlier by the
+            // session's write-permission check.)
+            var doc = makeSourceDocument(14l, 14l, "test");
+            var set = AnnotationSet.forTest("test");
+
+            var cas = makeCas("This is a test");
+            CasMetadataUtils.addOrUpdateCasMetadata(cas, CasMetadataUtils.TRANSIENT_CAS_TIMESTAMP,
+                    doc, set.id());
+            assertThat(CasMetadataUtils.isTransientCas(cas)).isTrue();
+
+            // Actual test - attempting to write it back must be rejected
+            assertThatExceptionOfType(IOException.class) //
+                    .isThrownBy(() -> sut.writeCas(doc, cas, set)) //
+                    .withMessageContaining("transient");
+
+            assertThat(sut.existsCas(doc, set)) //
+                    .as("Rejected write must not have created a file on disk") //
+                    .isFalse();
+        }
+    }
+
+    @Test
+    public void testTransientCheckToleratesOlderCasMetadataWithoutTimestampFeature()
+        throws Exception
+    {
+        // An older type system may contain a CASMetadata type that does not yet have the
+        // lastChangedOnDisk feature. Reading the timestamp (e.g. via the realWriteCas guard which
+        // runs on every write) must not fail in that case.
+        var tsd = UIMAFramework.getResourceSpecifierFactory().createTypeSystemDescription();
+        var type = tsd.addType(CASMetadata.class.getName(), "", CAS.TYPE_NAME_ANNOTATION);
+        type.addFeature("username", "", CAS.TYPE_NAME_STRING);
+
+        var cas = CasCreationUtils.createCas(tsd, null, null);
+        var casMetadataType = cas.getTypeSystem().getType(CASMetadata.class.getName());
+        cas.addFsToIndexes(cas.createAnnotation(casMetadataType, 0, 0));
+
+        assertThat(CasMetadataUtils.getLastChanged(cas))
+                .isEqualTo(CasMetadataUtils.UNKNOWN_CAS_TIMESTAMP);
+        assertThat(CasMetadataUtils.isTransientCas(cas)).isFalse();
+
+        // ... and such a CAS must not be marked transient, since the marker could not be read back.
+        assertThat(CasMetadataUtils.canMarkTransient(cas)).isFalse();
+    }
+
+    @Test
+    public void testThatCasWithTimestampFeatureCanBeMarkedTransient() throws Exception
+    {
+        var cas = makeCas("This is a test");
+
+        assertThat(CasMetadataUtils.canMarkTransient(cas)).isTrue();
     }
 
     @Test

--- a/inception/inception-curation-legacy/pom.xml
+++ b/inception/inception-curation-legacy/pom.xml
@@ -81,6 +81,11 @@
       <artifactId>inception-curation-api</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-annotation-storage-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>org.dkpro.core</groupId>

--- a/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/CasDiff.java
+++ b/inception/inception-curation-legacy/src/main/java/de/tudarmstadt/ukp/clarin/webanno/curation/casdiff/CasDiff.java
@@ -55,10 +55,10 @@ import org.apache.uima.jcas.tcas.Annotation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import de.tudarmstadt.ukp.clarin.webanno.api.type.CasMetadataSupport;
 import de.tudarmstadt.ukp.inception.curation.api.DiffAdapter;
 import de.tudarmstadt.ukp.inception.curation.api.Position;
 import de.tudarmstadt.ukp.inception.support.uima.ICasUtil;
-import de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil;
 
 public class CasDiff
 {
@@ -209,18 +209,9 @@ public class CasDiff
         if (LOG.isDebugEnabled()) {
             LOG.debug("Analyzing CAS group [{}]", aCasGroupId);
 
-            String collectionId = null;
-            String documentId = null;
-            try {
-                var dmd = WebAnnoCasUtil.getDocumentMetadata(aCas);
-                collectionId = getFeature(dmd, "collectionId", String.class);
-                documentId = getFeature(dmd, "documentId", String.class);
-                LOG.debug("User [{}] - Document [{}]", collectionId, documentId);
-            }
-            catch (IllegalArgumentException e) {
-                // We use this information only for debugging - so we can ignore if the information
-                // is missing.
-            }
+            var collectionId = CasMetadataSupport.getProjectName(aCas);
+            var documentId = CasMetadataSupport.getSourceDocumentName(aCas);
+            LOG.debug("User [{}] - Document [{}]", collectionId, documentId);
         }
 
         var type = aCas.getTypeSystem().getType(aType);

--- a/inception/inception-layer-docmetadata-api/pom.xml
+++ b/inception/inception-layer-docmetadata-api/pom.xml
@@ -35,6 +35,11 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-annotation-storage-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-api-annotation</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -62,10 +67,6 @@
     <dependency>
       <groupId>org.apache.uima</groupId>
       <artifactId>uimaj-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.uima</groupId>
-      <artifactId>uimafit-core</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/inception/inception-layer-docmetadata-api/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/document/api/DocumentPosition.java
+++ b/inception/inception-layer-docmetadata-api/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/document/api/DocumentPosition.java
@@ -18,12 +18,11 @@
 package de.tudarmstadt.ukp.inception.annotation.layer.document.api;
 
 import org.apache.uima.cas.text.AnnotationFS;
-import org.apache.uima.fit.util.FSUtil;
 import org.apache.uima.jcas.cas.AnnotationBase;
 
+import de.tudarmstadt.ukp.clarin.webanno.api.type.CasMetadataSupport;
 import de.tudarmstadt.ukp.inception.annotation.feature.link.LinkFeatureMultiplicityMode;
 import de.tudarmstadt.ukp.inception.curation.api.Position_ImplBase;
-import de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil;
 
 /**
  * Represents a document position.
@@ -91,18 +90,11 @@ public class DocumentPosition
 
         public Builder forAnnotation(AnnotationBase aAnnotation)
         {
+            // Document identity (used only for debugging/transparency) comes from the
+            // INCEpTION-internal CASMetadata which is stamped on every CAS load.
             var cas = aAnnotation.getCAS();
-            try {
-                var dmd = WebAnnoCasUtil.getDocumentMetadata(cas);
-                collectionId = FSUtil.getFeature(dmd, "collectionId", String.class);
-                documentId = FSUtil.getFeature(dmd, "documentId", String.class);
-            }
-            catch (IllegalArgumentException e) {
-                // We use this information only for debugging - so we can ignore if the information
-                // is missing.
-                collectionId = null;
-                documentId = null;
-            }
+            collectionId = CasMetadataSupport.getProjectName(cas);
+            documentId = CasMetadataSupport.getSourceDocumentName(cas);
 
             type = aAnnotation.getType().getName();
 

--- a/inception/inception-layer-docmetadata/src/test/java/de/tudarmstadt/ukp/inception/annotation/layer/document/curation/DocumentMetadataDiffAdapterTest.java
+++ b/inception/inception-layer-docmetadata/src/test/java/de/tudarmstadt/ukp/inception/annotation/layer/document/curation/DocumentMetadataDiffAdapterTest.java
@@ -32,6 +32,7 @@ import org.apache.uima.resource.metadata.impl.TypeSystemDescription_impl;
 import org.apache.uima.util.CasCreationUtils;
 import org.junit.jupiter.api.Test;
 
+import de.tudarmstadt.ukp.clarin.webanno.api.type.CASMetadata;
 import de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
 import de.tudarmstadt.ukp.inception.annotation.feature.link.LinkFeatureDiffMode;
@@ -79,15 +80,19 @@ class DocumentMetadataDiffAdapterTest
         var dld = tsd.addType(DOC_TYPE, "", CAS.TYPE_NAME_ANNOTATION);
         dld.addFeature("label", "", CAS.TYPE_NAME_STRING);
         var fullTsd = CasCreationUtils.mergeTypeSystems(
-                List.of(tsd, TypeSystemDescriptionFactory.createTypeSystemDescription()));
+                List.of(tsd, TypeSystemDescriptionFactory.createTypeSystemDescription(),
+                        TypeSystemDescriptionFactory.createTypeSystemDescription(
+                                "de/tudarmstadt/ukp/clarin/webanno/api/type/webanno-internal")));
 
         var jcas = JCasFactory.createJCas(fullTsd);
         var cas = jcas.getCas();
 
-        // ensure document metadata exists and set collection/document id
-        var dmd = DocumentMetaData.create(jcas);
-        dmd.setCollectionId("coll1");
-        dmd.setDocumentId("doc1");
+        // Document identity is taken from the INCEpTION-internal CASMetadata
+        var casMetadata = cas
+                .createAnnotation(cas.getTypeSystem().getType(CASMetadata.class.getName()), 0, 0);
+        FSUtil.setFeature(casMetadata, "projectName", "coll1");
+        FSUtil.setFeature(casMetadata, "sourceDocumentName", "doc1");
+        cas.addFsToIndexes(casMetadata);
 
         var type = cas.getTypeSystem().getType(DOC_TYPE);
         var a1 = cas.createAnnotation(type, 0, 0);

--- a/inception/inception-layer-relation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/curation/RelationDiffAdapterImpl.java
+++ b/inception/inception-layer-relation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/curation/RelationDiffAdapterImpl.java
@@ -38,12 +38,12 @@ import org.apache.uima.fit.util.FSUtil;
 import org.apache.uima.jcas.cas.AnnotationBase;
 import org.apache.uima.jcas.tcas.Annotation;
 
+import de.tudarmstadt.ukp.clarin.webanno.api.type.CasMetadataSupport;
 import de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.Dependency;
 import de.tudarmstadt.ukp.inception.annotation.layer.relation.api.RelationDiffAdapter;
 import de.tudarmstadt.ukp.inception.annotation.layer.relation.api.RelationPosition;
 import de.tudarmstadt.ukp.inception.curation.api.DiffAdapter_ImplBase;
 import de.tudarmstadt.ukp.inception.curation.api.Position;
-import de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil;
 
 public class RelationDiffAdapterImpl
     extends DiffAdapter_ImplBase
@@ -115,17 +115,11 @@ public class RelationDiffAdapterImpl
         var sourceFS = (AnnotationFS) aFS.getFeatureValue(type.getFeatureByBaseName(sourceFeature));
         var targetFS = (AnnotationFS) aFS.getFeatureValue(type.getFeatureByBaseName(targetFeature));
 
-        String collectionId = null;
-        String documentId = null;
-        try {
-            var dmd = WebAnnoCasUtil.getDocumentMetadata(aFS.getCAS());
-            collectionId = FSUtil.getFeature(dmd, "collectionId", String.class);
-            documentId = FSUtil.getFeature(dmd, "documentId", String.class);
-        }
-        catch (IllegalArgumentException e) {
-            // We use this information only for debugging - so we can ignore if the information
-            // is missing.
-        }
+        // Document identity (used only for debugging/transparency) comes from the
+        // INCEpTION-internal CASMetadata which is stamped on every CAS load.
+        var cas = aFS.getCAS();
+        var collectionId = CasMetadataSupport.getProjectName(cas);
+        var documentId = CasMetadataSupport.getSourceDocumentName(cas);
 
         String linkTargetText = null;
         if (aLinkTargetBegin != -1 && aFS.getCAS().getDocumentText() != null) {

--- a/inception/inception-layer-relation/src/test/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/curation/RelationDiffAdapterImplTest.java
+++ b/inception/inception-layer-relation/src/test/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/curation/RelationDiffAdapterImplTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.annotation.layer.relation.curation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.apache.uima.fit.factory.JCasFactory;
+import org.apache.uima.fit.factory.TypeSystemDescriptionFactory;
+import org.apache.uima.fit.util.FSUtil;
+import org.apache.uima.jcas.cas.AnnotationBase;
+import org.apache.uima.util.CasCreationUtils;
+import org.junit.jupiter.api.Test;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.type.CASMetadata;
+import de.tudarmstadt.ukp.dkpro.core.api.syntax.type.dependency.Dependency;
+
+class RelationDiffAdapterImplTest
+{
+    /**
+     * The relation position's collection/document identity must be read from the INCEpTION-internal
+     * {@link CASMetadata} ({@code projectName} / {@code sourceDocumentName}) - not from the DKPro
+     * {@code DocumentMetaData}.
+     */
+    @Test
+    void getPosition_readsIdentityFromCasMetadata() throws Exception
+    {
+        var tsd = CasCreationUtils.mergeTypeSystems(
+                List.of(TypeSystemDescriptionFactory.createTypeSystemDescription(),
+                        TypeSystemDescriptionFactory.createTypeSystemDescription(
+                                "de/tudarmstadt/ukp/clarin/webanno/api/type/webanno-internal")));
+        var jcas = JCasFactory.createJCas(tsd);
+        jcas.setDocumentText("Hello world");
+        var cas = jcas.getCas();
+
+        var casMetadata = cas
+                .createAnnotation(cas.getTypeSystem().getType(CASMetadata.class.getName()), 0, 0);
+        FSUtil.setFeature(casMetadata, "projectName", "coll1");
+        FSUtil.setFeature(casMetadata, "sourceDocumentName", "doc1");
+        cas.addFsToIndexes(casMetadata);
+
+        var dependency = new Dependency(jcas, 0, 5);
+        dependency.addToIndexes();
+
+        var pos = RelationDiffAdapterImpl.DEPENDENCY_DIFF_ADAPTER
+                .getPosition((AnnotationBase) dependency);
+
+        assertThat(pos.getCollectionId()).isEqualTo("coll1");
+        assertThat(pos.getDocumentId()).isEqualTo("doc1");
+    }
+
+    @Test
+    void getPosition_withoutCasMetadata_leavesIdentityNull() throws Exception
+    {
+        var tsd = TypeSystemDescriptionFactory.createTypeSystemDescription();
+        var jcas = JCasFactory.createJCas(tsd);
+        jcas.setDocumentText("Hello world");
+
+        var dependency = new Dependency(jcas, 0, 5);
+        dependency.addToIndexes();
+
+        var pos = RelationDiffAdapterImpl.DEPENDENCY_DIFF_ADAPTER
+                .getPosition((AnnotationBase) dependency);
+
+        assertThat(pos.getCollectionId()).isNull();
+        assertThat(pos.getDocumentId()).isNull();
+    }
+}

--- a/inception/inception-layer-span-api/pom.xml
+++ b/inception/inception-layer-span-api/pom.xml
@@ -34,6 +34,11 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-annotation-storage-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-api-annotation</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -71,10 +76,6 @@
     <dependency>
       <groupId>org.apache.uima</groupId>
       <artifactId>uimaj-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.uima</groupId>
-      <artifactId>uimafit-core</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/inception/inception-layer-span-api/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/api/SpanPosition.java
+++ b/inception/inception-layer-span-api/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/api/SpanPosition.java
@@ -20,13 +20,12 @@ package de.tudarmstadt.ukp.inception.annotation.layer.span.api;
 import java.util.Objects;
 
 import org.apache.uima.cas.text.AnnotationFS;
-import org.apache.uima.fit.util.FSUtil;
 import org.apache.uima.jcas.tcas.Annotation;
 
+import de.tudarmstadt.ukp.clarin.webanno.api.type.CasMetadataSupport;
 import de.tudarmstadt.ukp.inception.annotation.feature.link.LinkFeatureMultiplicityMode;
 import de.tudarmstadt.ukp.inception.curation.api.Position;
 import de.tudarmstadt.ukp.inception.curation.api.Position_ImplBase;
-import de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil;
 
 /**
  * Represents a span position in the text.
@@ -198,18 +197,11 @@ public class SpanPosition
 
         public Builder forAnnotation(Annotation aAnnotation)
         {
+            // Document identity (used only for debugging/transparency) comes from the
+            // INCEpTION-internal CASMetadata which is stamped on every CAS load.
             var cas = aAnnotation.getCAS();
-            try {
-                var dmd = WebAnnoCasUtil.getDocumentMetadata(cas);
-                collectionId = FSUtil.getFeature(dmd, "collectionId", String.class);
-                documentId = FSUtil.getFeature(dmd, "documentId", String.class);
-            }
-            catch (IllegalArgumentException e) {
-                // We use this information only for debugging - so we can ignore if the information
-                // is missing.
-                collectionId = null;
-                documentId = null;
-            }
+            collectionId = CasMetadataSupport.getProjectName(cas);
+            documentId = CasMetadataSupport.getSourceDocumentName(cas);
 
             type = aAnnotation.getType().getName();
             begin = aAnnotation.getBegin();

--- a/inception/inception-layer-span/src/test/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanPositionTest.java
+++ b/inception/inception-layer-span/src/test/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanPositionTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.annotation.layer.span;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.apache.uima.fit.factory.JCasFactory;
+import org.apache.uima.fit.factory.TypeSystemDescriptionFactory;
+import org.apache.uima.fit.util.FSUtil;
+import org.apache.uima.util.CasCreationUtils;
+import org.junit.jupiter.api.Test;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.type.CASMetadata;
+import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
+import de.tudarmstadt.ukp.inception.annotation.layer.span.api.SpanPosition;
+
+class SpanPositionTest
+{
+    /**
+     * The position's collection/document identity must be read from the INCEpTION-internal
+     * {@link CASMetadata} ({@code projectName} / {@code sourceDocumentName}) - not from the DKPro
+     * {@code DocumentMetaData}.
+     */
+    @Test
+    void forAnnotation_readsIdentityFromCasMetadata() throws Exception
+    {
+        var tsd = CasCreationUtils.mergeTypeSystems(
+                List.of(TypeSystemDescriptionFactory.createTypeSystemDescription(),
+                        TypeSystemDescriptionFactory.createTypeSystemDescription(
+                                "de/tudarmstadt/ukp/clarin/webanno/api/type/webanno-internal")));
+        var jcas = JCasFactory.createJCas(tsd);
+        jcas.setDocumentText("Hello world");
+        var cas = jcas.getCas();
+
+        var casMetadata = cas
+                .createAnnotation(cas.getTypeSystem().getType(CASMetadata.class.getName()), 0, 0);
+        FSUtil.setFeature(casMetadata, "projectName", "coll1");
+        FSUtil.setFeature(casMetadata, "sourceDocumentName", "doc1");
+        cas.addFsToIndexes(casMetadata);
+
+        var token = new Token(jcas, 0, 5);
+        token.addToIndexes();
+
+        var pos = SpanPosition.builder().forAnnotation(token).build();
+
+        assertThat(pos.getCollectionId()).isEqualTo("coll1");
+        assertThat(pos.getDocumentId()).isEqualTo("doc1");
+        assertThat(pos.getType()).isEqualTo(Token.class.getName());
+    }
+
+    @Test
+    void forAnnotation_withoutCasMetadata_leavesIdentityNull() throws Exception
+    {
+        var tsd = TypeSystemDescriptionFactory.createTypeSystemDescription();
+        var jcas = JCasFactory.createJCas(tsd);
+        jcas.setDocumentText("Hello world");
+
+        var token = new Token(jcas, 0, 5);
+        token.addToIndexes();
+
+        var pos = SpanPosition.builder().forAnnotation(token).build();
+
+        assertThat(pos.getCollectionId()).isNull();
+        assertThat(pos.getDocumentId()).isNull();
+    }
+}


### PR DESCRIPTION
**What's in the PR**
- Read document/collection identity in diff positions and adapters (SpanPosition, DocumentPosition, RelationDiffAdapterImpl) and CasDiff from the internal CASMetadata instead of the DKPro DocumentMetaData
- Remove the now-redundant manual DocumentMetaData stamping in AgreementServiceImpl, CalculatePairwiseAgreementTask and CalculatePerDocumentAgreementTask, including no longer mutating shared read-only CASes
- Add inception-annotation-storage-api dependency to inception-layer-span-api, inception-layer-docmetadata-api and inception-curation-legacy

**How to test manually**
* No specific test procedure

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
