### PR TITLE
#6087 - Keep data of annotators removed from the project accessible

### DIFF
--- a/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/config/CurationDocumentServiceAutoConfiguration.java
+++ b/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/config/CurationDocumentServiceAutoConfiguration.java
@@ -26,25 +26,23 @@ import org.springframework.context.annotation.Configuration;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasStorageService;
 import de.tudarmstadt.ukp.inception.curation.service.CurationDocumentService;
 import de.tudarmstadt.ukp.inception.curation.service.CurationDocumentServiceImpl;
-import de.tudarmstadt.ukp.inception.project.api.ProjectService;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import jakarta.persistence.EntityManager;
 
 @Configuration
 @AutoConfigureAfter(name = {
-        "de.tudarmstadt.ukp.clarin.webanno.project.config.ProjectServiceAutoConfiguration",
         "de.tudarmstadt.ukp.inception.schema.config.AnnotationSchemaServiceAutoConfiguration",
         "de.tudarmstadt.ukp.inception.curation.config.CurationServiceAutoConfiguration" })
-@ConditionalOnBean({ CasStorageService.class, AnnotationSchemaService.class, ProjectService.class })
+@ConditionalOnBean({ CasStorageService.class, AnnotationSchemaService.class })
 @EnableConfigurationProperties({ CurationPropertiesImpl.class })
 public class CurationDocumentServiceAutoConfiguration
 {
     @Bean(CurationDocumentService.SERVICE_NAME)
     public CurationDocumentService curationDocumentService(CasStorageService aCasStorageService,
-            AnnotationSchemaService aAnnotationService, ProjectService aProjectService,
-            CurationProperties aCurationProperties, EntityManager aEntityManager)
+            AnnotationSchemaService aAnnotationService, CurationProperties aCurationProperties,
+            EntityManager aEntityManager)
     {
         return new CurationDocumentServiceImpl(aCasStorageService, aAnnotationService,
-                aProjectService, aCurationProperties, aEntityManager);
+                aCurationProperties, aEntityManager);
     }
 }

--- a/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/service/CurationDocumentService.java
+++ b/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/service/CurationDocumentService.java
@@ -70,9 +70,17 @@ public interface CurationDocumentService
     List<SourceDocument> listCuratableSourceDocuments(Project aProject);
 
     /**
-     * @return list of users that have finished the given document
+     * @param aSourceDocument
+     *            the source document.
+     * @return the users that have curatable annotation data for the given document. A user is
+     *         curatable if they finished the document, or if they set their state to {@code IGNORE}
+     *         (i.e. it should no longer be annotated by them) after having actually opened it -
+     *         i.e. a CAS exists. An {@code IGNORE} document that was never opened carries no data
+     *         and does not make its owner curatable. This includes former annotators that no longer
+     *         hold the {@code ANNOTATOR} permission (e.g. removed from the project or role changed)
+     *         so their data remains accessible for curation. Users whose account was deleted
+     *         entirely are not included as they can no longer be represented as a {@link User}.
      */
-    @SuppressWarnings("javadoc")
     List<User> listCuratableUsers(SourceDocument aSourceDocument);
 
     Optional<Long> getCurationCasTimestamp(SourceDocument aDocument) throws IOException;

--- a/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/service/CurationDocumentServiceImpl.java
+++ b/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/service/CurationDocumentServiceImpl.java
@@ -18,35 +18,40 @@
 package de.tudarmstadt.ukp.inception.curation.service;
 
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet.CURATION_SET;
-import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.ANNOTATOR;
 import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.ANNOTATION_FINISHED;
 import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.CURATION_FINISHED;
 import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.CURATION_IN_PROGRESS;
 import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.CURATION_USER;
+import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.INITIAL_CAS_PSEUDO_USER;
+import static java.util.Comparator.comparing;
 
 import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 
 import org.apache.commons.lang3.Validate;
 import org.apache.uima.UIMAException;
 import org.apache.uima.cas.CAS;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasStorageService;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.ConcurentCasModificationException;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument_;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.inception.curation.config.CurationDocumentServiceAutoConfiguration;
 import de.tudarmstadt.ukp.inception.curation.config.CurationProperties;
-import de.tudarmstadt.ukp.inception.project.api.ProjectService;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import jakarta.persistence.EntityManager;
 
@@ -59,21 +64,21 @@ import jakarta.persistence.EntityManager;
 public class CurationDocumentServiceImpl
     implements CurationDocumentService
 {
+    private static final Logger LOG = LoggerFactory.getLogger(CurationDocumentServiceImpl.class);
+
     private final CurationProperties curationProperties;
     private final EntityManager entityManager;
     private final CasStorageService casStorageService;
     private final AnnotationSchemaService annotationService;
-    private final ProjectService projectService;
 
     @Autowired
     public CurationDocumentServiceImpl(CasStorageService aCasStorageService,
-            AnnotationSchemaService aAnnotationService, ProjectService aProjectService,
-            CurationProperties aCurationProperties, EntityManager aEntityManager)
+            AnnotationSchemaService aAnnotationService, CurationProperties aCurationProperties,
+            EntityManager aEntityManager)
     {
         casStorageService = aCasStorageService;
         annotationService = aAnnotationService;
         entityManager = aEntityManager;
-        projectService = aProjectService;
         curationProperties = aCurationProperties;
     }
 
@@ -114,25 +119,58 @@ public class CurationDocumentServiceImpl
     {
         Validate.notNull(aSourceDocument, "Document must be specified");
 
+        // We deliberately do not join ProjectPermission here: a user that left annotation data
+        // behind but no longer holds the ANNOTATOR permission (e.g. removed from the project or
+        // role changed) must remain curatable so their data stays accessible.
+        // The User join still excludes the curation/initial-CAS pseudo users as well as users whose
+        // account was deleted entirely (they have no User row).
         var query = String.join("\n", //
-                "SELECT u FROM User u", //
+                "SELECT u, d FROM User u", //
                 " JOIN AnnotationDocument as d", //
                 "   ON d.user = u.username", //
-                " JOIN ProjectPermission AS perm", //
-                "   ON d.project = perm.project AND d.user = perm.user", //
                 "WHERE u.username = d.user", //
-                "  AND perm.level = :level", //
                 "  AND d.document = :document", //
                 "  AND (d.state = :state or d.annotatorState = :ignore)", //
                 "ORDER BY u.username ASC");
 
-        return new ArrayList<>(entityManager //
-                .createQuery(query, User.class) //
+        var candidates = entityManager //
+                .createQuery(query, Object[].class) //
                 .setParameter("document", aSourceDocument) //
-                .setParameter("level", ANNOTATOR) //
                 .setParameter("state", AnnotationDocumentState.FINISHED) //
                 .setParameter("ignore", AnnotationDocumentState.IGNORE) //
-                .getResultList());
+                .getResultList();
+
+        var curatableUsers = new ArrayList<User>();
+        for (var candidate : candidates) {
+            var user = (User) candidate[0];
+            var annDoc = (AnnotationDocument) candidate[1];
+
+            // Each candidate either finished the document or set their own state to IGNORE (i.e.
+            // the document should no longer be annotated by them - for whatever reason). A finished
+            // document always has a CAS - it is created when the document is first opened - so its
+            // owner is curatable without further checks. Any other candidate got here via the
+            // IGNORE branch and only counts if a CAS was actually written, i.e. the annotator had
+            // opened the document before it was set to IGNORE - an IGNORE document that was never
+            // opened has no data to curate.
+            if (annDoc.getState() == AnnotationDocumentState.FINISHED
+                    || hasCas(aSourceDocument, user.getUsername())) {
+                curatableUsers.add(user);
+            }
+        }
+
+        return curatableUsers;
+    }
+
+    private boolean hasCas(SourceDocument aDocument, String aDataOwner)
+    {
+        try {
+            return casStorageService.existsCas(aDocument, AnnotationSet.forUser(aDataOwner));
+        }
+        catch (IOException e) {
+            LOG.warn("Unable to determine whether a CAS exists for [{}] on {} - assuming it does",
+                    aDataOwner, aDocument, e);
+            return true;
+        }
     }
 
     @Override
@@ -152,27 +190,43 @@ public class CurationDocumentServiceImpl
     {
         Validate.notNull(aProject, "Project must be specified");
 
-        // Get all annotators in the project
-        var users = projectService.listUsersWithRoleInProject(aProject, ANNOTATOR);
-        // Bail out already. HQL doesn't seem to like queries with an empty parameter right of "in"
-        if (users.isEmpty()) {
-            return new ArrayList<>();
-        }
-
+        // We deliberately do not restrict to current annotators: a document that only has finished
+        // or IGNORE annotation data from a former annotator (removed from the project or role
+        // changed) must still surface for curation so that data stays accessible. The pseudo users
+        // for the curation and initial CASes are excluded.
         var query = String.join("\n", //
-                "SELECT DISTINCT adoc.document", //
+                "SELECT adoc", //
                 "FROM AnnotationDocument AS adoc", //
                 "WHERE adoc.project = :project", //
-                "AND adoc.user in (:users)", //
-                "AND (adoc.state = :state or adoc.annotatorState = :ignore)", //
-                "ORDER BY adoc.document.name");
+                "AND adoc.user NOT IN (:pseudoUsers)", //
+                "AND (adoc.state = :state or adoc.annotatorState = :ignore)");
 
-        return entityManager.createQuery(query, SourceDocument.class) //
+        var candidates = entityManager.createQuery(query, AnnotationDocument.class) //
                 .setParameter("project", aProject) //
-                .setParameter("users", users.stream().map(User::getUsername).toList()) //
+                .setParameter("pseudoUsers", List.of(CURATION_USER, INITIAL_CAS_PSEUDO_USER)) //
                 .setParameter("state", AnnotationDocumentState.FINISHED) //
                 .setParameter("ignore", AnnotationDocumentState.IGNORE) //
                 .getResultList();
+
+        // A document is curatable only if at least one annotator actually produced data on it: a
+        // finished document always has a CAS, while a document the annotator set to IGNORE counts
+        // only if a CAS was actually written (same reasoning as in listCuratableUsers).
+        var curatableDocuments = new HashMap<Long, SourceDocument>();
+        for (var adoc : candidates) {
+            var document = adoc.getDocument();
+            if (curatableDocuments.containsKey(document.getId())) {
+                continue;
+            }
+
+            if (adoc.getState() == AnnotationDocumentState.FINISHED
+                    || hasCas(document, adoc.getAnnotationSet().id())) {
+                curatableDocuments.put(document.getId(), document);
+            }
+        }
+
+        var result = new ArrayList<>(curatableDocuments.values());
+        result.sort(comparing(SourceDocument::getName));
+        return result;
     }
 
     @Transactional

--- a/inception/inception-curation/src/test/java/de/tudarmstadt/ukp/inception/curation/service/CurationDocumentServiceImplTest.java
+++ b/inception/inception-curation/src/test/java/de/tudarmstadt/ukp/inception/curation/service/CurationDocumentServiceImplTest.java
@@ -17,13 +17,19 @@
  */
 package de.tudarmstadt.ukp.inception.curation.service;
 
+import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode.EXCLUSIVE_WRITE_ACCESS;
+import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession.openNested;
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState.FINISHED;
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState.IGNORE;
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.ANNOTATOR;
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.CURATOR;
 import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.ANNOTATION_FINISHED;
 import static de.tudarmstadt.ukp.clarin.webanno.security.model.Role.ROLE_USER;
+import static de.tudarmstadt.ukp.inception.annotation.storage.CasMetadataUtils.getInternalTypeSystem;
+import static de.tudarmstadt.ukp.inception.support.uima.WebAnnoCasUtil.createCas;
+import static java.util.Arrays.asList;
 import static org.apache.uima.fit.factory.TypeSystemDescriptionFactory.createTypeSystemDescription;
+import static org.apache.uima.util.CasCreationUtils.mergeTypeSystems;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -46,9 +52,11 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
+import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasStorageService;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.DocumentImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.constraints.config.ConstraintsServiceAutoConfiguration;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.ProjectPermission;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
@@ -94,8 +102,10 @@ class CurationDocumentServiceImplTest
     private @Autowired TestEntityManager testEntityManager;
 
     private @Autowired DocumentService documentService;
+    private @Autowired CasStorageService casStorageService;
     private @Autowired CurationDocumentServiceImpl sut;
 
+    private User current;
     private User beate;
     private User kevin;
     private Project testProject;
@@ -105,7 +115,7 @@ class CurationDocumentServiceImplTest
     void setup() throws Exception
     {
         // create users
-        var current = new User("current", ROLE_USER);
+        current = new User("current", ROLE_USER);
         beate = new User("beate", ROLE_USER);
         kevin = new User("kevin", ROLE_USER);
         testEntityManager.persist(current);
@@ -141,6 +151,54 @@ class CurationDocumentServiceImplTest
     }
 
     @Test
+    void listCuratableSourceDocuments_legacy_ShouldIncludeFormerAnnotatorsDocuments()
+    {
+        // "current" has a user account but no ANNOTATOR permission in the project (e.g. removed
+        // from the project or role changed). A document with only their finished data must still
+        // surface for curation so their data stays accessible.
+        var ann = documentService
+                .createOrUpdateAnnotationDocument(new AnnotationDocument("current", testDocument));
+        documentService.setAnnotationDocumentState(ann, FINISHED);
+
+        assertThat(sut.listCuratableSourceDocuments_legacy(testProject)) //
+                .as("Documents with only former-annotator data are curatable") //
+                .contains(testDocument);
+    }
+
+    @Test
+    void listCuratableSourceDocuments_legacy_ShouldIncludeIgnoredDocumentsOnlyWhenTheyHaveData()
+        throws Exception
+    {
+        var withData = new SourceDocument("withData", testProject, "text");
+        var withoutData = new SourceDocument("withoutData", testProject, "text");
+        testEntityManager.persist(withData);
+        testEntityManager.persist(withoutData);
+
+        // kevin opened "withData" (a CAS exists) before setting it to IGNORE.
+        testEntityManager.persist(AnnotationDocument.builder() //
+                .withUser("kevin") //
+                .forDocument(withData) //
+                .withAnnotatorState(IGNORE) //
+                .build());
+        writeCasFor(withData, "kevin");
+
+        // kevin set "withoutData" to IGNORE without ever opening it (no CAS).
+        testEntityManager.persist(AnnotationDocument.builder() //
+                .withUser("kevin") //
+                .forDocument(withoutData) //
+                .withAnnotatorState(IGNORE) //
+                .build());
+
+        // A CAS storage session is required so the CAS-existence check can run (as in the real
+        // curation flow, which always runs within such a session).
+        try (var session = openNested(true)) {
+            assertThat(sut.listCuratableSourceDocuments_legacy(testProject)) //
+                    .as("IGNORE documents are curatable only when the annotator produced data") //
+                    .containsExactly(withData);
+        }
+    }
+
+    @Test
     void testListCuratableSourceDocuments_new()
     {
         assertThat(sut.listCuratableSourceDocuments_new(testProject))
@@ -155,9 +213,58 @@ class CurationDocumentServiceImplTest
     }
 
     @Test
-    void listCuratableUsers_ShouldReturnFinishedUsers()
+    void listCuratableUsers_ShouldIncludeIgnoredDocumentsOnlyWhenTheyHaveData() throws Exception
     {
-        // create finished annotation documents
+        // beate finished the document - a finished document always has a CAS, so she is curatable.
+        testEntityManager.persist(AnnotationDocument.builder() //
+                .withUser("beate") //
+                .forDocument(testDocument) //
+                .withState(FINISHED) //
+                .build());
+
+        // kevin opened the document (a CAS exists) and then set it to IGNORE - his partial work is
+        // still curatable.
+        testEntityManager.persist(AnnotationDocument.builder() //
+                .withUser("kevin") //
+                .forDocument(testDocument) //
+                .withAnnotatorState(IGNORE) //
+                .build());
+        writeCasFor(testDocument, "kevin");
+
+        // current set the document to IGNORE without ever opening it (no CAS) - there is nothing to
+        // curate, so he is not curatable.
+        testEntityManager.persist(AnnotationDocument.builder() //
+                .withUser("current") //
+                .forDocument(testDocument) //
+                .withAnnotatorState(IGNORE) //
+                .build());
+
+        // A CAS storage session is required so the CAS-existence check can run (as in the real
+        // curation flow, which always runs within such a session).
+        try (var session = openNested(true)) {
+            assertThat(sut.listCuratableUsers(testDocument)) //
+                    .as("IGNORE documents are only curatable when the annotator produced data") //
+                    .containsExactly(beate, kevin);
+        }
+    }
+
+    private void writeCasFor(SourceDocument aDocument, String aUsername) throws Exception
+    {
+        try (var session = openNested(true)) {
+            var tsd = mergeTypeSystems(
+                    asList(createTypeSystemDescription(), getInternalTypeSystem()));
+            var cas = createCas(tsd);
+            session.add(AnnotationSet.forUser(aUsername), EXCLUSIVE_WRITE_ACCESS, cas);
+            casStorageService.writeCas(aDocument, cas, AnnotationSet.forUser(aUsername));
+        }
+    }
+
+    @Test
+    void listCuratableUsers_ShouldIncludeFormerAnnotatorsButNotDeletedAccounts()
+    {
+        // "beate" is a current annotator. "current" has a user account but no ANNOTATOR permission
+        // in the project (e.g. removed from the project or role changed). "ghost" left data behind
+        // but the user account was deleted entirely (no User row).
         testEntityManager.persist(AnnotationDocument.builder() //
                 .withUser("beate") //
                 .forDocument(testDocument) //
@@ -165,14 +272,22 @@ class CurationDocumentServiceImplTest
                 .build());
 
         testEntityManager.persist(AnnotationDocument.builder() //
-                .withUser("kevin") //
+                .withUser("current") //
                 .forDocument(testDocument) //
-                .withAnnotatorState(IGNORE) //
+                .withState(FINISHED) //
                 .build());
 
-        var finishedUsers = sut.listCuratableUsers(testDocument);
+        testEntityManager.persist(AnnotationDocument.builder() //
+                .withUser("ghost") //
+                .forDocument(testDocument) //
+                .withState(FINISHED) //
+                .build());
 
-        assertThat(finishedUsers).containsExactly(beate, kevin);
+        var curatableUsers = sut.listCuratableUsers(testDocument);
+
+        assertThat(curatableUsers) //
+                .as("Former annotators with data are curatable; deleted accounts are not") //
+                .containsExactly(beate, current);
     }
 
     @Test

--- a/inception/inception-documents-api/src/main/java/de/tudarmstadt/ukp/inception/documents/api/DocumentService.java
+++ b/inception/inception-documents-api/src/main/java/de/tudarmstadt/ukp/inception/documents/api/DocumentService.java
@@ -302,6 +302,26 @@ public interface DocumentService
         throws UIMAException, IOException;
 
     /**
+     * Resets the annotations for the given document and data owner back to the initial state. This
+     * overload accepts an {@link AnnotationSet} (i.e. is identified by the data owner's username)
+     * and therefore also works for former annotators whose user account no longer exists.
+     *
+     * @param aDocument
+     *            the source document.
+     * @param aSet
+     *            the data owner whose annotations are reset.
+     * @param aFlags
+     *            optional flags controlling the operation
+     * @throws UIMAException
+     *             if a data error occurs.
+     * @throws IOException
+     *             if an I/O error occurs.
+     */
+    void resetAnnotationCas(SourceDocument aDocument, AnnotationSet aSet,
+            AnnotationDocumentStateChangeFlag... aFlags)
+        throws UIMAException, IOException;
+
+    /**
      * A Method that checks if there is already an annotation document created for the source
      * document
      *
@@ -584,6 +604,54 @@ public interface DocumentService
      */
     List<AnnotationDocument> listAnnotationDocuments(Project aProject);
 
+    /**
+     * List the data owners for the given project: all users that currently hold the
+     * {@link PermissionLevel#ANNOTATOR ANNOTATOR} permission (including those who have not produced
+     * any annotation data yet), unioned with any user that has left annotation documents behind but
+     * no longer holds that permission (e.g. because they were removed from the project or had their
+     * role changed - or even had their account deleted entirely). The latter are flagged as former
+     * annotators in their {@link AnnotationSet#displayName() display name}. The curation and
+     * initial CAS pseudo users are not included.
+     *
+     * @param aProject
+     *            the project
+     * @return the current and former data owners as annotation sets.
+     */
+    List<AnnotationSet> listDataOwners(Project aProject);
+
+    /**
+     * Resolve a single data-owner name to the {@link AnnotationSet} to display for it, flagging
+     * former annotators and missing accounts so they can be told apart from current annotators (the
+     * singular counterpart to {@link #listDataOwners(Project)}):
+     * <ul>
+     * <li>a current annotator (the account still holds the {@link PermissionLevel#ANNOTATOR
+     * ANNOTATOR} permission in the project) resolves to an unmarked set;</li>
+     * <li>an existing account that no longer holds that permission (removed from the project or
+     * role changed) is flagged as a former annotator;</li>
+     * <li>a data owner whose account no longer exists is flagged as missing.</li>
+     * </ul>
+     *
+     * @param aProject
+     *            the project the data owner belongs to.
+     * @param aDataOwner
+     *            the data-owner name (i.e. the user name stored on an annotation document).
+     * @return the annotation set to display for the given data owner.
+     */
+    AnnotationSet getDataOwner(Project aProject, String aDataOwner);
+
+    /**
+     * Batch variant of {@link #getDataOwner(Project, String)} that resolves several data-owner
+     * names at once using a fixed number of queries rather than one lookup per name. The same
+     * current/former/missing (and deactivated) marker rules apply.
+     *
+     * @param aProject
+     *            the project the data owners belong to.
+     * @param aDataOwners
+     *            the data-owner names (i.e. the user names stored on annotation documents).
+     * @return a map from each requested data-owner name to the annotation set to display for it.
+     */
+    Map<String, AnnotationSet> getDataOwners(Project aProject, Collection<String> aDataOwners);
+
     List<AnnotationDocument> listAnnotationDocumentsInState(Project aProject,
             AnnotationDocumentState... aStates);
 
@@ -675,15 +743,27 @@ public interface DocumentService
 
     /**
      * List all annotation documents for this source document (including in active and deleted user
-     * annotation and those created by project admins or super admins for Test purpose. This method
-     * is called when a source document (or Project) is deleted so that associated annotation
-     * documents also get removed.
+     * annotation and those created by project admins or super admins. This method is called when a
+     * source document (or Project) is deleted so that associated annotation documents also get
+     * removed.
      *
      * @param document
      *            the source document.
      * @return the annotation documents.
      */
     List<AnnotationDocument> listAllAnnotationDocuments(SourceDocument document);
+
+    /**
+     * List all the {@link AnnotationDocument annotation documents} in a given project, regardless
+     * of whether their owner still holds a permission in the project or whether their user account
+     * still exists. Unlike {@link #listAnnotationDocuments(Project)}, this includes the data of
+     * former annotators (removed from the project, role changed, or account deleted).
+     *
+     * @param aProject
+     *            the project
+     * @return the annotation documents.
+     */
+    List<AnnotationDocument> listAllAnnotationDocuments(Project aProject);
 
     /**
      * Check if the user finished annotating the {@link SourceDocument} in this {@link Project}

--- a/inception/inception-documents/pom.xml
+++ b/inception/inception-documents/pom.xml
@@ -192,5 +192,30 @@
       <artifactId>uimafit-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-data-jpa-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-jpa-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-persistence</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hsqldb</groupId>
+      <artifactId>hsqldb</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/DocumentServiceImpl.java
+++ b/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/DocumentServiceImpl.java
@@ -27,6 +27,9 @@ import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState.IG
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentStateChangeFlag.EXPLICIT_ANNOTATOR_USER_ACTION;
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet.CURATION_SET;
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet.INITIAL_SET;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSetMarker.DEACTIVATED;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSetMarker.FORMER_ANNOTATOR;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSetMarker.MISSING;
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.ANNOTATOR;
 import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.ANNOTATION_FINISHED;
 import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.ANNOTATION_IN_PROGRESS;
@@ -42,11 +45,15 @@ import static de.tudarmstadt.ukp.inception.support.text.TextUtils.containsAnyCha
 import static de.tudarmstadt.ukp.inception.support.text.TextUtils.endsWithMatching;
 import static de.tudarmstadt.ukp.inception.support.text.TextUtils.sortAndRemoveDuplicateCharacters;
 import static de.tudarmstadt.ukp.inception.support.text.TextUtils.startsWithMatching;
+import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.CURATION_USER;
+import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.INITIAL_CAS_PSEUDO_USER;
 import static java.lang.String.format;
 import static java.lang.String.join;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
+import static java.util.Comparator.comparing;
 import static java.util.Objects.isNull;
+import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.lang3.ArrayUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.contains;
@@ -111,6 +118,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentStateTransition;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument_;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
+import de.tudarmstadt.ukp.clarin.webanno.security.model.User_;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentStorageService;
 import de.tudarmstadt.ukp.inception.documents.api.RepositoryProperties;
@@ -1190,20 +1198,28 @@ public class DocumentServiceImpl
             AnnotationDocumentStateChangeFlag... aFlags)
         throws UIMAException, IOException
     {
-        var adoc = getAnnotationDocument(aDocument, aUser);
+        resetAnnotationCas(aDocument, AnnotationSet.forUser(aUser.getUsername()), aFlags);
+    }
+
+    @Override
+    @Transactional
+    public void resetAnnotationCas(SourceDocument aDocument, AnnotationSet aSet,
+            AnnotationDocumentStateChangeFlag... aFlags)
+        throws UIMAException, IOException
+    {
+        var adoc = getAnnotationDocument(aDocument, aSet);
 
         // We read the initial CAS and then use it to override the CAS for the given document/user.
         // In order to do that, we must read the initial CAS unmanaged.
         var cas = createOrReadInitialCas(aDocument, FORCE_CAS_UPGRADE, UNMANAGED_ACCESS);
 
         // Add/update the CAS metadata
-        var timestamp = casStorageService.getCasTimestamp(aDocument,
-                AnnotationSet.forUser(aUser.getUsername()));
+        var timestamp = casStorageService.getCasTimestamp(aDocument, aSet);
         if (timestamp.isPresent()) {
-            addOrUpdateCasMetadata(cas, timestamp.get(), aDocument, aUser.getUsername());
+            addOrUpdateCasMetadata(cas, timestamp.get(), aDocument, aSet.id());
         }
 
-        writeAnnotationCas(cas, aDocument, aUser);
+        writeAnnotationCas(cas, aDocument, aSet);
 
         adoc.setTimestamp(null);
         adoc.setAnnotatorComment(null);
@@ -1254,6 +1270,197 @@ public class DocumentServiceImpl
                 .setParameter("project", aProject) //
                 .setParameter("level", ANNOTATOR) //
                 .getResultList();
+    }
+
+    @Override
+    @Transactional(noRollbackFor = NoResultException.class)
+    public List<AnnotationSet> listDataOwners(Project aProject)
+    {
+        Validate.notNull(aProject, "Project must be specified");
+
+        var dataOwners = new ArrayList<AnnotationSet>();
+
+        // Current annotators - including those that have not produced any annotation data yet.
+        var currentAnnotators = projectService.listUsersWithRoleInProject(aProject, ANNOTATOR);
+        currentAnnotators.stream() //
+                .map(user -> toAnnotationSet(user.getUsername(), user, true)) //
+                .forEach(dataOwners::add);
+
+        var currentAnnotatorNames = currentAnnotators.stream() //
+                .map(User::getUsername) //
+                .collect(toSet());
+
+        // Former annotators - users that left annotation data behind but no longer hold the
+        // ANNOTATOR permission (e.g. removed from the project or assigned a different role). Their
+        // account may even have been deleted entirely, in which case we fall back to the username.
+        // We only consider users that actually have annotation data: a NEW (or absent) annotation
+        // document carries no data - it is merely the result of an assignment. A locked (IGNORE)
+        // document only counts if a CAS was actually written before it was locked (see
+        // hasAnnotationData). The candidate query below narrows to non-NEW documents; the CAS check
+        // then weeds out owners whose only documents were locked without ever being worked on.
+        var cb = entityManager.getCriteriaBuilder();
+
+        var ownerQuery = cb.createQuery(String.class);
+        var adoc = ownerQuery.from(AnnotationDocument.class);
+        ownerQuery.select(adoc.get(AnnotationDocument_.user)).distinct(true) //
+                .where(cb.equal(adoc.get(AnnotationDocument_.project), aProject), //
+                        adoc.get(AnnotationDocument_.user)
+                                .in(CURATION_USER, INITIAL_CAS_PSEUDO_USER).not(), //
+                        cb.notEqual(adoc.get(AnnotationDocument_.state),
+                                AnnotationDocumentState.NEW));
+
+        var formerCandidates = entityManager.createQuery(ownerQuery).getResultList().stream() //
+                .filter(username -> !currentAnnotatorNames.contains(username)) //
+                .collect(toSet());
+
+        if (!formerCandidates.isEmpty()) {
+            // Load the candidates' non-NEW documents and keep only owners that actually have
+            // annotation data: a locked document may have been locked before the annotator ever
+            // opened it, in which case no CAS exists and the owner is not a data owner.
+            var docQuery = cb.createQuery(AnnotationDocument.class);
+            var cadoc = docQuery.from(AnnotationDocument.class);
+            docQuery.select(cadoc).where(cb.equal(cadoc.get(AnnotationDocument_.project), aProject), //
+                    cadoc.get(AnnotationDocument_.user).in(formerCandidates), //
+                    cb.notEqual(cadoc.get(AnnotationDocument_.state), AnnotationDocumentState.NEW));
+
+            var docsByOwner = entityManager.createQuery(docQuery).getResultList().stream() //
+                    .collect(groupingBy(ad -> ad.getAnnotationSet().id()));
+
+            var formerUsernames = formerCandidates.stream() //
+                    .filter(username -> hasAnnotationData(docsByOwner.get(username))) //
+                    .sorted() //
+                    .toList();
+
+            if (!formerUsernames.isEmpty()) {
+                var userQuery = cb.createQuery(User.class);
+                var userRoot = userQuery.from(User.class);
+                userQuery.select(userRoot).where(userRoot.get(User_.username).in(formerUsernames));
+
+                var formerUsersByName = new HashMap<String, User>();
+                entityManager.createQuery(userQuery).getResultList() //
+                        .forEach(user -> formerUsersByName.put(user.getUsername(), user));
+
+                for (var username : formerUsernames) {
+                    // These are by definition not current annotators, so toAnnotationSet yields a
+                    // FORMER_ANNOTATOR (account kept) or MISSING (account deleted) marker.
+                    dataOwners
+                            .add(toAnnotationSet(username, formerUsersByName.get(username), false));
+                }
+            }
+        }
+
+        dataOwners.sort(comparing(AnnotationSet::displayName));
+
+        return dataOwners;
+    }
+
+    @Override
+    @Transactional(noRollbackFor = NoResultException.class)
+    public AnnotationSet getDataOwner(Project aProject, String aDataOwner)
+    {
+        Validate.notNull(aProject, "Project must be specified");
+        Validate.notBlank(aDataOwner, "Data owner must be specified");
+
+        // The account may have been deleted entirely (e.g. former annotator removed from the
+        // system), in which case toAnnotationSet falls back to the bare user name (MISSING).
+        var user = entityManager.find(User.class, aDataOwner);
+        var isCurrentAnnotator = user != null && projectService.hasRole(user, aProject, ANNOTATOR);
+
+        return toAnnotationSet(aDataOwner, user, isCurrentAnnotator);
+    }
+
+    @Override
+    @Transactional(noRollbackFor = NoResultException.class)
+    public Map<String, AnnotationSet> getDataOwners(Project aProject,
+            Collection<String> aDataOwners)
+    {
+        Validate.notNull(aProject, "Project must be specified");
+        Validate.notNull(aDataOwners, "Data owners must be specified");
+
+        var result = new LinkedHashMap<String, AnnotationSet>();
+        if (aDataOwners.isEmpty()) {
+            return result;
+        }
+
+        // Resolve current-annotator membership and the user accounts in two bulk queries instead of
+        // hitting the database once per data owner.
+        var currentAnnotatorNames = projectService.listUsersWithRoleInProject(aProject, ANNOTATOR)
+                .stream() //
+                .map(User::getUsername) //
+                .collect(toSet());
+
+        var usersByName = new HashMap<String, User>();
+        entityManager.createQuery("FROM User WHERE username IN (:usernames)", User.class) //
+                .setParameter("usernames", aDataOwners) //
+                .getResultList() //
+                .forEach(user -> usersByName.put(user.getUsername(), user));
+
+        for (var dataOwner : aDataOwners) {
+            result.computeIfAbsent(dataOwner, owner -> toAnnotationSet(owner,
+                    usersByName.get(owner), currentAnnotatorNames.contains(owner)));
+        }
+
+        return result;
+    }
+
+    /**
+     * Build the display {@link AnnotationSet} for a single data owner, applying the marker
+     * precedence shared by {@link #listDataOwners}, {@link #getDataOwner} and
+     * {@link #getDataOwners} (in order): a data owner with no user account at all is flagged
+     * MISSING; an account that is still a current annotator but disabled is flagged DEACTIVATED; an
+     * account that no longer holds the annotator permission is flagged FORMER_ANNOTATOR (whether
+     * enabled or not); an enabled current annotator carries no marker.
+     */
+    private AnnotationSet toAnnotationSet(String aDataOwner, User aUser,
+            boolean aIsCurrentAnnotator)
+    {
+        if (aUser == null) {
+            return AnnotationSet.forUser(aDataOwner, MISSING);
+        }
+
+        if (!aIsCurrentAnnotator) {
+            return AnnotationSet.forUser(aUser, FORMER_ANNOTATOR);
+        }
+
+        if (!aUser.isEnabled()) {
+            return AnnotationSet.forUser(aUser, DEACTIVATED);
+        }
+
+        return AnnotationSet.forUser(aUser);
+    }
+
+    /**
+     * @return whether the given (non-NEW) annotation documents represent actual annotation data.
+     *         Documents in a taken state (IN_PROGRESS / FINISHED) always have a CAS - it is created
+     *         when the document is first opened. The remaining documents are locked (IGNORE) and
+     *         only count as data if a CAS was actually written before they were locked.
+     */
+    private boolean hasAnnotationData(List<AnnotationDocument> aDocuments)
+    {
+        if (aDocuments == null) {
+            return false;
+        }
+
+        for (var doc : aDocuments) {
+            if (doc.getState().isTaken()) {
+                return true;
+            }
+        }
+
+        for (var doc : aDocuments) {
+            try {
+                if (existsCas(doc)) {
+                    return true;
+                }
+            }
+            catch (IOException e) {
+                LOG.warn("Unable to determine whether a CAS exists for annotation document [{}] - "
+                        + "assuming it does", doc, e);
+                return true;
+            }
+        }
+
+        return false;
     }
 
     @Override
@@ -1314,6 +1521,22 @@ public class DocumentServiceImpl
                         AnnotationDocument.class)
                 .setParameter("project", aDocument.getProject()) //
                 .setParameter("document", aDocument) //
+                .getResultList();
+    }
+
+    @Override
+    @Transactional(noRollbackFor = NoResultException.class)
+    public List<AnnotationDocument> listAllAnnotationDocuments(Project aProject)
+    {
+        Validate.notNull(aProject, "Project must be specified");
+
+        // Unlike listAnnotationDocuments(Project), this does not join ProjectPermission/User, so it
+        // also returns the documents of former annotators (no longer holding a permission, or whose
+        // account was deleted).
+        return entityManager
+                .createQuery("FROM AnnotationDocument WHERE project = :project",
+                        AnnotationDocument.class)
+                .setParameter("project", aProject) //
                 .getResultList();
     }
 

--- a/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/cli/RebuildStateUpdatedFieldsCliCommand.java
+++ b/inception/inception-documents/src/main/java/de/tudarmstadt/ukp/inception/documents/cli/RebuildStateUpdatedFieldsCliCommand.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.documents.cli;
 
+import static de.tudarmstadt.ukp.inception.support.json.JSONUtil.fromJsonString;
 import static java.util.Arrays.asList;
 
 import java.util.Date;
@@ -38,7 +39,6 @@ import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.log.api.EventRepository;
 import de.tudarmstadt.ukp.inception.log.api.model.StateChangeDetails;
 import de.tudarmstadt.ukp.inception.project.api.ProjectService;
-import de.tudarmstadt.ukp.inception.support.json.JSONUtil;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
@@ -92,7 +92,7 @@ public class RebuildStateUpdatedFieldsCliCommand
             aLog.info("Processing project: {}", project);
 
             var srcDocs = documentService.listSourceDocuments(project);
-            var annDocs = documentService.listAnnotationDocuments(project);
+            var annDocs = documentService.listAllAnnotationDocuments(project);
             var stateChangeEvents = Set.of("ProjectStateChangedEvent", "DocumentStateChangedEvent",
                     "AnnotationStateChangeEvent");
 
@@ -103,8 +103,7 @@ public class RebuildStateUpdatedFieldsCliCommand
                 }
 
                 try {
-                    var details = JSONUtil.fromJsonString(StateChangeDetails.class,
-                            event.getDetails());
+                    var details = fromJsonString(StateChangeDetails.class, event.getDetails());
 
                     if ("ProjectStateChangedEvent".equals(event.getEvent())) {
                         if (project.getState() != ProjectState.fromString(details.getState())) {

--- a/inception/inception-documents/src/test/java/de/tudarmstadt/ukp/inception/documents/DocumentServiceImplDatabaseTest.java
+++ b/inception/inception-documents/src/test/java/de/tudarmstadt/ukp/inception/documents/DocumentServiceImplDatabaseTest.java
@@ -1,0 +1,566 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.documents;
+
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentStateChangeFlag.EXPLICIT_ANNOTATOR_USER_ACTION;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSetMarker.DEACTIVATED;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSetMarker.FORMER_ANNOTATOR;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSetMarker.MISSING;
+import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.ANNOTATOR;
+import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.CURATION_USER;
+import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.INITIAL_CAS_PSEUDO_USER;
+import static de.tudarmstadt.ukp.inception.support.logging.Logging.KEY_REPOSITORY_PATH;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Date;
+import java.util.Optional;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+import org.springframework.boot.persistence.autoconfigure.EntityScan;
+import org.springframework.context.ApplicationEventPublisher;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasStorageService;
+import de.tudarmstadt.ukp.clarin.webanno.api.export.DocumentImportExportService;
+import de.tudarmstadt.ukp.clarin.webanno.api.format.FormatSupport;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
+import de.tudarmstadt.ukp.clarin.webanno.model.Project;
+import de.tudarmstadt.ukp.clarin.webanno.model.ProjectPermission;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
+import de.tudarmstadt.ukp.inception.documents.api.DocumentStorageService;
+import de.tudarmstadt.ukp.inception.project.api.ProjectService;
+import jakarta.persistence.EntityManager;
+
+/**
+ * Database-backed tests for {@link DocumentServiceImpl} that only need a real
+ * {@link EntityManager}. The collaborators that would pull in modules depending on this one (CAS
+ * storage, import/export, schema) are mocked, so the service under test is constructed by hand
+ * rather than wired by Spring. Tests that exercise CAS storage / import-export live in the
+ * integration-level {@code DocumentServiceImplCasStorageTest} in the {@code inception-schema}
+ * module instead.
+ */
+@EnableAutoConfiguration
+@DataJpaTest(showSql = false, //
+        properties = { "spring.main.banner-mode=off" })
+@EntityScan({ //
+        "de.tudarmstadt.ukp.clarin.webanno.model", //
+        "de.tudarmstadt.ukp.clarin.webanno.security.model" })
+class DocumentServiceImplDatabaseTest
+{
+    private @Autowired TestEntityManager testEntityManager;
+
+    private ProjectService projectService;
+    private DocumentImportExportService importExportService;
+    private CasStorageService casStorageService;
+    private EntityManager entityManager;
+    private DocumentServiceImpl sut;
+
+    private User annotator1;
+    private Project project;
+
+    @BeforeEach
+    void setup()
+    {
+        // The service wraps its work in ProjectService.withProjectLogger(...), which requires the
+        // repository path to be present in the logging MDC.
+        MDC.put(KEY_REPOSITORY_PATH, "target/test-repository");
+
+        projectService = mock(ProjectService.class);
+        importExportService = mock(DocumentImportExportService.class);
+        casStorageService = mock(CasStorageService.class);
+        entityManager = testEntityManager.getEntityManager();
+        sut = new DocumentServiceImpl(null, casStorageService, importExportService, projectService,
+                mock(ApplicationEventPublisher.class), entityManager,
+                mock(DocumentStorageService.class));
+
+        annotator1 = new User("anno1");
+        testEntityManager.persist(annotator1);
+
+        project = new Project("project");
+        testEntityManager.persist(project);
+        testEntityManager
+                .persist(new ProjectPermission(project, annotator1.getUsername(), ANNOTATOR));
+    }
+
+    @AfterEach
+    void tearDown()
+    {
+        MDC.remove(KEY_REPOSITORY_PATH);
+    }
+
+    @Test
+    void testThatAnnotationDocumentsForNonExistingUserAreNotReturned()
+    {
+        var doc = sut.createSourceDocument(new SourceDocument("doc", project, "text"));
+
+        var ann = sut.createOrUpdateAnnotationDocument(
+                new AnnotationDocument(annotator1.getUsername(), doc));
+
+        assertThat(sut.listAnnotationDocuments(doc))
+                .as("As long as the user exists, the annotation document must be found")
+                .containsExactly(ann);
+
+        testEntityManager.remove(annotator1);
+        testEntityManager.flush();
+
+        assertThat(sut.listAnnotationDocuments(doc))
+                .as("When the user is deleted, the document must no longer be found") //
+                .isEmpty();
+    }
+
+    @Test
+    void thatListAllAnnotationDocumentsIncludesFormerAnnotators()
+    {
+        var doc = sut.createSourceDocument(new SourceDocument("doc", project, "text"));
+
+        var current = sut.createOrUpdateAnnotationDocument(
+                new AnnotationDocument(annotator1.getUsername(), doc));
+        // A former annotator: has data but holds no permission and has no user account.
+        var former = sut.createOrUpdateAnnotationDocument(new AnnotationDocument("ghost", doc));
+
+        assertThat(sut.listAnnotationDocuments(project)) //
+                .as("The permission-filtered list only contains current annotators") //
+                .containsExactly(current);
+
+        assertThat(sut.listAllAnnotationDocuments(project)) //
+                .as("The unfiltered list also contains former annotators") //
+                .containsExactlyInAnyOrder(current, former);
+    }
+
+    @Test
+    void thatCreateOrGetAnnotationDocumentsWithAnnotationSetsCreatesDocuments()
+    {
+        var doc = sut.createSourceDocument(new SourceDocument("doc1", project, "text"));
+
+        var set1 = AnnotationSet.forUser(annotator1);
+        var set2 = AnnotationSet.forTest("other");
+
+        var annDocs = sut.createOrGetAnnotationDocuments(doc, asList(set1, set2));
+
+        assertThat(annDocs).hasSize(2);
+        assertThat(sut.getAnnotationDocument(doc, set1)).isNotNull();
+        assertThat(sut.getAnnotationDocument(doc, set2)).isNotNull();
+    }
+
+    @Test
+    void thatCreateOrGetAnnotationDocumentsForMultipleDocumentsCreatesDocuments()
+    {
+        var doc1 = sut.createSourceDocument(new SourceDocument("doc1.txt", project, "text"));
+        var doc2 = sut.createSourceDocument(new SourceDocument("doc2.txt", project, "text"));
+
+        var set = AnnotationSet.forUser(annotator1);
+
+        var annDocs = sut.createOrGetAnnotationDocuments(asList(doc1, doc2), set);
+
+        assertThat(annDocs).hasSize(2);
+        assertThat(sut.getAnnotationDocument(doc1, set)).isNotNull();
+        assertThat(sut.getAnnotationDocument(doc2, set)).isNotNull();
+    }
+
+    @Test
+    void thatListAnnotationDocumentsProjectAndSetWorks()
+    {
+        var doc1 = sut.createSourceDocument(new SourceDocument("doc1", project, "text"));
+        var doc2 = sut.createSourceDocument(new SourceDocument("doc2", project, "text"));
+
+        var set = AnnotationSet.forUser(annotator1);
+
+        sut.createOrGetAnnotationDocument(doc1, set);
+        sut.createOrGetAnnotationDocument(doc2, set);
+
+        var docs = sut.listAnnotationDocuments(project, set);
+        assertThat(docs).isNotEmpty();
+        assertThat(docs).allMatch(a -> a.getAnnotationSet().equals(set));
+    }
+
+    @Test
+    void thatListAllDocumentsProjectAndSetReturnsNullForMissingDocs()
+    {
+        var doc1 = sut.createSourceDocument(new SourceDocument("doc1", project, "text"));
+        var doc2 = sut.createSourceDocument(new SourceDocument("doc2", project, "text"));
+
+        var set = AnnotationSet.forUser(annotator1);
+
+        var ann = sut.createOrGetAnnotationDocument(doc1, set);
+
+        var map = sut.listAllDocuments(project, set);
+        assertThat(map).containsEntry(doc1, ann);
+        assertThat(map).containsKey(doc2);
+        assertThat(map.get(doc2)).isNull();
+    }
+
+    @Test
+    void thatExistsAnnotationDocumentWithSetWorks()
+    {
+        var doc = sut.createSourceDocument(new SourceDocument("docx", project, "text"));
+        var set = AnnotationSet.forUser(annotator1);
+
+        assertThat(sut.existsAnnotationDocument(doc, set)).isFalse();
+        sut.createOrGetAnnotationDocument(doc, set);
+        assertThat(sut.existsAnnotationDocument(doc, set)).isTrue();
+    }
+
+    @Test
+    void thatExistsSourceDocumentWorks()
+    {
+        var doc1 = sut.createSourceDocument(new SourceDocument("s1", project, "text"));
+        var doc2 = sut.createSourceDocument(new SourceDocument("s2", project, "text"));
+
+        assertThat(sut.existsSourceDocument(project)).isTrue();
+        assertThat(sut.existsSourceDocument(project, doc1.getName())).isTrue();
+        assertThat(sut.existsSourceDocument(project, doc2.getName())).isTrue();
+        assertThat(sut.existsSourceDocument(project, "not-found.txt")).isFalse();
+    }
+
+    @Test
+    void thatListFinishedAnnotationDocumentsAndExistsWorks()
+    {
+        var doc = sut.createSourceDocument(new SourceDocument("fin.txt", project, "text"));
+        var set = AnnotationSet.forUser(annotator1);
+        var ann = sut.createOrGetAnnotationDocument(doc, set);
+
+        sut.setAnnotationDocumentState(ann, AnnotationDocumentState.FINISHED);
+
+        assertThat(sut.existsFinishedAnnotation(doc)).isTrue();
+        assertThat(sut.listFinishedAnnotationDocuments(doc)).isNotEmpty();
+        assertThat(sut.existsFinishedAnnotation(project)).isTrue();
+        assertThat(sut.listFinishedAnnotationDocuments(project)).isNotEmpty();
+    }
+
+    @Test
+    void thatListSupportedSourceDocumentsFiltersUnsupported()
+    {
+        when(importExportService.getFormatById("text"))
+                .thenReturn(Optional.of(mock(FormatSupport.class)));
+
+        var d1 = sut.createSourceDocument(new SourceDocument("f1.txt", project, "text"));
+        var d2 = sut.createSourceDocument(new SourceDocument("f2.txt", project, "unsupported"));
+
+        var res = sut.listSupportedSourceDocuments(project);
+        assertThat(res).contains(d1);
+        assertThat(res).doesNotContain(d2);
+    }
+
+    @Test
+    void thatUpdateStateUpdatedDirectlyWorks()
+    {
+        var doc = sut.createSourceDocument(new SourceDocument("ust.txt", project, "text"));
+        var set = AnnotationSet.forUser(annotator1);
+        var ann = sut.createOrGetAnnotationDocument(doc, set);
+
+        var d = new Date(1620000000000L);
+        sut.updateAnnotationDocumentStateUpdatedDirectly(ann.getId(), d);
+        // Flush pending changes, evict the persistence context and re-fetch to ensure we
+        // read the value updated directly in the DB
+        entityManager.flush();
+        entityManager.clear();
+        var annReloaded = sut.getAnnotationDocument(doc, set);
+        assertThat(annReloaded.getStateUpdated().getTime()).isEqualTo(d.getTime());
+
+        var src = sut.getSourceDocument(project, "ust.txt");
+        sut.updateSourceDocumentStateUpdatedDirectly(src.getId(), d);
+        // Flush pending changes, evict the persistence context and re-fetch to ensure we
+        // read the value updated directly in the DB
+        entityManager.flush();
+        entityManager.clear();
+        var srcReloaded = sut.getSourceDocument(project, "ust.txt");
+        assertThat(srcReloaded.getStateUpdated().getTime()).isEqualTo(d.getTime());
+    }
+
+    @Test
+    void thatExplicitUserActionsSetAnnotatorState()
+    {
+        var doc = sut.createSourceDocument(new SourceDocument("doc", project, "text"));
+
+        var ann = sut.createOrUpdateAnnotationDocument(
+                new AnnotationDocument(annotator1.getUsername(), doc));
+
+        sut.setAnnotationDocumentState(ann, AnnotationDocumentState.IGNORE);
+        assertThat(ann.getState()) //
+                .as("Implicit actions update the effective state") //
+                .isEqualTo(AnnotationDocumentState.IGNORE);
+        assertThat(ann.getAnnotatorState())
+                .as("Implicit actions cause the annotator state not to be set") //
+                .isNull();
+
+        sut.setAnnotationDocumentState(ann, AnnotationDocumentState.FINISHED,
+                EXPLICIT_ANNOTATOR_USER_ACTION);
+        assertThat(ann.getState()) //
+                .as("Explicit user actions update the effective state") //
+                .isEqualTo(AnnotationDocumentState.FINISHED);
+        assertThat(ann.getAnnotatorState())
+                .as("Explicit user actions cause the annotator state to be set")
+                .isEqualTo(AnnotationDocumentState.FINISHED);
+
+        sut.setAnnotationDocumentState(ann, AnnotationDocumentState.NEW);
+        assertThat(ann.getAnnotatorState()) //
+                .as("Resetting the document clears the annotator state") //
+                .isNull();
+        assertThat(ann.getState()) //
+                .as("Implicit actions update the effective state") //
+                .isEqualTo(AnnotationDocumentState.NEW);
+
+        sut.setAnnotationDocumentState(ann, AnnotationDocumentState.IN_PROGRESS,
+                EXPLICIT_ANNOTATOR_USER_ACTION);
+        sut.setAnnotationDocumentState(ann, AnnotationDocumentState.FINISHED);
+        assertThat(ann.getAnnotatorState())
+                .as("Implicit actions cause the annotator state not to be changed") //
+                .isEqualTo(AnnotationDocumentState.IN_PROGRESS);
+        assertThat(ann.getState()) //
+                .as("Implicit actions update the effective state") //
+                .isEqualTo(AnnotationDocumentState.FINISHED);
+
+        sut.setAnnotationDocumentState(ann, AnnotationDocumentState.FINISHED,
+                EXPLICIT_ANNOTATOR_USER_ACTION);
+        sut.setAnnotationDocumentState(ann, AnnotationDocumentState.IN_PROGRESS);
+        assertThat(ann.getAnnotatorState())
+                .as("Manager send document back to annotation updates annotator state") //
+                .isEqualTo(AnnotationDocumentState.IN_PROGRESS);
+        assertThat(ann.getState()) //
+                .as("Manager send document back to annotation updates effective state") //
+                .isEqualTo(AnnotationDocumentState.IN_PROGRESS);
+
+        sut.setAnnotationDocumentState(ann, AnnotationDocumentState.IN_PROGRESS,
+                EXPLICIT_ANNOTATOR_USER_ACTION);
+        sut.setAnnotationDocumentState(ann, AnnotationDocumentState.IGNORE);
+        assertThat(ann.getAnnotatorState())
+                .as("Manager locking document does not change the annotator state") //
+                .isEqualTo(AnnotationDocumentState.IN_PROGRESS);
+        assertThat(ann.getState()) //
+                .as("Manager locking document updates effective state") //
+                .isEqualTo(AnnotationDocumentState.IGNORE);
+    }
+
+    @Test
+    void thatListDataOwnersUnionsCurrentAndFormerAnnotators()
+    {
+        // anno1 (from setup) plus a second current annotator without any data yet
+        var anno2 = new User("anno2");
+        testEntityManager.persist(anno2);
+        when(projectService.listUsersWithRoleInProject(project, ANNOTATOR))
+                .thenReturn(asList(annotator1, anno2));
+
+        var doc = sut.createSourceDocument(new SourceDocument("doc", project, "text"));
+
+        // anno1 is a current annotator that has produced data
+        var anno1Doc = sut.createOrUpdateAnnotationDocument(
+                new AnnotationDocument(annotator1.getUsername(), doc));
+        sut.setAnnotationDocumentState(anno1Doc, AnnotationDocumentState.IN_PROGRESS);
+
+        // a former annotator: left data behind but no longer holds the annotator permission
+        var carol = User.builder().withUsername("carol").withUiName("carol-display").build();
+        testEntityManager.persist(carol);
+        var carolDoc = sut
+                .createOrUpdateAnnotationDocument(new AnnotationDocument(carol.getUsername(), doc));
+        sut.setAnnotationDocumentState(carolDoc, AnnotationDocumentState.FINISHED);
+
+        // a former annotator whose account has been deleted entirely
+        var ghostDoc = sut.createOrUpdateAnnotationDocument(new AnnotationDocument("ghost", doc));
+        sut.setAnnotationDocumentState(ghostDoc, AnnotationDocumentState.IN_PROGRESS);
+
+        // the curation and initial CAS pseudo users must not show up as data owners
+        sut.createOrUpdateAnnotationDocument(new AnnotationDocument(CURATION_USER, doc));
+        sut.createOrUpdateAnnotationDocument(new AnnotationDocument(INITIAL_CAS_PSEUDO_USER, doc));
+
+        assertThat(sut.listDataOwners(project)) //
+                .extracting(AnnotationSet::id, AnnotationSet::displayName) //
+                .containsExactly( //
+                        tuple("anno1", "anno1"), // current annotator with data
+                        tuple("anno2", "anno2"), // current annotator without data
+                        tuple("carol", "carol-display (former annotator)"), // former, account kept
+                        tuple("ghost", "ghost (missing!)")); // former, account deleted
+    }
+
+    @Test
+    void thatListDataOwnersIgnoresFormerAnnotatorsWithoutData()
+    {
+        when(projectService.listUsersWithRoleInProject(project, ANNOTATOR))
+                .thenReturn(asList(annotator1));
+
+        var doc = sut.createSourceDocument(new SourceDocument("doc", project, "text"));
+
+        // A former annotator that was only ever assigned the document (state NEW) but never
+        // produced any annotation data must not be reported as a data owner.
+        var dave = User.builder().withUsername("dave").withUiName("dave-display").build();
+        testEntityManager.persist(dave);
+        sut.createOrUpdateAnnotationDocument(new AnnotationDocument(dave.getUsername(), doc));
+
+        assertThat(sut.listDataOwners(project)) //
+                .extracting(AnnotationSet::id) //
+                .containsExactly("anno1"); // only the current annotator; dave is omitted
+    }
+
+    @Test
+    void thatListDataOwnersIgnoresFormerAnnotatorWithLockedButEmptyDocument()
+    {
+        when(projectService.listUsersWithRoleInProject(project, ANNOTATOR))
+                .thenReturn(asList(annotator1));
+
+        var doc = sut.createSourceDocument(new SourceDocument("doc", project, "text"));
+
+        // A former annotator whose only document was locked before they ever worked on it: the
+        // document is in IGNORE state but no CAS exists, so they are not a data owner.
+        var erin = User.builder().withUsername("erin").withUiName("erin-display").build();
+        testEntityManager.persist(erin);
+        var erinDoc = sut.createOrUpdateAnnotationDocument(new AnnotationDocument("erin", doc));
+        sut.setAnnotationDocumentState(erinDoc, AnnotationDocumentState.IGNORE);
+
+        // The mock CasStorageService reports no CAS by default.
+        assertThat(sut.listDataOwners(project)) //
+                .extracting(AnnotationSet::id) //
+                .containsExactly("anno1"); // erin is omitted - locked but no data
+    }
+
+    @Test
+    void thatListDataOwnersIncludesFormerAnnotatorWithLockedDocumentThatHasData() throws Exception
+    {
+        when(projectService.listUsersWithRoleInProject(project, ANNOTATOR))
+                .thenReturn(asList(annotator1));
+        // The former annotator did produce data before the document was locked.
+        when(casStorageService.existsCas(any(), any())).thenReturn(true);
+
+        var doc = sut.createSourceDocument(new SourceDocument("doc", project, "text"));
+
+        var frank = User.builder().withUsername("frank").withUiName("frank-display").build();
+        testEntityManager.persist(frank);
+        var frankDoc = sut.createOrUpdateAnnotationDocument(new AnnotationDocument("frank", doc));
+        sut.setAnnotationDocumentState(frankDoc, AnnotationDocumentState.IGNORE);
+
+        assertThat(sut.listDataOwners(project)) //
+                .extracting(AnnotationSet::id, AnnotationSet::displayName) //
+                .containsExactly( //
+                        tuple("anno1", "anno1"), //
+                        tuple("frank", "frank-display (former annotator)"));
+    }
+
+    @Test
+    void thatGetDataOwnerResolvesCurrentAnnotatorWithoutMarker()
+    {
+        when(projectService.hasRole(annotator1, project, ANNOTATOR)).thenReturn(true);
+
+        var set = sut.getDataOwner(project, annotator1.getUsername());
+
+        assertThat(set.id()).isEqualTo("anno1");
+        assertThat(set.marker()).isNull();
+    }
+
+    @Test
+    void thatGetDataOwnerResolvesFormerAnnotatorWithFormerMarker()
+    {
+        var carol = User.builder().withUsername("carol").withUiName("carol-display").build();
+        testEntityManager.persist(carol);
+        when(projectService.hasRole(carol, project, ANNOTATOR)).thenReturn(false);
+
+        var set = sut.getDataOwner(project, "carol");
+
+        assertThat(set.id()).isEqualTo("carol");
+        assertThat(set.displayName()).isEqualTo("carol-display (former annotator)");
+        assertThat(set.marker()).isEqualTo(FORMER_ANNOTATOR);
+    }
+
+    @Test
+    void thatGetDataOwnerResolvesMissingAccountWithMissingMarker()
+    {
+        // No user account with this name exists.
+        var set = sut.getDataOwner(project, "ghost");
+
+        assertThat(set.id()).isEqualTo("ghost");
+        assertThat(set.displayName()).isEqualTo("ghost (missing!)");
+        assertThat(set.marker()).isEqualTo(MISSING);
+    }
+
+    @Test
+    void thatListDataOwnersFlagsDisabledCurrentAnnotatorAsDeactivated()
+    {
+        // A disabled account that still holds the annotator permission stays a current data owner
+        // but is flagged as deactivated rather than former.
+        var disabled = User.builder().withUsername("anno2").withUiName("anno2-display")
+                .withEnabled(false).build();
+        testEntityManager.persist(disabled);
+        when(projectService.listUsersWithRoleInProject(project, ANNOTATOR))
+                .thenReturn(asList(annotator1, disabled));
+
+        assertThat(sut.listDataOwners(project)) //
+                .extracting(AnnotationSet::id, AnnotationSet::marker) //
+                .containsExactlyInAnyOrder( //
+                        tuple("anno1", null), // enabled current annotator
+                        tuple("anno2", DEACTIVATED)); // disabled current annotator
+    }
+
+    @Test
+    void thatGetDataOwnerFlagsDisabledCurrentAnnotatorAsDeactivated()
+    {
+        var disabled = User.builder().withUsername("dora").withUiName("dora-display")
+                .withEnabled(false).build();
+        testEntityManager.persist(disabled);
+        when(projectService.hasRole(disabled, project, ANNOTATOR)).thenReturn(true);
+
+        var set = sut.getDataOwner(project, "dora");
+
+        assertThat(set.id()).isEqualTo("dora");
+        assertThat(set.displayName()).isEqualTo("dora-display (deactivated)");
+        assertThat(set.marker()).isEqualTo(DEACTIVATED);
+    }
+
+    @Test
+    void thatGetDataOwnersResolvesAllMarkersInOneCall()
+    {
+        var disabled = User.builder().withUsername("dora").withUiName("dora-display")
+                .withEnabled(false).build();
+        testEntityManager.persist(disabled);
+        var carol = User.builder().withUsername("carol").withUiName("carol-display").build();
+        testEntityManager.persist(carol);
+
+        // anno1 (enabled) and dora (disabled) currently hold the annotator permission; carol and
+        // the non-existent ghost do not.
+        when(projectService.listUsersWithRoleInProject(project, ANNOTATOR))
+                .thenReturn(asList(annotator1, disabled));
+
+        var resolved = sut.getDataOwners(project, asList("anno1", "dora", "carol", "ghost"));
+
+        assertThat(resolved.keySet()) //
+                .as("Every requested data owner is resolved, preserving the requested order") //
+                .containsExactly("anno1", "dora", "carol", "ghost");
+        assertThat(resolved.get("anno1").marker()).isNull();
+        assertThat(resolved.get("dora").marker()).isEqualTo(DEACTIVATED);
+        assertThat(resolved.get("carol").marker()).isEqualTo(FORMER_ANNOTATOR);
+        assertThat(resolved.get("carol").displayName())
+                .isEqualTo("carol-display (former annotator)");
+        assertThat(resolved.get("ghost").marker()).isEqualTo(MISSING);
+    }
+
+    @SpringBootConfiguration
+    static class TestContext
+    {
+    }
+}

--- a/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/AnnotationSet.java
+++ b/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/AnnotationSet.java
@@ -27,13 +27,18 @@ import org.apache.commons.lang3.Validate;
 
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 
-public record AnnotationSet(String id, String displayName)
+public record AnnotationSet(String id, String name, AnnotationSetMarker marker)
     implements Serializable
 {
     public static final AnnotationSet EXPORT_SET = special("exportCas", "Export");
     public static final AnnotationSet PREDICTION_SET = special("predictionCas", "Prediction");
     public static final AnnotationSet INITIAL_SET = special(INITIAL_CAS_PSEUDO_USER, "Source");
     public static final AnnotationSet CURATION_SET = special(CURATION_USER, "Curator");
+
+    public AnnotationSet
+    {
+        Validate.notBlank(id, "id must not be blank");
+    }
 
     /**
      * @deprecated Use one of the factory methods, e.g. {@link #forUser(User)}
@@ -42,8 +47,11 @@ public record AnnotationSet(String id, String displayName)
     public AnnotationSet(String id)
     {
         this(id, id);
+    }
 
-        Validate.notBlank(id, "id must not be blank");
+    public AnnotationSet(String id, String name)
+    {
+        this(id, name, null);
     }
 
     @Override
@@ -68,6 +76,31 @@ public record AnnotationSet(String id, String displayName)
         return id;
     }
 
+    /**
+     * @return the {@link #name()} with the {@link #marker()} appended as a suffix (if any), e.g.
+     *         "jdoe (former annotator)". Use {@link #name()} to render the marker separately.
+     */
+    public String displayName()
+    {
+        return marker == null ? name : name + " (" + marker.getLabel() + ")";
+    }
+
+    /**
+     * @param aMarkers
+     *            the markers to check for
+     * @return whether this annotation set is flagged with any of the given markers.
+     */
+    public boolean hasAnyMarkers(AnnotationSetMarker... aMarkers)
+    {
+        for (var candidate : aMarkers) {
+            if (marker == candidate) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public static AnnotationSet forUser(String aUsername)
     {
         return new AnnotationSet(aUsername);
@@ -78,13 +111,23 @@ public record AnnotationSet(String id, String displayName)
         return new AnnotationSet(aUser.getUsername(), aUser.getUiName());
     }
 
+    public static AnnotationSet forUser(User aUser, AnnotationSetMarker aMarker)
+    {
+        return new AnnotationSet(aUser.getUsername(), aUser.getUiName(), aMarker);
+    }
+
+    public static AnnotationSet forUser(String aUsername, AnnotationSetMarker aMarker)
+    {
+        return new AnnotationSet(aUsername, aUsername, aMarker);
+    }
+
     public static AnnotationSet forTest(String aName)
     {
         return new AnnotationSet(aName);
     }
 
-    private static AnnotationSet special(String aPurpose, String aDisplayName)
+    private static AnnotationSet special(String aPurpose, String aName)
     {
-        return new AnnotationSet(aPurpose, aDisplayName);
+        return new AnnotationSet(aPurpose, aName);
     }
 }

--- a/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/AnnotationSetMarker.java
+++ b/inception/inception-model/src/main/java/de/tudarmstadt/ukp/clarin/webanno/model/AnnotationSetMarker.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.model;
+
+/**
+ * A marker appended to an {@link AnnotationSet#displayName()} to flag a special status of the data
+ * owner - e.g. that they still have annotation data on record but no longer hold the annotator
+ * permission in the project.
+ */
+public enum AnnotationSetMarker
+{
+    FORMER_ANNOTATOR("former annotator"), //
+    DEACTIVATED("deactivated"), //
+    MISSING("missing!");
+
+    private final String label;
+
+    AnnotationSetMarker(String aLabel)
+    {
+        label = aLabel;
+    }
+
+    public String getLabel()
+    {
+        return label;
+    }
+}

--- a/inception/inception-model/src/test/java/de/tudarmstadt/ukp/clarin/webanno/model/AnnotationSetTest.java
+++ b/inception/inception-model/src/test/java/de/tudarmstadt/ukp/clarin/webanno/model/AnnotationSetTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.model;
+
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSetMarker.FORMER_ANNOTATOR;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSetMarker.MISSING;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
+
+class AnnotationSetTest
+{
+    @Test
+    void thatCurrentAnnotatorIsNotFlaggedAsFormer()
+    {
+        var user = User.builder().withUsername("bob").withUiName("Bob").build();
+
+        var set = AnnotationSet.forUser(user);
+
+        assertThat(set.id()).isEqualTo("bob");
+        assertThat(set.name()).isEqualTo("Bob");
+        assertThat(set.displayName()).isEqualTo("Bob");
+        assertThat(set.marker()).isNull();
+        assertThat(set.hasAnyMarkers(FORMER_ANNOTATOR, MISSING)).isFalse();
+    }
+
+    @Test
+    void thatFormerAnnotatorIsFlaggedAndDisplayNameIsMarked()
+    {
+        var user = User.builder().withUsername("carol").withUiName("Carol").build();
+
+        var set = AnnotationSet.forUser(user, FORMER_ANNOTATOR);
+
+        assertThat(set.id()).isEqualTo("carol");
+        assertThat(set.name()).isEqualTo("Carol");
+        assertThat(set.displayName()).isEqualTo("Carol (former annotator)");
+        assertThat(set.marker()).isEqualTo(FORMER_ANNOTATOR);
+        assertThat(set.hasAnyMarkers(FORMER_ANNOTATOR, MISSING)).isTrue();
+        assertThat(set.hasAnyMarkers(MISSING)).isFalse();
+    }
+
+    @Test
+    void thatMissingAnnotatorIsFlaggedAsFormer()
+    {
+        var set = AnnotationSet.forUser("ghost", MISSING);
+
+        assertThat(set.id()).isEqualTo("ghost");
+        assertThat(set.name()).isEqualTo("ghost");
+        assertThat(set.displayName()).isEqualTo("ghost (missing!)");
+        assertThat(set.marker()).isEqualTo(MISSING);
+        assertThat(set.hasAnyMarkers(FORMER_ANNOTATOR, MISSING)).isTrue();
+    }
+
+    @Test
+    void thatEqualityIsByIdOnlyRegardlessOfDisplayNameAndMarker()
+    {
+        // The matrix relies on this: a marked column set must still match the unmarked set under
+        // which the annotation document is stored in the cell map.
+        var marked = AnnotationSet.forUser("carol", FORMER_ANNOTATOR);
+        var plain = AnnotationSet.forUser("carol");
+
+        assertThat(marked).isEqualTo(plain);
+        assertThat(marked.hashCode()).isEqualTo(plain.hashCode());
+    }
+}

--- a/inception/inception-pivot/pom.xml
+++ b/inception/inception-pivot/pom.xml
@@ -41,11 +41,6 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
-      <artifactId>inception-ui-project</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-schema-api</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/config/PivotAutoConfiguration.java
+++ b/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/config/PivotAutoConfiguration.java
@@ -42,7 +42,6 @@ import de.tudarmstadt.ukp.inception.pivot.report.ReportService;
 import de.tudarmstadt.ukp.inception.pivot.report.ReportServiceImpl;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
-import de.tudarmstadt.ukp.inception.project.api.ProjectService;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import jakarta.persistence.EntityManager;
 
@@ -108,11 +107,11 @@ public class PivotAutoConfiguration
     @Bean
     public ReportService reportService(EntityManager aEntityManager,
             AnnotationSchemaService aSchemaService, ExtractorSupportRegistry aExtractorRegistry,
-            AggregatorSupportRegistry aAggregatorRegistry, ProjectService aProjectService,
-            DocumentService aDocumentService, UserDao aUserService)
+            AggregatorSupportRegistry aAggregatorRegistry, DocumentService aDocumentService,
+            UserDao aUserService)
     {
         return new ReportServiceImpl(aEntityManager, aSchemaService, aExtractorRegistry,
-                aAggregatorRegistry, aProjectService, aDocumentService, aUserService);
+                aAggregatorRegistry, aDocumentService, aUserService);
     }
 
     @Bean

--- a/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/page/PivotTablePage.java
+++ b/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/page/PivotTablePage.java
@@ -38,7 +38,6 @@ import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.apache.wicket.Component;
@@ -66,12 +65,10 @@ import org.wicketstuff.annotation.mount.MountPath;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
-import de.tudarmstadt.ukp.clarin.webanno.model.ProjectUserPermissions;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
-import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.clarin.webanno.ui.core.page.ProjectPageBase;
-import de.tudarmstadt.ukp.clarin.webanno.ui.project.users.ProjectUserPermissionChoiceRenderer;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.pivot.api.aggregator.Aggregator;
 import de.tudarmstadt.ukp.inception.pivot.api.aggregator.AggregatorSupport;
@@ -252,8 +249,8 @@ public class PivotTablePage
         queue(new LambdaAjaxButton<ReportDecl>("save", (t, f) -> actionSaveTab(t, activeTab)));
         queue(new LambdaAjaxButton<ReportDecl>("run", this::actionRun));
 
-        var annotatorList = new ListMultipleChoice<ProjectUserPermissions>("annotators");
-        annotatorList.setChoiceRenderer(new ProjectUserPermissionChoiceRenderer());
+        var annotatorList = new ListMultipleChoice<AnnotationSet>("annotators");
+        annotatorList.setChoiceRenderer(new LambdaChoiceRenderer<>(AnnotationSet::displayName));
         annotatorList.setChoices(reportService.listDataOwners(getProject()));
         annotatorList.add(new LambdaAjaxFormComponentUpdatingBehavior(CHANGE_EVENT,
                 this::actionMarkActiveTabDirty));
@@ -654,10 +651,8 @@ public class PivotTablePage
         var dataOwners = (state.getAnnotators().isEmpty()
                 ? reportService.listDataOwners(getProject())
                 : state.getAnnotators()).stream() //
-                        .map(ProjectUserPermissions::getUser) //
-                        .filter(Optional::isPresent) //
-                        .map(Optional::get) //
-                        .map(User::getUsername).toList();
+                        .map(AnnotationSet::id) //
+                        .toList();
 
         var sessionOwner = userService.getCurrentUser();
         var states = state.getStates().isEmpty() ? asList(IN_PROGRESS, FINISHED, IGNORE)

--- a/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/report/ReportDecl.java
+++ b/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/report/ReportDecl.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
-import de.tudarmstadt.ukp.clarin.webanno.model.ProjectUserPermissions;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 
 public class ReportDecl
@@ -32,7 +32,7 @@ public class ReportDecl
 
     private AggregatorDecl aggregator;
 
-    private List<ProjectUserPermissions> annotators = new ArrayList<>();
+    private List<AnnotationSet> annotators = new ArrayList<>();
     private List<SourceDocument> documents = new ArrayList<>();
     private List<AnnotationDocumentState> states = new ArrayList<>();
     private List<ExtractorDecl> rowExtractors = new ArrayList<>();
@@ -49,12 +49,12 @@ public class ReportDecl
         aggregator = aAggregator;
     }
 
-    public List<ProjectUserPermissions> getAnnotators()
+    public List<AnnotationSet> getAnnotators()
     {
         return annotators;
     }
 
-    public void setAnnotators(List<ProjectUserPermissions> aAnnotators)
+    public void setAnnotators(List<AnnotationSet> aAnnotators)
     {
         annotators = aAnnotators != null ? aAnnotators : new ArrayList<>();
     }

--- a/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/report/ReportService.java
+++ b/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/report/ReportService.java
@@ -20,8 +20,8 @@ package de.tudarmstadt.ukp.inception.pivot.report;
 import java.util.List;
 import java.util.Optional;
 
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
-import de.tudarmstadt.ukp.clarin.webanno.model.ProjectUserPermissions;
 import de.tudarmstadt.ukp.inception.pivot.api.model.PivotReport;
 import de.tudarmstadt.ukp.inception.pivot.api.report.ReportDef;
 
@@ -43,5 +43,5 @@ public interface ReportService
 
     ResolvedReport resolve(ReportDef aDef, Project aProject);
 
-    List<ProjectUserPermissions> listDataOwners(Project aProject);
+    List<AnnotationSet> listDataOwners(Project aProject);
 }

--- a/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/report/ReportServiceImpl.java
+++ b/inception/inception-pivot/src/main/java/de/tudarmstadt/ukp/inception/pivot/report/ReportServiceImpl.java
@@ -17,9 +17,6 @@
  */
 package de.tudarmstadt.ukp.inception.pivot.report;
 
-import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.ANNOTATOR;
-import static java.util.Collections.emptySet;
-import static java.util.Comparator.comparing;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toMap;
@@ -33,11 +30,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
-import de.tudarmstadt.ukp.clarin.webanno.model.ProjectUserPermissions;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
-import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.pivot.api.aggregator.AggregatorSupportRegistry;
 import de.tudarmstadt.ukp.inception.pivot.api.extractor.ExtractorBindingResolutionContext;
@@ -47,7 +43,6 @@ import de.tudarmstadt.ukp.inception.pivot.api.report.ExtractorDef;
 import de.tudarmstadt.ukp.inception.pivot.api.report.FilterDef;
 import de.tudarmstadt.ukp.inception.pivot.api.model.PivotReport;
 import de.tudarmstadt.ukp.inception.pivot.api.report.ReportDef;
-import de.tudarmstadt.ukp.inception.project.api.ProjectService;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.support.json.JSONUtil;
 import de.tudarmstadt.ukp.inception.support.logging.LogMessage;
@@ -61,21 +56,19 @@ public class ReportServiceImpl
     private final AnnotationSchemaService schemaService;
     private final ExtractorSupportRegistry extractorRegistry;
     private final AggregatorSupportRegistry aggregatorRegistry;
-    private final ProjectService projectService;
     private final DocumentService documentService;
     private final UserDao userService;
     private final ObjectMapper jsonMapper;
 
     public ReportServiceImpl(EntityManager aEntityManager, AnnotationSchemaService aSchemaService,
             ExtractorSupportRegistry aExtractorRegistry,
-            AggregatorSupportRegistry aAggregatorRegistry, ProjectService aProjectService,
-            DocumentService aDocumentService, UserDao aUserService)
+            AggregatorSupportRegistry aAggregatorRegistry, DocumentService aDocumentService,
+            UserDao aUserService)
     {
         entityManager = aEntityManager;
         schemaService = aSchemaService;
         extractorRegistry = aExtractorRegistry;
         aggregatorRegistry = aAggregatorRegistry;
-        projectService = aProjectService;
         documentService = aDocumentService;
         userService = aUserService;
         jsonMapper = JSONUtil.getObjectMapper();
@@ -173,7 +166,7 @@ public class ReportServiceImpl
 
         var filter = new FilterDef();
         filter.setAnnotators(aDecl.getAnnotators().stream() //
-                .map(ProjectUserPermissions::getUsername) //
+                .map(AnnotationSet::id) //
                 .toList());
         filter.setDocuments(aDecl.getDocuments().stream() //
                 .map(SourceDocument::getName) //
@@ -334,13 +327,13 @@ public class ReportServiceImpl
             return;
         }
 
-        var byUsername = listDataOwners(aProject).stream() //
-                .collect(toMap(ProjectUserPermissions::getUsername, identity(), (a, $) -> a));
+        var byId = listDataOwners(aProject).stream() //
+                .collect(toMap(AnnotationSet::id, identity(), (a, $) -> a));
 
         for (var username : aFilter.getAnnotators()) {
-            var perm = byUsername.get(username);
-            if (perm != null) {
-                aDecl.getAnnotators().add(perm);
+            var dataOwner = byId.get(username);
+            if (dataOwner != null) {
+                aDecl.getAnnotators().add(dataOwner);
             }
             else {
                 aProblems.add(
@@ -371,22 +364,15 @@ public class ReportServiceImpl
     }
 
     @Override
-    public List<ProjectUserPermissions> listDataOwners(Project aProject)
+    public List<AnnotationSet> listDataOwners(Project aProject)
     {
-        var dataOwners = new ArrayList<ProjectUserPermissions>();
+        // Current and former annotators (the latter flagged in their display name).
+        var dataOwners = new ArrayList<>(documentService.listDataOwners(aProject));
 
-        projectService.listProjectUserPermissions(aProject).stream() //
-                .filter(p -> p.getRoles().contains(ANNOTATOR)) //
-                .sorted(comparing(p -> p.getUser().map(User::getUiName).orElse(p.getUsername()))) //
-                .forEach(dataOwners::add);
-
-        var curationUser = userService.getCurationUser();
-        dataOwners.add(new ProjectUserPermissions(aProject, curationUser.getUsername(),
-                curationUser, emptySet()));
-
-        var initialCasUser = userService.getInitialCasUser();
-        dataOwners.add(new ProjectUserPermissions(aProject, initialCasUser.getUsername(),
-                initialCasUser, emptySet()));
+        // The pivot can also report on the curation and initial CAS data which are not regular
+        // annotators and thus not included by DocumentService.listDataOwners(...).
+        dataOwners.add(AnnotationSet.forUser(userService.getCurationUser()));
+        dataOwners.add(AnnotationSet.forUser(userService.getInitialCasUser()));
 
         return dataOwners;
     }

--- a/inception/inception-pivot/src/test/java/de/tudarmstadt/ukp/inception/pivot/report/ReportServiceImplIntegrationTest.java
+++ b/inception/inception-pivot/src/test/java/de/tudarmstadt/ukp/inception/pivot/report/ReportServiceImplIntegrationTest.java
@@ -57,7 +57,7 @@ class ReportServiceImplIntegrationTest
     void setUp()
     {
         sut = new ReportServiceImpl(testEntityManager.getEntityManager(), null, null, null, null,
-                null, null);
+                null);
         project = createProject("Project A");
         otherProject = createProject("Project B");
     }

--- a/inception/inception-pivot/src/test/java/de/tudarmstadt/ukp/inception/pivot/report/ReportServiceImplTranslationTest.java
+++ b/inception/inception-pivot/src/test/java/de/tudarmstadt/ukp/inception/pivot/report/ReportServiceImplTranslationTest.java
@@ -19,7 +19,6 @@ package de.tudarmstadt.ukp.inception.pivot.report;
 
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState.FINISHED;
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState.IN_PROGRESS;
-import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.ANNOTATOR;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -28,7 +27,6 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
-import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,8 +36,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
-import de.tudarmstadt.ukp.clarin.webanno.model.ProjectUserPermissions;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
@@ -55,7 +53,6 @@ import de.tudarmstadt.ukp.inception.pivot.api.extractor.LayerBinding;
 import de.tudarmstadt.ukp.inception.pivot.api.report.AggregatorDef;
 import de.tudarmstadt.ukp.inception.pivot.api.report.ExtractorDef;
 import de.tudarmstadt.ukp.inception.pivot.api.report.ReportDef;
-import de.tudarmstadt.ukp.inception.project.api.ProjectService;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.support.logging.LogMessage;
 
@@ -65,7 +62,6 @@ class ReportServiceImplTranslationTest
     private @Mock AnnotationSchemaService schemaService;
     private @Mock ExtractorSupportRegistry extractorRegistry;
     private @Mock AggregatorSupportRegistry aggregatorRegistry;
-    private @Mock ProjectService projectService;
     private @Mock DocumentService documentService;
     private @Mock UserDao userService;
 
@@ -87,7 +83,7 @@ class ReportServiceImplTranslationTest
     void setUp()
     {
         sut = new ReportServiceImpl(null, schemaService, extractorRegistry, aggregatorRegistry,
-                projectService, documentService, userService);
+                documentService, userService);
 
         project = new Project();
         project.setName("p");
@@ -124,8 +120,7 @@ class ReportServiceImplTranslationTest
         decl.setRowExtractors(asList( //
                 new ExtractorDecl("documentName", "Token :: <doc>", new LayerBinding(tokenLayer)), //
                 new ExtractorDecl("featureValue", "Token.POS", new FeatureBinding(posFeature))));
-        decl.getAnnotators()
-                .add(new ProjectUserPermissions(project, "alice", alice, Set.of(ANNOTATOR)));
+        decl.getAnnotators().add(AnnotationSet.forUser(alice));
         decl.getDocuments().add(doc1);
         decl.getStates().add(FINISHED);
 
@@ -206,7 +201,7 @@ class ReportServiceImplTranslationTest
                 .containsExactly("documentName", "featureValue");
         assertThat(resolved.decl().getRowExtractors()).extracting(ExtractorDecl::binding) //
                 .containsExactly(new LayerBinding(tokenLayer), new FeatureBinding(posFeature));
-        assertThat(resolved.decl().getAnnotators()).extracting(ProjectUserPermissions::getUsername) //
+        assertThat(resolved.decl().getAnnotators()).extracting(AnnotationSet::id) //
                 .containsExactly("alice");
         assertThat(resolved.decl().getDocuments()).containsExactly(doc1);
         assertThat(resolved.decl().getStates()).containsExactly(IN_PROGRESS);
@@ -311,7 +306,7 @@ class ReportServiceImplTranslationTest
         var resolved = sut.resolve(def, project);
 
         assertThat(resolved.problems()).isEmpty();
-        assertThat(resolved.decl().getAnnotators()).extracting(ProjectUserPermissions::getUsername) //
+        assertThat(resolved.decl().getAnnotators()).extracting(AnnotationSet::id) //
                 .containsExactly("CURATION_USER", "INITIAL_CAS");
     }
 
@@ -368,11 +363,11 @@ class ReportServiceImplTranslationTest
 
     private void givenProjectDataOwners(Project aProject, User... aUsers)
     {
-        var perms = new java.util.ArrayList<ProjectUserPermissions>();
+        var dataOwners = new java.util.ArrayList<AnnotationSet>();
         for (var u : aUsers) {
-            perms.add(new ProjectUserPermissions(aProject, u.getUsername(), u, Set.of(ANNOTATOR)));
+            dataOwners.add(AnnotationSet.forUser(u));
         }
-        lenient().when(projectService.listProjectUserPermissions(aProject)).thenReturn(perms);
+        lenient().when(documentService.listDataOwners(aProject)).thenReturn(dataOwners);
         lenient().when(userService.getCurationUser()).thenReturn(curationUser);
         lenient().when(userService.getInitialCasUser()).thenReturn(initialCasUser);
     }

--- a/inception/inception-project-export/src/test/java/de/tudarmstadt/ukp/inception/project/export/AnnotationDocumentsExporterTest.java
+++ b/inception/inception-project-export/src/test/java/de/tudarmstadt/ukp/inception/project/export/AnnotationDocumentsExporterTest.java
@@ -17,8 +17,10 @@
  */
 package de.tudarmstadt.ukp.inception.project.export;
 
+import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.CURATION_USER;
 import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.INITIAL_CAS_PSEUDO_USER;
 import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toList;
 import static org.apache.commons.io.FilenameUtils.removeExtension;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -27,6 +29,8 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.ZipFile;
@@ -53,7 +57,6 @@ import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
-import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.inception.annotation.storage.CasStorageServiceImpl;
 import de.tudarmstadt.ukp.inception.annotation.storage.config.CasStorageBackupProperties;
 import de.tudarmstadt.ukp.inception.annotation.storage.config.CasStorageCachePropertiesImpl;
@@ -126,15 +129,13 @@ public class AnnotationDocumentsExporterTest
     void thatExportingAndImportingAgainWorks() throws Exception
     {
         var annDocs = annotationDocuments(sourceProject);
-        when(documentService.listAnnotationDocuments(any(Project.class))) //
+        when(documentService.listAllAnnotationDocuments(any(Project.class))) //
                 .thenReturn(annDocs);
         var srcDocs = sourceDocuments(sourceProject);
         when(documentService.listSourceDocuments(any(Project.class))) //
                 .thenReturn(srcDocs);
         when(documentService.existsCas(any())) //
                 .thenReturn(true);
-        when(userService.get(any(String.class)))
-                .thenAnswer(invocation -> new User(invocation.getArgument(0)));
 
         var exportFile = new File(tempFolder, "export.zip");
 
@@ -173,6 +174,109 @@ public class AnnotationDocumentsExporterTest
                         "glob:**/project/2/document/9/annotation/someuser.ser");
     }
 
+    /**
+     * Data of a former annotator (still has an account but no project permission) must still be
+     * exported and imported. Permission-independence of {@code listAllAnnotationDocuments} itself
+     * is covered by {@code DocumentServiceImplDatabaseTest}.
+     */
+    @Test
+    void thatDataOfUserWithoutProjectPermissionIsExportedAndImported() throws Exception
+    {
+        var srcDoc = sourceDocument(1, sourceProject);
+        var annDoc = AnnotationDocument.builder() //
+                .withId(1l) //
+                .withUser("former") //
+                .forDocument(srcDoc) //
+                .withState(AnnotationDocumentState.IN_PROGRESS) //
+                .build();
+
+        var imported = runExportThenImport(asList(srcDoc), asList(annDoc));
+
+        assertThat(imported).extracting(AnnotationDocument::getUser).contains("former");
+        assertThat(serFileNames()).contains("former.ser");
+    }
+
+    /**
+     * Data of a deleted-account user must still be exported and imported - exercises the removal of
+     * the {@code userRepository.get(user) != null} guard on the CAS export.
+     */
+    @Test
+    void thatDataOfNonExistentUserIsExportedAndImported() throws Exception
+    {
+        var srcDoc = sourceDocument(1, sourceProject);
+        var annDoc = AnnotationDocument.builder() //
+                .withId(1l) //
+                .withUser("ghost") //
+                .forDocument(srcDoc) //
+                .withState(AnnotationDocumentState.FINISHED) //
+                .build();
+
+        // userService.get(...) is intentionally not stubbed - unstubbed returns null, modelling the
+        // deleted account; the exporter must not depend on the account existing.
+        var imported = runExportThenImport(asList(srcDoc), asList(annDoc));
+
+        assertThat(imported).extracting(AnnotationDocument::getUser).contains("ghost");
+        assertThat(serFileNames()).contains("ghost.ser");
+    }
+
+    /**
+     * The curation CAS has its own exporter ({@code curation_ser}), so a CURATION_USER row must
+     * contribute its metadata (we own the AnnotationDocument table) but its CAS must not be written
+     * into {@code annotation_ser}.
+     */
+    @Test
+    void thatCurationPseudoUserCasIsNotExportedButItsMetadataIs() throws Exception
+    {
+        var srcDoc = sourceDocument(1, sourceProject);
+        var annDoc = AnnotationDocument.builder() //
+                .withId(1l) //
+                .withUser("someuser") //
+                .forDocument(srcDoc) //
+                .withState(AnnotationDocumentState.IN_PROGRESS) //
+                .build();
+        var curationDoc = AnnotationDocument.builder() //
+                .withId(2l) //
+                .withUser(CURATION_USER) //
+                .forDocument(srcDoc) //
+                .withState(AnnotationDocumentState.IN_PROGRESS) //
+                .build();
+
+        var imported = runExportThenImport(asList(srcDoc), asList(annDoc, curationDoc));
+
+        // Metadata for the curation row is owned by this exporter and round-trips...
+        assertThat(imported).extracting(AnnotationDocument::getUser) //
+                .contains("someuser", CURATION_USER);
+        // ...but the curation CAS must NOT be emitted here (only the regular user's is).
+        assertThat(serFileNames()) //
+                .contains("someuser.ser") //
+                .doesNotContain(CURATION_USER + ".ser");
+    }
+
+    /**
+     * A locked (IGNORE) document that has a CAS is real work set aside - both its state metadata
+     * and its CAS must round-trip. A locked document without a CAS stays excluded via
+     * {@code existsCas}.
+     */
+    @Test
+    void thatLockedDocumentWithDataIsExportedAndImported() throws Exception
+    {
+        var srcDoc = sourceDocument(1, sourceProject);
+        var annDoc = AnnotationDocument.builder() //
+                .withId(1l) //
+                .withUser("lockeduser") //
+                .forDocument(srcDoc) //
+                .withState(AnnotationDocumentState.IGNORE) //
+                .build();
+
+        var imported = runExportThenImport(asList(srcDoc), asList(annDoc));
+
+        assertThat(imported).anySatisfy(ad -> {
+            assertThat(ad.getUser()).isEqualTo("lockeduser");
+            assertThat(ad.getState()).isEqualTo(AnnotationDocumentState.IGNORE);
+        });
+        assertThat(serFileNames()).contains("lockeduser.ser");
+    }
+
     @Test
     void thatImportingAnnotationProjectWorks_3_6_1() throws Exception
     {
@@ -204,6 +308,46 @@ public class AnnotationDocumentsExporterTest
                 .containsExactlyInAnyOrder("example_sentence.txt", "example_sentence.txt");
         assertThat(imported).extracting(Pair::getValue)
                 .containsExactlyInAnyOrder(INITIAL_CAS_PSEUDO_USER, "admin");
+    }
+
+    private List<AnnotationDocument> runExportThenImport(List<SourceDocument> aSrcDocs,
+            List<AnnotationDocument> aAnnDocs)
+        throws Exception
+    {
+        when(documentService.listAllAnnotationDocuments(any(Project.class))).thenReturn(aAnnDocs);
+        when(documentService.listSourceDocuments(any(Project.class))).thenReturn(aSrcDocs);
+        when(documentService.existsCas(any())).thenReturn(true);
+
+        var exportFile = new File(tempFolder, "export.zip");
+        var exportRequest = FullProjectExportRequest.builder().withProject(sourceProject).build();
+        var monitor = new ProjectExportTaskMonitor(sourceProject, null, "test",
+                exportRequest.getFilenamePrefix());
+        var exportedProject = new ExportedProject();
+        try (var zos = new ZipOutputStream(new FileOutputStream(exportFile))) {
+            sut.exportData(exportRequest, monitor, exportedProject, zos);
+        }
+
+        reset(documentService);
+        when(documentService.listSourceDocuments(any(Project.class))).thenReturn(aSrcDocs);
+        var captor = ArgumentCaptor.forClass(AnnotationDocument.class);
+        when(documentService.createOrUpdateAnnotationDocument(captor.capture())).thenReturn(null);
+
+        var importRequest = ProjectImportRequest.builder().build();
+        try (var zipFile = new ZipFile(exportFile)) {
+            sut.importData(importRequest, targetProject, exportedProject, zipFile);
+        }
+
+        return captor.getAllValues();
+    }
+
+    private List<String> serFileNames() throws IOException
+    {
+        try (var stream = Files.walk(tempFolder.toPath())) {
+            return stream.filter(Files::isRegularFile) //
+                    .map(p -> p.getFileName().toString()) //
+                    .filter(n -> n.endsWith(".ser")) //
+                    .collect(toList());
+        }
     }
 
     private List<AnnotationDocument> annotationDocuments(Project aProject)

--- a/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/exporters/AnnotationDocumentExporter.java
+++ b/inception/inception-schema/src/main/java/de/tudarmstadt/ukp/inception/schema/exporters/AnnotationDocumentExporter.java
@@ -25,6 +25,7 @@ import static de.tudarmstadt.ukp.clarin.webanno.security.UserDaoImpl.RESERVED_US
 import static de.tudarmstadt.ukp.inception.project.api.ProjectService.ANNOTATION_FOLDER;
 import static de.tudarmstadt.ukp.inception.project.api.ProjectService.DOCUMENT_FOLDER;
 import static de.tudarmstadt.ukp.inception.project.api.ProjectService.PROJECT_FOLDER;
+import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.CURATION_USER;
 import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.INITIAL_CAS_PSEUDO_USER;
 import static de.tudarmstadt.ukp.inception.support.io.FastIOUtils.copy;
 import static java.lang.Math.ceil;
@@ -61,9 +62,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import com.github.benmanes.caffeine.cache.Caffeine;
-import com.github.benmanes.caffeine.cache.LoadingCache;
-
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasStorageService;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.DocumentImportExportService;
@@ -81,7 +79,6 @@ import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
-import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.documents.api.RepositoryProperties;
 import de.tudarmstadt.ukp.inception.documents.exporters.SourceDocumentExporter;
@@ -149,7 +146,14 @@ public class AnnotationDocumentExporter
     {
         var annotationDocuments = new ArrayList<ExportedAnnotationDocument>();
 
-        for (var annotationDocument : documentService.listAnnotationDocuments(aProject)) {
+        // Unfiltered list so the data of former annotators (no current role, or deleted account) is
+        // preserved. Keep the curation pseudo user (we own the AnnotationDocument table; its CAS is
+        // exported by the CuratedDocumentsExporter); skip the initial-CAS pseudo user.
+        for (var annotationDocument : documentService.listAllAnnotationDocuments(aProject)) {
+            if (INITIAL_CAS_PSEUDO_USER.equals(annotationDocument.getUser())) {
+                continue;
+            }
+
             var exAnnotationDocument = new ExportedAnnotationDocument();
             exAnnotationDocument.setName(annotationDocument.getDocument().getName());
             exAnnotationDocument.setState(annotationDocument.getState());
@@ -184,12 +188,8 @@ public class AnnotationDocumentExporter
         // Create a map containing the annotation documents for each source document. Doing this
         // as one DB access before the main processing to avoid hammering the DB in the loops
         // below.
-        var srcToAnnIdx = documentService.listAnnotationDocuments(project).stream()
+        var srcToAnnIdx = documentService.listAllAnnotationDocuments(project).stream()
                 .collect(groupingBy(doc -> doc.getDocument(), toList()));
-
-        // Cache user lookups to avoid constantly hitting the database
-        LoadingCache<String, User> usersCache = Caffeine.newBuilder()
-                .build(key -> userRepository.get(key));
 
         for (var srcDoc : documents) {
             // check if the export has been cancelled
@@ -247,12 +247,18 @@ public class AnnotationDocumentExporter
                 // Export annotations from regular users
                 for (var annDoc : srcToAnnIdx.computeIfAbsent(srcDoc, key -> emptyList())) {
 
-                    // copy annotation document only for existing users and the state of the
-                    // annotation document is not NEW/IGNORE
-                    if (usersCache.get(annDoc.getUser()) != null
-                            && documentService.existsCas(annDoc)
-                            && !annDoc.getState().equals(AnnotationDocumentState.NEW)
-                            && !annDoc.getState().equals(AnnotationDocumentState.IGNORE)) {
+                    // Curation CAS is exported by the CuratedDocumentsExporter, the initial CAS
+                    // explicitly above - skip them here to avoid duplicates under annotation_ser.
+                    if (CURATION_USER.equals(annDoc.getUser())
+                            || INITIAL_CAS_PSEUDO_USER.equals(annDoc.getUser())) {
+                        continue;
+                    }
+
+                    // Export the CAS of any owner that has one - including former annotators (whose
+                    // account may no longer exist) and locked documents worked on before locking.
+                    // Gate on existsCas (skips locked-but-never-opened) and exclude only NEW.
+                    if (documentService.existsCas(annDoc)
+                            && !annDoc.getState().equals(AnnotationDocumentState.NEW)) {
 
                         exportCas(aRequest, aStage, bulkOperationContext, srcDoc,
                                 annDoc.getAnnotationSet());

--- a/inception/inception-schema/src/test/java/de/tudarmstadt/ukp/inception/documents/service/DocumentServiceImplCasStorageTest.java
+++ b/inception/inception-schema/src/test/java/de/tudarmstadt/ukp/inception/documents/service/DocumentServiceImplCasStorageTest.java
@@ -69,6 +69,13 @@ import de.tudarmstadt.ukp.inception.project.api.ProjectService;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.config.AnnotationSchemaServiceAutoConfiguration;
 
+/**
+ * Integration-level tests for {@code DocumentServiceImpl} that exercise CAS storage and
+ * import/export. These need autoconfigurations from modules that depend on {@code inception-
+ * documents} (CAS storage, schema), so the test lives here rather than in the documents module. The
+ * purely database-backed query/state tests live in the {@code DocumentServiceImplDatabaseTest} in
+ * the {@code inception-documents} module.
+ */
 @EnableAutoConfiguration
 @DataJpaTest(showSql = false, //
         properties = { //
@@ -86,7 +93,7 @@ import de.tudarmstadt.ukp.inception.schema.config.AnnotationSchemaServiceAutoCon
         RepositoryAutoConfiguration.class, //
         AnnotationSchemaServiceAutoConfiguration.class, //
         SecurityAutoConfiguration.class })
-public class DocumentServiceImplDatabaseTest
+public class DocumentServiceImplCasStorageTest
 {
     static @TempDir Path tempFolder;
 
@@ -99,7 +106,6 @@ public class DocumentServiceImplDatabaseTest
     private @Autowired ProjectService projectService;
     private @Autowired UserDao userRepository;
     private @Autowired DocumentService sut;
-    private @Autowired jakarta.persistence.EntityManager entityManager;
 
     private User annotator1;
     private Project project;
@@ -111,112 +117,6 @@ public class DocumentServiceImplDatabaseTest
 
         project = projectService.createProject(new Project("project"));
         projectService.assignRole(project, annotator1, ANNOTATOR);
-    }
-
-    @Test
-    public void testThatAnnotationDocumentsForNonExistingUserAreNotReturned() throws Exception
-    {
-        var doc = sut.createSourceDocument(new SourceDocument("doc", project, "text"));
-
-        var ann = sut.createOrUpdateAnnotationDocument(
-                new AnnotationDocument(annotator1.getUsername(), doc));
-
-        assertThat(sut.listAnnotationDocuments(doc))
-                .as("As long as the user exists, the annotation document must be found")
-                .containsExactly(ann);
-
-        userRepository.delete(annotator1);
-
-        assertThat(sut.listAnnotationDocuments(doc))
-                .as("When the user is deleted, the document must no longer be found") //
-                .isEmpty();
-    }
-
-    @Test
-    public void thatCreateOrGetAnnotationDocumentsWithAnnotationSetsCreatesDocuments()
-        throws Exception
-    {
-        var doc = sut.createSourceDocument(new SourceDocument("doc1", project, "text"));
-
-        var set1 = AnnotationSet.forUser(annotator1);
-        var set2 = AnnotationSet.forTest("other");
-
-        var annDocs = sut.createOrGetAnnotationDocuments(doc, asList(set1, set2));
-
-        assertThat(annDocs).hasSize(2);
-        assertThat(sut.getAnnotationDocument(doc, set1)).isNotNull();
-        assertThat(sut.getAnnotationDocument(doc, set2)).isNotNull();
-    }
-
-    @Test
-    public void thatCreateOrGetAnnotationDocumentsForMultipleDocumentsCreatesDocuments()
-        throws Exception
-    {
-        var doc1 = sut.createSourceDocument(new SourceDocument("doc1.txt", project, "text"));
-        var doc2 = sut.createSourceDocument(new SourceDocument("doc2.txt", project, "text"));
-
-        var set = AnnotationSet.forUser(annotator1);
-
-        var annDocs = sut.createOrGetAnnotationDocuments(asList(doc1, doc2), set);
-
-        assertThat(annDocs).hasSize(2);
-        assertThat(sut.getAnnotationDocument(doc1, set)).isNotNull();
-        assertThat(sut.getAnnotationDocument(doc2, set)).isNotNull();
-    }
-
-    @Test
-    public void thatListAnnotationDocumentsProjectAndSetWorks() throws Exception
-    {
-        var doc1 = sut.createSourceDocument(new SourceDocument("doc1", project, "text"));
-        var doc2 = sut.createSourceDocument(new SourceDocument("doc2", project, "text"));
-
-        var set = AnnotationSet.forUser(annotator1);
-
-        sut.createOrGetAnnotationDocument(doc1, set);
-        sut.createOrGetAnnotationDocument(doc2, set);
-
-        var docs = sut.listAnnotationDocuments(project, set);
-        assertThat(docs).isNotEmpty();
-        assertThat(docs).allMatch(a -> a.getAnnotationSet().equals(set));
-    }
-
-    @Test
-    public void thatListAllDocumentsProjectAndSetReturnsNullForMissingDocs() throws Exception
-    {
-        var doc1 = sut.createSourceDocument(new SourceDocument("doc1", project, "text"));
-        var doc2 = sut.createSourceDocument(new SourceDocument("doc2", project, "text"));
-
-        var set = AnnotationSet.forUser(annotator1);
-
-        var ann = sut.createOrGetAnnotationDocument(doc1, set);
-
-        var map = sut.listAllDocuments(project, set);
-        assertThat(map).containsEntry(doc1, ann);
-        assertThat(map).containsKey(doc2);
-        assertThat(map.get(doc2)).isNull();
-    }
-
-    @Test
-    public void thatExistsAnnotationDocumentWithSetWorks() throws Exception
-    {
-        var doc = sut.createSourceDocument(new SourceDocument("docx", project, "text"));
-        var set = AnnotationSet.forUser(annotator1);
-
-        assertThat(sut.existsAnnotationDocument(doc, set)).isFalse();
-        sut.createOrGetAnnotationDocument(doc, set);
-        assertThat(sut.existsAnnotationDocument(doc, set)).isTrue();
-    }
-
-    @Test
-    public void thatExistsSourceDocumentWorks() throws Exception
-    {
-        var doc1 = sut.createSourceDocument(new SourceDocument("s1", project, "text"));
-        var doc2 = sut.createSourceDocument(new SourceDocument("s2", project, "text"));
-
-        assertThat(sut.existsSourceDocument(project)).isTrue();
-        assertThat(sut.existsSourceDocument(project, doc1.getName())).isTrue();
-        assertThat(sut.existsSourceDocument(project, doc2.getName())).isTrue();
-        assertThat(sut.existsSourceDocument(project, "not-found.txt")).isFalse();
     }
 
     @Test
@@ -347,33 +247,6 @@ public class DocumentServiceImplDatabaseTest
     }
 
     @Test
-    public void thatListFinishedAnnotationDocumentsAndExistsWorks() throws Exception
-    {
-        var doc = sut.createSourceDocument(new SourceDocument("fin.txt", project, "text"));
-        var set = AnnotationSet.forUser(annotator1);
-        var ann = sut.createOrGetAnnotationDocument(doc, set);
-
-        sut.setAnnotationDocumentState(ann, AnnotationDocumentState.FINISHED);
-
-        assertThat(sut.existsFinishedAnnotation(doc)).isTrue();
-        assertThat(sut.listFinishedAnnotationDocuments(doc)).isNotEmpty();
-        assertThat(sut.existsFinishedAnnotation(project)).isTrue();
-        assertThat(sut.listFinishedAnnotationDocuments(project)).isNotEmpty();
-    }
-
-    @Test
-    public void thatListSupportedSourceDocumentsFiltersUnsupported() throws Exception
-    {
-        var d1 = sut
-                .createSourceDocument(new SourceDocument("f1.txt", project, TextFormatSupport.ID));
-        var d2 = sut.createSourceDocument(new SourceDocument("f2.txt", project, "unsupported"));
-
-        var res = sut.listSupportedSourceDocuments(project);
-        assertThat(res).contains(d1);
-        assertThat(res).doesNotContain(d2);
-    }
-
-    @Test
     public void thatRemoveSourceDocumentRemovesDocAndAnnDocs() throws Exception
     {
         try (var session = CasStorageSession.open()) {
@@ -387,97 +260,6 @@ public class DocumentServiceImplDatabaseTest
             assertThat(sut.listSourceDocuments(project)).doesNotContain(doc);
             assertThat(sut.listAllAnnotationDocuments(doc)).isEmpty();
         }
-    }
-
-    @Test
-    public void thatUpdateStateUpdatedDirectlyWorks() throws Exception
-    {
-        var doc = sut
-                .createSourceDocument(new SourceDocument("ust.txt", project, TextFormatSupport.ID));
-        var set = AnnotationSet.forUser(annotator1);
-        var ann = sut.createOrGetAnnotationDocument(doc, set);
-
-        var d = new java.util.Date(1620000000000L);
-        sut.updateAnnotationDocumentStateUpdatedDirectly(ann.getId(), d);
-        // Flush pending changes, evict the persistence context and re-fetch to ensure we
-        // read the value updated directly in the DB
-        entityManager.flush();
-        entityManager.clear();
-        var annReloaded = sut.getAnnotationDocument(doc, set);
-        assertThat(annReloaded.getStateUpdated().getTime()).isEqualTo(d.getTime());
-
-        var src = sut.getSourceDocument(project, "ust.txt");
-        sut.updateSourceDocumentStateUpdatedDirectly(src.getId(), d);
-        // Flush pending changes, evict the persistence context and re-fetch to ensure we
-        // read the value updated directly in the DB
-        entityManager.flush();
-        entityManager.clear();
-        var srcReloaded = sut.getSourceDocument(project, "ust.txt");
-        assertThat(srcReloaded.getStateUpdated().getTime()).isEqualTo(d.getTime());
-    }
-
-    @Test
-    public void thatExplicitUserActionsSetAnnotatorState()
-    {
-        var doc = sut.createSourceDocument(new SourceDocument("doc", project, "text"));
-
-        var ann = sut.createOrUpdateAnnotationDocument(
-                new AnnotationDocument(annotator1.getUsername(), doc));
-
-        sut.setAnnotationDocumentState(ann, AnnotationDocumentState.IGNORE);
-        assertThat(ann.getState()) //
-                .as("Implicit actions update the effective state") //
-                .isEqualTo(AnnotationDocumentState.IGNORE);
-        assertThat(ann.getAnnotatorState())
-                .as("Implicit actions cause the annotator state not to be set") //
-                .isNull();
-
-        sut.setAnnotationDocumentState(ann, AnnotationDocumentState.FINISHED,
-                EXPLICIT_ANNOTATOR_USER_ACTION);
-        assertThat(ann.getState()) //
-                .as("Explicit user actions update the effective state") //
-                .isEqualTo(AnnotationDocumentState.FINISHED);
-        assertThat(ann.getAnnotatorState())
-                .as("Explicit user actions cause the annotator state to be set")
-                .isEqualTo(AnnotationDocumentState.FINISHED);
-
-        sut.setAnnotationDocumentState(ann, AnnotationDocumentState.NEW);
-        assertThat(ann.getAnnotatorState()) //
-                .as("Resetting the document clears the annotator state") //
-                .isNull();
-        assertThat(ann.getState()) //
-                .as("Implicit actions update the effective state") //
-                .isEqualTo(AnnotationDocumentState.NEW);
-
-        sut.setAnnotationDocumentState(ann, AnnotationDocumentState.IN_PROGRESS,
-                EXPLICIT_ANNOTATOR_USER_ACTION);
-        sut.setAnnotationDocumentState(ann, AnnotationDocumentState.FINISHED);
-        assertThat(ann.getAnnotatorState())
-                .as("Implicit actions cause the annotator state not to be changed") //
-                .isEqualTo(AnnotationDocumentState.IN_PROGRESS);
-        assertThat(ann.getState()) //
-                .as("Implicit actions update the effective state") //
-                .isEqualTo(AnnotationDocumentState.FINISHED);
-
-        sut.setAnnotationDocumentState(ann, AnnotationDocumentState.FINISHED,
-                EXPLICIT_ANNOTATOR_USER_ACTION);
-        sut.setAnnotationDocumentState(ann, AnnotationDocumentState.IN_PROGRESS);
-        assertThat(ann.getAnnotatorState())
-                .as("Manager send document back to annotation updates annotator state") //
-                .isEqualTo(AnnotationDocumentState.IN_PROGRESS);
-        assertThat(ann.getState()) //
-                .as("Manager send document back to annotation updates effective state") //
-                .isEqualTo(AnnotationDocumentState.IN_PROGRESS);
-
-        sut.setAnnotationDocumentState(ann, AnnotationDocumentState.IN_PROGRESS,
-                EXPLICIT_ANNOTATOR_USER_ACTION);
-        sut.setAnnotationDocumentState(ann, AnnotationDocumentState.IGNORE);
-        assertThat(ann.getAnnotatorState())
-                .as("Manager locking document does not change the annotator state") //
-                .isEqualTo(AnnotationDocumentState.IN_PROGRESS);
-        assertThat(ann.getState()) //
-                .as("Manager locking document updates effective state") //
-                .isEqualTo(AnnotationDocumentState.IGNORE);
     }
 
     @Test
@@ -499,6 +281,37 @@ public class DocumentServiceImplDatabaseTest
 
         try (var session = CasStorageSession.open()) {
             sut.resetAnnotationCas(doc, annotator1);
+        }
+
+        assertThat(ann.getState()).as("Resetting CAS sets effective state to NEW") //
+                .isEqualTo(AnnotationDocumentState.NEW);
+        assertThat(ann.getAnnotatorState()) //
+                .as("Resetting CAS clears the annotator state") //
+                .isNull();
+    }
+
+    @Test
+    public void thatResettingWorksForDataOwnerWithoutUserAccount() throws Exception
+    {
+        // A former annotator whose user account no longer exists, but who left annotation data
+        // behind. The AnnotationSet overload must reset their data without resolving a User.
+        var formerOwner = AnnotationSet.forUser("ghost");
+
+        var doc = sut
+                .createSourceDocument(new SourceDocument("doc.txt", project, TextFormatSupport.ID));
+
+        var ann = sut.createOrUpdateAnnotationDocument(new AnnotationDocument("ghost", doc));
+
+        try (var session = CasStorageSession.open()) {
+            sut.uploadSourceDocument(toInputStream("This is a test.", UTF_8), doc);
+        }
+
+        sut.setAnnotationDocumentState(ann, AnnotationDocumentState.IN_PROGRESS,
+                EXPLICIT_ANNOTATOR_USER_ACTION);
+        sut.setAnnotationDocumentState(ann, AnnotationDocumentState.IGNORE);
+
+        try (var session = CasStorageSession.open()) {
+            sut.resetAnnotationCas(doc, formerOwner);
         }
 
         assertThat(ann.getState()).as("Resetting CAS sets effective state to NEW") //

--- a/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/ReindexTask.java
+++ b/inception/inception-search-core/src/main/java/de/tudarmstadt/ukp/inception/search/ReindexTask.java
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
-import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.preferences.PreferencesService;
 import de.tudarmstadt.ukp.inception.project.api.ProjectService;
@@ -124,13 +124,16 @@ public class ReindexTask
                 // We can ignore this since we are rebuilding the index already anyway
             }
 
-            var usersWithPermissions = projectService.listUsersWithAnyRoleInProject(project)
-                    .stream() //
-                    .map(User::getUsername) //
+            // Index the data of all data owners - including former annotators (removed from the
+            // project, role changed, or account deleted) - so their annotations remain searchable.
+            // listDataOwners excludes the curation/initial pseudo users (indexed separately below)
+            // and owners without actual data.
+            var dataOwners = documentService.listDataOwners(project).stream() //
+                    .map(AnnotationSet::id) //
                     .collect(toUnmodifiableSet());
             var sourceDocuments = documentService.listSupportedSourceDocuments(project);
-            var annotationDocuments = documentService.listAnnotationDocuments(project).stream()
-                    .filter(annDoc -> usersWithPermissions.contains(annDoc.getUser())) //
+            var annotationDocuments = documentService.listAllAnnotationDocuments(project).stream()
+                    .filter(annDoc -> dataOwners.contains(annDoc.getUser())) //
                     .filter(annDoc -> sourceDocuments.contains(annDoc.getDocument())) //
                     .toList();
 

--- a/inception/inception-search-mtas/src/test/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndexTest.java
+++ b/inception/inception-search-mtas/src/test/java/de/tudarmstadt/ukp/inception/search/index/mtas/MtasDocumentIndexTest.java
@@ -17,7 +17,9 @@
  */
 package de.tudarmstadt.ukp.inception.search.index.mtas;
 
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState.IN_PROGRESS;
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet.CURATION_SET;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSetMarker.FORMER_ANNOTATOR;
 import static de.tudarmstadt.ukp.inception.annotation.storage.CasMetadataUtils.getInternalTypeSystem;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
@@ -78,6 +80,7 @@ import de.tudarmstadt.ukp.clarin.webanno.constraints.config.ConstraintsServiceAu
 import de.tudarmstadt.ukp.clarin.webanno.diag.config.CasDoctorAutoConfiguration;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
+import de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.project.config.ProjectServiceAutoConfiguration;
@@ -871,6 +874,70 @@ class MtasDocumentIndexTest
                 .isEqualTo(MtasDocumentIndex.CURRENT_SCHEMA_VERSION);
     }
 
+    /**
+     * A full re-index must retain the data of former annotators so it stays searchable.
+     * <p>
+     * We assert by counting live Lucene rows stamped {@code FIELD_USER=<former user>} via a
+     * {@link DirectoryReader}, not via {@code query()} (owner-scoped, so it never surfaces former
+     * data) nor {@code getAnnotationCountsPerDocument} (falls back to the INITIAL_CAS row, so it
+     * reads {@code > 0} even if the data was dropped). The {@code query()} before each read forces
+     * the deferred commit synchronously ({@code ensureAllIsCommitted}), so there is no commit race.
+     */
+    @Test
+    void thatFormerAnnotatorDataRemainsSearchableAfterReindex() throws Exception
+    {
+        var project = new Project("former-annotator-reindex");
+        createProject(project);
+
+        var annotator = userRepository.exists("former") ? userRepository.get("former")
+                : userRepository.create(new User("former", Role.ROLE_USER));
+
+        var doc = new SourceDocument("doc", project, "text");
+        uploadAndIndexDocument(Pair.of(doc, "The capital of Galicia is Santiago de Compostela ."));
+        var persistedDoc = documentService.getSourceDocument(project, doc.getName());
+
+        // While still a current annotator, the user produces annotation data which gets indexed
+        // incrementally.
+        projectService.assignRole(project, annotator, PermissionLevel.ANNOTATOR);
+        annotateDocument(project, annotator, persistedDoc);
+
+        // Mark the document IN_PROGRESS so it counts as actual data of the annotator: a NEW
+        // document is treated as "no data" and would be ignored by both listDataOwners and the
+        // reindex (which is the realistic state once an annotator has actually worked on it).
+        documentService.setAnnotationDocumentState(
+                documentService.getAnnotationDocument(persistedDoc, annotator), IN_PROGRESS);
+
+        // Force the deferred commit, then verify the annotator's own row is in the index.
+        searchService.query(user, project, "Galicia");
+        assertThat(countLiveRowsByUser(project, annotator.getUsername())) //
+                .as("annotator's own row is indexed while the user holds the annotator role") //
+                .isGreaterThan(0);
+
+        // The user is removed from the project -> they become a former annotator, i.e. a data
+        // owner who is no longer a current annotator but still has data in the project.
+        projectService.revokeRole(project, annotator, PermissionLevel.ANNOTATOR);
+        assertThat(documentService.listDataOwners(project)) //
+                .as("user is recognized as a former data owner after losing the annotator role") //
+                .anyMatch(set -> set.id().equals(annotator.getUsername())
+                        && set.hasAnyMarkers(FORMER_ANNOTATOR));
+
+        // A full re-index clears the index and rebuilds it from scratch. The previous,
+        // permission-filtered ReindexTask would have dropped the former annotator's data here.
+        searchService.enqueueReindexTask(project, user, "test former annotator reindex");
+        await("re-index to complete") //
+                .atMost(60, SECONDS) //
+                .pollInterval(200, MILLISECONDS) //
+                .until(() -> searchService.isIndexValid(project)
+                        && searchService.getIndexProgress(project).isEmpty());
+
+        // Force the deferred commit again, then verify the former annotator's row survived the
+        // rebuild.
+        searchService.query(user, project, "Galicia");
+        assertThat(countLiveRowsByUser(project, annotator.getUsername())) //
+                .as("former annotator's row remains in the index after a full re-index") //
+                .isGreaterThan(0);
+    }
+
     @SuppressWarnings("unchecked")
     private Index lookupCachedIndex(Project aProject) throws Exception
     {
@@ -1170,6 +1237,29 @@ class MtasDocumentIndexTest
                         continue;
                     }
                     if (aFieldId.equals(storedFields.document(i).get("id"))) {
+                        count++;
+                    }
+                }
+            }
+            return count;
+        }
+    }
+
+    private int countLiveRowsByUser(Project aProject, String aUser) throws Exception
+    {
+        var indexDir = indexFactory.getIndexDir(aProject);
+        try (var dir = FSDirectory.open(indexDir.toPath());
+                var reader = DirectoryReader.open(dir)) {
+            var count = 0;
+            for (var leafCtx : reader.leaves()) {
+                var leafReader = leafCtx.reader();
+                var storedFields = leafReader.storedFields();
+                var liveBits = leafReader.getLiveDocs();
+                for (var i = 0; i < leafReader.maxDoc(); i++) {
+                    if (liveBits != null && !liveBits.get(i)) {
+                        continue;
+                    }
+                    if (aUser.equals(storedFields.document(i).get("user"))) {
                         count++;
                     }
                 }

--- a/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/model/User.java
+++ b/inception/inception-security/src/main/java/de/tudarmstadt/ukp/clarin/webanno/security/model/User.java
@@ -111,13 +111,6 @@ public class User
         // No-args constructor required for ORM.
     }
 
-    public User(String aName, String aUiName)
-    {
-        username = aName;
-        uiName = aName;
-        enabled = true;
-    }
-
     /**
      * This constructor is mainly intended for testing.
      * 

--- a/inception/inception-ui-agreement/pom.xml
+++ b/inception/inception-ui-agreement/pom.xml
@@ -62,11 +62,6 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
-      <artifactId>inception-ui-project</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-support</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/inception/inception-ui-agreement/src/main/java/de/tudarmstadt/ukp/inception/ui/agreement/page/AgreementPage.java
+++ b/inception/inception-ui-agreement/src/main/java/de/tudarmstadt/ukp/inception/ui/agreement/page/AgreementPage.java
@@ -20,7 +20,6 @@ package de.tudarmstadt.ukp.inception.ui.agreement.page;
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet.CURATION_SET;
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet.INITIAL_SET;
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet.forUser;
-import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.ANNOTATOR;
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.CURATOR;
 import static de.tudarmstadt.ukp.clarin.webanno.model.PermissionLevel.MANAGER;
 import static de.tudarmstadt.ukp.clarin.webanno.ui.core.page.ProjectPageBase.NS_PROJECT;
@@ -84,12 +83,9 @@ import de.tudarmstadt.ukp.clarin.webanno.agreement.task.CalculatePerDocumentAgre
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationFeature;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
-import de.tudarmstadt.ukp.clarin.webanno.model.ProjectUserPermissions;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
-import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.clarin.webanno.ui.core.page.ProjectPageBase;
-import de.tudarmstadt.ukp.clarin.webanno.ui.project.users.ProjectUserPermissionChoiceRenderer;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
 import de.tudarmstadt.ukp.inception.annotation.layer.chain.api.ChainLayerSupport;
@@ -97,7 +93,6 @@ import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.documents.api.RepositoryProperties;
 import de.tudarmstadt.ukp.inception.documents.api.export.CrossDocumentExporter;
 import de.tudarmstadt.ukp.inception.documents.api.export.CrossDocumentExporterRegistry;
-import de.tudarmstadt.ukp.inception.project.api.ProjectService;
 import de.tudarmstadt.ukp.inception.scheduling.SchedulingService;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.support.help.DocLink;
@@ -120,7 +115,6 @@ public class AgreementPage
     private static final String MID_RESULTS = "results";
 
     private @SpringBean DocumentService documentService;
-    private @SpringBean ProjectService projectService;
     private @SpringBean AnnotationSchemaService schemaService;
     private @SpringBean UserDao userRepository;
     private @SpringBean AgreementMeasureSupportRegistry agreementRegistry;
@@ -192,9 +186,9 @@ public class AgreementPage
 
         queue(new CheckBox("compareWithInitialCas").setOutputMarkupId(true));
 
-        var annotatorList = new ListMultipleChoice<ProjectUserPermissions>("annotators");
-        annotatorList.setChoiceRenderer(new ProjectUserPermissionChoiceRenderer());
-        annotatorList.setChoices(listUsersWithPermissions());
+        var annotatorList = new ListMultipleChoice<AnnotationSet>("annotators");
+        annotatorList.setChoiceRenderer(new LambdaChoiceRenderer<>(AnnotationSet::displayName));
+        annotatorList.setChoices(listAnnotators());
         queue(annotatorList);
 
         var documentList = new ListMultipleChoice<SourceDocument>("documents");
@@ -267,12 +261,11 @@ public class AgreementPage
         return ams.isSupportingMoreThanTwoRaters();
     }
 
-    private List<ProjectUserPermissions> listUsersWithPermissions()
+    private List<AnnotationSet> listAnnotators()
     {
-        return projectService.listProjectUserPermissions(getProject()).stream() //
-                .filter(p -> p.getRoles().contains(ANNOTATOR)) //
-                .sorted(comparing(p -> p.getUser().map(User::getUiName).orElse(p.getUsername()))) //
-                .toList();
+        // Current and former annotators - the latter (removed from the project or with a changed
+        // role) are flagged in their display name so their leftover data stays accessible here.
+        return documentService.listDataOwners(getProject());
     }
 
     private List<SourceDocument> listDocuments()
@@ -620,14 +613,10 @@ public class AgreementPage
         }
 
         if (isEmpty(model.annotators)) {
-            listUsersWithPermissions().stream() //
-                    .map(t -> forUser(t.getUsername())) //
-                    .forEach(annotators::add);
+            annotators.addAll(listAnnotators());
         }
         else {
-            model.annotators.stream() //
-                    .map(t -> forUser(t.getUsername())) //
-                    .forEach(annotators::add);
+            annotators.addAll(model.annotators);
         }
 
         return annotators;
@@ -741,7 +730,7 @@ public class AgreementPage
 
         Pair<String, String> measure;
 
-        List<ProjectUserPermissions> annotators = new ArrayList<>();
+        List<AnnotationSet> annotators = new ArrayList<>();
 
         List<SourceDocument> documents = new ArrayList<>();
 

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/open/OpenDocumentDialogPanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/open/OpenDocumentDialogPanel.java
@@ -32,6 +32,7 @@ import static wicket.contrib.input.events.EventType.click;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -229,7 +230,9 @@ public class OpenDocumentDialogPanel
             return users;
         }
 
+        var seen = new HashSet<String>();
         for (var user : projectService.listUsersWithRoleInProject(project, ANNOTATOR)) {
+            seen.add(user.getUsername());
             var du = DecoratedObject.of(user);
             du.setLabel(user.getUiName());
             if (user.equals(sessionOwner)) {
@@ -238,6 +241,26 @@ public class OpenDocumentDialogPanel
             else {
                 users.add(du);
             }
+        }
+
+        // Former annotators: users that left annotation data behind but no longer hold the
+        // ANNOTATOR permission (e.g. removed from the project or assigned a different role). Their
+        // data stays accessible here as long as their account still exists - the display name
+        // already flags them as former annotators. Data owners whose account was deleted entirely
+        // cannot be opened in the editor yet (there is no User to drive the annotation state).
+        for (var dataOwner : documentService.listDataOwners(project)) {
+            if (seen.contains(dataOwner.id())) {
+                continue;
+            }
+
+            var user = userRepository.get(dataOwner.id());
+            if (user == null) {
+                continue;
+            }
+
+            var du = DecoratedObject.of(user);
+            du.setLabel(dataOwner.displayName());
+            users.add(du);
         }
 
         return users;

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebar.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebar.java
@@ -30,6 +30,7 @@ import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.feedback.IFeedback;
@@ -53,6 +54,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasProvider;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.AnnotationPage;
@@ -103,6 +105,7 @@ public class CurationSidebar
     private CheckGroup<User> selectedUsers;
     private DropDownChoice<String> curationTargetChoice;
     private ListView<User> users;
+    private IModel<Map<String, AnnotationSet>> dataOwners;
     private final Form<Void> usersForm;
     private CheckBox showMerged;
     private CheckBox showScore;
@@ -331,6 +334,12 @@ public class CurationSidebar
             }
         };
 
+        // Resolve the current/former/deactivated markers for the whole curatable-user list in a
+        // single batch instead of one permission lookup per rendered row.
+        dataOwners = LoadableDetachableModel
+                .of(() -> documentService.getDataOwners(getModelObject().getProject(),
+                        users.getModelObject().stream().map(User::getUsername).toList()));
+
         selectedUsers = new CheckGroup<User>("selectedUsers");
         selectedUsers.setModel(new LambdaModelAdapter<>( //
                 () -> curationSessionService.getSelectedUsers(sessionOwner, project.getId()), //
@@ -352,7 +361,22 @@ public class CurationSidebar
             return Model.of("Anonymized annotator " + (aUserListItem.getIndex() + 1));
         }
 
-        return aUserListItem.getModel().map(User::getUiName);
+        // Mark data owners that no longer hold the annotator permission (e.g. removed from the
+        // project or role changed) so the curator can tell them apart from current annotators. The
+        // markers are resolved in a single batch (see dataOwners).
+        var user = aUserListItem.getModelObject();
+        var dataOwner = dataOwners.getObject().get(user.getUsername());
+        return Model.of(dataOwner != null ? dataOwner.displayName() : user.getUiName());
+    }
+
+    @Override
+    protected void onDetach()
+    {
+        if (dataOwners != null) {
+            dataOwners.detach();
+        }
+
+        super.onDetach();
     }
 
     /**

--- a/inception/inception-ui-dashboard-activity/pom.xml
+++ b/inception/inception-ui-dashboard-activity/pom.xml
@@ -165,6 +165,10 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-collections4</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>jakarta.persistence</groupId>

--- a/inception/inception-ui-dashboard-activity/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/activity/ActivitiesDashletControllerImpl.java
+++ b/inception/inception-ui-dashboard-activity/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/activity/ActivitiesDashletControllerImpl.java
@@ -44,6 +44,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -159,7 +160,7 @@ public class ActivitiesDashletControllerImpl
 
         // Only managers can view other users' activity
         var dataOwner = getDataOwner(aDataOwner, sessionOwner);
-        if (!dataOwner.equals(sessionOwner)
+        if (!dataOwner.equals(sessionOwner.getUsername())
                 && !projectService.hasRole(sessionOwner, project, MANAGER)) {
             return new ActivitySummary(begin, end, emptyList(), emptyMap());
         }
@@ -248,7 +249,7 @@ public class ActivitiesDashletControllerImpl
 
         // Only managers can view other users' activity
         var dataOwner = getDataOwner(aDataOwner, sessionOwner);
-        if (!dataOwner.equals(sessionOwner)
+        if (!dataOwner.equals(sessionOwner.getUsername())
                 && !projectService.hasRole(sessionOwner, project, MANAGER)) {
             return new ActivityOverview(begin, end, emptyMap());
         }
@@ -271,33 +272,21 @@ public class ActivitiesDashletControllerImpl
     }
 
     private List<SummarizedLoggedEvent> summarizeEvents(Project project, Instant begin, Instant end,
-            User dataOwner)
+            String dataOwner)
     {
-        if (userRepository.getCurationUser().equals(dataOwner)) {
-            return eventRepository.summarizeEventsByDataOwner(dataOwner.getUsername(), project,
-                    begin, end);
+        if (CURATION_USER.equals(dataOwner)) {
+            return eventRepository.summarizeEventsByDataOwner(dataOwner, project, begin, end);
         }
 
-        return eventRepository.summarizeEventsBySessionOwner(dataOwner.getUsername(), project,
-                begin, end);
+        return eventRepository.summarizeEventsBySessionOwner(dataOwner, project, begin, end);
     }
 
-    private User getDataOwner(Optional<String> aDataOwner, User aSessionOwner)
+    private String getDataOwner(Optional<String> aDataOwner, User aSessionOwner)
     {
-        User dataOwner;
-
-        if (aDataOwner.isPresent()) {
-            dataOwner = userRepository.getUserOrCurationUser(aDataOwner.get());
-            if (dataOwner == null) {
-                throw new IllegalArgumentException(
-                        "User [" + aDataOwner.get() + "] does not exist");
-            }
-        }
-        else {
-            dataOwner = aSessionOwner;
-        }
-
-        return dataOwner;
+        // The data owner may be a former annotator whose account no longer exists (removed from
+        // the project, role changed or account deleted) - so we operate on the username and do not
+        // require the user account to still exist. Their logged events remain accessible.
+        return aDataOwner.filter(StringUtils::isNotBlank).orElseGet(aSessionOwner::getUsername);
     }
 
     @Override

--- a/inception/inception-ui-dashboard-activity/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/activity/panel/ActivityPanel.java
+++ b/inception/inception-ui-dashboard-activity/src/main/java/de/tudarmstadt/ukp/inception/ui/core/dashboard/activity/panel/ActivityPanel.java
@@ -22,6 +22,7 @@ import static de.tudarmstadt.ukp.inception.support.lambda.HtmlElementEvents.CHAN
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -34,9 +35,10 @@ import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
-import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
+import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.project.api.ProjectService;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxFormComponentUpdatingBehavior;
 import de.tudarmstadt.ukp.inception.support.svelte.SvelteBehavior;
@@ -50,11 +52,12 @@ public class ActivityPanel
     private @SpringBean ActivitiesDashletController controller;
     private @SpringBean ProjectService projectService;
     private @SpringBean UserDao userService;
+    private @SpringBean DocumentService documentService;
 
     private IModel<Project> projectModel = Model.of();
-    private IModel<User> userModel = Model.of();
+    private IModel<AnnotationSet> userModel = Model.of();
 
-    private DropDownChoice<User> userSelection;
+    private DropDownChoice<AnnotationSet> userSelection;
 
     private WebMarkupContainer content;
 
@@ -78,27 +81,28 @@ public class ActivityPanel
         content.add(new SvelteBehavior(this));
         add(content);
 
-        userSelection = new DropDownChoice<User>("user");
+        userSelection = new DropDownChoice<AnnotationSet>("user");
         userSelection.setOutputMarkupId(true);
         userSelection.setModel(userModel);
-        userSelection.setChoiceRenderer(new LambdaChoiceRenderer<>(user -> {
-            var username = user.toLongString();
-            if (username.equals(sessionOwner.getUsername())) {
-                username += " (me)";
+        userSelection.setChoiceRenderer(new LambdaChoiceRenderer<>(dataOwner -> {
+            var label = dataOwner.displayName();
+            if (dataOwner.id().equals(sessionOwner.getUsername())) {
+                label += " (me)";
             }
-            return username;
+            return label;
         }));
-        userSelection.setChoices(this::getUsersForCurrentProject);
+        userSelection.setChoices(this::getDataOwnersForCurrentProject);
         userSelection.add(new LambdaAjaxFormComponentUpdatingBehavior(CHANGE_EVENT,
                 this::actionChangeDataOwner));
         userSelection.setVisible(isManager);
 
-        var users = userSelection.getChoices();
-        if (users.contains(sessionOwner)) {
-            userModel.setObject(sessionOwner);
+        var dataOwners = userSelection.getChoices();
+        var sessionOwnerSet = AnnotationSet.forUser(sessionOwner);
+        if (dataOwners.contains(sessionOwnerSet)) {
+            userModel.setObject(sessionOwnerSet);
         }
-        else if (!users.isEmpty()) {
-            userModel.setObject(users.get(0));
+        else if (!dataOwners.isEmpty()) {
+            userModel.setObject(dataOwners.get(0));
         }
 
         add(userSelection);
@@ -107,15 +111,28 @@ public class ActivityPanel
     private void actionChangeDataOwner(AjaxRequestTarget aTarget)
     {
         getModelObject().put("dataOwner",
-                userModel.getObject() != null ? userModel.getObject().getUsername() : null);
+                userModel.getObject() != null ? userModel.getObject().id() : null);
         aTarget.add(userSelection, content);
     }
 
-    private List<User> getUsersForCurrentProject()
+    private List<AnnotationSet> getDataOwnersForCurrentProject()
     {
-        var users = new ArrayList<User>();
-        users.addAll(projectService.listUsersWithAnyRoleInProject(projectModel.getObject()));
-        users.add(userService.getCurationUser());
-        return users;
+        var project = projectModel.getObject();
+
+        // All users currently holding any role in the project, plus the curation user.
+        var dataOwners = new LinkedHashMap<String, AnnotationSet>();
+        for (var user : projectService.listUsersWithAnyRoleInProject(project)) {
+            dataOwners.put(user.getUsername(), AnnotationSet.forUser(user));
+        }
+        var curationUser = userService.getCurationUser();
+        dataOwners.put(curationUser.getUsername(), AnnotationSet.forUser(curationUser));
+
+        // Former annotators that left annotation data behind but no longer hold a role (removed
+        // from the project, role changed or account deleted) so their activity stays accessible.
+        for (var dataOwner : documentService.listDataOwners(project)) {
+            dataOwners.putIfAbsent(dataOwner.id(), dataOwner);
+        }
+
+        return new ArrayList<>(dataOwners.values());
     }
 }

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/casdoctor/CheckTask.java
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/casdoctor/CheckTask.java
@@ -146,8 +146,17 @@ public class CheckTask
                     getMessageSets().add(messageSet);
                 }
 
-                // Check regular annotator CASes
-                for (var ad : documentService.listAnnotationDocuments(sd)) {
+                // Check regular annotator CASes - including those of former annotators (removed
+                // from the project, role changed or account deleted) so their data is not skipped.
+                for (var ad : documentService.listAllAnnotationDocuments(sd)) {
+                    // The initial and curation CASes are checked separately above. Their
+                    // pseudo-user annotation documents are included in listAllAnnotationDocuments,
+                    // so skip them here to avoid checking those CASes a second time.
+                    var annotationSet = ad.getAnnotationSet();
+                    if (CURATION_SET.equals(annotationSet) || INITIAL_SET.equals(annotationSet)) {
+                        continue;
+                    }
+
                     var messageSet = new LogMessageSet(sd.getName() + " [" + ad.getUser() + "]");
                     try {
                         if (documentService.existsCas(ad)) {

--- a/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/casdoctor/RepairTask.java
+++ b/inception/inception-ui-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/project/casdoctor/RepairTask.java
@@ -152,8 +152,17 @@ public class RepairTask
                     getMessageSets().add(messageSet);
                 }
 
-                // Repair regular annotator CASes
-                for (var ad : documentService.listAnnotationDocuments(sd)) {
+                // Repair regular annotator CASes - including those of former annotators (removed
+                // from the project, role changed or account deleted) so their data is not skipped.
+                for (var ad : documentService.listAllAnnotationDocuments(sd)) {
+                    // The initial and curation CASes are repaired separately above. Their
+                    // pseudo-user annotation documents are included in listAllAnnotationDocuments,
+                    // so skip them here to avoid repairing those CASes a second time.
+                    var annotationSet = ad.getAnnotationSet();
+                    if (CURATION_SET.equals(annotationSet) || INITIAL_SET.equals(annotationSet)) {
+                        continue;
+                    }
+
                     var messageSet = new LogMessageSet(sd.getName() + " [" + ad.getUser() + "]");
                     try {
                         if (documentService.existsCas(ad)) {

--- a/inception/inception-versioning/src/main/java/de/tudarmstadt/ukp/inception/versioning/VersioningServiceImpl.java
+++ b/inception/inception-versioning/src/main/java/de/tudarmstadt/ukp/inception/versioning/VersioningServiceImpl.java
@@ -17,6 +17,8 @@
  */
 package de.tudarmstadt.ukp.inception.versioning;
 
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet.CURATION_SET;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet.INITIAL_SET;
 import static de.tudarmstadt.ukp.inception.project.api.ProjectService.DOCUMENT_FOLDER;
 import static de.tudarmstadt.ukp.inception.project.api.ProjectService.PROJECT_FOLDER;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -151,10 +153,20 @@ public class VersioningServiceImpl
                 }
             }
 
-            // Dump annotation documents
-            for (var annotationDocument : documentService.listAnnotationDocuments(sourceDocument)) {
+            // Dump annotation documents - including those of former annotators (removed from the
+            // project, role changed or account deleted) so the snapshot is a complete backup.
+            for (var annotationDocument : documentService
+                    .listAllAnnotationDocuments(sourceDocument)) {
 
                 var set = AnnotationSet.forUser(annotationDocument.getUser());
+
+                // The initial and curation CASes are dumped separately above. Their pseudo-user
+                // annotation documents are included in listAllAnnotationDocuments, so skip them
+                // here to avoid dumping those CASes a second time.
+                if (CURATION_SET.equals(set) || INITIAL_SET.equals(set)) {
+                    continue;
+                }
+
                 var annotationDocumentPath = sourceDir.resolve(set + ".xmi");
 
                 try (var session = CasStorageSession.openNested();

--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/DynamicWorkloadExtensionImpl.java
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/DynamicWorkloadExtensionImpl.java
@@ -25,13 +25,14 @@ import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.ANNOTA
 import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.CURATION_DOCUMENT_STATES;
 import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.CURATION_FINISHED;
 import static de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState.CURATION_IN_PROGRESS;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet.CURATION_SET;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet.INITIAL_SET;
 import static de.tudarmstadt.ukp.inception.support.json.JSONUtil.fromJsonString;
 import static java.util.stream.Collectors.toList;
 
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -48,6 +49,7 @@ import org.springframework.transaction.annotation.Transactional;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.ProjectState;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
@@ -284,15 +286,14 @@ public class DynamicWorkloadExtensionImpl
         }
 
         // Update the annotation document and source document states for the abandoned documents
-        Map<String, User> userCache = new HashMap<>();
         for (Entry<SourceDocument, Set<AnnotationDocument>> docSet : abandonedDocuments
                 .entrySet()) {
             if (AnnotationDocumentState.NEW == traits.getAbandonationState()) {
                 for (var adoc : docSet.getValue()) {
-                    User user = userCache.computeIfAbsent(adoc.getUser(),
-                            username -> userRepository.get(username));
+                    // Reset by data owner so this also works for deleted accounts
                     try (var session = CasStorageSession.openNested()) {
-                        documentService.resetAnnotationCas(adoc.getDocument(), user);
+                        documentService.resetAnnotationCas(adoc.getDocument(),
+                                AnnotationSet.forUser(adoc.getUser()));
                     }
                     catch (UIMAException | IOException e) {
                         log.error("Unable to reset abandoned document {}", adoc, e);
@@ -325,9 +326,18 @@ public class DynamicWorkloadExtensionImpl
             return;
         }
 
-        var stats = documentService.getAnnotationDocumentStats(aDocument);
-        var finishedCount = stats.get(AnnotationDocumentState.FINISHED);
-        var inProgressCount = stats.get(AnnotationDocumentState.IN_PROGRESS);
+        // Count all data owners towards completion - including former annotators - but exclude the
+        // curation/initial pseudo users.
+        var annotationDocuments = documentService.listAllAnnotationDocuments(aDocument).stream() //
+                .filter(annDoc -> !CURATION_SET.equals(annDoc.getAnnotationSet())) //
+                .filter(annDoc -> !INITIAL_SET.equals(annDoc.getAnnotationSet())) //
+                .toList();
+        var finishedCount = annotationDocuments.stream() //
+                .filter(annDoc -> annDoc.getState() == AnnotationDocumentState.FINISHED) //
+                .count();
+        var inProgressCount = annotationDocuments.stream() //
+                .filter(annDoc -> annDoc.getState() == IN_PROGRESS) //
+                .count();
 
         // If enough documents are finished, mark as finished
         if (finishedCount >= aRequiredAnnotatorCount) {

--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/management/DynamicWorkloadManagementPage.java
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/management/DynamicWorkloadManagementPage.java
@@ -30,12 +30,16 @@ import static de.tudarmstadt.ukp.inception.workload.dynamic.support.AnnotationQu
 import static de.tudarmstadt.ukp.inception.workload.dynamic.support.AnnotationQueueSortKeys.DOCUMENT;
 import static de.tudarmstadt.ukp.inception.workload.dynamic.support.AnnotationQueueSortKeys.FINISHED;
 import static de.tudarmstadt.ukp.inception.workload.dynamic.support.AnnotationQueueSortKeys.STATE;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet.CURATION_SET;
+import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet.INITIAL_SET;
 import static java.lang.String.format;
 import static java.time.Duration.ofMinutes;
 import static java.util.Arrays.asList;
 import static java.util.Comparator.comparing;
 import static java.util.Objects.isNull;
+import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -45,6 +49,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.form.AjaxFormChoiceComponentUpdatingBehavior;
@@ -87,6 +92,7 @@ import de.agilecoders.wicket.core.markup.html.bootstrap.form.BootstrapRadioChoic
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.comment.AnnotatorCommentDialogPanel;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
@@ -170,6 +176,8 @@ public class DynamicWorkloadManagementPage
     // Table
     private DataTable<AnnotationQueueItem, AnnotationQueueSortKeys> table;
 
+    private Map<String, AnnotationSet> dataOwnerIndex = new HashMap<>();
+
     // Modal dialog
     private ModalDialog modalDialog;
     private ChallengeResponseDialog resetDocumentDialog;
@@ -225,7 +233,7 @@ public class DynamicWorkloadManagementPage
                 AnnotationQueueItem::getInProgressCount));
         columns.add(new LambdaColumn<>(new ResourceModel("Finished"), FINISHED,
                 AnnotationQueueItem::getFinishedCount));
-        columns.add(new AnnotatorColumn(new ResourceModel("Annotators")));
+        columns.add(new AnnotatorColumn(new ResourceModel("Annotators"), () -> dataOwnerIndex));
         columns.add(new LambdaColumn<>(new ResourceModel("Updated"),
                 AnnotationQueueItem::getLastUpdated));
 
@@ -676,8 +684,14 @@ public class DynamicWorkloadManagementPage
         documentService.listSourceDocuments(project)
                 .forEach(d -> documentMap.put(d, new ArrayList<>()));
 
-        documentService.listAnnotationDocuments(project).forEach(ad -> documentMap
-                .computeIfAbsent(ad.getDocument(), d -> new ArrayList<>()).add(ad));
+        documentService.listAllAnnotationDocuments(project).stream() //
+                .filter(ad -> !CURATION_SET.equals(ad.getAnnotationSet())) //
+                .filter(ad -> !INITIAL_SET.equals(ad.getAnnotationSet())) //
+                .forEach(ad -> documentMap.computeIfAbsent(ad.getDocument(), d -> new ArrayList<>())
+                        .add(ad));
+
+        dataOwnerIndex = documentService.listDataOwners(project).stream()
+                .collect(toMap(AnnotationSet::id, identity()));
 
         var traits = dynamicWorkloadExtension.readTraits(workloadManagementService
                 .loadOrCreateWorkloadManagerConfiguration(currentProject.getObject()));
@@ -693,8 +707,8 @@ public class DynamicWorkloadManagementPage
     @OnEvent
     public void onAnnotatorColumnCellClickEvent(AnnotatorColumnCellClickEvent aEvent)
     {
-        var annotationDocument = documentService
-                .createOrGetAnnotationDocument(aEvent.getSourceDocument(), aEvent.getUser());
+        var annotationDocument = documentService.createOrGetAnnotationDocument(
+                aEvent.getSourceDocument(), aEvent.getAnnotationSet());
 
         var targetState = oneClickTransition(annotationDocument);
 
@@ -709,7 +723,7 @@ public class DynamicWorkloadManagementPage
     public void onAnnotatorColumnCellClickEvent(AnnotatorColumnCellShowAnnotatorCommentEvent aEvent)
     {
         var annDoc = documentService.getAnnotationDocument(aEvent.getSourceDocument(),
-                aEvent.getUser());
+                aEvent.getAnnotationSet());
         modalDialog.open(new AnnotatorCommentDialogPanel(ModalDialog.CONTENT_ID, Model.of(annDoc)),
                 aEvent.getTarget());
     }
@@ -729,28 +743,28 @@ public class DynamicWorkloadManagementPage
         // The AnnotatorColumnCellOpenContextMenuEvent is not serializable, so we need to extract
         // the information we need in the menu item here
         var document = aEvent.getSourceDocument();
-        var user = aEvent.getUser();
+        var annotationSet = aEvent.getAnnotationSet();
         items.add(new LambdaMenuItem("Reset",
-                _target -> actionResetAnnotationDocument(_target, document, user)));
+                _target -> actionResetAnnotationDocument(_target, document, annotationSet)));
         items.add(new LambdaMenuItem("Touch",
-                _target -> actionTouchAnnotationDocument(_target, document, user)));
+                _target -> actionTouchAnnotationDocument(_target, document, annotationSet)));
 
         contextMenu.onOpen(aEvent.getTarget(), aEvent.getCell());
     }
 
     private void actionResetAnnotationDocument(AjaxRequestTarget aTarget, SourceDocument aDocument,
-            User aUser)
+            AnnotationSet aAnnotationSet)
     {
         var dialogContent = new ResetAnnotationDocumentConfirmationDialogContentPanel(
                 ModalDialog.CONTENT_ID);
 
         dialogContent.setExpectedResponseModel(
-                Model.of(aUser.getUiName() + " / " + aDocument.getName()));
+                Model.of(aAnnotationSet.displayName() + " / " + aDocument.getName()));
         dialogContent.setConfirmAction(_target -> {
-            documentService.resetAnnotationCas(aDocument, aUser);
+            documentService.resetAnnotationCas(aDocument, aAnnotationSet);
 
             success(format("The annotations of document [%s] for user [%s] have been set reset.",
-                    aDocument.getName(), aUser.getUiName()));
+                    aDocument.getName(), aAnnotationSet.displayName()));
             _target.addChildren(getPage(), IFeedback.class);
 
             updateTable(_target);
@@ -760,14 +774,14 @@ public class DynamicWorkloadManagementPage
     }
 
     private void actionTouchAnnotationDocument(AjaxRequestTarget aTarget, SourceDocument aDocument,
-            User aUser)
+            AnnotationSet aAnnotationSet)
     {
-        var ann = documentService.getAnnotationDocument(aDocument, aUser);
+        var ann = documentService.getAnnotationDocument(aDocument, aAnnotationSet);
         ann.setTimestamp(new Date());
         documentService.createOrUpdateAnnotationDocument(ann);
 
         success(format("The timestamp of document [%s] for user [%s] has been updated.",
-                aDocument.getName(), aUser.getUiName()));
+                aDocument.getName(), aAnnotationSet.displayName()));
         aTarget.addChildren(getPage(), IFeedback.class);
 
         updateTable(aTarget);

--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/management/support/AnnotationStateList.java
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/management/support/AnnotationStateList.java
@@ -28,7 +28,9 @@ import static org.apache.wicket.event.Broadcast.BUBBLE;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 
+import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxEventBehavior;
 import org.apache.wicket.ajax.AjaxRequestTarget;
@@ -43,9 +45,9 @@ import org.apache.wicket.spring.injection.annot.SpringBean;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
-import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
-import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
+import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxEventBehavior;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxLink;
 import de.tudarmstadt.ukp.inception.workload.dynamic.management.support.event.AnnotatorColumnCellClickEvent;
@@ -57,16 +59,18 @@ public class AnnotationStateList
 {
     private static final long serialVersionUID = -8717096450102813443L;
 
-    private @SpringBean UserDao userRepository;
+    private @SpringBean DocumentService documentService;
 
     private final Duration abandonationTimeout;
+    private final IModel<Map<String, AnnotationSet>> dataOwnerIndex;
 
     public AnnotationStateList(String aId, IModel<List<AnnotationDocument>> aModel,
-            Duration aAbandonationTimeout)
+            Duration aAbandonationTimeout, IModel<Map<String, AnnotationSet>> aDataOwnerIndex)
     {
         super(aId, aModel);
 
         abandonationTimeout = aAbandonationTimeout;
+        dataOwnerIndex = aDataOwnerIndex;
 
         ListView<AnnotationDocument> annotationStates = new ListView<>("item", aModel)
         {
@@ -76,7 +80,12 @@ public class AnnotationStateList
             protected void populateItem(ListItem<AnnotationDocument> aItem)
             {
                 var row = aItem.getModelObject();
-                var user = userRepository.get(aItem.getModelObject().getUser());
+                var dataOwner = row.getAnnotationSet().id();
+                // The index carries the uiName and former/missing marker; the document's own
+                // getAnnotationSet() only has the bare user name. Fall back for owners not indexed.
+                var indexed = dataOwnerIndex.getObject().get(dataOwner);
+                var annotationSet = indexed != null ? indexed
+                        : documentService.getDataOwner(row.getDocument().getProject(), dataOwner);
 
                 var state = new WebMarkupContainer("state");
                 aItem.queue(state);
@@ -93,9 +102,10 @@ public class AnnotationStateList
                 }
                 else {
                     aItem.add(new AttributeAppender("class", "bg-secondary", " "));
-                    state.add(AjaxEventBehavior.onEvent("click", _target -> stateLabel.send(
-                            stateLabel, BUBBLE,
-                            new AnnotatorColumnCellClickEvent(_target, row.getDocument(), user))));
+                    state.add(AjaxEventBehavior.onEvent("click",
+                            _target -> stateLabel.send(stateLabel, BUBBLE,
+                                    new AnnotatorColumnCellClickEvent(_target, row.getDocument(),
+                                            annotationSet))));
                     state.add(new AttributeAppender("class", CSS_CLASS_STATE_TOGGLE, " "));
                 }
 
@@ -103,13 +113,23 @@ public class AnnotationStateList
                 stateLabel.setEscapeModelStrings(false); // SAFE - WE RENDER CONTROLLED SET OF ICONS
                 aItem.queue(stateLabel);
 
-                aItem.queue(new Label("annotatorName", user.getUiName()));
+                aItem.queue(new Label("annotatorName", annotationSet.name()));
+
+                // Mark former/missing data owners with a person-slash icon
+                var marker = annotationSet.marker();
+                var formerMarker = new WebMarkupContainer("formerMarker");
+                formerMarker.setVisible(marker != null);
+                if (marker != null) {
+                    formerMarker.add(AttributeModifier.replace("title", marker.getLabel()));
+                }
+                aItem.queue(formerMarker);
 
                 state.add(new LambdaAjaxEventBehavior("contextmenu",
-                        _t -> actionShowContextMenu(_t, state, row, user)).setPreventDefault(true));
+                        _t -> actionShowContextMenu(_t, state, row, annotationSet))
+                                .setPreventDefault(true));
 
                 var showComment = new LambdaAjaxLink("showComment",
-                        _t -> actionShowAnnotatorComment(_t, row.getDocument(), user));
+                        _t -> actionShowAnnotatorComment(_t, row.getDocument(), annotationSet));
                 showComment.add(visibleWhen(() -> isNotBlank(row.getAnnotatorComment())));
                 aItem.queue(showComment);
             }
@@ -119,17 +139,17 @@ public class AnnotationStateList
     }
 
     private void actionShowContextMenu(AjaxRequestTarget aTarget, Component aContext,
-            AnnotationDocument aAnnDoc, User aUser)
+            AnnotationDocument aAnnDoc, AnnotationSet aAnnotationSet)
     {
         send(aContext, BUBBLE, new AnnotatorStateOpenContextMenuEvent(aTarget, aContext,
-                aAnnDoc.getDocument(), aUser, aAnnDoc.getState()));
-        ;
+                aAnnDoc.getDocument(), aAnnotationSet, aAnnDoc.getState()));
     }
 
     private void actionShowAnnotatorComment(AjaxRequestTarget aTarget, SourceDocument aDoc,
-            User aUser)
+            AnnotationSet aAnnotationSet)
     {
-        send(this, BUBBLE, new AnnotatorColumnCellShowAnnotatorCommentEvent(aTarget, aDoc, aUser));
+        send(this, BUBBLE,
+                new AnnotatorColumnCellShowAnnotatorCommentEvent(aTarget, aDoc, aAnnotationSet));
     }
 
     private boolean isAbandoned(AnnotationDocument aAnnDoc)

--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/management/support/AnnotatorColumn.java
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/management/support/AnnotatorColumn.java
@@ -20,6 +20,7 @@ package de.tudarmstadt.ukp.inception.workload.dynamic.management.support;
 import static java.util.stream.Collectors.toList;
 
 import java.util.List;
+import java.util.Map;
 
 import org.apache.wicket.extensions.markup.html.repeater.data.grid.ICellPopulator;
 import org.apache.wicket.extensions.markup.html.repeater.data.table.LambdaColumn;
@@ -28,6 +29,7 @@ import org.apache.wicket.model.IModel;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.inception.workload.dynamic.support.AnnotationQueueItem;
 import de.tudarmstadt.ukp.inception.workload.dynamic.support.AnnotationQueueSortKeys;
 
@@ -36,9 +38,13 @@ public class AnnotatorColumn
 {
     private static final long serialVersionUID = 8324173231787296215L;
 
-    public AnnotatorColumn(IModel<String> aTitle)
+    private final IModel<Map<String, AnnotationSet>> dataOwnerIndex;
+
+    public AnnotatorColumn(IModel<String> aTitle,
+            IModel<Map<String, AnnotationSet>> aDataOwnerIndex)
     {
         super(aTitle, AnnotationQueueItem::getAnnotationDocuments);
+        dataOwnerIndex = aDataOwnerIndex;
     }
 
     @Override
@@ -53,6 +59,6 @@ public class AnnotatorColumn
                 .collect(toList()));
 
         aItem.add(new AnnotationStateList(aComponentId, annotators,
-                aRowModel.getObject().getAbandonationTimeout()));
+                aRowModel.getObject().getAbandonationTimeout(), dataOwnerIndex));
     }
 }

--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/management/support/event/AnnotatorColumnCellClickEvent.java
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/management/support/event/AnnotatorColumnCellClickEvent.java
@@ -20,8 +20,8 @@ package de.tudarmstadt.ukp.inception.workload.dynamic.management.support.event;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.wicketstuff.event.annotation.AbstractAjaxAwareEvent;
 
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
-import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 
 /**
  * Fired when a user clicks on a cell in an annotator column.
@@ -30,15 +30,15 @@ public class AnnotatorColumnCellClickEvent
     extends AbstractAjaxAwareEvent
 {
     private final SourceDocument sourceDocument;
-    private final User user;
+    private final AnnotationSet annotationSet;
 
     public AnnotatorColumnCellClickEvent(AjaxRequestTarget aTarget, SourceDocument aSourceDocument,
-            User aUser)
+            AnnotationSet aAnnotationSet)
     {
         super(aTarget);
 
         sourceDocument = aSourceDocument;
-        user = aUser;
+        annotationSet = aAnnotationSet;
     }
 
     public SourceDocument getSourceDocument()
@@ -46,8 +46,8 @@ public class AnnotatorColumnCellClickEvent
         return sourceDocument;
     }
 
-    public User getUser()
+    public AnnotationSet getAnnotationSet()
     {
-        return user;
+        return annotationSet;
     }
 }

--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/management/support/event/AnnotatorColumnCellShowAnnotatorCommentEvent.java
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/management/support/event/AnnotatorColumnCellShowAnnotatorCommentEvent.java
@@ -20,8 +20,8 @@ package de.tudarmstadt.ukp.inception.workload.dynamic.management.support.event;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.wicketstuff.event.annotation.AbstractAjaxAwareEvent;
 
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
-import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 
 /**
  * Fired when a user clicks on the annotator comment symbol.
@@ -30,15 +30,15 @@ public class AnnotatorColumnCellShowAnnotatorCommentEvent
     extends AbstractAjaxAwareEvent
 {
     private final SourceDocument sourceDocument;
-    private final User user;
+    private final AnnotationSet annotationSet;
 
     public AnnotatorColumnCellShowAnnotatorCommentEvent(AjaxRequestTarget aTarget,
-            SourceDocument aSourceDocument, User aUser)
+            SourceDocument aSourceDocument, AnnotationSet aAnnotationSet)
     {
         super(aTarget);
 
         sourceDocument = aSourceDocument;
-        user = aUser;
+        annotationSet = aAnnotationSet;
     }
 
     public SourceDocument getSourceDocument()
@@ -46,8 +46,8 @@ public class AnnotatorColumnCellShowAnnotatorCommentEvent
         return sourceDocument;
     }
 
-    public User getUser()
+    public AnnotationSet getAnnotationSet()
     {
-        return user;
+        return annotationSet;
     }
 }

--- a/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/management/support/event/AnnotatorStateOpenContextMenuEvent.java
+++ b/inception/inception-workload-dynamic/src/main/java/de/tudarmstadt/ukp/inception/workload/dynamic/management/support/event/AnnotatorStateOpenContextMenuEvent.java
@@ -22,8 +22,8 @@ import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.wicketstuff.event.annotation.AbstractAjaxAwareEvent;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
-import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 
 /**
  * Fired when a user right-clicks on an annotator state
@@ -34,16 +34,17 @@ public class AnnotatorStateOpenContextMenuEvent
     private final Component cell;
     private final SourceDocument sourceDocument;
     private final AnnotationDocumentState state;
-    private final User user;
+    private final AnnotationSet annotationSet;
 
     public AnnotatorStateOpenContextMenuEvent(AjaxRequestTarget aTarget, Component aCell,
-            SourceDocument aSourceDocument, User aUser, AnnotationDocumentState aState)
+            SourceDocument aSourceDocument, AnnotationSet aAnnotationSet,
+            AnnotationDocumentState aState)
     {
         super(aTarget);
 
         cell = aCell;
         sourceDocument = aSourceDocument;
-        user = aUser;
+        annotationSet = aAnnotationSet;
         state = aState;
     }
 
@@ -52,9 +53,9 @@ public class AnnotatorStateOpenContextMenuEvent
         return sourceDocument;
     }
 
-    public User getUser()
+    public AnnotationSet getAnnotationSet()
     {
-        return user;
+        return annotationSet;
     }
 
     public AnnotationDocumentState getState()

--- a/inception/inception-workload-dynamic/src/test/java/de/tudarmstadt/ukp/inception/workload/dynamic/DynamicWorkloadExtensionImplTest.java
+++ b/inception/inception-workload-dynamic/src/test/java/de/tudarmstadt/ukp/inception/workload/dynamic/DynamicWorkloadExtensionImplTest.java
@@ -20,6 +20,8 @@ package de.tudarmstadt.ukp.inception.workload.dynamic;
 import static java.lang.Thread.sleep;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static java.util.Arrays.asList;
+import static org.apache.uima.fit.util.CasUtil.getType;
+import static org.apache.uima.fit.util.CasUtil.select;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -48,6 +50,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
+import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.session.CasStorageSession;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.DocumentImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.constraints.config.ConstraintsServiceAutoConfiguration;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
@@ -55,12 +58,14 @@ import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocumentState;
 import de.tudarmstadt.ukp.clarin.webanno.project.config.ProjectServiceAutoConfiguration;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.security.config.SecurityAutoConfiguration;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.clarin.webanno.text.TextFormatSupport;
 import de.tudarmstadt.ukp.clarin.webanno.text.config.TextFormatsAutoConfiguration;
+import de.tudarmstadt.ukp.dkpro.core.api.ner.type.NamedEntity;
 import de.tudarmstadt.ukp.inception.annotation.storage.CasMetadataUtils;
 import de.tudarmstadt.ukp.inception.annotation.storage.config.CasStorageServiceAutoConfiguration;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
@@ -210,6 +215,91 @@ public class DynamicWorkloadExtensionImplTest
                 .as("Document was abandoned by other user, so it can be worked on now")
                 .map(SourceDocument::getName) //
                 .isPresent().get().isEqualTo("1.txt");
+    }
+
+    @Test
+    public void thatFormerAnnotatorFinishedWorkCountsTowardCompletion() throws Exception
+    {
+        // A user with annotation data but no ANNOTATOR role in the project - i.e. a former
+        // annotator. Their finished work must still count towards the required annotator count.
+        var former = userService.create(new User("former"));
+        var doc = createSourceDocument("1.txt");
+        documentService.createOrUpdateAnnotationDocument(AnnotationDocument.builder() //
+                .withUser(former.getUsername()) //
+                .forDocument(doc) //
+                .withState(AnnotationDocumentState.FINISHED) //
+                .build());
+
+        dynamicWorkloadExtension.updateDocumentState(doc, 1);
+
+        assertThat(documentService.getSourceDocument(project.getId(), doc.getId()).getState()) //
+                .as("A former annotator's finished work counts towards completion") //
+                .isEqualTo(SourceDocumentState.ANNOTATION_FINISHED);
+    }
+
+    @Test
+    public void thatAbandonmentResetsDocumentOfDeletedAccountWithoutError() throws Exception
+    {
+        // "ghost" has no user account at all - there is only an annotation document referencing the
+        // username. Abandonment handling must not skip it (or fail) just because the account is
+        // gone.
+        var doc = createSourceDocument("1.txt");
+        var ann = new AnnotationDocument("ghost", doc);
+        Fixtures.importTestSourceDocumentAndAddNamedEntity(documentService, ann);
+
+        // Push the document past the abandonation timeout
+        sleep(traits.getAbandonationTimeout().multipliedBy(2).toMillis());
+
+        // Must not throw - previously this NPE'd on userRepository.get("ghost") == null
+        dynamicWorkloadExtension.freshenStatus(project);
+
+        var reset = documentService.getAnnotationDocument(doc, AnnotationSet.forUser("ghost"));
+        assertThat(reset.getState()) //
+                .as("Abandoned document of a deleted-account user is reset to NEW") //
+                .isEqualTo(AnnotationDocumentState.NEW);
+    }
+
+    @Test
+    public void thatAbandonmentRetainsDeletedAccountDataWhenAbandonationStateIsIgnore()
+        throws Exception
+    {
+        assertAbandonmentRetainsData(AnnotationDocumentState.IGNORE);
+    }
+
+    @Test
+    public void thatAbandonmentRetainsDeletedAccountDataWhenAbandonationStateIsFinished()
+        throws Exception
+    {
+        assertAbandonmentRetainsData(AnnotationDocumentState.FINISHED);
+    }
+
+    private void assertAbandonmentRetainsData(AnnotationDocumentState aAbandonationState)
+        throws Exception
+    {
+        // Configure the project to retain abandoned work in the given (non-NEW) state
+        traits.setAbandonationState(aAbandonationState);
+        dynamicWorkloadExtension.writeTraits(traits, project);
+
+        // "ghost" has no user account - only an annotation document with a NamedEntity
+        var doc = createSourceDocument("1.txt");
+        var ann = new AnnotationDocument("ghost", doc);
+        Fixtures.importTestSourceDocumentAndAddNamedEntity(documentService, ann);
+
+        sleep(traits.getAbandonationTimeout().multipliedBy(2).toMillis());
+
+        dynamicWorkloadExtension.freshenStatus(project);
+
+        var abandoned = documentService.getAnnotationDocument(doc, AnnotationSet.forUser("ghost"));
+        assertThat(abandoned.getState()) //
+                .as("Abandoned document is moved to the configured retain state") //
+                .isEqualTo(aAbandonationState);
+
+        try (var session = CasStorageSession.open()) {
+            var cas = documentService.readAnnotationCas(doc, AnnotationSet.forUser("ghost"));
+            assertThat(select(cas, getType(cas, NamedEntity.class))) //
+                    .as("The former annotator's annotations are retained, not reset") //
+                    .isNotEmpty();
+        }
     }
 
     private SourceDocument createSourceDocument(String aName)

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/MatrixWorkloadManagementPage.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/MatrixWorkloadManagementPage.java
@@ -43,9 +43,7 @@ import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.Duration.ofMillis;
 import static java.util.Arrays.asList;
-import static java.util.Comparator.comparing;
 import static java.util.regex.Pattern.CASE_INSENSITIVE;
-import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.csv.CSVFormat.EXCEL;
@@ -388,8 +386,9 @@ public class MatrixWorkloadManagementPage
 
     private IResourceStream exportWorkload()
     {
-        var users = projectService.listUsersWithRoleInProject(getProject(), ANNOTATOR);
-        var annotators = buildAnnotatorList(users);
+        // Includes current and former annotators (and data owners without a user account), so the
+        // exported workload reflects everyone who left annotation data behind in the project.
+        var annotators = documentService.listDataOwners(getProject());
 
         return new PipedStreamResource(os -> {
             try (var aOut = new CSVPrinter(new OutputStreamWriter(os, UTF_8), EXCEL)) {
@@ -398,21 +397,6 @@ public class MatrixWorkloadManagementPage
                 exportWorkloadToCsv(aOut, annotators, documentRows);
             }
         }, MediaType.valueOf("text/csv"));
-    }
-
-    /**
-     * Builds a sorted list of AnnotationSet objects from a list of users.
-     * 
-     * @param users
-     *            the list of users to convert to AnnotationSets
-     * @return a list of AnnotationSets sorted by display name
-     */
-    static List<AnnotationSet> buildAnnotatorList(List<User> users)
-    {
-        return users.stream() //
-                .map(AnnotationSet::forUser) //
-                .sorted(comparing(AnnotationSet::displayName)) //
-                .toList();
     }
 
     /**
@@ -523,20 +507,21 @@ public class MatrixWorkloadManagementPage
         columns.add(new DocumentMatrixStateColumn());
         columns.add(new DocumentMatrixNameColumn());
 
-        var annotators = projectService.listUsersWithRoleInProject(getProject(), ANNOTATOR).stream() //
-                .map(AnnotationSet::forUser) //
-                .collect(toCollection(ArrayList::new));
+        // Current and former annotators (the latter - removed from the project or with a changed
+        // role - flagged in their display name) so that managers/curators can still see and triage
+        // the data of people who left the project. Data owners whose account was deleted entirely
+        // appear as well, since the matrix operates on annotation sets rather than user accounts.
+        var annotators = new ArrayList<>(documentService.listDataOwners(getProject()));
 
         if (isNotBlank(filter.getObject().getUserName())) {
             if (filter.getObject().isMatchUserNameAsRegex()) {
                 var p = Pattern
                         .compile(".*(" + filter.getObject().getUserName() + ").*", CASE_INSENSITIVE)
                         .asMatchPredicate().negate();
-                annotators.removeIf(u -> p.test(u.displayName()));
+                annotators.removeIf(u -> p.test(u.name()));
             }
             else {
-                annotators.removeIf(
-                        u -> !CI.contains(u.displayName(), filter.getObject().getUserName()));
+                annotators.removeIf(u -> !CI.contains(u.name(), filter.getObject().getUserName()));
             }
         }
 
@@ -579,20 +564,23 @@ public class MatrixWorkloadManagementPage
 
         if (selectedCells.size() == 1) {
             var annDoc = selectedCells.get(0);
-            var user = userRepository.get(annDoc.getUser());
+            var dataOwner = annDoc.getAnnotationSet();
+            // The account may no longer exist (former annotator), so fall back to the data owner's
+            // display name for the confirmation prompt.
+            var owner = userRepository.get(dataOwner.id());
+            var ownerLabel = owner != null ? owner.getUiName() : dataOwner.displayName();
             dialogContent.setExpectedResponseModel(
-                    Model.of(user.getUiName() + " / " + annDoc.getName()));
+                    Model.of(ownerLabel + " / " + annDoc.getDocument().getName()));
         }
         else {
             dialogContent.setExpectedResponseModel(Model.of(getProject().getName()));
         }
 
         dialogContent.setConfirmAction(_target -> {
-            var userCache = new HashMap<String, User>();
-            for (var document : selectedCells) {
-                var user = userCache.computeIfAbsent(document.getUser(),
-                        username -> userRepository.get(username));
-                documentService.resetAnnotationCas(document.getDocument(), user);
+            // Reset by annotation set (username) rather than user account so that the data of
+            // former annotators - including those whose account no longer exists - can be reset.
+            for (var annDoc : selectedCells) {
+                documentService.resetAnnotationCas(annDoc.getDocument(), annDoc.getAnnotationSet());
             }
 
             success(format("The %s document(s) have been set reset.", selectedCells.size()));
@@ -731,19 +719,20 @@ public class MatrixWorkloadManagementPage
     }
 
     private void actionResetAnnotationDocument(AjaxRequestTarget aTarget, SourceDocument aDocument,
-            AnnotationSet aUser)
+            AnnotationSet aDataOwner)
     {
         var dialogContent = new ResetAnnotationDocumentConfirmationDialogContentPanel(
                 ModalDialog.CONTENT_ID);
 
-        var user = userRepository.get(aUser.id());
-        dialogContent
-                .setExpectedResponseModel(Model.of(user.getUiName() + " / " + aDocument.getName()));
+        // Reset by annotation set so this also works for former annotators whose account no longer
+        // exists; the display name already flags them as former.
+        dialogContent.setExpectedResponseModel(
+                Model.of(aDataOwner.displayName() + " / " + aDocument.getName()));
         dialogContent.setConfirmAction(_target -> {
-            documentService.resetAnnotationCas(aDocument, user);
+            documentService.resetAnnotationCas(aDocument, aDataOwner);
 
             success(format("The annotations of document [%s] for user [%s] have been set reset.",
-                    aDocument.getName(), user.getUiName()));
+                    aDocument.getName(), aDataOwner.displayName()));
             _target.addChildren(getPage(), IFeedback.class);
 
             reloadMatrixData();
@@ -1327,7 +1316,11 @@ public class MatrixWorkloadManagementPage
             documentMatrixRows.put(srcDoc, new DocumentMatrixRow(srcDoc, annotators));
         }
 
-        for (var annDoc : documentService.listAnnotationDocuments(getProject())) {
+        // Use listAllAnnotationDocuments so the cells of former annotators (no longer holding a
+        // permission, or whose account was deleted) show their actual document state instead of
+        // falling back to NEW. The row's annotator set above stays limited to current annotators,
+        // so former annotators do not contribute to the rolled-up document/project state.
+        for (var annDoc : documentService.listAllAnnotationDocuments(getProject())) {
             documentMatrixRows.get(annDoc.getDocument()).add(annDoc);
         }
 

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/MatrixWorkloadManagementPage.utf8.properties
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/MatrixWorkloadManagementPage.utf8.properties
@@ -1,7 +1,7 @@
-# Licensed to the Technische Universität Darmstadt under one
+# Licensed to the Technische Universitï¿½t Darmstadt under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
-# regarding copyright ownership.  The Technische Universität Darmstadt 
+# regarding copyright ownership.  The Technische Universitï¿½t Darmstadt 
 # licenses this file to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/support/AnnotatorColumnHeaderPanel.html
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/support/AnnotatorColumnHeaderPanel.html
@@ -1,4 +1,3 @@
-<!DOCTYPE html>
 <!--
   Licensed to the Technische Universität Darmstadt under one
   or more contributor license agreements.  See the NOTICE file
@@ -16,18 +15,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 -->
-<html xmlns="http://www.w3.org/1999/xhtml"
-      xmlns:wicket="http://wicket.apache.org/dtds.data/wicket-xhtml1.4-strict.dtd">
-<wicket:panel>
-  <span wicket:id="item" class="badge rounded-pill me-1">
-    <span wicket:id="state">
-      <wicket:container wicket:id="stateSymbol"/>
-      <wicket:container wicket:id="annotatorName"/>
-      <i wicket:id="formerMarker" class="fas fa-user-slash ms-1"></i>
-    </span>
-    <a type="button" wicket:id="showComment" class="border-start ms-1 ps-2 text-reset">
-      <i class="fas fa-comment"></i>
-    </a>
-  </span>
-</wicket:panel>
+<html xmlns:wicket="http://wicket.apache.org">
+<wicket:panel><wicket:container wicket:id="name"/><i wicket:id="marker"
+    class="fas fa-exclamation-triangle text-warning ms-1"></i></wicket:panel>
 </html>

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/support/AnnotatorColumnHeaderPanel.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/support/AnnotatorColumnHeaderPanel.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.workload.matrix.management.support;
+
+import org.apache.wicket.AttributeModifier;
+import org.apache.wicket.markup.html.WebMarkupContainer;
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.model.ResourceModel;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
+
+/**
+ * Header for an annotator column in the document matrix. Shows the data owner's name and, for data
+ * owners carrying a marker (former annotator, deactivated account or missing/deleted account), a
+ * warning icon explaining their status (shown as a tooltip on hover).
+ */
+public class AnnotatorColumnHeaderPanel
+    extends Panel
+{
+    private static final long serialVersionUID = 1L;
+
+    public AnnotatorColumnHeaderPanel(String aId, AnnotationSet aAnnotationSet)
+    {
+        super(aId);
+
+        queue(new Label("name", aAnnotationSet.name()));
+
+        // The data owner may carry any marker (FORMER_ANNOTATOR, DEACTIVATED, MISSING), so the
+        // tooltip is resolved per-marker rather than assuming "former annotator".
+        var aMarker = aAnnotationSet.marker();
+        var marker = new WebMarkupContainer("marker");
+        marker.setVisible(aMarker != null);
+        if (aMarker != null) {
+            marker.add(AttributeModifier.replace("title",
+                    new ResourceModel("marker." + aMarker.name())));
+        }
+        queue(marker);
+    }
+}

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/support/AnnotatorColumnHeaderPanel.utf8.properties
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/support/AnnotatorColumnHeaderPanel.utf8.properties
@@ -1,0 +1,23 @@
+# Licensed to the Technische Universität Darmstadt under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The Technische Universität Darmstadt
+# licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+marker.FORMER_ANNOTATOR = Former annotator - no longer holds an annotator permission in this \
+    project. Their data is shown for inspection but does not contribute to the document or project \
+    state.
+marker.DEACTIVATED = Deactivated account - still an annotator in this project, but the account is \
+    currently disabled. Their data is shown for inspection but does not contribute to the document \
+    or project state.
+marker.MISSING = Missing account - the user account has been deleted. Their data is shown for \
+    inspection but does not contribute to the document or project state.

--- a/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/support/DocumentMatrixAnnotatorColumn.java
+++ b/inception/inception-workload-matrix/src/main/java/de/tudarmstadt/ukp/inception/workload/matrix/management/support/DocumentMatrixAnnotatorColumn.java
@@ -21,6 +21,7 @@ import static de.tudarmstadt.ukp.inception.workload.matrix.management.support.Do
 
 import java.util.Set;
 
+import org.apache.wicket.Component;
 import org.apache.wicket.extensions.markup.html.repeater.data.grid.ICellPopulator;
 import org.apache.wicket.extensions.markup.html.repeater.data.table.LambdaColumn;
 import org.apache.wicket.markup.repeater.Item;
@@ -41,7 +42,7 @@ public class DocumentMatrixAnnotatorColumn
     public DocumentMatrixAnnotatorColumn(AnnotationSet aAnnSet,
             IModel<Set<AnnotationSet>> aSelectedSets)
     {
-        super(Model.of(aAnnSet.displayName()), annotatorSortKey(aAnnSet),
+        super(Model.of(aAnnSet.name()), annotatorSortKey(aAnnSet),
                 row -> row.getAnnotationDocument(aAnnSet));
         annotationSet = aAnnSet;
         selectedUsers = aSelectedSets;
@@ -50,6 +51,14 @@ public class DocumentMatrixAnnotatorColumn
     public AnnotationSet getAnnotationSet()
     {
         return annotationSet;
+    }
+
+    @Override
+    public Component getHeader(String aComponentId)
+    {
+        // Render the plain name plus, for former annotators, a warning icon with an explanatory
+        // tooltip - instead of spelling out "(former annotator)" in the (narrow) column header.
+        return new AnnotatorColumnHeaderPanel(aComponentId, annotationSet);
     }
 
     @Override

--- a/inception/inception-workload-matrix/src/test/java/de/tudarmstadt/ukp/inception/workload/matrix/management/MatrixWorkloadManagementPageExportTest.java
+++ b/inception/inception-workload-matrix/src/test/java/de/tudarmstadt/ukp/inception/workload/matrix/management/MatrixWorkloadManagementPageExportTest.java
@@ -41,25 +41,6 @@ import de.tudarmstadt.ukp.inception.workload.matrix.management.support.DocumentM
 class MatrixWorkloadManagementPageExportTest
 {
     @Test
-    void testBuildAnnotatorListSortsByDisplayName()
-    {
-        // Create test users with different names to test sorting
-        var userCharlie = User.builder().withUsername("charlie").withUiName("Charlie").build();
-        var userAlice = User.builder().withUsername("alice").withUiName("Alice").build();
-        var userBob = User.builder().withUsername("bob").withUiName("Bob").build();
-
-        var users = List.of(userCharlie, userAlice, userBob);
-
-        // After the fix, this should return a sorted list by displayName
-        var result = MatrixWorkloadManagementPage.buildAnnotatorList(users);
-
-        assertThat(result).hasSize(3);
-        assertThat(result.get(0).displayName()).isEqualTo("Alice");
-        assertThat(result.get(1).displayName()).isEqualTo("Bob");
-        assertThat(result.get(2).displayName()).isEqualTo("Charlie");
-    }
-
-    @Test
     void testExportWorkloadToCsvFormat() throws IOException
     {
         // Create test users
@@ -67,10 +48,10 @@ class MatrixWorkloadManagementPageExportTest
         var userAlice = User.builder().withUsername("alice").withUiName("Alice").build();
         var userBob = User.builder().withUsername("bob").withUiName("Bob").build();
 
-        var users = List.of(userCharlie, userAlice, userBob);
-
-        // Build sorted annotator list using the fixed method
-        var annotators = MatrixWorkloadManagementPage.buildAnnotatorList(users);
+        // Annotators are provided to the CSV export pre-sorted by display name (as
+        // DocumentService.listDataOwners returns them).
+        var annotators = List.of(AnnotationSet.forUser(userAlice), AnnotationSet.forUser(userBob),
+                AnnotationSet.forUser(userCharlie));
 
         // Create test project and documents
         var project = Project.builder().withName("test-project").build();


### PR DESCRIPTION
**What's in the PR**
- Model annotators/data owners as AnnotationSet rather than User / ProjectUserPermissions, so a data owner need not correspond to a current (or any) user account
- Add DocumentService.listDataOwners / getDataOwner / getDataOwners to resolve data-owner names to AnnotationSets with a shared marker precedence: current (unmarked), DEACTIVATED (disabled but current), FORMER_ANNOTATOR (removed / role-changed), and MISSING (deleted account)
- Only report owners that actually have data: exclude NEW (mere assignment) and locked/IGNORE documents without a CAS; include finished and locked-with-data
- Switch data access from the permission-gated listAnnotationDocuments to the unfiltered listAllAnnotationDocuments (minus curation/initial pseudo-users) in export/import, re-indexing/search, CAS Doctor checks & repairs, the Git project snapshot, the rebuild-state CLI command, and workload state roll-ups
- Surface current/former/deactivated/missing data owners (with marker icons and tooltips) in the curation sidebar, the dynamic and matrix workload pages, the open-document dialog, the agreement/explorer/pivot pages, and the activity dashlet
- Keep current-annotator-only scope where appropriate: workload assignment and document state aggregation still consider current annotators only
- Reset annotation CAS by data owner (username) rather than user account, so reset works even when the account no longer exists
- Count former annotators' finished/in-progress work toward dynamic-workload completion, so removing an annotator no longer reverts a completed document
- Make abandonment handling tolerate deleted accounts by keying off the data owner instead of looking up a User
- Add test coverage across affected services and pages (former annotators with/without data, deactivated and deleted "ghost" accounts, locked-with/without-CAS documents); minor cleanups (removed the interim AnnotationSetResolver helper, dead dependencies, and a matrix name-filter fix)

**How to test manually**
* Remove an annotator from a project and check how the application performs then in various places like curation, explorer, agreement, workload management etc. - also in annotation when opening it as a manager/curator with the ability to view all annotator's data in read only mode

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
