### PR TITLE
#6091 - Document area collapses and scrolling stutters in Safari and Firefox for custom XML formats with namespaced section elements

### DIFF
--- a/inception/inception-html-apache-annotator-editor/pom.xml
+++ b/inception/inception-html-apache-annotator-editor/pom.xml
@@ -170,6 +170,17 @@
               <arguments>run build</arguments>
             </configuration>
           </execution>
+          <execution>
+            <id>bun test</id>
+            <goals>
+              <goal>bun</goal>
+            </goals>
+            <phase>${ts-test-phase}</phase>
+            <configuration>
+              <skip>${skipTests}</skip>
+              <arguments>run test</arguments>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
     </plugins>

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorEditor.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorEditor.ts
@@ -25,6 +25,7 @@ import {
 import DocumentStructureNavigator from '@inception-project/inception-js-api/src/documentStructure/DocumentStructureNavigator.svelte';
 import { ApacheAnnotatorVisualizer } from './ApacheAnnotatorVisualizer.svelte';
 import { ApacheAnnotatorSelector } from './ApacheAnnotatorSelector';
+import { normalizeSectionsForPinning } from './SectionPinning';
 import ApacheAnnotatorToolbar from './ApacheAnnotatorToolbar.svelte';
 import { annotatorState } from './ApacheAnnotatorState.svelte';
 import AnnotationDetailPopOver from '@inception-project/inception-js-api/src/widget/AnnotationDetailPopOver.svelte';
@@ -67,7 +68,8 @@ export class ApacheAnnotatorEditor implements AnnotationEditor {
         this.ajax = ajax;
         this.root = element;
         this.userPreferencesKey = userPreferencesKey;
-        this.sectionSelector = [...sectionElementLocalNames].join(',');
+        // Settled during init by normalizeSectionsForPinning (Step 1 below).
+        this.sectionSelector = '';
         this.protectedElements = protectedElements;
         this.documentStructure = documentStructure;
         const protectedSel = [...protectedElements].join(',');
@@ -105,8 +107,6 @@ export class ApacheAnnotatorEditor implements AnnotationEditor {
                     preferences.protectElements ?? defaultPreferences.protectElements;
             })
             .then(() => {
-                this.ensureSectionElementsHaveAnId();
-
                 // Move all content into a document container
                 const documentContainer = this.root.ownerDocument.createElement('div');
                 documentContainer.classList.add('iaa-document-container');
@@ -114,6 +114,19 @@ export class ApacheAnnotatorEditor implements AnnotationEditor {
                     documentContainer.appendChild(child)
                 );
 
+                // Step 1 (rendering fix): make section elements pinnable and
+                // settle the section selector. Schema-free; see SectionPinning.
+                // Must run before the IDs are assigned so they land on the
+                // wrapper elements rather than the soon-to-be-buried originals.
+                this.sectionSelector = normalizeSectionsForPinning(
+                    documentContainer,
+                    sectionElementLocalNames
+                );
+                this.ensureSectionElementsHaveAnId();
+
+                // Step 2 (table of contents): build the outline for the
+                // navigator. Operates on the post-pinning DOM; owns title and
+                // scroll-target extraction per format.
                 this.documentStructure.preprocess(documentContainer);
 
                 // Set up a container for the document navigation sidebar

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorEditorFactory.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorEditorFactory.ts
@@ -105,9 +105,14 @@ export class ApacheAnnotatorEditorFactory implements AnnotationEditorFactory {
 
 /**
  * Evaluate the format-supplied document-structure factory expression in the
- * iframe's window context (mirrors how the editor framework evaluates
- * props.editorFactory) and call it to produce the strategy. Falls back to a
- * noop strategy if no expression was provided or the eval fails.
+ * iframe's window context (mirrors how props.editorFactory is evaluated) and
+ * call it to produce the strategy. Falls back to {@link NoopDocumentStructure}
+ * if no expression was provided or the eval fails.
+ *
+ * Note: this only governs the table-of-contents outline. Making section
+ * elements pinnable across browsers is a separate, unconditional step
+ * (normalizeSectionsForPinning in the editor), independent of which strategy
+ * is chosen here.
  */
 function resolveDocumentStructure(
     element: Node,

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionAnnotationCreator.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionAnnotationCreator.ts
@@ -68,15 +68,18 @@ export class SectionAnnotationCreator {
             // <sec-wrap> wrappers (used to make namespaced XML sections pinnable)
             // are the exception: their own localName is 'sec-wrap', but they
             // carry the original element name in data-section-type, so use that.
-            // The override is gated on the element actually being such a wrapper
-            // -- an unrelated section that happens to have a data-section-type
-            // attribute must still be labelled by its own tag name.
-            const isWrapper =
+            // A synthetic wrapper is identified by all three of: tag 'sec-wrap',
+            // the XHTML namespace, AND the data-section-type marker attribute --
+            // the same definition SectionPinning uses to create them. Requiring
+            // the attribute means an unrelated <sec-wrap> (or any element that
+            // happens to carry data-section-type) is still labelled by its own
+            // tag name.
+            const wrapperType =
                 e.localName === 'sec-wrap' &&
-                e.namespaceURI === 'http://www.w3.org/1999/xhtml';
-            const sectionType =
-                (isWrapper && e.getAttribute('data-section-type')) || e.localName;
-            e.setAttribute('data-iaa-section-type', sectionType);
+                e.namespaceURI === 'http://www.w3.org/1999/xhtml'
+                    ? e.getAttribute('data-section-type')
+                    : null;
+            e.setAttribute('data-iaa-section-type', wrapperType || e.localName);
         });
     }
 

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionAnnotationCreator.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionAnnotationCreator.ts
@@ -64,11 +64,18 @@ export class SectionAnnotationCreator {
 
     private initializeSectionTypeAttributes() {
         this.root.querySelectorAll(this.sectionSelector).forEach((e, i) => {
-            // For synthetic <sec-wrap> wrappers (used to make namespaced XML
-            // sections pinnable) the localName is 'sec-wrap'; the original
-            // element name is preserved in data-section-type, so prefer it for
-            // the displayed section-type label.
-            const sectionType = e.getAttribute('data-section-type') ?? e.localName;
+            // The label is normally the element's own tag name. Synthetic
+            // <sec-wrap> wrappers (used to make namespaced XML sections pinnable)
+            // are the exception: their own localName is 'sec-wrap', but they
+            // carry the original element name in data-section-type, so use that.
+            // The override is gated on the element actually being such a wrapper
+            // -- an unrelated section that happens to have a data-section-type
+            // attribute must still be labelled by its own tag name.
+            const isWrapper =
+                e.localName === 'sec-wrap' &&
+                e.namespaceURI === 'http://www.w3.org/1999/xhtml';
+            const sectionType =
+                (isWrapper && e.getAttribute('data-section-type')) || e.localName;
             e.setAttribute('data-iaa-section-type', sectionType);
         });
     }

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionAnnotationCreator.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionAnnotationCreator.ts
@@ -64,7 +64,12 @@ export class SectionAnnotationCreator {
 
     private initializeSectionTypeAttributes() {
         this.root.querySelectorAll(this.sectionSelector).forEach((e, i) => {
-            e.setAttribute('data-iaa-section-type', e.localName);
+            // For synthetic <sec-wrap> wrappers (used to make namespaced XML
+            // sections pinnable) the localName is 'sec-wrap'; the original
+            // element name is preserved in data-section-type, so prefer it for
+            // the displayed section-type label.
+            const sectionType = e.getAttribute('data-section-type') ?? e.localName;
+            e.setAttribute('data-iaa-section-type', sectionType);
         });
     }
 

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionPinning.test.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionPinning.test.ts
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { normalizeSectionsForPinning } from './SectionPinning';
+
+const TEI_NS = 'http://www.tei-c.org/ns/1.0';
+const XHTML_NS = 'http://www.w3.org/1999/xhtml';
+
+let container: HTMLElement;
+
+beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+});
+
+afterEach(() => {
+    while (document.body.firstChild) {
+        document.body.removeChild(document.body.firstChild);
+    }
+});
+
+/**
+ * Concatenate all text-node data in document order. Used to verify that the
+ * wrap pass does not reorder text content -- the invariant that annotation
+ * character offsets depend on.
+ */
+function textInOrder(root: Node): string {
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, null);
+    let out = '';
+    let n: Node | null;
+    while ((n = walker.nextNode())) out += n.nodeValue ?? '';
+    return out;
+}
+
+/** Build a `<tei:div>...</tei:div>` element in the TEI namespace. */
+function teiEl(name: string, ...children: (Node | string)[]): Element {
+    const el = document.createElementNS(TEI_NS, name);
+    for (const c of children) {
+        el.appendChild(typeof c === 'string' ? document.createTextNode(c) : c);
+    }
+    return el;
+}
+
+describe('normalizeSectionsForPinning', () => {
+    it('is a no-op and returns empty when no section names are configured', () => {
+        container.appendChild(teiEl('div', 'one'));
+        const before = container.innerHTML;
+
+        const selector = normalizeSectionsForPinning(container, new Set());
+
+        expect(selector).toBe('');
+        expect(container.querySelectorAll('sec-wrap').length).toBe(0);
+        expect(container.innerHTML).toBe(before);
+    });
+
+    it('wraps a single namespaced element and returns the wrapper selector', () => {
+        const div = teiEl('div', 'body');
+        container.appendChild(div);
+
+        const selector = normalizeSectionsForPinning(container, new Set(['div']));
+
+        expect(selector).toBe('sec-wrap');
+        const wraps = container.querySelectorAll('sec-wrap');
+        expect(wraps.length).toBe(1);
+        // Wrapper is HTML-namespace so the editor's HTMLElement-only inline-style
+        // pinning will work on it -- the whole point of the wrap.
+        expect(wraps[0].namespaceURI).toBe(XHTML_NS);
+        expect(wraps[0]).toBeInstanceOf(HTMLElement);
+        expect(wraps[0].firstElementChild).toBe(div);
+        expect(div.namespaceURI).toBe(TEI_NS);
+        expect(wraps[0].getAttribute('data-section-type')).toBe('div');
+    });
+
+    it('leaves elements already in the HTML namespace untouched and returns their names', () => {
+        const xhtmlSection = document.createElement('section');
+        xhtmlSection.textContent = 'already html';
+        container.appendChild(xhtmlSection);
+
+        const selector = normalizeSectionsForPinning(container, new Set(['section']));
+
+        // Already an HTMLElement, so pinning works directly: no wrapping, and the
+        // section boundary stays the original element name.
+        expect(selector).toBe('section');
+        expect(container.querySelectorAll('sec-wrap').length).toBe(0);
+        expect(xhtmlSection.parentElement).toBe(container);
+    });
+
+    it('wraps nested sections at each level', () => {
+        const inner = teiEl('div', 'inner text');
+        const outer = teiEl('div', 'outer ', inner);
+        container.appendChild(outer);
+
+        normalizeSectionsForPinning(container, new Set(['div']));
+
+        const wraps = container.querySelectorAll('sec-wrap');
+        expect(wraps.length).toBe(2);
+        for (const w of Array.from(wraps)) {
+            expect(w.firstElementChild?.namespaceURI).toBe(TEI_NS);
+            expect(w.firstElementChild?.localName).toBe('div');
+        }
+        const outerWrap = container.firstElementChild!;
+        expect(outerWrap.localName).toBe('sec-wrap');
+        expect(outerWrap.firstElementChild).toBe(outer);
+        expect(outer.querySelector('sec-wrap')?.firstElementChild).toBe(inner);
+    });
+
+    it('preserves text content in document order so annotation offsets do not shift', () => {
+        const inner = teiEl('div', 'inner ');
+        const section1 = teiEl('div', 'first ', inner, 'middle ');
+        const section2 = teiEl('div', 'second ');
+        container.appendChild(document.createTextNode('lead '));
+        container.appendChild(section1);
+        container.appendChild(document.createTextNode(' between '));
+        container.appendChild(section2);
+        container.appendChild(document.createTextNode(' trail'));
+        const before = textInOrder(container);
+
+        normalizeSectionsForPinning(container, new Set(['div']));
+
+        expect(textInOrder(container)).toBe(before);
+    });
+
+    it('is idempotent: running twice does not double-wrap', () => {
+        const div = teiEl('div', 'body');
+        container.appendChild(div);
+
+        normalizeSectionsForPinning(container, new Set(['div']));
+        normalizeSectionsForPinning(container, new Set(['div']));
+
+        expect(container.querySelectorAll('sec-wrap').length).toBe(1);
+        expect(container.firstElementChild?.firstElementChild).toBe(div);
+    });
+
+    it('only wraps elements whose local name is configured', () => {
+        const wanted = teiEl('div', 'wrapme');
+        const skipped = teiEl('p', 'leaveme');
+        container.appendChild(wanted);
+        container.appendChild(skipped);
+
+        normalizeSectionsForPinning(container, new Set(['div']));
+
+        expect(container.querySelectorAll('sec-wrap').length).toBe(1);
+        expect(container.querySelector('sec-wrap')?.firstElementChild).toBe(wanted);
+        expect(skipped.parentElement).toBe(container);
+    });
+});

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionPinning.test.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionPinning.test.ts
@@ -133,7 +133,7 @@ describe('normalizeSectionsForPinning', () => {
         const outer = teiEl('div', 'outer ', inner);
         container.appendChild(outer);
 
-        normalizeSectionsForPinning(container, new Set(['div']));
+        const selector = normalizeSectionsForPinning(container, new Set(['div']));
 
         const wraps = container.querySelectorAll('sec-wrap');
         expect(wraps.length).toBe(2);
@@ -145,6 +145,13 @@ describe('normalizeSectionsForPinning', () => {
         expect(outerWrap.localName).toBe('sec-wrap');
         expect(outerWrap.firstElementChild).toBe(outer);
         expect(outer.querySelector('sec-wrap')?.firstElementChild).toBe(inner);
+        // Lock down the returned selector: all-namespaced => WRAPPER_SELECTOR,
+        // and it must resolve to exactly both wrappers (outer + inner), not the
+        // buried originals.
+        expect(selector).toBe(WRAPPER_SELECTOR);
+        expect(new Set(container.querySelectorAll(selector))).toEqual(
+            new Set(Array.from(wraps))
+        );
     });
 
     it('preserves text content in document order so annotation offsets do not shift', () => {
@@ -177,6 +184,10 @@ describe('normalizeSectionsForPinning', () => {
         // original elements.
         expect(first).toBe(WRAPPER_SELECTOR);
         expect(second).toBe(WRAPPER_SELECTOR);
+        // ...and it must resolve to exactly the one wrapper, never the buried
+        // original.
+        const wrap = container.firstElementChild!;
+        expect(Array.from(container.querySelectorAll(second))).toEqual([wrap]);
     });
 
     it('wraps a namespaced element named sec-wrap rather than mistaking it for the synthetic wrapper', () => {
@@ -207,6 +218,49 @@ describe('normalizeSectionsForPinning', () => {
         expect(wrap.firstElementChild).toBe(teiSecWrap);
     });
 
+    it('wraps a configured XHTML <sec-wrap> that lacks the synthetic marker attribute', () => {
+        // An XHTML <sec-wrap> is already an HTMLElement, so it needs no wrapping
+        // and is left in place (it goes through the already-pinnable branch).
+        // The point: it must NOT be treated as one of our synthetic wrappers --
+        // only elements carrying data-section-type are. Here it is configured as
+        // a section, so it should be reported via the original-name selector.
+        const plainSecWrap = document.createElement('sec-wrap'); // XHTML, no marker
+        plainSecWrap.textContent = 'plain';
+        container.appendChild(plainSecWrap);
+
+        const selector = normalizeSectionsForPinning(container, new Set(['sec-wrap']));
+
+        // Already HTML => nothing wrapped => original-name selector, and it has
+        // no data-section-type so WRAPPER_SELECTOR would not match it.
+        expect(selector).toBe('sec-wrap');
+        expect(plainSecWrap.parentElement).toBe(container);
+        expect(plainSecWrap.hasAttribute('data-section-type')).toBe(false);
+        expect(Array.from(container.querySelectorAll(WRAPPER_SELECTOR))).toEqual([]);
+    });
+
+    it('mixed selector reaches an HTML section that is nested inside a namespaced <sec-wrap>', () => {
+        // Regression for the :not() guard: a bare ':not(sec-wrap *)' would wrongly
+        // exclude a section nested in a *namespaced* <sec-wrap> (type selectors
+        // ignore namespace). The attribute-based ':not(sec-wrap[data-section-type] *)'
+        // must only exclude descendants of our synthetic wrappers.
+        const teiSecWrap = teiEl('sec-wrap'); // a non-wrapper that shares the name
+        const htmlSection = document.createElement('div');
+        htmlSection.textContent = 'nested html section';
+        teiSecWrap.appendChild(htmlSection);
+        const teiDiv = teiEl('div', 'namespaced section'); // forces a real wrapper
+        container.appendChild(teiSecWrap);
+        container.appendChild(teiDiv);
+
+        const selector = normalizeSectionsForPinning(container, new Set(['div']));
+
+        const matched = Array.from(container.querySelectorAll(selector));
+        const realWrap = container.querySelector(WRAPPER_SELECTOR)!;
+        expect(matched).toContain(realWrap); // wrapped namespaced div
+        // The HTML <div> nested under the *namespaced* <sec-wrap> is NOT inside a
+        // synthetic wrapper, so it must still be selected.
+        expect(matched).toContain(htmlSection);
+    });
+
     it('only wraps elements whose local name is configured', () => {
         const wanted = teiEl('div', 'wrapme');
         const skipped = teiEl('p', 'leaveme');
@@ -218,5 +272,48 @@ describe('normalizeSectionsForPinning', () => {
         expect(container.querySelectorAll('sec-wrap').length).toBe(1);
         expect(container.querySelector('sec-wrap')?.firstElementChild).toBe(wanted);
         expect(skipped.parentElement).toBe(container);
+    });
+
+    it('handles section local names containing CSS-special characters', () => {
+        // XML element names legitimately contain dots etc. A raw selector like
+        // 'foo.bar' would parse as element foo + class bar and silently match
+        // nothing, leaving the section unwrapped and unpinnable. The name must be
+        // escaped before use in querySelectorAll / :is(...).
+        const dotted = teiEl('foo.bar', 'body');
+        container.appendChild(dotted);
+
+        const selector = normalizeSectionsForPinning(container, new Set(['foo.bar']));
+
+        // It must have been wrapped (found despite the special character)...
+        const wrap = container.querySelector('sec-wrap')!;
+        expect(wrap).toBeTruthy();
+        expect(wrap.firstElementChild).toBe(dotted);
+        expect(wrap.getAttribute('data-section-type')).toBe('foo.bar');
+        // ...and the returned selector must be usable without throwing.
+        expect(() => container.querySelectorAll(selector)).not.toThrow();
+        expect(Array.from(container.querySelectorAll(selector))).toEqual([wrap]);
+    });
+
+    it('mixed guard keeps a genuine HTML section nested inside a wrapped namespaced ancestor', () => {
+        // Regression: the buried original is the wrapper's *direct* child, but a
+        // real already-HTML section can sit DEEPER inside a wrapped namespaced
+        // ancestor. A descendant-combinator :not(sec-wrap *) guard would wrongly
+        // drop it; the child-combinator guard must keep it.
+        const nestedHtml = document.createElement('div');
+        nestedHtml.textContent = 'nested html section';
+        const teiAncestor = teiEl('div', 'a', nestedHtml); // wrapped; deep html div kept
+        const htmlTop = document.createElement('div');
+        htmlTop.textContent = 'top html section';
+        container.appendChild(htmlTop);
+        container.appendChild(teiAncestor);
+
+        const selector = normalizeSectionsForPinning(container, new Set(['div']));
+
+        const matched = Array.from(container.querySelectorAll(selector));
+        const wrap = container.querySelector(WRAPPER_SELECTOR)!;
+        expect(matched).toContain(wrap); // the wrapped namespaced ancestor
+        expect(matched).toContain(htmlTop); // top-level HTML section
+        expect(matched).toContain(nestedHtml); // deep HTML section must NOT be excluded
+        expect(matched).not.toContain(teiAncestor); // buried original still excluded
     });
 });

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionPinning.test.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionPinning.test.ts
@@ -135,15 +135,20 @@ describe('normalizeSectionsForPinning', () => {
         expect(textInOrder(container)).toBe(before);
     });
 
-    it('is idempotent: running twice does not double-wrap', () => {
+    it('is idempotent: running twice does not double-wrap and keeps reporting the wrapper selector', () => {
         const div = teiEl('div', 'body');
         container.appendChild(div);
 
-        normalizeSectionsForPinning(container, new Set(['div']));
-        normalizeSectionsForPinning(container, new Set(['div']));
+        const first = normalizeSectionsForPinning(container, new Set(['div']));
+        const second = normalizeSectionsForPinning(container, new Set(['div']));
 
         expect(container.querySelectorAll('sec-wrap').length).toBe(1);
         expect(container.firstElementChild?.firstElementChild).toBe(div);
+        // The selector must stay 'sec-wrap' on the re-run: the wrappers still
+        // exist, so downstream must keep targeting them rather than the
+        // now-buried original elements.
+        expect(first).toBe('sec-wrap');
+        expect(second).toBe('sec-wrap');
     });
 
     it('only wraps elements whose local name is configured', () => {

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionPinning.test.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionPinning.test.ts
@@ -20,6 +20,11 @@ import { normalizeSectionsForPinning } from './SectionPinning';
 
 const TEI_NS = 'http://www.tei-c.org/ns/1.0';
 const XHTML_NS = 'http://www.w3.org/1999/xhtml';
+// The selector the function returns for "a wrapped section": the synthetic
+// wrappers are addressed by their data-section-type attribute, not by the bare
+// 'sec-wrap' tag name, so a buried namespaced original sharing that local name
+// is never matched.
+const WRAPPER_SELECTOR = 'sec-wrap[data-section-type]';
 
 let container: HTMLElement;
 
@@ -74,7 +79,7 @@ describe('normalizeSectionsForPinning', () => {
 
         const selector = normalizeSectionsForPinning(container, new Set(['div']));
 
-        expect(selector).toBe('sec-wrap');
+        expect(selector).toBe(WRAPPER_SELECTOR);
         const wraps = container.querySelectorAll('sec-wrap');
         expect(wraps.length).toBe(1);
         // Wrapper is HTML-namespace so the editor's HTMLElement-only inline-style
@@ -167,11 +172,11 @@ describe('normalizeSectionsForPinning', () => {
 
         expect(container.querySelectorAll('sec-wrap').length).toBe(1);
         expect(container.firstElementChild?.firstElementChild).toBe(div);
-        // The selector must stay 'sec-wrap' on the re-run: the wrappers still
-        // exist, so downstream must keep targeting them rather than the
-        // now-buried original elements.
-        expect(first).toBe('sec-wrap');
-        expect(second).toBe('sec-wrap');
+        // The selector must stay stable on the re-run: the wrappers still exist,
+        // so downstream must keep targeting them rather than the now-buried
+        // original elements.
+        expect(first).toBe(WRAPPER_SELECTOR);
+        expect(second).toBe(WRAPPER_SELECTOR);
     });
 
     it('wraps a namespaced element named sec-wrap rather than mistaking it for the synthetic wrapper', () => {
@@ -183,13 +188,19 @@ describe('normalizeSectionsForPinning', () => {
 
         const selector = normalizeSectionsForPinning(container, new Set(['sec-wrap']));
 
-        expect(selector).toBe('sec-wrap');
+        expect(selector).toBe(WRAPPER_SELECTOR);
         const wrap = container.firstElementChild!;
         // The wrapper is the synthetic XHTML one; the TEI sec-wrap is its child.
         expect(wrap.namespaceURI).toBe(XHTML_NS);
         expect(wrap).toBeInstanceOf(HTMLElement);
         expect(wrap.firstElementChild).toBe(teiSecWrap);
         expect(teiSecWrap.namespaceURI).toBe(TEI_NS);
+        // The returned selector must address only the pinnable wrapper, NOT the
+        // buried namespaced original (which shares the local name 'sec-wrap').
+        // This is the whole reason wrappers are selected by data-section-type.
+        const matched = Array.from(container.querySelectorAll(selector));
+        expect(matched).toEqual([wrap]);
+        expect(matched).not.toContain(teiSecWrap);
         // Running again must not double-wrap the now-pinnable structure.
         normalizeSectionsForPinning(container, new Set(['sec-wrap']));
         expect(container.querySelectorAll('sec-wrap').length).toBe(2); // xhtml wrapper + tei child, no more

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionPinning.test.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionPinning.test.ts
@@ -174,6 +174,28 @@ describe('normalizeSectionsForPinning', () => {
         expect(second).toBe('sec-wrap');
     });
 
+    it('wraps a namespaced element named sec-wrap rather than mistaking it for the synthetic wrapper', () => {
+        // A section element that happens to be a non-HTML <sec-wrap> (here in the
+        // TEI namespace) is itself unpinnable and must be wrapped. The idempotency
+        // skip must not fire on it just because its parent's local name matches.
+        const teiSecWrap = teiEl('sec-wrap', 'body');
+        container.appendChild(teiSecWrap);
+
+        const selector = normalizeSectionsForPinning(container, new Set(['sec-wrap']));
+
+        expect(selector).toBe('sec-wrap');
+        const wrap = container.firstElementChild!;
+        // The wrapper is the synthetic XHTML one; the TEI sec-wrap is its child.
+        expect(wrap.namespaceURI).toBe(XHTML_NS);
+        expect(wrap).toBeInstanceOf(HTMLElement);
+        expect(wrap.firstElementChild).toBe(teiSecWrap);
+        expect(teiSecWrap.namespaceURI).toBe(TEI_NS);
+        // Running again must not double-wrap the now-pinnable structure.
+        normalizeSectionsForPinning(container, new Set(['sec-wrap']));
+        expect(container.querySelectorAll('sec-wrap').length).toBe(2); // xhtml wrapper + tei child, no more
+        expect(wrap.firstElementChild).toBe(teiSecWrap);
+    });
+
     it('only wraps elements whose local name is configured', () => {
         const wanted = teiEl('div', 'wrapme');
         const skipped = teiEl('p', 'leaveme');

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionPinning.test.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionPinning.test.ts
@@ -100,6 +100,29 @@ describe('normalizeSectionsForPinning', () => {
         expect(xhtmlSection.parentElement).toBe(container);
     });
 
+    it('returns a combined selector when HTML and namespaced sections are mixed', () => {
+        // Same configured local name ('div') matches both an already-HTML <div>
+        // (left in place) and a namespaced TEI <div> (wrapped). The returned
+        // selector must reach the wrapper AND the untouched HTML div, but not
+        // the original TEI div now buried inside the wrapper.
+        const htmlDiv = document.createElement('div');
+        htmlDiv.textContent = 'html section';
+        const teiDiv = teiEl('div', 'tei section');
+        container.appendChild(htmlDiv);
+        container.appendChild(teiDiv);
+
+        const selector = normalizeSectionsForPinning(container, new Set(['div']));
+
+        expect(container.querySelectorAll('sec-wrap').length).toBe(1);
+        // What the editor will actually select afterwards:
+        const matched = Array.from(container.querySelectorAll(selector));
+        const wrap = container.querySelector('sec-wrap')!;
+        expect(matched).toContain(wrap); // the wrapped (was namespaced) section
+        expect(matched).toContain(htmlDiv); // the still-unwrapped HTML section
+        expect(matched).not.toContain(teiDiv); // buried original must not double-match
+        expect(matched.length).toBe(2);
+    });
+
     it('wraps nested sections at each level', () => {
         const inner = teiEl('div', 'inner text');
         const outer = teiEl('div', 'outer ', inner);

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionPinning.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionPinning.ts
@@ -42,9 +42,16 @@ const WRAPPER_TAG = 'sec-wrap';
  * separately by the {@link DocumentStructureStrategy}.
  *
  * @returns the CSS selector the editor should use for "a section" afterwards:
- *   {@code 'sec-wrap'} when any wrapping happened, the original element-name
- *   selector when every section was already HTML, or {@code ''} when no section
- *   elements were configured.
+ *   - {@code ''} when no section elements were configured.
+ *   - the original element-name selector (e.g. {@code 'div,p'}) when nothing
+ *     was wrapped because every matching section was already HTML.
+ *   - {@code 'sec-wrap'} when every matching section got wrapped.
+ *   - a combined selector (e.g.
+ *     {@code 'sec-wrap, :is(div,p):not(sec-wrap *)'}) when the document mixes
+ *     already-HTML sections (left in place) with namespaced ones (wrapped), so
+ *     downstream targets the wrappers AND the still-unwrapped HTML sections.
+ *     The {@code :not(sec-wrap *)} keeps the original elements now buried inside
+ *     a wrapper from matching twice.
  */
 export function normalizeSectionsForPinning(
     container: Element,
@@ -61,13 +68,15 @@ export function normalizeSectionsForPinning(
     // moves into the new wrapper and is still wrapped on a later iteration.
     const targets = Array.from(container.querySelectorAll(selector));
 
-    // True if wrappers exist when we are done -- whether created here or already
-    // present from an earlier run. The return value must reflect the resulting
-    // DOM, not just this invocation's actions, so a re-run keeps reporting the
-    // wrapper selector and downstream keeps targeting the wrappers.
+    // Track the resulting DOM (not just this run's actions) so the returned
+    // selector is correct even on a re-run or a mixed document.
     let hasWrappers = false;
+    let hasUnwrapped = false;
     for (const el of targets) {
-        if (el.namespaceURI === XHTML_NS) continue; // already pinnable
+        if (el.namespaceURI === XHTML_NS) {
+            hasUnwrapped = true; // already pinnable, stays as itself
+            continue;
+        }
 
         const parent = el.parentNode;
         if (!parent) continue;
@@ -87,7 +96,10 @@ export function normalizeSectionsForPinning(
         hasWrappers = true;
     }
 
-    // If every section was already HTML, no wrappers exist and the section
-    // boundaries are still the original elements.
-    return hasWrappers ? WRAPPER_TAG : selector;
+    if (!hasWrappers) return selector;
+    if (!hasUnwrapped) return WRAPPER_TAG;
+    // Mixed: target wrappers plus the still-unwrapped originals. The
+    // :not(sec-wrap *) guard excludes originals now buried inside a wrapper so
+    // they don't match alongside their own wrapper.
+    return `${WRAPPER_TAG}, :is(${selector}):not(${WRAPPER_TAG} *)`;
 }

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionPinning.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionPinning.ts
@@ -81,9 +81,13 @@ export function normalizeSectionsForPinning(
         const parent = el.parentNode;
         if (!parent) continue;
         // Idempotent: skip if already wrapped (e.g. run twice on the same tree).
+        // Match only our synthetic XHTML-namespace wrapper -- a section element
+        // that happens to be a namespaced <foo:sec-wrap> is NOT a real wrapper,
+        // is still a non-HTMLElement, and must itself be wrapped to be pinnable.
         if (
             parent.nodeType === Node.ELEMENT_NODE &&
-            (parent as Element).localName === WRAPPER_TAG
+            (parent as Element).localName === WRAPPER_TAG &&
+            (parent as Element).namespaceURI === XHTML_NS
         ) {
             hasWrappers = true;
             continue;

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionPinning.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionPinning.ts
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const XHTML_NS = 'http://www.w3.org/1999/xhtml';
+const WRAPPER_TAG = 'sec-wrap';
+
+/**
+ * Make every configured section element pinnable by the layout code.
+ *
+ * The visualizer pins each section's width/height by writing inline styles, but
+ * it only operates on HTMLElement (see the `instanceof HTMLElement` guard in
+ * ApacheAnnotatorVisualizer.materializeWidthAndHeight). A section element in a
+ * non-HTML XML namespace is a plain Element with no working `.style` -- the CSS
+ * engine ignores its `style` attribute even when set -- so it is silently
+ * skipped, which collapses the document area in Safari/Firefox (#6091).
+ *
+ * To make such an element pinnable it must become an HTML element, so this wraps
+ * each one in a synthetic XHTML-namespace {@code <sec-wrap>} and uses the
+ * wrapper as the section boundary. The wrap is structural only: no text nodes
+ * are added, removed, or reordered, so annotation character offsets are
+ * unchanged. The original element stays as the wrapper's only child, so format
+ * CSS keyed on its tag name still applies. Elements already in the HTML
+ * namespace are left as-is -- they are already pinnable.
+ *
+ * This is purely a rendering fix and knows nothing about document structure
+ * (titles, headings, outline): that is the navigator's concern, handled
+ * separately by the {@link DocumentStructureStrategy}.
+ *
+ * @returns the CSS selector the editor should use for "a section" afterwards:
+ *   {@code 'sec-wrap'} when any wrapping happened, the original element-name
+ *   selector when every section was already HTML, or {@code ''} when no section
+ *   elements were configured.
+ */
+export function normalizeSectionsForPinning(
+    container: Element,
+    sectionElementLocalNames: Set<string>
+): string {
+    if (sectionElementLocalNames.size === 0) return '';
+
+    const doc = container.ownerDocument;
+    const selector = [...sectionElementLocalNames].join(',');
+    if (!doc) return selector;
+
+    // Snapshot so we can mutate the tree while iterating. Document order means
+    // an ancestor is wrapped before its descendants, which is safe: a descendant
+    // moves into the new wrapper and is still wrapped on a later iteration.
+    const targets = Array.from(container.querySelectorAll(selector));
+
+    let wrapped = false;
+    for (const el of targets) {
+        if (el.namespaceURI === XHTML_NS) continue; // already pinnable
+
+        const parent = el.parentNode;
+        if (!parent) continue;
+        // Idempotent: skip if already wrapped (e.g. preprocess run twice).
+        if (
+            parent.nodeType === Node.ELEMENT_NODE &&
+            (parent as Element).localName === WRAPPER_TAG
+        ) {
+            continue;
+        }
+
+        const wrapper = doc.createElementNS(XHTML_NS, WRAPPER_TAG);
+        wrapper.setAttribute('data-section-type', el.localName);
+        parent.insertBefore(wrapper, el);
+        wrapper.appendChild(el);
+        wrapped = true;
+    }
+
+    // If every section was already HTML, no wrappers exist and the section
+    // boundaries are still the original elements.
+    return wrapped ? WRAPPER_TAG : selector;
+}

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionPinning.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionPinning.ts
@@ -18,6 +18,12 @@
 
 const XHTML_NS = 'http://www.w3.org/1999/xhtml';
 const WRAPPER_TAG = 'sec-wrap';
+// Attribute stamped on every synthetic wrapper (and only on those). Selecting by
+// it -- rather than by the bare tag name -- avoids matching a buried namespaced
+// original that happens to share the local name 'sec-wrap'. `querySelectorAll`
+// matches local names ignoring namespace, so the tag name alone is ambiguous.
+const WRAPPER_ATTR = 'data-section-type';
+const WRAPPER_SELECTOR = `${WRAPPER_TAG}[${WRAPPER_ATTR}]`;
 
 /**
  * Make every configured section element pinnable by the layout code.
@@ -41,17 +47,24 @@ const WRAPPER_TAG = 'sec-wrap';
  * (titles, headings, outline): that is the navigator's concern, handled
  * separately by the {@link DocumentStructureStrategy}.
  *
+ * Wrappers are identified by the {@code data-section-type} attribute they carry
+ * (selector {@code sec-wrap[data-section-type]}), never by the bare tag name:
+ * {@code querySelectorAll} matches local names ignoring namespace, so a buried
+ * namespaced original whose local name is also {@code sec-wrap} would otherwise
+ * be mistaken for a real wrapper.
+ *
  * @returns the CSS selector the editor should use for "a section" afterwards:
  *   - {@code ''} when no section elements were configured.
  *   - the original element-name selector (e.g. {@code 'div,p'}) when nothing
  *     was wrapped because every matching section was already HTML.
- *   - {@code 'sec-wrap'} when every matching section got wrapped.
+ *   - {@code 'sec-wrap[data-section-type]'} when every matching section got
+ *     wrapped.
  *   - a combined selector (e.g.
- *     {@code 'sec-wrap, :is(div,p):not(sec-wrap *)'}) when the document mixes
- *     already-HTML sections (left in place) with namespaced ones (wrapped), so
- *     downstream targets the wrappers AND the still-unwrapped HTML sections.
- *     The {@code :not(sec-wrap *)} keeps the original elements now buried inside
- *     a wrapper from matching twice.
+ *     {@code 'sec-wrap[data-section-type], :is(div,p):not(sec-wrap *)'}) when
+ *     the document mixes already-HTML sections (left in place) with namespaced
+ *     ones (wrapped), so downstream targets the wrappers AND the still-unwrapped
+ *     HTML sections. The {@code :not(sec-wrap *)} keeps the original elements now
+ *     buried inside a wrapper from matching twice.
  */
 export function normalizeSectionsForPinning(
     container: Element,
@@ -94,16 +107,18 @@ export function normalizeSectionsForPinning(
         }
 
         const wrapper = doc.createElementNS(XHTML_NS, WRAPPER_TAG);
-        wrapper.setAttribute('data-section-type', el.localName);
+        wrapper.setAttribute(WRAPPER_ATTR, el.localName);
         parent.insertBefore(wrapper, el);
         wrapper.appendChild(el);
         hasWrappers = true;
     }
 
     if (!hasWrappers) return selector;
-    if (!hasUnwrapped) return WRAPPER_TAG;
-    // Mixed: target wrappers plus the still-unwrapped originals. The
-    // :not(sec-wrap *) guard excludes originals now buried inside a wrapper so
-    // they don't match alongside their own wrapper.
-    return `${WRAPPER_TAG}, :is(${selector}):not(${WRAPPER_TAG} *)`;
+    if (!hasUnwrapped) return WRAPPER_SELECTOR;
+    // Mixed: target the synthetic wrappers plus the still-unwrapped originals.
+    // Wrappers are matched via WRAPPER_SELECTOR (the data-section-type attribute)
+    // so a buried original sharing the local name 'sec-wrap' is not picked up,
+    // and the :not(sec-wrap *) guard excludes any original now nested inside a
+    // wrapper from matching alongside its own wrapper.
+    return `${WRAPPER_SELECTOR}, :is(${selector}):not(${WRAPPER_TAG} *)`;
 }

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionPinning.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionPinning.ts
@@ -26,6 +26,44 @@ const WRAPPER_ATTR = 'data-section-type';
 const WRAPPER_SELECTOR = `${WRAPPER_TAG}[${WRAPPER_ATTR}]`;
 
 /**
+ * Whether {@code node} is one of *our* synthetic wrappers. The single source of
+ * truth for "is this a wrapper" across this module: a wrapper is an XHTML-
+ * namespace {@code <sec-wrap>} carrying the {@code data-section-type} attribute
+ * we stamp on it. Checking the attribute (not just tag + namespace) is what
+ * distinguishes our wrapper from an unrelated {@code <sec-wrap>} that some other
+ * markup might contain. Equivalent to matching {@link WRAPPER_SELECTOR}.
+ */
+function isSyntheticWrapper(node: Node | null): node is Element {
+    return (
+        node != null &&
+        node.nodeType === Node.ELEMENT_NODE &&
+        (node as Element).localName === WRAPPER_TAG &&
+        (node as Element).namespaceURI === XHTML_NS &&
+        (node as Element).hasAttribute(WRAPPER_ATTR)
+    );
+}
+
+/**
+ * Escape a section element's local name for safe use as a CSS type selector.
+ * The names come straight from format configuration ({@code props.sectionElements})
+ * and XML local names legitimately contain characters that are special in CSS --
+ * e.g. a dot ({@code <foo.bar>} would otherwise parse as element {@code foo}
+ * class {@code bar} and silently match nothing) or a leading digit (which throws
+ * {@code DOMException: Invalid selector} and would abort editor init). Prefer the
+ * platform {@code CSS.escape}; fall back to a minimal escaper when it is absent
+ * (e.g. the jsdom test environment).
+ */
+function escapeName(name: string): string {
+    const css = (globalThis as { CSS?: { escape?: (s: string) => string } }).CSS;
+    if (css?.escape) return css.escape(name);
+    // Minimal fallback: backslash-escape every non-(alphanumeric/-/_) character,
+    // and a leading digit, matching the relevant parts of CSS.escape's contract.
+    return name
+        .replace(/^[0-9]/, (d) => `\\3${d} `)
+        .replace(/[^a-zA-Z0-9\-_]/g, (c) => `\\${c}`);
+}
+
+/**
  * Make every configured section element pinnable by the layout code.
  *
  * The visualizer pins each section's width/height by writing inline styles, but
@@ -59,12 +97,13 @@ const WRAPPER_SELECTOR = `${WRAPPER_TAG}[${WRAPPER_ATTR}]`;
  *     was wrapped because every matching section was already HTML.
  *   - {@code 'sec-wrap[data-section-type]'} when every matching section got
  *     wrapped.
- *   - a combined selector (e.g.
- *     {@code 'sec-wrap[data-section-type], :is(div,p):not(sec-wrap *)'}) when
- *     the document mixes already-HTML sections (left in place) with namespaced
- *     ones (wrapped), so downstream targets the wrappers AND the still-unwrapped
- *     HTML sections. The {@code :not(sec-wrap *)} keeps the original elements now
- *     buried inside a wrapper from matching twice.
+ *   - a combined selector (e.g. {@code 'sec-wrap[data-section-type],
+ *     :is(div,p):not(sec-wrap[data-section-type] > *)'}) when the document mixes
+ *     already-HTML sections (left in place) with namespaced ones (wrapped), so
+ *     downstream targets the wrappers AND the still-unwrapped HTML sections. The
+ *     {@code :not(sec-wrap[data-section-type] > *)} guard uses the child
+ *     combinator so it excludes only each wrapper's direct buried original, not
+ *     a genuine HTML section nested deeper inside a wrapped ancestor.
  */
 export function normalizeSectionsForPinning(
     container: Element,
@@ -73,7 +112,8 @@ export function normalizeSectionsForPinning(
     if (sectionElementLocalNames.size === 0) return '';
 
     const doc = container.ownerDocument;
-    const selector = [...sectionElementLocalNames].join(',');
+    // Escape each name: XML local names may contain CSS-special characters.
+    const selector = [...sectionElementLocalNames].map(escapeName).join(',');
     if (!doc) return selector;
 
     // Snapshot so we can mutate the tree while iterating. Document order means
@@ -86,6 +126,13 @@ export function normalizeSectionsForPinning(
     let hasWrappers = false;
     let hasUnwrapped = false;
     for (const el of targets) {
+        // A synthetic wrapper we created earlier (only reachable when the config
+        // literally lists 'sec-wrap', or on a re-run): count it as a wrapper, not
+        // an unwrapped HTML section, so the returned selector stays stable.
+        if (isSyntheticWrapper(el)) {
+            hasWrappers = true;
+            continue;
+        }
         if (el.namespaceURI === XHTML_NS) {
             hasUnwrapped = true; // already pinnable, stays as itself
             continue;
@@ -94,14 +141,11 @@ export function normalizeSectionsForPinning(
         const parent = el.parentNode;
         if (!parent) continue;
         // Idempotent: skip if already wrapped (e.g. run twice on the same tree).
-        // Match only our synthetic XHTML-namespace wrapper -- a section element
-        // that happens to be a namespaced <foo:sec-wrap> is NOT a real wrapper,
-        // is still a non-HTMLElement, and must itself be wrapped to be pinnable.
-        if (
-            parent.nodeType === Node.ELEMENT_NODE &&
-            (parent as Element).localName === WRAPPER_TAG &&
-            (parent as Element).namespaceURI === XHTML_NS
-        ) {
+        // Only one of *our* synthetic wrappers counts -- a namespaced
+        // <foo:sec-wrap>, or any unrelated <sec-wrap> without our marker
+        // attribute, is NOT a wrapper, is still a non-HTMLElement, and must
+        // itself be wrapped to be pinnable.
+        if (isSyntheticWrapper(parent)) {
             hasWrappers = true;
             continue;
         }
@@ -116,9 +160,12 @@ export function normalizeSectionsForPinning(
     if (!hasWrappers) return selector;
     if (!hasUnwrapped) return WRAPPER_SELECTOR;
     // Mixed: target the synthetic wrappers plus the still-unwrapped originals.
-    // Wrappers are matched via WRAPPER_SELECTOR (the data-section-type attribute)
-    // so a buried original sharing the local name 'sec-wrap' is not picked up,
-    // and the :not(sec-wrap *) guard excludes any original now nested inside a
-    // wrapper from matching alongside its own wrapper.
-    return `${WRAPPER_SELECTOR}, :is(${selector}):not(${WRAPPER_TAG} *)`;
+    // The first half matches only real wrappers (via the data-section-type
+    // attribute). The :not(...) guard uses the CHILD combinator -- a buried
+    // original is always the *direct* child of its wrapper (we appendChild it),
+    // so `WRAPPER_SELECTOR > *` excludes exactly those originals. A descendant
+    // combinator (`WRAPPER_SELECTOR *`) would over-exclude: a genuine already-
+    // HTML section nested deeper inside a wrapped namespaced ancestor would be
+    // wrongly dropped from the section set.
+    return `${WRAPPER_SELECTOR}, :is(${selector}):not(${WRAPPER_SELECTOR} > *)`;
 }

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionPinning.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SectionPinning.ts
@@ -61,17 +61,22 @@ export function normalizeSectionsForPinning(
     // moves into the new wrapper and is still wrapped on a later iteration.
     const targets = Array.from(container.querySelectorAll(selector));
 
-    let wrapped = false;
+    // True if wrappers exist when we are done -- whether created here or already
+    // present from an earlier run. The return value must reflect the resulting
+    // DOM, not just this invocation's actions, so a re-run keeps reporting the
+    // wrapper selector and downstream keeps targeting the wrappers.
+    let hasWrappers = false;
     for (const el of targets) {
         if (el.namespaceURI === XHTML_NS) continue; // already pinnable
 
         const parent = el.parentNode;
         if (!parent) continue;
-        // Idempotent: skip if already wrapped (e.g. preprocess run twice).
+        // Idempotent: skip if already wrapped (e.g. run twice on the same tree).
         if (
             parent.nodeType === Node.ELEMENT_NODE &&
             (parent as Element).localName === WRAPPER_TAG
         ) {
+            hasWrappers = true;
             continue;
         }
 
@@ -79,10 +84,10 @@ export function normalizeSectionsForPinning(
         wrapper.setAttribute('data-section-type', el.localName);
         parent.insertBefore(wrapper, el);
         wrapper.appendChild(el);
-        wrapped = true;
+        hasWrappers = true;
     }
 
     // If every section was already HTML, no wrappers exist and the section
     // boundaries are still the original elements.
-    return wrapped ? WRAPPER_TAG : selector;
+    return hasWrappers ? WRAPPER_TAG : selector;
 }

--- a/inception/inception-io-xml/src/main/java/de/tudarmstadt/ukp/inception/io/xml/CustomXmlFormatFactory.java
+++ b/inception/inception-io-xml/src/main/java/de/tudarmstadt/ukp/inception/io/xml/CustomXmlFormatFactory.java
@@ -91,9 +91,10 @@ public class CustomXmlFormatFactory
         }
 
         scriptReferences = new ArrayList<ResourceReference>();
+        var basePath = description.getBasePath().normalize();
         for (var script : description.getScripts()) {
-            var scriptPath = description.getBasePath().resolve(script);
-            if (!scriptPath.startsWith(description.getBasePath())) {
+            var scriptPath = basePath.resolve(script).normalize();
+            if (!scriptPath.startsWith(basePath)) {
                 LOG.warn("Script in custom XML format [{}] has illegal path [{}]",
                         description.getId(), script);
                 continue;

--- a/inception/inception-io-xml/src/main/java/de/tudarmstadt/ukp/inception/io/xml/CustomXmlFormatFactory.java
+++ b/inception/inception-io-xml/src/main/java/de/tudarmstadt/ukp/inception/io/xml/CustomXmlFormatFactory.java
@@ -55,6 +55,7 @@ public class CustomXmlFormatFactory
     private final CustomXmlFormatPluginDescripion description;
     private final Application wicketApplication;
     private final List<ResourceReference> stylesheetReferences;
+    private final List<ResourceReference> scriptReferences;
 
     private WatchedResourceFile<PolicyCollection> policyResource;
 
@@ -88,6 +89,20 @@ public class CustomXmlFormatFactory
             wicketApplication.getResourceReferenceRegistry().registerResourceReference(ref);
             stylesheetReferences.add(ref);
         }
+
+        scriptReferences = new ArrayList<ResourceReference>();
+        for (var script : description.getScripts()) {
+            var scriptPath = description.getBasePath().resolve(script);
+            if (!scriptPath.startsWith(description.getBasePath())) {
+                LOG.warn("Script in custom XML format [{}] has illegal path [{}]",
+                        description.getId(), script);
+                continue;
+            }
+            var ref = new FileSystemResourceReference(
+                    PLUGINS_XML_FORMAT_BASE_NAME + description.getId() + "/" + script, scriptPath);
+            wicketApplication.getResourceReferenceRegistry().registerResourceReference(ref);
+            scriptReferences.add(ref);
+        }
     }
 
     @Override
@@ -106,6 +121,18 @@ public class CustomXmlFormatFactory
     public List<ResourceReference> getCssStylesheets()
     {
         return stylesheetReferences;
+    }
+
+    @Override
+    public List<ResourceReference> getJavaScripts()
+    {
+        return scriptReferences;
+    }
+
+    @Override
+    public Optional<String> getDocumentStructureFactory()
+    {
+        return Optional.ofNullable(description.getDocumentStructureFactory());
     }
 
     @Override

--- a/inception/inception-io-xml/src/main/java/de/tudarmstadt/ukp/inception/io/xml/CustomXmlFormatFactory.java
+++ b/inception/inception-io-xml/src/main/java/de/tudarmstadt/ukp/inception/io/xml/CustomXmlFormatFactory.java
@@ -91,7 +91,6 @@ public class CustomXmlFormatFactory
         }
 
         scriptReferences = new ArrayList<ResourceReference>();
-        var basePath = description.getBasePath().normalize();
         for (var script : description.getScripts()) {
             var scriptPath = basePath.resolve(script).normalize();
             if (!scriptPath.startsWith(basePath)) {

--- a/inception/inception-io-xml/src/main/java/de/tudarmstadt/ukp/inception/io/xml/CustomXmlFormatPluginDescripion.java
+++ b/inception/inception-io-xml/src/main/java/de/tudarmstadt/ukp/inception/io/xml/CustomXmlFormatPluginDescripion.java
@@ -36,6 +36,8 @@ public class CustomXmlFormatPluginDescripion
     private String name;
 
     private List<String> stylesheets = emptyList();
+    private List<String> scripts = emptyList();
+    private String documentStructureFactory;
     private Set<String> sectionElements = emptySet();
     private List<String> blockElements = emptyList();
     private boolean splitSentencesInBlockElements;
@@ -80,6 +82,26 @@ public class CustomXmlFormatPluginDescripion
     public void setStylesheets(List<String> aStylesheets)
     {
         stylesheets = aStylesheets;
+    }
+
+    public List<String> getScripts()
+    {
+        return scripts;
+    }
+
+    public void setScripts(List<String> aScripts)
+    {
+        scripts = aScripts;
+    }
+
+    public String getDocumentStructureFactory()
+    {
+        return documentStructureFactory;
+    }
+
+    public void setDocumentStructureFactory(String aDocumentStructureFactory)
+    {
+        documentStructureFactory = aDocumentStructureFactory;
     }
 
     public Set<String> getSectionElements()

--- a/inception/inception-io-xml/src/main/java/de/tudarmstadt/ukp/inception/io/xml/CustomXmlFormatPluginDescripion.java
+++ b/inception/inception-io-xml/src/main/java/de/tudarmstadt/ukp/inception/io/xml/CustomXmlFormatPluginDescripion.java
@@ -19,6 +19,7 @@ package de.tudarmstadt.ukp.inception.io.xml;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
+import static java.util.Objects.requireNonNullElse;
 
 import java.io.Serializable;
 import java.nio.file.Path;
@@ -81,7 +82,7 @@ public class CustomXmlFormatPluginDescripion
 
     public void setStylesheets(List<String> aStylesheets)
     {
-        stylesheets = aStylesheets;
+        stylesheets = requireNonNullElse(aStylesheets, emptyList());
     }
 
     public List<String> getScripts()
@@ -91,7 +92,7 @@ public class CustomXmlFormatPluginDescripion
 
     public void setScripts(List<String> aScripts)
     {
-        scripts = aScripts;
+        scripts = requireNonNullElse(aScripts, emptyList());
     }
 
     public String getDocumentStructureFactory()
@@ -111,12 +112,12 @@ public class CustomXmlFormatPluginDescripion
 
     public void setSectionElements(Set<String> aSectionElements)
     {
-        sectionElements = aSectionElements;
+        sectionElements = requireNonNullElse(aSectionElements, emptySet());
     }
 
     public void setBlockElements(List<String> aBlockElements)
     {
-        blockElements = aBlockElements;
+        blockElements = requireNonNullElse(aBlockElements, emptyList());
     }
 
     public List<String> getBlockElements()


### PR DESCRIPTION
**What's in the PR**
- Add `normalizeSectionsForPinning` (SectionPinning.ts): wraps non-HTML-namespace section elements in a synthetic XHTML `<sec-wrap>` so the editor's HTMLElement-only inline-style pinning works, fixing the Safari/Firefox document-area collapse; structural-only wrap that preserves text order and annotation offsets, skips already-HTML and already-wrapped elements, and returns the section selector to use afterwards
- Add SectionPinning.test.ts: covers no-op-when-empty, single/nested wrapping, namespace preservation, already-HTML skip, document-order/offset invariance, idempotency, and only-configured-names
- Run namespace wrapping as an explicit Step 1 in the editor init (before ID assignment), separate from the Step 2 table-of-contents `documentStructure.preprocess()`
- Update `resolveDocumentStructure` docs to note it governs only the TOC outline and that pinning is a separate unconditional step

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
