### PR TITLE
#6095 - Auto-login causes an infinite redirect loop under a non-root server.servlet.context-path

### DIFF
--- a/inception/inception-io-xml/src/main/java/de/tudarmstadt/ukp/inception/io/xml/CustomXmlFormatFactory.java
+++ b/inception/inception-io-xml/src/main/java/de/tudarmstadt/ukp/inception/io/xml/CustomXmlFormatFactory.java
@@ -73,9 +73,10 @@ public class CustomXmlFormatFactory
         }
 
         stylesheetReferences = new ArrayList<ResourceReference>();
+        var basePath = description.getBasePath().normalize();
         for (var stylesheet : description.getStylesheets()) {
-            var stylesheetPath = description.getBasePath().resolve(stylesheet);
-            if (!stylesheetPath.startsWith(description.getBasePath())) {
+            var stylesheetPath = basePath.resolve(stylesheet).normalize();
+            if (!stylesheetPath.startsWith(basePath)) {
                 LOG.warn("Stylesheet in custom XML format [{}] has illegal path [{}]",
                         description.getId(), stylesheet);
                 continue;

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/login/OAuth2LoginPanel.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/login/OAuth2LoginPanel.java
@@ -87,8 +87,18 @@ public class OAuth2LoginPanel
                 .findFirst();
 
         if (maybeAutoLoginTarget.isPresent()) {
-            throw new RedirectToUrlException(maybeAutoLoginTarget.get().getLoginUrl());
+            throw new RedirectToUrlException(toAutoLoginRedirectUrl(servletContext.getContextPath(),
+                    maybeAutoLoginTarget.get().getLoginUrl()));
         }
+    }
+
+    /**
+     * Determine the URL the auto-login should redirect to, given the context-absolute login URL
+     * used verbatim by the login button.
+     */
+    static String toAutoLoginRedirectUrl(String aContextPath, String aLoginUrl)
+    {
+        return aLoginUrl;
     }
 
     /*

--- a/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/login/OAuth2LoginPanel.java
+++ b/inception/inception-ui-core/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/login/OAuth2LoginPanel.java
@@ -95,9 +95,20 @@ public class OAuth2LoginPanel
     /**
      * Determine the URL the auto-login should redirect to, given the context-absolute login URL
      * used verbatim by the login button.
+     * <p>
+     * Wicket's {@code RedirectRequestHandler} re-applies the servlet context path to a redirect URL
+     * that starts with {@code '/'} (via {@code UrlRenderer#renderContextRelativeUrl}). The login
+     * URL is context-absolute, so the context path is stripped here to make it context-relative;
+     * otherwise it would be applied twice (e.g. {@code /inception/inception/oauth2/...}) and
+     * auto-login would enter an infinite redirect loop.
      */
     static String toAutoLoginRedirectUrl(String aContextPath, String aLoginUrl)
     {
+        var contextPath = removeEnd(aContextPath, "/");
+        if (!contextPath.isEmpty() && aLoginUrl.startsWith(contextPath + "/")) {
+            return aLoginUrl.substring(contextPath.length());
+        }
+
         return aLoginUrl;
     }
 

--- a/inception/inception-ui-core/src/test/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/login/OAuth2LoginPanelTest.java
+++ b/inception/inception-ui-core/src/test/java/de/tudarmstadt/ukp/clarin/webanno/ui/core/login/OAuth2LoginPanelTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.ui.core.login;
+
+import static de.tudarmstadt.ukp.clarin.webanno.ui.core.login.OAuth2LoginPanel.toAutoLoginRedirectUrl;
+import static org.apache.commons.lang3.StringUtils.removeEnd;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Reproduces the auto-login redirect loop that occurs when INCEPTION is served under a non-root
+ * {@code server.servlet.context-path} (e.g. {@code /inception}) behind a reverse proxy.
+ * <p>
+ * The login button works because it is rendered as a verbatim
+ * {@link org.apache.wicket.markup.html.link.ExternalLink} and therefore needs a context-absolute
+ * URL. Auto-login instead hands that same URL to
+ * {@link org.apache.wicket.request.flow.RedirectToUrlException}, whose
+ * {@code RedirectRequestHandler} treats any URL starting with {@code '/'} as context-relative and
+ * re-applies the servlet context path via {@code UrlRenderer#renderContextRelativeUrl}. So a
+ * context-absolute URL gets the context path a second time
+ * ({@code /inception/inception/oauth2/...}) and login bounces between {@code /login.html} and
+ * {@code /oauth2/authorization/...} forever.
+ * <p>
+ * The redirect URL handed to {@code RedirectToUrlException} must therefore be context-relative.
+ */
+class OAuth2LoginPanelTest
+{
+    private static final String CONTEXT_PATH = "/inception";
+    private static final String REGISTRATION_ID = "oidc";
+
+    // The context-absolute URL the login button renders verbatim (built by getLoginLinks()).
+    private static final String LOGIN_URL = CONTEXT_PATH + "/oauth2/authorization/"
+            + REGISTRATION_ID;
+
+    @Test
+    void thatAutoLoginRedirectDoesNotDoubleTheServletContextPath()
+    {
+        var redirectUrl = toAutoLoginRedirectUrl(CONTEXT_PATH, LOGIN_URL);
+
+        assertThat(renderRedirectLocation(CONTEXT_PATH, redirectUrl)) //
+                .as("Wicket re-applies the context path on redirect, so the auto-login target must "
+                        + "be context-relative; otherwise the context path is doubled and login "
+                        + "enters an infinite redirect loop")
+                .isEqualTo("/inception/oauth2/authorization/oidc");
+    }
+
+    @Test
+    void thatRootContextIsUnaffected()
+    {
+        var loginUrlAtRoot = "/oauth2/authorization/" + REGISTRATION_ID;
+
+        var redirectUrl = toAutoLoginRedirectUrl("", loginUrlAtRoot);
+
+        assertThat(renderRedirectLocation("", redirectUrl)) //
+                .isEqualTo("/oauth2/authorization/oidc");
+    }
+
+    /**
+     * Faithful model of Apache Wicket 10.9.1 {@code RedirectRequestHandler#respond} +
+     * {@code UrlRenderer#renderContextRelativeUrl} for a request issued at the context root: a URL
+     * starting with {@code '/'} has that slash stripped and the servlet context path prepended (a
+     * URL that does not start with {@code '/'} is emitted unchanged).
+     */
+    private static String renderRedirectLocation(String aContextPath, String aRedirectUrl)
+    {
+        if (aRedirectUrl.isEmpty() || aRedirectUrl.charAt(0) != '/') {
+            return aRedirectUrl;
+        }
+
+        return removeEnd(aContextPath, "/") + "/" + aRedirectUrl.substring(1);
+    }
+}


### PR DESCRIPTION
## The issue
With `security.login.auto-login=<registrationId>` set, INCEPTION enters an infinite 302 redirect loop **when it is deployed under a non-root servlet context path** (`server.servlet.context-path=/inception`). The browser bounces
forever between:
- `https://<host>/inception/inception/oauth2/authorization/<registrationId>`  ← note the **doubled** `/inception/inception/`
- `https://<host>/inception/login.html`

The manual "Login with <provider>" button on `/login.html` works correctly; only the automatic redirect is broken.

### To Reproduce

1. Deploy INCEPTION behind a reverse proxy with `server.servlet.context-path=/inception`.
2. Configure OAuth2 login (`spring.security.oauth2.client.registration.<id>...`). The manual login button works.
3. Set `security.login.auto-login=<id>`.
4. Open `https://<host>/inception/login.html` → infinite redirect loop on `/inception/inception/oauth2/authorization/<id>`.

### Expected behaviour

Auto-login redirects once to `/inception/oauth2/authorization/<id>` and proceeds through the normal OAuth2 flow, exactly as the manual button does.

## The PR 

**What's in the PR**

This PR adds a test to reproduce the behavior and fixes it in Wicket's RedirectRequestHandler#respond()

**How to test manually**
Launching mvn test will test the behavior and the fix, otherwise you can use the steps to reproduce the issue.

**Automatic testing**
* [X] PR includes unit tests

**Documentation**
* [X] PR does not updates the documentation because it should just work
