### PR TITLE
Await displayViewer

### DIFF
--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/pdfanno.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/pdfanno.ts
@@ -535,7 +535,7 @@ async function displayViewer(): Promise<void> {
     // Load a PDF file.
     return Promise.all([
         annoPage.loadVisualModel(vModelUrl),
-        annoPage.displayViewer(getPDFName(pdfUrl), pdfUrl),
+        annoPage.await displayViewer(getPDFName(pdfUrl), pdfUrl),
     ]).then(([vModel]) => {
         console.log('Loaded visual model and viewer');
 


### PR DESCRIPTION
The behavior in displayViewer might be relying on something a little implicit. The promise result gets used as if it were already resolved. this patch adds the missing await so the async path is actually sequenced. Sorry if this is intentional.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.