### PR TITLE
#6097 - Recommender produces no suggestions in the first project of a new installation

### DIFF
--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/AnnotationSuggestion.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/AnnotationSuggestion.java
@@ -121,26 +121,31 @@ public abstract class AnnotationSuggestion
         correction = aBuilder.correction;
         correctionExplanation = aBuilder.correctionExplanation;
 
-        recommenderId = aBuilder.recommenderId != null ? aBuilder.recommenderId
-                : (aBuilder.recommender != null ? aBuilder.recommender.getId() : 0);
+        // Boxed so null (unpersisted) is distinct from a genuine id of 0 (HSQLDB
+        // starts IDENTITY at 0). The asserts below check id != null, not id > 0.
+        Long srcRecommenderId = aBuilder.recommenderId != null ? aBuilder.recommenderId
+                : (aBuilder.recommender != null ? aBuilder.recommender.getId() : null);
+        Long srcLayerId = aBuilder.layerId != null ? aBuilder.layerId
+                : (aBuilder.recommender != null && aBuilder.recommender.getLayer() != null
+                        ? aBuilder.recommender.getLayer().getId()
+                        : null);
+
+        recommenderId = srcRecommenderId != null ? srcRecommenderId : 0;
 
         recommenderName = aBuilder.recommenderName != null ? aBuilder.recommenderName
                 : (aBuilder.recommender != null ? aBuilder.recommender.getName() : null);
 
-        layerId = aBuilder.layerId != null ? aBuilder.layerId
-                : (aBuilder.recommender != null && aBuilder.recommender.getLayer() != null
-                        ? aBuilder.recommender.getLayer().getId()
-                        : 0);
+        layerId = srcLayerId != null ? srcLayerId : 0;
 
         feature = aBuilder.feature != null ? aBuilder.feature
                 : (aBuilder.recommender != null && aBuilder.recommender.getFeature() != null
                         ? aBuilder.recommender.getFeature().getName()
                         : null);
 
-        assert layerId > 0l : "Layer must be persisted (id > 0) but was [" + layerId + "]";
-        assert recommenderId > 0l : "Recommender must be persisted (id > 0) but was "
-                + recommenderId + "]";
-        assert documentId > 0l : "Document must be persisted (id > 0) but was " + documentId + "]";
+        // documentId is a primitive long; it would already have NPE'd on unbox if
+        // the document were unpersisted, so it needs no separate guard here.
+        assert srcLayerId != null : "Layer must be persisted (id must be set)";
+        assert srcRecommenderId != null : "Recommender must be persisted (id must be set)";
         assert feature != null : "Feature cannot be null";
         assert recommenderName != null : "Recommender name cannot be null";
         assert generation >= 0 : "Generation cannot be negative but was [" + generation + "]";

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/AnnotationSuggestion.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/AnnotationSuggestion.java
@@ -144,9 +144,11 @@ public abstract class AnnotationSuggestion
                         ? aBuilder.recommender.getFeature().getName()
                         : null);
 
-        assert srcLayerId != null : "Layer must be persisted (id must be set)";
-        assert srcRecommenderId != null : "Recommender must be persisted (id must be set)";
-        assert srcDocumentId != null : "Document must be persisted (id must be set)";
+        assert srcLayerId != null : "Layer must be persisted but its id was [" + srcLayerId + "]";
+        assert srcRecommenderId != null : "Recommender must be persisted but its id was ["
+                + srcRecommenderId + "]";
+        assert srcDocumentId != null : "Document must be persisted but its id was [" + srcDocumentId
+                + "]";
         assert feature != null : "Feature cannot be null";
         assert recommenderName != null : "Recommender name cannot be null";
         assert generation >= 0 : "Generation cannot be negative but was [" + generation + "]";

--- a/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/AnnotationSuggestion.java
+++ b/inception/inception-recommendation-api/src/main/java/de/tudarmstadt/ukp/inception/recommendation/api/model/AnnotationSuggestion.java
@@ -115,20 +115,20 @@ public abstract class AnnotationSuggestion
         id = aBuilder.id;
         score = aBuilder.score;
         scoreExplanation = aBuilder.scoreExplanation;
-        documentId = aBuilder.documentId;
         autoAcceptMode = aBuilder.autoAcceptMode != null ? aBuilder.autoAcceptMode : NEVER;
         hidingFlags = aBuilder.hidingFlags;
         correction = aBuilder.correction;
         correctionExplanation = aBuilder.correctionExplanation;
 
-        // Boxed so null (unpersisted) is distinct from a genuine id of 0 (HSQLDB
-        // starts IDENTITY at 0). The asserts below check id != null, not id > 0.
+        // Boxed Long so null (unpersisted) is distinct from id 0, which is valid
+        // (HSQLDB starts IDENTITY at 0). Asserts check != null, not > 0.
         Long srcRecommenderId = aBuilder.recommenderId != null ? aBuilder.recommenderId
                 : (aBuilder.recommender != null ? aBuilder.recommender.getId() : null);
         Long srcLayerId = aBuilder.layerId != null ? aBuilder.layerId
                 : (aBuilder.recommender != null && aBuilder.recommender.getLayer() != null
                         ? aBuilder.recommender.getLayer().getId()
                         : null);
+        Long srcDocumentId = aBuilder.documentId;
 
         recommenderId = srcRecommenderId != null ? srcRecommenderId : 0;
 
@@ -137,15 +137,16 @@ public abstract class AnnotationSuggestion
 
         layerId = srcLayerId != null ? srcLayerId : 0;
 
+        documentId = srcDocumentId != null ? srcDocumentId : 0;
+
         feature = aBuilder.feature != null ? aBuilder.feature
                 : (aBuilder.recommender != null && aBuilder.recommender.getFeature() != null
                         ? aBuilder.recommender.getFeature().getName()
                         : null);
 
-        // documentId is a primitive long; it would already have NPE'd on unbox if
-        // the document were unpersisted, so it needs no separate guard here.
         assert srcLayerId != null : "Layer must be persisted (id must be set)";
         assert srcRecommenderId != null : "Recommender must be persisted (id must be set)";
+        assert srcDocumentId != null : "Document must be persisted (id must be set)";
         assert feature != null : "Feature cannot be null";
         assert recommenderName != null : "Recommender name cannot be null";
         assert generation >= 0 : "Generation cannot be negative but was [" + generation + "]";
@@ -418,7 +419,7 @@ public abstract class AnnotationSuggestion
         protected String recommenderName;
         protected Long layerId;
         protected String feature;
-        protected long documentId;
+        protected Long documentId;
         protected String label;
         protected String uiLabel;
         protected double score;

--- a/inception/inception-recommendation-api/src/test/java/de/tudarmstadt/ukp/inception/recommendation/api/model/AnnotationSuggestionTest.java
+++ b/inception/inception-recommendation-api/src/test/java/de/tudarmstadt/ukp/inception/recommendation/api/model/AnnotationSuggestionTest.java
@@ -19,6 +19,7 @@ package de.tudarmstadt.ukp.inception.recommendation.api.model;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import org.junit.jupiter.api.Test;
 
@@ -28,6 +29,66 @@ import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 
 public class AnnotationSuggestionTest
 {
+    @Test
+    public void thatPersistedEntitiesWithIdZeroAreAccepted()
+    {
+        // id 0 is a valid persisted id (HSQLDB starts IDENTITY at 0) and must not
+        // trip the persisted-entity asserts.
+        var doc = SourceDocument.builder().withId(0L).withName("doc0").build();
+        var layer = AnnotationLayer.builder().withId(0L).build();
+        var feature = AnnotationFeature.builder().withLayer(layer).withName("value").build();
+        var rec = Recommender.builder().withId(0L).withName("Recommender").withLayer(layer)
+                .withFeature(feature).build();
+
+        var suggestion = SpanSuggestion.builder() //
+                .withId(1) //
+                .withRecommender(rec) //
+                .withDocument(doc) //
+                .withPosition(0, 1) //
+                .withCoveredText("a") //
+                .withLabel("A") //
+                .withUiLabel("#A") //
+                .withScore(0.1) //
+                .withScoreExplanation("E1") //
+                .build();
+
+        assertThat(suggestion.getRecommenderId()).isZero();
+        assertThat(suggestion.getLayerId()).isZero();
+        assertThat(suggestion.getDocumentId()).isZero();
+        assertThat(suggestion.getRecommenderName()).isEqualTo("Recommender");
+    }
+
+    @Test
+    public void thatUnpersistedRecommenderIsRejected()
+    {
+        // A recommender with a null id (never persisted) must still be rejected.
+        var doc = SourceDocument.builder().withId(0L).withName("doc0").build();
+        var layer = AnnotationLayer.builder().withId(0L).build();
+        var feature = AnnotationFeature.builder().withLayer(layer).withName("value").build();
+        var unpersistedRec = Recommender.builder() // no withId(...) -> id is null
+                .withName("Recommender").withLayer(layer).withFeature(feature).build();
+
+        var builder = SpanSuggestion.builder() //
+                .withId(1) //
+                .withRecommender(unpersistedRec) //
+                .withDocument(doc) //
+                .withPosition(0, 1) //
+                .withCoveredText("a") //
+                .withLabel("A") //
+                .withUiLabel("#A");
+
+        // Only meaningful when assertions are enabled (-ea), as in the test JVM.
+        boolean assertionsEnabled = false;
+        assert assertionsEnabled = true; // side-effect sets the flag when -ea is on
+        if (assertionsEnabled) {
+            org.assertj.core.api.Assertions.assertThatThrownBy(builder::build)
+                    .isInstanceOf(AssertionError.class);
+        }
+        else {
+            assertThatNoException().isThrownBy(builder::build);
+        }
+    }
+
     @Test
     public void thatEqualsAndHashCodeAndCompareToWorkCorrectly()
     {

--- a/inception/inception-recommendation-api/src/test/java/de/tudarmstadt/ukp/inception/recommendation/api/model/AnnotationSuggestionTest.java
+++ b/inception/inception-recommendation-api/src/test/java/de/tudarmstadt/ukp/inception/recommendation/api/model/AnnotationSuggestionTest.java
@@ -19,7 +19,7 @@ package de.tudarmstadt.ukp.inception.recommendation.api.model;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.Test;
 
@@ -32,8 +32,7 @@ public class AnnotationSuggestionTest
     @Test
     public void thatPersistedEntitiesWithIdZeroAreAccepted()
     {
-        // id 0 is a valid persisted id (HSQLDB starts IDENTITY at 0) and must not
-        // trip the persisted-entity asserts.
+        // id 0 is a valid persisted id (HSQLDB starts IDENTITY at 0).
         var doc = SourceDocument.builder().withId(0L).withName("doc0").build();
         var layer = AnnotationLayer.builder().withId(0L).build();
         var feature = AnnotationFeature.builder().withLayer(layer).withName("value").build();
@@ -61,7 +60,6 @@ public class AnnotationSuggestionTest
     @Test
     public void thatUnpersistedRecommenderIsRejected()
     {
-        // A recommender with a null id (never persisted) must still be rejected.
         var doc = SourceDocument.builder().withId(0L).withName("doc0").build();
         var layer = AnnotationLayer.builder().withId(0L).build();
         var feature = AnnotationFeature.builder().withLayer(layer).withName("value").build();
@@ -77,16 +75,42 @@ public class AnnotationSuggestionTest
                 .withLabel("A") //
                 .withUiLabel("#A");
 
-        // Only meaningful when assertions are enabled (-ea), as in the test JVM.
+        requireAssertionsEnabled();
+        assertThatThrownBy(builder::build).isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    public void thatMissingDocumentIsRejected()
+    {
+        var layer = AnnotationLayer.builder().withId(0L).build();
+        var feature = AnnotationFeature.builder().withLayer(layer).withName("value").build();
+        var rec = Recommender.builder().withId(0L).withName("Recommender").withLayer(layer)
+                .withFeature(feature).build();
+
+        var builder = SpanSuggestion.builder() //
+                .withId(1) //
+                .withRecommender(rec) //
+                // no withDocument(...)
+                .withPosition(0, 1) //
+                .withCoveredText("a") //
+                .withLabel("A") //
+                .withUiLabel("#A");
+
+        requireAssertionsEnabled();
+        assertThatThrownBy(builder::build).isInstanceOf(AssertionError.class);
+    }
+
+    /**
+     * Rejection tests rely on {@code assert}, so fail fast if {@code -ea} is off rather than
+     * passing silently.
+     */
+    private static void requireAssertionsEnabled()
+    {
         boolean assertionsEnabled = false;
-        assert assertionsEnabled = true; // side-effect sets the flag when -ea is on
-        if (assertionsEnabled) {
-            org.assertj.core.api.Assertions.assertThatThrownBy(builder::build)
-                    .isInstanceOf(AssertionError.class);
-        }
-        else {
-            assertThatNoException().isThrownBy(builder::build);
-        }
+        assert assertionsEnabled = true; // side-effect: true only when -ea is on
+        assertThat(assertionsEnabled) //
+                .as("This test requires assertions to be enabled (-ea)") //
+                .isTrue();
     }
 
     @Test

--- a/inception/inception-scheduling/src/main/java/de/tudarmstadt/ukp/inception/scheduling/controller/model/MTaskStateUpdate.java
+++ b/inception/inception-scheduling/src/main/java/de/tudarmstadt/ukp/inception/scheduling/controller/model/MTaskStateUpdate.java
@@ -31,6 +31,12 @@ import de.tudarmstadt.ukp.inception.support.logging.LogMessage;
 
 public class MTaskStateUpdate
 {
+    /**
+     * {@link #getProjectId()} value used when an update is not associated with a project. A real
+     * project id can be 0 (HSQLDB starts IDENTITY at 0), so this must be negative.
+     */
+    public static final long NO_PROJECT = -1;
+
     private final int id;
     private final String title;
     private final long timestamp;
@@ -71,7 +77,7 @@ public class MTaskStateUpdate
 
         username = aMonitor.getUser();
 
-        projectId = aMonitor.getProject() != null ? aMonitor.getProject().getId() : -1;
+        projectId = aMonitor.getProject() != null ? aMonitor.getProject().getId() : NO_PROJECT;
         projectName = aMonitor.getProject() != null ? aMonitor.getProject().getName() : null;
 
         state = aMonitor.getState();

--- a/inception/inception-ui-scheduling/src/main/java/de/tudarmstadt/ukp/inception/ui/scheduling/controller/SchedulerWebsocketControllerImpl.java
+++ b/inception/inception-ui-scheduling/src/main/java/de/tudarmstadt/ukp/inception/ui/scheduling/controller/SchedulerWebsocketControllerImpl.java
@@ -97,7 +97,9 @@ public class SchedulerWebsocketControllerImpl
                     aUpdate);
         }
 
-        if (aUpdate.getProjectId() > 0) {
+        // -1 is the "no project" sentinel (see MTaskStateUpdate); a real project
+        // id of 0 is valid (HSQLDB starts IDENTITY at 0), so guard on >= 0.
+        if (aUpdate.getProjectId() >= 0) {
             var topic = SchedulerWebsocketController
                     .getProjectTaskUpdatesTopic(aUpdate.getProjectId());
             msgTemplate.convertAndSend("/topic" + topic, aUpdate);

--- a/inception/inception-ui-scheduling/src/main/java/de/tudarmstadt/ukp/inception/ui/scheduling/controller/SchedulerWebsocketControllerImpl.java
+++ b/inception/inception-ui-scheduling/src/main/java/de/tudarmstadt/ukp/inception/ui/scheduling/controller/SchedulerWebsocketControllerImpl.java
@@ -97,9 +97,7 @@ public class SchedulerWebsocketControllerImpl
                     aUpdate);
         }
 
-        // -1 is the "no project" sentinel (see MTaskStateUpdate); a real project
-        // id of 0 is valid (HSQLDB starts IDENTITY at 0), so guard on >= 0.
-        if (aUpdate.getProjectId() >= 0) {
+        if (aUpdate.getProjectId() != MTaskStateUpdate.NO_PROJECT) {
             var topic = SchedulerWebsocketController
                     .getProjectTaskUpdatesTopic(aUpdate.getProjectId());
             msgTemplate.convertAndSend("/topic" + topic, aUpdate);


### PR DESCRIPTION
**What's in the PR**
- Treat an entity id of 0 as persisted (not as "missing") when building annotation suggestions, so recommenders work in the first project/recommender/document on a fresh install where the default embedded database starts IDs at 0; check id != null instead of id > 0
- Add regression tests asserting a suggestion built from persisted entities with id 0 is accepted, while a recommender with a null (unpersisted) id is still rejected
- Broadcast task-state updates for a project with id 0 by guarding the project websocket dispatch on projectId >= 0 (the -1 "no project" sentinel) instead of projectId > 0, so background-task progress reaches the UI in the first project on a fresh install

**How to test manually**
* See issue description

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
