### PR TITLE
#6100 - Deleting a recently active project may intermittently fail with an error on MariaDB 11

### DIFF
--- a/inception/inception-app-webapp/src/test/java/de/tudarmstadt/ukp/inception/db/InceptionIntegrationTest_ImplBase.java
+++ b/inception/inception-app-webapp/src/test/java/de/tudarmstadt/ukp/inception/db/InceptionIntegrationTest_ImplBase.java
@@ -27,9 +27,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import java.lang.invoke.MethodHandles;
+import java.sql.SQLException;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
 import java.util.zip.ZipFile;
+
+import javax.sql.DataSource;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -111,6 +117,27 @@ public abstract class InceptionIntegrationTest_ImplBase
 
     @Autowired
     LearningRecordService learningRecordService;
+
+    @Autowired
+    DataSource dataSource;
+
+    /**
+     * Column names by which a table references the project it belongs to. Most tables use
+     * {@code project} (via {@code @JoinColumn(name = "project")}); a few use a variant. The
+     * orphan-scan ({@link #countProjectScopedRows}) treats any table carrying one of these columns
+     * as project-scoped.
+     */
+    private static final Set<String> PROJECT_COLUMN_NAMES = Set.of("project", "project_id",
+            "projectid");
+
+    /**
+     * Tables deliberately excluded from the orphan-scan because they are known NOT to be purged
+     * when a project is deleted. {@code logged_event} stores the project id as a bare column with
+     * no foreign key, and {@code ProjectServiceImpl#removeProject} does not purge it. Whether that
+     * is intentional is a separate open question - until it is decided, scanning it would make the
+     * test fail on existing behavior rather than on a regression.
+     */
+    private static final Set<String> ORPHAN_SCAN_IGNORED_TABLES = Set.of("logged_event");
 
     @BeforeAll
     static void setupClass(TestInfo aInfo)
@@ -274,5 +301,88 @@ public abstract class InceptionIntegrationTest_ImplBase
         finally {
             projectService.removeProject(project);
         }
+    }
+
+    @Test
+    void testRemovingProjectLeavesNoOrphanedRows() throws Exception
+    {
+        // Import a rich project that populates many project-scoped tables (documents, layers,
+        // features, recommenders, permissions, ...). This exercises both the tables cleaned up by
+        // Java code in removeProject/event listeners and those relying on database ON DELETE
+        // CASCADE - so a single delete checks the whole cascade chain under the current engine.
+        var request = ProjectImportRequest.builder() //
+                .withCreateMissingUsers(true) //
+                .withImportPermissions(true) //
+                .build();
+
+        Project project;
+        try (var zipFile = new ZipFile("src/test/resources/test-project-with-recommenders.zip")) {
+            project = projectExportService.importProject(request, zipFile);
+        }
+        var projectId = project.getId();
+
+        // Guard against a vacuous pass: the imported project must actually leave rows in several
+        // project-scoped tables, otherwise the post-deletion check below would trivially hold even
+        // if the cascade were completely broken.
+        var before = countProjectScopedRows(projectId);
+        assertThat(before.keySet()) //
+                .as("project-scoped tables populated by the imported project: %s", before) //
+                .hasSizeGreaterThanOrEqualTo(3);
+
+        projectService.removeProject(project);
+
+        // After deletion no project-scoped table may still reference the deleted project id.
+        // logged_event is intentionally excluded (see ORPHAN_SCAN_IGNORED_TABLES).
+        var after = countProjectScopedRows(projectId);
+        assertThat(after) //
+                .as("orphaned rows still referencing deleted project %s", projectId) //
+                .isEmpty();
+    }
+
+    /**
+     * Scans the live database schema for every table carrying a project-reference column (see
+     * {@link #PROJECT_COLUMN_NAMES}) and counts the rows referencing the given project. Tables are
+     * discovered via JDBC metadata rather than hard-coded so the scan stays correct as the schema
+     * evolves and works uniformly across all database engines. Only tables that actually have
+     * matching rows are returned.
+     *
+     * @return a map of table name to row count, containing only tables with a non-zero count.
+     */
+    private Map<String, Integer> countProjectScopedRows(long aProjectId) throws SQLException
+    {
+        var counts = new LinkedHashMap<String, Integer>();
+        try (var conn = dataSource.getConnection()) {
+            var meta = conn.getMetaData();
+            var quote = meta.getIdentifierQuoteString();
+
+            // Discover tables that reference a project, keyed by table name -> project column.
+            var projectTables = new LinkedHashMap<String, String>();
+            try (var cols = meta.getColumns(conn.getCatalog(), conn.getSchema(), "%", "%")) {
+                while (cols.next()) {
+                    var table = cols.getString("TABLE_NAME");
+                    var column = cols.getString("COLUMN_NAME");
+                    if (PROJECT_COLUMN_NAMES.contains(column.toLowerCase())
+                            && !ORPHAN_SCAN_IGNORED_TABLES.contains(table.toLowerCase())) {
+                        projectTables.putIfAbsent(table, column);
+                    }
+                }
+            }
+
+            for (var entry : projectTables.entrySet()) {
+                var sql = "SELECT COUNT(*) FROM " + quote + entry.getKey() + quote //
+                        + " WHERE " + quote + entry.getValue() + quote + " = ?";
+                try (var stmt = conn.prepareStatement(sql)) {
+                    stmt.setLong(1, aProjectId);
+                    try (var rs = stmt.executeQuery()) {
+                        rs.next();
+                        var n = rs.getInt(1);
+                        if (n > 0) {
+                            counts.put(entry.getKey(), n);
+                        }
+                    }
+                }
+            }
+        }
+        return counts;
     }
 }

--- a/inception/inception-app-webapp/src/test/java/de/tudarmstadt/ukp/inception/db/InceptionMariadb_11_6_IntegrationTest.java
+++ b/inception/inception-app-webapp/src/test/java/de/tudarmstadt/ukp/inception/db/InceptionMariadb_11_6_IntegrationTest.java
@@ -37,8 +37,7 @@ class InceptionMariadb_11_6_IntegrationTest
     static final MariaDBContainer<?> dbContainer = new MariaDBContainer<>("mariadb:11.6.2") //
             .withDatabaseName("testdb") //
             .withUsername("test") //
-            .withPassword("test") //
-            .withConfigurationOverride("mariadb_11_6");
+            .withPassword("test");
 
     static @TempDir Path tempDir;
 

--- a/inception/inception-app-webapp/src/test/java/de/tudarmstadt/ukp/inception/db/InceptionMariadb_11_7_IntegrationTest.java
+++ b/inception/inception-app-webapp/src/test/java/de/tudarmstadt/ukp/inception/db/InceptionMariadb_11_7_IntegrationTest.java
@@ -37,8 +37,7 @@ class InceptionMariadb_11_7_IntegrationTest
     static final MariaDBContainer<?> dbContainer = new MariaDBContainer<>("mariadb:11.7.2") //
             .withDatabaseName("testdb") //
             .withUsername("test") //
-            .withPassword("test") //
-            .withConfigurationOverride("mariadb_11_7");
+            .withPassword("test");
 
     static @TempDir Path tempDir;
 

--- a/inception/inception-app-webapp/src/test/java/de/tudarmstadt/ukp/inception/db/InceptionMariadb_11_8_IntegrationTest.java
+++ b/inception/inception-app-webapp/src/test/java/de/tudarmstadt/ukp/inception/db/InceptionMariadb_11_8_IntegrationTest.java
@@ -37,8 +37,7 @@ class InceptionMariadb_11_8_IntegrationTest
     static final MariaDBContainer<?> dbContainer = new MariaDBContainer<>("mariadb:11.8.2") //
             .withDatabaseName("testdb") //
             .withUsername("test") //
-            .withPassword("test") //
-            .withConfigurationOverride("mariadb_11_8");
+            .withPassword("test");
 
     static @TempDir Path tempDir;
 

--- a/inception/inception-app-webapp/src/test/java/de/tudarmstadt/ukp/inception/db/InceptionMySql_9_4_IntegrationTest.java
+++ b/inception/inception-app-webapp/src/test/java/de/tudarmstadt/ukp/inception/db/InceptionMySql_9_4_IntegrationTest.java
@@ -22,7 +22,6 @@ import java.nio.file.Path;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -31,7 +30,6 @@ import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
-@Disabled("Does not start up reliably on CI (GitHub)")
 @Testcontainers(disabledWithoutDocker = true)
 class InceptionMySql_9_4_IntegrationTest
 {

--- a/inception/inception-app-webapp/src/test/resources/mariadb_11_6/my.cnf
+++ b/inception/inception-app-webapp/src/test/resources/mariadb_11_6/my.cnf
@@ -1,6 +1,0 @@
-[mysqld]
-# Looks like we have problems (at least in tests, possibly generally) with this feature which
-# seems to be on by default since MariaDB 11.6.2:
-# InceptionMariadb_11_6_IntegrationTest$SpringApplcationContext.testDeletingSourceDocumentWithLearningRecordAttached
-# could not execute statement [(conn=4) Record has changed since last read in table 'project'] [delete from project where id=?]
-innodb_snapshot_isolation=0

--- a/inception/inception-app-webapp/src/test/resources/mariadb_11_7/my.cnf
+++ b/inception/inception-app-webapp/src/test/resources/mariadb_11_7/my.cnf
@@ -1,6 +1,0 @@
-[mysqld]
-# Looks like we have problems (at least in tests, possibly generally) with this feature which
-# seems to be on by default since MariaDB 11.6.2:
-# InceptionMariadb_11_6_IntegrationTest$SpringApplcationContext.testDeletingSourceDocumentWithLearningRecordAttached
-# could not execute statement [(conn=4) Record has changed since last read in table 'project'] [delete from project where id=?]
-innodb_snapshot_isolation=0

--- a/inception/inception-app-webapp/src/test/resources/mariadb_11_8/my.cnf
+++ b/inception/inception-app-webapp/src/test/resources/mariadb_11_8/my.cnf
@@ -1,6 +1,0 @@
-[mysqld]
-# Looks like we have problems (at least in tests, possibly generally) with this feature which
-# seems to be on by default since MariaDB 11.6.2:
-# InceptionMariadb_11_6_IntegrationTest$SpringApplcationContext.testDeletingSourceDocumentWithLearningRecordAttached
-# could not execute statement [(conn=4) Record has changed since last read in table 'project'] [delete from project where id=?]
-innodb_snapshot_isolation=0

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/installation_database_mariadb.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/installation_database_mariadb.adoc
@@ -138,7 +138,6 @@ innodb_file_format=barracuda        # Removed in MariaDB 10.6.0
 innodb_file_per_table=1             # Deprecated in MariaDB 11.0.1
 innodb_strict_mode=1
 innodb_default_row_format='dynamic'
-innodb_snapshot_isolation=0         # Probably required with MariaDB >= 11.6.2
 ----
 
 

--- a/inception/inception-project-api/src/main/java/de/tudarmstadt/ukp/inception/project/api/ProjectService.java
+++ b/inception/inception-project-api/src/main/java/de/tudarmstadt/ukp/inception/project/api/ProjectService.java
@@ -356,6 +356,19 @@ public interface ProjectService
     void removeProject(Project aProject) throws IOException;
 
     /**
+     * Checks whether the given project is currently being removed. This is the authoritative source
+     * of truth for "this project is pending deletion" and can be consulted by other components to
+     * avoid issuing new work against a project that is about to disappear. It becomes {@code true}
+     * at the very start of {@link #removeProject} (before tasks are drained and before the project
+     * row is locked) and {@code false} again once removal has finished.
+     *
+     * @param aProjectId
+     *            the project id
+     * @return whether the project is pending deletion
+     */
+    boolean isProjectDeletionPending(long aProjectId);
+
+    /**
      * List projects accessible by the given user
      *
      * @param aUser

--- a/inception/inception-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
+++ b/inception/inception-project/src/main/java/de/tudarmstadt/ukp/clarin/webanno/project/ProjectServiceImpl.java
@@ -63,6 +63,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.SetUtils;
@@ -104,6 +105,7 @@ import de.tudarmstadt.ukp.inception.project.api.event.ProjectStateChangedEvent;
 import de.tudarmstadt.ukp.inception.support.io.FastIOUtils;
 import de.tudarmstadt.ukp.inception.support.logging.BaseLoggers;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.LockModeType;
 import jakarta.persistence.NoResultException;
 
 /**
@@ -126,6 +128,13 @@ public class ProjectServiceImpl
     private final List<ProjectInitializer> projectInitializerProxy;
     private final List<FeatureInitializer> featureInitializerProxy;
     private final SecureRandom random;
+
+    /**
+     * Ids of projects currently being deleted. Maintained as the single authoritative source of
+     * truth for "this project is being removed" so that other components (e.g. the scheduling
+     * service) can avoid issuing new work against a project that is about to disappear.
+     */
+    private final Set<Long> deletionPending = ConcurrentHashMap.newKeySet();
 
     private List<ProjectInitializer> projectInitializers;
     private List<FeatureInitializer> featureInitializers;
@@ -783,17 +792,40 @@ public class ProjectServiceImpl
     @Transactional
     public void removeProject(Project aProject) throws IOException
     {
+        Validate.notNull(aProject, "Project must be specified");
+        Validate.notNull(aProject.getId(), "Project must have been saved before it can be removed");
+
         File logFile = null;
+
+        // Mark the project as pending deletion up-front - in memory, before any database access -
+        // so that other components stop issuing work against it (see isProjectDeletionPending).
+        // This must happen before the BeforeProjectRemovedEvent below, and crucially before we
+        // obtain the write lock: the event makes the scheduling service drain running tasks, and
+        // that drain must run while we hold NO lock on the project row. Otherwise a task that
+        // itself needs to update the project row would block on our lock while we wait for it to
+        // finish - a dead-lock.
+        deletionPending.add(aProject.getId());
         try (var logCtx = withProjectLogger(aProject)) {
             var start = System.currentTimeMillis();
 
-            // remove metadata from DB
-            var project = aProject;
-            if (!entityManager.contains(project)) {
-                project = entityManager.merge(project);
-            }
+            // Fire the BeforeProjectRemovedEvent first. The scheduling service (highest-precedence
+            // listener) drains running tasks for the project here while no write lock is held, and
+            // the cascade-cleanup listeners remove the project's child data. Only afterwards do we
+            // lock and delete the project row itself.
+            applicationEventPublisher.publishEvent(new BeforeProjectRemovedEvent(this, aProject));
 
-            applicationEventPublisher.publishEvent(new BeforeProjectRemovedEvent(this, project));
+            // Re-load the project with a write lock. After the drain above, the only remaining
+            // possible concurrent writer of the project row is a direct (non-task) update - this
+            // lock serializes the delete against it so that, under strict snapshot isolation
+            // (MariaDB 11.6+ where innodb_snapshot_isolation defaults to ON), the delete does not
+            // abort with a write-write conflict ("Record has changed since last read in table
+            // 'project'").
+            var project = entityManager.find(Project.class, aProject.getId(),
+                    LockModeType.PESSIMISTIC_WRITE);
+            if (project == null) {
+                LOG.debug("Project [{}] already removed - nothing to do", aProject.getId());
+                return;
+            }
 
             for (var permissions : getProjectPermissions(project)) {
                 entityManager.remove(permissions);
@@ -818,6 +850,9 @@ public class ProjectServiceImpl
             LOG.info("Removed project {} ({})", project,
                     formatDurationWords(System.currentTimeMillis() - start, true, true));
         }
+        finally {
+            deletionPending.remove(aProject.getId());
+        }
 
         // Delete the per-project log file after the logger MDC context has been closed so no
         // further log lines get routed to it. Best-effort: log appenders may still hold the
@@ -825,6 +860,12 @@ public class ProjectServiceImpl
         if (logFile != null && logFile.exists() && !FileUtils.deleteQuietly(logFile)) {
             LOG.warn("Could not delete project log file: [{}]", logFile);
         }
+    }
+
+    @Override
+    public boolean isProjectDeletionPending(long aProjectId)
+    {
+        return deletionPending.contains(aProjectId);
     }
 
     @Override

--- a/inception/inception-scheduling/src/main/java/de/tudarmstadt/ukp/inception/scheduling/SchedulingServiceImpl.java
+++ b/inception/inception-scheduling/src/main/java/de/tudarmstadt/ukp/inception/scheduling/SchedulingServiceImpl.java
@@ -31,11 +31,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
@@ -58,6 +56,7 @@ import org.springframework.security.core.session.SessionRegistry;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
+import de.tudarmstadt.ukp.inception.project.api.ProjectService;
 import de.tudarmstadt.ukp.inception.project.api.event.AfterProjectRemovedEvent;
 import de.tudarmstadt.ukp.inception.project.api.event.BeforeProjectRemovedEvent;
 import de.tudarmstadt.ukp.inception.scheduling.config.SchedulingProperties;
@@ -78,25 +77,26 @@ public class SchedulingServiceImpl
     private final ThreadPoolExecutor executor;
     private final ScheduledExecutorService watchdog;
     private final SessionRegistry sessionRegistry;
+    private final ProjectService projectService;
 
     private final List<Task> runningTasks;
     private final List<Task> enqueuedTasks;
     private final List<Task> pendingAcknowledgement;
-    private final Set<Project> deletionPending;
     private final Map<Project, AtomicInteger> suspended;
 
     @Autowired
     public SchedulingServiceImpl(ApplicationContext aApplicationContext,
-            SchedulingProperties aConfig, SessionRegistry aSessionRegistry)
+            SchedulingProperties aConfig, SessionRegistry aSessionRegistry,
+            ProjectService aProjectService)
     {
         sessionRegistry = aSessionRegistry;
         applicationContext = aApplicationContext;
+        projectService = aProjectService;
         executor = new InspectableThreadPoolExecutor(aConfig.getNumberOfThreads(),
                 aConfig.getQueueSize(), this::beforeExecute, this::afterExecute);
         runningTasks = Collections.synchronizedList(new ArrayList<>());
         enqueuedTasks = Collections.synchronizedList(new ArrayList<>());
         pendingAcknowledgement = Collections.synchronizedList(new ArrayList<>());
-        deletionPending = Collections.synchronizedSet(new LinkedHashSet<>());
         suspended = Collections.synchronizedMap(new LinkedHashMap<>());
         watchdog = Executors.newScheduledThreadPool(1);
         watchdog.scheduleAtFixedRate(this::scheduleEligibleTasks, 5, 5, SECONDS);
@@ -228,7 +228,8 @@ public class SchedulingServiceImpl
     {
         Validate.notNull(aTask, "Task cannot be null");
 
-        if (aTask.getProject() != null && deletionPending.contains(aTask.getProject())) {
+        if (aTask.getProject() != null && aTask.getProject().getId() != null
+                && projectService.isProjectDeletionPending(aTask.getProject().getId())) {
             LOG.debug("Not enqueuing task [{}] for project {} pending deletion", aTask,
                     aTask.getProject());
             return;
@@ -312,9 +313,7 @@ public class SchedulingServiceImpl
         var startTime = currentTimeMillis();
         var timeoutMillis = aTimeout.toMillis();
 
-        while (runningTasks.stream()
-                .anyMatch(t -> aProject.getId() != null ? aProject.equals(t.getProject())
-                        : aProject == t.getProject())) {
+        while (runningTasks.stream().anyMatch(t -> isTaskForProject(t, aProject))) {
             // LOG.trace("Waiting for running tasks to end on project {}", aProject);
 
             if (currentTimeMillis() - startTime > timeoutMillis) {
@@ -326,7 +325,7 @@ public class SchedulingServiceImpl
                 msg.append("\n");
                 msg.append("The following tasks are still running:\n");
                 runningTasks.stream() //
-                        .filter(t -> aProject.equals(t.getProject())) //
+                        .filter(t -> isTaskForProject(t, aProject)) //
                         .forEach(t -> {
                             msg.append("- ").append(t).append("\n");
                             for (var frame : t.getThread().getStackTrace()) {
@@ -551,9 +550,27 @@ public class SchedulingServiceImpl
     @Override
     public void stopAllTasksForProject(Project aProject)
     {
-        Validate.notNull(aProject, "Project name must be specified");
+        Validate.notNull(aProject, "Project must be specified");
 
-        stopAllTasksMatching(t -> t.getProject().equals(aProject));
+        stopAllTasksMatching(t -> isTaskForProject(t, aProject));
+    }
+
+    /**
+     * Matches a task to a project by id, falling back to identity for not-yet-persisted projects.
+     * Using the id (rather than {@link Project#equals}, which compares the slug and treats null
+     * slugs as equal) keeps task matching consistent with the deletion-pending check in
+     * {@link #enqueue} and avoids mismatches when a project has no slug or its slug changes.
+     */
+    private static boolean isTaskForProject(Task aTask, Project aProject)
+    {
+        var taskProject = aTask.getProject();
+        if (taskProject == null) {
+            return false;
+        }
+        if (aProject.getId() != null) {
+            return aProject.getId().equals(taskProject.getId());
+        }
+        return aProject == taskProject;
     }
 
     @Override
@@ -619,7 +636,9 @@ public class SchedulingServiceImpl
     @EventListener
     public void onBeforeProjectRemoved(BeforeProjectRemovedEvent aEvent) throws TimeoutException
     {
-        deletionPending.add(aEvent.getProject());
+        // The project is already marked as pending deletion by ProjectService#removeProject (which
+        // is the sole publisher of this event), so the enqueue() guard already blocks new tasks.
+        // Here we only need to drain tasks that are still running for the project.
         stopAllTasksForProject(aEvent.getProject());
         var timeout = Duration.ofMinutes(1);
         try {
@@ -648,7 +667,6 @@ public class SchedulingServiceImpl
     public void onAfterProjectRemoved(AfterProjectRemovedEvent aEvent) throws IOException
     {
         stopAllTasksForProject(aEvent.getProject());
-        deletionPending.remove(aEvent.getProject());
     }
 
     // Set order so this is handled before session info is removed from sessionRegistry
@@ -745,7 +763,6 @@ public class SchedulingServiceImpl
             getScheduledTasks().forEach(t -> lines.add("  Scheduled   : " + t));
             getRunningTasks().forEach(t -> lines.add("  Running     : " + t));
             suspended.forEach((p, c) -> lines.add("  Suspended   : " + p + " [" + c + "]"));
-            deletionPending.forEach(p -> lines.add("  Deleting    : " + p));
             getTasksPendingAcknowledgment().forEach(t -> lines.add("  Pending ack : " + t));
             if (!lines.isEmpty()) {
                 LOG.debug("Scheduler state:");

--- a/inception/inception-scheduling/src/main/java/de/tudarmstadt/ukp/inception/scheduling/config/SchedulingServiceAutoConfiguration.java
+++ b/inception/inception-scheduling/src/main/java/de/tudarmstadt/ukp/inception/scheduling/config/SchedulingServiceAutoConfiguration.java
@@ -47,9 +47,11 @@ public class SchedulingServiceAutoConfiguration
 
     @Bean
     public SchedulingService schedulingService(ApplicationContext aApplicationContext,
-            SchedulingProperties aConfig, SessionRegistry aSessionRegistry)
+            SchedulingProperties aConfig, SessionRegistry aSessionRegistry,
+            ProjectService aProjectService)
     {
-        return new SchedulingServiceImpl(aApplicationContext, aConfig, aSessionRegistry);
+        return new SchedulingServiceImpl(aApplicationContext, aConfig, aSessionRegistry,
+                aProjectService);
     }
 
     @Bean

--- a/inception/inception-scheduling/src/test/java/de/tudarmstadt/ukp/inception/scheduling/SchedulingServiceTest.java
+++ b/inception/inception-scheduling/src/test/java/de/tudarmstadt/ukp/inception/scheduling/SchedulingServiceTest.java
@@ -41,12 +41,14 @@ import org.springframework.context.ApplicationContext;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
+import de.tudarmstadt.ukp.inception.project.api.ProjectService;
 import de.tudarmstadt.ukp.inception.scheduling.config.SchedulingProperties;
 
 @ExtendWith(MockitoExtension.class)
 public class SchedulingServiceTest
 {
     private @Mock ApplicationContext mockContext;
+    private @Mock ProjectService projectService;
 
     private SchedulingServiceImpl sut;
 
@@ -56,7 +58,8 @@ public class SchedulingServiceTest
         when(mockContext.getAutowireCapableBeanFactory())
                 .thenReturn(mock(AutowireCapableBeanFactory.class));
 
-        sut = new SchedulingServiceImpl(mockContext, new SchedulingProperties(), null);
+        sut = new SchedulingServiceImpl(mockContext, new SchedulingProperties(), null,
+                projectService);
     }
 
     @AfterEach


### PR DESCRIPTION
**What's in the PR**
- Fix intermittent project deletion failure on MariaDB 11.6+ (innodb_snapshot_isolation): in ProjectService.removeProject, drain running tasks via BeforeProjectRemovedEvent before acquiring the write lock, then lock the project row and delete (drain-first ordering avoids both the write-write conflict on delete and the lock-vs-drain deadlock)
- Centralize the "project deletion pending" state as the authoritative ProjectService.isProjectDeletionPending(projectId), set at the start of removeProject and cleared when it finishes
- SchedulingServiceImpl: drop its own deletionPending set and consult ProjectService.isProjectDeletionPending instead; guard against tasks carrying an unpersisted (null-id) project; update bean wiring and unit test for the new constructor dependency
- Remove the innodb_snapshot_isolation=0 test workaround for MariaDB 11.6 / 11.7 / 11.8 so the database integration tests run against the stock production configuration
- Enable the MySQL 9.4 database integration test (was @Disabled)
- Add a database integration test asserting that removing a project leaves no orphaned rows in any project-scoped table

**How to test manually**
* See issue description

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
