### PR TITLE
#6102 - Outdated system requirements in documentation

### DIFF
--- a/inception/inception-app-webapp/pom.xml
+++ b/inception/inception-app-webapp/pom.xml
@@ -1077,6 +1077,7 @@
               <docinfo1>true</docinfo1>
               <project-version>${project.version}</project-version>
               <revnumber>${project.version}</revnumber>
+              <min-java-version>${maven.compiler.release}</min-java-version>
               <product-name>INCEpTION</product-name>
               <product-website-url>https://inception-project.github.io</product-website-url>
               <icons>font</icons>

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/installation_java.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/admin-guide/installation_java.adoc
@@ -20,13 +20,13 @@ NOTE: If you aim for a Docker-based deployment, it is useful for you to read the
       how the overall setup works. However, you will not have to install Java. If you use Docker Compose, you may also not have
       to install a database. Refer to the <<sect_docker>> section instead.
 
-You can install a Java 21 JDK using the following commands.
+You can install a Java {min-java-version} JDK using the following commands.
 
 .Installing Java from your Linux distribution
 [source,bash]
 ----
 $ apt update
-$ apt install openjdk-21-jdk
+$ apt install openjdk-{min-java-version}-jdk
 ----
 
 Alternative, you can install a more recent Java version e.g. from link:https://adoptium.net/temurin/releases[Adoptium].
@@ -39,6 +39,6 @@ $ apt install gpg
 $ wget -qO - https://packages.adoptium.net/artifactory/api/gpg/key/public | gpg --dearmor | tee /etc/apt/trusted.gpg.d/adoptium.gpg > /dev/null
 $ echo "deb https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list
 $ apt update
-$ apt install temurin-21-jdk
+$ apt install temurin-{min-java-version}-jdk
 ----
 

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/common/systemrequirements.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/common/systemrequirements.adoc
@@ -33,7 +33,7 @@ You should also be able to use {product-name} with other browsers such as Firefo
 | Linux (64bit), macOS (64bit), Windows (64bit)
 
 | Java Runtime Environment
-| version 21 or higher
+| version {min-java-version} or higher
 |===
 
 [.small]
@@ -46,13 +46,13 @@ The examples in this guide are based on a recent Debian Linux. Most of them shou
 | Linux (64bit), macOS (64bit), Windows (64bit)
 
 | Java Runtime Environment
-| version 21 or higher
+| version {min-java-version} or higher
 
 | DB Server
-| MariaDB version 10.6 or higher +
+| MariaDB version 10.11 or higher +
   MySQL version 8.0 or higher +
   MS SQL Server 2022 or higher (🧪 experimental) +
-  PostgreSQL 16.3 or higher (🧪 experimental) 
+  PostgreSQL 16 or higher (🧪 experimental)
 
 |===
 

--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/user-guide/getting-started.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/user-guide/getting-started.adoc
@@ -99,7 +99,7 @@ NOTE: **Hey system operators and admins!** If you install {product-name} not for
 
 == Installing Java
 
-In order to run {product-name}, you need to have Java installed in version 11 or higher.
+In order to run {product-name}, you need to have Java installed in version {min-java-version} or higher.
 If you do not have Java installed yet, please install the latest Java version e.g. from link:https://adoptopenjdk.net[AdoptOpenJDK^].
 
 == Download and start {product-name}

--- a/inception/inception-doc/src/test/java/de/tudarmstadt/ukp/inception/doc/GenerateDocumentation.java
+++ b/inception/inception-doc/src/test/java/de/tudarmstadt/ukp/inception/doc/GenerateDocumentation.java
@@ -33,6 +33,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.asciidoctor.Asciidoctor;
@@ -68,6 +69,7 @@ public class GenerateDocumentation
                 .attribute("docinfo1", "true") //
                 .attribute("project-version", "DEVELOPER BUILD") //
                 .attribute("revnumber", "DEVELOPER BUILD").attribute("product-name", "INCEpTION") //
+                .attribute("min-java-version", getMinJavaVersion()) //
                 .attribute("product-website-url", "https://inception-project.github.io") //
                 .icons(Attributes.FONT_ICONS) //
                 .tableOfContents(Placement.LEFT) //
@@ -150,6 +152,27 @@ public class GenerateDocumentation
                 createSymbolicLink(linkPath, p.toAbsolutePath());
             }
         }
+    }
+
+    private static final Pattern MIN_JAVA_VERSION_PATTERN = Pattern
+            .compile("<maven\\.compiler\\.release>\\s*(\\d+)\\s*</maven\\.compiler\\.release>");
+
+    /**
+     * Reads the minimum required Java version from the {@code maven.compiler.release} property in
+     * the {@code inception/pom.xml}. This keeps the documentation in sync with the actual build
+     * configuration without manual updates. The Maven-driven documentation build wires the same
+     * property into the {@code min-java-version} AsciiDoc attribute via the asciidoctor plugin
+     * configuration in {@code inception-app-webapp/pom.xml}.
+     */
+    private static String getMinJavaVersion() throws IOException
+    {
+        var pom = getInceptionDir().resolve("pom.xml");
+        var matcher = MIN_JAVA_VERSION_PATTERN.matcher(Files.readString(pom));
+        if (!matcher.find()) {
+            throw new IllegalStateException(
+                    "Could not find maven.compiler.release property in [" + pom + "]");
+        }
+        return matcher.group(1);
     }
 
     private static Path getInceptionDir()


### PR DESCRIPTION
**What's in the PR**
- Make minimum Java version in documentation track the `maven.compiler.release` Maven property instead of being hard-coded
- Wire a new `min-java-version` AsciiDoc attribute from `maven.compiler.release` via the asciidoctor plugin config in inception-app-webapp/pom.xml
- Read `maven.compiler.release` from inception/pom.xml in GenerateDocumentation to populate the `min-java-version` attribute for developer builds
- Replace hard-coded Java version references (21, 11) with `{min-java-version}` in the installation, system requirements, and getting-started docs
- Update documented database requirements: MariaDB 10.6 -> 10.11, PostgreSQL 16.3 -> 16

**How to test manually**
* Check if documentation is up-to-date

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
