### PR TITLE
#6040 - Improve LLM infrastructure

### DIFF
--- a/inception/inception-assistant-api/src/main/java/de/tudarmstadt/ukp/inception/assistant/model/MCallResponse.java
+++ b/inception/inception-assistant-api/src/main/java/de/tudarmstadt/ukp/inception/assistant/model/MCallResponse.java
@@ -32,7 +32,7 @@ import de.tudarmstadt.ukp.inception.support.json.JSONUtil;
 @JsonTypeName(MCallResponse.TYPE_CALL_RESPONSE)
 public record MCallResponse<T>(UUID id, String role, String actor, boolean internal,
         boolean ephemeral, MPerformanceMetrics performance, List<MReference> references,
-        String toolName, UUID context, Map<String, Object> arguments, T payload)
+        String toolCallId, String toolName, UUID context, Map<String, Object> arguments, T payload)
     implements MChatMessage
 {
 
@@ -42,7 +42,8 @@ public record MCallResponse<T>(UUID id, String role, String actor, boolean inter
     {
         this(aBuilder.id, aBuilder.role, aBuilder.actor, aBuilder.internal, aBuilder.ephemeral,
                 aBuilder.performance, aBuilder.references.values().stream().toList(),
-                aBuilder.toolName, aBuilder.context, aBuilder.arguments, aBuilder.payload);
+                aBuilder.toolCallId, aBuilder.toolName, aBuilder.context, aBuilder.arguments,
+                aBuilder.payload);
     }
 
     @JsonProperty(MMessage.TYPE_FIELD)
@@ -82,6 +83,7 @@ public record MCallResponse<T>(UUID id, String role, String actor, boolean inter
         private MPerformanceMetrics performance;
         private final Map<String, MReference> references = new LinkedHashMap<>();
         private final Map<String, Object> arguments = new LinkedHashMap<>();
+        private String toolCallId;
         private String toolName;
         private String toolActor;
         private T payload;
@@ -164,11 +166,13 @@ public record MCallResponse<T>(UUID id, String role, String actor, boolean inter
             arguments.clear();
 
             if (aToolCall == null) {
+                toolCallId = null;
                 toolName = null;
                 toolActor = null;
                 return this;
             }
 
+            toolCallId = aToolCall.id();
             toolName = ToolUtils.getFunctionName(aToolCall.method());
             toolActor = aToolCall.actor();
             for (var arg : aToolCall.arguments().entrySet()) {
@@ -185,8 +189,8 @@ public record MCallResponse<T>(UUID id, String role, String actor, boolean inter
             var effectiveActor = actor != null ? actor : (toolActor != null ? toolActor : "Tool");
 
             return new MCallResponse<>(effectiveId, role, effectiveActor, internal, ephemeral,
-                    performance, references.values().stream().toList(), toolName, context,
-                    arguments, payload);
+                    performance, references.values().stream().toList(), toolCallId, toolName,
+                    context, arguments, payload);
         }
     }
 }

--- a/inception/inception-assistant-api/src/main/java/de/tudarmstadt/ukp/inception/assistant/model/MToolCall.java
+++ b/inception/inception-assistant-api/src/main/java/de/tudarmstadt/ukp/inception/assistant/model/MToolCall.java
@@ -32,13 +32,14 @@ import de.tudarmstadt.ukp.inception.recommendation.imls.llm.AnnotationEditorCont
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ToolUtils;
 import de.tudarmstadt.ukp.inception.support.json.JSONUtil;
 
-public record MToolCall(String actor, @JsonIgnore Object instance, @JsonIgnore Method method,
-        @JsonIgnore boolean stop, String name, Map<String, Object> arguments)
+public record MToolCall(String id, String actor, @JsonIgnore Object instance,
+        @JsonIgnore Method method, @JsonIgnore boolean stop, String name,
+        Map<String, Object> arguments)
 {
     private MToolCall(Builder builder)
     {
-        this(builder.actor, builder.instance, builder.method, builder.stop, builder.name,
-                new LinkedHashMap<>(builder.arguments));
+        this(builder.id, builder.actor, builder.instance, builder.method, builder.stop,
+                builder.name, new LinkedHashMap<>(builder.arguments));
     }
 
     public Object invoke(User aSessionOwner, Project aProject, SourceDocument aDocument,
@@ -100,6 +101,7 @@ public record MToolCall(String actor, @JsonIgnore Object instance, @JsonIgnore M
 
     public static final class Builder
     {
+        private String id;
         private Object instance;
         private String name;
         private Method method;
@@ -109,6 +111,12 @@ public record MToolCall(String actor, @JsonIgnore Object instance, @JsonIgnore M
 
         private Builder()
         {
+        }
+
+        public Builder withId(String aId)
+        {
+            id = aId;
+            return this;
         }
 
         public Builder withActor(String aActor)

--- a/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/AgentLoop.java
+++ b/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/AgentLoop.java
@@ -17,8 +17,11 @@
  */
 package de.tudarmstadt.ukp.inception.assistant;
 
+import static com.github.victools.jsonschema.generator.Option.FORBIDDEN_ADDITIONAL_PROPERTIES_BY_DEFAULT;
 import static com.github.victools.jsonschema.generator.OptionPreset.PLAIN_JSON;
 import static com.github.victools.jsonschema.generator.SchemaVersion.DRAFT_2020_12;
+import static com.github.victools.jsonschema.module.jackson.JacksonOption.RESPECT_JSONPROPERTY_REQUIRED;
+import static de.tudarmstadt.ukp.inception.assistant.LlmAuth.apiKeyAuth;
 import static de.tudarmstadt.ukp.inception.assistant.config.AssistantChatProperties.CAP_TOOLS;
 import static de.tudarmstadt.ukp.inception.assistant.model.MChatRoles.ASSISTANT;
 import static de.tudarmstadt.ukp.inception.assistant.model.MChatRoles.SYSTEM;
@@ -27,10 +30,13 @@ import static de.tudarmstadt.ukp.inception.assistant.model.MChatRoles.USER;
 import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.ToolUtils.getFunctionActor;
 import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.ToolUtils.getFunctionName;
 import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.ToolUtils.getStop;
+import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ModelCapability.STREAMING;
+import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ModelCapability.TOOLS;
 import static java.lang.Math.floorDiv;
 import static java.lang.System.currentTimeMillis;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
 import static org.apache.commons.lang3.StringUtils.isBlank;
@@ -53,11 +59,9 @@ import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.victools.jsonschema.generator.Option;
 import com.github.victools.jsonschema.generator.SchemaGenerator;
 import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
 import com.github.victools.jsonschema.module.jackson.JacksonModule;
-import com.github.victools.jsonschema.module.jackson.JacksonOption;
 import com.knuddels.jtokkit.api.Encoding;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
@@ -85,8 +89,6 @@ import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.LlmChatClient
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.LlmEndpoint;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ToolCall;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ToolDescriptor;
-import de.tudarmstadt.ukp.inception.security.client.auth.AuthenticationTraits;
-import de.tudarmstadt.ukp.inception.security.client.auth.apikey.ApiKeyAuthenticationTraits;
 import de.tudarmstadt.ukp.inception.support.json.JSONUtil;
 import tools.jackson.databind.JsonNode;
 
@@ -110,10 +112,6 @@ public class AgentLoop
      * How much of the available context window to use (in percent) before cutting messages.
      */
     private static final int CONTEXT_LENGTH_SAFETY_PERCENTAGE = 90;
-
-    private static final String OPT_NUM_CTX = "num_ctx";
-    private static final String OPT_TOP_K = "top_k";
-    private static final String OPT_REPEAT_PENALTY = "repeat_penalty";
 
     private final AssistantProperties properties;
     private final LlmChatClient chatClient;
@@ -153,8 +151,8 @@ public class AgentLoop
         memory = aMemory;
         encoding = aEncoding;
         generator = new SchemaGenerator(new SchemaGeneratorConfigBuilder(DRAFT_2020_12, PLAIN_JSON) //
-                .with(Option.FORBIDDEN_ADDITIONAL_PROPERTIES_BY_DEFAULT) //
-                .with(new JacksonModule(JacksonOption.RESPECT_JSONPROPERTY_REQUIRED)) //
+                .with(FORBIDDEN_ADDITIONAL_PROPERTIES_BY_DEFAULT) //
+                .with(new JacksonModule(RESPECT_JSONPROPERTY_REQUIRED)) //
                 .build());
     }
 
@@ -242,10 +240,12 @@ public class AgentLoop
         var responseId = aResponseId != null ? aResponseId : UUID.randomUUID();
         var chatProperties = properties.getChat();
 
+        var adapterCapabilities = chatClient.supportedCapabilities();
+
         var toolBindings = new LinkedHashMap<String, ToolBinding>();
         var toolDescriptors = new ArrayList<ToolDescriptor>();
         if (isToolCallingEnabled() && chatProperties.getCapabilities().contains(CAP_TOOLS)
-                && !tools.isEmpty()) {
+                && adapterCapabilities.contains(TOOLS) && !tools.isEmpty()) {
             try {
                 collectTools(toolDescriptors, toolBindings);
             }
@@ -269,14 +269,22 @@ public class AgentLoop
                 .notDone() //
                 .build());
 
-        // Generate the actual response
+        // Generate the actual response. Prefer streaming, but fall back to a plain (non-streaming)
+        // exchange when the adapter does not declare STREAMING support.
         var startTime = currentTimeMillis();
         var firstTokenTime = new AtomicLong(0l);
-        var response = chatClient.chatStream(endpoint(), toChatMessages(aMessages), options,
-                chunk -> {
-                    firstTokenTime.compareAndSet(0l, currentTimeMillis());
-                    recordAndStreamChunk(responseId, chunk);
-                });
+        ChatResult response;
+        if (adapterCapabilities.contains(STREAMING)) {
+            response = chatClient.chatStream(endpoint(), toChatMessages(aMessages), options,
+                    chunk -> {
+                        firstTokenTime.compareAndSet(0l, currentTimeMillis());
+                        recordAndStreamChunk(responseId, chunk);
+                    });
+        }
+        else {
+            response = chatClient.chat(endpoint(), toChatMessages(aMessages), options);
+            firstTokenTime.compareAndSet(0l, currentTimeMillis());
+        }
         var tokens = completionTokens(response);
         var endTime = currentTimeMillis();
 
@@ -368,6 +376,19 @@ public class AgentLoop
 
     private ChatMessage toChatMessage(MChatMessage aMsg)
     {
+        // TODO [tool_call_id]: OpenAI/Azure require the provider-assigned tool-call id to be echoed
+        // back on both the assistant message (ToolCall.id()) and the TOOL-role result message
+        // (ChatMessage.toolCallId). The neutral ToolCall.id() IS captured by the OpenAI/Azure
+        // adapters on the response (see *LlmChatClient.toToolCalls -> wireCall.getId()), but the
+        // assistant-side model drops it: MToolCall (assistant-api) has no id field, so it is lost
+        // in
+        // AgentLoop.turn() when the MToolCall is built, and there is no way to correlate a TOOL
+        // result message back to its originating call here. Wiring this end-to-end requires adding
+        // an `id` to MToolCall (+ builder) in inception-assistant-api, threading call.id() into it
+        // in
+        // turn(), and setting it here for both the ASSISTANT re-emit and the TOOL result (4th ctor
+        // arg). Until then we pass null and rely on positional matching (works for Ollama; OpenAI/
+        // Azure single-tool-per-turn turns tolerate it). Deferred as a follow-up.
         List<ToolCall> toolCalls = emptyList();
         if (isNotEmpty(aMsg.toolCalls())) {
             toolCalls = aMsg.toolCalls().stream() //
@@ -392,24 +413,14 @@ public class AgentLoop
 
     private LlmEndpoint endpoint()
     {
-        AuthenticationTraits auth = null;
-        if (isNotBlank(properties.getChatApiKey())) {
-            var apiKeyAuth = new ApiKeyAuthenticationTraits();
-            apiKeyAuth.setApiKey(properties.getChatApiKey());
-            auth = apiKeyAuth;
-        }
-
         return new LlmEndpoint(chatClient.getId(), properties.getChatUrl(),
-                properties.getChat().getModel(), auth);
+                properties.getChat().getModel(), apiKeyAuth(properties.getChatApiKey()));
     }
 
     private ChatOptions buildOptions(AssistantChatProperties chatProperties, JsonNode aJsonSchema,
             List<ToolDescriptor> aTools)
     {
         var options = new LinkedHashMap<String, Object>();
-        options.put(OPT_NUM_CTX, chatProperties.getContextLength());
-        options.put(OPT_TOP_K, chatProperties.getTopK());
-        options.put(OPT_REPEAT_PENALTY, chatProperties.getRepeatPenalty());
 
         // Provider-specific escape hatch: explicit options override the typed settings.
         if (chatProperties.getOptions() != null) {
@@ -422,6 +433,9 @@ public class AgentLoop
                 .withOptions(options) //
                 .withTemperature(chatProperties.getTemperature()) //
                 .withTopP(chatProperties.getTopP()) //
+                .withContextLength(chatProperties.getContextLength()) //
+                .withTopK(chatProperties.getTopK()) //
+                .withRepeatPenalty(chatProperties.getRepeatPenalty()) //
                 .build();
     }
 
@@ -448,7 +462,7 @@ public class AgentLoop
     private static Map<String, Object> toArgumentMap(JsonNode aArguments)
     {
         if (aArguments == null || aArguments.isNull()) {
-            return new LinkedHashMap<>();
+            return emptyMap();
         }
 
         return JSONUtil.getObjectMapper().convertValue(aArguments, Map.class);

--- a/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/AgentLoop.java
+++ b/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/AgentLoop.java
@@ -111,12 +111,9 @@ public class AgentLoop
      */
     private static final int CONTEXT_LENGTH_SAFETY_PERCENTAGE = 90;
 
-    // Provider-specific (Ollama) generation option keys carried through ChatOptions#options().
     private static final String OPT_NUM_CTX = "num_ctx";
-    private static final String OPT_TOP_P = "top_p";
     private static final String OPT_TOP_K = "top_k";
     private static final String OPT_REPEAT_PENALTY = "repeat_penalty";
-    private static final String OPT_TEMPERATURE = "temperature";
 
     private final AssistantProperties properties;
     private final LlmChatClient chatClient;
@@ -411,17 +408,21 @@ public class AgentLoop
     {
         var options = new LinkedHashMap<String, Object>();
         options.put(OPT_NUM_CTX, chatProperties.getContextLength());
-        options.put(OPT_TOP_P, chatProperties.getTopP());
         options.put(OPT_TOP_K, chatProperties.getTopK());
         options.put(OPT_REPEAT_PENALTY, chatProperties.getRepeatPenalty());
-        options.put(OPT_TEMPERATURE, chatProperties.getTemperature());
 
-        // Provider-specific escape hatch: explicit options override the typed settings above.
+        // Provider-specific escape hatch: explicit options override the typed settings.
         if (chatProperties.getOptions() != null) {
             options.putAll(chatProperties.getOptions());
         }
 
-        return new ChatOptions(null, aJsonSchema, aTools, options);
+        return ChatOptions.builder() //
+                .withJsonSchema(aJsonSchema) //
+                .withTools(aTools) //
+                .withOptions(options) //
+                .withTemperature(chatProperties.getTemperature()) //
+                .withTopP(chatProperties.getTopP()) //
+                .build();
     }
 
     /**

--- a/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/AgentLoop.java
+++ b/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/AgentLoop.java
@@ -393,13 +393,13 @@ public class AgentLoop
     private LlmEndpoint endpoint()
     {
         AuthenticationTraits auth = null;
-        if (isNotBlank(properties.getApiKey())) {
+        if (isNotBlank(properties.getChatApiKey())) {
             var apiKeyAuth = new ApiKeyAuthenticationTraits();
-            apiKeyAuth.setApiKey(properties.getApiKey());
+            apiKeyAuth.setApiKey(properties.getChatApiKey());
             auth = apiKeyAuth;
         }
 
-        return new LlmEndpoint(chatClient.getId(), properties.getUrl(),
+        return new LlmEndpoint(chatClient.getId(), properties.getChatUrl(),
                 properties.getChat().getModel(), auth);
     }
 

--- a/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/AgentLoop.java
+++ b/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/AgentLoop.java
@@ -24,21 +24,28 @@ import static de.tudarmstadt.ukp.inception.assistant.model.MChatRoles.ASSISTANT;
 import static de.tudarmstadt.ukp.inception.assistant.model.MChatRoles.SYSTEM;
 import static de.tudarmstadt.ukp.inception.assistant.model.MChatRoles.TOOL;
 import static de.tudarmstadt.ukp.inception.assistant.model.MChatRoles.USER;
+import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.ToolUtils.getFunctionActor;
+import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.ToolUtils.getFunctionName;
+import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.ToolUtils.getStop;
 import static java.lang.Math.floorDiv;
 import static java.lang.System.currentTimeMillis;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.apache.commons.lang3.reflect.MethodUtils.getMethodsListWithAnnotation;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -68,16 +75,20 @@ import de.tudarmstadt.ukp.inception.assistant.model.MReference;
 import de.tudarmstadt.ukp.inception.assistant.model.MTextMessage;
 import de.tudarmstadt.ukp.inception.assistant.model.MTextMessage.Builder;
 import de.tudarmstadt.ukp.inception.assistant.model.MToolCall;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ChatMessage;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.Tool;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ToolLibrary;
-import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaChatMessage;
-import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaChatRequest;
-import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaChatResponse;
-import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaClient;
-import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaFunctionCall;
-import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaOptions;
-import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaTool;
-import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaToolCall;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ChatChunk;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ChatOptions;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ChatResult;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.LlmChatClient;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.LlmEndpoint;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ToolCall;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ToolDescriptor;
+import de.tudarmstadt.ukp.inception.security.client.auth.AuthenticationTraits;
+import de.tudarmstadt.ukp.inception.security.client.auth.apikey.ApiKeyAuthenticationTraits;
 import de.tudarmstadt.ukp.inception.support.json.JSONUtil;
+import tools.jackson.databind.JsonNode;
 
 /**
  * The {@code AgentLoop} class manages the main interaction loop for an AI agent within the
@@ -100,8 +111,15 @@ public class AgentLoop
      */
     private static final int CONTEXT_LENGTH_SAFETY_PERCENTAGE = 90;
 
+    // Provider-specific (Ollama) generation option keys carried through ChatOptions#options().
+    private static final String OPT_NUM_CTX = "num_ctx";
+    private static final String OPT_TOP_P = "top_p";
+    private static final String OPT_TOP_K = "top_k";
+    private static final String OPT_REPEAT_PENALTY = "repeat_penalty";
+    private static final String OPT_TEMPERATURE = "temperature";
+
     private final AssistantProperties properties;
-    private final OllamaClient ollamaClient;
+    private final LlmChatClient chatClient;
     private final User sessionOwner;
     private final Project project;
     private final List<ToolLibrary> tools = new ArrayList<>();
@@ -128,11 +146,11 @@ public class AgentLoop
                 MChatMessage responseMessage);
     }
 
-    public AgentLoop(AssistantProperties aProperties, OllamaClient aOllamaClient,
-            User aSessionOwner, Project aProject, Memory aMemory, Encoding aEncoding)
+    public AgentLoop(AssistantProperties aProperties, LlmChatClient aChatClient, User aSessionOwner,
+            Project aProject, Memory aMemory, Encoding aEncoding)
     {
         properties = aProperties;
-        ollamaClient = aOllamaClient;
+        chatClient = aChatClient;
         sessionOwner = aSessionOwner;
         project = aProject;
         memory = aMemory;
@@ -227,22 +245,21 @@ public class AgentLoop
         var responseId = aResponseId != null ? aResponseId : UUID.randomUUID();
         var chatProperties = properties.getChat();
 
-        var requestBuilder = buildRequest(aMessages, chatProperties) //
-                .withStream(true);
-
+        var toolBindings = new LinkedHashMap<String, ToolBinding>();
+        var toolDescriptors = new ArrayList<ToolDescriptor>();
         if (isToolCallingEnabled() && chatProperties.getCapabilities().contains(CAP_TOOLS)
                 && !tools.isEmpty()) {
             try {
-                var ollamaTools = tools.stream() //
-                        .flatMap(o -> OllamaTool.forService(o).stream()) //
-                        .toList();
-                requestBuilder.withTools(ollamaTools);
-
+                collectTools(toolDescriptors, toolBindings);
             }
             catch (Exception e) {
                 LOG.error("Unable to map tools", e);
+                toolDescriptors.clear();
+                toolBindings.clear();
             }
         }
+
+        var options = buildOptions(chatProperties, null, toolDescriptors);
 
         var references = new LinkedHashMap<String, MReference>();
         aMessages.stream() //
@@ -258,38 +275,37 @@ public class AgentLoop
         // Generate the actual response
         var startTime = currentTimeMillis();
         var firstTokenTime = new AtomicLong(0l);
-        var request = requestBuilder.build();
-        var response = ollamaClient.chat(properties.getUrl(), request, msg -> {
-            firstTokenTime.compareAndSet(0l, currentTimeMillis());
-            recordAndStreamMessage(responseId, msg);
-        });
-        var tokens = response.getEvalCount();
+        var response = chatClient.chatStream(endpoint(), toChatMessages(aMessages), options,
+                chunk -> {
+                    firstTokenTime.compareAndSet(0l, currentTimeMillis());
+                    recordAndStreamChunk(responseId, chunk);
+                });
+        var tokens = completionTokens(response);
         var endTime = currentTimeMillis();
 
         var toolCalls = new ArrayList<MToolCall>();
-        if (isNotEmpty(response.getMessage().toolCalls()) && isNotEmpty(request.getTools())) {
-            for (var call : response.getMessage().toolCalls()) {
-                var maybeTool = request.getTool(call);
-                if (maybeTool.isEmpty()) {
-                    throw new ToolNotFoundException(call.getFunction().getName());
+        if (isNotEmpty(response.toolCalls()) && !toolBindings.isEmpty()) {
+            for (var call : response.toolCalls()) {
+                var binding = toolBindings.get(call.name());
+                if (binding == null) {
+                    throw new ToolNotFoundException(call.name());
                 }
 
-                var tool = maybeTool.get();
                 toolCalls.add(MToolCall.builder() //
-                        .withActor(tool.getFunction().getActor()) //
-                        .withInstance(tool.getFunction().getService()) //
-                        .withName(tool.getFunction().getName()) //
-                        .withMethod(tool.getFunction().getImplementation()) //
-                        .withArguments(call.getFunction().getArguments()) //
-                        .withStop(tool.isStop()) //
+                        .withActor(binding.actor()) //
+                        .withInstance(binding.service()) //
+                        .withName(call.name()) //
+                        .withMethod(binding.method()) //
+                        .withArguments(toArgumentMap(call.arguments())) //
+                        .withStop(binding.stop()) //
                         .build());
             }
         }
 
         // Send a final and complete message also including final metrics
         var responseMessageBuilder = newMessage(responseId) //
-                .withContent(response.getMessage().content()) //
-                .withThinking(response.getMessage().thinking()) //
+                .withContent(response.message().content()) //
+                .withThinking(response.message().thinking()) //
                 .withPerformance(MPerformanceMetrics.builder() //
                         .withDelay(firstTokenTime.get() - startTime) //
                         .withDuration(endTime - firstTokenTime.get()) //
@@ -333,10 +349,11 @@ public class AgentLoop
                     .withRole(USER) //
                     .withContent(prompt + "\"\"\"\n" + aMessage.thinking() + "\n\"\"\"\n") //
                     .build();
-            var summaryRequest = buildRequest(asList(message), properties.getChat());
-            var summaryResponse = ollamaClient.chat(properties.getUrl(), summaryRequest.build());
+            var options = buildOptions(properties.getChat(), null, emptyList());
+            var summaryResponse = chatClient.chat(endpoint(), toChatMessages(asList(message)),
+                    options);
 
-            return summaryResponse.getMessage().content();
+            return summaryResponse.message().content();
         }
         catch (IOException e) {
             LOG.error("Unable to summarize thinking", e);
@@ -345,28 +362,107 @@ public class AgentLoop
         return "";
     }
 
-    private OllamaChatMessage toOllama(MChatMessage aMsg)
+    private List<ChatMessage> toChatMessages(List<? extends MChatMessage> aMessages)
     {
-        List<OllamaToolCall> toolCalls = null;
+        return aMessages.stream() //
+                .map(this::toChatMessage) //
+                .toList();
+    }
 
+    private ChatMessage toChatMessage(MChatMessage aMsg)
+    {
+        List<ToolCall> toolCalls = emptyList();
         if (isNotEmpty(aMsg.toolCalls())) {
-            toolCalls = new ArrayList<OllamaToolCall>();
-            var i = 0;
-            for (var tc : aMsg.toolCalls()) {
-                var functionCall = new OllamaFunctionCall();
-                functionCall.setIndex(i);
-                functionCall.setName(tc.name());
-                functionCall.setArguments(tc.arguments());
-                var toolCall = new OllamaToolCall();
-                toolCall.setFunction(functionCall);
-                toolCalls.add(toolCall);
-                i++;
-            }
+            toolCalls = aMsg.toolCalls().stream() //
+                    .map(tc -> new ToolCall(null, tc.name(),
+                            JSONUtil.getObjectMapper().valueToTree(tc.arguments()))) //
+                    .toList();
         }
 
-        return new OllamaChatMessage(aMsg.role(), aMsg.textRepresentation(), aMsg.thinking(),
-                toolCalls);
+        return new ChatMessage(roleOf(aMsg.role()), aMsg.textRepresentation(), aMsg.thinking(),
+                null, toolCalls);
     }
+
+    private static ChatMessage.Role roleOf(String aRole)
+    {
+        return switch (aRole) {
+        case SYSTEM -> ChatMessage.Role.SYSTEM;
+        case USER -> ChatMessage.Role.USER;
+        case TOOL -> ChatMessage.Role.TOOL;
+        default -> ChatMessage.Role.ASSISTANT;
+        };
+    }
+
+    private LlmEndpoint endpoint()
+    {
+        AuthenticationTraits auth = null;
+        if (isNotBlank(properties.getApiKey())) {
+            var apiKeyAuth = new ApiKeyAuthenticationTraits();
+            apiKeyAuth.setApiKey(properties.getApiKey());
+            auth = apiKeyAuth;
+        }
+
+        return new LlmEndpoint(chatClient.getId(), properties.getUrl(),
+                properties.getChat().getModel(), auth);
+    }
+
+    private ChatOptions buildOptions(AssistantChatProperties chatProperties, JsonNode aJsonSchema,
+            List<ToolDescriptor> aTools)
+    {
+        var options = new LinkedHashMap<String, Object>();
+        options.put(OPT_NUM_CTX, chatProperties.getContextLength());
+        options.put(OPT_TOP_P, chatProperties.getTopP());
+        options.put(OPT_TOP_K, chatProperties.getTopK());
+        options.put(OPT_REPEAT_PENALTY, chatProperties.getRepeatPenalty());
+        options.put(OPT_TEMPERATURE, chatProperties.getTemperature());
+
+        // Provider-specific escape hatch: explicit options override the typed settings above.
+        if (chatProperties.getOptions() != null) {
+            options.putAll(chatProperties.getOptions());
+        }
+
+        return new ChatOptions(null, aJsonSchema, aTools, options);
+    }
+
+    /**
+     * Derives the provider-neutral {@link ToolDescriptor}s sent to the model together with a
+     * name-keyed map of {@link ToolBinding}s used to reconstruct the {@link MToolCall} (actor,
+     * target instance/method, stop flag) once the model picks a tool — the neutral {@link ToolCall}
+     * only carries name and arguments.
+     */
+    private void collectTools(List<ToolDescriptor> aDescriptors, Map<String, ToolBinding> aBindings)
+    {
+        for (var library : tools) {
+            for (var method : getMethodsListWithAnnotation(library.getClass(), Tool.class, true,
+                    true)) {
+                method.setAccessible(true);
+                aDescriptors.add(ToolDescriptor.fromMethod(method));
+                aBindings.put(getFunctionName(method), new ToolBinding(
+                        getFunctionActor(method).orElse(null), library, method, getStop(method)));
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> toArgumentMap(JsonNode aArguments)
+    {
+        if (aArguments == null || aArguments.isNull()) {
+            return new LinkedHashMap<>();
+        }
+
+        return JSONUtil.getObjectMapper().convertValue(aArguments, Map.class);
+    }
+
+    private static int completionTokens(ChatResult aResult)
+    {
+        var usage = aResult.usage();
+        if (usage != null && usage.completionTokens() != null) {
+            return usage.completionTokens();
+        }
+        return 0;
+    }
+
+    private record ToolBinding(String actor, Object service, Method method, boolean stop) {}
 
     public <T> MCallResponse<T> call(Class<T> aResult, List<MTextMessage> aMessages)
         throws IOException
@@ -376,9 +472,7 @@ public class AgentLoop
         var responseId = UUID.randomUUID();
         var chatProperties = properties.getChat();
 
-        var requestBuilder = buildRequest(aMessages, chatProperties) //
-                .withFormat(schema) //
-                .withStream(false);
+        var options = buildOptions(chatProperties, schema, emptyList());
 
         var references = new LinkedHashMap<String, MReference>();
         aMessages.stream() //
@@ -387,12 +481,11 @@ public class AgentLoop
 
         // Generate the actual response
         var startTime = currentTimeMillis();
-        var request = requestBuilder.build();
-        var response = ollamaClient.chat(properties.getUrl(), request, null);
-        var tokens = response.getEvalCount();
+        var response = chatClient.chat(endpoint(), toChatMessages(aMessages), options);
+        var tokens = completionTokens(response);
         var endTime = currentTimeMillis();
 
-        var payload = JSONUtil.fromJsonString(aResult, response.getMessage().content());
+        var payload = JSONUtil.fromJsonString(aResult, response.message().content());
 
         // Send a final and complete message also including final metrics
         return MCallResponse.builder(aResult) //
@@ -407,23 +500,6 @@ public class AgentLoop
                 // Include all references in the final message again just to be sure
                 .withReferences(references.values()) //
                 .build();
-    }
-
-    private OllamaChatRequest.Builder buildRequest(List<? extends MChatMessage> aMessages,
-            AssistantChatProperties chatProperties)
-    {
-        var requestBuilder = OllamaChatRequest.builder() //
-                .withApiKey(properties.getApiKey()) //
-                .withModel(chatProperties.getModel()) //
-                .withMessages(aMessages.stream() //
-                        .map(this::toOllama) //
-                        .toList()) //
-                .withOption(OllamaOptions.NUM_CTX, chatProperties.getContextLength()) //
-                .withOption(OllamaOptions.TOP_P, chatProperties.getTopP()) //
-                .withOption(OllamaOptions.TOP_K, chatProperties.getTopK()) //
-                .withOption(OllamaOptions.REPEAT_PENALTY, chatProperties.getRepeatPenalty()) //
-                .withOption(OllamaOptions.TEMPERATURE, chatProperties.getTemperature());
-        return requestBuilder;
     }
 
     private void recordAndStreamMessage(UUID aResponseId, MChatMessage aMessage)
@@ -447,19 +523,19 @@ public class AgentLoop
         }
     }
 
-    private void recordAndStreamMessage(UUID responseId, OllamaChatResponse aMessage)
+    private void recordAndStreamChunk(UUID aResponseId, ChatChunk aChunk)
     {
-        if (isEmpty(aMessage.getMessage().content()) && isEmpty(aMessage.getMessage().thinking())) {
+        if (isEmpty(aChunk.contentDelta()) && isEmpty(aChunk.thinkingDelta())) {
             return;
         }
 
-        var message = newMessage(responseId) //
-                .withContent(aMessage.getMessage().content()) //
-                .withThinking(aMessage.getMessage().thinking()) //
+        var message = newMessage(aResponseId) //
+                .withContent(aChunk.contentDelta()) //
+                .withThinking(aChunk.thinkingDelta()) //
                 .notDone() //
                 .build();
 
-        recordAndStreamMessage(responseId, message);
+        recordAndStreamMessage(aResponseId, message);
     }
 
     private Builder newMessage(UUID responseId)

--- a/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/AgentLoop.java
+++ b/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/AgentLoop.java
@@ -282,8 +282,11 @@ public class AgentLoop
                     });
         }
         else {
-            response = chatClient.chat(endpoint(), toChatMessages(aMessages), options);
+            // For a non-streaming exchange the entire response arrives at once, so there is no
+            // meaningful time-to-first-token. Treat the delay as zero and attribute the full
+            // wall-clock time to the duration below.
             firstTokenTime.compareAndSet(0l, currentTimeMillis());
+            response = chatClient.chat(endpoint(), toChatMessages(aMessages), options);
         }
         var tokens = completionTokens(response);
         var endTime = currentTimeMillis();
@@ -297,6 +300,7 @@ public class AgentLoop
                 }
 
                 toolCalls.add(MToolCall.builder() //
+                        .withId(call.id()) //
                         .withActor(binding.actor()) //
                         .withInstance(binding.service()) //
                         .withName(call.name()) //
@@ -376,29 +380,24 @@ public class AgentLoop
 
     private ChatMessage toChatMessage(MChatMessage aMsg)
     {
-        // TODO [tool_call_id]: OpenAI/Azure require the provider-assigned tool-call id to be echoed
-        // back on both the assistant message (ToolCall.id()) and the TOOL-role result message
-        // (ChatMessage.toolCallId). The neutral ToolCall.id() IS captured by the OpenAI/Azure
-        // adapters on the response (see *LlmChatClient.toToolCalls -> wireCall.getId()), but the
-        // assistant-side model drops it: MToolCall (assistant-api) has no id field, so it is lost
-        // in
-        // AgentLoop.turn() when the MToolCall is built, and there is no way to correlate a TOOL
-        // result message back to its originating call here. Wiring this end-to-end requires adding
-        // an `id` to MToolCall (+ builder) in inception-assistant-api, threading call.id() into it
-        // in
-        // turn(), and setting it here for both the ASSISTANT re-emit and the TOOL result (4th ctor
-        // arg). Until then we pass null and rely on positional matching (works for Ollama; OpenAI/
-        // Azure single-tool-per-turn turns tolerate it). Deferred as a follow-up.
+        // OpenAI/Azure require the provider-assigned tool-call id to be echoed back on both the
+        // assistant message (ToolCall.id()) and the TOOL-role result message
+        // (ChatMessage.toolCallId) so the model can correlate a result to its originating call.
+        // Ollama ignores the id and matches positionally, so passing it through is harmless there.
         List<ToolCall> toolCalls = emptyList();
         if (isNotEmpty(aMsg.toolCalls())) {
             toolCalls = aMsg.toolCalls().stream() //
-                    .map(tc -> new ToolCall(null, tc.name(),
+                    .map(tc -> new ToolCall(tc.id(), tc.name(),
                             JSONUtil.getObjectMapper().valueToTree(tc.arguments()))) //
                     .toList();
         }
 
+        // For a TOOL-role result message, echo back the id of the call it answers.
+        var toolCallId = aMsg instanceof MCallResponse<?> callResponse ? callResponse.toolCallId()
+                : null;
+
         return new ChatMessage(roleOf(aMsg.role()), aMsg.textRepresentation(), aMsg.thinking(),
-                null, toolCalls);
+                toolCallId, toolCalls);
     }
 
     private static ChatMessage.Role roleOf(String aRole)

--- a/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/AssistantServiceImpl.java
+++ b/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/AssistantServiceImpl.java
@@ -70,7 +70,6 @@ import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ToolLibraryExtension
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.LlmChatClient;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.LlmChatClientExtensionPoint;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaClient;
-import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaLlmChatClient;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaShowRequest;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaShowResponse;
 import de.tudarmstadt.ukp.inception.support.io.WatchedResourceFile;
@@ -120,12 +119,11 @@ public class AssistantServiceImpl
 
     private LlmChatClient chatClient()
     {
-        // Provider is hardcoded to Ollama for now; once assistant config moves to UI-driven
-        // traits, this becomes traits.getProviderId().
-        return chatClientExtensionPoint.getExtension(OllamaLlmChatClient.ID) //
+        var providerId = properties.getChatProvider();
+        return chatClientExtensionPoint.getExtension(providerId) //
                 .orElseThrow(() -> new IllegalStateException(
-                        "Ollama LLM client not registered — is the inception-imls-ollama module on "
-                                + "the classpath?"));
+                        "No LLM client registered for chat provider [" + providerId
+                                + "] — is the corresponding module on the classpath?"));
     }
 
     @EventListener
@@ -447,10 +445,10 @@ public class AssistantServiceImpl
                 OllamaShowResponse modelInfo = null;
                 try {
                     LOG.info("Contacting [{}] to retrieve information about model [{}]...",
-                            properties.getUrl(), chatProperties.getModel());
-                    modelInfo = ollamaClient.getModelInfo(properties.getUrl(),
+                            properties.getChatUrl(), chatProperties.getModel());
+                    modelInfo = ollamaClient.getModelInfo(properties.getChatUrl(),
                             OllamaShowRequest.builder().withModel(chatProperties.getModel()) //
-                                    .withApiKey(properties.getApiKey()) //
+                                    .withApiKey(properties.getChatApiKey()) //
                                     .build());
                 }
                 catch (Exception e) {

--- a/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/AssistantServiceImpl.java
+++ b/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/AssistantServiceImpl.java
@@ -67,7 +67,10 @@ import de.tudarmstadt.ukp.inception.preferences.ClientSideUserPreferencesProvide
 import de.tudarmstadt.ukp.inception.project.api.event.AfterProjectRemovedEvent;
 import de.tudarmstadt.ukp.inception.project.api.event.BeforeProjectRemovedEvent;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ToolLibraryExtensionPoint;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.LlmChatClient;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.LlmChatClientExtensionPoint;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaClient;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaLlmChatClient;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaShowRequest;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaShowResponse;
 import de.tudarmstadt.ukp.inception.support.io.WatchedResourceFile;
@@ -82,6 +85,7 @@ public class AssistantServiceImpl
     private final SimpMessagingTemplate msgTemplate;
     private final MemoryManager memoryManager;
     private final OllamaClient ollamaClient;
+    private final LlmChatClientExtensionPoint chatClientExtensionPoint;
     private final AssistantProperties properties;
     private final EncodingRegistry encodingRegistry;
     private final RetrieverExtensionPoint retrieverExtensionPoint;
@@ -94,14 +98,15 @@ public class AssistantServiceImpl
 
     public AssistantServiceImpl(SessionRegistry aSessionRegistry,
             SimpMessagingTemplate aMsgTemplate, OllamaClient aOllamaClient,
-            AssistantProperties aProperties, EncodingRegistry aEncodingRegistry,
-            RetrieverExtensionPoint aRetrieverExtensionPoint,
+            LlmChatClientExtensionPoint aChatClientExtensionPoint, AssistantProperties aProperties,
+            EncodingRegistry aEncodingRegistry, RetrieverExtensionPoint aRetrieverExtensionPoint,
             ToolLibraryExtensionPoint aToolLibraryExtensionPoint)
     {
         sessionRegistry = aSessionRegistry;
         msgTemplate = aMsgTemplate;
         memoryManager = new MemoryManager();
         ollamaClient = aOllamaClient;
+        chatClientExtensionPoint = aChatClientExtensionPoint;
         properties = aProperties;
         encodingRegistry = aEncodingRegistry;
         retrieverExtensionPoint = aRetrieverExtensionPoint;
@@ -111,6 +116,16 @@ public class AssistantServiceImpl
                 .getResource("AssistantServiceUserPreferences.schema.json");
         userPreferencesSchema = new WatchedResourceFile<>(userPreferencesSchemaFile,
                 JSONUtil::loadJsonSchema);
+    }
+
+    private LlmChatClient chatClient()
+    {
+        // Provider is hardcoded to Ollama for now; once assistant config moves to UI-driven
+        // traits, this becomes traits.getProviderId().
+        return chatClientExtensionPoint.getExtension(OllamaLlmChatClient.ID) //
+                .orElseThrow(() -> new IllegalStateException(
+                        "Ollama LLM client not registered — is the inception-imls-ollama module on "
+                                + "the classpath?"));
     }
 
     @EventListener
@@ -214,7 +229,7 @@ public class AssistantServiceImpl
 
         try {
             var memory = memoryManager.getMemory(aSessionOwner.getUsername(), aProject);
-            var assistant = new AgentLoop(properties, ollamaClient, aSessionOwner, aProject, memory,
+            var assistant = new AgentLoop(properties, chatClient(), aSessionOwner, aProject, memory,
                     getEncoding());
             assistant.setSystemMessages(generateSystemMessages(aProject));
             assistant.setMessageStreamHandler(this::handleStreamedMessageFragment);
@@ -248,7 +263,7 @@ public class AssistantServiceImpl
             dispatchMessage(aSessionOwner.getUsername(), aProject, aMessage);
         }
 
-        var assistant = new AgentLoop(properties, ollamaClient, aSessionOwner, aProject, memory,
+        var assistant = new AgentLoop(properties, chatClient(), aSessionOwner, aProject, memory,
                 getEncoding());
         assistant.setSystemMessages(generateSystemMessages(aProject));
         assistant.setMessageStreamHandler(this::handleStreamedMessageFragment);
@@ -274,7 +289,7 @@ public class AssistantServiceImpl
             MTextMessage... aContextMessages)
     {
         var memory = memoryManager.getMemory(aSessionOwner.getUsername(), aProject);
-        var assistant = new AgentLoop(properties, ollamaClient, aSessionOwner, aProject, memory,
+        var assistant = new AgentLoop(properties, chatClient(), aSessionOwner, aProject, memory,
                 getEncoding());
         assistant.setIgnoreMemory(true);
         assistant.setSystemMessages(generateSystemMessages(aProject));
@@ -295,7 +310,7 @@ public class AssistantServiceImpl
             String aDataOwner, MTextMessage aMessage)
     {
         var memory = memoryManager.getMemory(aSessionOwner.getUsername(), aProject);
-        var assistant = new AgentLoop(properties, ollamaClient, aSessionOwner, aProject, memory,
+        var assistant = new AgentLoop(properties, chatClient(), aSessionOwner, aProject, memory,
                 getEncoding());
         assistant.setSystemMessages(generateSystemMessages(aProject));
         assistant.setEphemeralMessages(generateEphemeralMessages(aProject, aMessage));

--- a/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/AssistantServiceImpl.java
+++ b/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/AssistantServiceImpl.java
@@ -24,16 +24,21 @@ import static de.tudarmstadt.ukp.inception.assistant.model.MChatRoles.SYSTEM;
 import static de.tudarmstadt.ukp.inception.support.json.JSONUtil.toPrettyJsonString;
 import static java.lang.String.join;
 import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toCollection;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -69,9 +74,9 @@ import de.tudarmstadt.ukp.inception.project.api.event.BeforeProjectRemovedEvent;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ToolLibraryExtensionPoint;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.LlmChatClient;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.LlmChatClientExtensionPoint;
-import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaClient;
-import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaShowRequest;
-import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaShowResponse;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.LlmEndpoint;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ModelCapability;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ModelDetails;
 import de.tudarmstadt.ukp.inception.support.io.WatchedResourceFile;
 import de.tudarmstadt.ukp.inception.support.json.JSONUtil;
 
@@ -83,7 +88,6 @@ public class AssistantServiceImpl
     private final SessionRegistry sessionRegistry;
     private final SimpMessagingTemplate msgTemplate;
     private final MemoryManager memoryManager;
-    private final OllamaClient ollamaClient;
     private final LlmChatClientExtensionPoint chatClientExtensionPoint;
     private final AssistantProperties properties;
     private final EncodingRegistry encodingRegistry;
@@ -96,7 +100,7 @@ public class AssistantServiceImpl
     private WatchedResourceFile<Schema> userPreferencesSchema;
 
     public AssistantServiceImpl(SessionRegistry aSessionRegistry,
-            SimpMessagingTemplate aMsgTemplate, OllamaClient aOllamaClient,
+            SimpMessagingTemplate aMsgTemplate,
             LlmChatClientExtensionPoint aChatClientExtensionPoint, AssistantProperties aProperties,
             EncodingRegistry aEncodingRegistry, RetrieverExtensionPoint aRetrieverExtensionPoint,
             ToolLibraryExtensionPoint aToolLibraryExtensionPoint)
@@ -104,7 +108,6 @@ public class AssistantServiceImpl
         sessionRegistry = aSessionRegistry;
         msgTemplate = aMsgTemplate;
         memoryManager = new MemoryManager();
-        ollamaClient = aOllamaClient;
         chatClientExtensionPoint = aChatClientExtensionPoint;
         properties = aProperties;
         encodingRegistry = aEncodingRegistry;
@@ -129,7 +132,42 @@ public class AssistantServiceImpl
     @EventListener
     public void onContextRefreshedEvent(ContextRefreshedEvent aEvent)
     {
+        validateProviderConfiguration();
         autoDetectModelCapabilities();
+    }
+
+    /**
+     * Validates at startup that the configured chat (and, if set, embedding) provider ids resolve
+     * to a registered {@link LlmChatClient}. A misconfigured assistant should not take down the
+     * whole application context, so we log an actionable ERROR (listing the available provider ids)
+     * instead of throwing.
+     */
+    private void validateProviderConfiguration()
+    {
+        var chatProvider = properties.getChatProvider();
+        if (isBlank(chatProvider)
+                || chatClientExtensionPoint.getExtension(chatProvider).isEmpty()) {
+            LOG.error("No LLM client is registered for the configured chat provider [{}]. "
+                    + "The assistant will not work until this is fixed. Available providers: [{}]",
+                    chatProvider, availableProviderIds());
+        }
+
+        var embeddingProvider = properties.getEmbeddingProvider();
+        if (isNotBlank(embeddingProvider)
+                && chatClientExtensionPoint.getExtension(embeddingProvider).isEmpty()) {
+            LOG.error(
+                    "No LLM client is registered for the configured embedding provider [{}]. "
+                            + "Embedding-based features will not work until this is fixed. "
+                            + "Available providers: [{}]",
+                    embeddingProvider, availableProviderIds());
+        }
+    }
+
+    private String availableProviderIds()
+    {
+        return chatClientExtensionPoint.getExtensions().stream() //
+                .map(LlmChatClient::getId) //
+                .collect(joining(", "));
     }
 
     // Set order so this is handled before session info is removed from sessionRegistry
@@ -442,14 +480,11 @@ public class AssistantServiceImpl
 
         synchronized (chatProperties) {
             if (autoDetectCapabilities || autoDetectContextLength) {
-                OllamaShowResponse modelInfo = null;
+                ModelDetails details = null;
                 try {
                     LOG.info("Contacting [{}] to retrieve information about model [{}]...",
                             properties.getChatUrl(), chatProperties.getModel());
-                    modelInfo = ollamaClient.getModelInfo(properties.getChatUrl(),
-                            OllamaShowRequest.builder().withModel(chatProperties.getModel()) //
-                                    .withApiKey(properties.getChatApiKey()) //
-                                    .build());
+                    details = chatClient().describeModel(chatEndpoint()).orElse(null);
                 }
                 catch (Exception e) {
                     if (LOG.isDebugEnabled()) {
@@ -461,9 +496,8 @@ public class AssistantServiceImpl
                 }
 
                 if (autoDetectContextLength) {
-                    if (modelInfo != null && modelInfo.info() != null
-                            && modelInfo.info().getContextLength() != null) {
-                        chatProperties.setContextLength(modelInfo.info().getContextLength());
+                    if (details != null && details.contextLength() != null) {
+                        chatProperties.setContextLength(details.contextLength());
                         LOG.info("Auto-detected context length: {}",
                                 chatProperties.getContextLength());
                     }
@@ -476,19 +510,68 @@ public class AssistantServiceImpl
                 }
 
                 if (autoDetectCapabilities) {
-                    if (modelInfo != null && CollectionUtils.isNotEmpty(modelInfo.capabilities())) {
-                        chatProperties.setCapabilities(modelInfo.capabilities());
+                    if (details != null && !details.capabilities().isEmpty()) {
+                        chatProperties.setCapabilities(toAssistantCapabilities(details));
                         LOG.info("Auto-detected capabilties dimension of model [{}]: {}",
                                 chatProperties.getModel(), chatProperties.getCapabilities());
                     }
                     else {
-                        chatProperties.setCapabilities(Set.of(CAP_COMPLETION));
-                        LOG.info("Unable to auto-detect capabilities - using default: {}",
-                                chatProperties.getCapabilities());
+                        // The provider exposes no per-model capability introspection (e.g. the
+                        // OpenAI API has no such endpoint). Fall back to the capabilities the
+                        // adapter statically declares it supports rather than assuming
+                        // completion-only, so tool calling stays available on such providers.
+                        var staticCaps = toAssistantCapabilities(
+                                chatClient().supportedCapabilities());
+                        if (!staticCaps.isEmpty()) {
+                            chatProperties.setCapabilities(staticCaps);
+                            LOG.info(
+                                    "Model reported no capabilities - using adapter-declared "
+                                            + "capabilities for [{}]: {}",
+                                    chatClient().getId(), staticCaps);
+                        }
+                        else {
+                            chatProperties.setCapabilities(Set.of(CAP_COMPLETION));
+                            LOG.info("Unable to auto-detect capabilities - using default: {}",
+                                    chatProperties.getCapabilities());
+                        }
                     }
                 }
             }
         }
+    }
+
+    /**
+     * Translates the neutral {@link ModelCapability} set reported by the client into the
+     * assistant's own String capability tokens. Capabilities with no assistant-level equivalent are
+     * ignored. For an Ollama model reporting {@code completion}+{@code tools} this yields the same
+     * {@code {completion, tools}} set the previous Ollama-specific code produced.
+     */
+    private static Set<String> toAssistantCapabilities(ModelDetails aDetails)
+    {
+        return toAssistantCapabilities(aDetails.capabilities());
+    }
+
+    private static Set<String> toAssistantCapabilities(Collection<ModelCapability> aCapabilities)
+    {
+        return aCapabilities.stream() //
+                .map(AssistantServiceImpl::toAssistantCapability) //
+                .filter(c -> c != null) //
+                .collect(toCollection(LinkedHashSet::new));
+    }
+
+    private static String toAssistantCapability(ModelCapability aCapability)
+    {
+        return switch (aCapability) {
+        case CHAT -> CAP_COMPLETION;
+        case TOOLS -> CAP_TOOLS;
+        default -> null; // no assistant-level equivalent
+        };
+    }
+
+    private LlmEndpoint chatEndpoint()
+    {
+        return new LlmEndpoint(chatClient().getId(), properties.getChatUrl(),
+                properties.getChat().getModel(), LlmAuth.apiKeyAuth(properties.getChatApiKey()));
     }
 
     static record AssistantStateKey(String user, long projectId) {}

--- a/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/LlmAuth.java
+++ b/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/LlmAuth.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.assistant;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+import de.tudarmstadt.ukp.inception.security.client.auth.AuthenticationTraits;
+import de.tudarmstadt.ukp.inception.security.client.auth.apikey.ApiKeyAuthenticationTraits;
+
+/**
+ * Small helpers for building the authentication carried on an {@code LlmEndpoint} from the
+ * assistant's configured API keys.
+ */
+public final class LlmAuth
+{
+    private LlmAuth()
+    {
+        // No instances
+    }
+
+    /**
+     * Builds {@link ApiKeyAuthenticationTraits} for the given API key, or returns {@code null} when
+     * the key is blank (i.e. no authentication configured).
+     */
+    public static AuthenticationTraits apiKeyAuth(String aApiKey)
+    {
+        if (isBlank(aApiKey)) {
+            return null;
+        }
+
+        var auth = new ApiKeyAuthenticationTraits();
+        auth.setApiKey(aApiKey);
+        return auth;
+    }
+}

--- a/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/config/AssistantAutoConfiguration.java
+++ b/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/config/AssistantAutoConfiguration.java
@@ -65,12 +65,13 @@ public class AssistantAutoConfiguration
     @Bean
     public AssistantService assistantService(SessionRegistry aSessionRegistry,
             SimpMessagingTemplate aMsgTemplate, OllamaClient aOllamaClient,
-            AssistantProperties aProperties, EncodingRegistry aEncodingRegistry,
-            RetrieverExtensionPoint aRetrieverExtensionPoint,
+            LlmChatClientExtensionPoint aChatClientExtensionPoint, AssistantProperties aProperties,
+            EncodingRegistry aEncodingRegistry, RetrieverExtensionPoint aRetrieverExtensionPoint,
             ToolLibraryExtensionPoint aToolLibraryExtensionPoint)
     {
-        return new AssistantServiceImpl(aSessionRegistry, aMsgTemplate, aOllamaClient, aProperties,
-                aEncodingRegistry, aRetrieverExtensionPoint, aToolLibraryExtensionPoint);
+        return new AssistantServiceImpl(aSessionRegistry, aMsgTemplate, aOllamaClient,
+                aChatClientExtensionPoint, aProperties, aEncodingRegistry, aRetrieverExtensionPoint,
+                aToolLibraryExtensionPoint);
     }
 
     @Bean

--- a/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/config/AssistantAutoConfiguration.java
+++ b/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/config/AssistantAutoConfiguration.java
@@ -64,13 +64,13 @@ public class AssistantAutoConfiguration
 {
     @Bean
     public AssistantService assistantService(SessionRegistry aSessionRegistry,
-            SimpMessagingTemplate aMsgTemplate, OllamaClient aOllamaClient,
+            SimpMessagingTemplate aMsgTemplate,
             LlmChatClientExtensionPoint aChatClientExtensionPoint, AssistantProperties aProperties,
             EncodingRegistry aEncodingRegistry, RetrieverExtensionPoint aRetrieverExtensionPoint,
             ToolLibraryExtensionPoint aToolLibraryExtensionPoint)
     {
-        return new AssistantServiceImpl(aSessionRegistry, aMsgTemplate, aOllamaClient,
-                aChatClientExtensionPoint, aProperties, aEncodingRegistry, aRetrieverExtensionPoint,
+        return new AssistantServiceImpl(aSessionRegistry, aMsgTemplate, aChatClientExtensionPoint,
+                aProperties, aEncodingRegistry, aRetrieverExtensionPoint,
                 aToolLibraryExtensionPoint);
     }
 

--- a/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/config/AssistantChatProperties.java
+++ b/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/config/AssistantChatProperties.java
@@ -28,6 +28,23 @@ public interface AssistantChatProperties
     String CAP_COMPLETION = "completion";
     String CAP_TOOLS = "tools";
 
+    /**
+     * @return the LLM provider id for chat, or {@code null} to inherit the top-level
+     *         {@code assistant.provider}.
+     */
+    String getProvider();
+
+    /**
+     * @return the chat endpoint URL, or {@code null} to inherit the top-level
+     *         {@code assistant.url}.
+     */
+    String getUrl();
+
+    /**
+     * @return the chat API key, or {@code null} to inherit the top-level {@code assistant.api-key}.
+     */
+    String getApiKey();
+
     String getModel();
 
     Set<String> getCapabilities();

--- a/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/config/AssistantChatProperties.java
+++ b/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/config/AssistantChatProperties.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.assistant.config;
 
+import java.util.Map;
 import java.util.Set;
 
 public interface AssistantChatProperties
@@ -42,4 +43,13 @@ public interface AssistantChatProperties
     int getContextLength();
 
     String getEncoding();
+
+    /**
+     * Free-form, provider-specific generation options merged onto the request alongside the typed
+     * settings above. Keys must match the configured provider's wire API (e.g. {@code num_ctx},
+     * {@code top_k} for Ollama; {@code max_tokens}, {@code frequency_penalty} for OpenAI). Entries
+     * here override the typed settings when keys collide. The escape hatch for knobs that have no
+     * provider-neutral equivalent.
+     */
+    Map<String, Object> getOptions();
 }

--- a/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/config/AssistantEmbeddingProperties.java
+++ b/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/config/AssistantEmbeddingProperties.java
@@ -21,6 +21,24 @@ public interface AssistantEmbeddingProperties
 {
     public static final int AUTO_DETECT_DIMENSION = 0;
 
+    /**
+     * @return the LLM provider id for embeddings, or {@code null} to inherit the top-level
+     *         {@code assistant.provider}.
+     */
+    String getProvider();
+
+    /**
+     * @return the embedding endpoint URL, or {@code null} to inherit the top-level
+     *         {@code assistant.url}.
+     */
+    String getUrl();
+
+    /**
+     * @return the embedding API key, or {@code null} to inherit the top-level
+     *         {@code assistant.api-key}.
+     */
+    String getApiKey();
+
     String getModel();
 
     int getSeed();

--- a/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/config/AssistantProperties.java
+++ b/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/config/AssistantProperties.java
@@ -17,10 +17,24 @@
  */
 package de.tudarmstadt.ukp.inception.assistant.config;
 
+import static org.apache.commons.lang3.StringUtils.defaultIfBlank;
+
 public interface AssistantProperties
 {
+    /**
+     * @return the default LLM provider id, used when the chat/embedding sections do not override
+     *         it.
+     */
+    String getProvider();
+
+    /**
+     * @return the default endpoint URL, used when the chat/embedding sections do not override it.
+     */
     String getUrl();
 
+    /**
+     * @return the default API key, used when the chat/embedding sections do not override it.
+     */
     String getApiKey();
 
     AssistantChatProperties getChat();
@@ -34,4 +48,55 @@ public interface AssistantProperties
     AssitantUserGuideProperties getUserGuide();
 
     AssistantDocumentIndexProperties getDocumentIndex();
+
+    /**
+     * @return the effective chat provider id: the chat-section override, or the top-level default.
+     */
+    default String getChatProvider()
+    {
+        return defaultIfBlank(getChat().getProvider(), getProvider());
+    }
+
+    /**
+     * @return the effective chat endpoint URL: the chat-section override, or the top-level default.
+     */
+    default String getChatUrl()
+    {
+        return defaultIfBlank(getChat().getUrl(), getUrl());
+    }
+
+    /**
+     * @return the effective chat API key: the chat-section override, or the top-level default.
+     */
+    default String getChatApiKey()
+    {
+        return defaultIfBlank(getChat().getApiKey(), getApiKey());
+    }
+
+    /**
+     * @return the effective embedding provider id: the embedding-section override, or the top-level
+     *         default.
+     */
+    default String getEmbeddingProvider()
+    {
+        return defaultIfBlank(getEmbedding().getProvider(), getProvider());
+    }
+
+    /**
+     * @return the effective embedding endpoint URL: the embedding-section override, or the
+     *         top-level default.
+     */
+    default String getEmbeddingUrl()
+    {
+        return defaultIfBlank(getEmbedding().getUrl(), getUrl());
+    }
+
+    /**
+     * @return the effective embedding API key: the embedding-section override, or the top-level
+     *         default.
+     */
+    default String getEmbeddingApiKey()
+    {
+        return defaultIfBlank(getEmbedding().getApiKey(), getApiKey());
+    }
 }

--- a/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/config/AssistantPropertiesImpl.java
+++ b/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/config/AssistantPropertiesImpl.java
@@ -208,6 +208,12 @@ public class AssistantPropertiesImpl
          * {@code tools}. With {@code auto} the system queries the LLM service during startup to
          * determine the model's capabilities; setting this manually overrides the detection and
          * avoids the startup query.
+         * <p>
+         * {@code auto} is exclusive: if it is present, any other tokens listed alongside it are
+         * ignored and the capabilities are taken solely from detection. When the provider exposes
+         * no capability introspection (e.g. the OpenAI API), detection falls back to the
+         * capabilities the adapter statically declares it supports. To pin capabilities on such a
+         * provider, list them explicitly (e.g. {@code [completion, tools]}) without {@code auto}.
          */
         // Default ([auto]) is declared in META-INF/additional-spring-configuration-metadata.json
         // because the metadata processor cannot read instance initializer blocks.

--- a/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/config/AssistantPropertiesImpl.java
+++ b/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/config/AssistantPropertiesImpl.java
@@ -19,6 +19,8 @@ package de.tudarmstadt.ukp.inception.assistant.config;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -228,6 +230,13 @@ public class AssistantPropertiesImpl
          */
         private double temperature = 0.1;
 
+        /**
+         * Free-form, provider-specific generation options merged onto the request (and overriding
+         * the typed settings on key collisions). Keys must match the configured provider's wire
+         * API.
+         */
+        private final Map<String, Object> options = new LinkedHashMap<>();
+
         {
             capabilities.add(AUTO_DETECT_CAPABILITIES);
         }
@@ -299,6 +308,20 @@ public class AssistantPropertiesImpl
         public void setTemperature(double aTemperature)
         {
             temperature = aTemperature;
+        }
+
+        @Override
+        public Map<String, Object> getOptions()
+        {
+            return options;
+        }
+
+        public void setOptions(Map<String, Object> aOptions)
+        {
+            options.clear();
+            if (aOptions != null) {
+                options.putAll(aOptions);
+            }
         }
 
         @Override

--- a/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/config/AssistantPropertiesImpl.java
+++ b/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/config/AssistantPropertiesImpl.java
@@ -30,7 +30,10 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class AssistantPropertiesImpl
     implements AssistantProperties
 {
-    /** URL of the Ollama service. */
+    /** Default LLM provider id, used when the chat/embedding sections do not override it. */
+    private String provider = "ollama";
+
+    /** URL of the LLM service. */
     private String url = "http://localhost:11434";
 
     /** The name by which the assistant identifies itself. */
@@ -49,6 +52,17 @@ public class AssistantPropertiesImpl
     private final AssistantUserGuidePropertiesImpl userGuide = new AssistantUserGuidePropertiesImpl();
 
     private @Autowired AssistantDocumentIndexProperties documentIndex;
+
+    @Override
+    public String getProvider()
+    {
+        return provider;
+    }
+
+    public void setProvider(String aProvider)
+    {
+        provider = aProvider;
+    }
 
     public void setApiKey(String aApiKey)
     {
@@ -177,6 +191,15 @@ public class AssistantPropertiesImpl
     public static class AssistantChatPropertiesImpl
         implements AssistantChatProperties
     {
+        /** Chat LLM provider id; {@code null} inherits the top-level {@code assistant.provider}. */
+        private String provider = null;
+
+        /** Chat endpoint URL; {@code null} inherits the top-level {@code assistant.url}. */
+        private String url = null;
+
+        /** Chat API key; {@code null} inherits the top-level {@code assistant.api-key}. */
+        private String apiKey = null;
+
         /** The model used to drive the chat functionality of the assistant. */
         private String model = "llama3.2";
 
@@ -267,6 +290,39 @@ public class AssistantPropertiesImpl
         }
 
         @Override
+        public String getProvider()
+        {
+            return provider;
+        }
+
+        public void setProvider(String aProvider)
+        {
+            provider = aProvider;
+        }
+
+        @Override
+        public String getUrl()
+        {
+            return url;
+        }
+
+        public void setUrl(String aUrl)
+        {
+            url = aUrl;
+        }
+
+        @Override
+        public String getApiKey()
+        {
+            return apiKey;
+        }
+
+        public void setApiKey(String aApiKey)
+        {
+            apiKey = aApiKey;
+        }
+
+        @Override
         public double getTopP()
         {
             return topP;
@@ -350,6 +406,18 @@ public class AssistantPropertiesImpl
     public static class AssistantEmbeddingPropertiesImpl
         implements AssistantEmbeddingProperties
     {
+        /**
+         * Embedding LLM provider id; {@code null} inherits the top-level
+         * {@code assistant.provider}.
+         */
+        private String provider = null;
+
+        /** Embedding endpoint URL; {@code null} inherits the top-level {@code assistant.url}. */
+        private String url = null;
+
+        /** Embedding API key; {@code null} inherits the top-level {@code assistant.api-key}. */
+        private String apiKey = null;
+
         /** The model used to drive the search functionality of the assistant. */
         private String model = "granite-embedding";
 
@@ -393,6 +461,39 @@ public class AssistantPropertiesImpl
         public void setModel(String aModel)
         {
             model = aModel;
+        }
+
+        @Override
+        public String getProvider()
+        {
+            return provider;
+        }
+
+        public void setProvider(String aProvider)
+        {
+            provider = aProvider;
+        }
+
+        @Override
+        public String getUrl()
+        {
+            return url;
+        }
+
+        public void setUrl(String aUrl)
+        {
+            url = aUrl;
+        }
+
+        @Override
+        public String getApiKey()
+        {
+            return apiKey;
+        }
+
+        public void setApiKey(String aApiKey)
+        {
+            apiKey = aApiKey;
         }
 
         @Override

--- a/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/embedding/EmbeddingServiceImpl.java
+++ b/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/embedding/EmbeddingServiceImpl.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.inception.assistant.embedding;
 
 import static de.tudarmstadt.ukp.inception.assistant.config.AssistantEmbeddingProperties.AUTO_DETECT_DIMENSION;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
@@ -38,7 +39,8 @@ import de.tudarmstadt.ukp.inception.assistant.config.AssistantProperties;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.LlmChatClient;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.LlmChatClientExtensionPoint;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.LlmEndpoint;
-import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaLlmChatClient;
+import de.tudarmstadt.ukp.inception.security.client.auth.AuthenticationTraits;
+import de.tudarmstadt.ukp.inception.security.client.auth.apikey.ApiKeyAuthenticationTraits;
 
 public class EmbeddingServiceImpl
     implements EmbeddingService
@@ -140,18 +142,27 @@ public class EmbeddingServiceImpl
 
     private LlmChatClient client()
     {
-        // Provider is hardcoded to Ollama for now; once assistant config moves to UI-driven
-        // traits, this becomes traits.getProviderId().
-        return chatClientExtensionPoint.getExtension(OllamaLlmChatClient.ID) //
+        var providerId = properties.getEmbeddingProvider();
+        return chatClientExtensionPoint.getExtension(providerId) //
                 .orElseThrow(() -> new IllegalStateException(
-                        "Ollama LLM client not registered — is the inception-imls-ollama module on "
-                                + "the classpath?"));
+                        "No LLM client registered for embedding provider [" + providerId
+                                + "] — is the corresponding module on the classpath?"));
     }
 
     private LlmEndpoint endpoint()
     {
-        return new LlmEndpoint(OllamaLlmChatClient.ID, properties.getUrl(),
-                properties.getEmbedding().getModel(), null);
+        return new LlmEndpoint(properties.getEmbeddingProvider(), properties.getEmbeddingUrl(),
+                properties.getEmbedding().getModel(), embeddingAuth());
+    }
+
+    private AuthenticationTraits embeddingAuth()
+    {
+        if (isNotBlank(properties.getEmbeddingApiKey())) {
+            var auth = new ApiKeyAuthenticationTraits();
+            auth.setApiKey(properties.getEmbeddingApiKey());
+            return auth;
+        }
+        return null;
     }
 
     private Map<String, Object> embeddingOptions()
@@ -169,7 +180,7 @@ public class EmbeddingServiceImpl
             if (embeddingProperties.getDimension() == AUTO_DETECT_DIMENSION) {
                 try {
                     LOG.info("Contacting [{}] to auto-detect dimension of model [{}]...",
-                            properties.getUrl(), embeddingProperties.getModel());
+                            properties.getEmbeddingUrl(), embeddingProperties.getModel());
                     var vectors = client().embed(endpoint(),
                             List.of("We just need to know the dimension of the generated "
                                     + "embedding. Thanks!"),

--- a/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/embedding/EmbeddingServiceImpl.java
+++ b/inception/inception-assistant/src/main/java/de/tudarmstadt/ukp/inception/assistant/embedding/EmbeddingServiceImpl.java
@@ -18,7 +18,6 @@
 package de.tudarmstadt.ukp.inception.assistant.embedding;
 
 import static de.tudarmstadt.ukp.inception.assistant.config.AssistantEmbeddingProperties.AUTO_DETECT_DIMENSION;
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
@@ -39,8 +38,8 @@ import de.tudarmstadt.ukp.inception.assistant.config.AssistantProperties;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.LlmChatClient;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.LlmChatClientExtensionPoint;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.LlmEndpoint;
+import de.tudarmstadt.ukp.inception.assistant.LlmAuth;
 import de.tudarmstadt.ukp.inception.security.client.auth.AuthenticationTraits;
-import de.tudarmstadt.ukp.inception.security.client.auth.apikey.ApiKeyAuthenticationTraits;
 
 public class EmbeddingServiceImpl
     implements EmbeddingService
@@ -157,12 +156,7 @@ public class EmbeddingServiceImpl
 
     private AuthenticationTraits embeddingAuth()
     {
-        if (isNotBlank(properties.getEmbeddingApiKey())) {
-            var auth = new ApiKeyAuthenticationTraits();
-            auth.setApiKey(properties.getEmbeddingApiKey());
-            return auth;
-        }
-        return null;
+        return LlmAuth.apiKeyAuth(properties.getEmbeddingApiKey());
     }
 
     private Map<String, Object> embeddingOptions()

--- a/inception/inception-assistant/src/main/resources/META-INF/asciidoc/admin-guide/settings_assistant.adoc
+++ b/inception/inception-assistant/src/main/resources/META-INF/asciidoc/admin-guide/settings_assistant.adoc
@@ -109,12 +109,14 @@ Tune the balance between more randomness (high >= 1.0) and less randomness (low,
 | `r50k_base`, `p50k_base`, `p50k_edit`, `cl100k_base` or `o200k_base`
 
 | `assistant.chat.capabilities`
-| The capabilities of the model. 
-  Relevant values are `auto`, `completion`, and `tools`. 
+| The capabilities of the model.
+  Relevant values are `auto`, `completion`, and `tools`.
   If set to `auto`, the system will query the LLM service during startup to determine the capabilities of the model.
+  Auto-detection is only available for providers that expose a model-introspection API (e.g. Ollama); for other providers (such as OpenAI or Azure OpenAI) the query returns nothing and the system falls back to `completion` — set this value explicitly for those providers.
   You can use this setting to override the detected capabilities.
   E.g. if the model is reluctant to use tools and you prefer {product-name} to proactively provide context from the documents in the project, just provide `completion` here.
   It is also useful to avoid unnecessary queries to the LLM service during startup if you know the capabilities of the model already.
+  Regardless of what is configured here, a capability only takes effect if the selected provider's client is able to deliver it: capabilities the provider client does not support are silently ignored.
 | `auto`
 | `completion`, `tools`
 |===

--- a/inception/inception-assistant/src/test/java/de/tudarmstadt/ukp/inception/assistant/AgentLoopCapabilityGatingTest.java
+++ b/inception/inception-assistant/src/test/java/de/tudarmstadt/ukp/inception/assistant/AgentLoopCapabilityGatingTest.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.assistant;
+
+import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.ChatMessage.Role.ASSISTANT;
+import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ModelCapability.CHAT;
+import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ModelCapability.STREAMING;
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.knuddels.jtokkit.Encodings;
+import com.knuddels.jtokkit.api.Encoding;
+import com.knuddels.jtokkit.api.EncodingRegistry;
+
+import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
+import de.tudarmstadt.ukp.inception.assistant.config.AssistantDocumentIndexPropertiesImpl;
+import de.tudarmstadt.ukp.inception.assistant.config.AssistantPropertiesImpl;
+import de.tudarmstadt.ukp.inception.assistant.model.MTextMessage;
+import de.tudarmstadt.ukp.inception.assistant.tool.ClockToolLibrary;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ChatMessage;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ChatChunk;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ChatOptions;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ChatResult;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.LlmChatClient;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.LlmEndpoint;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ModelCapability;
+
+/**
+ * Offline unit tests for {@link AgentLoop}'s graceful degradation based on the adapter's declared
+ * {@link LlmChatClient#supportedCapabilities()}. Uses a recording stub client, so it does not
+ * require a running LLM server (unlike the integration-oriented {@link AgentLoopTest}).
+ */
+class AgentLoopCapabilityGatingTest
+{
+    private EncodingRegistry encodingRegistry = Encodings.newLazyEncodingRegistry();
+
+    private AssistantPropertiesImpl props;
+    private Memory memory;
+    private Encoding encoding;
+    private User user;
+
+    @BeforeEach
+    void setUp()
+    {
+        props = new AssistantPropertiesImpl();
+        props.setDocumentIndex(new AssistantDocumentIndexPropertiesImpl());
+        props.setUrl("http://localhost:11434");
+        props.getChat().setModel("some-model");
+
+        encoding = encodingRegistry.getEncoding(props.getChat().getEncoding())
+                .orElseThrow(() -> new IllegalStateException("Unknown encoding"));
+
+        memory = new Memory();
+        user = User.builder().withUsername("unit-test").build();
+    }
+
+    @Test
+    void testFallsBackToNonStreamingWhenStreamingUnsupported() throws Exception
+    {
+        var client = new RecordingChatClient(EnumSet.of(CHAT));
+        var sut = new AgentLoop(props, client, user, null, memory, encoding);
+
+        var response = sut.turn(List.of(userMessage("Hello")), null);
+
+        assertThat(client.chatCalled).isTrue();
+        assertThat(client.chatStreamCalled).isFalse();
+        assertThat(response.message().content()).isEqualTo("pong");
+    }
+
+    @Test
+    void testUsesStreamingWhenSupported() throws Exception
+    {
+        var client = new RecordingChatClient(EnumSet.of(CHAT, STREAMING));
+        var sut = new AgentLoop(props, client, user, null, memory, encoding);
+
+        var response = sut.turn(List.of(userMessage("Hello")), null);
+
+        assertThat(client.chatStreamCalled).isTrue();
+        assertThat(client.chatCalled).isFalse();
+        assertThat(response.message().content()).isEqualTo("pong");
+    }
+
+    @Test
+    void testDropsToolsWhenAdapterDoesNotSupportTools() throws Exception
+    {
+        // The assistant config wants tools, but the adapter does not declare TOOLS support.
+        props.getChat().setCapabilities(Set.of("tools"));
+
+        var client = new RecordingChatClient(EnumSet.of(CHAT, STREAMING));
+        var sut = new AgentLoop(props, client, user, null, memory, encoding);
+        sut.addToolLibrary(new ClockToolLibrary());
+        sut.setToolCallingEnabled(true);
+
+        sut.turn(List.of(userMessage("What time is it?")), null);
+
+        // No tools must reach the wire because the adapter cannot deliver them.
+        assertThat(client.lastOptions.tools()).isEmpty();
+    }
+
+    @Test
+    void testPassesToolsWhenAdapterSupportsTools() throws Exception
+    {
+        props.getChat().setCapabilities(Set.of("tools"));
+
+        var client = new RecordingChatClient(EnumSet.of(CHAT, STREAMING, ModelCapability.TOOLS));
+        var sut = new AgentLoop(props, client, user, null, memory, encoding);
+        sut.addToolLibrary(new ClockToolLibrary());
+        sut.setToolCallingEnabled(true);
+
+        sut.turn(List.of(userMessage("What time is it?")), null);
+
+        assertThat(client.lastOptions.tools()).isNotEmpty();
+    }
+
+    private static MTextMessage userMessage(String aContent)
+    {
+        return MTextMessage.builder() //
+                .withContent(aContent) //
+                .withRole("user") //
+                .withActor("tester") //
+                .build();
+    }
+
+    /**
+     * Recording {@link LlmChatClient} stub that answers with a fixed reply and remembers which
+     * transport path was taken and which options were passed.
+     */
+    private static final class RecordingChatClient
+        implements LlmChatClient
+    {
+        private final Set<ModelCapability> capabilities;
+
+        private boolean chatCalled = false;
+        private boolean chatStreamCalled = false;
+        private ChatOptions lastOptions;
+
+        RecordingChatClient(Set<ModelCapability> aCapabilities)
+        {
+            capabilities = aCapabilities;
+        }
+
+        @Override
+        public String getId()
+        {
+            return "stub";
+        }
+
+        @Override
+        public Set<ModelCapability> supportedCapabilities()
+        {
+            return capabilities;
+        }
+
+        @Override
+        public ChatResult chat(LlmEndpoint aEndpoint, List<ChatMessage> aMessages,
+                ChatOptions aOptions)
+        {
+            chatCalled = true;
+            lastOptions = aOptions;
+            return reply();
+        }
+
+        @Override
+        public ChatResult chatStream(LlmEndpoint aEndpoint, List<ChatMessage> aMessages,
+                ChatOptions aOptions, Consumer<ChatChunk> aOnChunk)
+        {
+            chatStreamCalled = true;
+            lastOptions = aOptions;
+            return reply();
+        }
+
+        private static ChatResult reply()
+        {
+            return new ChatResult(new ChatMessage(ASSISTANT, "pong"), emptyList(), null, null);
+        }
+    }
+}

--- a/inception/inception-assistant/src/test/java/de/tudarmstadt/ukp/inception/assistant/AgentLoopTest.java
+++ b/inception/inception-assistant/src/test/java/de/tudarmstadt/ukp/inception/assistant/AgentLoopTest.java
@@ -43,6 +43,7 @@ import de.tudarmstadt.ukp.inception.assistant.config.AssistantPropertiesImpl;
 import de.tudarmstadt.ukp.inception.assistant.model.MTextMessage;
 import de.tudarmstadt.ukp.inception.assistant.tool.ClockToolLibrary;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaClientImpl;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaLlmChatClient;
 import de.tudarmstadt.ukp.inception.support.test.http.HttpTestUtils;
 
 class AgentLoopTest
@@ -51,6 +52,7 @@ class AgentLoopTest
 
     private EncodingRegistry encodingRegistry = Encodings.newLazyEncodingRegistry();
     private OllamaClientImpl client = new OllamaClientImpl();
+    private OllamaLlmChatClient chatClient = new OllamaLlmChatClient(client);
 
     private AssistantPropertiesImpl props;
     private Memory memory;
@@ -82,7 +84,7 @@ class AgentLoopTest
     @Test
     void chatAgainstOllama() throws Exception
     {
-        var sut = new AgentLoop(props, client, user, null, memory, encoding);
+        var sut = new AgentLoop(props, chatClient, user, null, memory, encoding);
 
         var input = List.of(MTextMessage.builder() //
                 .withContent("Hello") //
@@ -104,7 +106,7 @@ class AgentLoopTest
     {
         // Setup AgentLoop with ClockToolLibrary
         props.getChat().setCapabilities(Set.of("tools"));
-        var sut = new AgentLoop(props, client, user, null, memory, encoding);
+        var sut = new AgentLoop(props, chatClient, user, null, memory, encoding);
         sut.addToolLibrary(new ClockToolLibrary());
         sut.setToolCallingEnabled(true);
 
@@ -163,7 +165,7 @@ class AgentLoopTest
                 .withActor("tester") //
                 .build();
 
-        var sut = new AgentLoop(props, client, user, null, memory, encoding);
+        var sut = new AgentLoop(props, chatClient, user, null, memory, encoding);
 
         sut.loop(null, "integration-test", message);
 

--- a/inception/inception-imls-azureai-openai/pom.xml
+++ b/inception/inception-imls-azureai-openai/pom.xml
@@ -123,6 +123,18 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-testing</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/inception/inception-imls-azureai-openai/pom.xml
+++ b/inception/inception-imls-azureai-openai/pom.xml
@@ -132,8 +132,14 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
           <configuration>
-            <ignoredNonTestScopedDependencies>
-              <dependency>org.slf4j:slf4j-api</dependency>
+            <!--
+              - slf4j-api is required transitively at compile time by a compile-scoped
+              - dependency (Eclipse resolves it on the compile classpath), but no main source
+              - here imports it directly, so analyze-only mis-flags it as test-only. Keep it at
+              - compile scope for Eclipse and tell the analyzer to ignore the false positive.
+              -->
+            <ignoredNonTestScopedDependencies combine.children="append">
+              <ignoredNonTestScopedDependency>org.slf4j:slf4j-api</ignoredNonTestScopedDependency>
             </ignoredNonTestScopedDependencies>
           </configuration>
         </plugin>

--- a/inception/inception-imls-azureai-openai/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiChatCompletionChoice.java
+++ b/inception/inception-imls-azureai-openai/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiChatCompletionChoice.java
@@ -25,6 +25,7 @@ public class AzureAiChatCompletionChoice
 {
     private @JsonProperty("index") int index;
     private @JsonProperty("message") AzureAiChatCompletionMessage message;
+    private @JsonProperty("delta") AzureAiChatCompletionMessage delta;
     private @JsonProperty("finish_reason") String finishReason;
 
     public int getIndex()
@@ -45,6 +46,20 @@ public class AzureAiChatCompletionChoice
     public void setMessage(AzureAiChatCompletionMessage aMessage)
     {
         message = aMessage;
+    }
+
+    /**
+     * @return the incremental message delta carried by a streaming chunk (Azure OpenAI sends
+     *         {@code delta} on streamed responses in place of the complete {@code message}).
+     */
+    public AzureAiChatCompletionMessage getDelta()
+    {
+        return delta;
+    }
+
+    public void setDelta(AzureAiChatCompletionMessage aDelta)
+    {
+        delta = aDelta;
     }
 
     public String getFinishReason()

--- a/inception/inception-imls-azureai-openai/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiChatCompletionFunction.java
+++ b/inception/inception-imls-azureai-openai/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiChatCompletionFunction.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.imls.llm.azureaiopenai.client;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import tools.jackson.databind.JsonNode;
+
+/**
+ * The {@code function} object nested inside an Azure OpenAI {@code tools[]} entry: a name, an
+ * optional description, and the JSON-schema {@code parameters} passed straight through from the
+ * neutral {@code ToolDescriptor.parametersSchema()}.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(NON_NULL)
+public class AzureAiChatCompletionFunction
+{
+    private final @JsonProperty("name") String name;
+    private final @JsonProperty("description") String description;
+    private final @JsonProperty("parameters") JsonNode parameters;
+
+    private AzureAiChatCompletionFunction(Builder aBuilder)
+    {
+        name = aBuilder.name;
+        description = aBuilder.description;
+        parameters = aBuilder.parameters;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public String getDescription()
+    {
+        return description;
+    }
+
+    public JsonNode getParameters()
+    {
+        return parameters;
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static final class Builder
+    {
+        private String name;
+        private String description;
+        private JsonNode parameters;
+
+        private Builder()
+        {
+        }
+
+        public Builder withName(String aName)
+        {
+            name = aName;
+            return this;
+        }
+
+        public Builder withDescription(String aDescription)
+        {
+            description = aDescription;
+            return this;
+        }
+
+        public Builder withParameters(JsonNode aParameters)
+        {
+            parameters = aParameters;
+            return this;
+        }
+
+        public AzureAiChatCompletionFunction build()
+        {
+            return new AzureAiChatCompletionFunction(this);
+        }
+    }
+}

--- a/inception/inception-imls-azureai-openai/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiChatCompletionMessage.java
+++ b/inception/inception-imls-azureai-openai/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiChatCompletionMessage.java
@@ -17,7 +17,13 @@
  */
 package de.tudarmstadt.ukp.inception.recommendation.imls.llm.azureaiopenai.client;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -25,6 +31,8 @@ public class AzureAiChatCompletionMessage
 {
     private @JsonProperty("role") String role;
     private @JsonProperty("content") String content;
+    private @JsonInclude(NON_EMPTY) @JsonProperty("tool_calls") List<AzureAiChatCompletionToolCall> toolCalls;
+    private @JsonInclude(NON_NULL) @JsonProperty("tool_call_id") String toolCallId;
 
     public AzureAiChatCompletionMessage()
     {
@@ -35,6 +43,15 @@ public class AzureAiChatCompletionMessage
     {
         role = aRole;
         content = aContent;
+    }
+
+    public AzureAiChatCompletionMessage(String aRole, String aContent,
+            List<AzureAiChatCompletionToolCall> aToolCalls, String aToolCallId)
+    {
+        role = aRole;
+        content = aContent;
+        toolCalls = aToolCalls;
+        toolCallId = aToolCallId;
     }
 
     public String getRole()
@@ -55,5 +72,25 @@ public class AzureAiChatCompletionMessage
     public void setContent(String aContent)
     {
         content = aContent;
+    }
+
+    public List<AzureAiChatCompletionToolCall> getToolCalls()
+    {
+        return toolCalls;
+    }
+
+    public void setToolCalls(List<AzureAiChatCompletionToolCall> aToolCalls)
+    {
+        toolCalls = aToolCalls;
+    }
+
+    public String getToolCallId()
+    {
+        return toolCallId;
+    }
+
+    public void setToolCallId(String aToolCallId)
+    {
+        toolCallId = aToolCallId;
     }
 }

--- a/inception/inception-imls-azureai-openai/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiChatCompletionRequest.java
+++ b/inception/inception-imls-azureai-openai/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiChatCompletionRequest.java
@@ -58,6 +58,7 @@ public class AzureAiChatCompletionRequest
     private final @JsonInclude(NON_NULL) @JsonProperty("temperature") Double temperature;
     private final @JsonInclude(NON_NULL) @JsonProperty("top_p") Double topP;
     private final @JsonInclude(NON_NULL) @JsonProperty("seed") Integer seed;
+    private final @JsonInclude(NON_NULL) @JsonProperty("reasoning_effort") String reasoningEffort;
     private final @JsonInclude(NON_EMPTY) @JsonProperty("tools") List<AzureAiChatCompletionTool> tools;
     private final @JsonInclude(NON_NULL) @JsonProperty("stream") Boolean stream;
     private final @JsonInclude(NON_NULL) @JsonProperty("stream_options") AzureAiChatCompletionStreamOptions streamOptions;
@@ -74,6 +75,7 @@ public class AzureAiChatCompletionRequest
         temperature = TEMPERATURE.get(builder.options);
         seed = SEED.get(builder.options);
         topP = TOP_P.get(builder.options);
+        reasoningEffort = builder.reasoningEffort;
         tools = builder.tools.isEmpty() ? null : builder.tools;
         stream = builder.stream ? Boolean.TRUE : null;
         // Ask Azure OpenAI to include a final usage chunk when streaming; harmless otherwise.
@@ -120,6 +122,11 @@ public class AzureAiChatCompletionRequest
         return seed;
     }
 
+    public String getReasoningEffort()
+    {
+        return reasoningEffort;
+    }
+
     public List<AzureAiChatCompletionTool> getTools()
     {
         return tools;
@@ -148,6 +155,7 @@ public class AzureAiChatCompletionRequest
         private Map<Option<?>, Object> options = new HashMap<>();
         private List<AzureAiChatCompletionMessage> messages = new ArrayList<>();
         private final List<AzureAiChatCompletionTool> tools = new ArrayList<>();
+        private String reasoningEffort;
         private boolean stream;
 
         private Builder()
@@ -218,6 +226,16 @@ public class AzureAiChatCompletionRequest
                             .build());
                 }
             }
+            return this;
+        }
+
+        /**
+         * Sets the Azure OpenAI {@code reasoning_effort} wire value ({@code low}/{@code medium}/
+         * {@code high}); {@code null} omits the field. Only reasoning models honor it.
+         */
+        public Builder withReasoningEffort(String aReasoningEffort)
+        {
+            reasoningEffort = aReasoningEffort;
             return this;
         }
 

--- a/inception/inception-imls-azureai-openai/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiChatCompletionRequest.java
+++ b/inception/inception-imls-azureai-openai/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiChatCompletionRequest.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.recommendation.imls.llm.azureaiopenai.client;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 import static java.util.Arrays.asList;
 
@@ -30,6 +31,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ToolDescriptor;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.support.traits.DoubleOption;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.support.traits.Option;
 
@@ -56,6 +58,9 @@ public class AzureAiChatCompletionRequest
     private final @JsonInclude(NON_NULL) @JsonProperty("temperature") Double temperature;
     private final @JsonInclude(NON_NULL) @JsonProperty("top_p") Double topP;
     private final @JsonInclude(NON_NULL) @JsonProperty("seed") Integer seed;
+    private final @JsonInclude(NON_EMPTY) @JsonProperty("tools") List<AzureAiChatCompletionTool> tools;
+    private final @JsonInclude(NON_NULL) @JsonProperty("stream") Boolean stream;
+    private final @JsonInclude(NON_NULL) @JsonProperty("stream_options") AzureAiChatCompletionStreamOptions streamOptions;
 
     private final List<AzureAiChatCompletionMessage> messages;
 
@@ -69,6 +74,10 @@ public class AzureAiChatCompletionRequest
         temperature = TEMPERATURE.get(builder.options);
         seed = SEED.get(builder.options);
         topP = TOP_P.get(builder.options);
+        tools = builder.tools.isEmpty() ? null : builder.tools;
+        stream = builder.stream ? Boolean.TRUE : null;
+        // Ask Azure OpenAI to include a final usage chunk when streaming; harmless otherwise.
+        streamOptions = builder.stream ? new AzureAiChatCompletionStreamOptions(true) : null;
     }
 
     public String getApiKey()
@@ -111,6 +120,21 @@ public class AzureAiChatCompletionRequest
         return seed;
     }
 
+    public List<AzureAiChatCompletionTool> getTools()
+    {
+        return tools;
+    }
+
+    public Boolean getStream()
+    {
+        return stream;
+    }
+
+    public AzureAiChatCompletionStreamOptions getStreamOptions()
+    {
+        return streamOptions;
+    }
+
     public static Builder builder()
     {
         return new Builder();
@@ -123,6 +147,8 @@ public class AzureAiChatCompletionRequest
         private AzureAiGenerateResponseFormat format;
         private Map<Option<?>, Object> options = new HashMap<>();
         private List<AzureAiChatCompletionMessage> messages = new ArrayList<>();
+        private final List<AzureAiChatCompletionTool> tools = new ArrayList<>();
+        private boolean stream;
 
         private Builder()
         {
@@ -168,6 +194,36 @@ public class AzureAiChatCompletionRequest
         public Builder withFormat(AzureAiGenerateResponseFormat aFormat)
         {
             format = aFormat;
+            return this;
+        }
+
+        /**
+         * Translates the provider-neutral {@link ToolDescriptor}s into Azure OpenAI's
+         * {@code tools[{"type":"function","function":{...}}]} wire shape. The
+         * {@code parametersSchema()} JSON node is passed straight through as the function's
+         * {@code parameters}.
+         */
+        public Builder withTools(List<ToolDescriptor> aTools)
+        {
+            tools.clear();
+            if (aTools != null) {
+                for (var descriptor : aTools) {
+                    var function = AzureAiChatCompletionFunction.builder() //
+                            .withName(descriptor.name()) //
+                            .withDescription(descriptor.description()) //
+                            .withParameters(descriptor.parametersSchema()) //
+                            .build();
+                    tools.add(AzureAiChatCompletionTool.builder() //
+                            .withFunction(function) //
+                            .build());
+                }
+            }
+            return this;
+        }
+
+        public Builder withStream(boolean aStream)
+        {
+            stream = aStream;
             return this;
         }
 

--- a/inception/inception-imls-azureai-openai/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiChatCompletionStreamOptions.java
+++ b/inception/inception-imls-azureai-openai/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiChatCompletionStreamOptions.java
@@ -17,56 +17,25 @@
  */
 package de.tudarmstadt.ukp.inception.recommendation.imls.llm.azureaiopenai.client;
 
-import java.util.List;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/**
+ * The Azure OpenAI {@code stream_options} object. With {@code include_usage=true}, the final
+ * streamed chunk carries a {@code usage} block (otherwise streaming responses omit usage entirely).
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class AzureAiChatCompletionResponse
+public class AzureAiChatCompletionStreamOptions
 {
-    private @JsonProperty("model") String model;
-    private @JsonProperty("created") long createdAt;
-    private @JsonProperty("choices") List<AzureAiChatCompletionChoice> choices;
-    private @JsonProperty("usage") AzureAiChatCompletionUsage usage;
+    private final @JsonProperty("include_usage") boolean includeUsage;
 
-    public String getModel()
+    public AzureAiChatCompletionStreamOptions(boolean aIncludeUsage)
     {
-        return model;
+        includeUsage = aIncludeUsage;
     }
 
-    public void setModel(String aModel)
+    public boolean isIncludeUsage()
     {
-        model = aModel;
-    }
-
-    public long getCreatedAt()
-    {
-        return createdAt;
-    }
-
-    public void setCreatedAt(long aCreatedAt)
-    {
-        createdAt = aCreatedAt;
-    }
-
-    public List<AzureAiChatCompletionChoice> getChoices()
-    {
-        return choices;
-    }
-
-    public void setChoices(List<AzureAiChatCompletionChoice> aChoices)
-    {
-        choices = aChoices;
-    }
-
-    public AzureAiChatCompletionUsage getUsage()
-    {
-        return usage;
-    }
-
-    public void setUsage(AzureAiChatCompletionUsage aUsage)
-    {
-        usage = aUsage;
+        return includeUsage;
     }
 }

--- a/inception/inception-imls-azureai-openai/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiChatCompletionTool.java
+++ b/inception/inception-imls-azureai-openai/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiChatCompletionTool.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.imls.llm.azureaiopenai.client;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * One entry in the Azure OpenAI request {@code tools[]} array:
+ * {@code {"type":"function","function":{...}}}.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AzureAiChatCompletionTool
+{
+    private final @JsonProperty("type") String type;
+    private final @JsonProperty("function") AzureAiChatCompletionFunction function;
+
+    private AzureAiChatCompletionTool(Builder aBuilder)
+    {
+        type = aBuilder.type;
+        function = aBuilder.function;
+    }
+
+    public String getType()
+    {
+        return type;
+    }
+
+    public AzureAiChatCompletionFunction getFunction()
+    {
+        return function;
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static final class Builder
+    {
+        private String type = "function";
+        private AzureAiChatCompletionFunction function;
+
+        private Builder()
+        {
+        }
+
+        public Builder withType(String aType)
+        {
+            type = aType;
+            return this;
+        }
+
+        public Builder withFunction(AzureAiChatCompletionFunction aFunction)
+        {
+            function = aFunction;
+            return this;
+        }
+
+        public AzureAiChatCompletionTool build()
+        {
+            return new AzureAiChatCompletionTool(this);
+        }
+    }
+}

--- a/inception/inception-imls-azureai-openai/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiChatCompletionToolCall.java
+++ b/inception/inception-imls-azureai-openai/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiChatCompletionToolCall.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.imls.llm.azureaiopenai.client;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * A tool call requested by the model on an assistant message, or echoed back when we resend the
+ * assistant turn. Azure OpenAI carries the function arguments as a JSON <em>string</em>, not an
+ * object; in streaming responses the {@code arguments} string arrives fragmented across chunks and
+ * must be concatenated by {@code index}.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(NON_NULL)
+public class AzureAiChatCompletionToolCall
+{
+    private @JsonProperty("index") Integer index;
+    private @JsonProperty("id") String id;
+    private @JsonProperty("type") String type;
+    private @JsonProperty("function") Function function;
+
+    public Integer getIndex()
+    {
+        return index;
+    }
+
+    public void setIndex(Integer aIndex)
+    {
+        index = aIndex;
+    }
+
+    public String getId()
+    {
+        return id;
+    }
+
+    public void setId(String aId)
+    {
+        id = aId;
+    }
+
+    public String getType()
+    {
+        return type;
+    }
+
+    public void setType(String aType)
+    {
+        type = aType;
+    }
+
+    public Function getFunction()
+    {
+        return function;
+    }
+
+    public void setFunction(Function aFunction)
+    {
+        function = aFunction;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonInclude(NON_NULL)
+    public static class Function
+    {
+        private @JsonProperty("name") String name;
+        private @JsonProperty("arguments") String arguments;
+
+        public String getName()
+        {
+            return name;
+        }
+
+        public void setName(String aName)
+        {
+            name = aName;
+        }
+
+        public String getArguments()
+        {
+            return arguments;
+        }
+
+        public void setArguments(String aArguments)
+        {
+            arguments = aArguments;
+        }
+    }
+}

--- a/inception/inception-imls-azureai-openai/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiChatCompletionUsage.java
+++ b/inception/inception-imls-azureai-openai/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiChatCompletionUsage.java
@@ -17,56 +17,43 @@
  */
 package de.tudarmstadt.ukp.inception.recommendation.imls.llm.azureaiopenai.client;
 
-import java.util.List;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class AzureAiChatCompletionResponse
+public class AzureAiChatCompletionUsage
 {
-    private @JsonProperty("model") String model;
-    private @JsonProperty("created") long createdAt;
-    private @JsonProperty("choices") List<AzureAiChatCompletionChoice> choices;
-    private @JsonProperty("usage") AzureAiChatCompletionUsage usage;
+    private @JsonProperty("prompt_tokens") long promptTokens;
+    private @JsonProperty("completion_tokens") long completionTokens;
+    private @JsonProperty("total_tokens") long totalTokens;
 
-    public String getModel()
+    public long getPromptTokens()
     {
-        return model;
+        return promptTokens;
     }
 
-    public void setModel(String aModel)
+    public void setPromptTokens(long aPromptTokens)
     {
-        model = aModel;
+        promptTokens = aPromptTokens;
     }
 
-    public long getCreatedAt()
+    public long getCompletionTokens()
     {
-        return createdAt;
+        return completionTokens;
     }
 
-    public void setCreatedAt(long aCreatedAt)
+    public void setCompletionTokens(long aCompletionTokens)
     {
-        createdAt = aCreatedAt;
+        completionTokens = aCompletionTokens;
     }
 
-    public List<AzureAiChatCompletionChoice> getChoices()
+    public long getTotalTokens()
     {
-        return choices;
+        return totalTokens;
     }
 
-    public void setChoices(List<AzureAiChatCompletionChoice> aChoices)
+    public void setTotalTokens(long aTotalTokens)
     {
-        choices = aChoices;
-    }
-
-    public AzureAiChatCompletionUsage getUsage()
-    {
-        return usage;
-    }
-
-    public void setUsage(AzureAiChatCompletionUsage aUsage)
-    {
-        usage = aUsage;
+        totalTokens = aTotalTokens;
     }
 }

--- a/inception/inception-imls-azureai-openai/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiOpenAiClient.java
+++ b/inception/inception-imls-azureai-openai/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiOpenAiClient.java
@@ -18,8 +18,24 @@
 package de.tudarmstadt.ukp.inception.recommendation.imls.llm.azureaiopenai.client;
 
 import java.io.IOException;
+import java.util.function.Consumer;
 
 public interface AzureAiOpenAiClient
 {
-    String generate(String aUrl, AzureAiChatCompletionRequest aRequest) throws IOException;
+    /**
+     * Perform a non-streaming chat completion. Returns the parsed wire response (choices, usage,
+     * finish reason); the neutral mapping to {@code ChatResult} is the adapter's job.
+     */
+    AzureAiChatCompletionResponse generate(String aUrl, AzureAiChatCompletionRequest aRequest)
+        throws IOException;
+
+    /**
+     * Perform a streaming (SSE) chat completion. {@code aContentCallback} receives each content
+     * delta as it arrives; the returned {@link AzureAiChatCompletionResponse} is assembled from the
+     * stream and carries the full content, tool calls, finish reason, and (when
+     * {@code stream_options.include_usage} was requested) usage.
+     */
+    AzureAiChatCompletionResponse generate(String aUrl, AzureAiChatCompletionRequest aRequest,
+            Consumer<String> aContentCallback)
+        throws IOException;
 }

--- a/inception/inception-imls-azureai-openai/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiOpenAiClientImpl.java
+++ b/inception/inception-imls-azureai-openai/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiOpenAiClientImpl.java
@@ -238,7 +238,7 @@ public class AzureAiOpenAiClientImpl
         }
 
         for (var deltaCall : aDeltaCalls) {
-            var index = deltaCall.getIndex() != null ? deltaCall.getIndex() : aAccumulator.size();
+            var index = resolveToolCallIndex(aAccumulator, deltaCall.getIndex(), deltaCall.getId());
             var target = aAccumulator.computeIfAbsent(index, i -> {
                 var tc = new AzureAiChatCompletionToolCall();
                 tc.setIndex(i);
@@ -266,6 +266,29 @@ public class AzureAiOpenAiClientImpl
                 }
             }
         }
+    }
+
+    /**
+     * Resolves the accumulator key for a tool-call delta. Well-behaved OpenAI-compatible servers
+     * send an explicit {@code index} on every fragment; that is always authoritative. When a server
+     * omits it, a fragment carrying an {@code id} marks the start of a new call (next free index),
+     * whereas an id-less continuation fragment (only {@code arguments}) belongs to the call started
+     * most recently, i.e. the highest index seen so far. Using {@code aAccumulator.size()} as the
+     * fallback mis-merged such continuations into a fresh index, splitting one call into several.
+     */
+    private static int resolveToolCallIndex(
+            TreeMap<Integer, AzureAiChatCompletionToolCall> aAccumulator, Integer aIndex,
+            String aId)
+    {
+        if (aIndex != null) {
+            return aIndex;
+        }
+
+        if (aId == null && !aAccumulator.isEmpty()) {
+            return aAccumulator.lastKey();
+        }
+
+        return aAccumulator.isEmpty() ? 0 : aAccumulator.lastKey() + 1;
     }
 
     private static AzureAiChatCompletionResponse assembleStreamedResponse(String aModel,

--- a/inception/inception-imls-azureai-openai/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiOpenAiClientImpl.java
+++ b/inception/inception-imls-azureai-openai/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiOpenAiClientImpl.java
@@ -24,21 +24,37 @@ import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.invoke.MethodHandles;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TreeMap;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ServerSentEvent;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ServerSentEventReader;
 import de.tudarmstadt.ukp.inception.support.json.JSONUtil;
 import tools.jackson.databind.ObjectMapper;
 
 public class AzureAiOpenAiClientImpl
     implements AzureAiOpenAiClient
 {
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
     public static final int HTTP_BAD_REQUEST = 400;
+
+    /** SSE {@code data:} payload that signals the end of the stream. */
+    private static final String SSE_DONE_MARKER = "[DONE]";
 
     protected final HttpClient client;
     private final ObjectMapper objectMapper = new ObjectMapper();
@@ -77,27 +93,198 @@ public class AzureAiOpenAiClientImpl
     }
 
     @Override
-    public String generate(String aUrl, AzureAiChatCompletionRequest aRequest) throws IOException
+    public AzureAiChatCompletionResponse generate(String aUrl,
+            AzureAiChatCompletionRequest aRequest)
+        throws IOException
     {
-        var request = HttpRequest.newBuilder() //
+        var response = sendRequest(buildChatHttpRequest(aUrl, aRequest));
+
+        handleError(response);
+
+        try (var is = response.body()) {
+            return objectMapper.readValue(is, AzureAiChatCompletionResponse.class);
+        }
+    }
+
+    @Override
+    public AzureAiChatCompletionResponse generate(String aUrl,
+            AzureAiChatCompletionRequest aRequest, Consumer<String> aContentCallback)
+        throws IOException
+    {
+        HttpResponse<Stream<String>> response;
+        try {
+            var request = buildChatHttpRequest(aUrl, aRequest);
+            response = client.send(request, HttpResponse.BodyHandlers.ofLines());
+        }
+        catch (IOException | InterruptedException e) {
+            throw new IOException("Error while sending request: " + e.getMessage(), e);
+        }
+
+        if (response.statusCode() >= HTTP_BAD_REQUEST) {
+            var body = response.body().collect(Collectors.joining("\n"));
+            throw new IOException(
+                    format("Request was not successful: [%d] - [%s]", response.statusCode(), body));
+        }
+
+        try (var events = ServerSentEventReader.parse(response.body())) {
+            return assembleSseStream(events, aRequest.getModel(), aContentCallback);
+        }
+    }
+
+    /**
+     * Assembles the SSE event stream of an Azure OpenAI streaming chat completion into a single
+     * {@link AzureAiChatCompletionResponse}. The terminal {@code data: [DONE]} sentinel stops
+     * assembly; {@code choices[].delta.content} is concatenated (and forwarded to
+     * {@code aContentCallback} per delta), fragmented {@code delta.tool_calls} are merged by index,
+     * and the final {@code usage} chunk (present when {@code stream_options.include_usage} was set)
+     * is captured. Package-private so it can be unit-tested with canned events and no live server.
+     */
+    AzureAiChatCompletionResponse assembleSseStream(Stream<ServerSentEvent> aEvents,
+            String aRequestModel, Consumer<String> aContentCallback)
+        throws IOException
+    {
+        var content = new StringBuilder();
+        // tool-call fragments keyed by their streaming index, so out-of-order deltas still merge.
+        var toolCallsByIndex = new TreeMap<Integer, AzureAiChatCompletionToolCall>();
+        String finishReason = null;
+        String role = null;
+        AzureAiChatCompletionUsage usage = null;
+        String model = aRequestModel;
+
+        var iter = aEvents.iterator();
+        while (iter.hasNext()) {
+            var payload = iter.next().data();
+            if (payload == null) {
+                continue;
+            }
+            if (SSE_DONE_MARKER.equals(payload)) {
+                break;
+            }
+
+            LOG.trace("SSE chunk: {}", payload);
+
+            var chunk = objectMapper.readValue(payload, AzureAiChatCompletionResponse.class);
+
+            if (chunk.getModel() != null) {
+                model = chunk.getModel();
+            }
+
+            if (chunk.getUsage() != null) {
+                usage = chunk.getUsage();
+            }
+
+            if (chunk.getChoices() == null || chunk.getChoices().isEmpty()) {
+                continue;
+            }
+
+            var choice = chunk.getChoices().get(0);
+            if (choice.getFinishReason() != null) {
+                finishReason = choice.getFinishReason();
+            }
+
+            var delta = choice.getDelta();
+            if (delta == null) {
+                continue;
+            }
+
+            if (delta.getRole() != null) {
+                role = delta.getRole();
+            }
+
+            if (delta.getContent() != null && !delta.getContent().isEmpty()) {
+                content.append(delta.getContent());
+                if (aContentCallback != null) {
+                    aContentCallback.accept(delta.getContent());
+                }
+            }
+
+            accumulateToolCalls(toolCallsByIndex, delta.getToolCalls());
+        }
+
+        return assembleStreamedResponse(model, role, content.toString(),
+                new ArrayList<>(toolCallsByIndex.values()), finishReason, usage);
+    }
+
+    private HttpRequest buildChatHttpRequest(String aUrl, AzureAiChatCompletionRequest aRequest)
+        throws IOException
+    {
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Sending chat request: {}", JSONUtil.toPrettyJsonString(aRequest));
+        }
+
+        // The deployment is embedded in the base URL and the API version is fixed; the model is not
+        // sent on the wire (it is @JsonIgnore in the request).
+        return HttpRequest.newBuilder() //
                 .uri(URI.create(
                         appendIfMissing(aUrl, "/") + "chat/completions?api-version=2023-05-15")) //
                 .header(CONTENT_TYPE, "application/json") //
                 .header("api-key", aRequest.getApiKey()) //
                 .POST(BodyPublishers.ofString(JSONUtil.toJsonString(aRequest), UTF_8)) //
                 .build();
+    }
 
-        var response = sendRequest(request);
-
-        handleError(response);
-
-        var result = new StringBuilder();
-        try (var is = response.body()) {
-            var completion = objectMapper.readValue(is, AzureAiChatCompletionResponse.class);
-            result.append(completion.getChoices().get(0).getMessage().getContent());
+    /**
+     * Merges the tool-call deltas of one streaming chunk into the per-index accumulator. Azure
+     * OpenAI fragments {@code function.arguments} across chunks and only sends {@code id} /
+     * {@code name} on the first fragment of each call, so the id/name are captured once and the
+     * argument strings are concatenated.
+     */
+    private static void accumulateToolCalls(
+            TreeMap<Integer, AzureAiChatCompletionToolCall> aAccumulator,
+            List<AzureAiChatCompletionToolCall> aDeltaCalls)
+    {
+        if (aDeltaCalls == null) {
+            return;
         }
 
-        return result.toString();
+        for (var deltaCall : aDeltaCalls) {
+            var index = deltaCall.getIndex() != null ? deltaCall.getIndex() : aAccumulator.size();
+            var target = aAccumulator.computeIfAbsent(index, i -> {
+                var tc = new AzureAiChatCompletionToolCall();
+                tc.setIndex(i);
+                tc.setType("function");
+                tc.setFunction(new AzureAiChatCompletionToolCall.Function());
+                return tc;
+            });
+
+            if (deltaCall.getId() != null) {
+                target.setId(deltaCall.getId());
+            }
+            if (deltaCall.getType() != null) {
+                target.setType(deltaCall.getType());
+            }
+
+            var deltaFn = deltaCall.getFunction();
+            if (deltaFn != null) {
+                if (deltaFn.getName() != null) {
+                    target.getFunction().setName(deltaFn.getName());
+                }
+                if (deltaFn.getArguments() != null) {
+                    var existing = target.getFunction().getArguments();
+                    target.getFunction().setArguments(
+                            (existing != null ? existing : "") + deltaFn.getArguments());
+                }
+            }
+        }
+    }
+
+    private static AzureAiChatCompletionResponse assembleStreamedResponse(String aModel,
+            String aRole, String aContent, List<AzureAiChatCompletionToolCall> aToolCalls,
+            String aFinishReason, AzureAiChatCompletionUsage aUsage)
+    {
+        var message = new AzureAiChatCompletionMessage(aRole != null ? aRole : "assistant",
+                aContent, aToolCalls.isEmpty() ? null : aToolCalls, null);
+
+        var choice = new AzureAiChatCompletionChoice();
+        choice.setIndex(0);
+        choice.setMessage(message);
+        choice.setFinishReason(aFinishReason);
+
+        var response = new AzureAiChatCompletionResponse();
+        response.setModel(aModel);
+        response.setChoices(new ArrayList<>(List.of(choice)));
+        response.setUsage(aUsage);
+        return response;
     }
 
     private void handleError(HttpResponse<InputStream> response) throws IOException

--- a/inception/inception-imls-azureai-openai/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiOpenAiLlmChatClient.java
+++ b/inception/inception-imls-azureai-openai/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiOpenAiLlmChatClient.java
@@ -79,6 +79,15 @@ public class AzureAiOpenAiLlmChatClient
                 .withMessages(messages) //
                 .withFormat(toResponseFormat(aOptions));
 
+        // Translate the provider-neutral fields to Azure OpenAI's parameters; explicit options
+        // below override them.
+        if (aOptions.temperature() != null) {
+            builder.withOption(AzureAiChatCompletionRequest.TEMPERATURE, aOptions.temperature());
+        }
+        if (aOptions.topP() != null) {
+            builder.withOption(AzureAiChatCompletionRequest.TOP_P, aOptions.topP());
+        }
+
         if (aOptions.options() != null) {
             builder.withExtraOptions(aOptions.options());
         }

--- a/inception/inception-imls-azureai-openai/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiOpenAiLlmChatClient.java
+++ b/inception/inception-imls-azureai-openai/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiOpenAiLlmChatClient.java
@@ -38,9 +38,11 @@ import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ChatChunk;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ChatOptions;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ChatResult;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.FinishReason;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.JsonResponseSanitizer;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.LlmChatClient;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.LlmEndpoint;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ModelCapability;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ReasoningEffort;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ToolCall;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.UsageInfo;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.support.response.ResponseFormat;
@@ -90,7 +92,10 @@ public class AzureAiOpenAiLlmChatClient
     {
         var request = buildChatRequest(aEndpoint, aMessages, aOptions, false);
         var response = client.generate(aEndpoint.url(), request);
-        return toChatResult(response);
+        // Trim surrounding whitespace as the pre-refactor path did. Only on the non-streaming path:
+        // the streaming path forwards raw deltas to the caller, so trimming the final content there
+        // would make it disagree with what was already streamed.
+        return trimContent(toChatResult(response, aOptions.isJsonRequested()));
     }
 
     @Override
@@ -103,7 +108,7 @@ public class AzureAiOpenAiLlmChatClient
         // surfaced; thinking stays null.
         Consumer<String> contentCallback = delta -> aOnChunk.accept(new ChatChunk(delta, null));
         var response = client.generate(aEndpoint.url(), request, contentCallback);
-        return toChatResult(response);
+        return toChatResult(response, aOptions.isJsonRequested());
     }
 
     private AzureAiChatCompletionRequest buildChatRequest(LlmEndpoint aEndpoint,
@@ -126,6 +131,10 @@ public class AzureAiOpenAiLlmChatClient
                 v -> builder.withOption(AzureAiChatCompletionRequest.TEMPERATURE, v));
         applyIfPresent(aOptions.topP(),
                 v -> builder.withOption(AzureAiChatCompletionRequest.TOP_P, v));
+        // Azure OpenAI reasoning_effort only accepts low/medium/high; the neutral effort is clamped
+        // and MODEL_DEFAULT/NONE map to null (field omitted) by toOpenAiReasoningEffort.
+        applyIfPresent(toOpenAiReasoningEffort(aOptions.reasoningEffort()),
+                builder::withReasoningEffort);
 
         if (aOptions.options() != null) {
             builder.withExtraOptions(aOptions.options());
@@ -170,7 +179,8 @@ public class AzureAiOpenAiLlmChatClient
         return toolCall;
     }
 
-    private static ChatResult toChatResult(AzureAiChatCompletionResponse aResponse)
+    private static ChatResult toChatResult(AzureAiChatCompletionResponse aResponse,
+            boolean aJsonRequested)
     {
         if (aResponse.getChoices() == null || aResponse.getChoices().isEmpty()) {
             return new ChatResult(new ChatMessage(ChatMessage.Role.ASSISTANT, ""), emptyList(),
@@ -181,6 +191,7 @@ public class AzureAiOpenAiLlmChatClient
         var message = choice.getMessage();
 
         var content = message != null && message.getContent() != null ? message.getContent() : "";
+        content = JsonResponseSanitizer.stripCodeFenceIf(aJsonRequested, content);
 
         var toolCalls = toToolCalls(message);
 
@@ -190,6 +201,19 @@ public class AzureAiOpenAiLlmChatClient
 
         return new ChatResult(new ChatMessage(ChatMessage.Role.ASSISTANT, content, null, null),
                 toolCalls, finishReason, usage);
+    }
+
+    private static ChatResult trimContent(ChatResult aResult)
+    {
+        var message = aResult.message();
+        if (message == null || message.content() == null) {
+            return aResult;
+        }
+
+        var trimmed = new ChatMessage(message.role(), message.content().trim(), message.thinking(),
+                message.toolCallId(), message.toolCalls());
+        return new ChatResult(trimmed, aResult.toolCalls(), aResult.finishReason(),
+                aResult.usage());
     }
 
     private static List<ToolCall> toToolCalls(AzureAiChatCompletionMessage aMessage)
@@ -298,5 +322,32 @@ public class AzureAiOpenAiLlmChatClient
         }
 
         return null;
+    }
+
+    /**
+     * Maps the neutral {@link ReasoningEffort} to the Azure OpenAI {@code reasoning_effort} wire
+     * value, which only accepts {@code low}/{@code medium}/{@code high}.
+     * {@link ReasoningEffort#MODEL_DEFAULT} returns {@code null} so the field is omitted.
+     * {@link ReasoningEffort#NONE} also returns {@code null} and thereby <em>degrades</em> to the
+     * model default: Azure OpenAI has no "off" switch, so unlike Ollama we cannot suppress
+     * reasoning — omitting the field lets a reasoning model reason at its default and a
+     * non-reasoning model ignore it. {@link ReasoningEffort#MAX} clamps to {@code high} (there is
+     * no higher wire level).
+     *
+     * @param aEffort
+     *            the neutral effort, possibly {@code null}
+     * @return the wire value, or {@code null} to omit the field
+     */
+    private static String toOpenAiReasoningEffort(ReasoningEffort aEffort)
+    {
+        if (aEffort == null) {
+            return null;
+        }
+        return switch (aEffort) {
+        case MODEL_DEFAULT, NONE -> null;
+        case LOW -> "low";
+        case MEDIUM -> "medium";
+        case HIGH, MAX -> "high";
+        };
     }
 }

--- a/inception/inception-imls-azureai-openai/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiOpenAiLlmChatClient.java
+++ b/inception/inception-imls-azureai-openai/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiOpenAiLlmChatClient.java
@@ -19,32 +19,47 @@ package de.tudarmstadt.ukp.inception.recommendation.imls.llm.azureaiopenai.clien
 
 import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.azureaiopenai.client.AzureAiResponseFormatType.JSON_OBJECT;
 import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.azureaiopenai.client.AzureAiResponseFormatType.JSON_SCHEMA;
+import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ChatOptionsTranslator.applyIfPresent;
+import static java.util.Collections.emptyList;
 
 import java.io.IOException;
-import java.util.List;
-
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ChatMessage;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ChatChunk;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ChatOptions;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ChatResult;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.FinishReason;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.LlmChatClient;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.LlmEndpoint;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ModelCapability;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ToolCall;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.UsageInfo;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.support.response.ResponseFormat;
 import de.tudarmstadt.ukp.inception.security.client.auth.apikey.ApiKeyAuthenticationTraits;
+import de.tudarmstadt.ukp.inception.support.json.JSONUtil;
+import tools.jackson.databind.JsonNode;
 
 /**
  * {@link LlmChatClient} adapter for Azure OpenAI Service. The Azure URL embeds the deployment name
  * and API version, so {@link LlmEndpoint#model()} is not sent on the wire (it is captured by the
- * URL). Delegates to the existing {@link AzureAiOpenAiClient}; pure pass-through with no
- * recommender-specific defaults applied here.
+ * URL). Delegates to the existing {@link AzureAiOpenAiClient}; behaviour is a faithful translation,
+ * with no recommender-specific defaults applied here.
  */
 public class AzureAiOpenAiLlmChatClient
     implements LlmChatClient
 {
     public static final String ID = "azure-openai";
+
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private final AzureAiOpenAiClient client;
 
@@ -62,39 +77,189 @@ public class AzureAiOpenAiLlmChatClient
     @Override
     public Set<ModelCapability> supportedCapabilities()
     {
-        return EnumSet.of(ModelCapability.CHAT, ModelCapability.JSON_SCHEMA);
+        return EnumSet.of( //
+                ModelCapability.CHAT, //
+                ModelCapability.JSON_SCHEMA, //
+                ModelCapability.STREAMING, //
+                ModelCapability.TOOLS);
     }
 
     @Override
     public ChatResult chat(LlmEndpoint aEndpoint, List<ChatMessage> aMessages, ChatOptions aOptions)
         throws IOException
     {
+        var request = buildChatRequest(aEndpoint, aMessages, aOptions, false);
+        var response = client.generate(aEndpoint.url(), request);
+        return toChatResult(response);
+    }
+
+    @Override
+    public ChatResult chatStream(LlmEndpoint aEndpoint, List<ChatMessage> aMessages,
+            ChatOptions aOptions, Consumer<ChatChunk> aOnChunk)
+        throws IOException
+    {
+        var request = buildChatRequest(aEndpoint, aMessages, aOptions, true);
+        // Azure OpenAI standard chat has no separate thinking channel, so only the content delta is
+        // surfaced; thinking stays null.
+        Consumer<String> contentCallback = delta -> aOnChunk.accept(new ChatChunk(delta, null));
+        var response = client.generate(aEndpoint.url(), request, contentCallback);
+        return toChatResult(response);
+    }
+
+    private AzureAiChatCompletionRequest buildChatRequest(LlmEndpoint aEndpoint,
+            List<ChatMessage> aMessages, ChatOptions aOptions, boolean aStream)
+    {
         var messages = aMessages.stream() //
-                .map(m -> new AzureAiChatCompletionMessage(m.role().getName(), m.content())) //
+                .map(AzureAiOpenAiLlmChatClient::toChatCompletionMessage) //
                 .toList();
 
         var builder = AzureAiChatCompletionRequest.builder() //
                 .withApiKey(apiKey(aEndpoint)) //
                 .withModel(aEndpoint.model()) //
                 .withMessages(messages) //
-                .withFormat(toResponseFormat(aOptions));
+                .withFormat(toResponseFormat(aOptions)) //
+                .withStream(aStream);
 
         // Translate the provider-neutral fields to Azure OpenAI's parameters; explicit options
         // below override them.
-        if (aOptions.temperature() != null) {
-            builder.withOption(AzureAiChatCompletionRequest.TEMPERATURE, aOptions.temperature());
-        }
-        if (aOptions.topP() != null) {
-            builder.withOption(AzureAiChatCompletionRequest.TOP_P, aOptions.topP());
-        }
+        applyIfPresent(aOptions.temperature(),
+                v -> builder.withOption(AzureAiChatCompletionRequest.TEMPERATURE, v));
+        applyIfPresent(aOptions.topP(),
+                v -> builder.withOption(AzureAiChatCompletionRequest.TOP_P, v));
 
         if (aOptions.options() != null) {
             builder.withExtraOptions(aOptions.options());
         }
 
-        var responseText = client.generate(aEndpoint.url(), builder.build()).trim();
+        if (aOptions.tools() != null && !aOptions.tools().isEmpty()) {
+            builder.withTools(aOptions.tools());
+        }
 
-        return ChatResult.of(new ChatMessage(ChatMessage.Role.ASSISTANT, responseText));
+        return builder.build();
+    }
+
+    private static AzureAiChatCompletionMessage toChatCompletionMessage(ChatMessage aMessage)
+    {
+        List<AzureAiChatCompletionToolCall> toolCalls = null;
+        if (aMessage.toolCalls() != null && !aMessage.toolCalls().isEmpty()) {
+            toolCalls = new ArrayList<>();
+            for (var call : aMessage.toolCalls()) {
+                toolCalls.add(toWireToolCall(call));
+            }
+        }
+
+        // Azure OpenAI requires tool_call_id on tool-result (role=tool) messages so the model can
+        // match the result to its preceding call.
+        return new AzureAiChatCompletionMessage(aMessage.role().getName(), aMessage.content(),
+                toolCalls, aMessage.toolCallId());
+    }
+
+    private static AzureAiChatCompletionToolCall toWireToolCall(ToolCall aCall)
+    {
+        var function = new AzureAiChatCompletionToolCall.Function();
+        function.setName(aCall.name());
+        // Azure OpenAI carries the arguments as a JSON string, not an object.
+        function.setArguments(aCall.arguments() != null && !aCall.arguments().isNull() //
+                ? aCall.arguments().toString() //
+                : "{}");
+
+        var toolCall = new AzureAiChatCompletionToolCall();
+        toolCall.setId(aCall.id());
+        toolCall.setType("function");
+        toolCall.setFunction(function);
+        return toolCall;
+    }
+
+    private static ChatResult toChatResult(AzureAiChatCompletionResponse aResponse)
+    {
+        if (aResponse.getChoices() == null || aResponse.getChoices().isEmpty()) {
+            return new ChatResult(new ChatMessage(ChatMessage.Role.ASSISTANT, ""), emptyList(),
+                    null, toUsageInfo(aResponse.getUsage()));
+        }
+
+        var choice = aResponse.getChoices().get(0);
+        var message = choice.getMessage();
+
+        var content = message != null && message.getContent() != null ? message.getContent() : "";
+
+        var toolCalls = toToolCalls(message);
+
+        var finishReason = toFinishReason(choice.getFinishReason());
+
+        var usage = toUsageInfo(aResponse.getUsage());
+
+        return new ChatResult(new ChatMessage(ChatMessage.Role.ASSISTANT, content, null, null),
+                toolCalls, finishReason, usage);
+    }
+
+    private static List<ToolCall> toToolCalls(AzureAiChatCompletionMessage aMessage)
+    {
+        if (aMessage == null || aMessage.getToolCalls() == null
+                || aMessage.getToolCalls().isEmpty()) {
+            return emptyList();
+        }
+
+        var result = new ArrayList<ToolCall>();
+        for (var wireCall : aMessage.getToolCalls()) {
+            var name = wireCall.getFunction() != null ? wireCall.getFunction().getName() : null;
+            var arguments = wireCall.getFunction() != null ? wireCall.getFunction().getArguments()
+                    : null;
+            result.add(new ToolCall(wireCall.getId(), name, parseArguments(arguments)));
+        }
+        return result;
+    }
+
+    /**
+     * Parses the Azure OpenAI tool-call {@code arguments} JSON <em>string</em> into a
+     * {@link JsonNode}. A malformed or non-object payload must not abort the whole turn, so on any
+     * parse failure - or if the payload does not represent a JSON object - an empty object node is
+     * returned instead.
+     */
+    private static JsonNode parseArguments(String aArguments)
+    {
+        if (aArguments == null || aArguments.isBlank()) {
+            return JSONUtil.getObjectMapper().createObjectNode();
+        }
+
+        try {
+            var node = JSONUtil.getObjectMapper().readTree(aArguments);
+            if (node == null || !node.isObject()) {
+                LOG.warn("Ignoring non-object tool-call arguments: [{}]", aArguments);
+                return JSONUtil.getObjectMapper().createObjectNode();
+            }
+            return node;
+        }
+        catch (Exception e) {
+            LOG.warn("Ignoring malformed tool-call arguments: [{}]", aArguments, e);
+            return JSONUtil.getObjectMapper().createObjectNode();
+        }
+    }
+
+    private static FinishReason toFinishReason(String aFinishReason)
+    {
+        if (aFinishReason == null) {
+            return null;
+        }
+
+        return switch (aFinishReason) {
+        case "stop" -> FinishReason.STOP;
+        case "length" -> FinishReason.LENGTH;
+        case "tool_calls" -> FinishReason.TOOL_CALLS;
+        case "content_filter" -> FinishReason.CONTENT_FILTER;
+        default -> FinishReason.OTHER;
+        };
+    }
+
+    private static UsageInfo toUsageInfo(AzureAiChatCompletionUsage aUsage)
+    {
+        if (aUsage == null) {
+            return null;
+        }
+
+        return new UsageInfo( //
+                aUsage.getPromptTokens() != 0 ? (int) aUsage.getPromptTokens() : null, //
+                aUsage.getCompletionTokens() != 0 ? (int) aUsage.getCompletionTokens() : null, //
+                aUsage.getTotalTokens() != 0 ? (int) aUsage.getTotalTokens() : null);
     }
 
     private static String apiKey(LlmEndpoint aEndpoint)

--- a/inception/inception-imls-azureai-openai/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiOpenAiClientIntegrationTest.java
+++ b/inception/inception-imls-azureai-openai/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiOpenAiClientIntegrationTest.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package de.tudarmstadt.ukp.inception.recommendation.imls.azureaiopenai.client;
+package de.tudarmstadt.ukp.inception.recommendation.imls.llm.azureaiopenai.client;
 
 import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.azureaiopenai.client.AzureAiGenerateResponseFormat.JSON_OBJECT;
 import static org.assertj.core.api.Assumptions.assumeThat;
@@ -27,45 +27,47 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import de.tudarmstadt.ukp.inception.recommendation.imls.llm.azureaiopenai.client.AzureAiChatCompletionRequest;
-import de.tudarmstadt.ukp.inception.recommendation.imls.llm.azureaiopenai.client.AzureAiOpenAiClientImpl;
-
-class OpenAiClientTest
+/**
+ * Live-server tests for {@link AzureAiOpenAiClientImpl}. Guarded by the {@code azure-base-url} and
+ * {@code azure-api-key} system properties so they are skipped unless a real Azure OpenAI deployment
+ * is configured. Offline behavior is covered by {@link AzureAiOpenAiClientTest}.
+ */
+class AzureAiOpenAiClientIntegrationTest
 {
     private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-    private static final String OPENAI_BASE_URL = System.getProperty("openai-base-url");
-    private static final String OPENAI_API_KEY = System.getProperty("openai-api-key");
+    private static final String AZURE_BASE_URL = System.getProperty("azure-base-url");
+    private static final String AZURE_API_KEY = System.getProperty("azure-api-key");
 
     private AzureAiOpenAiClientImpl sut = new AzureAiOpenAiClientImpl();
 
     @BeforeAll
     static void setupClass()
     {
-        assumeThat(OPENAI_BASE_URL).isNotBlank();
-        assumeThat(OPENAI_API_KEY).isNotBlank();
+        assumeThat(AZURE_BASE_URL).isNotBlank();
+        assumeThat(AZURE_API_KEY).isNotBlank();
     }
 
     @Test
     void testNonStream() throws Exception
     {
-        var response = sut.generate(OPENAI_BASE_URL, AzureAiChatCompletionRequest.builder() //
+        var response = sut.generate(AZURE_BASE_URL, AzureAiChatCompletionRequest.builder() //
                 // .withModel("gpt-35-turbo-0301") //
-                .withApiKey(OPENAI_API_KEY) //
+                .withApiKey(AZURE_API_KEY) //
                 .withPrompt("Tell me a joke.") //
                 .build());
-        LOG.info("Response: [{}]", response.trim());
+        LOG.info("Response: [{}]", response.getChoices().get(0).getMessage().getContent().trim());
     }
 
     @Test
     void testJson() throws Exception
     {
-        var response = sut.generate(OPENAI_BASE_URL, AzureAiChatCompletionRequest.builder() //
+        var response = sut.generate(AZURE_BASE_URL, AzureAiChatCompletionRequest.builder() //
                 // .withModel("gpt-35-turbo-0301") //
-                .withApiKey(OPENAI_API_KEY) //
+                .withApiKey(AZURE_API_KEY) //
                 .withPrompt("Generate a JSON map with the key/value pairs `a = 1` and `b = 2`") //
                 .withFormat(JSON_OBJECT) //
                 .build());
-        LOG.info("Response: [{}]", response.trim());
+        LOG.info("Response: [{}]", response.getChoices().get(0).getMessage().getContent().trim());
     }
 }

--- a/inception/inception-imls-azureai-openai/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiOpenAiClientLiveTest.java
+++ b/inception/inception-imls-azureai-openai/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiOpenAiClientLiveTest.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.imls.llm.azureaiopenai.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ToolDescriptor;
+import de.tudarmstadt.ukp.inception.support.json.JSONUtil;
+import de.tudarmstadt.ukp.inception.support.test.http.HttpTestUtils;
+import de.tudarmstadt.ukp.inception.support.test.llm.OllamazureContainer;
+
+/**
+ * Exercises {@link AzureAiOpenAiClientImpl} end-to-end against the Azure OpenAI wire protocol,
+ * served by an {@link OllamazureContainer} (ollamazure) that forwards to a locally running Ollama.
+ * This covers the Azure-specific request route
+ * ({@code /openai/deployments/{deployment}/chat/completions?api-version=}), the SSE stream
+ * assembly, and streamed tool-call handling against a real wire — none of which the offline
+ * {@link AzureAiOpenAiClientTest} can reach. For a real Azure OpenAI deployment (via system
+ * properties) see {@link AzureAiOpenAiClientIntegrationTest}.
+ * <p>
+ * Requires Docker (for ollamazure) and a local Ollama with {@code nemotron-3-nano:4b} pulled;
+ * skipped otherwise. nemotron-3-nano:4b reliably fills visible content and calls tools, so one
+ * model covers the chat, stream and tool tests. It reaches the host's Ollama via
+ * {@code host.docker.internal}.
+ */
+@Testcontainers(disabledWithoutDocker = true)
+class AzureAiOpenAiClientLiveTest
+{
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    // A small hybrid model that reliably fills visible content and calls tools, so one model serves
+    // the chat, stream and tool tests.
+    private static final String MODEL = "nemotron-3-nano:4b";
+    private static final String OLLAMA_URL = "http://localhost:11434";
+
+    @Container
+    private static final OllamazureContainer ollamazure = new OllamazureContainer(MODEL);
+
+    private final AzureAiOpenAiClientImpl sut = new AzureAiOpenAiClientImpl();
+
+    @BeforeAll
+    static void requireLocalOllama()
+    {
+        // ollamazure forwards to the host's Ollama; the container only provides the Azure front.
+        assumeThat(HttpTestUtils.checkURL(OLLAMA_URL)) //
+                .as("local Ollama reachable at " + OLLAMA_URL) //
+                .isTrue();
+    }
+
+    private AzureAiChatCompletionRequest.Builder request(String aModel)
+    {
+        return AzureAiChatCompletionRequest.builder() //
+                .withModel(aModel) //
+                .withApiKey("not-used-by-ollamazure");
+    }
+
+    @Test
+    void testNonStream() throws Exception
+    {
+        var response = sut.generate(ollamazure.getAzureBaseUrl(MODEL), request(MODEL) //
+                .withPrompt("Tell me a joke in one sentence.") //
+                .build());
+
+        var choice = response.getChoices().get(0);
+        LOG.info("Response: [{}], finish=[{}], usage=[{}]", choice.getMessage().getContent(),
+                choice.getFinishReason(), response.getUsage());
+        assertThat(choice.getMessage().getContent()).isNotBlank();
+        assertThat(choice.getFinishReason()).isNotNull();
+        assertThat(response.getUsage()).isNotNull();
+        assertThat(response.getUsage().getTotalTokens()).isPositive();
+    }
+
+    @Test
+    void testStream() throws Exception
+    {
+        var deltas = new ArrayList<String>();
+
+        var response = sut.generate(ollamazure.getAzureBaseUrl(MODEL), request(MODEL) //
+                .withPrompt("Count from 1 to 5.") //
+                .withStream(true) //
+                .build(), deltas::add);
+
+        var choice = response.getChoices().get(0);
+        LOG.info("Got {} deltas, final: [{}], finish=[{}], usage=[{}]", deltas.size(),
+                choice.getMessage().getContent(), choice.getFinishReason(), response.getUsage());
+        assertThat(deltas).isNotEmpty();
+        assertThat(choice.getMessage().getContent()).isNotBlank();
+        assertThat(choice.getFinishReason()).isNotNull();
+        // usage arrives as a trailing SSE chunk (stream_options.include_usage); its capture is part
+        // of what this test exercises.
+        assertThat(response.getUsage()).isNotNull();
+        assertThat(response.getUsage().getTotalTokens()).isPositive();
+    }
+
+    @Test
+    void testStreamWithTool() throws Exception
+    {
+        var response = sut.generate(ollamazure.getAzureBaseUrl(MODEL), request(MODEL) //
+                .withPrompt("What is the current weather in Berlin? Use the tool.") //
+                .withTools(List.of(weatherTool())) //
+                .withStream(true) //
+                .build(), delta -> {
+                });
+
+        var choice = response.getChoices().get(0);
+        var toolCalls = choice.getMessage().getToolCalls();
+        LOG.info("finish=[{}], tool calls=[{}]", choice.getFinishReason(), toolCalls);
+
+        // Exercises the streamed delta.tool_calls path (accumulateToolCalls) end-to-end.
+        assertThat(choice.getFinishReason()).isEqualTo("tool_calls");
+        assertThat(toolCalls).hasSize(1);
+        assertThat(toolCalls.get(0).getFunction().getName()).isEqualTo("get_current_weather");
+        assertThat(toolCalls.get(0).getFunction().getArguments()).contains("Berlin");
+    }
+
+    private static ToolDescriptor weatherTool()
+    {
+        var schema = JSONUtil.getObjectMapper().createObjectNode();
+        schema.put("type", "object");
+        schema.putObject("properties").putObject("location").put("type", "string");
+        schema.putArray("required").add("location");
+        return new ToolDescriptor("get_current_weather", "Get the current weather for a city",
+                schema);
+    }
+}

--- a/inception/inception-imls-azureai-openai/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiOpenAiClientTest.java
+++ b/inception/inception-imls-azureai-openai/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiOpenAiClientTest.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package de.tudarmstadt.ukp.inception.recommendation.imls.llm.chatgpt.client;
+package de.tudarmstadt.ukp.inception.recommendation.imls.llm.azureaiopenai.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -27,13 +27,13 @@ import org.junit.jupiter.api.Test;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ServerSentEventReader;
 
 /**
- * Offline unit tests for {@link ChatGptClientImpl}'s SSE stream assembly, driven by canned
+ * Offline unit tests for {@link AzureAiOpenAiClientImpl}'s SSE stream assembly, driven by canned
  * {@code data:} lines (parsed via {@link ServerSentEventReader}) with no live server. Live-server
- * behavior is covered by {@link OpenAiClientIntegrationTest}.
+ * behavior is covered by {@link AzureAiOpenAiClientIntegrationTest}.
  */
-class OpenAiClientTest
+class AzureAiOpenAiClientTest
 {
-    private final ChatGptClientImpl sut = new ChatGptClientImpl();
+    private final AzureAiOpenAiClientImpl sut = new AzureAiOpenAiClientImpl();
 
     @Test
     void testSseContentAssemblyAndCallbacks() throws Exception

--- a/inception/inception-imls-azureai-openai/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiOpenAiLlmChatClientIntegrationTest.java
+++ b/inception/inception-imls-azureai-openai/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiOpenAiLlmChatClientIntegrationTest.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package de.tudarmstadt.ukp.inception.recommendation.imls.llm.chatgpt.client;
+package de.tudarmstadt.ukp.inception.recommendation.imls.llm.azureaiopenai.client;
 
 import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.ChatMessage.Role.USER;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,7 +35,6 @@ import de.tudarmstadt.ukp.inception.recommendation.imls.llm.Tool;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ToolParam;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ChatChunk;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ChatOptions;
-import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.FinishReason;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.LlmEndpoint;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ToolDescriptor;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.support.response.ResponseFormat;
@@ -44,30 +43,60 @@ import de.tudarmstadt.ukp.inception.support.json.JSONUtil;
 import de.tudarmstadt.ukp.inception.support.test.http.HttpTestUtils;
 
 /**
- * Exercises {@link ChatGptLlmChatClient} against Ollama's OpenAI-compatible endpoint. The
- * {@code /v1} path segment is appended by the client, so the endpoint URL points at the Ollama
- * root. Requires a local Ollama with {@code nemotron-3-nano:4b} pulled; skipped otherwise.
+ * Exercises {@link AzureAiOpenAiLlmChatClient} end-to-end against a locally running
+ * <a href="https://github.com/sinedied/ollamazure">ollamazure</a>, a local emulator of the Azure
+ * OpenAI REST API (deployment name in the URL path, {@code api-version} query parameter) backed by
+ * Ollama. ollamazure needs no Azure credentials - the {@code api-key} header must merely be
+ * present, and its value is ignored.
+ * <p>
+ * The test is skipped (JUnit assumption, not a failure) unless ollamazure is reachable, mirroring
+ * {@code OllamaLlmChatClientIntegrationTest}. Start it yourself before running - the test does not:
+ *
+ * <pre>
+ * npm install -g ollamazure
+ * ollamazure
+ * </pre>
+ *
+ * with the default completions model {@code phi3} and embeddings model {@code all-minilm:l6-v2} on
+ * the default port 4041. Overridable via system properties: {@code ollamazure-base-url} (the server
+ * root used for the reachability probe), {@code ollamazure-deployment-url} (the Azure-shaped base
+ * URL handed to the client, deployment path included), and {@code ollamazure-chat-model}. Offline
+ * request/response mapping is covered by {@link AzureAiOpenAiLlmChatClientTest}.
  */
-class ChatGptLlmChatClientIntegrationTest
+class AzureAiOpenAiLlmChatClientIntegrationTest
 {
     private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-    private static final String OLLAMA_URL = "http://localhost:11434";
-    private static final String MODEL = "nemotron-3-nano:4b";
+    /** ollamazure server root - used only for the reachability probe. */
+    private static final String BASE_URL = System.getProperty("ollamazure-base-url",
+            "http://localhost:4041/");
 
-    private final ChatGptLlmChatClient sut = new ChatGptLlmChatClient(new ChatGptClientImpl());
+    /** ollamazure's default completions model, doubling as the Azure "deployment" name. */
+    private static final String CHAT_MODEL = System.getProperty("ollamazure-chat-model", "phi3");
+
+    /**
+     * Azure-shaped base URL that already embeds the deployment path, matching what
+     * {@link AzureAiOpenAiClientImpl} expects (it appends
+     * {@code chat/completions?api-version=...}).
+     */
+    private static final String DEPLOYMENT_URL = System.getProperty("ollamazure-deployment-url",
+            "http://localhost:4041/openai/deployments/" + CHAT_MODEL);
+
+    private final AzureAiOpenAiLlmChatClient sut = new AzureAiOpenAiLlmChatClient(
+            new AzureAiOpenAiClientImpl());
 
     @BeforeAll
-    static void checkIfOllamaIsRunning()
+    static void checkIfOllamazureIsRunning()
     {
-        assumeThat(HttpTestUtils.checkURL(OLLAMA_URL)).isTrue();
+        assumeThat(HttpTestUtils.checkURL(BASE_URL)).isTrue();
     }
 
-    private static LlmEndpoint endpoint(String aModel)
+    private static LlmEndpoint endpoint()
     {
+        // ollamazure ignores the key value but the client requires a non-blank key to be present.
         var auth = new ApiKeyAuthenticationTraits();
-        auth.setApiKey("not-used-by-ollama");
-        return new LlmEndpoint(ChatGptLlmChatClient.ID, OLLAMA_URL, aModel, auth);
+        auth.setApiKey("dummy-key");
+        return new LlmEndpoint(AzureAiOpenAiLlmChatClient.ID, DEPLOYMENT_URL, CHAT_MODEL, auth);
     }
 
     @Test
@@ -75,11 +104,13 @@ class ChatGptLlmChatClientIntegrationTest
     {
         var messages = List.of(new ChatMessage(USER, "Tell me a joke in one sentence."));
 
-        var result = sut.chat(endpoint(MODEL), messages, ChatOptions.defaults());
+        var result = sut.chat(endpoint(), messages, ChatOptions.defaults());
 
         LOG.info("Response: [{}]", result.message().content());
+        LOG.info("Usage: {}", result.usage());
         assertThat(result.message().content()).isNotBlank();
         assertThat(result.message().role()).isEqualTo(ChatMessage.Role.ASSISTANT);
+        assertThat(result.finishReason()).isNotNull();
     }
 
     @Test
@@ -89,10 +120,9 @@ class ChatGptLlmChatClientIntegrationTest
                 "Return a JSON object with the keys `a` set to 1 and `b` set to 2."));
         var options = new ChatOptions(ResponseFormat.JSON, null, List.of(), null);
 
-        var result = sut.chat(endpoint(MODEL), messages, options);
+        var result = sut.chat(endpoint(), messages, options);
 
         LOG.info("Response: [{}]", result.message().content());
-        // Provider promised JSON object response; verify it parses.
         assertThat(JSONUtil.getObjectMapper().readTree(result.message().content())).isNotNull();
     }
 
@@ -102,20 +132,11 @@ class ChatGptLlmChatClientIntegrationTest
         var messages = List.of(new ChatMessage(USER, "Count from 1 to 5."));
         var chunks = new ArrayList<ChatChunk>();
 
-        var result = sut.chatStream(endpoint(MODEL), messages, ChatOptions.defaults(), chunks::add);
+        var result = sut.chatStream(endpoint(), messages, ChatOptions.defaults(), chunks::add);
 
         LOG.info("Got {} chunks, final: [{}]", chunks.size(), result.message().content());
         assertThat(chunks).isNotEmpty();
         assertThat(result.message().content()).isNotBlank();
-    }
-
-    @Test
-    void testListModels() throws Exception
-    {
-        var models = sut.listModels(endpoint(null));
-
-        LOG.info("Models: {}", models);
-        assertThat(models).extracting("id").contains(MODEL);
     }
 
     static class WeatherService
@@ -139,21 +160,15 @@ class ChatGptLlmChatClientIntegrationTest
                 .of(new ChatMessage(USER, "What is the current weather in Berlin? Use the tool."));
         var options = new ChatOptions(null, null, List.of(weatherTool), null);
 
-        var result = sut.chat(endpoint(MODEL), messages, options);
+        var result = sut.chat(endpoint(), messages, options);
 
         LOG.info("Finish reason: {}, tool calls: {}", result.finishReason(), result.toolCalls());
 
         assertThat(result.toolCalls()).as("tool calls").isNotEmpty();
-        assertThat(result.finishReason()).isEqualTo(FinishReason.TOOL_CALLS);
 
         var call = result.toolCalls().get(0);
         assertThat(call.name()).isEqualTo("get_current_weather");
         assertThat(call.arguments()).as("arguments JsonNode").isNotNull();
         assertThat(call.arguments().isObject()).as("arguments is an object node").isTrue();
-
-        var location = call.arguments().get("location");
-        assertThat(location).as("location argument node").isNotNull();
-        assertThat(location.isTextual()).as("location node is TextNode").isTrue();
-        assertThat(location.asText()).containsIgnoringCase("berlin");
     }
 }

--- a/inception/inception-imls-azureai-openai/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiOpenAiLlmChatClientTest.java
+++ b/inception/inception-imls-azureai-openai/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/azureaiopenai/client/AzureAiOpenAiLlmChatClientTest.java
@@ -15,18 +15,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package de.tudarmstadt.ukp.inception.recommendation.imls.llm.chatgpt.client;
+package de.tudarmstadt.ukp.inception.recommendation.imls.llm.azureaiopenai.client;
 
 import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.ChatMessage.Role.ASSISTANT;
 import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.ChatMessage.Role.TOOL;
 import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.ChatMessage.Role.USER;
 import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
 import static java.util.List.of;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.function.Consumer;
 
 import org.junit.jupiter.api.Test;
@@ -37,21 +35,25 @@ import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.FinishReason;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.LlmEndpoint;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ToolCall;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ToolDescriptor;
+import de.tudarmstadt.ukp.inception.security.client.auth.apikey.ApiKeyAuthenticationTraits;
 import de.tudarmstadt.ukp.inception.support.json.JSONUtil;
 
 /**
- * Offline unit tests for {@link ChatGptLlmChatClient} exercising request building and wire-response
- * mapping without a live OpenAI server. Live-server behavior is covered by
- * {@link ChatGptLlmChatClientIntegrationTest}.
+ * Offline unit tests for {@link AzureAiOpenAiLlmChatClient} exercising request building and
+ * wire-response mapping without a live Azure OpenAI server. Live-server behavior is covered by
+ * {@link AzureAiOpenAiClientIntegrationTest}.
  */
-class ChatGptLlmChatClientTest
+class AzureAiOpenAiLlmChatClientTest
 {
-    private final CapturingChatGptClient client = new CapturingChatGptClient();
-    private final ChatGptLlmChatClient sut = new ChatGptLlmChatClient(client);
+    private final CapturingAzureAiOpenAiClient client = new CapturingAzureAiOpenAiClient();
+    private final AzureAiOpenAiLlmChatClient sut = new AzureAiOpenAiLlmChatClient(client);
 
     private static LlmEndpoint endpoint()
     {
-        return new LlmEndpoint(ChatGptLlmChatClient.ID, "http://localhost", "some-model", null);
+        var auth = new ApiKeyAuthenticationTraits();
+        auth.setApiKey("secret-key");
+        return new LlmEndpoint(AzureAiOpenAiLlmChatClient.ID, "http://localhost", "some-model",
+                auth);
     }
 
     private static ToolDescriptor weatherTool()
@@ -129,6 +131,22 @@ class ChatGptLlmChatClientTest
                 .contains("Berlin");
     }
 
+    /**
+     * Azure identifies the model via the deployment embedded in the URL, so the {@code model} field
+     * must be {@code @JsonIgnore} and never appear in the serialized request body.
+     */
+    @Test
+    void testModelIsNotSerializedOnTheWire() throws Exception
+    {
+        client.response = cannedTextResponse("ok");
+
+        sut.chat(endpoint(), of(new ChatMessage(USER, "Hi")), ChatOptions.defaults());
+
+        var json = JSONUtil.toJsonString(client.lastRequest);
+        assertThat(json).doesNotContain("\"model\"");
+        assertThat(json).doesNotContain("some-model");
+    }
+
     @Test
     void testResponseMappingWithToolCallsUsageAndFinishReason() throws Exception
     {
@@ -158,7 +176,8 @@ class ChatGptLlmChatClientTest
                   "usage": { "prompt_tokens": 11, "completion_tokens": 7, "total_tokens": 18 }
                 }
                 """;
-        client.response = JSONUtil.getObjectMapper().readValue(json, ChatCompletionResponse.class);
+        client.response = JSONUtil.getObjectMapper().readValue(json,
+                AzureAiChatCompletionResponse.class);
 
         var result = sut.chat(endpoint(), of(new ChatMessage(USER, "Weather?")),
                 ChatOptions.defaults());
@@ -195,7 +214,8 @@ class ChatGptLlmChatClientTest
                   ]
                 }
                 """;
-        client.response = JSONUtil.getObjectMapper().readValue(json, ChatCompletionResponse.class);
+        client.response = JSONUtil.getObjectMapper().readValue(json,
+                AzureAiChatCompletionResponse.class);
 
         var result = sut.chat(endpoint(), of(new ChatMessage(USER, "Go")), ChatOptions.defaults());
 
@@ -225,14 +245,14 @@ class ChatGptLlmChatClientTest
                 .finishReason();
     }
 
-    private static ChatCompletionResponse cannedTextResponse(String aContent)
+    private static AzureAiChatCompletionResponse cannedTextResponse(String aContent)
     {
-        var message = new ChatCompletionMessage("assistant", aContent);
-        var choice = new ChatCompletionChoice();
+        var message = new AzureAiChatCompletionMessage("assistant", aContent);
+        var choice = new AzureAiChatCompletionChoice();
         choice.setIndex(0);
         choice.setMessage(message);
         choice.setFinishReason("stop");
-        var response = new ChatCompletionResponse();
+        var response = new AzureAiChatCompletionResponse();
         response.setChoices(asList(choice));
         return response;
     }
@@ -241,16 +261,17 @@ class ChatGptLlmChatClientTest
      * Records the last request and returns a canned response, so the adapter can be exercised with
      * no live server.
      */
-    private static final class CapturingChatGptClient
-        implements ChatGptClient
+    private static final class CapturingAzureAiOpenAiClient
+        implements AzureAiOpenAiClient
     {
-        private ChatCompletionRequest lastRequest;
-        private ChatCompletionRequest lastStreamRequest;
-        private ChatCompletionResponse response;
-        private ChatCompletionResponse streamResponse;
+        private AzureAiChatCompletionRequest lastRequest;
+        private AzureAiChatCompletionRequest lastStreamRequest;
+        private AzureAiChatCompletionResponse response;
+        private AzureAiChatCompletionResponse streamResponse;
 
         @Override
-        public ChatCompletionResponse chat(String aUrl, ChatCompletionRequest aRequest)
+        public AzureAiChatCompletionResponse generate(String aUrl,
+                AzureAiChatCompletionRequest aRequest)
             throws IOException
         {
             lastRequest = aRequest;
@@ -258,19 +279,12 @@ class ChatGptLlmChatClientTest
         }
 
         @Override
-        public ChatCompletionResponse chat(String aUrl, ChatCompletionRequest aRequest,
-                Consumer<String> aContentCallback)
+        public AzureAiChatCompletionResponse generate(String aUrl,
+                AzureAiChatCompletionRequest aRequest, Consumer<String> aContentCallback)
             throws IOException
         {
             lastStreamRequest = aRequest;
             return streamResponse;
-        }
-
-        @Override
-        public List<ChatGptModel> listModels(String aUrl, ListModelsRequest aRequest)
-            throws IOException
-        {
-            return emptyList();
         }
     }
 }

--- a/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/chatgpt/client/ChatCompletionChoice.java
+++ b/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/chatgpt/client/ChatCompletionChoice.java
@@ -25,6 +25,7 @@ public class ChatCompletionChoice
 {
     private @JsonProperty("index") int index;
     private @JsonProperty("message") ChatCompletionMessage message;
+    private @JsonProperty("delta") ChatCompletionMessage delta;
     private @JsonProperty("finish_reason") String finishReason;
 
     public int getIndex()
@@ -45,6 +46,20 @@ public class ChatCompletionChoice
     public void setMessage(ChatCompletionMessage aMessage)
     {
         message = aMessage;
+    }
+
+    /**
+     * The incremental message delta carried by a streaming chunk (OpenAI sends {@code delta} on
+     * streamed responses in place of the complete {@code message}).
+     */
+    public ChatCompletionMessage getDelta()
+    {
+        return delta;
+    }
+
+    public void setDelta(ChatCompletionMessage aDelta)
+    {
+        delta = aDelta;
     }
 
     public String getFinishReason()

--- a/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/chatgpt/client/ChatCompletionFunction.java
+++ b/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/chatgpt/client/ChatCompletionFunction.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.imls.llm.chatgpt.client;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import tools.jackson.databind.JsonNode;
+
+/**
+ * The {@code function} object nested inside an OpenAI {@code tools[]} entry: a name, an optional
+ * description, and the JSON-schema {@code parameters} passed straight through from the neutral
+ * {@code ToolDescriptor.parametersSchema()}.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(NON_NULL)
+public class ChatCompletionFunction
+{
+    private final @JsonProperty("name") String name;
+    private final @JsonProperty("description") String description;
+    private final @JsonProperty("parameters") JsonNode parameters;
+
+    private ChatCompletionFunction(Builder aBuilder)
+    {
+        name = aBuilder.name;
+        description = aBuilder.description;
+        parameters = aBuilder.parameters;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public String getDescription()
+    {
+        return description;
+    }
+
+    public JsonNode getParameters()
+    {
+        return parameters;
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static final class Builder
+    {
+        private String name;
+        private String description;
+        private JsonNode parameters;
+
+        private Builder()
+        {
+        }
+
+        public Builder withName(String aName)
+        {
+            name = aName;
+            return this;
+        }
+
+        public Builder withDescription(String aDescription)
+        {
+            description = aDescription;
+            return this;
+        }
+
+        public Builder withParameters(JsonNode aParameters)
+        {
+            parameters = aParameters;
+            return this;
+        }
+
+        public ChatCompletionFunction build()
+        {
+            return new ChatCompletionFunction(this);
+        }
+    }
+}

--- a/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/chatgpt/client/ChatCompletionMessage.java
+++ b/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/chatgpt/client/ChatCompletionMessage.java
@@ -17,7 +17,13 @@
  */
 package de.tudarmstadt.ukp.inception.recommendation.imls.llm.chatgpt.client;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -25,6 +31,8 @@ public class ChatCompletionMessage
 {
     private @JsonProperty("role") String role;
     private @JsonProperty("content") String content;
+    private @JsonInclude(NON_EMPTY) @JsonProperty("tool_calls") List<ChatCompletionToolCall> toolCalls;
+    private @JsonInclude(NON_NULL) @JsonProperty("tool_call_id") String toolCallId;
 
     public ChatCompletionMessage()
     {
@@ -35,6 +43,15 @@ public class ChatCompletionMessage
     {
         role = aRole;
         content = aContent;
+    }
+
+    public ChatCompletionMessage(String aRole, String aContent,
+            List<ChatCompletionToolCall> aToolCalls, String aToolCallId)
+    {
+        role = aRole;
+        content = aContent;
+        toolCalls = aToolCalls;
+        toolCallId = aToolCallId;
     }
 
     public String getRole()
@@ -55,5 +72,25 @@ public class ChatCompletionMessage
     public void setContent(String aContent)
     {
         content = aContent;
+    }
+
+    public List<ChatCompletionToolCall> getToolCalls()
+    {
+        return toolCalls;
+    }
+
+    public void setToolCalls(List<ChatCompletionToolCall> aToolCalls)
+    {
+        toolCalls = aToolCalls;
+    }
+
+    public String getToolCallId()
+    {
+        return toolCallId;
+    }
+
+    public void setToolCallId(String aToolCallId)
+    {
+        toolCallId = aToolCallId;
     }
 }

--- a/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/chatgpt/client/ChatCompletionRequest.java
+++ b/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/chatgpt/client/ChatCompletionRequest.java
@@ -55,6 +55,7 @@ public class ChatCompletionRequest
     private final @JsonInclude(NON_NULL) @JsonProperty("temperature") Double temperature;
     private final @JsonInclude(NON_NULL) @JsonProperty("top_p") Double topP;
     private final @JsonInclude(NON_NULL) @JsonProperty("seed") Integer seed;
+    private final @JsonInclude(NON_NULL) @JsonProperty("reasoning_effort") String reasoningEffort;
     private final @JsonInclude(NON_EMPTY) @JsonProperty("tools") List<ChatCompletionTool> tools;
     private final @JsonInclude(NON_NULL) @JsonProperty("stream") Boolean stream;
     private final @JsonInclude(NON_NULL) @JsonProperty("stream_options") ChatCompletionStreamOptions streamOptions;
@@ -68,6 +69,7 @@ public class ChatCompletionRequest
         temperature = TEMPERATURE.get(builder.options);
         seed = SEED.get(builder.options);
         topP = TOP_P.get(builder.options);
+        reasoningEffort = builder.reasoningEffort;
         tools = builder.tools.isEmpty() ? null : builder.tools;
         stream = builder.stream ? Boolean.TRUE : null;
         // Ask OpenAI to include a final usage chunk when streaming; harmless otherwise.
@@ -92,6 +94,11 @@ public class ChatCompletionRequest
     public List<ChatCompletionMessage> getMessages()
     {
         return messages;
+    }
+
+    public String getReasoningEffort()
+    {
+        return reasoningEffort;
     }
 
     public List<ChatCompletionTool> getTools()
@@ -121,6 +128,7 @@ public class ChatCompletionRequest
         private ChatGptResponseFormat format;
         private final List<ChatCompletionMessage> messages = new ArrayList<>();
         private final List<ChatCompletionTool> tools = new ArrayList<>();
+        private String reasoningEffort;
         private boolean stream;
         private final Map<Option<?>, Object> options = new HashMap<>();
 
@@ -197,6 +205,16 @@ public class ChatCompletionRequest
                             .build());
                 }
             }
+            return this;
+        }
+
+        /**
+         * Sets the OpenAI {@code reasoning_effort} wire value ({@code low}/{@code medium}/
+         * {@code high}); {@code null} omits the field. Only reasoning models honor it.
+         */
+        public Builder withReasoningEffort(String aReasoningEffort)
+        {
+            reasoningEffort = aReasoningEffort;
             return this;
         }
 

--- a/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/chatgpt/client/ChatCompletionRequest.java
+++ b/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/chatgpt/client/ChatCompletionRequest.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.recommendation.imls.llm.chatgpt.client;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 import static java.util.Arrays.asList;
 
@@ -30,6 +31,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ToolDescriptor;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.support.traits.Option;
 
 public class ChatCompletionRequest
@@ -53,6 +55,9 @@ public class ChatCompletionRequest
     private final @JsonInclude(NON_NULL) @JsonProperty("temperature") Double temperature;
     private final @JsonInclude(NON_NULL) @JsonProperty("top_p") Double topP;
     private final @JsonInclude(NON_NULL) @JsonProperty("seed") Integer seed;
+    private final @JsonInclude(NON_EMPTY) @JsonProperty("tools") List<ChatCompletionTool> tools;
+    private final @JsonInclude(NON_NULL) @JsonProperty("stream") Boolean stream;
+    private final @JsonInclude(NON_NULL) @JsonProperty("stream_options") ChatCompletionStreamOptions streamOptions;
 
     private ChatCompletionRequest(Builder builder)
     {
@@ -63,6 +68,10 @@ public class ChatCompletionRequest
         temperature = TEMPERATURE.get(builder.options);
         seed = SEED.get(builder.options);
         topP = TOP_P.get(builder.options);
+        tools = builder.tools.isEmpty() ? null : builder.tools;
+        stream = builder.stream ? Boolean.TRUE : null;
+        // Ask OpenAI to include a final usage chunk when streaming; harmless otherwise.
+        streamOptions = builder.stream ? new ChatCompletionStreamOptions(true) : null;
     }
 
     public String getApiKey()
@@ -85,6 +94,21 @@ public class ChatCompletionRequest
         return messages;
     }
 
+    public List<ChatCompletionTool> getTools()
+    {
+        return tools;
+    }
+
+    public Boolean getStream()
+    {
+        return stream;
+    }
+
+    public ChatCompletionStreamOptions getStreamOptions()
+    {
+        return streamOptions;
+    }
+
     public static Builder builder()
     {
         return new Builder();
@@ -96,6 +120,8 @@ public class ChatCompletionRequest
         private String apiKey;
         private ChatGptResponseFormat format;
         private final List<ChatCompletionMessage> messages = new ArrayList<>();
+        private final List<ChatCompletionTool> tools = new ArrayList<>();
+        private boolean stream;
         private final Map<Option<?>, Object> options = new HashMap<>();
 
         private Builder()
@@ -147,6 +173,36 @@ public class ChatCompletionRequest
         public Builder withResponseFormat(ChatGptResponseFormat aFormat)
         {
             format = aFormat;
+            return this;
+        }
+
+        /**
+         * Translates the provider-neutral {@link ToolDescriptor}s into OpenAI's
+         * {@code tools[{"type":"function","function":{...}}]} wire shape. The
+         * {@code parametersSchema()} JSON node is passed straight through as the function's
+         * {@code parameters}.
+         */
+        public Builder withTools(List<ToolDescriptor> aTools)
+        {
+            tools.clear();
+            if (aTools != null) {
+                for (var descriptor : aTools) {
+                    var function = ChatCompletionFunction.builder() //
+                            .withName(descriptor.name()) //
+                            .withDescription(descriptor.description()) //
+                            .withParameters(descriptor.parametersSchema()) //
+                            .build();
+                    tools.add(ChatCompletionTool.builder() //
+                            .withFunction(function) //
+                            .build());
+                }
+            }
+            return this;
+        }
+
+        public Builder withStream(boolean aStream)
+        {
+            stream = aStream;
             return this;
         }
 

--- a/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/chatgpt/client/ChatCompletionStreamOptions.java
+++ b/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/chatgpt/client/ChatCompletionStreamOptions.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.imls.llm.chatgpt.client;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * The OpenAI {@code stream_options} object. With {@code include_usage=true}, the final streamed
+ * chunk carries a {@code usage} block (otherwise streaming responses omit usage entirely).
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ChatCompletionStreamOptions
+{
+    private final @JsonProperty("include_usage") boolean includeUsage;
+
+    public ChatCompletionStreamOptions(boolean aIncludeUsage)
+    {
+        includeUsage = aIncludeUsage;
+    }
+
+    public boolean isIncludeUsage()
+    {
+        return includeUsage;
+    }
+}

--- a/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/chatgpt/client/ChatCompletionTool.java
+++ b/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/chatgpt/client/ChatCompletionTool.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.imls.llm.chatgpt.client;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * One entry in the OpenAI request {@code tools[]} array:
+ * {@code {"type":"function","function":{...}}}.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ChatCompletionTool
+{
+    private final @JsonProperty("type") String type;
+    private final @JsonProperty("function") ChatCompletionFunction function;
+
+    private ChatCompletionTool(Builder aBuilder)
+    {
+        type = aBuilder.type;
+        function = aBuilder.function;
+    }
+
+    public String getType()
+    {
+        return type;
+    }
+
+    public ChatCompletionFunction getFunction()
+    {
+        return function;
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static final class Builder
+    {
+        private String type = "function";
+        private ChatCompletionFunction function;
+
+        private Builder()
+        {
+        }
+
+        public Builder withType(String aType)
+        {
+            type = aType;
+            return this;
+        }
+
+        public Builder withFunction(ChatCompletionFunction aFunction)
+        {
+            function = aFunction;
+            return this;
+        }
+
+        public ChatCompletionTool build()
+        {
+            return new ChatCompletionTool(this);
+        }
+    }
+}

--- a/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/chatgpt/client/ChatCompletionToolCall.java
+++ b/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/chatgpt/client/ChatCompletionToolCall.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.imls.llm.chatgpt.client;
+
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * A tool call requested by the model on an assistant message, or echoed back when we resend the
+ * assistant turn. OpenAI carries the function arguments as a JSON <em>string</em>, not an object;
+ * in streaming responses the {@code arguments} string arrives fragmented across chunks and must be
+ * concatenated by {@code index}.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(NON_NULL)
+public class ChatCompletionToolCall
+{
+    private @JsonProperty("index") Integer index;
+    private @JsonProperty("id") String id;
+    private @JsonProperty("type") String type;
+    private @JsonProperty("function") Function function;
+
+    public Integer getIndex()
+    {
+        return index;
+    }
+
+    public void setIndex(Integer aIndex)
+    {
+        index = aIndex;
+    }
+
+    public String getId()
+    {
+        return id;
+    }
+
+    public void setId(String aId)
+    {
+        id = aId;
+    }
+
+    public String getType()
+    {
+        return type;
+    }
+
+    public void setType(String aType)
+    {
+        type = aType;
+    }
+
+    public Function getFunction()
+    {
+        return function;
+    }
+
+    public void setFunction(Function aFunction)
+    {
+        function = aFunction;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonInclude(NON_NULL)
+    public static class Function
+    {
+        private @JsonProperty("name") String name;
+        private @JsonProperty("arguments") String arguments;
+
+        public String getName()
+        {
+            return name;
+        }
+
+        public void setName(String aName)
+        {
+            name = aName;
+        }
+
+        public String getArguments()
+        {
+            return arguments;
+        }
+
+        public void setArguments(String aArguments)
+        {
+            arguments = aArguments;
+        }
+    }
+}

--- a/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/chatgpt/client/ChatGptClient.java
+++ b/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/chatgpt/client/ChatGptClient.java
@@ -19,10 +19,25 @@ package de.tudarmstadt.ukp.inception.recommendation.imls.llm.chatgpt.client;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.function.Consumer;
 
 public interface ChatGptClient
 {
-    String chat(String aUrl, ChatCompletionRequest aRequest) throws IOException;
+    /**
+     * Perform a non-streaming chat completion. Returns the parsed wire response (choices, usage,
+     * finish reason); the neutral mapping to {@code ChatResult} is the adapter's job.
+     */
+    ChatCompletionResponse chat(String aUrl, ChatCompletionRequest aRequest) throws IOException;
+
+    /**
+     * Perform a streaming (SSE) chat completion. {@code aContentCallback} receives each content
+     * delta as it arrives; the returned {@link ChatCompletionResponse} is assembled from the stream
+     * and carries the full content, tool calls, finish reason, and (when
+     * {@code stream_options.include_usage} was requested) usage.
+     */
+    ChatCompletionResponse chat(String aUrl, ChatCompletionRequest aRequest,
+            Consumer<String> aContentCallback)
+        throws IOException;
 
     List<ChatGptModel> listModels(String aUrl, ListModelsRequest aRequest) throws IOException;
 }

--- a/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/chatgpt/client/ChatGptClientImpl.java
+++ b/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/chatgpt/client/ChatGptClientImpl.java
@@ -33,13 +33,20 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.TreeMap;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ServerSentEvent;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ServerSentEventReader;
 import de.tudarmstadt.ukp.inception.support.json.JSONUtil;
 import tools.jackson.databind.ObjectMapper;
 
@@ -49,6 +56,9 @@ public class ChatGptClientImpl
     private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private static final String AUTHORIZATION = "Authorization";
+
+    /** SSE {@code data:} payload that signals the end of the stream. */
+    private static final String SSE_DONE_MARKER = "[DONE]";
 
     private static final String LIMIT_REQUESTS_DAY = "x-ratelimit-limit-requests-day";
     private static final String LIMIT_TOKENS_MINUTE = "x-ratelimit-limit-tokens-minute";
@@ -96,10 +106,148 @@ public class ChatGptClientImpl
     }
 
     @Override
-    public String chat(String aUrl, ChatCompletionRequest aRequest) throws IOException
+    public ChatCompletionResponse chat(String aUrl, ChatCompletionRequest aRequest)
+        throws IOException
     {
         var startTime = System.currentTimeMillis();
 
+        var response = sendChatRequest(aUrl, aRequest);
+
+        handleError(response);
+
+        ChatCompletionResponse completion;
+        try (var is = response.body()) {
+            var buffer = IOUtils.toString(is, UTF_8);
+            if (LOG.isTraceEnabled()) {
+                for (var header : response.headers().map().entrySet()) {
+                    LOG.trace("Header - {}: {}", header.getKey(), header.getValue());
+                }
+                LOG.trace("JSON Response: {}", buffer);
+            }
+
+            parseRateLimitInfo(response);
+
+            completion = objectMapper.readValue(buffer, ChatCompletionResponse.class);
+
+            logTimings(completion);
+        }
+
+        LOG.trace("[{}] responds ({} ms)", aRequest.getModel(), currentTimeMillis() - startTime);
+
+        return completion;
+    }
+
+    @Override
+    public ChatCompletionResponse chat(String aUrl, ChatCompletionRequest aRequest,
+            Consumer<String> aContentCallback)
+        throws IOException
+    {
+        var startTime = System.currentTimeMillis();
+
+        HttpResponse<Stream<String>> response;
+        try {
+            var request = buildChatHttpRequest(aUrl, aRequest);
+            response = client.send(request, HttpResponse.BodyHandlers.ofLines());
+        }
+        catch (IOException | InterruptedException e) {
+            throw new IOException("Error while sending request: " + e.getMessage(), e);
+        }
+
+        if (response.statusCode() >= HTTP_BAD_REQUEST) {
+            var body = response.body().collect(Collectors.joining("\n"));
+            throw new IOException(
+                    format("Request was not successful: [%d] - [%s]", response.statusCode(), body));
+        }
+
+        parseRateLimitInfo(response);
+
+        try (var events = ServerSentEventReader.parse(response.body())) {
+            var completion = assembleSseStream(events, aRequest.getModel(), aContentCallback);
+
+            LOG.trace("[{}] responds ({} ms)", aRequest.getModel(),
+                    currentTimeMillis() - startTime);
+
+            return completion;
+        }
+    }
+
+    /**
+     * Assembles the SSE event stream of an OpenAI streaming chat completion into a single
+     * {@link ChatCompletionResponse}. The terminal {@code data: [DONE]} sentinel stops assembly;
+     * {@code choices[].delta.content} is concatenated (and forwarded to {@code aContentCallback}
+     * per delta), fragmented {@code delta.tool_calls} are merged by index, and the final
+     * {@code usage} chunk (present when {@code stream_options.include_usage} was set) is captured.
+     * Package-private so it can be unit-tested with canned events and no live server.
+     */
+    ChatCompletionResponse assembleSseStream(Stream<ServerSentEvent> aEvents, String aRequestModel,
+            Consumer<String> aContentCallback)
+        throws IOException
+    {
+        var content = new StringBuilder();
+        // tool-call fragments keyed by their streaming index, so out-of-order deltas still merge.
+        var toolCallsByIndex = new TreeMap<Integer, ChatCompletionToolCall>();
+        String finishReason = null;
+        String role = null;
+        ChatCompletionUsage usage = null;
+        String model = aRequestModel;
+
+        var iter = aEvents.iterator();
+        while (iter.hasNext()) {
+            var payload = iter.next().data();
+            if (payload == null) {
+                continue;
+            }
+            if (SSE_DONE_MARKER.equals(payload)) {
+                break;
+            }
+
+            LOG.trace("SSE chunk: {}", payload);
+
+            var chunk = objectMapper.readValue(payload, ChatCompletionResponse.class);
+
+            if (chunk.getModel() != null) {
+                model = chunk.getModel();
+            }
+
+            if (chunk.getUsage() != null) {
+                usage = chunk.getUsage();
+            }
+
+            if (chunk.getChoices() == null || chunk.getChoices().isEmpty()) {
+                continue;
+            }
+
+            var choice = chunk.getChoices().get(0);
+            if (choice.getFinishReason() != null) {
+                finishReason = choice.getFinishReason();
+            }
+
+            var delta = choice.getDelta();
+            if (delta == null) {
+                continue;
+            }
+
+            if (delta.getRole() != null) {
+                role = delta.getRole();
+            }
+
+            if (delta.getContent() != null && !delta.getContent().isEmpty()) {
+                content.append(delta.getContent());
+                if (aContentCallback != null) {
+                    aContentCallback.accept(delta.getContent());
+                }
+            }
+
+            accumulateToolCalls(toolCallsByIndex, delta.getToolCalls());
+        }
+
+        return assembleStreamedResponse(model, role, content.toString(),
+                new ArrayList<>(toolCallsByIndex.values()), finishReason, usage);
+    }
+
+    private HttpRequest buildChatHttpRequest(String aUrl, ChatCompletionRequest aRequest)
+        throws IOException
+    {
         if (LOG.isTraceEnabled()) {
             LOG.trace("Sending chat request: {}", JSONUtil.toPrettyJsonString(aRequest));
         }
@@ -114,67 +262,121 @@ public class ChatGptClientImpl
 
         request.POST(BodyPublishers.ofString(JSONUtil.toJsonString(aRequest), UTF_8));
 
-        var response = sendRequest(request.build());
+        return request.build();
+    }
 
-        handleError(response);
+    private HttpResponse<InputStream> sendChatRequest(String aUrl, ChatCompletionRequest aRequest)
+        throws IOException
+    {
+        return sendRequest(buildChatHttpRequest(aUrl, aRequest));
+    }
 
-        var result = new StringBuilder();
-        try (var is = response.body()) {
-            var buffer = IOUtils.toString(is, UTF_8);
-            if (LOG.isTraceEnabled()) {
-                for (var header : response.headers().map().entrySet()) {
-                    LOG.trace("Header - {}: {}", header.getKey(), header.getValue());
-                }
-                LOG.trace("JSON Response: {}", buffer);
-            }
+    private void logTimings(ChatCompletionResponse completion)
+    {
+        if (LOG.isDebugEnabled() && completion.getTimeInfo() != null
+                && completion.getUsage() != null) {
+            var promptEvalTokenPerSecond = completion.getUsage().getPromptTokens()
+                    / completion.getTimeInfo().getPromptTime();
+            var evalTokenPerSecond = completion.getUsage().getCompletionTokens()
+                    / completion.getTimeInfo().getCompletionTime();
+            LOG.debug("Tokens  - prompt: {} ({} per sec) response: {} ({} per sec)", //
+                    completion.getUsage().getPromptTokens(), //
+                    promptEvalTokenPerSecond, //
+                    completion.getUsage().getCompletionTokens(), //
+                    evalTokenPerSecond);
+            LOG.debug("Timings - queue: {}sec  prompt: {}sec  response: {}s  total: {}sec", //
+                    completion.getTimeInfo().getQueueTime(), //
+                    completion.getTimeInfo().getPromptTime(), //
+                    completion.getTimeInfo().getCompletionTime(), //
+                    completion.getTimeInfo().getTotalTime());
+        }
+    }
 
-            var rateLimitInfo = new RateLimitInfo();
-            response.headers().firstValue(LIMIT_REQUESTS_DAY) //
-                    .map(NumberUtils::toInt) //
-                    .ifPresent(rateLimitInfo::setLimitRequestsDay);
-            response.headers().firstValue(LIMIT_TOKENS_MINUTE) //
-                    .map(NumberUtils::toInt) //
-                    .ifPresent(rateLimitInfo::setLimitTokensMinute);
-            response.headers().firstValue(REMAINING_REQUESTS_DAY) //
-                    .map(NumberUtils::toInt) //
-                    .ifPresent(rateLimitInfo::setRemainingRequestsDay);
-            response.headers().firstValue(REMAINING_TOKENS_MINUTE) //
-                    .map(NumberUtils::toInt) //
-                    .ifPresent(rateLimitInfo::setRemainingTokensMinute);
-            response.headers().firstValue(RESET_REQUESTS_DAY) //
-                    .map(NumberUtils::toDouble) //
-                    .ifPresent(rateLimitInfo::setResetRequestsDay);
-            response.headers().firstValue(RESET_TOKENS_MINUTE) //
-                    .map(NumberUtils::toDouble) //
-                    .ifPresent(rateLimitInfo::setResetTokensMinute);
+    private RateLimitInfo parseRateLimitInfo(HttpResponse<?> response)
+    {
+        var rateLimitInfo = new RateLimitInfo();
+        response.headers().firstValue(LIMIT_REQUESTS_DAY) //
+                .map(NumberUtils::toInt) //
+                .ifPresent(rateLimitInfo::setLimitRequestsDay);
+        response.headers().firstValue(LIMIT_TOKENS_MINUTE) //
+                .map(NumberUtils::toInt) //
+                .ifPresent(rateLimitInfo::setLimitTokensMinute);
+        response.headers().firstValue(REMAINING_REQUESTS_DAY) //
+                .map(NumberUtils::toInt) //
+                .ifPresent(rateLimitInfo::setRemainingRequestsDay);
+        response.headers().firstValue(REMAINING_TOKENS_MINUTE) //
+                .map(NumberUtils::toInt) //
+                .ifPresent(rateLimitInfo::setRemainingTokensMinute);
+        response.headers().firstValue(RESET_REQUESTS_DAY) //
+                .map(NumberUtils::toDouble) //
+                .ifPresent(rateLimitInfo::setResetRequestsDay);
+        response.headers().firstValue(RESET_TOKENS_MINUTE) //
+                .map(NumberUtils::toDouble) //
+                .ifPresent(rateLimitInfo::setResetTokensMinute);
+        return rateLimitInfo;
+    }
 
-            var completion = objectMapper.readValue(buffer, ChatCompletionResponse.class);
-
-            if (LOG.isDebugEnabled() && completion.getTimeInfo() != null
-                    && completion.getUsage() != null) {
-                var promptEvalTokenPerSecond = completion.getUsage().getPromptTokens()
-                        / completion.getTimeInfo().getPromptTime();
-                var evalTokenPerSecond = completion.getUsage().getCompletionTokens()
-                        / completion.getTimeInfo().getCompletionTime();
-                LOG.debug("Tokens  - prompt: {} ({} per sec) response: {} ({} per sec)", //
-                        completion.getUsage().getPromptTokens(), //
-                        promptEvalTokenPerSecond, //
-                        completion.getUsage().getCompletionTokens(), //
-                        evalTokenPerSecond);
-                LOG.debug("Timings - queue: {}sec  prompt: {}sec  response: {}s  total: {}sec", //
-                        completion.getTimeInfo().getQueueTime(),
-                        completion.getTimeInfo().getPromptTime(),
-                        completion.getTimeInfo().getCompletionTime(),
-                        completion.getTimeInfo().getTotalTime());
-            }
-
-            result.append(completion.getChoices().get(0).getMessage().getContent());
+    /**
+     * Merges the tool-call deltas of one streaming chunk into the per-index accumulator. OpenAI
+     * fragments {@code function.arguments} across chunks and only sends {@code id} / {@code name}
+     * on the first fragment of each call, so the id/name are captured once and the argument strings
+     * are concatenated.
+     */
+    private static void accumulateToolCalls(TreeMap<Integer, ChatCompletionToolCall> aAccumulator,
+            List<ChatCompletionToolCall> aDeltaCalls)
+    {
+        if (aDeltaCalls == null) {
+            return;
         }
 
-        LOG.trace("[{}] responds ({} ms): [{}]", aRequest.getModel(),
-                currentTimeMillis() - startTime, result.toString());
+        for (var deltaCall : aDeltaCalls) {
+            var index = deltaCall.getIndex() != null ? deltaCall.getIndex() : aAccumulator.size();
+            var target = aAccumulator.computeIfAbsent(index, i -> {
+                var tc = new ChatCompletionToolCall();
+                tc.setIndex(i);
+                tc.setType("function");
+                tc.setFunction(new ChatCompletionToolCall.Function());
+                return tc;
+            });
 
-        return result.toString();
+            if (deltaCall.getId() != null) {
+                target.setId(deltaCall.getId());
+            }
+            if (deltaCall.getType() != null) {
+                target.setType(deltaCall.getType());
+            }
+
+            var deltaFn = deltaCall.getFunction();
+            if (deltaFn != null) {
+                if (deltaFn.getName() != null) {
+                    target.getFunction().setName(deltaFn.getName());
+                }
+                if (deltaFn.getArguments() != null) {
+                    var existing = target.getFunction().getArguments();
+                    target.getFunction().setArguments(
+                            (existing != null ? existing : "") + deltaFn.getArguments());
+                }
+            }
+        }
+    }
+
+    private static ChatCompletionResponse assembleStreamedResponse(String aModel, String aRole,
+            String aContent, List<ChatCompletionToolCall> aToolCalls, String aFinishReason,
+            ChatCompletionUsage aUsage)
+    {
+        var message = new ChatCompletionMessage(aRole != null ? aRole : "assistant", aContent,
+                aToolCalls.isEmpty() ? null : aToolCalls, null);
+
+        var choice = new ChatCompletionChoice();
+        choice.setIndex(0);
+        choice.setMessage(message);
+        choice.setFinishReason(aFinishReason);
+
+        var response = new ChatCompletionResponse();
+        response.setModel(aModel);
+        response.setChoices(new ArrayList<>(List.of(choice)));
+        response.setUsage(aUsage);
+        return response;
     }
 
     @Override

--- a/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/chatgpt/client/ChatGptClientImpl.java
+++ b/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/chatgpt/client/ChatGptClientImpl.java
@@ -330,7 +330,7 @@ public class ChatGptClientImpl
         }
 
         for (var deltaCall : aDeltaCalls) {
-            var index = deltaCall.getIndex() != null ? deltaCall.getIndex() : aAccumulator.size();
+            var index = resolveToolCallIndex(aAccumulator, deltaCall.getIndex(), deltaCall.getId());
             var target = aAccumulator.computeIfAbsent(index, i -> {
                 var tc = new ChatCompletionToolCall();
                 tc.setIndex(i);
@@ -358,6 +358,28 @@ public class ChatGptClientImpl
                 }
             }
         }
+    }
+
+    /**
+     * Resolves the accumulator key for a tool-call delta. Well-behaved OpenAI-compatible servers
+     * send an explicit {@code index} on every fragment; that is always authoritative. When a server
+     * omits it, a fragment carrying an {@code id} marks the start of a new call (next free index),
+     * whereas an id-less continuation fragment (only {@code arguments}) belongs to the call started
+     * most recently, i.e. the highest index seen so far. Using {@code aAccumulator.size()} as the
+     * fallback mis-merged such continuations into a fresh index, splitting one call into several.
+     */
+    private static int resolveToolCallIndex(TreeMap<Integer, ChatCompletionToolCall> aAccumulator,
+            Integer aIndex, String aId)
+    {
+        if (aIndex != null) {
+            return aIndex;
+        }
+
+        if (aId == null && !aAccumulator.isEmpty()) {
+            return aAccumulator.lastKey();
+        }
+
+        return aAccumulator.isEmpty() ? 0 : aAccumulator.lastKey() + 1;
     }
 
     private static ChatCompletionResponse assembleStreamedResponse(String aModel, String aRole,

--- a/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/chatgpt/client/ChatGptLlmChatClient.java
+++ b/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/chatgpt/client/ChatGptLlmChatClient.java
@@ -19,22 +19,36 @@ package de.tudarmstadt.ukp.inception.recommendation.imls.llm.chatgpt.client;
 
 import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.chatgpt.client.ChatGptResponseFormatType.JSON_OBJECT;
 import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.chatgpt.client.ChatGptResponseFormatType.JSON_SCHEMA;
+import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ChatOptionsTranslator.applyIfPresent;
+import static java.util.Collections.emptyList;
 
 import java.io.IOException;
-import java.util.List;
-
+import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
 
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ChatMessage;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ChatChunk;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ChatOptions;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ChatResult;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.FinishReason;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.LlmChatClient;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.LlmEndpoint;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ModelCapability;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ModelInfo;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ToolCall;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.UsageInfo;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.support.response.ResponseFormat;
 import de.tudarmstadt.ukp.inception.security.client.auth.apikey.ApiKeyAuthenticationTraits;
+import de.tudarmstadt.ukp.inception.support.json.JSONUtil;
+import tools.jackson.databind.JsonNode;
 
 /**
  * {@link LlmChatClient} adapter for the OpenAI chat-completions API (and OpenAI-compatible
@@ -46,6 +60,8 @@ public class ChatGptLlmChatClient
     implements LlmChatClient
 {
     public static final String ID = "openai";
+
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private final ChatGptClient client;
 
@@ -63,39 +79,187 @@ public class ChatGptLlmChatClient
     @Override
     public Set<ModelCapability> supportedCapabilities()
     {
-        return EnumSet.of(ModelCapability.CHAT, ModelCapability.JSON_SCHEMA);
+        return EnumSet.of( //
+                ModelCapability.CHAT, //
+                ModelCapability.JSON_SCHEMA, //
+                ModelCapability.STREAMING, //
+                ModelCapability.TOOLS);
     }
 
     @Override
     public ChatResult chat(LlmEndpoint aEndpoint, List<ChatMessage> aMessages, ChatOptions aOptions)
         throws IOException
     {
+        var request = buildChatRequest(aEndpoint, aMessages, aOptions, false);
+        var response = client.chat(aEndpoint.url(), request);
+        return toChatResult(response);
+    }
+
+    @Override
+    public ChatResult chatStream(LlmEndpoint aEndpoint, List<ChatMessage> aMessages,
+            ChatOptions aOptions, Consumer<ChatChunk> aOnChunk)
+        throws IOException
+    {
+        var request = buildChatRequest(aEndpoint, aMessages, aOptions, true);
+        // OpenAI standard chat has no separate thinking channel, so only the content delta is
+        // surfaced; thinking stays null.
+        Consumer<String> contentCallback = delta -> aOnChunk.accept(new ChatChunk(delta, null));
+        var response = client.chat(aEndpoint.url(), request, contentCallback);
+        return toChatResult(response);
+    }
+
+    private ChatCompletionRequest buildChatRequest(LlmEndpoint aEndpoint,
+            List<ChatMessage> aMessages, ChatOptions aOptions, boolean aStream)
+    {
         var messages = aMessages.stream() //
-                .map(m -> new ChatCompletionMessage(m.role().getName(), m.content())) //
+                .map(ChatGptLlmChatClient::toChatCompletionMessage) //
                 .toList();
 
         var builder = ChatCompletionRequest.builder() //
                 .withApiKey(apiKey(aEndpoint)) //
                 .withModel(aEndpoint.model()) //
                 .withMessages(messages) //
-                .withResponseFormat(toResponseFormat(aOptions));
+                .withResponseFormat(toResponseFormat(aOptions)) //
+                .withStream(aStream);
 
         // Translate the provider-neutral fields to OpenAI's parameters; explicit options below
         // override them.
-        if (aOptions.temperature() != null) {
-            builder.withOption(ChatCompletionRequest.TEMPERATURE, aOptions.temperature());
-        }
-        if (aOptions.topP() != null) {
-            builder.withOption(ChatCompletionRequest.TOP_P, aOptions.topP());
-        }
+        applyIfPresent(aOptions.temperature(),
+                v -> builder.withOption(ChatCompletionRequest.TEMPERATURE, v));
+        applyIfPresent(aOptions.topP(), v -> builder.withOption(ChatCompletionRequest.TOP_P, v));
 
         if (aOptions.options() != null) {
             builder.withExtraOptions(aOptions.options());
         }
 
-        var responseText = client.chat(aEndpoint.url(), builder.build()).trim();
+        if (aOptions.tools() != null && !aOptions.tools().isEmpty()) {
+            builder.withTools(aOptions.tools());
+        }
 
-        return ChatResult.of(new ChatMessage(ChatMessage.Role.ASSISTANT, responseText));
+        return builder.build();
+    }
+
+    private static ChatCompletionMessage toChatCompletionMessage(ChatMessage aMessage)
+    {
+        List<ChatCompletionToolCall> toolCalls = null;
+        if (aMessage.toolCalls() != null && !aMessage.toolCalls().isEmpty()) {
+            toolCalls = new ArrayList<>();
+            for (var call : aMessage.toolCalls()) {
+                toolCalls.add(toWireToolCall(call));
+            }
+        }
+
+        // OpenAI requires tool_call_id on tool-result (role=tool) messages so the model can match
+        // the result to its preceding call (unlike Ollama's positional matching).
+        return new ChatCompletionMessage(aMessage.role().getName(), aMessage.content(), toolCalls,
+                aMessage.toolCallId());
+    }
+
+    private static ChatCompletionToolCall toWireToolCall(ToolCall aCall)
+    {
+        var function = new ChatCompletionToolCall.Function();
+        function.setName(aCall.name());
+        // OpenAI carries the arguments as a JSON string, not an object.
+        function.setArguments(aCall.arguments() != null && !aCall.arguments().isNull() //
+                ? aCall.arguments().toString() //
+                : "{}");
+
+        var toolCall = new ChatCompletionToolCall();
+        toolCall.setId(aCall.id());
+        toolCall.setType("function");
+        toolCall.setFunction(function);
+        return toolCall;
+    }
+
+    private static ChatResult toChatResult(ChatCompletionResponse aResponse)
+    {
+        if (aResponse.getChoices() == null || aResponse.getChoices().isEmpty()) {
+            return new ChatResult(new ChatMessage(ChatMessage.Role.ASSISTANT, ""), emptyList(),
+                    null, toUsageInfo(aResponse.getUsage()));
+        }
+
+        var choice = aResponse.getChoices().get(0);
+        var message = choice.getMessage();
+
+        var content = message != null && message.getContent() != null ? message.getContent() : "";
+
+        var toolCalls = toToolCalls(message);
+
+        var finishReason = toFinishReason(choice.getFinishReason());
+
+        var usage = toUsageInfo(aResponse.getUsage());
+
+        return new ChatResult(new ChatMessage(ChatMessage.Role.ASSISTANT, content, null, null),
+                toolCalls, finishReason, usage);
+    }
+
+    private static List<ToolCall> toToolCalls(ChatCompletionMessage aMessage)
+    {
+        if (aMessage == null || aMessage.getToolCalls() == null
+                || aMessage.getToolCalls().isEmpty()) {
+            return emptyList();
+        }
+
+        var result = new ArrayList<ToolCall>();
+        for (var wireCall : aMessage.getToolCalls()) {
+            var name = wireCall.getFunction() != null ? wireCall.getFunction().getName() : null;
+            var arguments = wireCall.getFunction() != null ? wireCall.getFunction().getArguments()
+                    : null;
+            result.add(new ToolCall(wireCall.getId(), name, parseArguments(arguments)));
+        }
+        return result;
+    }
+
+    /**
+     * Parses the OpenAI tool-call {@code arguments} JSON <em>string</em> into a {@link JsonNode}. A
+     * malformed or non-object payload must not abort the whole turn, so on any parse failure - or
+     * if the payload does not represent a JSON object - an empty object node is returned instead.
+     */
+    private static JsonNode parseArguments(String aArguments)
+    {
+        if (aArguments == null || aArguments.isBlank()) {
+            return JSONUtil.getObjectMapper().createObjectNode();
+        }
+
+        try {
+            var node = JSONUtil.getObjectMapper().readTree(aArguments);
+            if (node == null || !node.isObject()) {
+                LOG.warn("Ignoring non-object tool-call arguments: [{}]", aArguments);
+                return JSONUtil.getObjectMapper().createObjectNode();
+            }
+            return node;
+        }
+        catch (Exception e) {
+            LOG.warn("Ignoring malformed tool-call arguments: [{}]", aArguments, e);
+            return JSONUtil.getObjectMapper().createObjectNode();
+        }
+    }
+
+    private static FinishReason toFinishReason(String aFinishReason)
+    {
+        if (aFinishReason == null) {
+            return null;
+        }
+
+        return switch (aFinishReason) {
+        case "stop" -> FinishReason.STOP;
+        case "length" -> FinishReason.LENGTH;
+        case "tool_calls" -> FinishReason.TOOL_CALLS;
+        case "content_filter" -> FinishReason.CONTENT_FILTER;
+        default -> FinishReason.OTHER;
+        };
+    }
+
+    private static UsageInfo toUsageInfo(ChatCompletionUsage aUsage)
+    {
+        if (aUsage == null) {
+            return null;
+        }
+
+        return new UsageInfo( //
+                aUsage.getPromptTokens() != 0 ? (int) aUsage.getPromptTokens() : null, //
+                aUsage.getCompletionTokens() != 0 ? (int) aUsage.getCompletionTokens() : null, //
+                aUsage.getTotalTokens() != 0 ? (int) aUsage.getTotalTokens() : null);
     }
 
     @Override

--- a/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/chatgpt/client/ChatGptLlmChatClient.java
+++ b/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/chatgpt/client/ChatGptLlmChatClient.java
@@ -80,6 +80,15 @@ public class ChatGptLlmChatClient
                 .withMessages(messages) //
                 .withResponseFormat(toResponseFormat(aOptions));
 
+        // Translate the provider-neutral fields to OpenAI's parameters; explicit options below
+        // override them.
+        if (aOptions.temperature() != null) {
+            builder.withOption(ChatCompletionRequest.TEMPERATURE, aOptions.temperature());
+        }
+        if (aOptions.topP() != null) {
+            builder.withOption(ChatCompletionRequest.TOP_P, aOptions.topP());
+        }
+
         if (aOptions.options() != null) {
             builder.withExtraOptions(aOptions.options());
         }

--- a/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/chatgpt/client/ChatGptLlmChatClient.java
+++ b/inception/inception-imls-chatgpt/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/chatgpt/client/ChatGptLlmChatClient.java
@@ -39,10 +39,12 @@ import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ChatChunk;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ChatOptions;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ChatResult;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.FinishReason;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.JsonResponseSanitizer;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.LlmChatClient;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.LlmEndpoint;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ModelCapability;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ModelInfo;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ReasoningEffort;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ToolCall;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.UsageInfo;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.support.response.ResponseFormat;
@@ -92,7 +94,10 @@ public class ChatGptLlmChatClient
     {
         var request = buildChatRequest(aEndpoint, aMessages, aOptions, false);
         var response = client.chat(aEndpoint.url(), request);
-        return toChatResult(response);
+        // Trim surrounding whitespace as the pre-refactor path did. Only on the non-streaming path:
+        // the streaming path forwards raw deltas to the caller, so trimming the final content there
+        // would make it disagree with what was already streamed.
+        return trimContent(toChatResult(response, aOptions.isJsonRequested()));
     }
 
     @Override
@@ -105,7 +110,7 @@ public class ChatGptLlmChatClient
         // surfaced; thinking stays null.
         Consumer<String> contentCallback = delta -> aOnChunk.accept(new ChatChunk(delta, null));
         var response = client.chat(aEndpoint.url(), request, contentCallback);
-        return toChatResult(response);
+        return toChatResult(response, aOptions.isJsonRequested());
     }
 
     private ChatCompletionRequest buildChatRequest(LlmEndpoint aEndpoint,
@@ -127,6 +132,10 @@ public class ChatGptLlmChatClient
         applyIfPresent(aOptions.temperature(),
                 v -> builder.withOption(ChatCompletionRequest.TEMPERATURE, v));
         applyIfPresent(aOptions.topP(), v -> builder.withOption(ChatCompletionRequest.TOP_P, v));
+        // OpenAI reasoning_effort only accepts low/medium/high; the neutral effort is clamped and
+        // MODEL_DEFAULT/NONE map to null (field omitted) by toOpenAiReasoningEffort.
+        applyIfPresent(toOpenAiReasoningEffort(aOptions.reasoningEffort()),
+                builder::withReasoningEffort);
 
         if (aOptions.options() != null) {
             builder.withExtraOptions(aOptions.options());
@@ -171,7 +180,7 @@ public class ChatGptLlmChatClient
         return toolCall;
     }
 
-    private static ChatResult toChatResult(ChatCompletionResponse aResponse)
+    private static ChatResult toChatResult(ChatCompletionResponse aResponse, boolean aJsonRequested)
     {
         if (aResponse.getChoices() == null || aResponse.getChoices().isEmpty()) {
             return new ChatResult(new ChatMessage(ChatMessage.Role.ASSISTANT, ""), emptyList(),
@@ -182,6 +191,7 @@ public class ChatGptLlmChatClient
         var message = choice.getMessage();
 
         var content = message != null && message.getContent() != null ? message.getContent() : "";
+        content = JsonResponseSanitizer.stripCodeFenceIf(aJsonRequested, content);
 
         var toolCalls = toToolCalls(message);
 
@@ -191,6 +201,19 @@ public class ChatGptLlmChatClient
 
         return new ChatResult(new ChatMessage(ChatMessage.Role.ASSISTANT, content, null, null),
                 toolCalls, finishReason, usage);
+    }
+
+    private static ChatResult trimContent(ChatResult aResult)
+    {
+        var message = aResult.message();
+        if (message == null || message.content() == null) {
+            return aResult;
+        }
+
+        var trimmed = new ChatMessage(message.role(), message.content().trim(), message.thinking(),
+                message.toolCallId(), message.toolCalls());
+        return new ChatResult(trimmed, aResult.toolCalls(), aResult.finishReason(),
+                aResult.usage());
     }
 
     private static List<ToolCall> toToolCalls(ChatCompletionMessage aMessage)
@@ -304,5 +327,32 @@ public class ChatGptLlmChatClient
         }
 
         return null;
+    }
+
+    /**
+     * Maps the neutral {@link ReasoningEffort} to the OpenAI {@code reasoning_effort} wire value,
+     * which only accepts {@code low}/{@code medium}/{@code high}.
+     * {@link ReasoningEffort#MODEL_DEFAULT} returns {@code null} so the field is omitted.
+     * {@link ReasoningEffort#NONE} also returns {@code null} and thereby <em>degrades</em> to the
+     * model default: OpenAI has no "off" switch, so unlike Ollama we cannot suppress reasoning —
+     * omitting the field lets a reasoning model reason at its default and a non-reasoning model
+     * ignore it. {@link ReasoningEffort#MAX} clamps to {@code high} (there is no higher wire
+     * level).
+     *
+     * @param aEffort
+     *            the neutral effort, possibly {@code null}
+     * @return the wire value, or {@code null} to omit the field
+     */
+    private static String toOpenAiReasoningEffort(ReasoningEffort aEffort)
+    {
+        if (aEffort == null) {
+            return null;
+        }
+        return switch (aEffort) {
+        case MODEL_DEFAULT, NONE -> null;
+        case LOW -> "low";
+        case MEDIUM -> "medium";
+        case HIGH, MAX -> "high";
+        };
     }
 }

--- a/inception/inception-imls-chatgpt/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/chatgpt/client/ChatCompletionMessageTest.java
+++ b/inception/inception-imls-chatgpt/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/chatgpt/client/ChatCompletionMessageTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.imls.llm.chatgpt.client;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import de.tudarmstadt.ukp.inception.support.json.JSONUtil;
+
+class ChatCompletionMessageTest
+{
+    /**
+     * OpenAI/Azure return HTTP 400 if a {@code role:tool} message in a multi-round tool loop is
+     * sent without the {@code tool_call_id} of the call it answers. This guards that the id
+     * survives serialization (it is {@code @JsonInclude(NON_NULL)}).
+     */
+    @Test
+    void thatToolResultMessageSerializesToolCallId() throws Exception
+    {
+        var message = new ChatCompletionMessage("tool", "sunny", null, "call_abc123");
+
+        var json = JSONUtil.getObjectMapper().valueToTree(message);
+
+        assertThat(json.get("tool_call_id")).isNotNull();
+        assertThat(json.get("tool_call_id").asText()).isEqualTo("call_abc123");
+    }
+
+    /**
+     * When re-sending the conversation history, the assistant message that requested the tool must
+     * echo the call {@code id} so the following {@code role:tool} result can be correlated.
+     */
+    @Test
+    void thatAssistantToolCallSerializesId() throws Exception
+    {
+        var function = new ChatCompletionToolCall.Function();
+        function.setName("get_current_weather");
+        function.setArguments("{\"location\":\"Berlin\"}");
+        var toolCall = new ChatCompletionToolCall();
+        toolCall.setId("call_abc123");
+        toolCall.setType("function");
+        toolCall.setFunction(function);
+
+        var message = new ChatCompletionMessage("assistant", "", List.of(toolCall), null);
+
+        var json = JSONUtil.getObjectMapper().valueToTree(message);
+
+        assertThat(json.get("tool_calls")).isNotNull();
+        assertThat(json.get("tool_calls").get(0).get("id").asText()).isEqualTo("call_abc123");
+        // A pure tool-request assistant message carries no tool_call_id itself.
+        assertThat(json.get("tool_call_id")).isNull();
+    }
+
+    /**
+     * Non-tool messages must not emit a {@code tool_call_id} field at all - an explicit
+     * {@code null} would be rejected by strict validators.
+     */
+    @Test
+    void thatPlainMessageOmitsToolCallId() throws Exception
+    {
+        var message = new ChatCompletionMessage("user", "Hello", emptyList(), null);
+
+        var json = JSONUtil.getObjectMapper().valueToTree(message);
+
+        assertThat(json.get("tool_call_id")).isNull();
+    }
+}

--- a/inception/inception-imls-chatgpt/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/chatgpt/client/ChatGptLlmChatClientIntegrationTest.java
+++ b/inception/inception-imls-chatgpt/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/chatgpt/client/ChatGptLlmChatClientIntegrationTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.imls.llm.chatgpt.client;
+
+import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.ChatMessage.Role.USER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import java.lang.invoke.MethodHandles;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ChatMessage;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ChatOptions;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.LlmEndpoint;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.support.response.ResponseFormat;
+import de.tudarmstadt.ukp.inception.security.client.auth.apikey.ApiKeyAuthenticationTraits;
+import de.tudarmstadt.ukp.inception.support.json.JSONUtil;
+import de.tudarmstadt.ukp.inception.support.test.http.HttpTestUtils;
+
+/**
+ * Exercises {@link ChatGptLlmChatClient} against Ollama's OpenAI-compatible endpoint. The
+ * {@code /v1} path segment is appended by the client, so the endpoint URL points at the Ollama
+ * root. Requires a local Ollama with {@code ministral-3:8b} pulled; skipped otherwise.
+ */
+class ChatGptLlmChatClientIntegrationTest
+{
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    private static final String OLLAMA_URL = "http://localhost:11434";
+    private static final String MODEL = "ministral-3:8b";
+
+    private final ChatGptLlmChatClient sut = new ChatGptLlmChatClient(new ChatGptClientImpl());
+
+    @BeforeAll
+    static void checkIfOllamaIsRunning()
+    {
+        assumeThat(HttpTestUtils.checkURL(OLLAMA_URL)).isTrue();
+    }
+
+    private static LlmEndpoint endpoint(String aModel)
+    {
+        var auth = new ApiKeyAuthenticationTraits();
+        auth.setApiKey("not-used-by-ollama");
+        return new LlmEndpoint(ChatGptLlmChatClient.ID, OLLAMA_URL, aModel, auth);
+    }
+
+    @Test
+    void testChat() throws Exception
+    {
+        var messages = List.of(new ChatMessage(USER, "Tell me a joke in one sentence."));
+
+        var result = sut.chat(endpoint(MODEL), messages, ChatOptions.defaults());
+
+        LOG.info("Response: [{}]", result.message().content());
+        assertThat(result.message().content()).isNotBlank();
+        assertThat(result.message().role()).isEqualTo(ChatMessage.Role.ASSISTANT);
+    }
+
+    @Test
+    void testChatWithJsonResponseFormat() throws Exception
+    {
+        var messages = List.of(new ChatMessage(USER,
+                "Return a JSON object with the keys `a` set to 1 and `b` set to 2."));
+        var options = new ChatOptions(ResponseFormat.JSON, null, List.of(), null);
+
+        var result = sut.chat(endpoint(MODEL), messages, options);
+
+        LOG.info("Response: [{}]", result.message().content());
+        // Provider promised JSON object response; verify it parses.
+        assertThat(JSONUtil.getObjectMapper().readTree(result.message().content())).isNotNull();
+    }
+
+    @Test
+    void testListModels() throws Exception
+    {
+        var models = sut.listModels(endpoint(null));
+
+        LOG.info("Models: {}", models);
+        assertThat(models).extracting("id").contains(MODEL);
+    }
+}

--- a/inception/inception-imls-chatgpt/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/chatgpt/client/OpenAiClientIntegrationTest.java
+++ b/inception/inception-imls-chatgpt/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/chatgpt/client/OpenAiClientIntegrationTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.imls.llm.chatgpt.client;
+
+import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.chatgpt.ChatGptRecommenderTraits.OPENAI_API_URL;
+import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.chatgpt.client.ChatGptResponseFormatType.JSON_OBJECT;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import java.lang.invoke.MethodHandles;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class OpenAiClientIntegrationTest
+{
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    private static final String CHATGPT_BASE_URL = System.getProperty("chatgpt-base-url",
+            OPENAI_API_URL);
+    private static final String CHATGPT_API_KEY = System.getProperty("chatgpt-api-key");
+
+    private ChatGptClientImpl sut = new ChatGptClientImpl();
+
+    @BeforeAll
+    static void setupClass()
+    {
+        assumeThat(CHATGPT_BASE_URL).isNotBlank();
+        assumeThat(CHATGPT_API_KEY).isNotBlank();
+    }
+
+    @Test
+    void testNonStream() throws Exception
+    {
+        var response = sut.chat(CHATGPT_BASE_URL, ChatCompletionRequest.builder() //
+                .withApiKey(CHATGPT_API_KEY) //
+                .withPrompt("Tell me a joke.") //
+                .build());
+        LOG.info("Response: [{}]", response.getChoices().get(0).getMessage().getContent());
+    }
+
+    @Test
+    void testJson() throws Exception
+    {
+        var response = sut.chat(CHATGPT_BASE_URL, ChatCompletionRequest.builder() //
+                .withApiKey(CHATGPT_API_KEY) //
+                .withPrompt("Generate a JSON map with the key/value pairs `a = 1` and `b = 2`") //
+                .withResponseFormat(ChatGptResponseFormat.builder().withType(JSON_OBJECT).build()) //
+                .build());
+        LOG.info("Response: [{}]", response.getChoices().get(0).getMessage().getContent());
+    }
+
+    @Test
+    void testListModel() throws Exception
+    {
+        var response = sut.listModels(CHATGPT_BASE_URL, ListModelsRequest.builder() //
+                .withApiKey(CHATGPT_API_KEY) //
+                .build());
+        LOG.info("Response: [{}]", response);
+    }
+}

--- a/inception/inception-imls-chatgpt/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/chatgpt/client/OpenAiClientTest.java
+++ b/inception/inception-imls-chatgpt/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/chatgpt/client/OpenAiClientTest.java
@@ -87,4 +87,65 @@ class OpenAiClientTest
                 .isEqualTo("{\"city\":\"Berlin\"}");
         assertThat(response.getChoices().get(0).getFinishReason()).isEqualTo("tool_calls");
     }
+
+    @Test
+    void testSseToolCallFragmentsWithoutIndexAreMergedIntoOneCall() throws Exception
+    {
+        // Some OpenAI-compatible servers omit "index" on continuation chunks. The id-less
+        // continuation fragments must merge into the call started by the first (id-bearing)
+        // fragment rather than each spawning a fresh call.
+        var lines = List.of( //
+                "data: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"arguments\":\"\"}}]}}]}", //
+                "", //
+                "data: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"function\":{\"arguments\":\"{\\\"city\\\":\"}}]}}]}", //
+                "", //
+                "data: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"function\":{\"arguments\":\"\\\"Berlin\\\"}\"}}]}}]}", //
+                "", //
+                "data: {\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}]}", //
+                "", //
+                "data: [DONE]");
+
+        var response = sut.assembleSseStream(ServerSentEventReader.parse(lines.stream()), "m",
+                null);
+
+        var toolCalls = response.getChoices().get(0).getMessage().getToolCalls();
+        assertThat(toolCalls).hasSize(1);
+        assertThat(toolCalls.get(0).getId()).isEqualTo("call_1");
+        assertThat(toolCalls.get(0).getFunction().getName()).isEqualTo("get_weather");
+        assertThat(toolCalls.get(0).getFunction().getArguments())
+                .isEqualTo("{\"city\":\"Berlin\"}");
+    }
+
+    @Test
+    void testSseMultipleToolCallsWithoutIndexAreKeptSeparate() throws Exception
+    {
+        // Two distinct calls, each streamed as an id-bearing opener followed by an id-less
+        // continuation, all without "index". A new id must start a new call while id-less
+        // fragments extend the call opened most recently.
+        var lines = List.of( //
+                "data: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"get_weather\",\"arguments\":\"{\\\"city\\\":\"}}]}}]}", //
+                "", //
+                "data: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"function\":{\"arguments\":\"\\\"Berlin\\\"}\"}}]}}]}", //
+                "", //
+                "data: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"id\":\"call_2\",\"type\":\"function\",\"function\":{\"name\":\"get_time\",\"arguments\":\"{\\\"tz\\\":\"}}]}}]}", //
+                "", //
+                "data: {\"choices\":[{\"index\":0,\"delta\":{\"tool_calls\":[{\"function\":{\"arguments\":\"\\\"CET\\\"}\"}}]}}]}", //
+                "", //
+                "data: {\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}]}", //
+                "", //
+                "data: [DONE]");
+
+        var response = sut.assembleSseStream(ServerSentEventReader.parse(lines.stream()), "m",
+                null);
+
+        var toolCalls = response.getChoices().get(0).getMessage().getToolCalls();
+        assertThat(toolCalls).hasSize(2);
+        assertThat(toolCalls.get(0).getId()).isEqualTo("call_1");
+        assertThat(toolCalls.get(0).getFunction().getName()).isEqualTo("get_weather");
+        assertThat(toolCalls.get(0).getFunction().getArguments())
+                .isEqualTo("{\"city\":\"Berlin\"}");
+        assertThat(toolCalls.get(1).getId()).isEqualTo("call_2");
+        assertThat(toolCalls.get(1).getFunction().getName()).isEqualTo("get_time");
+        assertThat(toolCalls.get(1).getFunction().getArguments()).isEqualTo("{\"tz\":\"CET\"}");
+    }
 }

--- a/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/ChatBasedLlmRecommenderImplBase.java
+++ b/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/ChatBasedLlmRecommenderImplBase.java
@@ -20,7 +20,6 @@ package de.tudarmstadt.ukp.inception.recommendation.imls.llm;
 import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.support.prompt.PromptContextGenerator.VAR_EXAMPLES;
 import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.support.prompt.PromptContextGenerator.getPromptContextGenerator;
 import static de.tudarmstadt.ukp.inception.scheduling.ProgressScope.SCOPE_UNITS;
-import static java.util.Collections.emptyList;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.apache.commons.lang3.exception.ExceptionUtils.getRootCauseMessage;
 
@@ -164,7 +163,11 @@ public abstract class ChatBasedLlmRecommenderImplBase<T extends LlmRecommenderTr
                 traits.getAuthentication(), traits.getCapabilities());
 
         var options = recommenderDefaults(traits.getOptions());
-        var chatOptions = new ChatOptions(aResponseformat, aJsonSchema, emptyList(), options);
+        var chatOptions = ChatOptions.builder() //
+                .withResponseFormat(aResponseformat) //
+                .withJsonSchema(aJsonSchema) //
+                .withOptions(options) //
+                .build();
 
         var result = client.chat(endpoint, aPrompt, chatOptions);
         LOG.trace("[{}] response: [{}]", providerId, result.message().content());

--- a/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/ChatMessage.java
+++ b/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/ChatMessage.java
@@ -17,7 +17,13 @@
  */
 package de.tudarmstadt.ukp.inception.recommendation.imls.llm;
 
+import static java.util.Collections.emptyList;
+
+import java.util.List;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ToolCall;
 
 /**
  * A single chat message exchanged with the LLM.
@@ -32,12 +38,28 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
  * @param toolCallId
  *            for {@link Role#TOOL} messages, the id of the call this is the result of (set by the
  *            provider in the preceding assistant turn); {@code null} for all other roles
+ * @param toolCalls
+ *            for {@link Role#ASSISTANT} messages, the tool invocations the model requested on this
+ *            turn; carried back into the conversation history on subsequent turns so the model can
+ *            see its own prior calls. Never {@code null} — empty when the message carries no calls.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record ChatMessage(Role role, String content, String thinking, String toolCallId) {
+public record ChatMessage(Role role, String content, String thinking, String toolCallId,
+        List<ToolCall> toolCalls)
+{
+    public ChatMessage
+    {
+        toolCalls = toolCalls != null ? toolCalls : emptyList();
+    }
+
     public ChatMessage(Role aRole, String aContent)
     {
-        this(aRole, aContent, null, null);
+        this(aRole, aContent, null, null, emptyList());
+    }
+
+    public ChatMessage(Role aRole, String aContent, String aThinking, String aToolCallId)
+    {
+        this(aRole, aContent, aThinking, aToolCallId, emptyList());
     }
 
     public static enum Role

--- a/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/client/ChatOptions.java
+++ b/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/client/ChatOptions.java
@@ -30,8 +30,9 @@ import tools.jackson.databind.JsonNode;
 
 /**
  * Per-call generation parameters for {@link LlmChatClient#chat}. Provider-neutral knobs that most
- * providers share ({@link #temperature}, {@link #topP}) are first-class fields; anything without a
- * neutral equivalent (e.g. {@code num_ctx}, {@code top_k} for Ollama) rides in {@link #options}.
+ * providers share ({@link #temperature}, {@link #topP}, {@link #topK}, {@link #repeatPenalty},
+ * {@link #contextLength}) are first-class fields; anything without a neutral equivalent rides in
+ * {@link #options}.
  * <p>
  * Each adapter is responsible for translating the neutral fields into its backend's parameters (the
  * wire name is the adapter's to decide, not assumed here) and for letting matching {@link #options}
@@ -50,6 +51,12 @@ import tools.jackson.databind.JsonNode;
  *            sampling temperature, or {@code null} to leave the provider default
  * @param topP
  *            nucleus-sampling threshold, or {@code null} to leave the provider default
+ * @param topK
+ *            top-k sampling limit, or {@code null} to leave the provider default
+ * @param repeatPenalty
+ *            penalty applied to repeated tokens, or {@code null} to leave the provider default
+ * @param contextLength
+ *            size of the context window to use, or {@code null} to leave the provider default
  */
 public record ChatOptions( //
         ResponseFormat responseFormat, //
@@ -57,7 +64,10 @@ public record ChatOptions( //
         List<ToolDescriptor> tools, //
         Map<String, Object> options, //
         Double temperature, //
-        Double topP)
+        Double topP, //
+        Integer topK, //
+        Double repeatPenalty, //
+        Integer contextLength)
 {
     public ChatOptions
     {
@@ -71,7 +81,7 @@ public record ChatOptions( //
     public ChatOptions(ResponseFormat aResponseFormat, JsonNode aJsonSchema,
             List<ToolDescriptor> aTools, Map<String, Object> aOptions)
     {
-        this(aResponseFormat, aJsonSchema, aTools, aOptions, null, null);
+        this(aResponseFormat, aJsonSchema, aTools, aOptions, null, null, null, null, null);
     }
 
     public static ChatOptions defaults()
@@ -92,6 +102,9 @@ public record ChatOptions( //
         private Map<String, Object> options = emptyMap();
         private Double temperature;
         private Double topP;
+        private Integer topK;
+        private Double repeatPenalty;
+        private Integer contextLength;
 
         private Builder()
         {
@@ -133,9 +146,28 @@ public record ChatOptions( //
             return this;
         }
 
+        public Builder withTopK(Integer aTopK)
+        {
+            topK = aTopK;
+            return this;
+        }
+
+        public Builder withRepeatPenalty(Double aRepeatPenalty)
+        {
+            repeatPenalty = aRepeatPenalty;
+            return this;
+        }
+
+        public Builder withContextLength(Integer aContextLength)
+        {
+            contextLength = aContextLength;
+            return this;
+        }
+
         public ChatOptions build()
         {
-            return new ChatOptions(responseFormat, jsonSchema, tools, options, temperature, topP);
+            return new ChatOptions(responseFormat, jsonSchema, tools, options, temperature, topP,
+                    topK, repeatPenalty, contextLength);
         }
     }
 }

--- a/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/client/ChatOptions.java
+++ b/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/client/ChatOptions.java
@@ -57,6 +57,10 @@ import tools.jackson.databind.JsonNode;
  *            penalty applied to repeated tokens, or {@code null} to leave the provider default
  * @param contextLength
  *            size of the context window to use, or {@code null} to leave the provider default
+ * @param reasoningEffort
+ *            requested reasoning/thinking effort, or {@code null} /
+ *            {@link ReasoningEffort#MODEL_DEFAULT} to leave the model default (only meaningful for
+ *            models that support reasoning)
  */
 public record ChatOptions( //
         ResponseFormat responseFormat, //
@@ -67,7 +71,8 @@ public record ChatOptions( //
         Double topP, //
         Integer topK, //
         Double repeatPenalty, //
-        Integer contextLength)
+        Integer contextLength, //
+        ReasoningEffort reasoningEffort)
 {
     public ChatOptions
     {
@@ -81,12 +86,22 @@ public record ChatOptions( //
     public ChatOptions(ResponseFormat aResponseFormat, JsonNode aJsonSchema,
             List<ToolDescriptor> aTools, Map<String, Object> aOptions)
     {
-        this(aResponseFormat, aJsonSchema, aTools, aOptions, null, null, null, null, null);
+        this(aResponseFormat, aJsonSchema, aTools, aOptions, null, null, null, null, null, null);
     }
 
     public static ChatOptions defaults()
     {
         return new ChatOptions(null, null, emptyList(), emptyMap());
+    }
+
+    /**
+     * @return whether the caller requested JSON output, i.e. a {@link #jsonSchema()} was supplied
+     *         or the {@link #responseFormat()} is {@link ResponseFormat#JSON}. Adapters use this to
+     *         decide whether to unwrap a Markdown code fence from the model content.
+     */
+    public boolean isJsonRequested()
+    {
+        return jsonSchema != null || responseFormat == ResponseFormat.JSON;
     }
 
     public static Builder builder()
@@ -105,6 +120,7 @@ public record ChatOptions( //
         private Integer topK;
         private Double repeatPenalty;
         private Integer contextLength;
+        private ReasoningEffort reasoningEffort;
 
         private Builder()
         {
@@ -164,10 +180,16 @@ public record ChatOptions( //
             return this;
         }
 
+        public Builder withReasoningEffort(ReasoningEffort aReasoningEffort)
+        {
+            reasoningEffort = aReasoningEffort;
+            return this;
+        }
+
         public ChatOptions build()
         {
             return new ChatOptions(responseFormat, jsonSchema, tools, options, temperature, topP,
-                    topK, repeatPenalty, contextLength);
+                    topK, repeatPenalty, contextLength, reasoningEffort);
         }
     }
 }

--- a/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/client/ChatOptions.java
+++ b/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/client/ChatOptions.java
@@ -19,7 +19,9 @@ package de.tudarmstadt.ukp.inception.recommendation.imls.llm.client;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.unmodifiableMap;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -27,8 +29,13 @@ import de.tudarmstadt.ukp.inception.recommendation.imls.llm.support.response.Res
 import tools.jackson.databind.JsonNode;
 
 /**
- * Per-call generation parameters for {@link LlmChatClient#chat}. Provider-specific knobs
- * (temperature, top_p, seed, ...) ride in {@link #options}.
+ * Per-call generation parameters for {@link LlmChatClient#chat}. Provider-neutral knobs that most
+ * providers share ({@link #temperature}, {@link #topP}) are first-class fields; anything without a
+ * neutral equivalent (e.g. {@code num_ctx}, {@code top_k} for Ollama) rides in {@link #options}.
+ * <p>
+ * Each adapter is responsible for translating the neutral fields into its backend's parameters (the
+ * wire name is the adapter's to decide, not assumed here) and for letting matching {@link #options}
+ * entries override them.
  *
  * @param responseFormat
  *            requested response format, or {@code null} for unconstrained
@@ -37,16 +44,98 @@ import tools.jackson.databind.JsonNode;
  * @param tools
  *            tools the model may call; empty list disables tool calling
  * @param options
- *            free-form provider-specific options (temperature, top_p, seed, ...)
+ *            free-form provider-specific options; keys must match the provider's wire API. Override
+ *            the typed fields on key collision.
+ * @param temperature
+ *            sampling temperature, or {@code null} to leave the provider default
+ * @param topP
+ *            nucleus-sampling threshold, or {@code null} to leave the provider default
  */
 public record ChatOptions( //
         ResponseFormat responseFormat, //
         JsonNode jsonSchema, //
         List<ToolDescriptor> tools, //
-        Map<String, Object> options)
+        Map<String, Object> options, //
+        Double temperature, //
+        Double topP)
 {
+    public ChatOptions
+    {
+        // Defensively copy so the record owns immutable collections regardless of how it was built
+        // (canonical/convenience constructor or builder) and cannot be mutated through a retained
+        // caller reference.
+        tools = tools != null ? List.copyOf(tools) : emptyList();
+        options = options != null ? unmodifiableMap(new LinkedHashMap<>(options)) : emptyMap();
+    }
+
+    public ChatOptions(ResponseFormat aResponseFormat, JsonNode aJsonSchema,
+            List<ToolDescriptor> aTools, Map<String, Object> aOptions)
+    {
+        this(aResponseFormat, aJsonSchema, aTools, aOptions, null, null);
+    }
+
     public static ChatOptions defaults()
     {
         return new ChatOptions(null, null, emptyList(), emptyMap());
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static final class Builder
+    {
+        private ResponseFormat responseFormat;
+        private JsonNode jsonSchema;
+        private List<ToolDescriptor> tools = emptyList();
+        private Map<String, Object> options = emptyMap();
+        private Double temperature;
+        private Double topP;
+
+        private Builder()
+        {
+        }
+
+        public Builder withResponseFormat(ResponseFormat aResponseFormat)
+        {
+            responseFormat = aResponseFormat;
+            return this;
+        }
+
+        public Builder withJsonSchema(JsonNode aJsonSchema)
+        {
+            jsonSchema = aJsonSchema;
+            return this;
+        }
+
+        public Builder withTools(List<ToolDescriptor> aTools)
+        {
+            tools = aTools != null ? aTools : emptyList();
+            return this;
+        }
+
+        public Builder withOptions(Map<String, Object> aOptions)
+        {
+            options = aOptions != null ? aOptions : emptyMap();
+            return this;
+        }
+
+        public Builder withTemperature(Double aTemperature)
+        {
+            temperature = aTemperature;
+            return this;
+        }
+
+        public Builder withTopP(Double aTopP)
+        {
+            topP = aTopP;
+            return this;
+        }
+
+        public ChatOptions build()
+        {
+            return new ChatOptions(responseFormat, jsonSchema, tools, options, temperature, topP);
+        }
     }
 }

--- a/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/client/ChatOptionsTranslator.java
+++ b/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/client/ChatOptionsTranslator.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.imls.llm.client;
+
+import java.util.function.Consumer;
+
+/**
+ * Helpers shared by the {@link LlmChatClient} adapters when translating the provider-neutral
+ * {@link ChatOptions} fields into their backend's parameters.
+ * <p>
+ * The wire names differ per provider (and some neutral knobs have no equivalent at all on a given
+ * backend), so this helper deliberately does not know any wire names. It only factors out the
+ * null-check-and-apply pattern that every adapter repeats: each adapter drives it with its own
+ * builder setter and wire name.
+ */
+public final class ChatOptionsTranslator
+{
+    private ChatOptionsTranslator()
+    {
+        // No instances
+    }
+
+    /**
+     * Invokes {@code aSetter} with {@code aValue} only when the value is present
+     * (non-{@code null}), mirroring "leave the provider default when the neutral field was not
+     * set".
+     *
+     * @param aValue
+     *            the neutral option value, possibly {@code null}
+     * @param aSetter
+     *            the adapter-specific action applying the value to its request builder
+     */
+    public static <T> void applyIfPresent(T aValue, Consumer<T> aSetter)
+    {
+        if (aValue != null) {
+            aSetter.accept(aValue);
+        }
+    }
+}

--- a/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/client/JsonResponseSanitizer.java
+++ b/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/client/JsonResponseSanitizer.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.imls.llm.client;
+
+import java.util.regex.Pattern;
+
+/**
+ * Cleans up model chat content that was requested as JSON but came back wrapped in a Markdown code
+ * fence. Some models (observed with qwen3.5 in Ollama's JSON mode) emit
+ * <code>```json\n{...}\n```</code> even when a JSON response format or schema was requested, which
+ * makes a downstream {@code readTree}/{@code readValue} of the content fail. The adapters call this
+ * only when JSON output was requested, so ordinary prose that happens to contain a fenced block is
+ * never touched.
+ */
+public final class JsonResponseSanitizer
+{
+    // Optional leading fence (``` or ~~~) with an optional language tag on the same line, and the
+    // matching trailing fence. DOTALL so the JSON body may span multiple lines; the body is
+    // captured reluctantly so a trailing fence is not swallowed into it.
+    private static final Pattern FENCED = Pattern.compile( //
+            "^\\s*(?:```|~~~)[ \\t]*[a-zA-Z0-9_-]*[ \\t]*\\R(.*?)\\R?[ \\t]*(?:```|~~~)\\s*$", //
+            Pattern.DOTALL);
+
+    private JsonResponseSanitizer()
+    {
+        // No instances
+    }
+
+    /**
+     * Strips a single surrounding Markdown code fence from {@code aContent} if the whole string is
+     * exactly one fenced block; otherwise returns {@code aContent} unchanged. {@code null} is
+     * returned as-is.
+     *
+     * @param aContent
+     *            the raw model content, possibly fence-wrapped
+     * @return the unwrapped content, or the original when there is no enclosing fence
+     */
+    public static String stripCodeFence(String aContent)
+    {
+        if (aContent == null) {
+            return null;
+        }
+
+        var matcher = FENCED.matcher(aContent);
+        if (matcher.matches()) {
+            return matcher.group(1);
+        }
+
+        return aContent;
+    }
+
+    /**
+     * Convenience guard for the common adapter case: only unwrap the fence when JSON output was
+     * actually requested. Some models wrap JSON-mode output in a Markdown code fence; unwrapping it
+     * lets downstream JSON parsing of the content succeed. When {@code aJsonRequested} is
+     * {@code false} the content is returned untouched, so ordinary prose that happens to contain a
+     * fenced block is never altered.
+     *
+     * @param aJsonRequested
+     *            whether the caller requested JSON output (see
+     *            {@link ChatOptions#isJsonRequested()})
+     * @param aContent
+     *            the raw model content, possibly fence-wrapped
+     * @return the unwrapped content when JSON was requested and a fence was present; otherwise
+     *         {@code aContent} unchanged
+     */
+    public static String stripCodeFenceIf(boolean aJsonRequested, String aContent)
+    {
+        return aJsonRequested ? stripCodeFence(aContent) : aContent;
+    }
+}

--- a/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/client/LlmChatClient.java
+++ b/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/client/LlmChatClient.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 
@@ -117,5 +118,17 @@ public interface LlmChatClient
     default List<ModelInfo> listModels(LlmEndpoint aEndpoint) throws IOException
     {
         return List.of();
+    }
+
+    /**
+     * Describe the model configured on the endpoint, so the assistant can auto-detect its context
+     * window and declared capabilities instead of assuming a specific provider. Returns
+     * {@link Optional#empty()} when the provider exposes no such introspection API (the caller then
+     * keeps its configured defaults). Adapters translate their backend's own capability tokens into
+     * {@link ModelCapability} values.
+     */
+    default Optional<ModelDetails> describeModel(LlmEndpoint aEndpoint) throws IOException
+    {
+        return Optional.empty();
     }
 }

--- a/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/client/ModelDetails.java
+++ b/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/client/ModelDetails.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.imls.llm.client;
+
+import static java.util.Collections.emptySet;
+
+import java.util.Set;
+
+/**
+ * Provider-neutral description of a configured model, as reported by
+ * {@link LlmChatClient#describeModel}. Distinct from {@link ModelInfo}, which is a lightweight
+ * discovery entry (id/display name) returned by {@link LlmChatClient#listModels}: this type carries
+ * the richer per-model properties the assistant uses to auto-configure itself (context window size
+ * and the capabilities the model declares).
+ * <p>
+ * Any field may be absent when the provider does not expose it: {@code contextLength} is
+ * {@code null} when unknown, and {@code capabilities} is empty when the provider does not report a
+ * capability list. Adapters translate their backend's own capability tokens into
+ * {@link ModelCapability} values.
+ *
+ * @param contextLength
+ *            the model's context window in tokens, or {@code null} if the provider did not report
+ *            it
+ * @param capabilities
+ *            capabilities the model declares; empty when the provider does not report them
+ */
+public record ModelDetails( //
+        Integer contextLength, //
+        Set<ModelCapability> capabilities)
+{
+    public ModelDetails
+    {
+        capabilities = capabilities != null ? Set.copyOf(capabilities) : emptySet();
+    }
+}

--- a/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/client/ReasoningEffort.java
+++ b/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/client/ReasoningEffort.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.imls.llm.client;
+
+/**
+ * Provider-neutral requested reasoning/thinking effort for a chat call. Adapters translate this to
+ * whatever their backend supports and degrade levels the backend lacks (see the per-adapter
+ * translation). Only meaningful for models that support reasoning; ignored otherwise.
+ * <p>
+ * {@link #MODEL_DEFAULT} (or a {@code null} {@code ChatOptions.reasoningEffort()}) leaves the
+ * choice to the model — the adapter sends no effort/thinking field on the wire.
+ */
+public enum ReasoningEffort
+{
+    /** Leave the effort to the model default; the adapter sends nothing on the wire. */
+    MODEL_DEFAULT,
+
+    /**
+     * Explicitly suppress reasoning where the backend supports turning it off (e.g. Ollama sends
+     * {@code think: false}). Backends without an "off" switch degrade this to the model default:
+     * the OpenAI/Azure {@code reasoning_effort} field only accepts {@code low}/{@code medium}/
+     * {@code high}, so {@code NONE} there behaves like {@link #MODEL_DEFAULT} (the field is
+     * omitted) and a reasoning model still reasons at its default.
+     */
+    NONE,
+
+    LOW,
+
+    MEDIUM,
+
+    HIGH,
+
+    /**
+     * Highest available reasoning; adapters clamp to their maximum when they have no {@code max}.
+     */
+    MAX;
+}

--- a/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/client/ServerSentEvent.java
+++ b/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/client/ServerSentEvent.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.imls.llm.client;
+
+/**
+ * A single dispatched server-sent event, as interpreted per the
+ * <a href="https://html.spec.whatwg.org/multipage/server-sent-events.html">WHATWG event-stream
+ * specification</a>. Multi-line {@code data:} fields have already been folded into {@link #data()}
+ * (joined with {@code \n}). Any field absent from the event is {@code null}.
+ *
+ * @param event
+ *            the {@code event:} field, or {@code null} (the spec default type is {@code message})
+ * @param data
+ *            the folded {@code data:} payload; never {@code null} for a dispatched event (events
+ *            without a data field are not dispatched)
+ * @param id
+ *            the {@code id:} field, or {@code null}
+ * @param retry
+ *            the {@code retry:} reconnection time in milliseconds, or {@code null} if absent or not
+ *            a valid integer
+ */
+public record ServerSentEvent( //
+        String event, //
+        String data, //
+        String id, //
+        Long retry)
+{}

--- a/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/client/ServerSentEventReader.java
+++ b/inception/inception-imls-llm-support/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/client/ServerSentEventReader.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.imls.llm.client;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * Turns the already-line-split body of a {@code text/event-stream} response into a lazy stream of
+ * dispatched {@link ServerSentEvent}s, following the <a href=
+ * "https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation">WHATWG
+ * event-stream interpretation</a>: fields accumulate until a blank line dispatches the event,
+ * multiple {@code data:} fields fold into one payload joined with {@code \n}, a single leading
+ * space after the colon is stripped, lines starting with {@code :} are comments, and unrecognized
+ * fields are ignored. Events without a {@code data} field are not dispatched.
+ * <p>
+ * The framing is provider-neutral: it knows nothing about {@code [DONE]} sentinels or chunk JSON —
+ * those are the calling adapter's concern.
+ * <p>
+ * Deviation from the spec: a pending event still buffered when the underlying line stream ends is
+ * flushed rather than discarded. The spec discards an event not terminated by a blank line, but
+ * real providers routinely omit the trailing blank line before closing the connection, so
+ * discarding it would drop the last chunk.
+ * <p>
+ * The returned stream is lazy and pulls from the source on demand; closing it closes the source, so
+ * a caller that breaks out early (e.g. on a {@code [DONE]} payload) stops reading the connection.
+ */
+public final class ServerSentEventReader
+{
+    private ServerSentEventReader()
+    {
+        // No instances
+    }
+
+    public static Stream<ServerSentEvent> parse(Stream<String> aLines)
+    {
+        var lineIterator = aLines.iterator();
+        var eventIterator = new EventIterator(lineIterator);
+        var spliterator = Spliterators.spliteratorUnknownSize(eventIterator,
+                Spliterator.ORDERED | Spliterator.NONNULL);
+        return StreamSupport.stream(spliterator, false).onClose(aLines::close);
+    }
+
+    private static final class EventIterator
+        implements Iterator<ServerSentEvent>
+    {
+        private final Iterator<String> lines;
+        private ServerSentEvent next;
+        private boolean exhausted;
+
+        EventIterator(Iterator<String> aLines)
+        {
+            lines = aLines;
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            if (next == null && !exhausted) {
+                next = readNext();
+                if (next == null) {
+                    exhausted = true;
+                }
+            }
+            return next != null;
+        }
+
+        @Override
+        public ServerSentEvent next()
+        {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+            var result = next;
+            next = null;
+            return result;
+        }
+
+        /**
+         * Reads lines until an event dispatches (blank line terminating a block that had a
+         * {@code data} field) or the source is exhausted, flushing any trailing event on EOF.
+         * Returns {@code null} once no further event can be produced.
+         */
+        private ServerSentEvent readNext()
+        {
+            var builder = new EventBuilder();
+
+            while (lines.hasNext()) {
+                var line = lines.next();
+
+                if (line.isEmpty()) {
+                    if (builder.hasData()) {
+                        return builder.build();
+                    }
+                    // Blank line with nothing buffered (or a comment-only block): reset and keep
+                    // looking rather than dispatching an empty event.
+                    builder = new EventBuilder();
+                    continue;
+                }
+
+                if (line.charAt(0) == ':') {
+                    // Comment line
+                    continue;
+                }
+
+                var colon = line.indexOf(':');
+                String field;
+                String value;
+                if (colon < 0) {
+                    field = line;
+                    value = "";
+                }
+                else {
+                    field = line.substring(0, colon);
+                    value = line.substring(colon + 1);
+                    // Strip a single leading space, per spec.
+                    if (!value.isEmpty() && value.charAt(0) == ' ') {
+                        value = value.substring(1);
+                    }
+                }
+
+                builder.field(field, value);
+            }
+
+            // EOF: flush a trailing event that never got its terminating blank line.
+            if (builder.hasData()) {
+                return builder.build();
+            }
+
+            return null;
+        }
+    }
+
+    private static final class EventBuilder
+    {
+        private String event;
+        private StringBuilder data;
+        private String id;
+        private Long retry;
+
+        boolean hasData()
+        {
+            return data != null;
+        }
+
+        void field(String aField, String aValue)
+        {
+            switch (aField) {
+            case "event":
+                event = aValue;
+                break;
+            case "data":
+                if (data == null) {
+                    data = new StringBuilder(aValue);
+                }
+                else {
+                    data.append('\n').append(aValue);
+                }
+                break;
+            case "id":
+                // Per spec, an id containing a NUL is ignored; otherwise it sets the last event id.
+                if (aValue.indexOf('\0') < 0) {
+                    id = aValue;
+                }
+                break;
+            case "retry":
+                try {
+                    retry = Long.valueOf(aValue);
+                }
+                catch (NumberFormatException e) {
+                    // Ignore a non-integer retry, per spec.
+                }
+                break;
+            default:
+                // Unknown field: ignore.
+                break;
+            }
+        }
+
+        ServerSentEvent build()
+        {
+            return new ServerSentEvent(event, data == null ? null : data.toString(), id, retry);
+        }
+    }
+}

--- a/inception/inception-imls-llm-support/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/client/JsonResponseSanitizerTest.java
+++ b/inception/inception-imls-llm-support/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/client/JsonResponseSanitizerTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.imls.llm.client;
+
+import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.JsonResponseSanitizer.stripCodeFence;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class JsonResponseSanitizerTest
+{
+    @Test
+    void thatLanguageTaggedFenceIsStripped()
+    {
+        // The exact shape observed from qwen3.5:4b in Ollama JSON mode.
+        var fenced = "```json\n{\n  \"a\": 1,\n  \"b\": 2\n}\n```";
+
+        assertThat(stripCodeFence(fenced)).isEqualTo("{\n  \"a\": 1,\n  \"b\": 2\n}");
+    }
+
+    @Test
+    void thatPlainFenceIsStripped()
+    {
+        assertThat(stripCodeFence("```\n{\"a\":1}\n```")).isEqualTo("{\"a\":1}");
+    }
+
+    @Test
+    void thatTildeFenceIsStripped()
+    {
+        assertThat(stripCodeFence("~~~json\n{\"a\":1}\n~~~")).isEqualTo("{\"a\":1}");
+    }
+
+    @Test
+    void thatSurroundingWhitespaceIsTolerated()
+    {
+        assertThat(stripCodeFence("  \n```json\n{\"a\":1}\n```  \n")).isEqualTo("{\"a\":1}");
+    }
+
+    @Test
+    void thatUnfencedJsonIsUnchanged()
+    {
+        assertThat(stripCodeFence("{\"a\":1}")).isEqualTo("{\"a\":1}");
+    }
+
+    @Test
+    void thatContentWithAnInlineFenceIsUnchanged()
+    {
+        // Not a whole-string fenced block, so it must be left alone.
+        var prose = "Here is the answer:\n```json\n{\"a\":1}\n```\nHope that helps!";
+
+        assertThat(stripCodeFence(prose)).isEqualTo(prose);
+    }
+
+    @Test
+    void thatNullIsReturnedAsIs()
+    {
+        assertThat(stripCodeFence(null)).isNull();
+    }
+
+    @Test
+    void thatEmptyStringIsUnchanged()
+    {
+        assertThat(stripCodeFence("")).isEmpty();
+    }
+}

--- a/inception/inception-imls-llm-support/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/client/ServerSentEventReaderTest.java
+++ b/inception/inception-imls-llm-support/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/client/ServerSentEventReaderTest.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.imls.llm.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+class ServerSentEventReaderTest
+{
+    private static List<ServerSentEvent> parse(String... aLines)
+    {
+        return ServerSentEventReader.parse(Stream.of(aLines)).toList();
+    }
+
+    @Test
+    void thatBlankLineDispatchesEvent()
+    {
+        var events = parse( //
+                "data: first", //
+                "", //
+                "data: second", //
+                "");
+
+        assertThat(events).extracting(ServerSentEvent::data) //
+                .containsExactly("first", "second");
+    }
+
+    @Test
+    void thatMultipleDataLinesAreFoldedWithNewline()
+    {
+        var events = parse( //
+                "data: line one", //
+                "data: line two", //
+                "");
+
+        assertThat(events).extracting(ServerSentEvent::data) //
+                .containsExactly("line one\nline two");
+    }
+
+    @Test
+    void thatEventAndIdFieldsAreParsed()
+    {
+        var events = parse( //
+                "event: message", //
+                "id: 42", //
+                "data: hello", //
+                "");
+
+        assertThat(events)
+                .extracting(ServerSentEvent::event, ServerSentEvent::id, ServerSentEvent::data)
+                .containsExactly(tuple("message", "42", "hello"));
+    }
+
+    @Test
+    void thatCommentLinesAreIgnored()
+    {
+        var events = parse( //
+                ": this is a comment", //
+                "data: payload", //
+                "");
+
+        assertThat(events).extracting(ServerSentEvent::data).containsExactly("payload");
+    }
+
+    @Test
+    void thatOnlySingleLeadingSpaceIsStripped()
+    {
+        var events = parse( //
+                "data:  two-leading-spaces", //
+                "");
+
+        // One leading space stripped, the second retained.
+        assertThat(events).extracting(ServerSentEvent::data).containsExactly(" two-leading-spaces");
+    }
+
+    @Test
+    void thatFieldWithoutColonHasEmptyValue()
+    {
+        var events = parse( //
+                "data", //
+                "");
+
+        assertThat(events).extracting(ServerSentEvent::data).containsExactly("");
+    }
+
+    @Test
+    void thatEventWithoutDataIsNotDispatched()
+    {
+        var events = parse( //
+                "event: ping", //
+                "", //
+                "data: real", //
+                "");
+
+        assertThat(events).extracting(ServerSentEvent::data).containsExactly("real");
+    }
+
+    @Test
+    void thatTrailingEventWithoutBlankLineIsFlushed()
+    {
+        var events = parse( //
+                "data: no-terminating-blank");
+
+        assertThat(events).extracting(ServerSentEvent::data)
+                .containsExactly("no-terminating-blank");
+    }
+
+    @Test
+    void thatUnknownFieldsAreIgnored()
+    {
+        var events = parse( //
+                "foo: bar", //
+                "data: kept", //
+                "");
+
+        assertThat(events).extracting(ServerSentEvent::data).containsExactly("kept");
+    }
+
+    @Test
+    void thatRetryIsParsedAndInvalidRetryIgnored()
+    {
+        var valid = parse("retry: 3000", "data: x", "");
+        assertThat(valid).extracting(ServerSentEvent::retry).containsExactly(3000L);
+
+        var invalid = parse("retry: soon", "data: x", "");
+        assertThat(invalid).extracting(ServerSentEvent::retry).containsOnlyNulls();
+    }
+}

--- a/inception/inception-imls-ollama/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/ollama/client/OllamaChatRequest.java
+++ b/inception/inception-imls-ollama/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/ollama/client/OllamaChatRequest.java
@@ -42,7 +42,9 @@ public class OllamaChatRequest
     private String model;
     private List<OllamaChatMessage> messages;
     private boolean stream;
-    private @JsonInclude(Include.NON_NULL) Boolean think;
+    // Ollama accepts a boolean (true/false) or a level string ("low"/"medium"/"high"/"max"),
+    // depending on the model; hence Object. null omits the field (model default).
+    private @JsonInclude(Include.NON_NULL) Object think;
     private @JsonInclude(Include.NON_NULL) JsonNode format;
     private @JsonInclude(Include.NON_DEFAULT) boolean raw;
     private @JsonInclude(Include.NON_EMPTY) Map<String, Object> options = new HashMap<>();
@@ -121,7 +123,9 @@ public class OllamaChatRequest
         private String model;
         private List<OllamaChatMessage> messages = new ArrayList<>();
         private final List<OllamaTool> tools = new ArrayList<>();
-        private Boolean think = false;
+        // null = omit the wire field so Ollama applies the model default (thinking models think,
+        // others don't). A Boolean forces on/off; a level string ("low".."max") tunes depth.
+        private Object think = null;
 
         private JsonNode format;
         private boolean raw;
@@ -222,8 +226,14 @@ public class OllamaChatRequest
             return this;
         }
 
-        // FIXME: ollama would also support low/medium/high for some models
-        public <T> Builder withThink(Boolean aThink)
+        /**
+         * @param aThink
+         *            {@code null} to omit the field (model default), {@link Boolean} to force
+         *            thinking on/off, or a level string ({@code "low"}/{@code "medium"}/
+         *            {@code "high"}/{@code "max"}) to tune reasoning depth. gpt-oss-style models
+         *            accept only the level strings.
+         */
+        public Builder withThink(Object aThink)
         {
             think = aThink;
             return this;

--- a/inception/inception-imls-ollama/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/ollama/client/OllamaLlmChatClient.java
+++ b/inception/inception-imls-ollama/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/ollama/client/OllamaLlmChatClient.java
@@ -17,7 +17,11 @@
  */
 package de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client;
 
+import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ChatOptionsTranslator.applyIfPresent;
+import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaOptions.NUM_CTX;
+import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaOptions.REPEAT_PENALTY;
 import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaOptions.TEMPERATURE;
+import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaOptions.TOP_K;
 import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaOptions.TOP_P;
 
 import java.io.IOException;
@@ -25,6 +29,7 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 
@@ -36,6 +41,7 @@ import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.FinishReason;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.LlmChatClient;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.LlmEndpoint;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ModelCapability;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ModelDetails;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ModelInfo;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ToolCall;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ToolDescriptor;
@@ -140,6 +146,48 @@ public class OllamaLlmChatClient
                 .toList();
     }
 
+    @Override
+    public Optional<ModelDetails> describeModel(LlmEndpoint aEndpoint) throws IOException
+    {
+        var response = client.getModelInfo(aEndpoint.url(), OllamaShowRequest.builder() //
+                .withModel(aEndpoint.model()) //
+                .withApiKey(apiKey(aEndpoint)) //
+                .build());
+
+        var contextLength = response.info() != null ? response.info().getContextLength() : null;
+
+        var capabilities = EnumSet.noneOf(ModelCapability.class);
+        if (response.capabilities() != null) {
+            response.capabilities().stream() //
+                    .map(OllamaLlmChatClient::toModelCapability) //
+                    .filter(c -> c != null) //
+                    .forEach(capabilities::add);
+        }
+
+        return Optional.of(new ModelDetails(contextLength, capabilities));
+    }
+
+    /**
+     * Translates one of Ollama's own capability tokens (as reported by {@code ollama show}) into
+     * the provider-neutral {@link ModelCapability}. Returns {@code null} for tokens that have no
+     * neutral equivalent (e.g. {@code insert}) or that are unknown, so callers can filter them out.
+     */
+    private static ModelCapability toModelCapability(String aOllamaCapability)
+    {
+        if (aOllamaCapability == null) {
+            return null;
+        }
+
+        return switch (aOllamaCapability) {
+        case "completion" -> ModelCapability.CHAT;
+        case "tools" -> ModelCapability.TOOLS;
+        case "vision" -> ModelCapability.VISION;
+        case "thinking" -> ModelCapability.THINKING;
+        case "embedding" -> ModelCapability.EMBEDDINGS;
+        default -> null; // e.g. "insert" - no neutral equivalent
+        };
+    }
+
     private OllamaChatRequest buildChatRequest(LlmEndpoint aEndpoint, List<ChatMessage> aMessages,
             ChatOptions aOptions, boolean aStream)
     {
@@ -157,12 +205,11 @@ public class OllamaLlmChatClient
 
         // Translate the provider-neutral fields to Ollama's parameters; explicit options below
         // override them.
-        if (aOptions.temperature() != null) {
-            builder.withOption(TEMPERATURE, aOptions.temperature());
-        }
-        if (aOptions.topP() != null) {
-            builder.withOption(TOP_P, aOptions.topP());
-        }
+        applyIfPresent(aOptions.temperature(), v -> builder.withOption(TEMPERATURE, v));
+        applyIfPresent(aOptions.topP(), v -> builder.withOption(TOP_P, v));
+        applyIfPresent(aOptions.contextLength(), v -> builder.withOption(NUM_CTX, v));
+        applyIfPresent(aOptions.topK(), v -> builder.withOption(TOP_K, v));
+        applyIfPresent(aOptions.repeatPenalty(), v -> builder.withOption(REPEAT_PENALTY, v));
 
         if (aOptions.options() != null) {
             builder.withExtraOptions(aOptions.options());

--- a/inception/inception-imls-ollama/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/ollama/client/OllamaLlmChatClient.java
+++ b/inception/inception-imls-ollama/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/ollama/client/OllamaLlmChatClient.java
@@ -169,7 +169,25 @@ public class OllamaLlmChatClient
     {
         // tool_call_id is not currently part of the OllamaChatMessage DTO; Ollama matches tool
         // results to calls positionally. Drop the id on the way out.
-        return new OllamaChatMessage(aMessage.role().getName(), aMessage.content());
+        var toolCalls = aMessage.toolCalls().stream() //
+                .map(OllamaLlmChatClient::toOllamaToolCall) //
+                .toList();
+        return new OllamaChatMessage(aMessage.role().getName(), aMessage.content(),
+                aMessage.thinking(), toolCalls);
+    }
+
+    private static OllamaToolCall toOllamaToolCall(ToolCall aCall)
+    {
+        var functionCall = new OllamaFunctionCall();
+        functionCall.setName(aCall.name());
+        if (aCall.arguments() != null && !aCall.arguments().isNull()) {
+            @SuppressWarnings("unchecked")
+            var arguments = JSONUtil.getObjectMapper().convertValue(aCall.arguments(), Map.class);
+            functionCall.setArguments(arguments);
+        }
+        var toolCall = new OllamaToolCall();
+        toolCall.setFunction(functionCall);
+        return toolCall;
     }
 
     private static OllamaTool toOllamaTool(ToolDescriptor aDescriptor)

--- a/inception/inception-imls-ollama/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/ollama/client/OllamaLlmChatClient.java
+++ b/inception/inception-imls-ollama/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/ollama/client/OllamaLlmChatClient.java
@@ -38,11 +38,13 @@ import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ChatChunk;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ChatOptions;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ChatResult;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.FinishReason;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.JsonResponseSanitizer;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.LlmChatClient;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.LlmEndpoint;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ModelCapability;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ModelDetails;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ModelInfo;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ReasoningEffort;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ToolCall;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ToolDescriptor;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.UsageInfo;
@@ -96,7 +98,7 @@ public class OllamaLlmChatClient
     {
         var request = buildChatRequest(aEndpoint, aMessages, aOptions, false);
         var response = client.chat(aEndpoint.url(), request);
-        return toChatResult(response);
+        return toChatResult(response, aOptions.isJsonRequested());
     }
 
     @Override
@@ -116,7 +118,7 @@ public class OllamaLlmChatClient
             aOnChunk.accept(new ChatChunk(msg.content(), msg.thinking()));
         };
         var response = client.chat(aEndpoint.url(), request, callback);
-        return toChatResult(response);
+        return toChatResult(response, aOptions.isJsonRequested());
     }
 
     @Override
@@ -200,7 +202,7 @@ public class OllamaLlmChatClient
                 .withModel(aEndpoint.model()) //
                 .withMessages(messages) //
                 .withFormat(toFormat(aOptions)) //
-                .withThink(false) //
+                .withThink(toThink(aOptions.reasoningEffort())) //
                 .withStream(aStream);
 
         // Translate the provider-neutral fields to Ollama's parameters; explicit options below
@@ -295,12 +297,13 @@ public class OllamaLlmChatClient
         return builder.build();
     }
 
-    private static ChatResult toChatResult(OllamaChatResponse aResponse)
+    private static ChatResult toChatResult(OllamaChatResponse aResponse, boolean aJsonRequested)
     {
         var ollamaMessage = aResponse.getMessage();
         var content = ollamaMessage != null && ollamaMessage.content() != null //
                 ? ollamaMessage.content() //
                 : "";
+        content = JsonResponseSanitizer.stripCodeFenceIf(aJsonRequested, content);
         var role = ollamaMessage != null && ollamaMessage.role() != null //
                 ? roleFromOllama(ollamaMessage.role()) //
                 : ChatMessage.Role.ASSISTANT;
@@ -358,6 +361,27 @@ public class OllamaLlmChatClient
             return JsonNodeFactory.instance.textNode("json");
         }
         return null;
+    }
+
+    /**
+     * Maps the neutral {@link ReasoningEffort} to Ollama's {@code think} wire value: {@code null} /
+     * {@code MODEL_DEFAULT} omit the field (model default), {@code NONE} sends {@code false}, and
+     * the levels pass through as their lowercase strings (Ollama honors {@code low}/{@code medium}/
+     * {@code high}/{@code max} on models that support them). Returns {@code null} to omit.
+     */
+    private static Object toThink(ReasoningEffort aEffort)
+    {
+        if (aEffort == null) {
+            return null;
+        }
+        return switch (aEffort) {
+        case MODEL_DEFAULT -> null;
+        case NONE -> Boolean.FALSE;
+        case LOW -> "low";
+        case MEDIUM -> "medium";
+        case HIGH -> "high";
+        case MAX -> "max";
+        };
     }
 
     private static String apiKey(LlmEndpoint aEndpoint)

--- a/inception/inception-imls-ollama/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/ollama/client/OllamaLlmChatClient.java
+++ b/inception/inception-imls-ollama/src/main/java/de/tudarmstadt/ukp/inception/recommendation/imls/llm/ollama/client/OllamaLlmChatClient.java
@@ -17,6 +17,9 @@
  */
 package de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client;
 
+import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaOptions.TEMPERATURE;
+import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaOptions.TOP_P;
+
 import java.io.IOException;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -151,6 +154,15 @@ public class OllamaLlmChatClient
                 .withFormat(toFormat(aOptions)) //
                 .withThink(false) //
                 .withStream(aStream);
+
+        // Translate the provider-neutral fields to Ollama's parameters; explicit options below
+        // override them.
+        if (aOptions.temperature() != null) {
+            builder.withOption(TEMPERATURE, aOptions.temperature());
+        }
+        if (aOptions.topP() != null) {
+            builder.withOption(TOP_P, aOptions.topP());
+        }
 
         if (aOptions.options() != null) {
             builder.withExtraOptions(aOptions.options());

--- a/inception/inception-imls-ollama/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/ollama/OllamaRecommenderTest.java
+++ b/inception/inception-imls-ollama/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/ollama/OllamaRecommenderTest.java
@@ -71,7 +71,7 @@ class OllamaRecommenderTest
 {
     private final static Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-    private static final String DEFAULT_MODEL = "ministral-3:8b";
+    private static final String DEFAULT_MODEL = "nemotron-3-nano:4b";
 
     private @Mock AnnotationSchemaService schemaSerivce;
 

--- a/inception/inception-imls-ollama/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/ollama/client/OllamaClientImplTest.java
+++ b/inception/inception-imls-ollama/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/ollama/client/OllamaClientImplTest.java
@@ -52,7 +52,7 @@ import tools.jackson.databind.node.JsonNodeFactory;
 
 class OllamaClientImplTest
 {
-    private static final String DEFAULT_MODEL = "ministral-3:8b";
+    private static final String DEFAULT_MODEL = "nemotron-3-nano:4b";
 
     private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 

--- a/inception/inception-imls-ollama/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/ollama/client/OllamaLlmChatClientIntegrationTest.java
+++ b/inception/inception-imls-ollama/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/ollama/client/OllamaLlmChatClientIntegrationTest.java
@@ -37,6 +37,7 @@ import de.tudarmstadt.ukp.inception.recommendation.imls.llm.Tool;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ToolParam;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ChatChunk;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ChatOptions;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ReasoningEffort;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.FinishReason;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.LlmEndpoint;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ToolDescriptor;
@@ -49,15 +50,18 @@ import de.tudarmstadt.ukp.inception.support.test.http.HttpTestUtils;
 
 /**
  * Exercises {@link OllamaLlmChatClient} against a locally running Ollama. Requires {@code
- * ministral-3:8b} and {@code granite-embedding:278m-fp16} to be pulled; skipped if no Ollama is
- * reachable.
+ * nemotron-3-nano:4b} (chat/tool/JSON/thinking) and {@code granite-embedding:278m-fp16}
+ * (embeddings) to be pulled; skipped if no Ollama is reachable.
  */
 class OllamaLlmChatClientIntegrationTest
 {
     private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-    private static final String CHAT_MODEL = "ministral-3:8b";
+    private static final String CHAT_MODEL = "nemotron-3-nano:4b";
     private static final String EMBED_MODEL = "granite-embedding:278m-fp16";
+    // nemotron-3-nano is a hybrid model: the same model serves the chat/tool/JSON tests and the
+    // thinking tests (it has a toggleable thinking channel).
+    private static final String THINKING_MODEL = CHAT_MODEL;
 
     private final OllamaLlmChatClient sut = new OllamaLlmChatClient(
             new OllamaClientImpl(HttpClient.newBuilder().build(), new OllamaMetricsImpl()));
@@ -87,6 +91,48 @@ class OllamaLlmChatClientIntegrationTest
         assertThat(result.finishReason()).isNotNull();
         assertThat(result.usage()).isNotNull();
         assertThat(result.usage().totalTokens()).isPositive();
+    }
+
+    /**
+     * A reasoning model, left at its default thinking behavior (the client no longer forces
+     * {@code think=false}), must still return a non-empty final answer in {@code content} — the
+     * reasoning goes into {@code thinking}, not instead of the answer.
+     */
+    @Test
+    void testChatWithThinkingModelDefault() throws Exception
+    {
+        var messages = List.of(new ChatMessage(USER, "What is 17 + 25? Answer briefly."));
+
+        var result = sut.chat(endpoint(THINKING_MODEL), messages, ChatOptions.defaults());
+
+        LOG.info("Content: [{}]", result.message().content());
+        LOG.info("Thinking: [{}]", result.message().thinking());
+        assertThat(result.message().content()) //
+                .as("final answer is not swallowed by the thinking output") //
+                .isNotBlank();
+    }
+
+    /**
+     * Explicitly requesting reasoning via {@link ChatOptions#reasoningEffort()} must surface the
+     * model's reasoning in {@code thinking} while still returning the final answer in
+     * {@code content}.
+     */
+    @Test
+    void testChatWithThinkingEnabled() throws Exception
+    {
+        var messages = List.of(new ChatMessage(USER, "What is 17 + 25? Answer briefly."));
+        var options = ChatOptions.builder().withReasoningEffort(ReasoningEffort.HIGH).build();
+
+        var result = sut.chat(endpoint(THINKING_MODEL), messages, options);
+
+        LOG.info("Content: [{}]", result.message().content());
+        LOG.info("Thinking: [{}]", result.message().thinking());
+        assertThat(result.message().thinking()) //
+                .as("reasoning is surfaced separately when reasoning effort is requested") //
+                .isNotBlank();
+        assertThat(result.message().content()) //
+                .as("final answer is still present alongside the thinking") //
+                .isNotBlank();
     }
 
     @Test

--- a/inception/inception-imls-ollama/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/ollama/client/OllamaLlmChatClientIntegrationTest.java
+++ b/inception/inception-imls-ollama/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/ollama/client/OllamaLlmChatClientIntegrationTest.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.recommendation.imls.ollama.client;
+
+import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.ChatMessage.Role.USER;
+import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.OllamaRecommenderTraits.DEFAULT_OLLAMA_URL;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import java.lang.invoke.MethodHandles;
+import java.net.http.HttpClient;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ChatMessage;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.Tool;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ToolParam;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ChatChunk;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ChatOptions;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.FinishReason;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.LlmEndpoint;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ToolDescriptor;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaClientImpl;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaLlmChatClient;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaMetricsImpl;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.support.response.ResponseFormat;
+import de.tudarmstadt.ukp.inception.support.json.JSONUtil;
+import de.tudarmstadt.ukp.inception.support.test.http.HttpTestUtils;
+
+/**
+ * Exercises {@link OllamaLlmChatClient} against a locally running Ollama. Requires {@code
+ * ministral-3:8b} and {@code granite-embedding:278m-fp16} to be pulled; skipped if no Ollama is
+ * reachable.
+ */
+class OllamaLlmChatClientIntegrationTest
+{
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    private static final String CHAT_MODEL = "ministral-3:8b";
+    private static final String EMBED_MODEL = "granite-embedding:278m-fp16";
+
+    private final OllamaLlmChatClient sut = new OllamaLlmChatClient(
+            new OllamaClientImpl(HttpClient.newBuilder().build(), new OllamaMetricsImpl()));
+
+    @BeforeAll
+    static void checkIfOllamaIsRunning()
+    {
+        assumeThat(HttpTestUtils.checkURL(DEFAULT_OLLAMA_URL)).isTrue();
+    }
+
+    private static LlmEndpoint endpoint(String aModel)
+    {
+        return new LlmEndpoint(OllamaLlmChatClient.ID, DEFAULT_OLLAMA_URL, aModel, null);
+    }
+
+    @Test
+    void testChat() throws Exception
+    {
+        var messages = List.of(new ChatMessage(USER, "Tell me a joke in one sentence."));
+
+        var result = sut.chat(endpoint(CHAT_MODEL), messages, ChatOptions.defaults());
+
+        LOG.info("Response: [{}]", result.message().content());
+        LOG.info("Usage: {}", result.usage());
+        assertThat(result.message().content()).isNotBlank();
+        assertThat(result.message().role()).isEqualTo(ChatMessage.Role.ASSISTANT);
+        assertThat(result.finishReason()).isNotNull();
+        assertThat(result.usage()).isNotNull();
+        assertThat(result.usage().totalTokens()).isPositive();
+    }
+
+    @Test
+    void testChatWithJsonResponseFormat() throws Exception
+    {
+        var messages = List.of(new ChatMessage(USER,
+                "Return a JSON object with the keys `a` set to 1 and `b` set to 2."));
+        var options = new ChatOptions(ResponseFormat.JSON, null, List.of(), null);
+
+        var result = sut.chat(endpoint(CHAT_MODEL), messages, options);
+
+        LOG.info("Response: [{}]", result.message().content());
+        assertThat(JSONUtil.getObjectMapper().readTree(result.message().content())).isNotNull();
+    }
+
+    @Test
+    void testChatStream() throws Exception
+    {
+        var messages = List.of(new ChatMessage(USER, "Count from 1 to 5."));
+        var chunks = new ArrayList<ChatChunk>();
+
+        var result = sut.chatStream(endpoint(CHAT_MODEL), messages, ChatOptions.defaults(),
+                chunks::add);
+
+        LOG.info("Got {} chunks, final: [{}]", chunks.size(), result.message().content());
+        assertThat(chunks).isNotEmpty();
+        assertThat(result.message().content()).isNotBlank();
+    }
+
+    @Test
+    void testEmbed() throws Exception
+    {
+        var vectors = sut.embed(endpoint(EMBED_MODEL), List.of("hello world", "good morning"),
+                null);
+
+        assertThat(vectors).hasSize(2);
+        assertThat(vectors.get(0)).isNotEmpty();
+        assertThat(vectors.get(0).length).isEqualTo(vectors.get(1).length);
+        LOG.info("Embedding dim: {}", vectors.get(0).length);
+    }
+
+    @Test
+    void testListModels() throws Exception
+    {
+        var models = sut.listModels(endpoint(null));
+
+        LOG.info("Models: {}", models);
+        assertThat(models).extracting("id").contains(CHAT_MODEL);
+    }
+
+    static class WeatherService
+    {
+        @Tool(value = "get_current_weather", description = "Get the current weather for a given location.")
+        @SuppressWarnings("unused")
+        String getCurrentWeather(@ToolParam(value = "location", //
+                description = "The city to get the weather for.") String aLocation)
+        {
+            return "sunny";
+        }
+    }
+
+    @Test
+    void testChatWithTool() throws Exception
+    {
+        var weatherTool = ToolDescriptor.fromMethod(
+                WeatherService.class.getDeclaredMethod("getCurrentWeather", String.class));
+
+        var messages = List
+                .of(new ChatMessage(USER, "What is the current weather in Berlin? Use the tool."));
+        var options = new ChatOptions(null, null, List.of(weatherTool), null);
+
+        var result = sut.chat(endpoint(CHAT_MODEL), messages, options);
+
+        LOG.info("Finish reason: {}, tool calls: {}", result.finishReason(), result.toolCalls());
+
+        assertThat(result.toolCalls()).as("tool calls").isNotEmpty();
+        assertThat(result.finishReason()).isEqualTo(FinishReason.TOOL_CALLS);
+
+        var call = result.toolCalls().get(0);
+        assertThat(call.name()).isEqualTo("get_current_weather");
+        assertThat(call.arguments()).as("arguments JsonNode").isNotNull();
+        assertThat(call.arguments().isObject()).as("arguments is an object node").isTrue();
+
+        // valueToTree should yield proper value nodes — not POJONode wrappers — so the
+        // JSON-tree-style type predicates report correctly.
+        var location = call.arguments().get("location");
+        assertThat(location).as("location argument node").isNotNull();
+        assertThat(location.isTextual()).as("location node is TextNode").isTrue();
+        assertThat(location.asText()).containsIgnoringCase("berlin");
+    }
+}

--- a/inception/inception-imls-ollama/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/ollama/client/OllamaLlmChatClientTest.java
+++ b/inception/inception-imls-ollama/src/test/java/de/tudarmstadt/ukp/inception/recommendation/imls/ollama/client/OllamaLlmChatClientTest.java
@@ -18,163 +18,182 @@
 package de.tudarmstadt.ukp.inception.recommendation.imls.ollama.client;
 
 import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.ChatMessage.Role.USER;
-import static de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.OllamaRecommenderTraits.DEFAULT_OLLAMA_URL;
+import static java.util.List.of;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assumptions.assumeThat;
 
-import java.lang.invoke.MethodHandles;
 import java.net.http.HttpClient;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 
-import org.junit.jupiter.api.BeforeAll;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ChatMessage;
-import de.tudarmstadt.ukp.inception.recommendation.imls.llm.Tool;
-import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ToolParam;
-import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ChatChunk;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ChatOptions;
-import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.FinishReason;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.LlmEndpoint;
-import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ToolDescriptor;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.client.ModelCapability;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaChatRequest;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaChatResponse;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaClient;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaClientImpl;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaEmbedRequest;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaGenerateRequest;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaGenerateResponse;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaLlmChatClient;
 import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaMetricsImpl;
-import de.tudarmstadt.ukp.inception.recommendation.imls.llm.support.response.ResponseFormat;
-import de.tudarmstadt.ukp.inception.support.json.JSONUtil;
-import de.tudarmstadt.ukp.inception.support.test.http.HttpTestUtils;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaModelInfo;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaShowRequest;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaShowResponse;
+import de.tudarmstadt.ukp.inception.recommendation.imls.llm.ollama.client.OllamaTag;
 
 /**
- * Exercises {@link OllamaLlmChatClient} against a locally running Ollama. Requires {@code
- * ministral-3:8b} and {@code granite-embedding:278m-fp16} to be pulled; skipped if no Ollama is
- * reachable.
+ * Offline unit tests for {@link OllamaLlmChatClient} that exercise request building without a
+ * running Ollama. Live-server behavior is covered by {@link OllamaLlmChatClientIntegrationTest}.
  */
 class OllamaLlmChatClientTest
 {
-    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-
-    private static final String CHAT_MODEL = "ministral-3:8b";
-    private static final String EMBED_MODEL = "granite-embedding:278m-fp16";
-
     private final OllamaLlmChatClient sut = new OllamaLlmChatClient(
             new OllamaClientImpl(HttpClient.newBuilder().build(), new OllamaMetricsImpl()));
 
-    @BeforeAll
-    static void checkIfOllamaIsRunning()
+    private static LlmEndpoint endpoint()
     {
-        assumeThat(HttpTestUtils.checkURL(DEFAULT_OLLAMA_URL)).isTrue();
-    }
-
-    private static LlmEndpoint endpoint(String aModel)
-    {
-        return new LlmEndpoint(OllamaLlmChatClient.ID, DEFAULT_OLLAMA_URL, aModel, null);
-    }
-
-    @Test
-    void testChat() throws Exception
-    {
-        var messages = List.of(new ChatMessage(USER, "Tell me a joke in one sentence."));
-
-        var result = sut.chat(endpoint(CHAT_MODEL), messages, ChatOptions.defaults());
-
-        LOG.info("Response: [{}]", result.message().content());
-        LOG.info("Usage: {}", result.usage());
-        assertThat(result.message().content()).isNotBlank();
-        assertThat(result.message().role()).isEqualTo(ChatMessage.Role.ASSISTANT);
-        assertThat(result.finishReason()).isNotNull();
-        assertThat(result.usage()).isNotNull();
-        assertThat(result.usage().totalTokens()).isPositive();
-    }
-
-    @Test
-    void testChatWithJsonResponseFormat() throws Exception
-    {
-        var messages = List.of(new ChatMessage(USER,
-                "Return a JSON object with the keys `a` set to 1 and `b` set to 2."));
-        var options = new ChatOptions(ResponseFormat.JSON, null, List.of(), null);
-
-        var result = sut.chat(endpoint(CHAT_MODEL), messages, options);
-
-        LOG.info("Response: [{}]", result.message().content());
-        assertThat(JSONUtil.getObjectMapper().readTree(result.message().content())).isNotNull();
-    }
-
-    @Test
-    void testChatStream() throws Exception
-    {
-        var messages = List.of(new ChatMessage(USER, "Count from 1 to 5."));
-        var chunks = new ArrayList<ChatChunk>();
-
-        var result = sut.chatStream(endpoint(CHAT_MODEL), messages, ChatOptions.defaults(),
-                chunks::add);
-
-        LOG.info("Got {} chunks, final: [{}]", chunks.size(), result.message().content());
-        assertThat(chunks).isNotEmpty();
-        assertThat(result.message().content()).isNotBlank();
-    }
-
-    @Test
-    void testEmbed() throws Exception
-    {
-        var vectors = sut.embed(endpoint(EMBED_MODEL), List.of("hello world", "good morning"),
+        return new LlmEndpoint(OllamaLlmChatClient.ID, "http://localhost:11434", "some-model",
                 null);
-
-        assertThat(vectors).hasSize(2);
-        assertThat(vectors.get(0)).isNotEmpty();
-        assertThat(vectors.get(0).length).isEqualTo(vectors.get(1).length);
-        LOG.info("Embedding dim: {}", vectors.get(0).length);
     }
 
     @Test
-    void testListModels() throws Exception
+    void testTypedOptionsAreTranslatedToOllamaWireNames() throws Exception
     {
-        var models = sut.listModels(endpoint(null));
+        var options = ChatOptions.builder() //
+                .withContextLength(4096) //
+                .withTopK(40) //
+                .withRepeatPenalty(1.1) //
+                .build();
 
-        LOG.info("Models: {}", models);
-        assertThat(models).extracting("id").contains(CHAT_MODEL);
+        var request = buildChatRequest(options);
+
+        // The neutral typed fields must reach Ollama under its own wire names, byte-identical to
+        // the previous behavior where AgentLoop put these keys into the free-form options map.
+        assertThat(request.getOptions()) //
+                .containsEntry("num_ctx", 4096) //
+                .containsEntry("top_k", 40) //
+                .containsEntry("repeat_penalty", 1.1);
     }
 
-    static class WeatherService
+    @Test
+    void testUnsetTypedOptionsDoNotLeakToTheWire() throws Exception
     {
-        @Tool(value = "get_current_weather", description = "Get the current weather for a given location.")
-        @SuppressWarnings("unused")
-        String getCurrentWeather(@ToolParam(value = "location", //
-                description = "The city to get the weather for.") String aLocation)
+        var request = buildChatRequest(ChatOptions.defaults());
+
+        assertThat(request.getOptions()) //
+                .doesNotContainKeys("num_ctx", "top_k", "repeat_penalty");
+    }
+
+    /**
+     * Invokes the private {@code buildChatRequest} via reflection so the assertion does not require
+     * a running Ollama.
+     */
+    private OllamaChatRequest buildChatRequest(ChatOptions aOptions) throws Exception
+    {
+        var method = OllamaLlmChatClient.class.getDeclaredMethod("buildChatRequest",
+                LlmEndpoint.class, List.class, ChatOptions.class, boolean.class);
+        method.setAccessible(true);
+        return (OllamaChatRequest) method.invoke(sut, endpoint(), of(new ChatMessage(USER, "Hi")),
+                aOptions, false);
+    }
+
+    @Test
+    void testDescribeModelMapsContextLengthAndCapabilities() throws Exception
+    {
+        var info = new OllamaModelInfo();
+        info.setProperty("llama.context_length", 8192);
+
+        // "insert" has no neutral equivalent and must be dropped; the rest must be translated.
+        var showResponse = new OllamaShowResponse(null,
+                of("completion", "tools", "vision", "thinking", "embedding", "insert"), null, info);
+
+        var describingSut = new OllamaLlmChatClient(new StubOllamaClient(showResponse));
+
+        var details = describingSut.describeModel(endpoint());
+
+        assertThat(details).isPresent();
+        assertThat(details.get().contextLength()).isEqualTo(8192);
+        assertThat(details.get().capabilities()) //
+                .containsExactlyInAnyOrder(ModelCapability.CHAT, ModelCapability.TOOLS,
+                        ModelCapability.VISION, ModelCapability.THINKING,
+                        ModelCapability.EMBEDDINGS);
+    }
+
+    @Test
+    void testDescribeModelWithoutModelInfoYieldsNullContextLength() throws Exception
+    {
+        var showResponse = new OllamaShowResponse(null, of("completion"), null, null);
+
+        var describingSut = new OllamaLlmChatClient(new StubOllamaClient(showResponse));
+
+        var details = describingSut.describeModel(endpoint());
+
+        assertThat(details).isPresent();
+        assertThat(details.get().contextLength()).isNull();
+        assertThat(details.get().capabilities()).containsExactly(ModelCapability.CHAT);
+    }
+
+    /**
+     * Minimal hand-written {@link OllamaClient} stub (no Mockito in this module) that only answers
+     * {@code getModelInfo}; all other operations are unsupported.
+     */
+    private static final class StubOllamaClient
+        implements OllamaClient
+    {
+        private final OllamaShowResponse showResponse;
+
+        StubOllamaClient(OllamaShowResponse aShowResponse)
         {
-            return "sunny";
+            showResponse = aShowResponse;
         }
-    }
 
-    @Test
-    void testChatWithTool() throws Exception
-    {
-        var weatherTool = ToolDescriptor.fromMethod(
-                WeatherService.class.getDeclaredMethod("getCurrentWeather", String.class));
+        @Override
+        public OllamaShowResponse getModelInfo(String aUrl, OllamaShowRequest aRequest)
+        {
+            return showResponse;
+        }
 
-        var messages = List
-                .of(new ChatMessage(USER, "What is the current weather in Berlin? Use the tool."));
-        var options = new ChatOptions(null, null, List.of(weatherTool), null);
+        @Override
+        public String generate(String aUrl, OllamaGenerateRequest aRequest)
+        {
+            throw new UnsupportedOperationException();
+        }
 
-        var result = sut.chat(endpoint(CHAT_MODEL), messages, options);
+        @Override
+        public String generate(String aUrl, OllamaGenerateRequest aRequest,
+                Consumer<OllamaGenerateResponse> aCallback)
+        {
+            throw new UnsupportedOperationException();
+        }
 
-        LOG.info("Finish reason: {}, tool calls: {}", result.finishReason(), result.toolCalls());
+        @Override
+        public OllamaChatResponse chat(String aUrl, OllamaChatRequest aRequest)
+        {
+            throw new UnsupportedOperationException();
+        }
 
-        assertThat(result.toolCalls()).as("tool calls").isNotEmpty();
-        assertThat(result.finishReason()).isEqualTo(FinishReason.TOOL_CALLS);
+        @Override
+        public OllamaChatResponse chat(String aUrl, OllamaChatRequest aRequest,
+                Consumer<OllamaChatResponse> aCallback)
+        {
+            throw new UnsupportedOperationException();
+        }
 
-        var call = result.toolCalls().get(0);
-        assertThat(call.name()).isEqualTo("get_current_weather");
-        assertThat(call.arguments()).as("arguments JsonNode").isNotNull();
-        assertThat(call.arguments().isObject()).as("arguments is an object node").isTrue();
+        @Override
+        public List<OllamaTag> listModels(String aUrl, String aApiKey)
+        {
+            throw new UnsupportedOperationException();
+        }
 
-        // valueToTree should yield proper value nodes — not POJONode wrappers — so the
-        // JSON-tree-style type predicates report correctly.
-        var location = call.arguments().get("location");
-        assertThat(location).as("location argument node").isNotNull();
-        assertThat(location.isTextual()).as("location node is TextNode").isTrue();
-        assertThat(location.asText()).containsIgnoringCase("berlin");
+        @Override
+        public List<Pair<String, float[]>> embed(String aUrl, OllamaEmbedRequest aRequest)
+        {
+            throw new UnsupportedOperationException();
+        }
     }
 }

--- a/inception/inception-testing/pom.xml
+++ b/inception/inception-testing/pom.xml
@@ -66,6 +66,17 @@
       <artifactId>junit-jupiter-api</artifactId>
     </dependency>
 
+    <!-- Testcontainers - used by the LLM test-support helpers (e.g. OllamazureContainer).
+         Compile-scoped because they are part of this module's main API. -->
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers-junit-jupiter</artifactId>
+    </dependency>
+
     <!-- UIMA -->
     <dependency>
       <groupId>org.apache.uima</groupId>
@@ -97,4 +108,25 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <configuration>
+            <usedDependencies combine.children="append">
+              <!--
+                - Not referenced by this module's own code, but re-exported so that consumers of
+                - the LLM test-support helpers get the @Testcontainers/@Container JUnit 5
+                - integration alongside the core testcontainers API.
+              -->
+              <usedDependency>org.testcontainers:testcontainers-junit-jupiter</usedDependency>
+            </usedDependencies>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>

--- a/inception/inception-testing/src/main/java/de/tudarmstadt/ukp/inception/support/test/llm/OllamazureContainer.java
+++ b/inception/inception-testing/src/main/java/de/tudarmstadt/ukp/inception/support/test/llm/OllamazureContainer.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.support.test.llm;
+
+import static java.time.Duration.ofMinutes;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+
+/**
+ * A Testcontainers container running
+ * <a href="https://github.com/sinedied/ollamazure">ollamazure</a> — a local emulator of the Azure
+ * OpenAI wire protocol that forwards to an Ollama backend. This lets the Azure OpenAI client be
+ * exercised end-to-end (including its
+ * {@code /openai/deployments/{deployment}/chat/completions?api-version=} route and its SSE
+ * assembly) against a real local Ollama, without an Azure deployment or API key.
+ * <p>
+ * The image is built on the fly from the {@code Dockerfile} resource next to this class, so no
+ * pre-published image is required. The container forwards to an Ollama reachable from
+ * <em>inside</em> the container; by default that is the host's Ollama via
+ * {@code host.docker.internal}. The caller is responsible for ensuring that Ollama is running and
+ * that the requested model is pulled — this container only provides the Azure-protocol front.
+ * <p>
+ * Typical use, guarded so it skips when Docker or Ollama is absent:
+ *
+ * <pre>
+ * &#64;Testcontainers(disabledWithoutDocker = true)
+ * class MyTest
+ * {
+ *     &#64;Container
+ *     static OllamazureContainer ollamazure = new OllamazureContainer("nemotron-3-nano:4b");
+ *
+ *     &#64;BeforeAll
+ *     static void requireOllama()
+ *     {
+ *         assumeThat(HttpTestUtils.checkURL("http://localhost:11434")).isTrue();
+ *     }
+ *
+ *     // point the Azure client at ollamazure.getAzureBaseUrl()
+ * }
+ * </pre>
+ */
+public class OllamazureContainer
+    extends GenericContainer<OllamazureContainer>
+{
+    private static final int OLLAMAZURE_PORT = 4041;
+
+    private static final String DOCKERFILE = "de/tudarmstadt/ukp/inception/support/test/llm/"
+            + "ollamazure/Dockerfile";
+
+    /**
+     * Ollama URL as seen from inside the container. Defaults to the host's Ollama; overridable via
+     * {@link #withOllamaUrl} (e.g. to target an Ollama running in a sibling container on a shared
+     * network).
+     */
+    private String ollamaUrl = "http://host.docker.internal:11434";
+
+    private final String model;
+
+    /**
+     * Embeddings model ollamazure is configured with. ollamazure touches this model at startup, so
+     * it must be one the backend Ollama already has pulled — otherwise startup fails on the pull.
+     * Defaults to the same model the Ollama integration tests use.
+     */
+    private String embeddingsModel = "granite-embedding:278m-fp16";
+
+    /**
+     * @param aModel
+     *            the Ollama model that ollamazure should route completions to. It is also used as
+     *            the Azure deployment name (ollamazure runs with {@code --use-deployment}), so the
+     *            deployment segment of the URL selects this model.
+     */
+    public OllamazureContainer(String aModel)
+    {
+        super(new ImageFromDockerfile().withFileFromClasspath("Dockerfile", DOCKERFILE));
+        model = aModel;
+
+        withExposedPorts(OLLAMAZURE_PORT);
+        // Make the host reachable as host.docker.internal on Linux (already resolvable on
+        // Docker Desktop for macOS/Windows).
+        withExtraHost("host.docker.internal", "host-gateway");
+        waitingFor(Wait.forListeningPort().withStartupTimeout(ofMinutes(2)));
+    }
+
+    /**
+     * Override the Ollama backend URL as seen from inside the container (default:
+     * {@code http://host.docker.internal:11434}).
+     */
+    public OllamazureContainer withOllamaUrl(String aOllamaUrl)
+    {
+        ollamaUrl = aOllamaUrl;
+        return this;
+    }
+
+    /**
+     * Override the embeddings model (default: {@code granite-embedding:278m-fp16}). Must be pulled
+     * in the backend Ollama, as ollamazure touches it at startup.
+     */
+    public OllamazureContainer withEmbeddingsModel(String aEmbeddingsModel)
+    {
+        embeddingsModel = aEmbeddingsModel;
+        return this;
+    }
+
+    @Override
+    protected void configure()
+    {
+        // -d/--use-deployment makes ollamazure treat the deployment name in the URL as the model
+        // name, so a single container can serve the requested model under its own deployment path.
+        setCommand("--use-deployment", "--ollama-url", ollamaUrl, "--model", model, "--embeddings",
+                embeddingsModel);
+    }
+
+    /**
+     * The deployment name served by this container (equal to the model name).
+     */
+    public String getDeployment()
+    {
+        return model;
+    }
+
+    /**
+     * The base URL to configure the Azure OpenAI client with, for the default deployment (the model
+     * passed to the constructor). See {@link #getAzureBaseUrl(String)}.
+     */
+    public String getAzureBaseUrl()
+    {
+        return getAzureBaseUrl(model);
+    }
+
+    /**
+     * The base URL to configure the Azure OpenAI client with for a specific deployment. The client
+     * appends {@code chat/completions?api-version=...}, yielding ollamazure's expected Azure route
+     * {@code /openai/deployments/{deployment}/chat/completions}.
+     * <p>
+     * Because ollamazure runs with {@code --use-deployment}, the deployment segment selects the
+     * Ollama model directly, so a single container can serve <em>any</em> pulled model — not only
+     * the one passed to the constructor. The caller is responsible for the requested model being
+     * pulled in the backend Ollama.
+     */
+    public String getAzureBaseUrl(String aDeployment)
+    {
+        return "http://" + getHost() + ":" + getMappedPort(OLLAMAZURE_PORT) + "/openai/deployments/"
+                + aDeployment + "/";
+    }
+}

--- a/inception/inception-testing/src/main/resources/de/tudarmstadt/ukp/inception/support/test/llm/ollamazure/Dockerfile
+++ b/inception/inception-testing/src/main/resources/de/tudarmstadt/ukp/inception/support/test/llm/ollamazure/Dockerfile
@@ -1,0 +1,14 @@
+# Minimal image running ollamazure (https://github.com/sinedied/ollamazure), a local emulator of
+# the Azure OpenAI wire protocol that forwards to an Ollama backend. Built on-the-fly by
+# Testcontainers (see OllamazureContainer); ollamazure is a pure-JS npm package, so this is a small,
+# quick-to-build layer on top of a Node base image.
+FROM node:20-alpine
+
+# Pin the version so test behavior is reproducible; bump deliberately.
+RUN npm install -g ollamazure@1.4.1
+
+EXPOSE 4041
+
+# Bind to all interfaces so the mapped port is reachable from the host. The Ollama backend URL and
+# the -d/--use-deployment flag are supplied as the command by OllamazureContainer.
+ENTRYPOINT ["ollamazure", "--yes", "--host", "0.0.0.0"]


### PR DESCRIPTION
**What's in the PR**
* Adds provider-neutral temperature / topP to ChatOptions and translates them in the Ollama/OpenAI/Azure adapters while preserving provider-specific overrides via the options bag.
* Extends message/adapter plumbing to carry tool calls through conversation history (notably for Ollama) and updates the assistant loop to use the neutral client interfaces.
* Makes the assistant’s chat and embedding endpoints/provider/auth configurable (top-level defaults + per-section overrides), updating wiring and tests accordingly.

**How to test manually**
* Check if assistant still works

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
