### PR TITLE
#6106 - Keyboard-based annotation creation mode

### DIFF
--- a/inception/inception-doc/src/main/resources/META-INF/asciidoc/user-guide/editors.adoc
+++ b/inception/inception-doc/src/main/resources/META-INF/asciidoc/user-guide/editors.adoc
@@ -75,6 +75,37 @@ A line-oriented presentation of the text using inter-linear annotations that als
 
 This editor renders documents imported using a XML/HTML-based format such as <<sect_formats_mhtml>> or <<sect_formats_htmldoc>>. It is build on top of link:https://annotator.apache.org[Apache Annotator]. It supports rendering span annotations but not relations or link features.
 
+[[sect_editors_html_apache_annotator_keyboard]]
+=== Keyboard navigation
+
+The editor offers an optional keyboard cursor that allows navigating the document and creating
+span annotations without using the mouse. It can be turned on using the **Keyboard cursor** toggle
+in the editor toolbar. The setting is remembered as a user preference.
+
+When the keyboard cursor is enabled, a text cursor is placed in the document and the following
+keys are available:
+
+* kbd:[←] / kbd:[→] move the cursor one character to the left or right.
+* kbd:[↑] / kbd:[↓] move the cursor one line up or down.
+* kbd:[Shift + ←] / kbd:[Shift + →] extend (or shrink) the selection one character at a time.
+* kbd:[Enter] creates a span annotation over the current selection.
+* kbd:[Space] selects the annotation at the cursor position.
+* kbd:[Backspace] deletes the annotation at the cursor position.
+
+After creating an annotation, the focus moves to the feature editors in the right sidebar so that
+a label can be entered right away. Pressing kbd:[Esc] returns the focus to the document and places
+the cursor at the end of the annotation that was just created, allowing the next annotation to be
+created without reaching for the mouse.
+
+To act on an existing annotation, move the cursor into its highlight and press kbd:[Space] to select
+it or kbd:[Backspace] to delete it. If a single annotation covers that position, the action is
+applied immediately. If multiple annotations overlap there, a small popup appears listing them: use
+kbd:[↑] / kbd:[↓] to move between the entries, kbd:[Enter] to apply the action to the highlighted
+annotation, or kbd:[Esc] to close the popup without selecting or deleting.
+
+NOTE: When the document contains protected elements (e.g. images or tables), the cursor and
+selection automatically skip over them so that such elements are never partially selected.
+
 [[sect_editors_html_recogitojs]]
 == 🧪 HTML (RecogitoJS)
 

--- a/inception/inception-external-editor/pom.xml
+++ b/inception/inception-external-editor/pom.xml
@@ -187,6 +187,10 @@
       <artifactId>wicket-request</artifactId>
     </dependency>
     <dependency>
+      <groupId>de.agilecoders.wicket</groupId>
+      <artifactId>wicket-bootstrap-extensions</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.danekja</groupId>
       <artifactId>jdk-serializable-functional</artifactId>
     </dependency>

--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/ExternalAnnotationEditorBase.java
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/ExternalAnnotationEditorBase.java
@@ -19,6 +19,7 @@ package de.tudarmstadt.ukp.inception.externaleditor;
 
 import static de.tudarmstadt.ukp.clarin.webanno.security.WicketSecurityUtils.getCsrfTokenFromSession;
 import static de.tudarmstadt.ukp.inception.support.lambda.LambdaBehavior.visibleWhen;
+import static de.tudarmstadt.ukp.inception.support.wicket.ServletContextUtils.referenceToUrl;
 import static de.tudarmstadt.ukp.inception.support.wicket.WicketUtil.wrapInTryCatch;
 import static de.tudarmstadt.ukp.inception.websocket.config.WebsocketConfig.WS_ENDPOINT;
 import static java.lang.String.format;
@@ -28,6 +29,7 @@ import static org.apache.wicket.markup.head.OnDomReadyHeaderItem.forScript;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Optional;
 
 import org.apache.wicket.Component;
@@ -41,6 +43,7 @@ import org.apache.wicket.request.cycle.RequestCycle;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.slf4j.Logger;
 
+import de.agilecoders.wicket.extensions.markup.html.bootstrap.icon.FontAwesome7CssReference;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasProvider;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.inception.diam.editor.DiamAjaxBehavior;
@@ -232,12 +235,39 @@ public abstract class ExternalAnnotationEditorBase
     private String getPropertiesAsJson()
     {
         var props = getProperties();
+        injectIFrameStylesheets(props);
         try {
             return JSONUtil.toInterpretableJsonString(props);
         }
         catch (IOException e) {
             throw new IllegalStateException(e);
         }
+    }
+
+    /**
+     * Make FontAwesome available inside the editor IFrame. The document IFrame does not inherit the
+     * host page's stylesheets, so editor toolbars/overlays rendered into the IFrame document cannot
+     * use icons unless FontAwesome is explicitly loaded there. The stylesheet sources are injected
+     * client-side by the external editor loader after the document has loaded, so this covers both
+     * the raw-HTML and the generated-document rendering paths. We only augment editors that already
+     * opt into IFrame stylesheet injection (i.e. that have set stylesheet sources).
+     */
+    private void injectIFrameStylesheets(AnnotationEditorProperties aProps)
+    {
+        var sources = aProps.getStylesheetSources();
+        if (sources == null) {
+            return;
+        }
+
+        var fontAwesome = referenceToUrl(context, FontAwesome7CssReference.instance());
+        if (sources.contains(fontAwesome)) {
+            return;
+        }
+
+        var augmented = new ArrayList<String>(sources.size() + 1);
+        augmented.add(fontAwesome);
+        augmented.addAll(sources);
+        aProps.setStylesheetSources(augmented);
     }
 
     private CharSequence destroyScript()

--- a/inception/inception-html-apache-annotator-editor/src/main/java/de/tudarmstadt/ukp/inception/apacheannotatoreditor/ApacheAnnotatorHtmlAnnotationEditorFactoryUserPreferences.schema.json
+++ b/inception/inception-html-apache-annotator-editor/src/main/java/de/tudarmstadt/ukp/inception/apacheannotatoreditor/ApacheAnnotatorHtmlAnnotationEditorFactoryUserPreferences.schema.json
@@ -25,6 +25,9 @@
     },
     "showTables": {
       "type": "boolean"
+    },
+    "keyboardCursorEnabled": {
+      "type": "boolean"
     }
   },
   "additionalProperties": false

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorEditor.scss
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorEditor.scss
@@ -398,8 +398,38 @@ sec-wrap {
     padding: 5px 15px;
 }
 
-.iaa-menu .iaa-menu-item:hover {
+// Header shown in the keyboard-driven popup to indicate its mode (select/delete).
+.iaa-menu .iaa-menu-header {
+    padding: 3px 15px;
+    font-size: 0.8em;
+    font-weight: bold;
+    text-transform: uppercase;
+    color: gray;
+    border-bottom: solid #eee 1px;
+}
+
+.iaa-menu.iaa-menu-delete .iaa-menu-header {
+    color: rgb(220, 53, 69);
+}
+
+.iaa-menu:focus {
+    outline: none;
+}
+
+.iaa-menu .iaa-menu-item:hover,
+.iaa-menu .iaa-menu-item.iaa-menu-item-active {
     background-color: whitesmoke;
+}
+
+.iaa-menu .iaa-menu-item.iaa-menu-item-active {
+    outline: solid 2px rgba(0, 123, 255, 0.5);
+    outline-offset: -2px;
+}
+
+// In delete mode the active entry is highlighted in red to signal that pressing
+// Enter removes the annotation rather than selecting it.
+.iaa-menu.iaa-menu-delete .iaa-menu-item.iaa-menu-item-active {
+    outline-color: rgba(220, 53, 69, 0.6);
 }
 
 .iaa-menu-item .iaa-label {

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorEditor.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorEditor.ts
@@ -37,6 +37,7 @@ import {
     type SelectionLike,
     expandSelectionOverProtectedElements,
 } from './Utilities';
+import { KeyboardEditorMode } from './KeyboardEditorMode';
 
 export class ApacheAnnotatorEditor implements AnnotationEditor {
     private ajax: DiamAjax;
@@ -56,6 +57,8 @@ export class ApacheAnnotatorEditor implements AnnotationEditor {
     private protectedElementsMatcher?: (el: Element) => boolean;
     private activeResizeCleanup: (() => void) | undefined = undefined;
     private documentStructure: DocumentStructureStrategy;
+    private documentContainer: HTMLElement | undefined = undefined;
+    private keyboardMode: KeyboardEditorMode | undefined = undefined;
 
     public constructor(
         element: Element,
@@ -84,6 +87,7 @@ export class ApacheAnnotatorEditor implements AnnotationEditor {
             showTables: true,
             documentStructureWidth: 0.2,
             protectElements: true,
+            keyboardCursorEnabled: false,
         };
         let preferences = Object.assign({}, defaultPreferences);
 
@@ -105,6 +109,8 @@ export class ApacheAnnotatorEditor implements AnnotationEditor {
                     preferences.documentStructureWidth ?? defaultPreferences.documentStructureWidth;
                 annotatorState.protectElements =
                     preferences.protectElements ?? defaultPreferences.protectElements;
+                annotatorState.keyboardCursorEnabled =
+                    preferences.keyboardCursorEnabled ?? defaultPreferences.keyboardCursorEnabled;
             })
             .then(() => {
                 // Move all content into a document container
@@ -151,6 +157,8 @@ export class ApacheAnnotatorEditor implements AnnotationEditor {
                 this.vis.protectedElementSelector = [...protectedElements].join(',');
                 this.selector = new ApacheAnnotatorSelector(this.root, this.ajax);
 
+                this.documentContainer = documentContainer;
+
                 // Add auxiliary controls
                 this.documentStructureNavigator = this.createDocumentNavigator(
                     this.navigatorContainer,
@@ -158,6 +166,15 @@ export class ApacheAnnotatorEditor implements AnnotationEditor {
                     this.documentStructure
                 );
                 this.toolbar = this.createToolbar();
+
+                this.keyboardMode = new KeyboardEditorMode(
+                    this.root,
+                    documentContainer,
+                    this.ajax,
+                    this.protectedElementsMatcher,
+                    this.selector
+                );
+                this.keyboardMode.enable(annotatorState.keyboardCursorEnabled);
 
                 this.popover = mount(AnnotationDetailPopOver, {
                     target: this.root.ownerDocument.body,
@@ -337,6 +354,9 @@ export class ApacheAnnotatorEditor implements AnnotationEditor {
                         this.navigatorContainer.style.maxWidth = `${width}px`;
                     });
                 },
+                keyboardCursorPreferencesChanged: (e: Event) => {
+                    this.keyboardMode?.enable(annotatorState.keyboardCursorEnabled);
+                },
             },
         });
     }
@@ -422,11 +442,17 @@ export class ApacheAnnotatorEditor implements AnnotationEditor {
 
     scrollTo(args: { offset: number; position?: string; pingRanges?: Offsets[] }): void {
         if (!this.initializationComplete) {
-            this.deferredInitializationSteps.push(() => this.vis.scrollTo(args));
+            this.deferredInitializationSteps.push(() => {
+                this.vis.scrollTo(args);
+                // Keep the keyboard caret with the jump target so the next cursor-key
+                // press continues from here instead of scrolling the view back.
+                this.keyboardMode?.moveCaretToOffset(args.offset);
+            });
             return;
         }
 
         this.vis?.scrollTo(args);
+        this.keyboardMode?.moveCaretToOffset(args.offset);
     }
 
     destroy(): void {
@@ -453,5 +479,8 @@ export class ApacheAnnotatorEditor implements AnnotationEditor {
 
         this.vis?.destroy();
         this.selector?.destroy();
+        try {
+            this.keyboardMode?.destroy();
+        } catch {}
     }
 }

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorSelector.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorSelector.ts
@@ -16,9 +16,20 @@
  * limitations under the License.
  */
 import type { DiamAjax, VID } from '@inception-project/inception-js-api';
-import { getInlineLabelClientRect, highlights, isPointInRect } from './Utilities';
+import { getInlineLabelClientRect, highlights, isPointInRect, rangeClientRect } from './Utilities';
 import { NO_LABEL } from './ApacheAnnotatorVisualizer.svelte';
 import { createPopper, type Instance } from '@popperjs/core';
+
+/**
+ * How the overlapping-annotation popup behaves:
+ * - `mouse`: opened by clicking a stack of annotations. Each entry can be selected
+ *   (click the label) or deleted (click the ❌), so both affordances are shown.
+ * - `keyboard-select`: opened via the keyboard to pick an annotation to select. Only
+ *   selection is offered (no ❌); activating an entry selects it.
+ * - `keyboard-delete`: opened via the keyboard to pick an annotation to delete.
+ *   Activating an entry deletes it and the entry is styled as destructive.
+ */
+type PopupMode = 'mouse' | 'keyboard-select' | 'keyboard-delete';
 
 export class ApacheAnnotatorSelector {
     private ajax: DiamAjax;
@@ -28,11 +39,76 @@ export class ApacheAnnotatorSelector {
     private popupContent: HTMLElement | undefined;
     private popupAnchor: HTMLElement | undefined;
 
+    // Keyboard navigation state for the overlapping-annotation popup
+    private menuItems: HTMLElement[] = [];
+    private activeIndex: number = -1;
+    private focusFallback: HTMLElement | undefined;
+    private popupKeydownHandler: ((e: KeyboardEvent) => void) | undefined;
+    private popupMode: PopupMode = 'mouse';
+
     public constructor(element: Element, ajax: DiamAjax) {
         this.ajax = ajax;
         this.root = element;
 
         this.root.addEventListener('mousedown', (e) => this.onMouseDown(e));
+    }
+
+    /**
+     * Select the annotation(s) at the given caret range. Intended for keyboard-driven
+     * selection. If a single annotation covers the caret it is selected directly;
+     * if multiple annotations overlap, a keyboard-navigable popup is shown so the user
+     * can pick one. Returns true if there was at least one annotation at the caret.
+     *
+     * @param range a (typically collapsed) caret range inside the document
+     * @param focusFallback element to return focus to if the popup is dismissed via Escape
+     */
+    public selectAtCaret(range: Range, focusFallback?: HTMLElement): boolean {
+        return this.actionAtCaret(range, 'keyboard-select', focusFallback);
+    }
+
+    /**
+     * Delete the annotation(s) at the given caret range. Intended for keyboard-driven
+     * deletion. If a single annotation covers the caret it is deleted directly; if
+     * multiple annotations overlap, a keyboard-navigable popup is shown so the user can
+     * pick which one to delete. Returns true if there was at least one annotation at the
+     * caret.
+     *
+     * @param range a (typically collapsed) caret range inside the document
+     * @param focusFallback element to return focus to after deleting or when the popup is
+     *     dismissed via Escape
+     */
+    public deleteAtCaret(range: Range, focusFallback?: HTMLElement): boolean {
+        return this.actionAtCaret(range, 'keyboard-delete', focusFallback);
+    }
+
+    private actionAtCaret(
+        range: Range,
+        mode: 'keyboard-select' | 'keyboard-delete',
+        focusFallback?: HTMLElement
+    ): boolean {
+        this.destroyPopup();
+
+        const hls = highlights(range.startContainer);
+        if (hls.length === 0) return false;
+
+        if (hls.length === 1) {
+            const vid = hls[0].getAttribute('data-iaa-id');
+            if (!vid) return false;
+            if (mode === 'keyboard-delete') {
+                this.ajax.deleteAnnotation(vid);
+                focusFallback?.focus();
+            } else {
+                this.ajax.selectAnnotation(vid);
+            }
+            return true;
+        }
+
+        const rect = rangeClientRect(range);
+        if (!rect) return false;
+
+        this.focusFallback = focusFallback;
+        this.createPopup(rect.left, rect.bottom, hls, true, mode);
+        return true;
     }
 
     private onMouseDown(event: Event): void {
@@ -51,12 +127,20 @@ export class ApacheAnnotatorSelector {
     private destroyPopup() {
         if (!this.popup) return;
 
+        if (this.popupContent && this.popupKeydownHandler) {
+            this.popupContent.removeEventListener('keydown', this.popupKeydownHandler);
+        }
         this.popup.destroy();
         this.popupContent?.remove();
         this.popupAnchor?.remove();
         this.popup = undefined;
         this.popupContent = undefined;
         this.popupAnchor = undefined;
+        this.popupKeydownHandler = undefined;
+        this.menuItems = [];
+        this.activeIndex = -1;
+        this.focusFallback = undefined;
+        this.popupMode = 'mouse';
     }
 
     public isVisible(): boolean {
@@ -87,46 +171,146 @@ export class ApacheAnnotatorSelector {
             return;
         }
 
-        this.createPopup(mouseEvent, hls);
+        this.createPopup(mouseEvent.clientX, mouseEvent.clientY, hls, false, 'mouse');
     }
 
-    private createPopup(mouseEvent: MouseEvent, hls: HTMLElement[]) {
+    private createPopup(
+        clientX: number,
+        clientY: number,
+        hls: HTMLElement[],
+        focusForKeyboard: boolean,
+        mode: PopupMode = 'mouse'
+    ) {
+        this.popupMode = mode;
+
         this.popupAnchor = document.createElement('div');
         this.popupAnchor.style.position = 'absolute';
-        this.popupAnchor.style.top = `${mouseEvent.clientY + window.scrollY}px`;
-        this.popupAnchor.style.left = `${mouseEvent.clientX}px`;
+        this.popupAnchor.style.top = `${clientY + window.scrollY}px`;
+        this.popupAnchor.style.left = `${clientX}px`;
         this.popupAnchor.style.pointerEvents = 'none';
         this.popupAnchor.style.visibility = 'hidden';
         this.root.ownerDocument.body.appendChild(this.popupAnchor);
 
+        // The ❌ per-entry button is only offered for mouse interaction. In the
+        // keyboard modes the popup does exactly one thing (select or delete), made
+        // explicit by a header instead.
+        const showDeleteButton = mode === 'mouse';
+
         this.popupContent = document.createElement('div');
         this.popupContent.classList.add('iaa-menu');
+        // Signal delete intent so the active entry can be styled as destructive.
+        if (mode === 'keyboard-delete') {
+            this.popupContent.classList.add('iaa-menu-delete');
+        }
+        // Make the menu focusable so it can capture keyboard navigation keys.
+        this.popupContent.tabIndex = -1;
+
+        // In the keyboard modes, show a header indicating whether picking an entry
+        // selects or deletes it.
+        if (mode !== 'mouse') {
+            const header = document.createElement('div');
+            header.classList.add('iaa-menu-header');
+            header.textContent = mode === 'keyboard-delete' ? 'Delete…' : 'Select…';
+            this.popupContent.appendChild(header);
+        }
+
+        this.menuItems = [];
         for (const hl of hls) {
             const vid = hl.getAttribute('data-iaa-id');
             if (!vid) continue;
 
             const menuItem = document.createElement('div');
             menuItem.classList.add('iaa-menu-item');
+            menuItem.dataset.vid = vid;
 
             const label = hl.getAttribute('data-iaa-label') || NO_LABEL;
             const labelArea = document.createElement('div');
             labelArea.classList.add('iaa-label');
             labelArea.textContent = label !== NO_LABEL ? label : 'no label';
             labelArea.style.cursor = 'pointer';
-            labelArea.addEventListener('click', (e) => this.onSelectAnnotation(e, vid));
+            // Activating an entry selects it, except in keyboard-delete mode where it
+            // deletes it.
+            labelArea.addEventListener('click', (e) => this.activateItem(e, vid));
             menuItem.appendChild(labelArea);
 
-            const deleteButton = document.createElement('a');
-            deleteButton.classList.add('iaa-btn');
-            deleteButton.textContent = '❌';
-            deleteButton.addEventListener('click', (e) => this.onDeleteAnnotation(e, vid));
-            menuItem.appendChild(deleteButton);
+            if (showDeleteButton) {
+                const deleteButton = document.createElement('a');
+                deleteButton.classList.add('iaa-btn');
+                deleteButton.textContent = '❌';
+                deleteButton.addEventListener('click', (e) => this.onDeleteAnnotation(e, vid));
+                menuItem.appendChild(deleteButton);
+            }
 
+            this.menuItems.push(menuItem);
             this.popupContent.appendChild(menuItem);
         }
         this.root.ownerDocument.body.appendChild(this.popupContent);
 
         this.popup = createPopper(this.popupAnchor, this.popupContent, { placement: 'top' });
+
+        this.popupKeydownHandler = (e: KeyboardEvent) => this.onPopupKeyDown(e);
+        this.popupContent.addEventListener('keydown', this.popupKeydownHandler);
+
+        if (focusForKeyboard) {
+            this.setActive(0);
+            this.popupContent.focus();
+        }
+    }
+
+    private setActive(index: number) {
+        if (this.menuItems.length === 0) return;
+        const n = this.menuItems.length;
+        const next = ((index % n) + n) % n;
+        this.menuItems.forEach((item, i) =>
+            item.classList.toggle('iaa-menu-item-active', i === next)
+        );
+        this.activeIndex = next;
+        this.menuItems[next].scrollIntoView({ block: 'nearest' });
+    }
+
+    private onPopupKeyDown(e: KeyboardEvent) {
+        if (!this.popupContent) return;
+
+        switch (e.key) {
+            case 'ArrowDown':
+                e.preventDefault();
+                e.stopPropagation();
+                this.setActive(this.activeIndex + 1);
+                break;
+            case 'ArrowUp':
+                e.preventDefault();
+                e.stopPropagation();
+                this.setActive(this.activeIndex - 1);
+                break;
+            case 'Enter':
+                e.preventDefault();
+                e.stopPropagation();
+                if (this.activeIndex >= 0) {
+                    const vid = this.menuItems[this.activeIndex]?.dataset.vid;
+                    if (vid) this.activateItem(e, vid);
+                }
+                break;
+            case 'Escape': {
+                e.preventDefault();
+                e.stopPropagation();
+                const fallback = this.focusFallback;
+                this.destroyPopup();
+                fallback?.focus();
+                break;
+            }
+        }
+    }
+
+    /**
+     * Perform the popup's primary action on an entry: delete in keyboard-delete mode,
+     * otherwise select.
+     */
+    private activateItem(event: Event, id: VID) {
+        if (this.popupMode === 'keyboard-delete') {
+            this.onDeleteAnnotation(event, id);
+        } else {
+            this.onSelectAnnotation(event, id);
+        }
     }
 
     private onSelectAnnotation(event: Event, id: VID) {
@@ -139,8 +323,13 @@ export class ApacheAnnotatorSelector {
     private onDeleteAnnotation(event: Event, id: VID) {
         console.log(`Deleting annotation ${id}`);
         event.stopPropagation();
+        // Capture before destroyPopup() clears it: after a keyboard-driven delete we
+        // return focus to the document so the user can keep annotating without the
+        // mouse. For mouse-driven deletes (no fallback) this is a no-op.
+        const fallback = this.focusFallback;
         this.destroyPopup();
         this.ajax.deleteAnnotation(id);
+        fallback?.focus();
     }
 
     destroy(): void {

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorState.svelte.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorState.svelte.ts
@@ -25,4 +25,5 @@ export const annotatorState = $state({
     showImages: true,
     showTables: true,
     protectElements: true,
+    keyboardCursorEnabled: false,
 });

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorToolbar.svelte
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorToolbar.svelte
@@ -63,6 +63,12 @@
         dispatch('renderingPreferencesChanged', {});
     });
 
+    $effect(() => {
+        annotatorState.keyboardCursorEnabled;
+        savePreferences();
+        dispatch('keyboardCursorPreferencesChanged', {});
+    });
+
     let preferencesDebounceTimeout: number | undefined = undefined;
 
     function savePreferences() {
@@ -79,6 +85,7 @@
                 showDocumentStructure: annotatorState.showDocumentStructure,
                 showImages: annotatorState.showImages,
                 showTables: annotatorState.showTables,
+                keyboardCursorEnabled: annotatorState.keyboardCursorEnabled,
                 documentStructureWidth: annotatorState.documentStructureWidth,
                 protectElements: annotatorState.protectElements,
             });
@@ -86,66 +93,113 @@
     }
 </script>
 
-<div class="bootstrap card card-header border-0 border-bottom rounded-0 p-1" role="toolbar">
-    <div class="d-flex align-items-center">
-        <div class="form-check form-switch mx-2">
-            <input
-                class="form-check-input"
-                type="checkbox"
-                role="switch"
-                id="inlineLabelsEnabled"
-                bind:checked={annotatorState.showLabels}
-            />
-            <label class="form-check-label" for="inlineLabelsEnabled">Inline labels</label>
-        </div>
+<div
+    class="bootstrap card-header border-0 border-bottom rounded-0 p-1 d-flex flex-row flex-wrap align-items-center"
+    role="toolbar"
+>
+    <div class="btn-group btn-group-sm" role="group" aria-label="Display options">
+        <input
+            class="btn-check"
+            type="checkbox"
+            id="inlineLabelsEnabled"
+            autocomplete="off"
+            bind:checked={annotatorState.showLabels}
+        />
+        <label
+            class="btn btn-outline-secondary"
+            for="inlineLabelsEnabled"
+            title="Inline labels"
+            aria-label="Inline labels"
+        >
+            <i class="fas fa-tag"></i>
+        </label>
+
         {#if sectionSelector}
-            <div class="form-check form-switch mx-2">
-                <input
-                    class="form-check-input"
-                    type="checkbox"
-                    role="switch"
-                    id="aggregatedLabelsEnabled"
-                    bind:checked={annotatorState.showAggregatedLabels}
-                />
-                <label class="form-check-label" for="aggregatedLabelsEnabled">Section labels</label>
-            </div>
+            <input
+                class="btn-check"
+                type="checkbox"
+                id="aggregatedLabelsEnabled"
+                autocomplete="off"
+                bind:checked={annotatorState.showAggregatedLabels}
+            />
+            <label
+                class="btn btn-outline-secondary"
+                for="aggregatedLabelsEnabled"
+                title="Section labels"
+                aria-label="Section labels"
+            >
+                <i class="fas fa-tags"></i>
+            </label>
         {/if}
+
         <!--
-    <div class="form-check form-switch mx-2">
-      <input class="form-check-input" type="checkbox" role="switch" id="showEmptyHighlights" bind:checked={annotatorState.showEmptyHighlights}>
-      <label class="form-check-label" for="showEmptyHighlights">Empties</label>
-    </div>
-    -->
-        <div class="form-check form-switch mx-2">
-            <input
-                class="form-check-input"
-                type="checkbox"
-                role="switch"
-                id="imagesEnabled"
-                bind:checked={annotatorState.showImages}
-            />
-            <label class="form-check-label" for="imagesEnabled">Images</label>
-        </div>
-        <div class="form-check form-switch mx-2">
-            <input
-                class="form-check-input"
-                type="checkbox"
-                role="switch"
-                id="tablesEnabled"
-                bind:checked={annotatorState.showTables}
-            />
-            <label class="form-check-label" for="tablesEnabled">Tables</label>
-        </div>
-        <div class="form-check form-switch mx-2">
-            <input
-                class="form-check-input"
-                type="checkbox"
-                role="switch"
-                id="documentStructureEnabled"
-                bind:checked={annotatorState.showDocumentStructure}
-            />
-            <label class="form-check-label" for="documentStructureEnabled">Outline</label>
-        </div>
+        <input class="btn-check" type="checkbox" id="showEmptyHighlights" autocomplete="off" bind:checked={annotatorState.showEmptyHighlights}>
+        <label class="btn btn-outline-secondary" for="showEmptyHighlights" title="Empty highlights" aria-label="Empty highlights"><i class="fas fa-square"></i></label>
+        -->
+
+        <input
+            class="btn-check"
+            type="checkbox"
+            id="imagesEnabled"
+            autocomplete="off"
+            bind:checked={annotatorState.showImages}
+        />
+        <label
+            class="btn btn-outline-secondary"
+            for="imagesEnabled"
+            title="Images"
+            aria-label="Images"
+        >
+            <i class="fas fa-image"></i>
+        </label>
+
+        <input
+            class="btn-check"
+            type="checkbox"
+            id="tablesEnabled"
+            autocomplete="off"
+            bind:checked={annotatorState.showTables}
+        />
+        <label
+            class="btn btn-outline-secondary"
+            for="tablesEnabled"
+            title="Tables"
+            aria-label="Tables"
+        >
+            <i class="fas fa-table"></i>
+        </label>
+
+        <input
+            class="btn-check"
+            type="checkbox"
+            id="documentStructureEnabled"
+            autocomplete="off"
+            bind:checked={annotatorState.showDocumentStructure}
+        />
+        <label
+            class="btn btn-outline-secondary"
+            for="documentStructureEnabled"
+            title="Outline"
+            aria-label="Outline"
+        >
+            <i class="fas fa-list-ul"></i>
+        </label>
+
+        <input
+            class="btn-check"
+            type="checkbox"
+            id="keyboardCursorEnabled"
+            autocomplete="off"
+            bind:checked={annotatorState.keyboardCursorEnabled}
+        />
+        <label
+            class="btn btn-outline-secondary"
+            for="keyboardCursorEnabled"
+            title="Keyboard cursor"
+            aria-label="Keyboard cursor"
+        >
+            <i class="fas fa-keyboard"></i>
+        </label>
     </div>
 </div>
 

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/KeyboardEditorMode.scss
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/KeyboardEditorMode.scss
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Custom caret used in keyboard annotation mode. The native caret is a thin 1px
+// line that is easy to lose in dense text, so we hide it and draw our own thicker,
+// coloured bar (see KeyboardEditorMode) that briefly pulses whenever it moves to
+// help the user keep track of the editing position.
+.iaa-document-container.iaa-caret-custom {
+    caret-color: transparent;
+}
+
+.iaa-caret-overlay {
+    position: fixed;
+    width: 2px;
+    margin-left: -1px; // centre the 2px bar on the caret position
+    background-color: #007bff;
+    border-radius: 1px;
+    pointer-events: none;
+    z-index: 1000;
+    // Blink, but never fully disappear, so the caret stays locatable at a glance.
+    animation: iaa-caret-blink 1.1s linear infinite;
+}
+
+// While the caret is moving (see KeyboardEditorMode#markCaretMoved) it is held
+// solid -- no blink -- so it stays clearly visible during continuous navigation
+// instead of flickering. The class is removed shortly after movement stops.
+.iaa-caret-overlay.iaa-caret-moving {
+    animation: none;
+    opacity: 1;
+}
+
+// Glow ring around the caret. Invisible at rest, shown instantly while the caret
+// is moving, and fading out over the transition once movement pauses.
+.iaa-caret-ring {
+    position: absolute;
+    inset: -2px;
+    border-radius: 2px;
+    pointer-events: none;
+    box-shadow: 0 0 0 0 rgba(0, 123, 255, 0);
+    background-color: rgba(0, 123, 255, 0);
+    transition:
+        box-shadow 0.4s ease-out,
+        background-color 0.4s ease-out;
+}
+
+.iaa-caret-overlay.iaa-caret-moving .iaa-caret-ring {
+    box-shadow: 0 0 0 4px rgba(0, 123, 255, 0.4);
+    background-color: rgba(0, 123, 255, 0.3);
+    // Appear instantly on movement; the fade-out happens via the rule above once the
+    // moving class is dropped.
+    transition: none;
+}
+
+@keyframes iaa-caret-blink {
+    0%,
+    50% {
+        opacity: 1;
+    }
+    50.01%,
+    100% {
+        opacity: 0.2;
+    }
+}

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/KeyboardEditorMode.support.test.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/KeyboardEditorMode.support.test.ts
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import {
+    caretOffsetOf,
+    findFirstWordStartOffset,
+    isSelectionBackward,
+    findProtectedBounds,
+    safeCaretOffset,
+} from './KeyboardEditorMode.support';
+
+// Matcher used across the protected-element tests: an element is protected when it
+// carries the `protected` class. Mirrors how the editor flags atomic content.
+const isProtected = (el: Element) => el.classList.contains('protected');
+
+beforeEach(() => {
+    document.body.innerHTML = '';
+});
+
+describe('caretOffsetOf', () => {
+    it('returns the absolute offset of the caret within the root', () => {
+        document.body.innerHTML = `<div id="root"><span>abc</span><span>defg</span></div>`;
+        const root = document.getElementById('root') as Element;
+        const secondText = root.querySelectorAll('span')[1].firstChild as Text;
+
+        const range = document.createRange();
+        range.setStart(secondText, 2); // caret between 'de' and 'fg' -> 'abc' + 2 = 5
+        range.collapse(true);
+
+        expect(caretOffsetOf(root, range)).toBe(5);
+    });
+
+    it('returns 0 for a caret at the very start of the content', () => {
+        document.body.innerHTML = `<div id="root">hello</div>`;
+        const root = document.getElementById('root') as Element;
+        const range = document.createRange();
+        range.setStart(root.firstChild as Text, 0);
+        range.collapse(true);
+
+        expect(caretOffsetOf(root, range)).toBe(0);
+    });
+
+});
+
+describe('findFirstWordStartOffset', () => {
+    it('skips leading whitespace and returns the first non-space offset', () => {
+        document.body.innerHTML = `<div id="root">   <span>  hi</span></div>`;
+        const root = document.getElementById('root') as Element;
+        // '   ' (3) + '  ' (2) = 5 before the 'h'.
+        expect(findFirstWordStartOffset(root)).toBe(5);
+    });
+
+    it('returns the offset within the first text node that has content', () => {
+        document.body.innerHTML = `<div id="root">ab</div>`;
+        const root = document.getElementById('root') as Element;
+        expect(findFirstWordStartOffset(root)).toBe(0);
+    });
+
+    it('returns 0 when the content is entirely whitespace', () => {
+        document.body.innerHTML = `<div id="root">   <span>   </span></div>`;
+        const root = document.getElementById('root') as Element;
+        expect(findFirstWordStartOffset(root)).toBe(0);
+    });
+});
+
+describe('isSelectionBackward', () => {
+    it('is false for a forward selection within a single text node', () => {
+        document.body.innerHTML = `<div id="root">abcdef</div>`;
+        const text = (document.getElementById('root') as Element).firstChild as Text;
+        expect(isSelectionBackward({ anchorNode: text, anchorOffset: 1, focusNode: text, focusOffset: 4 }))
+            .toBe(false);
+    });
+
+    it('is true for a backward selection within a single text node', () => {
+        document.body.innerHTML = `<div id="root">abcdef</div>`;
+        const text = (document.getElementById('root') as Element).firstChild as Text;
+        expect(isSelectionBackward({ anchorNode: text, anchorOffset: 4, focusNode: text, focusOffset: 1 }))
+            .toBe(true);
+    });
+
+    it('is true when the focus node precedes the anchor node in document order', () => {
+        document.body.innerHTML = `<div id="root"><span id="a">aa</span><span id="b">bb</span></div>`;
+        const a = (document.getElementById('a') as Element).firstChild as Text;
+        const b = (document.getElementById('b') as Element).firstChild as Text;
+        // anchor in b, focus in a -> focus precedes anchor -> backward
+        expect(isSelectionBackward({ anchorNode: b, anchorOffset: 0, focusNode: a, focusOffset: 0 }))
+            .toBe(true);
+        // anchor in a, focus in b -> forward
+        expect(isSelectionBackward({ anchorNode: a, anchorOffset: 0, focusNode: b, focusOffset: 0 }))
+            .toBe(false);
+    });
+
+    it('is false when either endpoint is missing', () => {
+        expect(isSelectionBackward({ anchorNode: null, anchorOffset: 0, focusNode: null, focusOffset: 0 }))
+            .toBe(false);
+    });
+});
+
+describe('findProtectedBounds', () => {
+    it('returns null when no matcher is configured', () => {
+        document.body.innerHTML = `<div id="root"><span class="protected">x</span></div>`;
+        const root = document.getElementById('root') as Element;
+        const node = root.querySelector('.protected')!.firstChild;
+        expect(findProtectedBounds(root, node, undefined)).toBeNull();
+    });
+
+    it('returns null when the node is not inside a protected element', () => {
+        document.body.innerHTML = `<div id="root"><span>plain</span></div>`;
+        const root = document.getElementById('root') as Element;
+        const node = root.querySelector('span')!.firstChild;
+        expect(findProtectedBounds(root, node, isProtected)).toBeNull();
+    });
+
+    it('returns the offset bounds of the enclosing protected element', () => {
+        document.body.innerHTML = `<div id="root">ab<span class="protected">CDE</span>fg</div>`;
+        const root = document.getElementById('root') as Element;
+        const node = root.querySelector('.protected')!.firstChild;
+        // 'ab' precedes the protected span (start 2), text 'CDE' has length 3 (end 5).
+        expect(findProtectedBounds(root, node, isProtected)).toEqual({ start: 2, end: 5 });
+    });
+
+    it('walks up to the OUTERMOST protected ancestor when protected elements nest', () => {
+        document.body.innerHTML =
+            `<div id="root">ab<span class="protected outer">C<span class="protected inner">DE</span>F</span>g</div>`;
+        const root = document.getElementById('root') as Element;
+        const innerText = root.querySelector('.inner')!.firstChild;
+        // Outer protected span starts after 'ab' (2), spans 'CDEF' (length 4) -> end 6.
+        expect(findProtectedBounds(root, innerText, isProtected)).toEqual({ start: 2, end: 6 });
+    });
+});
+
+describe('safeCaretOffset', () => {
+    beforeEach(() => {
+        document.body.innerHTML = `<div id="root">ab<span class="protected">CDE</span>fg</div>`;
+    });
+
+    it('snaps an offset inside a protected element to the protected start', () => {
+        const root = document.getElementById('root') as Element;
+        // Offset 3 lands inside 'CDE' (protected, offsets 2..5) -> snaps back to 2.
+        expect(safeCaretOffset(root, 3, isProtected)).toBe(2);
+    });
+
+    it('leaves an offset outside any protected element unchanged', () => {
+        const root = document.getElementById('root') as Element;
+        expect(safeCaretOffset(root, 1, isProtected)).toBe(1);
+    });
+
+    it('returns the offset unchanged when no matcher is configured', () => {
+        const root = document.getElementById('root') as Element;
+        expect(safeCaretOffset(root, 3, undefined)).toBe(3);
+    });
+});

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/KeyboardEditorMode.support.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/KeyboardEditorMode.support.ts
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Pure offset/selection helpers extracted from KeyboardEditorMode so the caret
+// positioning logic can be unit-tested without a live editor instance. These
+// functions take their inputs explicitly instead of reading instance state.
+
+import { calculateStartOffset, offsetToRange } from '@inception-project/inception-js-api';
+import { nodeToElement } from './Utilities';
+
+export interface ProtectedBounds {
+    start: number;
+    end: number;
+}
+
+export type ProtectedElementsMatcher = (el: Element) => boolean;
+
+/**
+ * Absolute document offset of a range's collapsed-start position, relative to
+ * `root`. Returns null when the start container cannot be located under `root`.
+ */
+export function caretOffsetOf(root: Node, range: Range): number | null {
+    const base = calculateStartOffset(root, range.startContainer);
+    if (base < 0) return null;
+    return base + range.startOffset;
+}
+
+/**
+ * Offset of the first non-whitespace character under `contentRoot`, or 0 when the
+ * content is entirely whitespace (or the walk throws).
+ */
+export function findFirstWordStartOffset(contentRoot: Node, doc?: Document): number {
+    try {
+        const ownerDoc = doc ?? contentRoot.ownerDocument ?? document;
+        const walker = ownerDoc.createTreeWalker(contentRoot, NodeFilter.SHOW_TEXT, {
+            acceptNode(node: Node) {
+                const v = node.nodeValue || '';
+                return /\S/.test(v) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT;
+            },
+        } as any);
+        let n = walker.nextNode();
+        while (n) {
+            const txt = n.nodeValue || '';
+            const idx = txt.search(/\S/);
+            if (idx >= 0) {
+                return calculateStartOffset(contentRoot, n) + idx;
+            }
+            n = walker.nextNode();
+        }
+    } catch {
+        // ignore
+    }
+    return 0;
+}
+
+interface SelectionLike {
+    anchorNode: Node | null;
+    anchorOffset: number;
+    focusNode: Node | null;
+    focusOffset: number;
+}
+
+/**
+ * Whether the selection runs right-to-left, i.e. its focus precedes its anchor in
+ * document order. Used to preserve selection direction when re-applying a range.
+ */
+export function isSelectionBackward(sel: SelectionLike): boolean {
+    const { anchorNode, anchorOffset, focusNode, focusOffset } = sel;
+    if (!anchorNode || !focusNode) return false;
+    if (anchorNode === focusNode) return focusOffset < anchorOffset;
+    // The selection is backward if the focus precedes the anchor in document order.
+    return !!(anchorNode.compareDocumentPosition(focusNode) & Node.DOCUMENT_POSITION_PRECEDING);
+}
+
+/**
+ * Offset bounds of the OUTERMOST protected ancestor of `node`, or null when `node`
+ * is not inside a protected element (or no matcher is configured). Walks all the way
+ * up because protected elements may nest and the caret must treat the whole atomic
+ * unit as a single obstacle.
+ */
+export function findProtectedBounds(
+    contentRoot: Node,
+    node: Node | null,
+    protectedElementsMatcher?: ProtectedElementsMatcher
+): ProtectedBounds | null {
+    if (!protectedElementsMatcher) return null;
+
+    let el = nodeToElement(node);
+    let outermost: Element | null = null;
+    while (el && el !== contentRoot && contentRoot.contains(el)) {
+        if (protectedElementsMatcher(el)) {
+            outermost = el;
+        }
+        el = el.parentElement;
+    }
+    if (!outermost) return null;
+    const start = calculateStartOffset(contentRoot, outermost);
+    const end = start + (outermost.textContent ? outermost.textContent.length : 0);
+    return { start, end };
+}
+
+/**
+ * Snap an offset that lands inside a protected element to the start of the OUTERMOST
+ * protected ancestor, so restoration never drops the caret into an atomic element.
+ * Returns the offset unchanged when it is already safe.
+ */
+export function safeCaretOffset(
+    contentRoot: Node,
+    offset: number,
+    protectedElementsMatcher?: ProtectedElementsMatcher
+): number {
+    const range = offsetToRange(contentRoot, offset, offset);
+    const bounds = range
+        ? findProtectedBounds(contentRoot, range.startContainer, protectedElementsMatcher)
+        : null;
+    return bounds ? bounds.start : offset;
+}

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/KeyboardEditorMode.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/KeyboardEditorMode.ts
@@ -1,0 +1,884 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    calculateStartOffset,
+    offsetToRange,
+    positionToOffset,
+    type DiamAjax,
+} from '@inception-project/inception-js-api';
+import './KeyboardEditorMode.scss';
+import { annotatorState } from './ApacheAnnotatorState.svelte';
+import { getSafeRangeForSelection, nodeToElement, rangeClientRect } from './Utilities';
+import * as support from './KeyboardEditorMode.support';
+import type { ApacheAnnotatorSelector } from './ApacheAnnotatorSelector';
+
+export class KeyboardEditorMode {
+    private root: Element;
+    private documentContainer: HTMLElement;
+    private ajax: DiamAjax;
+    private protectedElementsMatcher?: (el: Element) => boolean;
+    private selector?: ApacheAnnotatorSelector;
+
+    private keyboardHandlerCleanup: (() => void) | undefined = undefined;
+    private contentEditableCleanup: (() => void) | undefined = undefined;
+    // Absolute offset of the last collapsed caret known to sit OUTSIDE any protected
+    // element. Used as the travel-direction origin when the caret subsequently lands
+    // inside a protected element, so it can be skipped to the correct (far) edge
+    // without depending on which key was pressed.
+    private lastSafeCaretOffset: number | null = null;
+    // The selection we placed deliberately (a click or a programmatic jump). The
+    // selection sanitizer skips exactly this change, matched by the selection's
+    // identity, so a deliberate caret placement is never snapped away. This replaces
+    // an earlier timer-based skip that raced the (asynchronous) selectionchange event.
+    private programmaticSelection: { node: Node; offset: number } | null = null;
+    // Where to place the caret when focus returns to the document (Escape from a
+    // feature editor, or reclaiming orphaned focus after a deletion). Set to the end
+    // of a just-created annotation, or to the caret position from before a
+    // select/delete; whichever happened most recently wins.
+    private rememberedCaretOffset: number | null = null;
+
+    // Custom caret overlay shown while keyboard mode is active (the native caret is
+    // hidden) so the editing position is easier to spot in dense text.
+    private caretOverlay?: HTMLElement;
+    private caretOverlayCleanup?: () => void;
+    private lastCaretRectKey: string | null = null;
+    private caretMoveTimer?: number;
+    private caretOverlayRaf?: number;
+
+    public constructor(
+        root: Element,
+        documentContainer: HTMLElement,
+        ajax: DiamAjax,
+        protectedElementsMatcher?: (el: Element) => boolean,
+        selector?: ApacheAnnotatorSelector
+    ) {
+        this.root = root;
+        this.documentContainer = documentContainer;
+        this.ajax = ajax;
+        this.protectedElementsMatcher = protectedElementsMatcher;
+        this.selector = selector;
+    }
+
+    public enable(enable: boolean) {
+        // Remove existing handlers first so a repeated enable(true) does not stack a
+        // second set of listeners. The content-editable handlers in particular would
+        // otherwise leak and never reset contentEditable back to 'false', so tear them
+        // down unconditionally here (not only on the !enable path) before re-enabling.
+        if (this.keyboardHandlerCleanup) {
+            this.keyboardHandlerCleanup();
+            this.keyboardHandlerCleanup = undefined;
+        }
+        this.disableCaretOverlay();
+        this.disableContentEditableMode();
+
+        if (!enable) {
+            return;
+        }
+
+        this.documentContainer.tabIndex = 0;
+
+        this.documentContainer.focus();
+        const doc = this.root.ownerDocument;
+        const sel = doc.getSelection();
+        const contentRoot = this.documentContainer;
+        if (sel) {
+            const withinRoot = !!sel.anchorNode && contentRoot.contains(sel.anchorNode as Node);
+            if (sel.rangeCount === 0 || !withinRoot) {
+                const firstOffset = this.findFirstWordStartOffset(contentRoot);
+                const startRange = offsetToRange(contentRoot, firstOffset, firstOffset);
+                if (startRange) {
+                    sel.removeAllRanges();
+                    sel.addRange(startRange);
+                }
+            }
+        }
+
+        const handler = (e: KeyboardEvent) => this.onKeyDown(e);
+        doc.addEventListener('keydown', handler, true);
+
+        const selectionHandler = this.selectionHandler.bind(this);
+        doc.addEventListener('selectionchange', selectionHandler);
+        doc.addEventListener('mouseup', selectionHandler);
+
+        const clickHandler = this.clickHandler.bind(this);
+        this.documentContainer.addEventListener('click', clickHandler);
+
+        // The editor runs inside a same-origin iframe while the feature editor
+        // sidebar lives in the parent document. After creating an annotation the
+        // browser focus moves to that sidebar, so to let the user return to the
+        // document with Escape we must also listen on the top document.
+        const topDoc = this.getTopDocument();
+        const topEscapeHandler = (e: KeyboardEvent) => this.onTopDocumentKeyDown(e);
+        // When the feature editor that holds focus is removed (e.g. its annotation
+        // is deleted), the browser drops focus to <body> instead of returning it to
+        // the document. Watch for the sidebar losing focus to nothing so we can
+        // reclaim it and let the user keep annotating from the keyboard.
+        const topFocusOutHandler = (e: FocusEvent) => this.onTopDocumentFocusOut(e);
+        if (topDoc && topDoc !== doc) {
+            topDoc.addEventListener('keydown', topEscapeHandler, true);
+            topDoc.addEventListener('focusout', topFocusOutHandler, true);
+        }
+
+        this.keyboardHandlerCleanup = () => {
+            doc.removeEventListener('keydown', handler, true);
+            doc.removeEventListener('selectionchange', selectionHandler);
+            doc.removeEventListener('mouseup', selectionHandler);
+            this.documentContainer.removeEventListener('click', clickHandler);
+            if (topDoc && topDoc !== doc) {
+                topDoc.removeEventListener('keydown', topEscapeHandler, true);
+                topDoc.removeEventListener('focusout', topFocusOutHandler, true);
+            }
+        };
+
+        this.enableContentEditableMode();
+
+        this.enableCaretOverlay();
+    }
+
+    private clickHandler(ev: MouseEvent) {
+        try {
+            if (ev.button !== 0) return;
+            const contentRoot = this.documentContainer;
+            if (!contentRoot.contains(ev.target as Node)) return;
+            this.placeCaretAtEvent(ev);
+            // Mark the just-placed caret as deliberate so the sanitizer skips exactly
+            // this selection change (matched by identity, not a wall-clock timer).
+            this.markSelectionProgrammatic();
+        } catch (e) {
+            console.debug('clickHandler error', e);
+        }
+    }
+
+    private selectionHandler() {
+        // Skip the change we just made deliberately (a click or programmatic jump),
+        // matched by the selection's identity. A stale marker (selection has since
+        // moved elsewhere) is dropped so normal sanitization resumes.
+        if (this.consumeProgrammaticSelection()) return;
+
+        if (!annotatorState.keyboardCursorEnabled || !annotatorState.protectElements) return;
+
+        try {
+            const doc = this.root.ownerDocument;
+            const sel = doc.getSelection();
+            const contentRoot = this.documentContainer;
+            if (sel && sel.rangeCount > 0) {
+                if (sel.isCollapsed) {
+                    const curRange = sel.getRangeAt(0);
+                    const curPos = this.caretOffsetOf(curRange);
+                    const bounds = this.findProtectedBounds(sel.anchorNode as Node | null);
+                    if (bounds) {
+                        const { start, end } = bounds;
+                        const prev = this.lastSafeCaretOffset;
+                        let targetPos: number;
+                        if (prev != null && prev <= start) {
+                            // Entered from before the element -> moving forward -> skip to end.
+                            targetPos = end;
+                        } else if (prev != null && prev >= end) {
+                            // Entered from after the element -> moving backward -> skip to start.
+                            targetPos = start;
+                        } else if (curPos != null) {
+                            // No usable origin: fall back to the nearest edge.
+                            targetPos =
+                                Math.abs(curPos - start) <= Math.abs(curPos - end) ? start : end;
+                        } else {
+                            targetPos = start;
+                        }
+                        const newRange = offsetToRange(contentRoot, targetPos, targetPos);
+                        if (newRange) {
+                            sel.removeAllRanges();
+                            sel.addRange(newRange);
+                        }
+                        // The snapped edge is itself a safe origin for the next move.
+                        this.lastSafeCaretOffset = targetPos;
+                    } else if (curPos != null) {
+                        // Caret is in safe territory; remember it as the direction origin.
+                        this.lastSafeCaretOffset = curPos;
+                    }
+                } else {
+                    // Only sanitize a range selection when one of its boundaries
+                    // actually lands inside a protected element (svg/math). The
+                    // sanitizer rebuilds the selection by round-tripping it through
+                    // CAS character offsets; a replaced element such as an <img>
+                    // contributes zero characters, so the positions just before and
+                    // just after it collapse to the same offset. Re-applying that
+                    // round-tripped range every selectionchange would therefore snap
+                    // the focus back to the image and trap it there, preventing
+                    // Shift+Arrow from extending the selection across the image into
+                    // the text beyond. When no boundary is inside a protected element
+                    // there is nothing to expand, so leave the native selection alone
+                    // -- the browser already selects across images correctly.
+                    const boundaryInProtected =
+                        this.findProtectedBounds(sel.anchorNode as Node | null) != null ||
+                        this.findProtectedBounds(sel.focusNode as Node | null) != null;
+                    if (!boundaryInProtected) return;
+
+                    const safeRange = getSafeRangeForSelection(
+                        sel,
+                        contentRoot,
+                        this.protectedElementsMatcher,
+                        annotatorState.protectElements
+                    );
+                    if (safeRange) {
+                        this.applyRangeToSelection(sel, safeRange);
+                    }
+                }
+            }
+        } catch (e) {
+            console.debug('selectionHandler error', e);
+        }
+    }
+
+    private onKeyDown(e: KeyboardEvent) {
+        if (!annotatorState.keyboardCursorEnabled) return;
+
+        // While the overlapping-annotation selector popup is open, let it handle the
+        // keyboard (arrow navigation, Enter to select, Escape to dismiss). We must not
+        // move the caret or run our own Escape handling underneath it.
+        if (this.selector?.isVisible()) {
+            return;
+        }
+
+        // Escape reclaims focus from outside the document (e.g. the feature editor
+        // sidebar that gets focused after creating an annotation) so the user can
+        // continue navigating/annotating with the keyboard without reaching for the
+        // mouse. Handle this before the INPUT/TEXTAREA early-return below because the
+        // focus is typically inside a feature editor input at that point.
+        if (e.key === 'Escape') {
+            const active = this.root.ownerDocument.activeElement;
+            if (active && !this.documentContainer.contains(active)) {
+                e.preventDefault();
+                e.stopPropagation();
+                this.returnFocusToEditor();
+                return;
+            }
+        }
+
+        const tgt = e.target as Element | null;
+        if (tgt instanceof HTMLElement) {
+            if (['INPUT', 'TEXTAREA', 'SELECT'].includes(tgt.tagName)) {
+                return;
+            }
+        }
+
+        const doc = this.root.ownerDocument;
+        const sel = doc.getSelection();
+        if (!sel) return;
+
+        // Refresh the caret overlay right after the browser applies a caret-moving
+        // key. The browser coalesces selectionchange events, so during fast movement
+        // it may not fire per keypress; this guarantees the overlay repositions and
+        // pulses for every individual move. Scheduled on the next frame so the caret
+        // has actually moved before we measure it.
+        if (
+            [
+                'ArrowLeft',
+                'ArrowRight',
+                'ArrowUp',
+                'ArrowDown',
+                'Home',
+                'End',
+                'PageUp',
+                'PageDown',
+            ].includes(e.key)
+        ) {
+            this.scheduleCaretOverlayUpdate();
+        }
+
+        // Space selects the annotation at the caret. If multiple annotations
+        // overlap there, a keyboard-navigable popup is shown to pick one.
+        if (e.key === ' ') {
+            e.preventDefault();
+            const range = sel.rangeCount ? sel.getRangeAt(0) : null;
+            if (range && this.selector) {
+                // Remember the exact caret position before selecting so that pressing
+                // Escape in the feature editor returns the caret here (not merely to
+                // the start of the selected annotation), and so it can be restored if
+                // the selected annotation is subsequently deleted.
+                this.rememberedCaretOffset = this.caretOffsetOf(range);
+                this.selector.selectAtCaret(range, this.documentContainer);
+            }
+            return;
+        }
+
+        // Backspace deletes the annotation at the caret. If multiple annotations
+        // overlap there, the same popup is shown to pick which one to delete.
+        if (e.key === 'Backspace') {
+            e.preventDefault();
+            const range = sel.rangeCount ? sel.getRangeAt(0) : null;
+            if (range && this.selector) {
+                // Remember the caret so focus/caret can be restored after the
+                // deletion re-renders the document.
+                this.rememberedCaretOffset = this.caretOffsetOf(range);
+                this.selector.deleteAtCaret(range, this.documentContainer);
+            }
+            return;
+        }
+
+        if (e.key === 'Enter' && !e.shiftKey) {
+            if (sel.isCollapsed) return;
+            e.preventDefault();
+
+            const contentRoot = this.documentContainer;
+            const safeRange = getSafeRangeForSelection(
+                sel,
+                contentRoot,
+                this.protectedElementsMatcher,
+                annotatorState.protectElements
+            );
+            if (!safeRange) return;
+
+            const anchorOffset =
+                calculateStartOffset(contentRoot, safeRange.startContainer) + safeRange.startOffset;
+            const focusOffset =
+                calculateStartOffset(contentRoot, safeRange.endContainer) + safeRange.endOffset;
+            const begin = Math.min(anchorOffset, focusOffset);
+            const end = Math.max(anchorOffset, focusOffset);
+
+            // Remember where the annotation ended so that pressing Escape in the
+            // feature editor can return the caret here and let the user continue.
+            // This supersedes any remembered select/delete caret position.
+            this.rememberedCaretOffset = end;
+
+            sel.removeAllRanges();
+            this.ajax.createSpanAnnotation([[begin, end]], '');
+            return;
+        }
+    }
+
+    /**
+     * Resolve the absolute document offset of a (collapsed) caret range, or null if it
+     * cannot be determined. calculateStartOffset returns -1 on failure; guard against
+     * it so a corrupted -1-based offset is never remembered and later used to misplace
+     * the caret at the start of the document.
+     */
+    private caretOffsetOf(range: Range): number | null {
+        return support.caretOffsetOf(this.documentContainer, range);
+    }
+
+    private findFirstWordStartOffset(contentRoot: Node): number {
+        return support.findFirstWordStartOffset(contentRoot, this.root?.ownerDocument ?? undefined);
+    }
+
+    /**
+     * Record the current selection as one we placed deliberately so the sanitizer
+     * skips exactly that change (see the programmaticSelection field).
+     */
+    private markSelectionProgrammatic() {
+        const sel = this.root.ownerDocument.getSelection();
+        if (sel && sel.rangeCount > 0) {
+            const r = sel.getRangeAt(0);
+            this.programmaticSelection = { node: r.startContainer, offset: r.startOffset };
+        } else {
+            this.programmaticSelection = null;
+        }
+    }
+
+    /**
+     * If the current selection is still the one we just placed deliberately, consume
+     * the marker and return true so the sanitizer skips this change. A stale marker is
+     * dropped (returns false) so normal sanitization resumes.
+     */
+    private consumeProgrammaticSelection(): boolean {
+        const pending = this.programmaticSelection;
+        if (!pending) return false;
+        this.programmaticSelection = null;
+        const sel = this.root.ownerDocument.getSelection();
+        if (sel && sel.rangeCount > 0) {
+            const r = sel.getRangeAt(0);
+            if (r.startContainer === pending.node && r.startOffset === pending.offset) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private isSelectionBackward(sel: Selection): boolean {
+        return support.isSelectionBackward(sel);
+    }
+
+    private applyRangeToSelection(sel: Selection, range: Range) {
+        try {
+            // A Range is always normalized start->end, so re-applying it would
+            // discard the selection's direction and flip a backward (right-to-left)
+            // selection to forward. That moves the focus to the wrong end and makes
+            // the next Shift+Left collapse the selection instead of extending it.
+            // Preserve the original direction so keyboard extension keeps growing.
+            const backward = this.isSelectionBackward(sel);
+            if ((sel as any).setBaseAndExtent) {
+                if (backward) {
+                    (sel as any).setBaseAndExtent(
+                        range.endContainer,
+                        range.endOffset,
+                        range.startContainer,
+                        range.startOffset
+                    );
+                } else {
+                    (sel as any).setBaseAndExtent(
+                        range.startContainer,
+                        range.startOffset,
+                        range.endContainer,
+                        range.endOffset
+                    );
+                }
+            } else {
+                sel.removeAllRanges();
+                sel.addRange(range);
+            }
+        } catch (e) {
+            console.debug('applyRangeToSelection error', e);
+        }
+    }
+
+    private findProtectedBounds(node: Node | null): { start: number; end: number } | null {
+        return support.findProtectedBounds(this.documentContainer, node, this.protectedElementsMatcher);
+    }
+
+    private safeCaretOffset(offset: number): number {
+        return support.safeCaretOffset(
+            this.documentContainer,
+            offset,
+            this.protectedElementsMatcher
+        );
+    }
+
+    private enableContentEditableMode() {
+        try {
+            const host = this.documentContainer;
+            host.contentEditable = 'true';
+
+            const beforeInput = (ev: InputEvent) => ev.preventDefault();
+            const pasteHandler = (ev: ClipboardEvent) => ev.preventDefault();
+            const dropHandler = (ev: DragEvent) => ev.preventDefault();
+
+            const inputHandler = (ev: Event) => {
+                ev.stopImmediatePropagation();
+                if ((ev as any).preventDefault) (ev as any).preventDefault();
+            };
+
+            const keyBlock = (ev: KeyboardEvent) => {
+                const nav = [
+                    'ArrowLeft',
+                    'ArrowRight',
+                    'ArrowUp',
+                    'ArrowDown',
+                    'Tab',
+                    'Home',
+                    'End',
+                    'PageUp',
+                    'PageDown',
+                ];
+                if (nav.includes(ev.key) || ev.ctrlKey || ev.metaKey || ev.altKey) return;
+                if (
+                    ev.key.length === 1 ||
+                    ev.key === 'Backspace' ||
+                    ev.key === 'Delete' ||
+                    ev.key === 'Enter'
+                ) {
+                    ev.preventDefault();
+                    ev.stopImmediatePropagation();
+                }
+            };
+
+            host.addEventListener('beforeinput', beforeInput as EventListener);
+            host.addEventListener('input', inputHandler as EventListener);
+            host.addEventListener('paste', pasteHandler as EventListener);
+            host.addEventListener('cut', pasteHandler as EventListener);
+            host.addEventListener('drop', dropHandler as EventListener);
+            host.addEventListener('keydown', keyBlock as EventListener);
+
+            this.contentEditableCleanup = () => {
+                host.removeEventListener('beforeinput', beforeInput as EventListener);
+                host.removeEventListener('input', inputHandler as EventListener);
+                host.removeEventListener('paste', pasteHandler as EventListener);
+                host.removeEventListener('cut', pasteHandler as EventListener);
+                host.removeEventListener('drop', dropHandler as EventListener);
+                host.removeEventListener('keydown', keyBlock as EventListener);
+                host.contentEditable = 'false';
+                this.contentEditableCleanup = undefined;
+            };
+        } catch (e) {
+            console.debug('enableContentEditableMode error', e);
+        }
+    }
+
+    private disableContentEditableMode() {
+        if (this.contentEditableCleanup) {
+            this.contentEditableCleanup();
+            this.contentEditableCleanup = undefined;
+        }
+    }
+
+    private placeCaretAtEvent(ev: MouseEvent) {
+        const doc = this.root.ownerDocument;
+        const contentRoot = this.documentContainer;
+        const pos = positionToOffset(contentRoot, ev.clientX, ev.clientY);
+        if (pos < 0) return;
+
+        const range = offsetToRange(contentRoot, pos, pos);
+        if (!range) return;
+
+        const sel = doc.getSelection();
+        if (!sel) return;
+
+        sel.removeAllRanges();
+        sel.addRange(range);
+
+        if (annotatorState.protectElements) {
+            const safeRange = getSafeRangeForSelection(sel, contentRoot);
+            if (safeRange) {
+                this.applyRangeToSelection(sel, safeRange);
+            }
+        }
+
+        // Record the resulting collapsed caret as the safe direction origin so a
+        // subsequent arrow press into a protected element skips the right way.
+        const placed = sel.rangeCount ? sel.getRangeAt(0) : null;
+        if (placed && placed.collapsed) {
+            const off = this.caretOffsetOf(placed);
+            if (off != null) this.lastSafeCaretOffset = off;
+        }
+    }
+
+    /**
+     * Resolve the top-level document (the parent INCEpTION page that hosts the
+     * feature editor sidebar). Returns null if it cannot be reached, e.g. because
+     * the hosting iframe turns out to be cross-origin.
+     */
+    private getTopDocument(): Document | null {
+        try {
+            const win = this.root.ownerDocument.defaultView;
+            const top = win?.top;
+            return top ? top.document : null;
+        } catch {
+            return null;
+        }
+    }
+
+    private onTopDocumentKeyDown(e: KeyboardEvent) {
+        if (!annotatorState.keyboardCursorEnabled) return;
+        if (e.key !== 'Escape') return;
+
+        try {
+            const topDoc = this.getTopDocument();
+            const active = topDoc?.activeElement as Element | null;
+            // Only reclaim focus when it currently sits in the feature editor
+            // sidebar (where it lands after creating an annotation).
+            if (active && active.closest && active.closest('.feature-editors-sidebar')) {
+                e.preventDefault();
+                e.stopPropagation();
+                this.returnFocusToEditor();
+            }
+        } catch (err) {
+            console.debug('onTopDocumentKeyDown error', err);
+        }
+    }
+
+    /**
+     * Reclaim focus into the document after it was orphaned to {@code <body>}.
+     * This happens when the feature editor that held focus is removed because its
+     * annotation was deleted, leaving the user unable to continue keyboard
+     * navigation. We only act when the focus is genuinely lost (i.e. sitting on the
+     * top document body) so that we never steal focus while the user is still
+     * typing in a feature editor (after creating or selecting an annotation).
+     */
+    private onTopDocumentFocusOut(e: FocusEvent) {
+        if (!annotatorState.keyboardCursorEnabled) return;
+        // If focus moved to a real element there is nothing to reclaim. A removed
+        // focused element transfers focus to nothing (relatedTarget == null).
+        if (e.relatedTarget) return;
+
+        const doc = this.root.ownerDocument;
+        const win = doc.defaultView || window;
+        // Defer until the focus transition has settled so activeElement reflects
+        // the final state (body when the focused element was removed).
+        win.setTimeout(() => {
+            try {
+                if (!annotatorState.keyboardCursorEnabled) return;
+                const topDoc = this.getTopDocument();
+                if (!topDoc || topDoc === doc) return;
+                const active = topDoc.activeElement;
+                // Focus landed on a real control (e.g. another feature editor) or
+                // moved into the editor iframe -> leave it alone.
+                if (active && active !== topDoc.body) return;
+                this.returnFocusToEditor(this.rememberedCaretOffset);
+            } catch (err) {
+                console.debug('onTopDocumentFocusOut error', err);
+            }
+        }, 0);
+    }
+
+    /**
+     * Move focus back into the document and place the caret at the given offset. When
+     * no offset is given, fall back to the position remembered from the last action:
+     * the end of the most recently created annotation, or otherwise the caret position
+     * from before the last select/delete. Used both for Escape-to-return after creating
+     * or selecting an annotation and for reclaiming orphaned focus after a deletion.
+     */
+    private returnFocusToEditor(caretOffset?: number | null) {
+        const doc = this.root.ownerDocument;
+
+        // Commit any pending feature editor value by blurring whatever is focused
+        // before we steal focus, so the label the user just typed is not lost. The
+        // focused element may live in the parent document, where a cross-realm
+        // `instanceof HTMLElement` would fail, so we duck-type the blur() call.
+        const blurActive = (d: Document | null | undefined) => {
+            const active = d?.activeElement as any;
+            if (active && active !== this.documentContainer && typeof active.blur === 'function') {
+                active.blur();
+            }
+        };
+        blurActive(this.getTopDocument());
+        blurActive(doc);
+
+        // Focusing the container would, by default, scroll it into view — which jumps
+        // the viewport to the top of the document. The caret is restored just below to
+        // where the user already was (on-screen), so suppress the automatic scroll.
+        this.documentContainer.focus({ preventScroll: true });
+
+        const requested = caretOffset != null ? caretOffset : this.rememberedCaretOffset;
+        if (requested != null) {
+            const contentRoot = this.documentContainer;
+            // Never restore the caret inside a protected element; snap it out if needed.
+            const offset = this.safeCaretOffset(requested);
+            const range = offsetToRange(contentRoot, offset, offset);
+            if (range) {
+                const sel = doc.getSelection();
+                if (sel) {
+                    sel.removeAllRanges();
+                    sel.addRange(range);
+                }
+                // Remember as the safe direction origin for subsequent navigation.
+                this.lastSafeCaretOffset = offset;
+            }
+        }
+        this.rememberedCaretOffset = null;
+    }
+
+    /**
+     * Move the keyboard caret to the given document offset. Used when the view is
+     * scrolled to a new location by something other than caret movement — opening a
+     * document (scroll to the last edit location) or selecting an annotation in the
+     * sidebar. Without this the caret stays where it was, so the first cursor-key press
+     * scrolls the view back to it, undoing the jump.
+     *
+     * Only acts while keyboard navigation is enabled. Deliberately does not move focus:
+     * the jump may originate from the sidebar, and stealing focus into the document
+     * would be intrusive. Setting a collapsed selection neither scrolls nor focuses on
+     * its own, so the explicit scroll remains in charge of the viewport.
+     */
+    public moveCaretToOffset(offset: number | null | undefined) {
+        if (!annotatorState.keyboardCursorEnabled) return;
+        if (offset == null || offset < 0) return;
+
+        try {
+            const doc = this.root.ownerDocument;
+            const contentRoot = this.documentContainer;
+            // Never place the caret inside a protected element; snap it out if needed.
+            const safe = this.safeCaretOffset(offset);
+            const range = offsetToRange(contentRoot, safe, safe);
+            if (!range) return;
+
+            const sel = doc.getSelection();
+            if (!sel) return;
+
+            sel.removeAllRanges();
+            sel.addRange(range);
+
+            // Record the placed caret as the safe direction origin for the next move.
+            this.lastSafeCaretOffset = safe;
+
+            // Treat this like a deliberate caret placement (as with a click): mark the
+            // selection so the sanitizer skips exactly this change (matched by identity)
+            // and a stale directional snap does not relocate the caret away from the
+            // jump target.
+            this.markSelectionProgrammatic();
+
+            // Keep the custom caret overlay in sync with the programmatic move.
+            this.updateCaretOverlay();
+        } catch (e) {
+            console.debug('moveCaretToOffset error', e);
+        }
+    }
+
+    /**
+     * Show a custom caret overlay while keyboard mode is active. The native caret is
+     * only a thin 1px line that is easily lost in dense text, so we hide it (via the
+     * {@code iaa-caret-custom} class) and draw our own thicker, coloured bar at the
+     * caret position. The bar follows the caret on selection changes, scrolling and
+     * resizing, and briefly pulses whenever it moves to draw the eye to the new spot.
+     */
+    private enableCaretOverlay() {
+        if (this.caretOverlay) return;
+
+        const doc = this.root.ownerDocument;
+        const win = doc.defaultView || window;
+
+        this.documentContainer.classList.add('iaa-caret-custom');
+
+        const overlay = doc.createElement('div');
+        overlay.className = 'iaa-caret-overlay';
+        overlay.style.display = 'none';
+        // The glow is a dedicated child element (rather than a pseudo-element on the
+        // overlay) so its CSS transition can be driven independently of the overlay's
+        // blink animation -- see the .iaa-caret-moving .iaa-caret-ring rules in the SCSS.
+        const ring = doc.createElement('div');
+        ring.className = 'iaa-caret-ring';
+        overlay.appendChild(ring);
+        doc.body.appendChild(overlay);
+        this.caretOverlay = overlay;
+        this.lastCaretRectKey = null;
+
+        const update = () => this.scheduleCaretOverlayUpdate();
+        // selectionchange catches caret moves and (re)placement; scroll and resize
+        // keep the fixed-position overlay aligned with the content underneath it.
+        doc.addEventListener('selectionchange', update);
+        win.addEventListener('scroll', update, true);
+        win.addEventListener('resize', update);
+
+        this.caretOverlayCleanup = () => {
+            doc.removeEventListener('selectionchange', update);
+            win.removeEventListener('scroll', update, true);
+            win.removeEventListener('resize', update);
+        };
+
+        this.updateCaretOverlay();
+    }
+
+    /**
+     * Coalesce caret-overlay refreshes into a single measurement per animation frame.
+     * selectionchange, capture-phase scroll (which fires for every nested scroller),
+     * resize and per-keystroke refreshes would otherwise each force a synchronous
+     * layout via getBoundingClientRect/getClientRects — janky on large documents.
+     */
+    private scheduleCaretOverlayUpdate() {
+        if (this.caretOverlayRaf != null) return;
+        const win = this.root.ownerDocument.defaultView || window;
+        this.caretOverlayRaf = win.requestAnimationFrame(() => {
+            this.caretOverlayRaf = undefined;
+            this.updateCaretOverlay();
+        });
+    }
+
+    private disableCaretOverlay() {
+        if (this.caretOverlayCleanup) {
+            this.caretOverlayCleanup();
+            this.caretOverlayCleanup = undefined;
+        }
+        if (this.caretOverlayRaf != null) {
+            const win = this.root.ownerDocument.defaultView || window;
+            win.cancelAnimationFrame(this.caretOverlayRaf);
+            this.caretOverlayRaf = undefined;
+        }
+        if (this.caretMoveTimer != null) {
+            const win = this.root.ownerDocument.defaultView || window;
+            win.clearTimeout(this.caretMoveTimer);
+            this.caretMoveTimer = undefined;
+        }
+        this.caretOverlay?.remove();
+        this.caretOverlay = undefined;
+        this.lastCaretRectKey = null;
+        this.documentContainer.classList.remove('iaa-caret-custom');
+    }
+
+    private updateCaretOverlay() {
+        const overlay = this.caretOverlay;
+        if (!overlay) return;
+
+        const hide = () => {
+            overlay.style.display = 'none';
+            this.lastCaretRectKey = null;
+        };
+
+        if (!annotatorState.keyboardCursorEnabled) {
+            hide();
+            return;
+        }
+
+        const doc = this.root.ownerDocument;
+        const sel = doc.getSelection();
+        // Only show the caret for a collapsed selection; while text is selected the
+        // native selection highlight already marks the position.
+        if (!sel || sel.rangeCount === 0 || !sel.isCollapsed) {
+            hide();
+            return;
+        }
+
+        const range = sel.getRangeAt(0);
+        const contentRoot = this.documentContainer;
+        if (!contentRoot.contains(range.startContainer)) {
+            hide();
+            return;
+        }
+
+        const rect = rangeClientRect(range, true);
+        if (!rect) {
+            hide();
+            return;
+        }
+
+        let height = rect.height;
+        if (!height) {
+            // A collapsed range at a boundary can report zero height; fall back to
+            // the line/font metrics of the surrounding element.
+            const el = nodeToElement(range.startContainer);
+            const cs = el ? (doc.defaultView || window).getComputedStyle(el) : null;
+            height = (cs && (parseFloat(cs.lineHeight) || parseFloat(cs.fontSize))) || 16;
+        }
+
+        overlay.style.display = 'block';
+        overlay.style.left = `${rect.left}px`;
+        overlay.style.top = `${rect.top}px`;
+        overlay.style.height = `${height}px`;
+
+        const key = `${Math.round(rect.left)},${Math.round(rect.top)}`;
+        // Mark the caret as moving on an actual move (not first appearance or a
+        // no-op update) so it stays solid and glowing during continuous movement.
+        if (this.lastCaretRectKey !== null && this.lastCaretRectKey !== key) {
+            this.markCaretMoved();
+        }
+        this.lastCaretRectKey = key;
+    }
+
+    /**
+     * Mark the caret as currently moving: it is held solid (no blink) with a steady
+     * glow while movement continues, and only fades back to the idle blinking caret
+     * once movement has paused briefly. This keeps the caret clearly visible during
+     * continuous navigation instead of flickering as a per-move pulse fades in and
+     * out.
+     */
+    private markCaretMoved() {
+        const overlay = this.caretOverlay;
+        if (!overlay) return;
+        const win = this.root.ownerDocument.defaultView || window;
+        overlay.classList.add('iaa-caret-moving');
+        if (this.caretMoveTimer != null) win.clearTimeout(this.caretMoveTimer);
+        this.caretMoveTimer = win.setTimeout(() => {
+            this.caretMoveTimer = undefined;
+            this.caretOverlay?.classList.remove('iaa-caret-moving');
+        }, 220);
+    }
+
+    public destroy() {
+        if (this.keyboardHandlerCleanup) {
+            this.keyboardHandlerCleanup();
+            this.keyboardHandlerCleanup = undefined;
+        }
+        this.disableCaretOverlay();
+        this.disableContentEditableMode();
+    }
+}

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/Utilities.test.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/Utilities.test.ts
@@ -59,6 +59,8 @@ import {
     compileNsSelector,
     closestWithMatcher,
     expandSelectionOverProtectedElements,
+    nodeToElement,
+    rangeClientRect,
 } from './Utilities';
 
 describe('expandSelectionOverProtectedElements', () => {
@@ -358,6 +360,10 @@ describe('extendHighlightOverProtectedElements', () => {
         expect(wrapper).not.toBeNull();
         expect(wrapper.tagName.toLowerCase()).toBe('mark');
         expect(wrapper.getAttribute('data-iaa-id')).toBe('v1');
+        // Wrapper highlights must be non-editable so the browser caret treats the
+        // protected element as atomic and cannot type inside it. (jsdom reflects this
+        // on the IDL property rather than the contenteditable attribute.)
+        expect((wrapper as HTMLElement).contentEditable).toBe('false');
 
         // Calling returned callback removes wrapper and calls the old callback
         returned();
@@ -737,5 +743,76 @@ describe('groupHighlightsByVid', () => {
         const list = document.querySelectorAll('.iaa-highlighted') as NodeListOf<Element>;
         const groups = groupHighlightsByVid(list);
         expect(groups.size).toBe(0);
+    });
+});
+
+describe('nodeToElement', () => {
+    it('returns null for a null node', () => {
+        expect(nodeToElement(null)).toBeNull();
+    });
+
+    it('returns an Element node as-is', () => {
+        document.body.innerHTML = `<div id="el">x</div>`;
+        const el = document.getElementById('el') as Element;
+        expect(nodeToElement(el)).toBe(el);
+    });
+
+    it('resolves a Text node to its parent element', () => {
+        document.body.innerHTML = `<div id="el">hello</div>`;
+        const el = document.getElementById('el') as Element;
+        expect(nodeToElement(el.firstChild as Text)).toBe(el);
+    });
+});
+
+describe('rangeClientRect', () => {
+    // Build a minimal Range-like object so the branch logic can be tested without
+    // relying on jsdom layout (which reports empty/zero rects for real ranges).
+    const fakeRange = (opts: {
+        clientRects?: DOMRect[];
+        bounding?: DOMRect | null;
+    }): Range => {
+        return {
+            getClientRects: () =>
+                ({
+                    length: opts.clientRects?.length ?? 0,
+                    0: opts.clientRects?.[0],
+                }) as unknown as DOMRectList,
+            getBoundingClientRect: () => opts.bounding as DOMRect,
+        } as unknown as Range;
+    };
+
+    it('returns the first client rect by default', () => {
+        const first = new DOMRect(10, 20, 5, 12);
+        const rect = rangeClientRect(fakeRange({ clientRects: [first] }));
+        expect(rect).toBe(first);
+    });
+
+    it('falls back to the bounding rect when there are no client rects (default mode)', () => {
+        const bounding = new DOMRect(1, 2, 3, 4);
+        const rect = rangeClientRect(fakeRange({ clientRects: [], bounding }));
+        expect(rect).toBe(bounding);
+    });
+
+    it('returns null when neither client rects nor a bounding rect are available', () => {
+        expect(rangeClientRect(fakeRange({ clientRects: [], bounding: null }))).toBeNull();
+    });
+
+    it('prefers a positioned bounding rect when preferBounding is set', () => {
+        const bounding = new DOMRect(0, 100, 0, 14); // zero width collapsed caret, positioned
+        const first = new DOMRect(0, 0, 5, 14);
+        const rect = rangeClientRect(fakeRange({ clientRects: [first], bounding }), true);
+        expect(rect).toBe(bounding);
+    });
+
+    it('falls back to a client rect when the bounding rect is unpositioned (preferBounding)', () => {
+        const bounding = new DOMRect(0, 0, 0, 0); // height/top/left all zero -> not usable
+        const first = new DOMRect(7, 8, 3, 14);
+        const rect = rangeClientRect(fakeRange({ clientRects: [first], bounding }), true);
+        expect(rect).toBe(first);
+    });
+
+    it('returns null when preferBounding has neither a positioned bounding nor client rects', () => {
+        const bounding = new DOMRect(0, 0, 0, 0);
+        expect(rangeClientRect(fakeRange({ clientRects: [], bounding }), true)).toBeNull();
     });
 });

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/Utilities.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/Utilities.ts
@@ -108,13 +108,8 @@ export function extendHighlightOverProtectedElements(
     // Clone the range so we don't mutate the caller's target range unexpectedly
     const searchRange = target.cloneRange();
 
-    // Helper to get an element from a node (handles Text nodes)
-    const elementFor = (node: Node): Element | null => {
-        return node instanceof Element ? node : node.parentElement;
-    };
-
-    const startEl = elementFor(searchRange.startContainer);
-    const endEl = elementFor(searchRange.endContainer);
+    const startEl = nodeToElement(searchRange.startContainer);
+    const endEl = nodeToElement(searchRange.endContainer);
 
     // Expand the range such that the start is before the closest protected ancestor of the start container and the end
     // is after the closest protected ancestor of the end container. This ensures that all protected elements
@@ -170,6 +165,13 @@ export function extendHighlightOverProtectedElements(
             for (const name in attributes) {
                 highlight.setAttribute(name, attributes[name]);
             }
+        }
+        // Make wrapper highlights non-editable to keep them atomic for the
+        // browser caret (prevents typing inside protected wrappers).
+        try {
+            highlight.contentEditable = 'false';
+        } catch {
+            // ignore if not supported
         }
         const range = document.createRange();
         range.selectNode(protectedElement);
@@ -329,6 +331,42 @@ export function getInlineLabelClientRect(highlight: Element): DOMRect {
     }
 
     return new DOMRect(r.left, r.top, cr ? cr.left - r.left : 0, r.height);
+}
+
+/**
+ * Coerce a DOM node to its nearest Element: an Element is returned as-is, any other
+ * node (Text, comment, ...) resolves to its parentElement.
+ */
+export function nodeToElement(node: Node | null): Element | null {
+    if (!node) return null;
+    if (node instanceof Element) return node;
+    return node.parentElement;
+}
+
+/**
+ * Resolve the on-screen rectangle of a DOM Range, or null when none is available.
+ * With preferBounding, getBoundingClientRect() is tried first (modern browsers report
+ * it with a correct position and zero width for a collapsed caret), otherwise the
+ * first client rect is preferred; each falls back to the other.
+ */
+export function rangeClientRect(range: Range, preferBounding = false): DOMRect | null {
+    if (preferBounding) {
+        const bounding = range.getBoundingClientRect() as DOMRect;
+        if (bounding && (bounding.height > 0 || bounding.top > 0 || bounding.left > 0)) {
+            return bounding;
+        }
+        const rects = range.getClientRects();
+        if (rects && rects.length > 0) {
+            return rects[0] as DOMRect;
+        }
+        return null;
+    }
+
+    const rects = range.getClientRects();
+    if (rects && rects.length > 0) {
+        return rects[0] as DOMRect;
+    }
+    return (range.getBoundingClientRect() as DOMRect) || null;
 }
 
 /**

--- a/inception/inception-html-recogito-editor/src/main/ts/src/recogito/RecogitoEditorToolbar.svelte
+++ b/inception/inception-html-recogito-editor/src/main/ts/src/recogito/RecogitoEditorToolbar.svelte
@@ -46,18 +46,26 @@
     }
 </script>
 
-<div class="bootstrap card card-header border-0 border-bottom rounded-0 p-1" role="toolbar">
-    <div class="d-flex">
-        <div class="form-check form-switch mx-2">
-            <input
-                class="form-check-input"
-                type="checkbox"
-                role="switch"
-                id="inlineLabelsEnabled"
-                bind:checked={annotatorState.showLabels}
-            />
-            <label class="form-check-label" for="inlineLabelsEnabled">Labels</label>
-        </div>
+<div
+    class="bootstrap card-header border-0 border-bottom rounded-0 p-1 d-flex flex-row flex-wrap align-items-center"
+    role="toolbar"
+>
+    <div class="btn-group btn-group-sm" role="group" aria-label="Display options">
+        <input
+            class="btn-check"
+            type="checkbox"
+            id="inlineLabelsEnabled"
+            autocomplete="off"
+            bind:checked={annotatorState.showLabels}
+        />
+        <label
+            class="btn btn-outline-secondary"
+            for="inlineLabelsEnabled"
+            title="Labels"
+            aria-label="Labels"
+        >
+            <i class="fas fa-tag"></i>
+        </label>
     </div>
 </div>
 

--- a/inception/inception-js-api/src/main/ts/src/widget/AnnotationDetailPopOver.svelte
+++ b/inception/inception-js-api/src/main/ts/src/widget/AnnotationDetailPopOver.svelte
@@ -53,6 +53,11 @@
         root.addEventListener(AnnotationOutEvent.eventType, onAnnotationOut);
         root.addEventListener('mousemove', onMouseMove);
         root.addEventListener('mousedown', onMouseDown);
+        // Keyboard focus lives on a container that is an *ancestor* of `root` (the
+        // document content is nested inside the focused/keyboard element), so keydown
+        // events bubble away from `root` and never reach a listener on it. Listen on
+        // the document instead, which every keydown reaches by bubbling.
+        root.ownerDocument.addEventListener('keydown', onKeyDown);
     });
 
     onDestroy(() => {
@@ -60,6 +65,7 @@
         root.removeEventListener(AnnotationOutEvent.eventType, onAnnotationOut);
         root.removeEventListener('mousemove', onMouseMove);
         root.removeEventListener('mousedown', onMouseDown);
+        root.ownerDocument.removeEventListener('keydown', onKeyDown);
     });
 
     $effect(() => {
@@ -94,6 +100,20 @@
             popoverTimeoutId = undefined;
         }
         annotation = undefined;
+    }
+
+    function onKeyDown(e: KeyboardEvent) {
+        // Once the user starts driving with the keyboard (e.g. keyboard-based caret
+        // navigation), the mouse-hover popover only gets in the way. Hide it the same
+        // way a mouse click does. It reappears when the mouse next hovers an annotation,
+        // so it stays out of the way while the mouse sits still during keyboard use.
+        if (popoverTimeoutId) {
+            window.clearTimeout(popoverTimeoutId);
+            popoverTimeoutId = undefined;
+        }
+        if (annotation) {
+            annotation = undefined;
+        }
     }
 
     function onAnnotationOver(e: AnnotationOverEvent) {


### PR DESCRIPTION
**What's in the PR**
- Documentation: Updated user guide for editors
- Added keyboard-based annotation creation mode support to Apache Annotator editor
- Implemented KeyboardEditorMode component with styling and utilities
- Updated ApacheAnnotatorEditor and related components to support keyboard mode
- Updated ApacheAnnotatorSelector and ApacheAnnotatorState for keyboard input handling
- Updated ApacheAnnotatorToolbar for keyboard mode integration
- Updated Utilities with keyboard mode helper functions and tests
- Added wicket-bootstrap-extensions dependency
- Updated ExternalAnnotationEditorBase for external editor integration
- Updated ApacheAnnotatorHtmlAnnotationEditorFactoryUserPreferences schema
- Updated RecogitoEditorToolbar for editor toolbar enhancements
- Updated AnnotationDetailPopOver widget

**How to test manually**
* Open a HTML file
* Enable keyboard navigation mode
* Test

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [x] PR updates documentation
