### PR TITLE
#6108 - Relation support for the Apache Annotator HTML editor mode

### DIFF
--- a/inception/inception-assistant-ui/src/main/ts_template/package.json
+++ b/inception/inception-assistant-ui/src/main/ts_template/package.json
@@ -19,9 +19,6 @@
     "type": "git",
     "url": "git+https://github.com/inception-project/inception.git"
   },
-  "bugs": {
-    "url": "https://github.com/inception-project/issues"
-  },
   "overrides": {
     "minimatch": "${minimatch.version}",
     "immutable": "${immutable.version}",

--- a/inception/inception-html-apache-annotator-editor/src/main/java/de/tudarmstadt/ukp/inception/apacheannotatoreditor/ApacheAnnotatorHtmlAnnotationEditorFactoryUserPreferences.schema.json
+++ b/inception/inception-html-apache-annotator-editor/src/main/java/de/tudarmstadt/ukp/inception/apacheannotatoreditor/ApacheAnnotatorHtmlAnnotationEditorFactoryUserPreferences.schema.json
@@ -28,6 +28,13 @@
     },
     "keyboardCursorEnabled": {
       "type": "boolean"
+    },
+    "showRelationLabels": {
+      "type": "boolean"
+    },
+    "lineSpacing": {
+      "type": "string",
+      "enum": ["low", "mid", "high", "xhigh"]
     }
   },
   "additionalProperties": false

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorEditor.scss
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorEditor.scss
@@ -113,10 +113,31 @@ sec-wrap {
 
 .i7n-wrapper {
     position: relative;
-    line-height: 1.8;
+    line-height: 1.8; // default; overridden by the .iaa-line-spacing-* presets below
     overflow: auto;
     padding-left: var(--vertical-tray-width-left);
     padding-right: var(--vertical-tray-width-right);
+}
+
+/**
+ * Line-spacing presets. Toggled as a class on the editor root by applyLineSpacing();
+ * line-height inherits down to the document content.
+ */
+.iaa-line-spacing-low {
+    line-height: 1.4;
+}
+
+.iaa-line-spacing-mid {
+    line-height: 1.8;
+}
+
+.iaa-line-spacing-high {
+    line-height: 2.6;
+}
+
+.iaa-line-spacing-xhigh {
+    line-height: 5.2; // double the `high` preset; the arc bow scale is already capped (see
+                      // ARC_BOW_SCALE_MAX) so the stacked-arc bow matches `high` rather than scaling further.
 }
 
 /**

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorEditor.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorEditor.ts
@@ -27,7 +27,12 @@ import { ApacheAnnotatorVisualizer } from './ApacheAnnotatorVisualizer.svelte';
 import { ApacheAnnotatorSelector } from './ApacheAnnotatorSelector';
 import { normalizeSectionsForPinning } from './SectionPinning';
 import ApacheAnnotatorToolbar from './ApacheAnnotatorToolbar.svelte';
-import { annotatorState } from './ApacheAnnotatorState.svelte';
+import {
+    annotatorState,
+    defaultAnnotatorPreferences as defaultPreferences,
+    LINE_SPACINGS,
+    type LineSpacing,
+} from './ApacheAnnotatorState.svelte';
 import AnnotationDetailPopOver from '@inception-project/inception-js-api/src/widget/AnnotationDetailPopOver.svelte';
 import { mount, tick, unmount } from 'svelte';
 import {
@@ -71,24 +76,13 @@ export class ApacheAnnotatorEditor implements AnnotationEditor {
         this.ajax = ajax;
         this.root = element;
         this.userPreferencesKey = userPreferencesKey;
-        // Settled during init by normalizeSectionsForPinning (Step 1 below).
+        // Settled during init by normalizeSectionsForPinning.
         this.sectionSelector = '';
         this.protectedElements = protectedElements;
         this.documentStructure = documentStructure;
         const protectedSel = [...protectedElements].join(',');
         this.protectedElementsMatcher = compileNsSelector(protectedSel) || undefined;
 
-        const defaultPreferences = {
-            showLabels: true,
-            showAggregatedLabels: false,
-            showEmptyHighlights: false,
-            showDocumentStructure: false,
-            showImages: true,
-            showTables: true,
-            documentStructureWidth: 0.2,
-            protectElements: true,
-            keyboardCursorEnabled: false,
-        };
         let preferences = Object.assign({}, defaultPreferences);
 
         ajax.loadPreferences(userPreferencesKey)
@@ -97,6 +91,8 @@ export class ApacheAnnotatorEditor implements AnnotationEditor {
                 console.log('Loaded preferences', preferences);
 
                 annotatorState.showLabels = preferences.showLabels ?? defaultPreferences.showLabels;
+                annotatorState.showRelationLabels =
+                    preferences.showRelationLabels ?? defaultPreferences.showRelationLabels;
                 annotatorState.showAggregatedLabels =
                     preferences.showAggregatedLabels ?? defaultPreferences.showAggregatedLabels;
                 annotatorState.showEmptyHighlights =
@@ -111,55 +107,57 @@ export class ApacheAnnotatorEditor implements AnnotationEditor {
                     preferences.protectElements ?? defaultPreferences.protectElements;
                 annotatorState.keyboardCursorEnabled =
                     preferences.keyboardCursorEnabled ?? defaultPreferences.keyboardCursorEnabled;
+                const loadedLineSpacing = preferences.lineSpacing ?? defaultPreferences.lineSpacing;
+                annotatorState.lineSpacing = LINE_SPACINGS.includes(
+                    loadedLineSpacing as LineSpacing
+                )
+                    ? (loadedLineSpacing as LineSpacing)
+                    : 'mid';
+                this.applyLineSpacing();
             })
             .then(() => {
-                // Move all content into a document container
                 const documentContainer = this.root.ownerDocument.createElement('div');
                 documentContainer.classList.add('iaa-document-container');
                 [...this.root.ownerDocument.body.children].forEach((child) =>
                     documentContainer.appendChild(child)
                 );
 
-                // Step 1 (rendering fix): make section elements pinnable and
-                // settle the section selector. Schema-free; see SectionPinning.
-                // Must run before the IDs are assigned so they land on the
-                // wrapper elements rather than the soon-to-be-buried originals.
+                // Make section elements pinnable and settle the section selector. This must run
+                // before the IDs are assigned so they land on the wrapper elements rather than the
+                // soon-to-be-buried originals.
                 this.sectionSelector = normalizeSectionsForPinning(
                     documentContainer,
                     sectionElementLocalNames
                 );
                 this.ensureSectionElementsHaveAnId();
 
-                // Step 2 (table of contents): build the outline for the
-                // navigator. Operates on the post-pinning DOM; owns title and
-                // scroll-target extraction per format.
+                // Build the outline for the navigator, operating on the post-pinning DOM.
                 this.documentStructure.preprocess(documentContainer);
 
-                // Set up a container for the document navigation sidebar
                 this.navigatorContainer = this.root.ownerDocument.createElement('div');
                 this.navigatorContainer.classList.add('iaa-document-navigator');
 
-                // Set up a split pane to host the document and the document structure navigation sidebar
                 this.horizSplitPane = this.createHorizontalSplitPane(
                     this.navigatorContainer,
                     documentContainer
                 );
 
-                // Add the split pane to the document
                 this.root.ownerDocument.body.appendChild(this.horizSplitPane);
 
-                // Add the editor components for the document container
+                // The selector is created first so the visualizer's relation-drag controller can
+                // defer multi-hit target disambiguation to it.
+                this.selector = new ApacheAnnotatorSelector(this.root, this.ajax);
                 this.vis = new ApacheAnnotatorVisualizer(
                     this.root,
                     this.ajax,
-                    this.sectionSelector
+                    this.sectionSelector,
+                    (clientX, clientY, targets, onPick) =>
+                        this.selector.pickRelationTarget(clientX, clientY, targets, onPick)
                 );
                 this.vis.protectedElementSelector = [...protectedElements].join(',');
-                this.selector = new ApacheAnnotatorSelector(this.root, this.ajax);
 
                 this.documentContainer = documentContainer;
 
-                // Add auxiliary controls
                 this.documentStructureNavigator = this.createDocumentNavigator(
                     this.navigatorContainer,
                     documentContainer,
@@ -184,10 +182,8 @@ export class ApacheAnnotatorEditor implements AnnotationEditor {
                     },
                 });
 
-                // Event handler for creating an annotion or selecting an annotation
                 this.root.addEventListener('mouseup', (e) => this.onMouseUp(e));
 
-                // Event handler for opening the context menu
                 this.root.addEventListener('contextmenu', (e) => this.onRightClick(e));
 
                 // Prevent right-click from triggering a selection event
@@ -233,7 +229,6 @@ export class ApacheAnnotatorEditor implements AnnotationEditor {
         divider.addEventListener('mousedown', (e) => {
             if (e.buttons !== 1) return;
 
-            // Clean up any previous resize operation
             if (this.activeResizeCleanup) {
                 this.activeResizeCleanup();
             }
@@ -357,8 +352,35 @@ export class ApacheAnnotatorEditor implements AnnotationEditor {
                 keyboardCursorPreferencesChanged: (e: Event) => {
                     this.keyboardMode?.enable(annotatorState.keyboardCursorEnabled);
                 },
+                lineSpacingPreferencesChanged: (e: Event) => {
+                    this.applyLineSpacing();
+                    // The new line-height reflows the text, moving every highlight. Re-materialize
+                    // the locked section dimensions and re-render so arcs/stubs follow the new
+                    // positions. Only the geometry changed — the annotation data is unchanged — so
+                    // re-render from the cached data instead of a full server round-trip.
+                    this.vis?.optimizeLayout('line spacing');
+                    this.vis?.rerender();
+                },
+                relationLabelPreferencesChanged: (e: Event) => {
+                    // Pure visual toggle — the labels are already drawn, so just flip the mode.
+                    this.vis?.refreshRelationLabelMode();
+                },
             },
         });
+    }
+
+    /**
+     * Apply the active line-spacing preset as a class on the editor root, matching the
+     * class-toggle pattern used by the other visual preferences (e.g. `iaa-hide-images`).
+     * The heights live in SCSS; `line-height` inherits down to the document content.
+     */
+    private applyLineSpacing(): void {
+        const root = this.root as HTMLElement;
+        LINE_SPACINGS.forEach((s) => root.classList.remove(`iaa-line-spacing-${s}`));
+        const spacing = LINE_SPACINGS.includes(annotatorState.lineSpacing)
+            ? annotatorState.lineSpacing
+            : 'mid';
+        root.classList.add(`iaa-line-spacing-${spacing}`);
     }
 
     private createDocumentNavigator(

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorSelector.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorSelector.ts
@@ -28,8 +28,12 @@ import { createPopper, type Instance } from '@popperjs/core';
  *   selection is offered (no ❌); activating an entry selects it.
  * - `keyboard-delete`: opened via the keyboard to pick an annotation to delete.
  *   Activating an entry deletes it and the entry is styled as destructive.
+ * - `relation-target`: opened by a relation-creation drag that ended on a stack of
+ *   several spans. Activating an entry resolves the
+ *   pending pick callback with the chosen vid instead of selecting/deleting; dismissing
+ *   the popup cancels the relation. No ❌ buttons.
  */
-type PopupMode = 'mouse' | 'keyboard-select' | 'keyboard-delete';
+type PopupMode = 'mouse' | 'keyboard-select' | 'keyboard-delete' | 'relation-target';
 
 export class ApacheAnnotatorSelector {
     private ajax: DiamAjax;
@@ -45,6 +49,10 @@ export class ApacheAnnotatorSelector {
     private focusFallback: HTMLElement | undefined;
     private popupKeydownHandler: ((e: KeyboardEvent) => void) | undefined;
     private popupMode: PopupMode = 'mouse';
+    // In 'relation-target' mode, the drag controller's callback to resolve with the
+    // chosen target vid. Cleared (without being called) when the popup is dismissed,
+    // which the controller treats as a cancel.
+    private pendingTargetPick: ((vid: VID) => void) | undefined;
 
     public constructor(element: Element, ajax: DiamAjax) {
         this.ajax = ajax;
@@ -111,8 +119,24 @@ export class ApacheAnnotatorSelector {
         return true;
     }
 
+    /**
+     * Ask the user which of several overlapping spans is a relation's target. The popup
+     * opens at the drop point; `onPick` fires with the chosen vid, or not at all if the
+     * popup is dismissed (which the caller treats as a cancel). `hls` must already be deduplicated by vid.
+     */
+    public pickRelationTarget(
+        clientX: number,
+        clientY: number,
+        hls: HTMLElement[],
+        onPick: (vid: VID) => void
+    ): void {
+        this.destroyPopup();
+        if (hls.length === 0) return;
+        this.pendingTargetPick = onPick;
+        this.createPopup(clientX, clientY, hls, true, 'relation-target');
+    }
+
     private onMouseDown(event: Event): void {
-        // Destroy popup if clicked outside of popup
         if (!this.isVisible()) {
             return;
         }
@@ -141,6 +165,7 @@ export class ApacheAnnotatorSelector {
         this.activeIndex = -1;
         this.focusFallback = undefined;
         this.popupMode = 'mouse';
+        this.pendingTargetPick = undefined;
     }
 
     public isVisible(): boolean {
@@ -153,7 +178,6 @@ export class ApacheAnnotatorSelector {
         this.destroyPopup();
 
         const hls = event.target instanceof Node ? highlights(event.target) : [];
-        // No need to show selector if there is no annotation
         if (hls.length === 0) return;
 
         if (
@@ -205,12 +229,16 @@ export class ApacheAnnotatorSelector {
         // Make the menu focusable so it can capture keyboard navigation keys.
         this.popupContent.tabIndex = -1;
 
-        // In the keyboard modes, show a header indicating whether picking an entry
-        // selects or deletes it.
+        // Outside plain mouse mode, show a header indicating what activating an entry does.
         if (mode !== 'mouse') {
             const header = document.createElement('div');
             header.classList.add('iaa-menu-header');
-            header.textContent = mode === 'keyboard-delete' ? 'Delete…' : 'Select…';
+            header.textContent =
+                mode === 'keyboard-delete'
+                    ? 'Delete…'
+                    : mode === 'relation-target'
+                      ? 'Relation target…'
+                      : 'Select…';
             this.popupContent.appendChild(header);
         }
 
@@ -303,14 +331,25 @@ export class ApacheAnnotatorSelector {
 
     /**
      * Perform the popup's primary action on an entry: delete in keyboard-delete mode,
-     * otherwise select.
+     * resolve the relation-target pick in relation-target mode, otherwise select.
      */
     private activateItem(event: Event, id: VID) {
         if (this.popupMode === 'keyboard-delete') {
             this.onDeleteAnnotation(event, id);
+        } else if (this.popupMode === 'relation-target') {
+            this.onPickRelationTarget(event, id);
         } else {
             this.onSelectAnnotation(event, id);
         }
+    }
+
+    private onPickRelationTarget(event: Event, id: VID) {
+        event.stopPropagation();
+        // Capture before destroyPopup() clears it: destroy first so the controller's
+        // createRelationAnnotation runs against a torn-down popup, then resolve.
+        const pick = this.pendingTargetPick;
+        this.destroyPopup();
+        pick?.(id);
     }
 
     private onSelectAnnotation(event: Event, id: VID) {

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorToolbar.svelte
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorToolbar.svelte
@@ -17,8 +17,15 @@
 -->
 <script lang="ts">
     import type { DiamAjax } from '@inception-project/inception-js-api';
-    import { annotatorState } from './ApacheAnnotatorState.svelte';
+    import { annotatorState, type LineSpacing } from './ApacheAnnotatorState.svelte';
     import { createEventDispatcher } from 'svelte';
+
+    const lineSpacingOptions: { value: LineSpacing; title: string; label: string }[] = [
+        { value: 'low', title: 'Compact line spacing', label: 'S' },
+        { value: 'mid', title: 'Normal line spacing', label: 'M' },
+        { value: 'high', title: 'Relaxed line spacing', label: 'L' },
+        { value: 'xhigh', title: 'Extra relaxed line spacing', label: 'X' },
+    ];
 
     interface Props {
         ajax: DiamAjax;
@@ -30,15 +37,15 @@
 
     let dispatch = createEventDispatcher();
 
-    const defaultPreferences = {
-        showLabels: true,
-        showAggregatedLabels: false,
-        showEmptyHighlights: false,
-        showDocumentStructure: false,
-        showImages: true,
-        showTables: true,
-        documentStructureWidth: 0.2,
-    };
+    // Svelte runs every $effect once on mount. The editor applies the loaded preferences
+    // explicitly during setup, so those mount runs must not (a) PUT the just-loaded values
+    // straight back (a no-op save) nor (b) re-trigger the line-spacing relayout the visualizer
+    // constructor already performed. `initialized` (plain, not $state, so flipping it never
+    // re-runs an effect) gates both; a trailing effect flips it after the first cycle. The
+    // load-bearing mount dispatches (annotation load, hide-classes, navigator, relation labels)
+    // are intentionally left to fire — only the save and the redundant line-spacing dispatch
+    // are suppressed.
+    let initialized = false;
 
     $effect(() => {
         annotatorState.showDocumentStructure;
@@ -69,9 +76,33 @@
         dispatch('keyboardCursorPreferencesChanged', {});
     });
 
+    $effect(() => {
+        annotatorState.lineSpacing;
+        savePreferences();
+        // Redundant on mount: the constructor already materialized geometry with the loaded
+        // line spacing applied. Only dispatch on genuine user changes.
+        if (!initialized) return;
+        dispatch('lineSpacingPreferencesChanged', {});
+    });
+
+    $effect(() => {
+        annotatorState.showRelationLabels;
+        savePreferences();
+        dispatch('relationLabelPreferencesChanged', {});
+    });
+
+    // Declared last so it runs after every effect above has completed its initial (mount) pass,
+    // marking the end of setup. From here on, the effects act on genuine user changes.
+    $effect(() => {
+        initialized = true;
+    });
+
     let preferencesDebounceTimeout: number | undefined = undefined;
 
     function savePreferences() {
+        // Skip the mount-time pass: it would PUT the just-loaded values straight back.
+        if (!initialized) return;
+
         if (preferencesDebounceTimeout) {
             window.clearTimeout(preferencesDebounceTimeout);
             preferencesDebounceTimeout = undefined;
@@ -88,6 +119,8 @@
                 keyboardCursorEnabled: annotatorState.keyboardCursorEnabled,
                 documentStructureWidth: annotatorState.documentStructureWidth,
                 protectElements: annotatorState.protectElements,
+                lineSpacing: annotatorState.lineSpacing,
+                showRelationLabels: annotatorState.showRelationLabels,
             });
         }, 250);
     }
@@ -97,7 +130,25 @@
     class="bootstrap card-header border-0 border-bottom rounded-0 p-1 d-flex flex-row flex-wrap align-items-center"
     role="toolbar"
 >
-    <div class="btn-group btn-group-sm" role="group" aria-label="Display options">
+    <div class="btn-group btn-group-sm" role="group" aria-label="Outline">
+        <input
+            class="btn-check"
+            type="checkbox"
+            id="documentStructureEnabled"
+            autocomplete="off"
+            bind:checked={annotatorState.showDocumentStructure}
+        />
+        <label
+            class="btn btn-outline-secondary"
+            for="documentStructureEnabled"
+            title="Outline"
+            aria-label="Outline"
+        >
+            <i class="fas fa-list-ul"></i>
+        </label>
+    </div>
+
+    <div class="btn-group btn-group-sm ms-1" role="group" aria-label="Labels">
         <input
             class="btn-check"
             type="checkbox"
@@ -132,26 +183,28 @@
             </label>
         {/if}
 
+        <input
+            class="btn-check"
+            type="checkbox"
+            id="relationLabelsEnabled"
+            autocomplete="off"
+            bind:checked={annotatorState.showRelationLabels}
+        />
+        <label
+            class="btn btn-outline-secondary"
+            for="relationLabelsEnabled"
+            title="Relation labels (otherwise shown on hover)"
+            aria-label="Relation labels"
+        >
+            <i class="fas fa-diagram-project"></i>
+        </label>
+    </div>
+
+    <div class="btn-group btn-group-sm ms-1" role="group" aria-label="Content">
         <!--
         <input class="btn-check" type="checkbox" id="showEmptyHighlights" autocomplete="off" bind:checked={annotatorState.showEmptyHighlights}>
         <label class="btn btn-outline-secondary" for="showEmptyHighlights" title="Empty highlights" aria-label="Empty highlights"><i class="fas fa-square"></i></label>
         -->
-
-        <input
-            class="btn-check"
-            type="checkbox"
-            id="imagesEnabled"
-            autocomplete="off"
-            bind:checked={annotatorState.showImages}
-        />
-        <label
-            class="btn btn-outline-secondary"
-            for="imagesEnabled"
-            title="Images"
-            aria-label="Images"
-        >
-            <i class="fas fa-image"></i>
-        </label>
 
         <input
             class="btn-check"
@@ -172,19 +225,51 @@
         <input
             class="btn-check"
             type="checkbox"
-            id="documentStructureEnabled"
+            id="imagesEnabled"
             autocomplete="off"
-            bind:checked={annotatorState.showDocumentStructure}
+            bind:checked={annotatorState.showImages}
         />
         <label
             class="btn btn-outline-secondary"
-            for="documentStructureEnabled"
-            title="Outline"
-            aria-label="Outline"
+            for="imagesEnabled"
+            title="Images"
+            aria-label="Images"
         >
-            <i class="fas fa-list-ul"></i>
+            <i class="fas fa-image"></i>
         </label>
+    </div>
 
+    <div
+        class="input-group input-group-sm w-auto ms-1"
+        role="group"
+        aria-label="Line spacing"
+    >
+        <span class="input-group-text" title="Line spacing" aria-hidden="true">
+            <i class="fas fa-bars"></i>
+        </span>
+
+        {#each lineSpacingOptions as { value, title, label } (value)}
+            <input
+                class="btn-check"
+                type="radio"
+                name="lineSpacing"
+                id="lineSpacing-{value}"
+                autocomplete="off"
+                checked={annotatorState.lineSpacing === value}
+                onchange={() => (annotatorState.lineSpacing = value)}
+            />
+            <label
+                class="btn btn-outline-secondary"
+                for="lineSpacing-{value}"
+                {title}
+                aria-label={title}
+            >
+                {label}
+            </label>
+        {/each}
+    </div>
+
+    <div class="btn-group btn-group-sm ms-auto" role="group" aria-label="Keyboard">
         <input
             class="btn-check"
             type="checkbox"

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorVisualizer.svelte.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorVisualizer.svelte.ts
@@ -36,14 +36,15 @@ import { ResizeManager } from './ResizeManager';
 import { bgToFgColor } from '@inception-project/inception-js-api/src/util/Coloring';
 import { SectionAnnotationVisualizer } from './SectionAnnotationVisualizer';
 import { SectionAnnotationCreator } from './SectionAnnotationCreator';
+import { RelationVisualizer } from './RelationVisualizer';
+import { RelationGripLayer, GRIP_CLASS } from './RelationGripLayer';
+import { RelationDragController, type PickRelationTarget } from './RelationDragController';
 import {
     groupHighlightsByVid,
     removeClassFromAncestors,
     safeHighlightText,
     compileNsSelector,
 } from './Utilities';
-
-export const CLASS_RELATED = 'iaa-related';
 
 export const NO_LABEL = '◌';
 export const ERROR_LABEL = '🔴';
@@ -77,10 +78,17 @@ export class ApacheAnnotatorVisualizer {
     private sectionSelector: string;
     private sectionAnnotationVisualizer: SectionAnnotationVisualizer;
     private sectionAnnotationCreator: SectionAnnotationCreator;
+    private relationVisualizer: RelationVisualizer;
+    private relationGripLayer: RelationGripLayer;
+    private relationDragController: RelationDragController;
 
     private data?: AnnotatedText;
 
     private scrolling = false;
+    /** Scroll container the relation re-band listener is attached to; detached on destroy. */
+    private scrollContainer?: Element;
+    /** Pending rAF handle coalescing scroll events into one relation re-band per frame. */
+    private relationScrollRaf?: number;
     private lastScrollTop: number | undefined = undefined;
     private lastMarkerTop: number | undefined = undefined;
     private scrollMutationObserver: MutationObserver | undefined = undefined;
@@ -110,7 +118,12 @@ export class ApacheAnnotatorVisualizer {
         }
     }
 
-    constructor(element: Element, ajax: DiamAjax, sectionSelector: string) {
+    constructor(
+        element: Element,
+        ajax: DiamAjax,
+        sectionSelector: string,
+        pickRelationTarget: PickRelationTarget
+    ) {
         this.ajax = ajax;
         this.root = element;
         this.sectionSelector = sectionSelector;
@@ -141,31 +154,65 @@ export class ApacheAnnotatorVisualizer {
             this.ajax,
             this.sectionSelector
         );
+        this.relationVisualizer = new RelationVisualizer(this.root, this.ajax, (vid) =>
+            this.getHighlightsForAnnotation(vid)
+        );
+        this.relationDragController = new RelationDragController(
+            this.root,
+            this.ajax,
+            this.relationVisualizer,
+            pickRelationTarget
+        );
+        this.relationGripLayer = new RelationGripLayer(
+            this.root,
+            (vid) => this.getHighlightsForAnnotation(vid),
+            (grip, e) => this.relationDragController.onGripPointerDown(grip, e)
+        );
 
         // Event handlers for the resizer component
         this.root.addEventListener('mouseover', (e) => this.showResizer(e));
 
-        // Event handlers for custom events
+        // Event handlers for custom events. A relation-creation grip proxies its span, so hovering a
+        // grip emits the same enter/leave events as hovering the span text — bringing up the detail
+        // popover for the grip's annotation (the events bubble through the overlay to the editor root).
         this.root.addEventListener('mouseover', (event) => {
-            if (!(event instanceof MouseEvent) || !(event.target instanceof HTMLElement)) return;
-            const vid = event.target.getAttribute('data-iaa-id');
+            if (!(event instanceof MouseEvent)) return;
+            const vid = this.hoveredAnnotationVid(event.target);
             if (!vid) return;
             const annotation = this.data?.getAnnotation(vid);
             if (!annotation) return;
-            event.target.dispatchEvent(new AnnotationOverEvent(annotation, event));
+            (event.target as Element).dispatchEvent(new AnnotationOverEvent(annotation, event));
         });
         this.root.addEventListener('mouseout', (event) => {
-            if (!(event instanceof MouseEvent) || !(event.target instanceof HTMLElement)) return;
-            const vid = event.target.getAttribute('data-iaa-id');
+            if (!(event instanceof MouseEvent)) return;
+            const vid = this.hoveredAnnotationVid(event.target);
             if (!vid) return;
             const annotation = this.data?.getAnnotation(vid);
             if (!annotation) return;
-            event.target.dispatchEvent(new AnnotationOutEvent(annotation, event));
+            (event.target as Element).dispatchEvent(new AnnotationOutEvent(annotation, event));
         });
 
         // Add event handlers for highlighting extent of the annotation the mouse is currently over
         this.root.addEventListener('mouseover', (e) => this.addHoverHighlight(e as MouseEvent));
         this.root.addEventListener('mouseout', (e) => this.removeHoverHighlight(e as MouseEvent));
+
+        // Surface relation-creation grips for the hovered span stack.
+        this.root.addEventListener('mouseover', (e) =>
+            this.relationGripLayer.handlePointerOver((e as MouseEvent).target)
+        );
+        this.root.addEventListener('mouseleave', () => this.relationGripLayer.clear());
+
+        // Re-band relations on manual scroll, independent of the ViewportTracker (see onContentScroll).
+        this.scrollContainer = this.root.closest('.i7n-wrapper') || this.root;
+        this.scrollContainer.addEventListener('scroll', this.onContentScroll, { passive: true });
+    }
+
+    /**
+     * Apply the current relation-label visibility preference without re-rendering. The labels are
+     * already in the overlay; this just flips the CSS mode class (see RelationVisualizer).
+     */
+    public refreshRelationLabelMode(): void {
+        this.relationVisualizer.setLabelsAlwaysVisible(annotatorState.showRelationLabels);
     }
 
     public optimizeLayout(trigger: string) {
@@ -264,9 +311,9 @@ export class ApacheAnnotatorVisualizer {
 
         try {
             const nodes = element.querySelectorAll(sectionSelector);
-            const measurements : { n: HTMLElement, height: number, width: number }[] = [];
+            const measurements: { n: HTMLElement; height: number; width: number }[] = [];
 
-            // PASS 1: Clear any previously set midnHeight/minWidth styles
+            // Clear any previously set minHeight/minWidth styles
             nodes.forEach((n) => {
                 if (!(n instanceof HTMLElement)) return;
                 n.style.minHeight = '';
@@ -278,9 +325,8 @@ export class ApacheAnnotatorVisualizer {
                 n.style.boxSizing = '';
             });
 
-            // PASS 2: READ (Batch all measurements)
-            // The browser calculates layout once here, and reuses it for subsequent reads
-            // as long as no write operations occur in between.
+            // Read: batch all measurements. The browser calculates layout once here, and
+            // reuses it for subsequent reads as long as no write operations occur in between.
             nodes.forEach((n) => {
                 if (!(n instanceof HTMLElement)) return;
 
@@ -298,9 +344,8 @@ export class ApacheAnnotatorVisualizer {
                 }
             });
 
-            // PASS 3: WRITE (Batch all mutations)
-            // Now we apply styles. This invalidates layout, but since we are done reading,
-            // we don't force a recalculation until the next frame/paint.
+            // Write: batch all mutations. Applying styles invalidates layout, but since we
+            // are done reading, we don't force a recalculation until the next frame/paint.
             measurements.forEach(({ n, height, width }) => {
                 if (height > 0 || width > 0) {
                     n.style.boxSizing = 'border-box';
@@ -333,10 +378,26 @@ export class ApacheAnnotatorVisualizer {
         if (vid) this.resizer.show(vid);
     }
 
+    /**
+     * The annotation vid a hover target represents: a highlight (`data-iaa-id`) or one of its
+     * relation-creation grips, which proxy their span via `data-grip-vid`. The grip deliberately omits
+     * `data-iaa-id` (so `highlights()` / the drop hit-test never treat it as an annotation), so it is
+     * resolved separately here. This lets a grip hover drive the same span echo (`iaa-hover`) and
+     * detail popover as hovering the span text.
+     */
+    private hoveredAnnotationVid(target: EventTarget | null): VID | null {
+        if (!(target instanceof Element)) return null;
+        return (
+            target.getAttribute('data-iaa-id') ??
+            target.closest<HTMLElement>('.' + GRIP_CLASS)?.dataset.gripVid ??
+            null
+        );
+    }
+
     private addHoverHighlight(event: MouseEvent) {
         if (!(event.target instanceof Element)) return;
 
-        const vid = event.target.getAttribute('data-iaa-id');
+        const vid = this.hoveredAnnotationVid(event.target);
         if (!vid) return;
 
         if (this.addHoverTimeout) {
@@ -378,6 +439,17 @@ export class ApacheAnnotatorVisualizer {
         this.doLoadAnnotations({ allowRenderSkip: false });
     }
 
+    /**
+     * Re-render highlights/arcs from the cached annotation data without a server round-trip.
+     * Use for view-only changes (e.g. line spacing) where the geometry changed but the
+     * annotation data did not. No-ops until the first load has populated the cache.
+     */
+    rerender(): void {
+        if (this.data) {
+            this.renderAnnotations(this.data);
+        }
+    }
+
     private doLoadAnnotations(opts: { allowRenderSkip: boolean }): void {
         const allowSkip = opts.allowRenderSkip;
         if (this.loadAnnotationsTimeout) {
@@ -405,6 +477,12 @@ export class ApacheAnnotatorVisualizer {
                 range: this.tracker.currentRange,
                 includeText: false,
                 clipSpans: false,
+                // Request un-clipped arcs with real per-endpoint placeholders (real VID and
+                // window-relative offset) instead of the shared VID_BEFORE/VID_AFTER sentinels,
+                // and pull in relations whose endpoints lie outside the window. Stub tips,
+                // far-endpoint navigation and labels all rely on these real endpoints.
+                clipArcs: false,
+                longArcs: true,
                 format: 'compact_v2',
             };
 
@@ -435,6 +513,8 @@ export class ApacheAnnotatorVisualizer {
 
             this.clearHighlights();
             this.resizer.hide();
+            // Grips reference the old highlight DOM; drop them before it is torn down and rebuilt.
+            this.relationGripLayer.clear();
 
             if (doc.spans) {
                 console.log(`Loaded ${doc.spans.size} span annotations`);
@@ -466,9 +546,8 @@ export class ApacheAnnotatorVisualizer {
                 this.renderVerticalSelectionMarker(doc);
             }
 
-            if (doc.relations) {
-                this.renderSelectedRelationEndpointHighlights(doc);
-            }
+            this.refreshRelationLabelMode();
+            this.renderRelations(doc);
 
             const endTime = performance.now();
             console.log(`Client-side rendering took ${endTime - startTime}ms`);
@@ -480,6 +559,50 @@ export class ApacheAnnotatorVisualizer {
             this.tracker?.resume({ waitFrames: 2, suppressInitialRefresh: true });
         }
     }
+
+    /**
+     * Draw the relation overlay for `doc`, banded around the *current* viewport. Split out of
+     * renderAnnotations so it can also run on bare scroll (see onContentScroll) without a full
+     * span re-render or an Ajax reload.
+     */
+    private renderRelations(doc: AnnotatedText, remeasureContent = true): void {
+        if (doc.relations) {
+            const container = this.root.closest('.i7n-wrapper') || this.root;
+            this.relationVisualizer.render(
+                doc,
+                {
+                    viewport: container.getBoundingClientRect(),
+                    seclusionMargin: SECLUSION_MARGIN_PX,
+                },
+                { remeasureContent }
+            );
+        } else {
+            this.relationVisualizer.clear();
+        }
+    }
+
+    /**
+     * Re-band the relation overlay on manual scroll. Arcs are only drawn for a band around the
+     * current viewport (perf); the band is expressed in viewport coordinates and therefore moves
+     * with the viewport on *every* scroll frame. This is a paint concern, distinct from the
+     * ViewportTracker's data window: the tracker decides which offset range to fetch/render (coarse,
+     * debounced, and deliberately a superset that only changes when new content scrolls in — see
+     * ViewportTracker.handleIntersectRange), whereas the band must follow the viewport continuously
+     * even while the data window stays put. So this handler is not a workaround for the tracker; it
+     * would be needed even with a perfectly tight tracker. Recompute the band directly from
+     * already-loaded data on each scroll frame; this is cheap (redraws arcs only — no Ajax, no span
+     * re-render). Skipped during programmatic scrolling, which drives its own render at completion.
+     */
+    private onContentScroll = (): void => {
+        if (this.scrolling) return;
+        if (this.relationScrollRaf !== undefined) return;
+        this.relationScrollRaf = requestAnimationFrame(() => {
+            this.relationScrollRaf = undefined;
+            // Bare scroll: the content has not reflowed, only the viewport moved. Skip the overlay
+            // resize + bow-scale remeasure (see RelationVisualizer.render); just re-band and redraw.
+            if (this.data) this.renderRelations(this.data, false);
+        });
+    };
 
     private renderVerticalSelectionMarker(doc: AnnotatedText) {
         // We assume for the moment that only one annotation can be selected at a time
@@ -606,24 +729,6 @@ export class ApacheAnnotatorVisualizer {
 
     private getAllTextMarkers() {
         return this.root.querySelectorAll('.iaa-text-marker');
-    }
-
-    private renderSelectedRelationEndpointHighlights(doc: AnnotatedText) {
-        const selectedAnnotationVids = doc.markedAnnotations.get('focus') || [];
-        for (const relation of doc.relations.values()) {
-            if (!selectedAnnotationVids.includes(relation.vid)) {
-                continue;
-            }
-
-            const sourceVid = relation.arguments[0][0];
-            const targetVid = relation.arguments[1][0];
-            this.getHighlightsForAnnotation(sourceVid).forEach((e) =>
-                e.classList.add(CLASS_RELATED)
-            );
-            this.getHighlightsForAnnotation(targetVid).forEach((e) =>
-                e.classList.add(CLASS_RELATED)
-            );
-        }
     }
 
     // eslint-disable-next-line no-undef
@@ -918,6 +1023,9 @@ export class ApacheAnnotatorVisualizer {
             this.scrolling = true;
             this.sectionAnnotationVisualizer.suspend();
             this.sectionAnnotationCreator.suspend();
+            this.relationVisualizer.suspend();
+            // Grip anchors go stale as the content scrolls; clear and let hover re-derive them.
+            this.relationGripLayer.clear();
 
             // Watch the scroll container for DOM mutations during scrolling. Async
             // renders (e.g. section summary spacers) can shift content above the
@@ -989,6 +1097,7 @@ export class ApacheAnnotatorVisualizer {
         this.scrolling = false;
         this.sectionAnnotationCreator.resume();
         this.sectionAnnotationVisualizer.resume();
+        this.relationVisualizer.resume();
         this.lastScrollTop = undefined;
         this.lastMarkerTop = undefined;
     }
@@ -1014,8 +1123,13 @@ export class ApacheAnnotatorVisualizer {
     destroy(): void {
         this.sectionAnnotationCreator.destroy();
         this.sectionAnnotationVisualizer.destroy();
+        this.relationVisualizer.destroy();
+        this.relationGripLayer.destroy();
+        this.relationDragController.destroy();
         this.tracker.disconnect();
         this.sectionTracker.disconnect();
+        this.scrollContainer?.removeEventListener('scroll', this.onContentScroll);
+        if (this.relationScrollRaf !== undefined) cancelAnimationFrame(this.relationScrollRaf);
         this.clearHighlights();
     }
 }

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ArrowMarkerPool.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ArrowMarkerPool.ts
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { svgEl } from './SvgUtilities';
+
+/**
+ * Geometry of the triangular arrowhead {@link SVGMarkerElement}. The defaults describe a 7×7
+ * user-space head whose tip sits at the path end, suitable for relation arcs.
+ */
+export interface ArrowMarkerGeometry {
+    viewBox: string;
+    refX: number;
+    refY: number;
+    width: number;
+    height: number;
+    orient: string;
+    markerUnits: string;
+    /** Path drawn inside the marker; it is filled with the relation color. */
+    path: string;
+}
+
+export const DEFAULT_ARROW_MARKER_GEOMETRY: ArrowMarkerGeometry = {
+    viewBox: '0 0 10 10',
+    refX: 9,
+    refY: 5,
+    width: 7,
+    height: 7,
+    orient: 'auto-start-reverse',
+    markerUnits: 'userSpaceOnUse',
+    path: 'M 0 0 L 10 5 L 0 10 z'
+};
+
+/**
+ * Lazily creates one arrowhead `<marker>` per distinct color inside a container element and
+ * returns its id for use in `marker-start`/`marker-end`.
+ *
+ * Ids are minted from an internal counter rather than derived from the color string. A marker's
+ * fill is fixed at creation, so two distinct colors that mapped to the same id would render one
+ * with the other's arrowhead color. A sanitized-color id scheme (e.g. stripping non-alphanumeric
+ * characters) is not injective — `rgb(10,2,30)` and `rgb(1,0,230)` collapse to the same key — so
+ * we key the lookup on the raw color and let the counter guarantee unique ids.
+ *
+ * Intentionally local to the Apache Annotator editor: it only emits a single fixed `<path>` triangle
+ * and is not yet general enough to serve the brat / pdf editors.
+ */
+export class ArrowMarkerPool {
+    private readonly ids = new Map<string, string>();
+    private seq = 0;
+
+    constructor(
+        private readonly container: SVGElement,
+        private readonly idPrefix = 'iaa-arrowhead-',
+        private readonly geometry: ArrowMarkerGeometry = DEFAULT_ARROW_MARKER_GEOMETRY
+    ) {}
+
+    /** Returns the id of the arrowhead marker for `color`, creating it on first request. */
+    markerFor(color: string): string {
+        const existing = this.ids.get(color);
+        if (existing) return existing;
+
+        const id = this.idPrefix + this.seq++;
+        this.ids.set(color, id);
+
+        const g = this.geometry;
+        const marker = svgEl('marker', undefined, {
+            id,
+            viewBox: g.viewBox,
+            refX: g.refX,
+            refY: g.refY,
+            markerWidth: g.width,
+            markerHeight: g.height,
+            orient: g.orient,
+            markerUnits: g.markerUnits,
+        });
+
+        const tri = svgEl('path', undefined, { d: g.path, fill: color });
+        marker.appendChild(tri);
+
+        this.container.appendChild(marker);
+        return id;
+    }
+
+    /**
+     * Forgets all markers handed out so far. Call this after emptying the container so that ids
+     * are reissued from scratch for the next render; it does not remove DOM nodes itself.
+     */
+    clear(): void {
+        this.ids.clear();
+        this.seq = 0;
+    }
+}

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/RelationDragController.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/RelationDragController.ts
@@ -1,0 +1,219 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { type DiamAjax, type VID } from '@inception-project/inception-js-api';
+import { type RelationVisualizer } from './RelationVisualizer';
+import { GRIP_CLASS } from './RelationGripLayer';
+import { distinctHighlightStack, getInlineLabelClientRect, isPointInRect } from './Utilities';
+
+/**
+ * The relation-creation drag state machine.
+ *
+ *   IDLE → (grip mousedown) → ARMED → (move > threshold) → DRAGGING → (mouseup) → COMMIT/CANCEL
+ *
+ * The move/up listeners live on `window` in the capture phase so a release outside the iframe still
+ * resolves and so the terminating mouseup can be stopped before the editor root reads the selection
+ * and creates a span. A grip click that never crosses the threshold does nothing.
+ */
+
+const DRAG_THRESHOLD_PX = 5;
+
+/**
+ * Show the target-disambiguation popup and resolve with the chosen vid. Dismissing the popup must
+ * not call `onPick` — that is a cancel. Wired to ApacheAnnotatorSelector.pickRelationTarget.
+ */
+export type PickRelationTarget = (
+    clientX: number,
+    clientY: number,
+    targets: HTMLElement[],
+    onPick: (vid: VID) => void
+) => void;
+
+/** Toggled on the content root during a drag for the grabbing cursor and to suppress text selection. */
+const CLASS_DRAGGING = 'iaa-relation-dragging';
+
+type State = 'idle' | 'armed' | 'dragging';
+
+export class RelationDragController {
+    private root: Element;
+    private ajax: DiamAjax;
+    private relationVisualizer: RelationVisualizer;
+    private pickTarget: PickRelationTarget;
+
+    private state: State = 'idle';
+    private sourceVid: VID | null = null;
+    /** Rubber-band origin (viewport coords): the centre of the source grip at mousedown. */
+    private sourcePoint = { x: 0, y: 0 };
+    private color = '';
+    /** mousedown position, for the move-distance threshold that separates a click from a drag. */
+    private originX = 0;
+    private originY = 0;
+
+    public constructor(
+        root: Element,
+        ajax: DiamAjax,
+        relationVisualizer: RelationVisualizer,
+        pickTarget: PickRelationTarget
+    ) {
+        this.root = root;
+        this.ajax = ajax;
+        this.relationVisualizer = relationVisualizer;
+        this.pickTarget = pickTarget;
+    }
+
+    /** Arm a drag from a grip (its mousedown handler, wired by RelationGripLayer). */
+    public onGripPointerDown(grip: HTMLElement, e: MouseEvent): void {
+        if (e.button !== 0) return; // primary button only
+        const vid = grip.dataset.gripVid;
+        if (!vid) return;
+
+        // Keep the gesture off the editor: no text selection, and (keyboard mode) no caret drop.
+        e.preventDefault();
+        e.stopPropagation();
+
+        this.state = 'armed';
+        this.sourceVid = vid;
+        const r = grip.getBoundingClientRect();
+        this.sourcePoint = { x: r.left + r.width / 2, y: r.top + r.height / 2 };
+        this.color = grip.style.getPropertyValue('--iaa-grip-color').trim();
+        this.originX = e.clientX;
+        this.originY = e.clientY;
+
+        window.addEventListener('mousemove', this.onWindowMove, true);
+        window.addEventListener('mouseup', this.onWindowUp, true);
+        window.addEventListener('keydown', this.onWindowKey, true);
+    }
+
+    private onWindowMove = (e: MouseEvent): void => {
+        if (this.state === 'armed') {
+            const dist = Math.hypot(e.clientX - this.originX, e.clientY - this.originY);
+            if (dist <= DRAG_THRESHOLD_PX) return;
+            this.state = 'dragging';
+            this.root.classList.add(CLASS_DRAGGING);
+            this.relationVisualizer.beginDragArc(this.color);
+        }
+
+        if (this.state === 'dragging') {
+            this.relationVisualizer.updateDragArc(this.sourcePoint, { x: e.clientX, y: e.clientY });
+            e.preventDefault();
+        }
+    };
+
+    private onWindowUp = (e: MouseEvent): void => {
+        if (this.state === 'dragging') {
+            // Stop the editor root's mouseup from also reading the selection and creating a span
+            // where the drag ended.
+            e.preventDefault();
+            e.stopPropagation();
+            this.commitAt(e);
+        }
+        // ARMED → up with no drag is a plain grip click: do nothing.
+        this.teardown();
+    };
+
+    private onWindowKey = (e: KeyboardEvent): void => {
+        if (e.key === 'Escape') {
+            e.preventDefault();
+            e.stopPropagation();
+            this.teardown();
+        }
+    };
+
+    /** Resolve the drop target under the cursor and create the relation (or cancel). */
+    private commitAt(e: MouseEvent): void {
+        if (this.sourceVid == null) return;
+        const source = this.sourceVid;
+
+        const under = this.root.ownerDocument.elementFromPoint(e.clientX, e.clientY);
+
+        // A grip proxies its span: grips sit over the span start (the inline-label region) with
+        // pointer-events:auto and survive the drag, so a release aimed there lands on the grip, whose
+        // data-grip-vid — not data-iaa-id — means highlights() resolves nothing. Target the grip's
+        // span directly (also lets a fanned grip pick one of several overlapping spans without a popup).
+        const grip = under instanceof Element ? under.closest<HTMLElement>('.' + GRIP_CLASS) : null;
+        if (grip?.dataset.gripVid) {
+            this.commitRelation(source, grip.dataset.gripVid, e);
+            return;
+        }
+
+        // Resolve the span stack under the cursor (overlay and rubber band are pointer-events:none,
+        // so elementFromPoint reaches the content). The stack is innermost-first, one entry per vid.
+        const stack = distinctHighlightStack(under);
+
+        if (stack.length === 0) {
+            return; // nothing under the drop → cancel
+        }
+
+        // A drop on an inline label targets exactly that label's annotation (the innermost highlight)
+        // even when it is nested in others — otherwise the drop resolves the whole ancestor stack and
+        // pops up the menu though the label already names one span. Mirrors the click-selection path
+        // in ApacheAnnotatorSelector.showSelector.
+        const innermost = stack[0];
+        if (stack.length === 1 || this.droppedOnInlineLabel(e, innermost)) {
+            const vid = innermost.getAttribute('data-iaa-id');
+            if (vid) this.commitRelation(source, vid, e);
+            return;
+        }
+
+        // Several overlapping spans under shared text → disambiguate via the selector popup.
+        // The drop event is captured for the deferred commit so the relation-type dialog opens at the
+        // drop; dismissing the popup never calls back, i.e. cancels.
+        this.pickTarget(e.clientX, e.clientY, stack, (vid) => {
+            this.commitRelation(source, vid, e);
+        });
+    }
+
+    /**
+     * Create the relation unless it would be an unintended self-loop. A relation whose target is its
+     * own source is only created when Shift is held at drop time — otherwise a tiny drag that releases
+     * back over the source (e.g. onto the source's own still-visible grip) would silently create a
+     * span-to-itself loop. Mirrors brat, where self-loops require Shift (AnnotatorUI.endArcCreation).
+     */
+    private commitRelation(source: VID, target: VID, e: MouseEvent): void {
+        if (source === target && !e.shiftKey) return;
+        this.ajax.createRelationAnnotation(source, target, e);
+    }
+
+    /**
+     * Whether the drop point is on `hl`'s inline label. The class guard scopes this to label mode
+     * (the class is only set when labels are shown); getInlineLabelClientRect throws on a highlight
+     * with no leading text node, hence the try/catch.
+     */
+    private droppedOnInlineLabel(e: MouseEvent, hl: HTMLElement): boolean {
+        if (!hl.classList.contains('iaa-inline-label')) return false;
+        try {
+            return isPointInRect({ x: e.clientX, y: e.clientY }, getInlineLabelClientRect(hl));
+        } catch {
+            return false;
+        }
+    }
+
+    private teardown(): void {
+        window.removeEventListener('mousemove', this.onWindowMove, true);
+        window.removeEventListener('mouseup', this.onWindowUp, true);
+        window.removeEventListener('keydown', this.onWindowKey, true);
+        this.root.classList.remove(CLASS_DRAGGING);
+        this.relationVisualizer.clearDragArc();
+        this.state = 'idle';
+        this.sourceVid = null;
+    }
+
+    /** Abort any in-flight drag and detach listeners (called from the visualizer's destroy). */
+    public destroy(): void {
+        this.teardown();
+    }
+}

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/RelationGripLayer.scss
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/RelationGripLayer.scss
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Transient overlay hosting relation-creation grips. Like .iaa-relation-overlay it is an
+// absolutely-positioned child of the content root and scrolls with the inline marks. Grips are
+// positioned relative to this layer's top-left, so it must be `position: absolute` to act as their
+// containing block (see RelationGripLayer.captureOrigin). It sits above the relation arc overlay
+// (z-index 5) so grips are never hidden behind an arc.
+.iaa-relation-grip-layer {
+    position: absolute;
+    top: 0;
+    left: 0;
+    overflow: visible;
+    pointer-events: none;
+    z-index: 6;
+}
+
+// A single grip knob, anchored above the start of its span and color-coded after it. left/top are
+// set inline (the anchor); the negative margins centre the knob horizontally on the span start and
+// lift it clear of the text. Only the knob is interactive — the layer is not.
+.iaa-relation-grip {
+    position: absolute;
+    width: 9px;
+    height: 9px;
+    margin-left: -4.5px;
+    margin-top: -9px;
+    box-sizing: border-box;
+    border-radius: 50%;
+    background-color: var(--iaa-grip-color, #888888);
+    border: 1px solid var(--bs-body-bg, #ffffff);
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.25);
+    pointer-events: auto;
+    cursor: grab;
+    transition: transform 0.08s ease-out;
+
+    // Invisible, larger hit target around the small visible knob so the pointer can land on it
+    // easily — and, crucially, so the catchable area reaches down toward the line, shrinking the
+    // dead gap the cursor must cross from the text. Paired with the JS linger (GRIP_LINGER_MS).
+    &::before {
+        content: '';
+        position: absolute;
+        inset: -7px -7px -10px;
+    }
+
+    &:hover {
+        transform: scale(1.35);
+    }
+}
+
+// Echo: while a grip is hovered, every fragment of its owning span gets this class — the
+// inverse of normal highlight-hover. Same kind of glow as `.iaa-hover`, but keyed to the span's own
+// `--iaa-border-color` (which the grip is coloured after) rather than the generic focus colour, so the
+// emphasis visually rhymes with the knob the user is pointing at and the grip→span mapping is obvious.
+.iaa-relation-source-candidate {
+    &:not(.iaa-inline-label) {
+        filter: drop-shadow(0 0 clamp(3px, 0.3em, 10px) var(--iaa-border-color, #888888))
+            brightness(var(--hover-brightness, 1.2));
+    }
+
+    &.iaa-inline-label {
+        border-color: var(--iaa-border-color, #888888);
+        filter: drop-shadow(0 0 clamp(3px, 0.3em, 10px) var(--iaa-border-color, #888888))
+            brightness(var(--hover-brightness, 1.2));
+    }
+}

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/RelationGripLayer.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/RelationGripLayer.ts
@@ -1,0 +1,320 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import './RelationGripLayer.scss';
+import { type VID } from '@inception-project/inception-js-api';
+import { collectFragmentRects, type HighlightResolver } from './RelationVisualizer';
+import { distinctHighlightStack, fanAngle } from './Utilities';
+
+/**
+ * Surfaces relation-creation "grips" on hover. A grip is a small
+ * drag affordance anchored above the start of a hovered span. It is *not* the highlighted text, so
+ * it never competes with the native text-selection gesture that creates spans.
+ *
+ * Ownership contract with ApacheAnnotatorVisualizer (mirrors RelationVisualizer): the main
+ * visualizer decides *when* grips are refreshed or cleared (hover events, re-render, scroll). This
+ * class owns *what* is drawn and installs no recompute triggers of its own.
+ */
+
+const LAYER_CLASS = 'iaa-relation-grip-layer';
+/** Class on each grip knob. Exported so the drag controller can recognise a grip as a drop target
+ * and resolve it to its span via `data-grip-vid` (a grip proxies its span; see RelationDragController). */
+export const GRIP_CLASS = 'iaa-relation-grip';
+/** Echo class added to every fragment of a grip's owning vid while the grip is hovered:
+ * the inverse of normal highlight-hover — pointing at the grip emphasises the span it proxies, making
+ * the grip→span mapping unambiguous. Styled in RelationGripLayer.scss. */
+const ECHO_CLASS = 'iaa-relation-source-candidate';
+
+/** Vertical gap (px) between a grip's anchor (the span-start, on the text baseline box) and the
+ * knob, so the knob sits just above the line rather than on top of the ink. */
+const GRIP_RISE_PX = 4;
+
+/**
+ * Linger (ms) before grips are torn down once the pointer leaves the highlight. A grip sits in the
+ * empty space *above* the line, so travelling text→grip necessarily crosses a non-highlight gap;
+ * clearing immediately would dismiss the grip before the cursor can reach it. The deferred clear is
+ * cancelled the moment the pointer lands on a grip (or back on the stack).
+ */
+const GRIP_LINGER_MS = 400;
+
+/** Total angular spread of a fan of coincident grips, symmetric around vertical. */
+const FAN_SPREAD_RAD = (90 * Math.PI) / 180;
+/** Smallest fan radius; the actual radius grows with the knob count (see layoutFan). */
+const FAN_BASE_RADIUS_PX = 12;
+/** Minimum straight-line gap (chord) kept between adjacent knobs so each stays clickable. */
+const FAN_MIN_CHORD_PX = 11;
+/** Anchors within this many px (both axes) count as the same span-start and get fanned together. */
+const ANCHOR_TOLERANCE_PX = 2;
+
+/** A grip's resolved anchor before fan layout: where its span starts on screen, and its colour. */
+interface GripSpec {
+    vid: VID;
+    /** Span-start fragment left/top in viewport coordinates (pre origin-subtraction). */
+    left: number;
+    top: number;
+    color: string;
+}
+
+export class RelationGripLayer {
+    private root: Element;
+    private resolveHighlights: HighlightResolver;
+
+    /**
+     * Transient overlay holding the grip knobs. It is a sibling of the inline <mark>s under the
+     * content root — deliberately NOT among the `.iaa-highlighted` marks — so `highlights()` (and
+     * therefore the drop hit-test) never mistakes a grip for an annotation.
+     */
+    private layer: HTMLElement;
+
+    /** Layer top-left in viewport coordinates, captured fresh whenever grips are (re)built. */
+    private origin = { left: 0, top: 0 };
+
+    /**
+     * Sorted, comma-joined vids of the stack the grips currently represent; null when no grips are
+     * shown. Used to skip rebuilding while the pointer stays within the same highlight stack.
+     */
+    private currentKey: string | null = null;
+
+    /** Pending linger timeout handle (see GRIP_LINGER_MS); undefined when none is scheduled. */
+    private clearTimer: number | undefined;
+
+    /**
+     * Fragments currently carrying the echo class (the hovered grip's owning vid). Tracked so the
+     * echo can be lifted even when the grip is torn down without a mouseleave — e.g. grips are
+     * cleared on scroll / re-render while one is hovered, which does not reliably fire mouseleave.
+     */
+    private echoed: Element[] = [];
+
+    /** Invoked on a grip's mousedown to arm a relation drag (RelationDragController); optional so the
+     * layer can be used for grip display alone. */
+    private onGripPointerDown?: (grip: HTMLElement, e: MouseEvent) => void;
+
+    public constructor(
+        root: Element,
+        resolveHighlights: HighlightResolver,
+        onGripPointerDown?: (grip: HTMLElement, e: MouseEvent) => void
+    ) {
+        this.root = root;
+        this.resolveHighlights = resolveHighlights;
+        this.onGripPointerDown = onGripPointerDown;
+
+        this.layer = document.createElement('div');
+        this.layer.classList.add(LAYER_CLASS);
+        // The layer itself is inert; individual grips opt back into pointer events so they can be
+        // hovered and dragged.
+        this.layer.style.pointerEvents = 'none';
+        this.root.appendChild(this.layer);
+    }
+
+    /**
+     * React to the pointer moving over the content. Pass the event target; grips are (re)built for
+     * the hovered highlight stack, or cleared when the pointer is over neither a highlight nor a
+     * grip. Hovering a grip keeps the current grips (it is not a highlight, so a naive re-derive
+     * would otherwise tear them down).
+     */
+    public handlePointerOver(target: EventTarget | null): void {
+        // Pointer is on a grip (or the layer): keep the grips and cancel any pending teardown so the
+        // user can travel from the text up to the knob across the empty gap without losing it.
+        if (target instanceof Element && target.closest('.' + LAYER_CLASS)) {
+            this.cancelPendingClear();
+            return;
+        }
+
+        const vids = this.vidsAt(target);
+        if (vids.length === 0) {
+            // Off the highlight but maybe heading for the grip — defer the teardown (linger).
+            this.scheduleClear();
+            return;
+        }
+        this.cancelPendingClear();
+        this.show(vids);
+    }
+
+    /** Defer a teardown by GRIP_LINGER_MS unless one is already pending; cancelled if the pointer
+     * reaches a grip or returns to the stack. */
+    private scheduleClear(): void {
+        if (this.clearTimer !== undefined || this.currentKey === null) return;
+        this.clearTimer = window.setTimeout(() => {
+            this.clearTimer = undefined;
+            this.clear();
+        }, GRIP_LINGER_MS);
+    }
+
+    private cancelPendingClear(): void {
+        if (this.clearTimer !== undefined) {
+            window.clearTimeout(this.clearTimer);
+            this.clearTimer = undefined;
+        }
+    }
+
+    /** Distinct vids of the highlight stack under the given node. */
+    private vidsAt(target: EventTarget | null): VID[] {
+        const node = target instanceof Node ? target : null;
+        return distinctHighlightStack(node).map((h) => h.getAttribute('data-iaa-id') as VID);
+    }
+
+    private show(vids: VID[]): void {
+        const key = [...vids].sort().join(',');
+        if (key === this.currentKey) return;
+
+        this.clear();
+        this.captureOrigin();
+
+        const viewport = this.viewportRect();
+        const specs: GripSpec[] = [];
+        for (const vid of vids) {
+            const spec = this.resolveGrip(vid, viewport);
+            if (spec) specs.push(spec);
+        }
+
+        // Spans that start at the same point on screen produce coincident knobs; fan each such group
+        // so every knob stays individually targetable. Without inline labels, overlapping
+        // spans genuinely share a start, so this is where fanning matters. In inline-label mode each
+        // span's label tag occupies a distinct x, so anchors differ, every group is a singleton, and
+        // layoutFan degenerates to the plain single-knob placement.
+        for (const group of this.groupByAnchor(specs)) {
+            this.layoutFan(group);
+        }
+        this.currentKey = key;
+    }
+
+    /** Resolve a vid to its grip anchor (span start on the first in-view line) and colour; null if
+     * the span has no visible fragment (e.g. it is secluded / scrolled off). */
+    private resolveGrip(vid: VID, viewport: DOMRect): GripSpec | null {
+        const hls = this.resolveHighlights(vid);
+        if (hls.length === 0) return null;
+
+        // collectFragmentRects returns one rect per visual line, sorted top-to-bottom, so the first
+        // in-view rect is the span's start on screen (anchoring to an off-screen earlier fragment of
+        // a multi-line span would put the grip outside the viewport).
+        const fragment = collectFragmentRects(hls).find(
+            (r) => r.bottom >= viewport.top && r.top <= viewport.bottom
+        );
+        if (!fragment) return null;
+
+        // Color-code each grip after its span so the grip→span mapping is unambiguous.
+        // `--iaa-color` holds the *contrast* foreground (black/white via bgToFgColor) used for
+        // label text — identical across most spans and useless for distinguishing them.
+        // `--iaa-border-color` carries the span's actual color, which is what we want.
+        return { vid, left: fragment.left, top: fragment.top, color: this.gripColor(hls[0]) };
+    }
+
+    /** Bucket specs whose anchors coincide (same span start on the same line, within tolerance). */
+    private groupByAnchor(specs: GripSpec[]): GripSpec[][] {
+        const groups: GripSpec[][] = [];
+        for (const spec of specs) {
+            const group = groups.find(
+                (g) =>
+                    Math.abs(g[0].left - spec.left) <= ANCHOR_TOLERANCE_PX &&
+                    Math.abs(g[0].top - spec.top) <= ANCHOR_TOLERANCE_PX
+            );
+            if (group) group.push(spec);
+            else groups.push([spec]);
+        }
+        return groups;
+    }
+
+    /**
+     * Lay out one group of coincident grips as a symmetric upward arc centred on the span start.
+     * A single grip keeps the original placement (the middle of the fan); additional knobs splay out
+     * (±sin) and up (1−cos). The radius grows with the knob count so adjacent knobs keep a clickable
+     * gap (chord ≥ FAN_MIN_CHORD_PX) even when several spans share a start.
+     */
+    private layoutFan(group: GripSpec[]): void {
+        const n = group.length;
+        const delta = n > 1 ? FAN_SPREAD_RAD / (n - 1) : 0;
+        const radius =
+            n > 1
+                ? Math.max(FAN_BASE_RADIUS_PX, FAN_MIN_CHORD_PX / (2 * Math.sin(delta / 2)))
+                : 0;
+
+        group.forEach((spec, i) => {
+            const angle = fanAngle(i, n, FAN_SPREAD_RAD);
+            const left = spec.left - this.origin.left + radius * Math.sin(angle);
+            const top =
+                spec.top - this.origin.top - GRIP_RISE_PX - radius * (1 - Math.cos(angle));
+            this.layer.appendChild(this.createGrip(spec, left, top));
+        });
+    }
+
+    /** Create one grip knob at the given layer-relative position. */
+    private createGrip(spec: GripSpec, left: number, top: number): HTMLElement {
+        const grip = document.createElement('div');
+        grip.className = GRIP_CLASS;
+        // NOT data-iaa-id: highlights()/closestHighlight key on [data-iaa-id], so a grip carrying it
+        // would be resolved as a drop target / annotation. data-grip-vid keeps the vid off that path.
+        grip.dataset.gripVid = String(spec.vid);
+        grip.style.left = left + 'px';
+        grip.style.top = top + 'px';
+        if (this.onGripPointerDown) {
+            grip.addEventListener('mousedown', (e) => this.onGripPointerDown!(grip, e));
+        }
+        // Echo: hovering the grip emphasises its span. mouseenter/leave (not over/out)
+        // because the grip has no children to bubble from and we want exactly the grip's own bounds.
+        grip.addEventListener('mouseenter', () => this.echo(spec.vid));
+        grip.addEventListener('mouseleave', () => this.clearEcho());
+        if (spec.color) grip.style.setProperty('--iaa-grip-color', spec.color);
+        return grip;
+    }
+
+    /** Emphasise every fragment of `vid` (the hovered grip's span); replaces any prior echo. */
+    private echo(vid: VID): void {
+        this.clearEcho();
+        const hls = this.resolveHighlights(vid);
+        hls.forEach((h) => h.classList.add(ECHO_CLASS));
+        this.echoed = Array.from(hls);
+    }
+
+    /** Lift the current echo, if any. Idempotent. */
+    private clearEcho(): void {
+        for (const el of this.echoed) el.classList.remove(ECHO_CLASS);
+        this.echoed = [];
+    }
+
+    private gripColor(highlight: Element): string {
+        const style = getComputedStyle(highlight);
+        return (
+            style.getPropertyValue('--iaa-border-color').trim() ||
+            style.getPropertyValue('--iaa-color').trim()
+        );
+    }
+
+    private viewportRect(): DOMRect {
+        const wrapper = this.root.closest('.i7n-wrapper') || this.root;
+        return wrapper.getBoundingClientRect();
+    }
+
+    private captureOrigin(): void {
+        const r = this.layer.getBoundingClientRect();
+        this.origin = { left: r.left, top: r.top };
+    }
+
+    /** Remove all grips. Called by the main visualizer on re-render and scroll, and internally
+     * before rebuilding for a new stack. */
+    public clear(): void {
+        this.cancelPendingClear();
+        this.clearEcho();
+        if (this.currentKey === null && !this.layer.firstChild) return;
+        this.layer.replaceChildren();
+        this.currentKey = null;
+    }
+
+    public destroy(): void {
+        this.cancelPendingClear();
+        this.layer.remove();
+    }
+}

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/RelationVisualizer.scss
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/RelationVisualizer.scss
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Overlay layer that hosts relation arcs and stubs. It is an absolutely-positioned child of the
+// editor content root and scrolls with the inline marks it connects. overflow:visible
+// ensures arcs that bow above the content box are not clipped.
+.iaa-relation-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    overflow: visible;
+    pointer-events: none;
+    z-index: 5;
+}
+
+.iaa-relation-arc {
+    fill: none;
+    stroke-width: 1.5px;
+    opacity: 0.8;
+
+    &.iaa-relation-active,
+    &.iaa-relation-selected {
+        opacity: 1;
+        stroke-width: 2.5px;
+    }
+}
+
+.iaa-relation-stub {
+    fill: none;
+    stroke-width: 1.5px;
+    opacity: 0.8;
+
+    // Active/selected state is toggled on the enclosing stub group.
+    .iaa-relation-active &,
+    .iaa-relation-selected & {
+        opacity: 1;
+        stroke-width: 2.5px;
+    }
+}
+
+// Invisible, wide hit target laid over a thin arc/stub so it is easy to bring the mouse into
+// contact with. Transparent stroke still receives pointer events with pointer-events: stroke.
+.iaa-relation-hit {
+    fill: none;
+    stroke: transparent;
+    stroke-width: 12px;
+    pointer-events: stroke;
+    cursor: pointer;
+}
+
+// Transparent, but the larger radius makes the tip easy to click/hover.
+.iaa-relation-stub-tip {
+    &:hover {
+        fill: rgba(0, 0, 0, 0.08) !important;
+    }
+}
+
+// Rubber-band arc shown while creating a relation by dragging from a grip.
+// Dashed to read as provisional; non-interactive so it never blocks the drop hit-test.
+.iaa-relation-drag {
+    fill: none;
+    stroke-width: 2px;
+    stroke-dasharray: 5 4;
+    opacity: 0.9;
+    pointer-events: none;
+}
+
+// While a creation drag is in progress the content root carries this class: force the grabbing
+// cursor everywhere and suppress text selection so the gesture cannot start a span selection.
+.iaa-relation-dragging {
+    user-select: none;
+
+    &,
+    & * {
+        cursor: grabbing !important;
+    }
+}
+
+.iaa-relation-label {
+    font-size: 10px;
+    text-anchor: middle;
+    dominant-baseline: middle;
+    pointer-events: none;
+    // White halo for legibility over text.
+    stroke: var(--bs-body-bg, #fff);
+    stroke-width: 3px;
+    paint-order: stroke;
+
+    // Default (toggle off): labels are hidden at rest and only revealed while their relation is
+    // hovered (active) or selected. The overlay carries .iaa-relation-labels-visible when the
+    // toggle is on.
+    visibility: hidden;
+
+    &.iaa-relation-active,
+    &.iaa-relation-selected {
+        visibility: visible;
+    }
+}
+
+.iaa-relation-labels-visible .iaa-relation-label {
+    visibility: visible;
+}
+
+// A collapsed bucket of near-coincident arcs: a single representative arc, dashed to read as
+// "stands for several", carrying a count badge. Hovering expands it into the individual fanned arcs.
+.iaa-relation-bundle-collapsed .iaa-relation-arc {
+    stroke-dasharray: 4 3;
+}
+
+.iaa-relation-fan-badge {
+    font-size: 10px;
+    font-weight: bold;
+    text-anchor: middle;
+    dominant-baseline: middle;
+    pointer-events: none;
+    stroke: var(--bs-body-bg, #fff);
+    stroke-width: 3px;
+    paint-order: stroke;
+}

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/RelationVisualizer.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/RelationVisualizer.ts
@@ -1,0 +1,1267 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import './RelationVisualizer.scss';
+import {
+    AnnotatedText,
+    AnnotationOutEvent,
+    AnnotationOverEvent,
+    type DiamAjax,
+    Relation,
+    type VID,
+} from '@inception-project/inception-js-api';
+import { ArrowMarkerPool } from './ArrowMarkerPool';
+import { SVG_NS, svgEl } from './SvgUtilities';
+import { fanAngle } from './Utilities';
+
+/**
+ * Renders relations for the Apache Annotator editor:
+ *  - relations whose endpoints both fall inside an "effect-range band" are drawn as full arcs;
+ *  - relations crossing the band boundary are drawn as directional (up/down) stubs with a
+ *    clickable tip that jumps to the far endpoint;
+ *  - pass-through relations (both ends outside the band) are not drawn.
+ *
+ * Ownership contract with ApacheAnnotatorVisualizer: the main visualizer owns *when* to
+ * recompute (scroll/resize/reflow scheduling, debouncing). This class owns *what* to draw and
+ * must NOT install its own recompute triggers — it is driven via render().
+ */
+
+const CLASS_RELATED = 'iaa-related';
+
+/** Applied to an arc/stub while the mouse is over it (visual "active" state). */
+const CLASS_ACTIVE = 'iaa-relation-active';
+
+/**
+ * Applied to the currently selected (focused) relation's arc/stub. Shares the active styling, but
+ * is kept independent of hover so it persists when the mouse leaves (the hover handler only toggles
+ * CLASS_ACTIVE).
+ */
+const CLASS_SELECTED = 'iaa-relation-selected';
+
+/** On the overlay: relation labels are shown at rest. Without it, labels appear only on hover. */
+const CLASS_LABELS_VISIBLE = 'iaa-relation-labels-visible';
+
+/** The rubber-band arc drawn while a relation is being created by dragging. */
+const CLASS_DRAG = 'iaa-relation-drag';
+
+/**
+ * Effect-range band size as a fraction of the seclusion margin.
+ *
+ * The band must sit strictly *between* the viewport and the non-secluded region. The non-secluded
+ * region is the viewport grown by the seclusion margin (the IntersectionObserver `rootMargin` in
+ * ApacheAnnotatorVisualizer). Choosing a fraction < 1 guarantees the band is contained in the
+ * non-secluded region, so any endpoint we classify as "in band" is actually rendered (has a real
+ * rect) rather than secluded — which is exactly the precondition the full-arc / stub-origin
+ * geometry relies on. It also keeps on-screen arc density bounded independent of document length.
+ */
+const BAND_SECLUSION_FRACTION = 0.5;
+
+/** Default stroke colour when a relation carries none. */
+const DEFAULT_COLOR = '#888888';
+
+/** Length (px) of a directional stub leaving its in-band endpoint. */
+const STUB_LENGTH_PX = 26;
+
+/** Total angular spread (radians) over which a span's stubs in one direction are fanned. */
+const FAN_SPREAD_RAD = (60 * Math.PI) / 180;
+
+/** Beyond this many stubs in one direction from one span, collapse into a single counted badge. */
+const FAN_COLLAPSE_THRESHOLD = 3;
+
+/**
+ * Proximity tolerance (px) for deciding two arc endpoints are "the same point" when clustering arcs
+ * that share an endpoint (see clusterArcs / sharesEndpoint). Two relations leaving the same span in
+ * the same vertical direction anchor to the very same point (distance 0), so this is really a slack
+ * for measurement noise and for near- (not exactly-) coincident endpoints. (Arcs leaving one span in
+ * opposite directions anchor to opposite edges — see anchorOf — so they fall in separate clusters,
+ * which is correct: they don't overlap.) Kept small (~one character) so unrelated relations
+ * that merely pass close by are not merged. A fixed grid is unusable here — it splits points that
+ * straddle a cell boundary no matter how close.
+ */
+const ARC_CLUSTER_TOL_PX = 14;
+
+/** Bow (px) of the first arc in a cluster. Kept compact so the lowest arc hugs its own line. */
+const ARC_BASE_BOW_PX = 12;
+
+/**
+ * Extra bow (px) added per stacked arc so each arc in a cluster curves higher than the last. A stacked
+ * arc's apex (where its label sits) rises by only *half* the bow step, so this must be ≳ 2× the label
+ * height (10px) for the labels not to overlap — hence 22, not the visually-sufficient ~12 the arcs
+ * alone would need. At wider line spacing this is scaled up further (see ARC_BOW_REFERENCE_LINE_HEIGHT).
+ */
+const ARC_BOW_STEP_PX = 22;
+
+/**
+ * The per-stack bow step (not the base bow) is scaled by the content's line-height relative to this
+ * reference (the `mid` preset's 1.8), so when the user picks a roomier line spacing the extra vertical
+ * space is spent spreading stacked arcs — and their labels — further apart. The base bow stays fixed
+ * so the first arc keeps a compact height and never rides up into the line above. Clamped to keep
+ * extreme line-heights from going silly.
+ */
+const ARC_BOW_REFERENCE_LINE_HEIGHT = 1.8;
+const ARC_BOW_SCALE_MIN = 0.6;
+const ARC_BOW_SCALE_MAX = 1.2;
+
+/**
+ * Fraction of the bow kept for a perfectly vertical chord. The bow is a *perpendicular* offset, so on
+ * a near-vertical arc it pushes the curve sideways — a fixed offset that the eye reads as strong
+ * curvature there, while the same offset on a long horizontal arc is an invisible vertical sag. We
+ * therefore scale the bow by the chord's horizontalness (cos²θ): full bow when horizontal, down to
+ * this fraction when vertical. cos² (rather than |cos|) makes the falloff bite by the diagonal — a 45°
+ * arc keeps ~60%, not ~78% — which is where the over-curving is already visible. Not zero, so stacked
+ * vertical arcs still separate a little.
+ */
+const ARC_VERTICAL_BOW_MIN_FACTOR = 0.25;
+
+/** Beyond this many arcs in one tight cluster, collapse into a single bundled arc + count badge. */
+const ARC_COLLAPSE_THRESHOLD = 4;
+
+/** Resolves the rendered highlight elements (the inline <mark>s) for an annotation VID. */
+export type HighlightResolver = (vid: VID) => NodeListOf<Element>;
+
+interface Endpoint {
+    vid: VID;
+    /**
+     * Window-relative begin offset, or null when unknown (span absent from doc.spans, or a placeholder
+     * with no offsets). Used only as the *fallback* for up/down direction when geometry is unavailable
+     * — i.e. for a secluded out-of-band partner (see stubGoesUp). null is deliberate: a `?? 0` default
+     * is indistinguishable from a genuine document-start endpoint and would bias every unknown partner
+     * to compare as "earlier".
+     */
+    offset: number | null;
+    /** Label of the endpoint span, used for the stub hover preview. */
+    label: string;
+    /**
+     * In-band highlight fragments in viewport coordinates, one rect per visual line. A highlight
+     * that wraps across lines yields several fragments; the anchor is chosen among them at draw
+     * time (see chooseFragment / nearestFragmentPair). Anchoring to a single union bounding box
+     * instead would put the attachment point in the empty gap between wrapped fragments, off the
+     * actual ink. Empty when no fragment intersects the band.
+     */
+    rects: DOMRect[];
+    /**
+     * Vertical centre (viewport coords) of this endpoint's rendered fragments when it is *out of band*
+     * but still rendered (not secluded). An out-of-band endpoint lies wholly above or below the band —
+     * if any fragment reached the band it would be in-band — so this single y is enough to place a stub
+     * partner up or down without consulting offsets. null when in-band (irrelevant) or secluded
+     * (unmeasured — fall back to offset order).
+     */
+    outerMidY: number | null;
+    inBand: boolean;
+}
+
+/** A single stub to be drawn from an in-band span toward an out-of-band partner. */
+interface Stub {
+    relation: Relation;
+    near: Endpoint;
+    far: Endpoint;
+    color: string;
+    goesUp: boolean;
+}
+
+/**
+ * A full arc to be drawn between two in-band endpoints. The anchor points are resolved (and cached
+ * here) *before* bucketing so arcs can be grouped by rendered geometry rather than by endpoint VID.
+ * Coordinates are overlay-local (already passed through toLocal).
+ */
+interface Arc {
+    relation: Relation;
+    sAnchor: { x: number; y: number };
+    tAnchor: { x: number; y: number };
+}
+
+export class RelationVisualizer {
+    private root: Element;
+    private ajax: DiamAjax;
+    private resolveHighlights: HighlightResolver;
+
+    private overlay: SVGSVGElement;
+    private defs: SVGDefsElement;
+
+    /** Overlay top-left in viewport coordinates, captured fresh at the start of each render. */
+    private origin = { left: 0, top: 0 };
+    /** Pools one arrowhead marker per color in <defs>; reset each render via clear(). */
+    private arrowMarkers: ArrowMarkerPool;
+    /** VIDs of the focused (selected) annotations for the current render; drives CLASS_SELECTED. */
+    private focusedVids = new Set<VID>();
+    /** Effect-range band (viewport coordinates) for the current render; consulted by anchorOf. */
+    private band = { top: 0, bottom: 0 };
+
+    /** Line-spacing-derived bow multiplier for the current render (see ARC_BOW_REFERENCE_LINE_HEIGHT). */
+    private bowScale = 1;
+
+    /**
+     * Inline marks currently carrying CLASS_RELATED (the focus-coupling tint). Tracked so clear()
+     * can strip the class from exactly these — O(coupled), at most a couple of elements — instead of
+     * a full-subtree querySelectorAll over the content root on every render.
+     */
+    private coupledElements = new Set<Element>();
+
+    // Per-render memoization (band and DOM are constant within one render() call, so a vid's
+    // resolved highlights and endpoint geometry never change mid-render). Both are cleared at the
+    // top of render(). A span that participates in several relations — or is both a source and a
+    // target — is thus measured once instead of once per appearance.
+    private highlightCache = new Map<VID, NodeListOf<Element>>();
+    private endpointCache = new Map<VID, Endpoint>();
+    /** Per-render cache of label-tag rects (inline-label mode); null = no in-band label for the vid. */
+    private labelRectCache = new Map<VID, DOMRect | null>();
+
+    /** The transient relation-creation rubber-band path, while a drag is in progress; else undefined. */
+    private dragArc?: SVGPathElement;
+
+    public constructor(root: Element, ajax: DiamAjax, resolveHighlights: HighlightResolver) {
+        this.root = root;
+        this.ajax = ajax;
+        this.resolveHighlights = resolveHighlights;
+
+        this.overlay = document.createElementNS(SVG_NS, 'svg');
+        this.overlay.classList.add('iaa-relation-overlay');
+        // The overlay is non-interactive; only the stub tips opt back into pointer events.
+        this.overlay.style.pointerEvents = 'none';
+
+        this.defs = document.createElementNS(SVG_NS, 'defs');
+        this.overlay.appendChild(this.defs);
+        this.arrowMarkers = new ArrowMarkerPool(this.defs);
+
+        // Positioning context: the overlay is a child of `root` (the content layer that
+        // also holds the inline <mark>s) and scrolls together with them. Coordinates are mapped via
+        // toLocal(), which subtracts the overlay's *current* client rect — an SVG with no viewBox
+        // maps user-space (0,0) to its own top-left corner, so this is correct regardless of the
+        // overlay's offset parent or the scroll position, as long as the rect is read fresh each
+        // render (see captureOrigin). overflow:visible (in the SCSS) keeps arcs from being clipped.
+        this.root.appendChild(this.overlay);
+    }
+
+    // suspend()/resume() are driven by the main visualizer's scroll lifecycle, but they are
+    // intentionally NO-OPS: the overlay is an absolutely-positioned child of the content root and
+    // scrolls together with the inline marks, so it needs neither hiding nor recomputation during a
+    // scroll. We deliberately do NOT keep a `suspended` flag to gate render() — doing so previously
+    // blanked all relations, because the main's suspend/resume pairing is scroll-scoped and can
+    // leave us suspended after the initial load.
+    public suspend(): void {
+        // intentionally no-op — see comment above
+    }
+
+    public resume(): void {
+        // intentionally no-op — see comment above
+    }
+
+    /**
+     * Control whether relation labels are shown at rest. When false, labels are hidden until the
+     * relation is hovered (the active state reveals them — see RelationVisualizer.scss). This is a
+     * pure CSS-class toggle on the persistent overlay, so it takes effect without a re-render.
+     */
+    public setLabelsAlwaysVisible(visible: boolean): void {
+        this.overlay.classList.toggle(CLASS_LABELS_VISIBLE, visible);
+    }
+
+    // --- relation-creation rubber-band ------------------------------------------------------
+    //
+    // RelationDragController drives these; the band is drawn into the *shared* overlay so it uses
+    // the same coordinate system and arrowhead pool as the real arcs. The overlay rect is captured
+    // once at beginDragArc — a creation drag is a short gesture during which the content does not
+    // scroll — and reused per move, so updateDragArc does no per-frame layout read.
+
+    /** Begin a rubber-band drag arc in the given color. */
+    public beginDragArc(color: string): void {
+        // The overlay may be unsized if the document carries no relations yet; size + locate it now.
+        this.sizeOverlayToContent();
+        this.captureOrigin();
+        this.clearDragArc();
+
+        const stroke = color || DEFAULT_COLOR;
+        this.dragArc = svgEl('path', CLASS_DRAG, {
+            d: '',
+            stroke,
+            'marker-end': `url(#${this.arrowMarkers.markerFor(stroke)})`,
+        });
+        // Inert: it must never intercept the drop hit-test (document.elementFromPoint).
+        this.dragArc.style.pointerEvents = 'none';
+        this.overlay.appendChild(this.dragArc);
+    }
+
+    /** Re-plot the rubber band from a source point to the cursor (both in viewport coordinates). */
+    public updateDragArc(
+        fromClient: { x: number; y: number },
+        toClient: { x: number; y: number }
+    ): void {
+        if (!this.dragArc) return;
+        const s = this.toLocal(fromClient.x, fromClient.y);
+        const t = this.toLocal(toClient.x, toClient.y);
+        const c = bezierControlPoint(s.x, s.y, t.x, t.y, 18);
+        this.dragArc.setAttribute('d', `M ${s.x} ${s.y} Q ${c.x} ${c.y} ${t.x} ${t.y}`);
+    }
+
+    /** Remove the rubber band (drag committed or cancelled). */
+    public clearDragArc(): void {
+        this.dragArc?.remove();
+        this.dragArc = undefined;
+    }
+
+    public destroy(): void {
+        this.clear();
+        this.overlay.remove();
+    }
+
+    public clear(): void {
+        // Reset the overlay to just an empty <defs>: replaceChildren drops every arc/stub/marker in
+        // one operation (and re-parents the reused defs node), then empties the defs' pooled markers.
+        this.overlay.replaceChildren(this.defs);
+        this.defs.replaceChildren();
+        this.arrowMarkers.clear();
+        this.coupledElements.forEach((e) => e.classList.remove(CLASS_RELATED));
+        this.coupledElements.clear();
+    }
+
+    /**
+     * Redraw the relation overlay for the given document. Called from
+     * ApacheAnnotatorVisualizer.renderAnnotations and on its recompute events.
+     */
+    public render(
+        doc: AnnotatedText,
+        bandInputs: { viewport: DOMRect; seclusionMargin: number },
+        opts: { remeasureContent?: boolean } = {}
+    ): void {
+        // remeasureContent: the document content geometry may have changed (data load, line-spacing
+        // reflow, resize), so the content-derived measurements must be refreshed. On a bare scroll
+        // re-band the content has NOT reflowed — only the viewport (and thus the band) moved — so the
+        // overlay's content extent and the line-height-derived bow scale are unchanged: reuse the
+        // cached values and skip a forced layout flush (sizeOverlayToContent) plus a getComputedStyle
+        // every frame. (The per-endpoint geometry below is still re-measured each frame.)
+        const remeasureContent = opts.remeasureContent ?? true;
+
+        this.clear();
+        if (!doc.relations || doc.relations.size === 0) return;
+
+        if (remeasureContent) this.sizeOverlayToContent();
+        this.captureOrigin();
+
+        this.highlightCache.clear();
+        this.endpointCache.clear();
+        this.labelRectCache.clear();
+
+        const band = this.computeBand(bandInputs);
+        this.band = band;
+        if (remeasureContent) this.bowScale = this.measureBowScale();
+        this.focusedVids = new Set(doc.markedAnnotations?.get('focus') || []);
+
+        // Collect full arcs flat, then cluster by endpoint proximity *after* the loop (see
+        // clusterArcs) so that not only stacked relations between the same two spans but also arcs to
+        // distinct-yet-coincident endpoints (A→B and A→C with B,C on the same word) end up in one
+        // cluster and get fanned apart. Stubs are grouped by their in-band span + direction so a
+        // span's many out-of-band relations can be fanned / collapsed.
+        const arcs: Arc[] = [];
+        const stubGroups = new Map<string, Stub[]>();
+
+        // Endpoint coupling is focus-only. The arcs/stubs already advertise every rendered relation,
+        // so tinting all endpoints all the time is just noise; we couple only the focused relation as a
+        // cheap "these two belong together" cue. Collected here but applied *after* the measurement
+        // loop: coupleEndpoints writes classList on the inline marks, and doing that mid-loop would
+        // invalidate layout and force the next endpoint's getClientRects() to re-flush (thrash).
+        const coupledVids = new Set<VID>();
+
+        for (const relation of doc.relations.values()) {
+            const sourceVid = relation.arguments[0]?.targetId;
+            const targetVid = relation.arguments[1]?.targetId;
+            if (sourceVid == null || targetVid == null) continue;
+
+            const source = this.resolveEndpoint(doc, sourceVid, band);
+            const target = this.resolveEndpoint(doc, targetVid, band);
+
+            if (this.focusedVids.has(relation.vid)) {
+                coupledVids.add(sourceVid);
+                coupledVids.add(targetVid);
+            }
+
+            const color = relation.color || DEFAULT_COLOR;
+
+            if (source.inBand && target.inBand) {
+                const sAnchor = this.anchorOf(source, target);
+                const tAnchor = this.anchorOf(target, source);
+                arcs.push({ relation, sAnchor, tAnchor });
+            } else if (source.inBand) {
+                this.queueStub(stubGroups, {
+                    relation,
+                    near: source,
+                    far: target,
+                    color,
+                    goesUp: this.stubGoesUp(source, target),
+                });
+            } else if (target.inBand) {
+                this.queueStub(stubGroups, {
+                    relation,
+                    near: target,
+                    far: source,
+                    color,
+                    goesUp: this.stubGoesUp(target, source),
+                });
+            }
+            // else: pass-through (both out of band) -> draw nothing.
+        }
+
+        // Apply coupling now that all measurement is done — no getClientRects() runs after this, so
+        // the classList writes cannot trigger a layout re-flush.
+        coupledVids.forEach((vid) => this.coupleEndpoints(vid));
+
+        for (const cluster of clusterArcs(arcs)) {
+            this.drawArcBucket(cluster);
+        }
+        for (const stubs of stubGroups.values()) {
+            this.drawStubGroup(stubs);
+        }
+    }
+
+    // --- geometry helpers -------------------------------------------------------------------
+
+    private resolveEndpoint(
+        doc: AnnotatedText,
+        vid: VID,
+        band: { top: number; bottom: number }
+    ): Endpoint {
+        const cached = this.endpointCache.get(vid);
+        if (cached) return cached;
+
+        const highlights = this.resolveHighlightsCached(vid);
+        const span = doc.spans?.get(vid);
+        const offset = span?.offsets?.[0]?.[0] ?? null;
+        const label = span?.label || '';
+
+        // Skip the getClientRects() forced layout for endpoints that cannot be in the band. An
+        // in-band endpoint is by construction non-secluded: the band (viewport grown by
+        // BAND_SECLUSION_FRACTION of the seclusion margin) is a strict subset of the non-secluded
+        // region (viewport grown by the full margin — see computeBand). So if *every* highlight of
+        // this annotation is secluded, all its fragments lie at least a full margin from the
+        // viewport and would all be filtered out by the band test anyway — measuring them is pure
+        // waste. closest() is a structural walk that does not flush layout, unlike getClientRects().
+        // (We require *all* highlights to be secluded so an annotation straddling the seclusion
+        // boundary, with a fragment still reaching into the band, is measured normally.)
+        const allSecluded =
+            highlights.length > 0 &&
+            Array.from(highlights).every((h) => h.closest('.iaa-secluded') != null);
+
+        // One rect per visual line (a wrapped highlight contributes several). Measure once, then keep
+        // only the fragments that fall inside the band — those are the candidate anchor fragments.
+        const allFragments = allSecluded ? [] : collectFragmentRects(highlights);
+        const rects = allFragments.filter((r) => r.bottom >= band.top && r.top <= band.bottom);
+        const inBand = rects.length > 0;
+
+        // For an out-of-band-but-rendered endpoint, remember where it sits vertically so a stub can
+        // point toward it from real geometry rather than offsets (see stubGoesUp). Its fragments all
+        // lie on one side of the band, so their mid-y is unambiguous. Free: collectFragmentRects above
+        // already measured them.
+        const outerMidY =
+            !inBand && allFragments.length > 0
+                ? (Math.min(...allFragments.map((r) => r.top)) +
+                      Math.max(...allFragments.map((r) => r.bottom))) /
+                  2
+                : null;
+
+        const endpoint: Endpoint = { vid, offset, label, rects, outerMidY, inBand };
+        this.endpointCache.set(vid, endpoint);
+        return endpoint;
+    }
+
+    /**
+     * Up/down direction for a stub from the in-band `near` endpoint toward its out-of-band `far`
+     * partner: true points up (partner earlier/above), false down (partner later/below).
+     *
+     * Geometry first: a rendered (non-secluded) partner lies wholly above or below the band, so its
+     * vertical position alone decides the direction — robust, and immune to the offset hazards above
+     * (a missing/zero begin offset). Only when the partner is secluded (no geometry) do we fall back
+     * to document order by begin offset, and only when both offsets are actually known; otherwise we
+     * default downward (treat the partner as later in the document).
+     */
+    private stubGoesUp(near: Endpoint, far: Endpoint): boolean {
+        if (far.outerMidY != null) {
+            return far.outerMidY < this.nearAnchorMidY(near);
+        }
+        if (far.offset != null && near.offset != null) {
+            return far.offset < near.offset;
+        }
+        return false;
+    }
+
+    /**
+     * Vertical centre (viewport coords) of the anchor the stub will actually leave from, so the
+     * direction test matches the drawn geometry in *both* label modes: the inline-label tag when
+     * labels are on and in band (where full arcs and stubs attach — see anchorOf / drawStubGroup),
+     * otherwise the in-band span fragments. labelRectFor is memoized for this render.
+     */
+    private nearAnchorMidY(near: Endpoint): number {
+        const labelRect = this.labelRectFor(near.vid);
+        if (labelRect) return labelRect.top + labelRect.height / 2;
+        if (near.rects.length > 0) {
+            const top = Math.min(...near.rects.map((r) => r.top));
+            const bottom = Math.max(...near.rects.map((r) => r.bottom));
+            return (top + bottom) / 2;
+        }
+        return 0;
+    }
+
+    /** Memoized {@link resolveHighlights} for the current render (cleared at the top of render()). */
+    private resolveHighlightsCached(vid: VID): NodeListOf<Element> {
+        let highlights = this.highlightCache.get(vid);
+        if (!highlights) {
+            highlights = this.resolveHighlights(vid);
+            this.highlightCache.set(vid, highlights);
+        }
+        return highlights;
+    }
+
+    private computeBand(bandInputs: { viewport: DOMRect; seclusionMargin: number }): {
+        top: number;
+        bottom: number;
+    } {
+        // Band = viewport grown by a fraction of the seclusion margin, so it lies strictly between
+        // the viewport and the non-secluded region. Coordinates are viewport-space, which
+        // is what the endpoint rects (getBoundingClientRect) are measured in.
+        const { viewport, seclusionMargin } = bandInputs;
+        const margin = seclusionMargin * BAND_SECLUSION_FRACTION;
+        return { top: viewport.top - margin, bottom: viewport.bottom + margin };
+    }
+
+    /** Convert a viewport-space point to overlay-local coordinates. */
+    private toLocal(clientX: number, clientY: number): { x: number; y: number } {
+        return { x: clientX - this.origin.left, y: clientY - this.origin.top };
+    }
+
+    private captureOrigin(): void {
+        const r = this.overlay.getBoundingClientRect();
+        this.origin = { left: r.left, top: r.top };
+    }
+
+    private sizeOverlayToContent(): void {
+        const el = this.root as HTMLElement;
+        // The overlay is an absolutely-positioned child of `root`, so its own size contributes to
+        // root.scrollWidth/scrollHeight. Measuring without collapsing it first ratchets the overlay
+        // up and never lets it shrink: once the content has been tall (e.g. a roomy line-spacing
+        // preset) the oversized overlay keeps root.scrollHeight large even after the content reflows
+        // shorter, so the user can scroll past the text into a blank region where no arcs are drawn
+        // (#6108). Collapse to zero first so scroll* reflects the *content* extent, not the stale
+        // overlay. scrollWidth/scrollHeight force a layout flush, so the collapse costs no extra reflow.
+        this.overlay.setAttribute('width', '0');
+        this.overlay.setAttribute('height', '0');
+        this.overlay.style.width = '0';
+        this.overlay.style.height = '0';
+        const width = el.scrollWidth;
+        const height = el.scrollHeight;
+        this.overlay.setAttribute('width', String(width));
+        this.overlay.setAttribute('height', String(height));
+        this.overlay.style.width = width + 'px';
+        this.overlay.style.height = height + 'px';
+    }
+
+    // --- full arcs --------------------------------------------------------------------------
+
+    /**
+     * Overlay-local anchor for `from`'s arc endpoint, attached at the chosen rect's horizontal centre.
+     *
+     * The edge (top vs bottom) is chosen by where the partner sits: if `toward` lies on a clearly
+     * lower line we leave from the *bottom* edge, otherwise the *top* edge. This keeps a downward arc
+     * from having to climb over the top of its own span before heading down (and an upward arc from
+     * dropping below its span first). "Lower line" = the partner's nearest fragment's vertical centre
+     * is below this fragment's bottom, i.e. they don't share a line.
+     *
+     * In inline-label mode we prefer the annotation's *label tag* (the "ACTOR"/"A"/"B" box): unlike
+     * the span text, every overlapping annotation at the same position renders its own label, so the
+     * label boxes are spatially distinct and give each relation a unique, non-overlapping attachment
+     * point without any artificial endpoint offset. Otherwise — labels off, or the label is out of
+     * band — we fall back to the span fragment nearest `toward` (so a wrapped highlight leaves real
+     * ink instead of the empty gap a union bounding box would centre on). inBand guarantees `from`
+     * carries at least one rect, so nearestFragmentPair always returns a defined pair.
+     */
+    private anchorOf(from: Endpoint, toward: Endpoint): { x: number; y: number } {
+        const { source: fromRect, target: towardRect } = nearestFragmentPair(
+            from.rects,
+            toward.rects
+        );
+        const below = towardRect.top + towardRect.height / 2 > fromRect.bottom;
+
+        const labelRect = this.labelRectFor(from.vid);
+        if (labelRect) {
+            const y = below ? labelRect.bottom : labelRect.top;
+            return this.toLocal(labelRect.left + labelRect.width / 2, y);
+        }
+        const y = below ? fromRect.bottom : fromRect.top;
+        return this.toLocal(fromRect.left + fromRect.width / 2, y);
+    }
+
+    /**
+     * Rect of the annotation's inline label tag, or null when not applicable (labels off, or the
+     * labelled first highlight is not in the band). The label is a `::before` pseudo-element on the
+     * `.iaa-first-highlight` mark, so it cannot be measured directly; we instead take the box between
+     * the mark's left edge and where its real text content begins. A Range over the mark's child
+     * nodes covers only the text (pseudo-elements are not in the DOM), so its left edge marks the end
+     * of the label. Result is memoized per render (a shared endpoint is measured once).
+     */
+    private labelRectFor(vid: VID): DOMRect | null {
+        const cached = this.labelRectCache.get(vid);
+        if (cached !== undefined) return cached;
+
+        let result: DOMRect | null = null;
+        const highlights = this.resolveHighlightsCached(vid);
+        let firstMark: Element | undefined;
+        for (const h of highlights) {
+            if (
+                h.classList.contains('iaa-inline-label') &&
+                h.classList.contains('iaa-first-highlight')
+            ) {
+                firstMark = h;
+                break;
+            }
+        }
+
+        // markRect is the first *line* of the labelled mark (the line carrying the ::before label).
+        const markRect = firstMark?.getClientRects()[0];
+        // Only use the label when it actually sits in the band — otherwise a span whose start is far
+        // off-screen would drag the arc endpoint out of view; fall back to the in-band fragment.
+        if (markRect && markRect.bottom >= this.band.top && markRect.top <= this.band.bottom) {
+            const range = document.createRange();
+            range.selectNodeContents(firstMark!);
+            // Use the range's FIRST client rect (the text run on the label's line), not its bounding
+            // box: a wrapped mark's bounding box spans every line, so its left edge is the far-left
+            // start of a *later* line, which would make the "label box" swallow the whole first line
+            // and anchor the arc in the span text. The first client rect's left is where the real
+            // text begins on the label's line, i.e. immediately after the ::before label.
+            const contentRect = range.getClientRects()[0];
+            const right =
+                contentRect && contentRect.left > markRect.left ? contentRect.left : markRect.right;
+            result = new DOMRect(
+                markRect.left,
+                markRect.top,
+                right - markRect.left,
+                markRect.height
+            );
+        }
+
+        this.labelRectCache.set(vid, result);
+        return result;
+    }
+
+    /**
+     * Draw one cluster of full arcs that share an endpoint (see clusterArcs). We sort them stably,
+     * then either fan them apart by bow or — only when the cluster is *tight* (every arc coincident
+     * at both ends, i.e. truly stacked/redundant) and over threshold — collapse them into a single
+     * bundled arc with a count badge that expands on hover. A loose cluster (arcs leaving a common
+     * hub toward different places) is always fanned, never collapsed: a single representative arc
+     * would misrepresent where the others actually go. A cluster containing the focused relation is
+     * never collapsed, so the selection is always visible.
+     *
+     * Fanning is done *per side* of the hub: arcs leaving the shared endpoint in opposite horizontal
+     * directions don't overlap, so each side restarts its bow tiers at the compact base bow (stackIndex
+     * 0) instead of one side inheriting the other's tiers and floating needlessly high. This mirrors
+     * the up/down split the stub code already does (see queueStub).
+     */
+    private drawArcBucket(arcs: Arc[]): void {
+        arcs.sort(arcStackOrder);
+        const hasFocused = arcs.some((a) => this.focusedVids.has(a.relation.vid));
+        if (arcs.length > ARC_COLLAPSE_THRESHOLD && !hasFocused && isTightCluster(arcs)) {
+            this.drawCollapsedArcBucket(arcs);
+            return;
+        }
+
+        // Partition by the side each arc leaves the shared hub (left of it, right of it, or straight
+        // up/down), then stack each side independently so every side's lowest arc hugs its line.
+        const hub = clusterHub(arcs);
+        const sides = new Map<number, Arc[]>();
+        for (const arc of arcs) {
+            const far = near(arc.sAnchor, hub) ? arc.tAnchor : arc.sAnchor;
+            const side = Math.sign(far.x - hub.x);
+            const group = sides.get(side);
+            if (group) group.push(arc);
+            else sides.set(side, [arc]);
+        }
+        // arcs is already in arcStackOrder, so each side's slice preserves that order.
+        for (const group of sides.values()) {
+            group.forEach((arc, i) => this.drawFullArc(arc, i, this.overlay));
+        }
+    }
+
+    /**
+     * Bow (and hence Bézier control point) for the i-th stacked arc. The endpoints are left exactly
+     * where they were anchored — we deliberately do NOT offset them, so every arc stays attached to
+     * its real endpoint (its label tag in inline-label mode; the span otherwise) rather than floating
+     * above the text. Separation of stacked arcs therefore comes entirely from the bow, which grows
+     * monotonically with the stack index (i = 0, 1, 2 …) and stays strictly positive (i = 0 lies on
+     * the chord; bezierControlPoint biases every arc upward and applies Math.abs, so the stack never
+     * folds onto itself). When several arcs share an endpoint the arrowheads necessarily coincide
+     * there — they are told apart by hovering (each bow is individually targetable) and, on the side
+     * where the endpoints differ, by the label-tag anchoring that keeps overlapping annotations'
+     * attachment points distinct (see anchorOf).
+     */
+    /**
+     * Bow multiplier from the content's current line-height, normalised to the `mid` preset so the
+     * default spacing is 1× (see ARC_BOW_REFERENCE_LINE_HEIGHT). Computed as a unitless ratio
+     * (line-height ÷ font-size) so it is independent of the absolute font size. `getComputedStyle`
+     * usually resolves unitless line-heights to px, so we divide back out; the `'normal'` and bare-
+     * number cases are handled for completeness.
+     */
+    private measureBowScale(): number {
+        const cs = getComputedStyle(this.root as Element);
+        const fontSize = parseFloat(cs.fontSize) || 16;
+        const lh = cs.lineHeight;
+        let ratio: number;
+        if (lh === 'normal') ratio = 1.2;
+        else if (lh.endsWith('px')) ratio = (parseFloat(lh) || fontSize) / fontSize;
+        else ratio = parseFloat(lh) || ARC_BOW_REFERENCE_LINE_HEIGHT;
+        const scale = ratio / ARC_BOW_REFERENCE_LINE_HEIGHT;
+        return Math.min(ARC_BOW_SCALE_MAX, Math.max(ARC_BOW_SCALE_MIN, scale));
+    }
+
+    private arcStackGeometry(
+        arc: Arc,
+        stackIndex: number
+    ): {
+        s: { x: number; y: number };
+        t: { x: number; y: number };
+        c: { x: number; y: number };
+    } {
+        const s = arc.sAnchor;
+        const t = arc.tAnchor;
+        // Damp the bow as the chord tilts from horizontal (factor 1) toward vertical (factor
+        // ARC_VERTICAL_BOW_MIN_FACTOR), keeping horizontal arcs unchanged while flattening the sideways
+        // bulge a vertical arc would otherwise show (see ARC_VERTICAL_BOW_MIN_FACTOR).
+        const len = Math.hypot(t.x - s.x, t.y - s.y);
+        const horizontalness = len === 0 ? 0 : Math.abs(t.x - s.x) / len;
+        const damp =
+            ARC_VERTICAL_BOW_MIN_FACTOR +
+            (1 - ARC_VERTICAL_BOW_MIN_FACTOR) * horizontalness * horizontalness;
+        // Only the per-stack step is scaled by line spacing, NOT the base bow: the first arc
+        // (stackIndex 0) keeps a fixed, compact height so it stays close to its own line at any
+        // spacing, while wider spacing is spent spreading the *higher* arcs apart (see
+        // ARC_BOW_REFERENCE_LINE_HEIGHT). Scaling the base too made the whole stack ride up into the
+        // line above in the roomier presets.
+        const distance = (ARC_BASE_BOW_PX + ARC_BOW_STEP_PX * stackIndex * this.bowScale) * damp;
+        const c = bezierControlPoint(s.x, s.y, t.x, t.y, distance);
+        return { s, t, c };
+    }
+
+    private drawFullArc(arc: Arc, stackIndex: number, container: SVGElement): void {
+        const relation = arc.relation;
+        const color = relation.color || DEFAULT_COLOR;
+        const { s, t, c } = this.arcStackGeometry(arc, stackIndex);
+
+        const d = `M ${s.x} ${s.y} Q ${c.x} ${c.y} ${t.x} ${t.y}`;
+        const path = svgEl('path', 'iaa-relation-arc', {
+            d,
+            stroke: color,
+            'marker-end': `url(#${this.arrowMarkers.markerFor(color)})`,
+        });
+        container.appendChild(path);
+
+        // With no backend-supplied label, fall back to the parenthesised layer name rather than the
+        // generic "ArgN" role label carried on the second argument. The label element is always
+        // created (when there is text); whether it shows at rest is a CSS concern driven by the
+        // overlay's labels-visible mode, and on hover it is revealed via the active state.
+        const label =
+            relation.label || (relation.layer?.name ? `(${relation.layer.name})` : undefined);
+        const active: SVGElement[] = [path];
+        if (label) {
+            // Place the label on the curve's own apex — the point at t = 0.5, which is
+            // 0.25*P0 + 0.5*C + 0.25*P2. We deliberately add NO per-index lift: the apex already
+            // rises with the bow, and a separate lift detached the label from its arc (it grew at the
+            // full bow step while the apex rises only ~half of it). Stacked arcs separate their labels
+            // via the apex itself — vertically by the bow and horizontally when the endpoints differ.
+            const mx = 0.25 * s.x + 0.5 * c.x + 0.25 * t.x;
+            const my = 0.25 * s.y + 0.5 * c.y + 0.25 * t.y;
+            const text = svgEl('text', 'iaa-relation-label', { x: mx, y: my, fill: color });
+            text.textContent = label;
+            container.appendChild(text);
+            active.push(text);
+        }
+
+        // Invisible wide hit path on top of the thin arc so it is easy to hover; it drives the
+        // active state (which also reveals the label when labels are hover-only) and the enter/leave
+        // annotation events for the popover.
+        const hit = svgEl('path', 'iaa-relation-hit', { d });
+        this.attachRelationHover(hit, active, relation);
+        container.appendChild(hit);
+    }
+
+    /**
+     * Collapse a dense bucket into a single representative arc topped by a `×N` badge, hiding the
+     * individual fanned arcs until hover (mirrors drawCollapsedFan for stubs). Hovering the
+     * representative arc reveals the full fan; each revealed arc is then independently hoverable and
+     * clickable. The representative's wide hit path overlaps the median fanned arc's hit path, so the
+     * pointer stays within the group while travelling between them and the fan does not flicker.
+     */
+    private drawCollapsedArcBucket(arcs: Arc[]): void {
+        const n = arcs.length;
+        const color = arcs[0].relation.color || DEFAULT_COLOR;
+        const g = svgEl('g', 'iaa-relation-arc-bundle');
+
+        // Hidden expansion: the individual arcs, fanned, revealed on hover. The rects are already
+        // measured, so this introduces no recompute.
+        const expanded = svgEl('g', 'iaa-relation-bundle-expanded');
+        expanded.style.display = 'none';
+        arcs.forEach((arc, i) => this.drawFullArc(arc, i, expanded));
+
+        // Collapsed: a single representative arc at the median bow, with a count badge at its apex.
+        const collapsed = svgEl('g', 'iaa-relation-bundle-collapsed');
+        const mid = (n - 1) / 2;
+        const { s, t, c } = this.arcStackGeometry(arcs[0], mid);
+        const d = `M ${s.x} ${s.y} Q ${c.x} ${c.y} ${t.x} ${t.y}`;
+        const path = svgEl('path', 'iaa-relation-arc', {
+            d,
+            stroke: color,
+            'marker-end': `url(#${this.arrowMarkers.markerFor(color)})`,
+        });
+        const mx = 0.25 * s.x + 0.5 * c.x + 0.25 * t.x;
+        const my = 0.25 * s.y + 0.5 * c.y + 0.25 * t.y;
+        const badge = svgEl('text', 'iaa-relation-fan-badge', { x: mx, y: my, fill: color });
+        badge.textContent = `×${n}`;
+        const title = svgEl('title');
+        title.textContent = arcs
+            .map((a) => a.relation.label || a.relation.layer?.name || '')
+            .filter(Boolean)
+            .join('\n');
+        const hit = svgEl('path', 'iaa-relation-hit', { d });
+        this.blockEditorGestures(hit);
+        collapsed.appendChild(path);
+        collapsed.appendChild(hit);
+        collapsed.appendChild(badge);
+        collapsed.appendChild(title);
+
+        g.appendChild(expanded);
+        g.appendChild(collapsed);
+        this.wireExpandOnHover(g, expanded, collapsed);
+        this.overlay.appendChild(g);
+    }
+
+    /** Reveal the fanned `expanded` group on hover, swapping it for the `collapsed` representative. */
+    private wireExpandOnHover(g: SVGGElement, expanded: SVGElement, collapsed: SVGElement): void {
+        g.addEventListener('mouseenter', () => {
+            expanded.style.display = '';
+            collapsed.style.display = 'none';
+        });
+        g.addEventListener('mouseleave', () => {
+            expanded.style.display = 'none';
+            collapsed.style.display = '';
+        });
+    }
+
+    // --- stubs & fan-out --------------------------------------------------------------------
+
+    private queueStub(groups: Map<string, Stub[]>, stub: Stub): void {
+        // Group per in-band span and per direction: a span's up-stubs and down-stubs fan out
+        // independently.
+        const key = `${stub.near.vid}|${stub.goesUp ? 'up' : 'down'}`;
+        const list = groups.get(key) || [];
+        list.push(stub);
+        groups.set(key, list);
+    }
+
+    private drawStubGroup(stubs: Stub[]): void {
+        // TODO: cross-span stub collision is not handled. We only fan a single span's stubs here;
+        // neighbouring spans' fans can still overlap. Global collision handling is deferred.
+        const near = stubs[0].near;
+        const goesUp = stubs[0].goesUp;
+
+        // Leave from the label tag in inline-label mode (consistent with full arcs — the label is
+        // unique per overlapping annotation), at its top edge for an up-stub and its bottom edge for a
+        // down-stub. Otherwise leave from the in-band fragment closest to the travel direction: the
+        // topmost fragment's top edge going up, the bottommost's bottom edge going down.
+        const labelRect = this.labelRectFor(near.vid);
+        let anchorClient: { x: number; y: number };
+        if (labelRect) {
+            anchorClient = {
+                x: labelRect.left + labelRect.width / 2,
+                y: goesUp ? labelRect.top : labelRect.bottom,
+            };
+        } else {
+            if (!near.rects.length) return;
+            const fragment = goesUp
+                ? near.rects.reduce((a, b) => (b.top < a.top ? b : a))
+                : near.rects.reduce((a, b) => (b.bottom > a.bottom ? b : a));
+            anchorClient = {
+                x: fragment.left + fragment.width / 2,
+                y: goesUp ? fragment.top : fragment.bottom,
+            };
+        }
+        const anchor = this.toLocal(anchorClient.x, anchorClient.y);
+
+        if (stubs.length > FAN_COLLAPSE_THRESHOLD) {
+            this.drawCollapsedFan(anchor, goesUp, stubs);
+            return;
+        }
+
+        const n = stubs.length;
+        stubs.forEach((stub, i) => {
+            this.overlay.appendChild(this.fanStub(anchor, goesUp, stub, i, n));
+        });
+    }
+
+    // Build one fanned stub: an angle symmetric around vertical, its tip, and the stub group with
+    // its tip attached. The lean is purely cosmetic — direction accuracy to an off-screen point is
+    // explicitly out of scope. The `n === 1` guard keeps the single-stub case (and any
+    // future lowering of FAN_COLLAPSE_THRESHOLD) from dividing by zero.
+    private fanStub(
+        anchor: { x: number; y: number },
+        goesUp: boolean,
+        stub: Stub,
+        i: number,
+        n: number
+    ): SVGGElement {
+        const angle = fanAngle(i, n, FAN_SPREAD_RAD);
+        const tip = {
+            x: anchor.x + STUB_LENGTH_PX * Math.sin(angle),
+            y: anchor.y + (goesUp ? -1 : 1) * STUB_LENGTH_PX * Math.cos(angle),
+        };
+        const g = this.makeStub(anchor, tip, stub, goesUp);
+        this.attachTip(g, tip, stub);
+        return g;
+    }
+
+    private drawCollapsedFan(
+        anchor: { x: number; y: number },
+        goesUp: boolean,
+        stubs: Stub[]
+    ): void {
+        const color = stubs[0].color;
+        const g = svgEl('g', 'iaa-relation-fan');
+
+        // Hidden expansion: the individual stubs, fanned, revealed on hover. This is a
+        // purely local visual toggle and introduces no recompute (the rects are already measured).
+        const expanded = svgEl('g', 'iaa-relation-fan-expanded');
+        expanded.style.display = 'none';
+        const n = stubs.length;
+        stubs.forEach((stub, i) => {
+            expanded.appendChild(this.fanStub(anchor, goesUp, stub, i, n));
+        });
+
+        // Collapsed badge: a single straight stub topped by a count.
+        const collapsed = svgEl('g', 'iaa-relation-fan-collapsed');
+        const tipY = anchor.y + (goesUp ? -STUB_LENGTH_PX : STUB_LENGTH_PX);
+        const line = svgEl('path', 'iaa-relation-stub', {
+            d: `M ${anchor.x} ${anchor.y} L ${anchor.x} ${tipY}`,
+            stroke: color,
+        });
+        const badge = svgEl('text', 'iaa-relation-fan-badge', {
+            x: anchor.x,
+            y: tipY + (goesUp ? -2 : 9),
+            fill: color,
+        });
+        badge.textContent = `${goesUp ? '▴' : '▾'}${stubs.length}`;
+        const title = svgEl('title');
+        title.textContent = stubs
+            .map((s) => s.far.label)
+            .filter(Boolean)
+            .join('\n');
+        collapsed.appendChild(line);
+        collapsed.appendChild(badge);
+        collapsed.appendChild(title);
+
+        // A transparent backdrop keeps the hover continuous across the whole fan region so the
+        // pointer can travel from the badge to any expanded tip without collapsing.
+        const half = STUB_LENGTH_PX;
+        const hit = svgEl('rect', undefined, {
+            x: anchor.x - half,
+            y: goesUp ? anchor.y - half - 6 : anchor.y,
+            width: half * 2,
+            height: half + 6,
+            fill: 'transparent',
+        });
+        hit.style.pointerEvents = 'auto';
+        this.blockEditorGestures(hit);
+
+        g.appendChild(hit);
+        g.appendChild(expanded);
+        g.appendChild(collapsed);
+        this.wireExpandOnHover(g, expanded, collapsed);
+        this.overlay.appendChild(g);
+    }
+
+    private makeStub(
+        anchor: { x: number; y: number },
+        tip: { x: number; y: number },
+        stub: Stub,
+        goesUp: boolean
+    ): SVGGElement {
+        const d = `M ${anchor.x} ${anchor.y} L ${tip.x} ${tip.y}`;
+        const g = svgEl('g');
+        const path = svgEl('path', 'iaa-relation-stub', {
+            d,
+            stroke: stub.color,
+            'marker-end': `url(#${this.arrowMarkers.markerFor(stub.color)})`,
+        });
+        g.appendChild(path);
+
+        // Wide invisible hit line so the thin stub is easy to hover. mouseenter/mouseleave on the
+        // group also covers the tip target, so the whole stub reacts as one.
+        const hit = svgEl('path', 'iaa-relation-hit', { d });
+        g.appendChild(hit);
+
+        this.attachRelationHover(g, [g], stub.relation);
+        return g;
+    }
+
+    /**
+     * Keep an interactive overlay target's mouse gestures from reaching the editor root, whose
+     * mouseup handler would otherwise read a (stale/empty) selection and try to create a span — the
+     * overlay sits after all text, so the resolved offset lands past the document end. preventDefault
+     * on mousedown also stops a text selection from starting under the target; click still fires.
+     */
+    private blockEditorGestures(el: SVGElement): void {
+        el.addEventListener('mousedown', (e) => {
+            e.stopPropagation();
+            e.preventDefault();
+        });
+        el.addEventListener('mouseup', (e) => e.stopPropagation());
+    }
+
+    /**
+     * Make an arc/stub react to the mouse: toggle the active state on its visible elements and emit
+     * the bubbling enter/leave annotation events the detail popover listens for. Uses
+     * mouseenter/mouseleave (no per-child refiring) so a multi-element stub reacts as one unit, and
+     * dispatches from the hover target so the event bubbles through the overlay to the editor root.
+     */
+    private attachRelationHover(
+        target: SVGElement,
+        active: SVGElement[],
+        relation: Relation
+    ): void {
+        // The selected relation stays in the active look permanently (independent of hover).
+        if (this.focusedVids.has(relation.vid)) {
+            active.forEach((el) => el.classList.add(CLASS_SELECTED));
+        }
+
+        target.addEventListener('mouseenter', (e) => {
+            active.forEach((el) => el.classList.add(CLASS_ACTIVE));
+            target.dispatchEvent(new AnnotationOverEvent(relation, e));
+        });
+        target.addEventListener('mouseleave', (e) => {
+            active.forEach((el) => el.classList.remove(CLASS_ACTIVE));
+            target.dispatchEvent(new AnnotationOutEvent(relation, e));
+        });
+
+        // A click selects the relation. blockEditorGestures keeps the mousedown/mouseup/click from
+        // reaching the editor root: in normal mode that would open the selector / try to create a
+        // span; in keyboard mode it would move the (contentEditable) caret. stopPropagation on the
+        // click additionally keeps it from the keyboard mode's caret-placement click handler.
+        this.blockEditorGestures(target);
+        target.addEventListener('click', (e) => {
+            e.stopPropagation();
+            this.ajax.selectAnnotation(relation.vid);
+        });
+    }
+
+    /** Add a clickable, hoverable hit target at a stub tip that jumps to the far endpoint. */
+    private attachTip(g: SVGGElement, tip: { x: number; y: number }, stub: Stub): void {
+        const hit = svgEl('circle', 'iaa-relation-stub-tip', {
+            cx: tip.x,
+            cy: tip.y,
+            r: 8,
+            fill: 'transparent',
+        });
+        hit.style.pointerEvents = 'auto';
+        hit.style.cursor = 'pointer';
+        this.blockEditorGestures(hit);
+        hit.addEventListener('click', (e) => {
+            e.stopPropagation();
+            this.ajax.selectAnnotation(stub.far.vid, { scrollTo: true });
+        });
+        const title = svgEl('title');
+        title.textContent = stub.far.label || String(stub.far.vid);
+        hit.appendChild(title);
+        g.appendChild(hit);
+    }
+
+    private coupleEndpoints(vid: VID): void {
+        this.resolveHighlightsCached(vid).forEach((e) => {
+            e.classList.add(CLASS_RELATED);
+            this.coupledElements.add(e);
+        });
+    }
+}
+
+/** Whether two points are within ARC_CLUSTER_TOL_PX of each other. */
+function near(a: { x: number; y: number }, b: { x: number; y: number }): boolean {
+    return Math.hypot(a.x - b.x, a.y - b.y) <= ARC_CLUSTER_TOL_PX;
+}
+
+/**
+ * Stable stacking order within a cluster: the arc to a higher target sits below the arc to a lower one
+ * (target y, then target x), with source y and finally VID as deterministic tie-breakers for arcs
+ * whose anchors coincide.
+ */
+function arcStackOrder(a: Arc, b: Arc): number {
+    const aVid = String(a.relation.vid);
+    const bVid = String(b.relation.vid);
+    return (
+        a.tAnchor.y - b.tAnchor.y ||
+        a.tAnchor.x - b.tAnchor.x ||
+        a.sAnchor.y - b.sAnchor.y ||
+        (aVid < bVid ? -1 : aVid > bVid ? 1 : 0)
+    );
+}
+
+/**
+ * The endpoint shared by every arc in a cluster (the point they fan out from). Tested against the
+ * representative's two anchors; the one near an endpoint of *every* arc is the hub. Falls back to the
+ * representative's source for a degenerate chain cluster (single-link clustering can in principle link
+ * A–B and B–C with no common point), where no per-side split is meaningful anyway.
+ */
+function clusterHub(arcs: Arc[]): { x: number; y: number } {
+    for (const candidate of [arcs[0].sAnchor, arcs[0].tAnchor]) {
+        if (arcs.every((a) => near(a.sAnchor, candidate) || near(a.tAnchor, candidate))) {
+            return candidate;
+        }
+    }
+    return arcs[0].sAnchor;
+}
+
+/** Whether two arcs share at least one endpoint (within tolerance), in any orientation. */
+function sharesEndpoint(a: Arc, b: Arc): boolean {
+    return (
+        near(a.sAnchor, b.sAnchor) ||
+        near(a.tAnchor, b.tAnchor) ||
+        near(a.sAnchor, b.tAnchor) ||
+        near(a.tAnchor, b.sAnchor)
+    );
+}
+
+/** Whether every arc in a cluster coincides with the first at *both* ends (a redundant stack). */
+function isTightCluster(arcs: Arc[]): boolean {
+    const rep = arcs[0];
+    return arcs.every(
+        (a) =>
+            (near(a.sAnchor, rep.sAnchor) && near(a.tAnchor, rep.tAnchor)) ||
+            (near(a.sAnchor, rep.tAnchor) && near(a.tAnchor, rep.sAnchor))
+    );
+}
+
+/**
+ * Group arcs that share an endpoint into clusters that will be fanned apart by bow, so arcs meeting
+ * at a common point (relations from one source span, into one target span, multiple relations
+ * between the same two spans, or A→B and A→C with B,C coincident) each get a distinct, individually
+ * hoverable curve instead of stacking invisibly. Matching is unordered and pair-agnostic.
+ *
+ * Greedy single-link clustering against each cluster's representative (its first arc). We match on a
+ * *shared* endpoint rather than requiring both endpoints near, because label-tag anchoring spreads
+ * coincident targets onto their distinct label boxes (so A and B on one word land ~25px apart) — the
+ * arcs would no longer be "near at both ends" yet still collide at the shared source and need
+ * separating. Whether such a loose cluster may also be *collapsed* is decided separately
+ * (isTightCluster). A fixed grid is unusable here: it splits points that straddle a cell boundary no
+ * matter how close. n is tiny (arcs with both endpoints in the band), so the scan cost is moot.
+ */
+function clusterArcs(arcs: Arc[]): Arc[][] {
+    const clusters: Arc[][] = [];
+    for (const arc of arcs) {
+        const hit = clusters.find((c) => sharesEndpoint(arc, c[0]));
+        if (hit) hit.push(arc);
+        else clusters.push([arc]);
+    }
+    return clusters;
+}
+
+/**
+ * Collapse the client rects of an annotation's highlight elements into one rect per visual line.
+ *
+ * A highlight that wraps across lines reports several client rects (one per line fragment); several
+ * adjacent highlight elements on the same line report several rects too. We union rects that share a
+ * line so each returned rect spans exactly one line's highlighted run — giving a horizontal centre
+ * that lies on actual ink rather than in the gap a full bounding box would straddle.
+ *
+ * Line membership is decided by comparing a fragment's vertical *centre* against a stable per-line
+ * reference centre (the line's first fragment, by top), with a tolerance of half the shorter box.
+ * We deliberately do NOT test whether the centre falls inside the accumulated union's band: the union
+ * grows downward as fragments merge, so one tall fragment (an inline image, a larger-font child) whose
+ * box overflows into the next line would keep swallowing the lines below it, merging two visual lines
+ * into a single rect whose horizontal centre lands in the empty gap between them.
+ */
+export function collectFragmentRects(highlights: NodeListOf<Element>): DOMRect[] {
+    const rects: DOMRect[] = [];
+    highlights.forEach((h) => {
+        for (const r of h.getClientRects()) {
+            if (r.width > 0 || r.height > 0) rects.push(r);
+        }
+    });
+
+    const lines: DOMRect[] = [];
+    const refMids: number[] = [];
+    const refHeights: number[] = [];
+    for (const r of rects.sort((a, b) => a.top - b.top)) {
+        const mid = r.top + r.height / 2;
+        const i = lines.length - 1;
+        if (i >= 0 && Math.abs(mid - refMids[i]) <= Math.min(refHeights[i], r.height) / 2) {
+            lines[i] = unionRect(lines[i], r);
+        } else {
+            lines.push(r);
+            refMids.push(mid);
+            refHeights.push(r.height);
+        }
+    }
+    return lines;
+}
+
+function unionRect(a: DOMRect, b: DOMRect): DOMRect {
+    const left = Math.min(a.left, b.left);
+    const top = Math.min(a.top, b.top);
+    const right = Math.max(a.right, b.right);
+    const bottom = Math.max(a.bottom, b.bottom);
+    return new DOMRect(left, top, right - left, bottom - top);
+}
+
+/** The pair of fragments (one per side) whose centres are closest — the ends an arc should join. */
+function nearestFragmentPair(
+    source: DOMRect[],
+    target: DOMRect[]
+): { source: DOMRect; target: DOMRect } {
+    let best = { source: source[0], target: target[0] };
+    let bestDistSq = Infinity;
+    for (const s of source) {
+        const scx = s.left + s.width / 2;
+        const scy = s.top + s.height / 2;
+        for (const t of target) {
+            const dx = scx - (t.left + t.width / 2);
+            const dy = scy - (t.top + t.height / 2);
+            const distSq = dx * dx + dy * dy;
+            if (distSq < bestDistSq) {
+                bestDistSq = distSq;
+                best = { source: s, target: t };
+            }
+        }
+    }
+    return best;
+}
+
+/**
+ * Perpendicular control point for a quadratic Bézier bowing `distance` px off the chord midpoint
+ * (adapted from pdf-editor2's findBezierControlPoint).
+ */
+function bezierControlPoint(
+    x1: number,
+    y1: number,
+    x2: number,
+    y2: number,
+    distance: number
+): { x: number; y: number } {
+    const cx = (x1 + x2) / 2;
+    const cy = (y1 + y2) / 2;
+    const dx = x2 - x1;
+    const dy = y2 - y1;
+    const len = Math.hypot(dx, dy);
+    if (len === 0) return { x: cx, y: cy - distance };
+    // Unit normal (perpendicular). Bias upward (negative y) so arcs bow over the text.
+    let nx = -dy / len;
+    let ny = dx / len;
+    if (ny > 0) {
+        nx = -nx;
+        ny = -ny;
+    }
+    return { x: cx + nx * Math.abs(distance), y: cy + ny * Math.abs(distance) };
+}

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SvgUtilities.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/SvgUtilities.ts
@@ -16,25 +16,19 @@
  * limitations under the License.
  */
 
+export const SVG_NS = 'http://www.w3.org/2000/svg';
+
 /**
- * Line-spacing presets. The actual line-heights live in SCSS next to the
- * `.i7n-wrapper` rule (`iaa-line-spacing-low|mid|high|xhigh`); `mid` is the default.
+ * Create an SVG element with an optional class and attributes, stringifying numeric values.
+ * Centralises the createElementNS + setAttribute + classList boilerplate.
  */
-export type LineSpacing = 'low' | 'mid' | 'high' | 'xhigh';
-export const LINE_SPACINGS: readonly LineSpacing[] = ['low', 'mid', 'high', 'xhigh'];
-
-export const defaultAnnotatorPreferences = {
-    showLabels: true,
-    showRelationLabels: true,
-    showAggregatedLabels: false,
-    showEmptyHighlights: false,
-    showDocumentStructure: false,
-    documentStructureWidth: 0.2,
-    showImages: true,
-    showTables: true,
-    protectElements: true,
-    keyboardCursorEnabled: false,
-    lineSpacing: 'mid' as LineSpacing,
-};
-
-export const annotatorState = $state({ ...defaultAnnotatorPreferences });
+export function svgEl<K extends keyof SVGElementTagNameMap>(
+    tag: K,
+    className?: string,
+    attrs: Record<string, string | number> = {}
+): SVGElementTagNameMap[K] {
+    const el = document.createElementNS(SVG_NS, tag) as SVGElementTagNameMap[K];
+    if (className) el.classList.add(className);
+    for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, String(v));
+    return el;
+}

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/Utilities.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/Utilities.ts
@@ -47,7 +47,6 @@ export function querySelectorAllInRange(range: Range, selector: string): Element
             : (range.commonAncestorContainer.parentElement as Node) ||
               range.commonAncestorContainer;
 
-    // console.log(`Searching in ${walkerRoot.textContent}`)
     const walker = document.createTreeWalker(walkerRoot, NodeFilter.SHOW_ELEMENT, {
         acceptNode: (node: Node) => {
             return range.intersectsNode(node) ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT;
@@ -308,6 +307,26 @@ export function highlights(target: Node | null): HTMLElement[] {
 }
 
 /**
+ * The highlight stack under the given node, innermost-first, with at most one element per VID.
+ * Highlights without a VID are skipped.
+ *
+ * @param target a DOM node.
+ * @returns the deduplicated highlight elements ordered innermost-first.
+ */
+export function distinctHighlightStack(target: Node | null): HTMLElement[] {
+    const stack: HTMLElement[] = [];
+    const seen = new Set<string>();
+    for (const h of highlights(target)) {
+        const vid = h.getAttribute('data-iaa-id');
+        if (vid && !seen.has(vid)) {
+            seen.add(vid);
+            stack.push(h);
+        }
+    }
+    return stack;
+}
+
+/**
  * Calculates the rectangle of the inline label for the given highlight.
  *
  * @param highlight a highlight element.
@@ -387,6 +406,19 @@ export function isPointInRect(point: { x: number; y: number }, rect: DOMRect): b
         point.y >= rect.top &&
         point.y <= rect.bottom
     );
+}
+
+/**
+ * Angle of the `i`-th item in a fan of `n` items, spread symmetrically around 0 over `spread`
+ * radians. A single item (`n === 1`) sits at 0, which also avoids dividing by `n - 1 === 0`.
+ *
+ * @param i zero-based index of the item.
+ * @param n total number of items in the fan.
+ * @param spread total angular spread in radians.
+ * @returns the item's angle in radians, in `[-spread/2, spread/2]`.
+ */
+export function fanAngle(i: number, n: number, spread: number): number {
+    return n === 1 ? 0 : -spread / 2 + (spread * i) / (n - 1);
 }
 
 /**
@@ -603,9 +635,6 @@ export function expandSelectionOverProtectedElements(
     if (focusNode == null) {
         focusNode = sel.focusNode;
     }
-
-    // console.log(`Anchor node ${sel.anchorNode} ${sel.anchorOffset} -> ${anchorNode} ${anchorOffset}`)
-    // console.log(`Focus node ${sel.focusNode} ${sel.focusOffset} -> ${focusNode} ${focusOffset}`)
 
     return { anchorNode, anchorOffset, focusNode, focusOffset };
 }

--- a/inception/inception-js-api/src/main/ts/src/util/ViewportTracker.ts
+++ b/inception/inception-js-api/src/main/ts/src/util/ViewportTracker.ts
@@ -205,6 +205,12 @@ export class ViewportTracker {
         this.redrawTimeoutId = undefined;
     }
 
+    /**
+     * The tracked visible offset range. NOTE: this is a *superset* of the strictly-visible range,
+     * not a tight bound — it is only recomputed when elements are added to the visible set, never
+     * when they leave (see handleIntersectRange). Consumers must treat it as "at least this much is
+     * visible" and never assume content outside it is absent.
+     */
     public get currentRange(): [number, number] {
         return this._currentRange;
     }
@@ -238,8 +244,6 @@ export class ViewportTracker {
             style.display === 'table-row' ||
             style.display === 'list-item'
         );
-
-        // return !style.display.startsWith('inline') && !style.display.includes('math')
     }
 
     private initializeElementTracking(element: Element): void {
@@ -253,10 +257,6 @@ export class ViewportTracker {
             this.shouldTrack(e)
         );
         console.debug(`Found ${trackingCandidates.length} tracking candidates`);
-
-        // const displayStyles = new Set<string>()
-        // trackingCandidates.map(e => getComputedStyle(e).display).forEach(e => displayStyles.add(e))
-        // console.debug('Display styles found: ', displayStyles)
 
         if (trackingCandidates.length > 0) {
             trackingCandidates = trackingCandidates.map((e) => {
@@ -316,7 +316,25 @@ export class ViewportTracker {
             // Ignore any entries while paused
             return;
         }
-        // Avoid triggering the callback if no new elements have become visible
+
+        // We only recompute the range / fire the callback when elements have been *added* to the
+        // visible set, never when they merely leave it. This asymmetry is intentional and safe:
+        //
+        //  - An addition can reveal content that lies outside the current range, so consumers
+        //    (e.g. the annotation fetch window) must be told to extend their coverage.
+        //  - A removal can only ever *shrink* the true visible range. Skipping the recompute then
+        //    means `_currentRange` stays wider than strictly necessary, i.e. it becomes a SUPERSET
+        //    of what is actually on screen. That is harmless: every consumer treats the range as
+        //    "cover at least this much", so a superset over-covers but never drops content.
+        //
+        // Removals are still applied to `_visibleElements` below on every batch, so the stale-wide
+        // bounds are pruned lazily on the next addition-bearing batch (which recomputes a tight
+        // range over the then-current set). The net effect is fewer redundant callbacks/loads while
+        // the visible range only contracts (e.g. scrolling to the document end or fast flings),
+        // with the range tightening again as soon as new content scrolls in.
+        //
+        // Invariant for consumers: `currentRange` is a superset of the truly-visible range; do not
+        // rely on it being a tight bound.
         let visibleElementsAdded = 0;
 
         entries.forEach((entry) => {


### PR DESCRIPTION
**What's in the PR**
- Add relation rendering to the Apache Annotator HTML editor: relations with both endpoints inside the effect-range band are drawn as full arcs, band-crossing relations as directional up/down stubs whose clickable tip jumps to the far endpoint, and pass-through relations are not drawn (RelationVisualizer)
- Add relation-creation by dragging from a span: a drag state machine (IDLE -> ARMED -> DRAGGING -> COMMIT/CANCEL) with window-level capture listeners so a release outside the iframe still resolves and does not leak into span creation (RelationDragController)
- Add hover-surfaced relation-creation "grips": a small drag affordance anchored above a hovered span's start that proxies the span without competing with the native text-selection gesture (RelationGripLayer)
- Add a target-disambiguation popup ("relation-target" mode) so a relation drag ending on overlapping spans lets the user pick which span is the target; dismissing cancels the relation (ApacheAnnotatorSelector.pickRelationTarget)
- Add a pooled per-color SVG arrowhead marker registry plus an svgEl element-creation helper (ArrowMarkerPool)
- Add a relation-labels preference and toolbar toggle: labels shown at rest vs. on hover, applied as a pure CSS mode flip without re-rendering
- Add line-spacing presets (low/mid/high/xhigh) with toolbar S/M/L/X buttons, applied as a class on the editor root; cap the arc bow scale so xhigh stacking matches the high preset
- Re-band the relation overlay around the current viewport on manual scroll, coalesced to one redraw per frame
- Fix overlay sizing so it collapses to zero before measuring content extent, preventing scrolling past the text into a blank region with no arcs (#6108)
- Add showRelationLabels and lineSpacing to the editor user-preferences schema
- Document ViewportTracker's visible range as a superset (recomputed only when elements are added), and remove dead display-style probing code
- Add distinctHighlightStack and fanAngle helpers (Utilities)
- Remove the invalid bugs URL from inception-assistant-ui package.json

**How to test manually**
* Try using relations in the Apache Annotator HTML editor

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [x] PR updates documentation
