### PR TITLE
#6112 - Allow sorting by tokens and sentences in open document dialog

### DIFF
--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/open/AnnotationDocumentTable.html
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/open/AnnotationDocumentTable.html
@@ -24,8 +24,8 @@
     .document-table tr td, .document-table tr th { text-align: center; }
     .document-table tr th { white-space: nowrap; }
     .document-table tr td:nth-child(2), .document-table tr th:nth-child(2) { text-align: left; width: 100%;}
-    .document-table tr td:nth-child(3), .document-table tr th:nth-child(3) { white-space: nowrap;}
-    .document-table tr td:nth-child(4), .document-table tr th:nth-child(4) { white-space: nowrap;}
+    .document-table tr td:nth-child(3), .document-table tr th:nth-child(3) { white-space: nowrap; text-align: right;}
+    .document-table tr td:nth-child(4), .document-table tr th:nth-child(4) { white-space: nowrap; text-align: right;}
     .document-table tr td:nth-child(5), .document-table tr th:nth-child(5) { white-space: nowrap;}
     .document-table tr td:nth-child(6), .document-table tr th:nth-child(6) { white-space: nowrap;}
     .document-table col.s, .document-table tr.s , .document-table td.s { background-color: var(--primary); }

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/open/AnnotationDocumentTable.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/open/AnnotationDocumentTable.java
@@ -22,7 +22,9 @@ import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState.IN
 import static de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState.NEW;
 import static de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.open.AnnotationDocumentTableSortKeys.CREATED;
 import static de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.open.AnnotationDocumentTableSortKeys.NAME;
+import static de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.open.AnnotationDocumentTableSortKeys.SENTENCES;
 import static de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.open.AnnotationDocumentTableSortKeys.STATE;
+import static de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.open.AnnotationDocumentTableSortKeys.TOKENS;
 import static de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.open.AnnotationDocumentTableSortKeys.UPDATED;
 import static de.tudarmstadt.ukp.inception.support.lambda.HtmlElementEvents.INPUT_EVENT;
 import static de.tudarmstadt.ukp.inception.support.lambda.HtmlElementEvents.KEYDOWN_EVENT;
@@ -87,9 +89,9 @@ public class AnnotationDocumentTable
                 item -> item.getState()));
         columns.add(new AnnotationDocumentOpenActionColumn(this, new ResourceModel("DocumentName"),
                 NAME));
-        columns.add(new LambdaColumn<>(new ResourceModel("DocumentTokens"),
+        columns.add(new LambdaColumn<>(new ResourceModel("DocumentTokens"), TOKENS,
                 $ -> renderCount($.getDocument(), DocumentStatistics::tokenCount)));
-        columns.add(new LambdaColumn<>(new ResourceModel("DocumentSentences"),
+        columns.add(new LambdaColumn<>(new ResourceModel("DocumentSentences"), SENTENCES,
                 $ -> renderCount($.getDocument(), DocumentStatistics::sentenceCount)));
         columns.add(new LambdaColumn<>(new ResourceModel("DocumentCreated"), CREATED,
                 $ -> renderDate($.getDocument().getCreated())));
@@ -152,7 +154,7 @@ public class AnnotationDocumentTable
 
     private String renderCount(SourceDocument aDoc, ToLongFunction<DocumentStatistics> aAccessor)
     {
-        var stats = dataProvider.getPageStatistics().get(aDoc.getId());
+        var stats = dataProvider.getStatistics().get(aDoc.getId());
         if (stats == null) {
             return "-";
         }

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/open/AnnotationDocumentTableDataProvider.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/open/AnnotationDocumentTableDataProvider.java
@@ -18,6 +18,8 @@
 package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.open;
 
 import static de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.open.AnnotationDocumentTableSortKeys.NAME;
+import static de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.open.AnnotationDocumentTableSortKeys.SENTENCES;
+import static de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.open.AnnotationDocumentTableSortKeys.TOKENS;
 import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
@@ -30,6 +32,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.ToLongFunction;
 import java.util.stream.Stream;
 
 import org.apache.wicket.extensions.markup.html.repeater.data.table.filter.IFilterStateLocator;
@@ -52,7 +55,8 @@ public class AnnotationDocumentTableDataProvider
     private IModel<List<AnnotationDocument>> data;
     private SerializableFunction<Collection<SourceDocument>, //
             Map<Long, DocumentStatistics>> statisticsLoader;
-    private transient Map<Long, DocumentStatistics> pageStatistics;
+    private Map<Long, DocumentStatistics> statistics;
+    private boolean statisticsComplete;
 
     public AnnotationDocumentTableDataProvider(IModel<List<AnnotationDocument>> aDocuments)
     {
@@ -72,37 +76,64 @@ public class AnnotationDocumentTableDataProvider
     }
 
     /**
-     * Statistics for the current page as populated by the most recent {@link #iterator} call.
-     * Returns an empty map if no loader has been wired or before the table has been rendered.
+     * Statistics available to the table for rendering and sorting. Depending on the active sort,
+     * this holds either the statistics for the current page or - once token/sentence sorting has
+     * been requested - the cached statistics for the whole document set. Returns an empty map if no
+     * loader has been wired or before the table has been rendered.
      */
-    public Map<Long, DocumentStatistics> getPageStatistics()
+    public Map<Long, DocumentStatistics> getStatistics()
     {
-        return pageStatistics != null ? pageStatistics : emptyMap();
+        return statistics != null ? statistics : emptyMap();
+    }
+
+    /**
+     * Drops the cached statistics. Must be called when the underlying document list or the data
+     * owner changes, since the statistics are specific to that combination.
+     */
+    public void clearStatistics()
+    {
+        statistics = null;
+        statisticsComplete = false;
     }
 
     @Override
     public Iterator<? extends AnnotationDocument> iterator(long aFirst, long aCount)
     {
         var filteredData = filter(data.getObject());
+
+        var sortProperty = getSort().getProperty();
+        var sortByStatistics = sortProperty == TOKENS || sortProperty == SENTENCES;
+
+        // Sorting by token/sentence count needs statistics for the whole document set, not just
+        // the currently visible page. Load them for the full (unfiltered) set once and cache them
+        // so that toggling the sort direction or switching back to another sort column does not
+        // trigger another lookup. The cache is dropped via clearStatistics() when the document
+        // list or the data owner changes.
+        if (sortByStatistics && statisticsLoader != null && !statisticsComplete) {
+            statistics = loadStatistics(data.getObject());
+            statisticsComplete = true;
+        }
+
         filteredData.sort(this::comparator);
+
         var page = filteredData //
                 .subList((int) aFirst, (int) (aFirst + aCount));
 
-        if (statisticsLoader != null) {
-            var srcDocs = page.stream() //
-                    .map(AnnotationDocument::getDocument) //
-                    .collect(toList());
-            pageStatistics = statisticsLoader.apply(srcDocs);
+        // For non-statistics sorts we only need the counts for the visible page - unless the full
+        // set has already been cached, in which case we just reuse it.
+        if (statisticsLoader != null && !statisticsComplete) {
+            statistics = loadStatistics(page);
         }
 
         return page.iterator();
     }
 
-    @Override
-    public void detach()
+    private Map<Long, DocumentStatistics> loadStatistics(List<AnnotationDocument> aDocuments)
     {
-        super.detach();
-        pageStatistics = null;
+        var srcDocs = aDocuments.stream() //
+                .map(AnnotationDocument::getDocument) //
+                .collect(toList());
+        return statisticsLoader.apply(srcDocs);
     }
 
     private int comparator(AnnotationDocument o1, AnnotationDocument o2)
@@ -113,6 +144,10 @@ public class AnnotationDocumentTableDataProvider
             return dir * (o1.getName().compareTo(o2.getName()));
         case STATE:
             return dir * (o1.getState().getName().compareTo(o2.getState().getName()));
+        case TOKENS:
+            return dir * compareStatistics(o1, o2, DocumentStatistics::tokenCount);
+        case SENTENCES:
+            return dir * compareStatistics(o1, o2, DocumentStatistics::sentenceCount);
         case CREATED:
             return dir * compare(o1.getDocument().getCreated(), o2.getDocument().getCreated());
         case UPDATED:
@@ -120,6 +155,17 @@ public class AnnotationDocumentTableDataProvider
         default:
             return 0;
         }
+    }
+
+    private int compareStatistics(AnnotationDocument o1, AnnotationDocument o2,
+            ToLongFunction<DocumentStatistics> aAccessor)
+    {
+        var stats = getStatistics();
+        var s1 = stats.get(o1.getDocument().getId());
+        var s2 = stats.get(o2.getDocument().getId());
+        var v1 = s1 != null ? aAccessor.applyAsLong(s1) : null;
+        var v2 = s2 != null ? aAccessor.applyAsLong(s2) : null;
+        return compare(v1, v2);
     }
 
     public List<AnnotationDocument> filter(List<AnnotationDocument> aData)

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/open/AnnotationDocumentTableSortKeys.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/open/AnnotationDocumentTableSortKeys.java
@@ -19,5 +19,5 @@ package de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.open;
 
 public enum AnnotationDocumentTableSortKeys
 {
-    NAME, STATE, CREATED, UPDATED;
+    NAME, STATE, TOKENS, SENTENCES, CREATED, UPDATED;
 }

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/open/OpenDocumentDialogPanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/open/OpenDocumentDialogPanel.java
@@ -212,6 +212,10 @@ public class OpenDocumentDialogPanel
     {
         table.getDataProvider().getModel().setObject(listDocuments());
 
+        // Statistics are specific to the selected data owner and document list, so the cached
+        // values are no longer valid once a different user is picked.
+        table.getDataProvider().clearStatistics();
+
         aTarget.add(table);
     }
 

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/actionbar/opendocument/CurationDocumentTable.html
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/actionbar/opendocument/CurationDocumentTable.html
@@ -24,8 +24,8 @@
     .document-table tr td, .document-table tr th { text-align: center; }
     .document-table tr th { white-space: nowrap; }
     .document-table tr td:nth-child(2), .document-table tr th:nth-child(2) { text-align: left; width: 100%;}
-    .document-table tr td:nth-child(3), .document-table tr th:nth-child(3) { white-space: nowrap;}
-    .document-table tr td:nth-child(4), .document-table tr th:nth-child(4) { white-space: nowrap;}
+    .document-table tr td:nth-child(3), .document-table tr th:nth-child(3) { white-space: nowrap; text-align: right;}
+    .document-table tr td:nth-child(4), .document-table tr th:nth-child(4) { white-space: nowrap; text-align: right;}
     .document-table tr td:nth-child(5), .document-table tr th:nth-child(5) { white-space: nowrap;}
     .document-table tr td:nth-child(6), .document-table tr th:nth-child(6) { white-space: nowrap;}
     .document-table col.s, .document-table tr.s , .document-table td.s { background-color: var(--primary); }

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/actionbar/opendocument/CurationDocumentTable.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/actionbar/opendocument/CurationDocumentTable.java
@@ -26,7 +26,9 @@ import static de.tudarmstadt.ukp.inception.support.lambda.HtmlElementEvents.KEYD
 import static de.tudarmstadt.ukp.inception.support.lambda.KeyCodes.ENTER;
 import static de.tudarmstadt.ukp.inception.ui.curation.actionbar.opendocument.CurationDocumentTableSortKeys.CREATED;
 import static de.tudarmstadt.ukp.inception.ui.curation.actionbar.opendocument.CurationDocumentTableSortKeys.NAME;
+import static de.tudarmstadt.ukp.inception.ui.curation.actionbar.opendocument.CurationDocumentTableSortKeys.SENTENCES;
 import static de.tudarmstadt.ukp.inception.ui.curation.actionbar.opendocument.CurationDocumentTableSortKeys.STATE;
+import static de.tudarmstadt.ukp.inception.ui.curation.actionbar.opendocument.CurationDocumentTableSortKeys.TOKENS;
 import static de.tudarmstadt.ukp.inception.ui.curation.actionbar.opendocument.CurationDocumentTableSortKeys.UPDATED;
 import static java.time.Duration.ofMillis;
 import static org.apache.wicket.event.Broadcast.BUBBLE;
@@ -88,9 +90,9 @@ public class CurationDocumentTable
                 item -> item.getState()));
         columns.add(new CurationDocumentOpenActionColumn(this, new ResourceModel("DocumentName"),
                 NAME));
-        columns.add(new LambdaColumn<>(new ResourceModel("DocumentTokens"),
+        columns.add(new LambdaColumn<>(new ResourceModel("DocumentTokens"), TOKENS,
                 $ -> renderCount($, DocumentStatistics::tokenCount)));
-        columns.add(new LambdaColumn<>(new ResourceModel("DocumentSentences"),
+        columns.add(new LambdaColumn<>(new ResourceModel("DocumentSentences"), SENTENCES,
                 $ -> renderCount($, DocumentStatistics::sentenceCount)));
         columns.add(new LambdaColumn<>(new ResourceModel("DocumentCreated"), CREATED,
                 $ -> renderDate($.getCreated())));
@@ -163,7 +165,7 @@ public class CurationDocumentTable
 
     private String renderCount(SourceDocument aDoc, ToLongFunction<DocumentStatistics> aAccessor)
     {
-        var stats = dataProvider.getPageStatistics().get(aDoc.getId());
+        var stats = dataProvider.getStatistics().get(aDoc.getId());
         if (stats == null) {
             return "-";
         }

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/actionbar/opendocument/CurationDocumentTableDataProvider.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/actionbar/opendocument/CurationDocumentTableDataProvider.java
@@ -18,6 +18,8 @@
 package de.tudarmstadt.ukp.inception.ui.curation.actionbar.opendocument;
 
 import static de.tudarmstadt.ukp.inception.ui.curation.actionbar.opendocument.CurationDocumentTableSortKeys.NAME;
+import static de.tudarmstadt.ukp.inception.ui.curation.actionbar.opendocument.CurationDocumentTableSortKeys.SENTENCES;
+import static de.tudarmstadt.ukp.inception.ui.curation.actionbar.opendocument.CurationDocumentTableSortKeys.TOKENS;
 import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
@@ -30,6 +32,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.ToLongFunction;
 import java.util.stream.Stream;
 
 import org.apache.wicket.extensions.markup.html.repeater.data.table.filter.IFilterStateLocator;
@@ -51,7 +54,8 @@ public class CurationDocumentTableDataProvider
     private List<SourceDocument> data;
     private SerializableFunction<Collection<SourceDocument>, //
             Map<Long, DocumentStatistics>> statisticsLoader;
-    private transient Map<Long, DocumentStatistics> pageStatistics;
+    private Map<Long, DocumentStatistics> statistics;
+    private boolean statisticsComplete;
 
     public CurationDocumentTableDataProvider(IModel<List<SourceDocument>> aDocuments)
     {
@@ -70,31 +74,47 @@ public class CurationDocumentTableDataProvider
         statisticsLoader = aLoader;
     }
 
-    public Map<Long, DocumentStatistics> getPageStatistics()
+    /**
+     * Statistics available to the table for rendering and sorting. Depending on the active sort,
+     * this holds either the statistics for the current page or - once token/sentence sorting has
+     * been requested - the cached statistics for the whole document set. Returns an empty map if no
+     * loader has been wired or before the table has been rendered.
+     */
+    public Map<Long, DocumentStatistics> getStatistics()
     {
-        return pageStatistics != null ? pageStatistics : emptyMap();
+        return statistics != null ? statistics : emptyMap();
     }
 
     @Override
     public Iterator<? extends SourceDocument> iterator(long aFirst, long aCount)
     {
         var filteredData = filter(data);
+
+        var sortProperty = getSort().getProperty();
+        var sortByStatistics = sortProperty == TOKENS || sortProperty == SENTENCES;
+
+        // Sorting by token/sentence count needs statistics for the whole document set, not just
+        // the currently visible page. Load them for the full (unfiltered) set once and cache them
+        // so that toggling the sort direction or switching back to another sort column does not
+        // trigger another lookup. The document list is fixed for the lifetime of the dialog, so the
+        // cache never needs to be invalidated.
+        if (sortByStatistics && statisticsLoader != null && !statisticsComplete) {
+            statistics = statisticsLoader.apply(data);
+            statisticsComplete = true;
+        }
+
         filteredData.sort(this::comparator);
+
         var page = filteredData //
                 .subList((int) aFirst, (int) (aFirst + aCount));
 
-        if (statisticsLoader != null) {
-            pageStatistics = statisticsLoader.apply(page);
+        // For non-statistics sorts we only need the counts for the visible page - unless the full
+        // set has already been cached, in which case we just reuse it.
+        if (statisticsLoader != null && !statisticsComplete) {
+            statistics = statisticsLoader.apply(page);
         }
 
         return page.iterator();
-    }
-
-    @Override
-    public void detach()
-    {
-        super.detach();
-        pageStatistics = null;
     }
 
     private int comparator(SourceDocument o1, SourceDocument o2)
@@ -105,6 +125,10 @@ public class CurationDocumentTableDataProvider
             return dir * (o1.getName().compareTo(o2.getName()));
         case STATE:
             return dir * (o1.getState().getName().compareTo(o2.getState().getName()));
+        case TOKENS:
+            return dir * compareStatistics(o1, o2, DocumentStatistics::tokenCount);
+        case SENTENCES:
+            return dir * compareStatistics(o1, o2, DocumentStatistics::sentenceCount);
         case CREATED:
             return dir * compare(o1.getCreated(), o2.getCreated());
         case UPDATED:
@@ -112,6 +136,17 @@ public class CurationDocumentTableDataProvider
         default:
             return 0;
         }
+    }
+
+    private int compareStatistics(SourceDocument o1, SourceDocument o2,
+            ToLongFunction<DocumentStatistics> aAccessor)
+    {
+        var stats = getStatistics();
+        var s1 = stats.get(o1.getId());
+        var s2 = stats.get(o2.getId());
+        var v1 = s1 != null ? aAccessor.applyAsLong(s1) : null;
+        var v2 = s2 != null ? aAccessor.applyAsLong(s2) : null;
+        return compare(v1, v2);
     }
 
     private List<SourceDocument> filter(List<SourceDocument> aData)

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/actionbar/opendocument/CurationDocumentTableSortKeys.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/actionbar/opendocument/CurationDocumentTableSortKeys.java
@@ -19,5 +19,5 @@ package de.tudarmstadt.ukp.inception.ui.curation.actionbar.opendocument;
 
 public enum CurationDocumentTableSortKeys
 {
-    NAME, STATE, CREATED, UPDATED;
+    NAME, STATE, TOKENS, SENTENCES, CREATED, UPDATED;
 }


### PR DESCRIPTION
**What's in the PR**
- Add TOKENS and SENTENCES to AnnotationDocumentTableSortKeys enum
- Make Tokens and Sentences columns sortable by passing sort keys to LambdaColumn
- Right-align Tokens and Sentences columns in table styling
- Refactor statistics caching in AnnotationDocumentTableDataProvider to distinguish full-set and page-level loads
- Load full-set statistics when sorting by token/sentence count; load only visible page otherwise
- Cache loaded statistics persistently and reuse across sort/page operations
- Add clearStatistics() method to invalidate cache when document list or data owner changes
- Add compareStatistics() helper method for token/sentence count comparisons
- Call clearStatistics() when user selection changes in open-document dialog
- Same for curation dialog

**How to test manually**
* Try sorting by tokens/sentences

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
