### PR TITLE
#6121 - Introduce getters for script and stylesheet sources

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,20 +26,6 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - name: Free disk space
-      # Must run before "Harden Runner" since that disables sudo, which this needs.
-      # Only deletes local files (no network), so it is compatible with the egress block.
-      if: runner.os == 'Linux'
-      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
-      with:
-        tool-cache: true
-        android: true
-        dotnet: true
-        haskell: true
-        large-packages: true
-        docker-images: true
-        swap-storage: true
-
     - name: Harden Runner
       uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
       with:
@@ -125,7 +111,7 @@ jobs:
 
     - name: Build with Maven
       if: "!(matrix.os == 'ubuntu-latest' && github.event_name == 'push')"
-      run: mvn --show-version --batch-mode --errors --fail-at-end --no-transfer-progress clean verify -T 1C
+      run: mvn --show-version --batch-mode --errors --fail-at-end --no-transfer-progress clean verify -T 1C ${{ matrix.os == 'ubuntu-latest' && '-Pci-docker-cleanup' || '' }}
 
     - name: Build with Maven and publish artifacts
       if: matrix.os == 'ubuntu-latest' && github.event_name == 'push'
@@ -133,7 +119,7 @@ jobs:
         # `MAVEN_USERNAME` and `MAVEN_PASSWORD` are used in `~/.m2/settings.xml` created by `setup-java` action
         MAVEN_USERNAME: ${{ secrets.UKP_MAVEN_USER }}
         MAVEN_PASSWORD: ${{ secrets.UKP_MAVEN_TOKEN }}
-      run: mvn --show-version --batch-mode --errors --fail-at-end --no-transfer-progress -DdeployAtEnd=true clean deploy
+      run: mvn --show-version --batch-mode --errors --fail-at-end --no-transfer-progress -DdeployAtEnd=true clean deploy -Pci-docker-cleanup
 
     - name: Publish Test Report
       uses: mikepenz/action-junit-report@49b2ca06f62aa7ef83ae6769a2179271e160d8e4 # v6.3.1

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,6 +26,20 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+    - name: Free disk space
+      # Must run before "Harden Runner" since that disables sudo, which this needs.
+      # Only deletes local files (no network), so it is compatible with the egress block.
+      if: runner.os == 'Linux'
+      uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+      with:
+        tool-cache: true
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: true
+        docker-images: true
+        swap-storage: true
+
     - name: Harden Runner
       uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
       with:

--- a/inception/inception-app-webapp/pom.xml
+++ b/inception/inception-app-webapp/pom.xml
@@ -1297,6 +1297,56 @@
     </pluginManagement>
   </build>
   <profiles>
+    <!--
+      - On CI the Docker images pulled by Testcontainers across the whole reactor (the knowledge
+      - base triplestores, Solr, OpenSearch, Keycloak, Kafka and the ~11 database images exercised
+      - by this module's own tests) accumulate and can exhaust the runner disk while the WAR is
+      - being assembled. The web application is the reactor chokepoint: every Docker-using module it
+      - depends on (inception-kb, -external-search-solr, -external-search-opensearch, -security,
+      - -remote) has finished by the time this module builds, so nothing is using those images and
+      - it is a safe place to reclaim the space. We prune twice:
+      -   1. before this module's own database tests run - frees the images the other modules left
+      -      behind, giving the database tests headroom;
+      -   2. before the WAR is assembled - frees this module's database images, which are no longer
+      -      needed once its tests have finished.
+      - Disabled by default so developer machines are untouched; activated explicitly on CI via
+      - -Pci-docker-cleanup. Requires the 'docker' CLI on the PATH.
+    -->
+    <profile>
+      <id>ci-docker-cleanup</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>exec-maven-plugin</artifactId>
+            <configuration>
+              <executable>sh</executable>
+              <arguments>
+                <argument>-c</argument>
+                <!-- Log free space before/after; tolerate a non-zero exit so a cleanup hiccup never fails the build -->
+                <argument>echo '=== disk before docker prune ==='; df -h /; docker system prune --all --force || true; echo '=== disk after docker prune ==='; df -h /</argument>
+              </arguments>
+            </configuration>
+            <executions>
+              <execution>
+                <id>prune-docker-images-before-tests</id>
+                <phase>process-test-classes</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>prune-docker-images-before-packaging</id>
+                <phase>prepare-package</phase>
+                <goals>
+                  <goal>exec</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>m2e</id>
       <activation>

--- a/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/annotation/BratAnnotationEditor.java
+++ b/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/annotation/BratAnnotationEditor.java
@@ -25,6 +25,7 @@ import static java.util.Arrays.asList;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.List;
 
 import org.apache.uima.cas.CAS;
 import org.apache.wicket.Component;
@@ -117,9 +118,22 @@ public class BratAnnotationEditor
         // The factory is the JS call. Cf. the "globalName" in build.js and the factory method
         // defined in main.ts
         props.setEditorFactory("Brat.factory()");
-        props.setStylesheetSources(asList(referenceToUrl(servletContext, BratCssReference.get())));
-        props.setScriptSources(asList(referenceToUrl(servletContext, BratResourceReference.get())));
         return props;
+    }
+
+    @Override
+    protected List<String> getStylesheetSources()
+    {
+        // super.getStylesheetSources() intentionally not called here - this editor is not
+        // customizable
+        return asList(referenceToUrl(servletContext, BratCssReference.get()));
+    }
+
+    @Override
+    protected List<String> getScriptSources()
+    {
+        // super.getScriptSources() intentionally not called here - this editor is not customizable
+        return asList(referenceToUrl(servletContext, BratResourceReference.get()));
     }
 
     @Override

--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/ExternalAnnotationEditor.java
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/ExternalAnnotationEditor.java
@@ -18,8 +18,10 @@
 package de.tudarmstadt.ukp.inception.externaleditor;
 
 import static de.tudarmstadt.ukp.inception.externaleditor.config.ExternalEditorLoader.PLUGINS_EDITOR_BASE_URL;
-import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.substringAfter;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.wicket.Component;
 import org.apache.wicket.markup.html.basic.Label;
@@ -102,14 +104,30 @@ public class ExternalAnnotationEditor
 
         var props = super.getProperties();
         props.setEditorFactory(pluginDesc.getFactory());
-        props.setStylesheetSources(pluginDesc.getStylesheets().stream() //
-                .map(this::getUrlForPluginAsset) //
-                .collect(toList()));
-        props.setScriptSources(pluginDesc.getScripts().stream() //
-                .map(this::getUrlForPluginAsset) //
-                .collect(toList()));
         props.setSectionElements(pluginDesc.getSectionElements());
 
         return props;
+    }
+
+    @Override
+    protected List<String> getStylesheetSources()
+    {
+        var sources = new ArrayList<String>();
+        getDescription().getStylesheets().stream() //
+                .map(this::getUrlForPluginAsset) //
+                .forEach(sources::add);
+        sources.addAll(super.getStylesheetSources());
+        return sources;
+    }
+
+    @Override
+    protected List<String> getScriptSources()
+    {
+        var sources = new ArrayList<String>();
+        sources.addAll(super.getScriptSources());
+        getDescription().getScripts().stream() //
+                .map(this::getUrlForPluginAsset) //
+                .forEach(sources::add);
+        return sources;
     }
 }

--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/ExternalAnnotationEditorBase.java
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/ExternalAnnotationEditorBase.java
@@ -30,6 +30,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import org.apache.wicket.Component;
@@ -45,6 +46,7 @@ import org.slf4j.Logger;
 
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.icon.FontAwesome7CssReference;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasProvider;
+import de.tudarmstadt.ukp.clarin.webanno.api.export.DocumentImportExportService;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.inception.diam.editor.DiamAjaxBehavior;
 import de.tudarmstadt.ukp.inception.diam.editor.DiamJavaScriptReference;
@@ -63,6 +65,7 @@ import de.tudarmstadt.ukp.inception.externaleditor.command.QueuedEditorCommandsM
 import de.tudarmstadt.ukp.inception.externaleditor.command.ScrollToCommand;
 import de.tudarmstadt.ukp.inception.externaleditor.model.AnnotationEditorProperties;
 import de.tudarmstadt.ukp.inception.externaleditor.resources.ExternalEditorJavascriptResourceReference;
+import de.tudarmstadt.ukp.inception.io.xml.css.StylesheetRegistry;
 import de.tudarmstadt.ukp.inception.preferences.ClientSideUserPreferencesProvider;
 import de.tudarmstadt.ukp.inception.preferences.PreferencesService;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
@@ -87,6 +90,8 @@ public abstract class ExternalAnnotationEditorBase
     private @SpringBean AnnotationEditorExtensionRegistry extensionRegistry;
     private @SpringBean ServletContext context;
     private @SpringBean UserDao userService;
+    private @SpringBean StylesheetRegistry stylesheetRegistry;
+    private @SpringBean DocumentImportExportService documentImportExportService;
 
     private final String editorFactoryId;
 
@@ -129,6 +134,36 @@ public abstract class ExternalAnnotationEditorBase
         return annotationEditorRegistry.getEditorFactory(editorFactoryId);
     }
 
+    protected List<String> getStylesheetSources()
+    {
+        var sources = new ArrayList<String>();
+
+        for (var reference : stylesheetRegistry.listStylesheetReferences()) {
+            sources.add(referenceToUrl(context, reference));
+        }
+
+        return sources;
+    }
+
+    /**
+     * Build the script source list. Format-specific adapters (e.g. the document-structure factory
+     * registered by {@code NisoDocumentStructure.min.js}) must come before the editor JS so their
+     * globals are registered by the time the editor bundle initializes and reads
+     * {@code props.documentStructureFactory}. The external-editor loader inserts scripts with
+     * {@code script.async = false}, so this ordering is honoured.
+     */
+    protected List<String> getScriptSources()
+    {
+        var sources = new ArrayList<String>();
+
+        for (var reference : documentImportExportService
+                .getFormatJavaScripts(getModelObject().getDocument())) {
+            sources.add(referenceToUrl(context, reference));
+        }
+
+        return sources;
+    }
+
     protected DiamAjaxBehavior createDiamBehavior()
     {
         return new DiamAjaxBehavior(contextMenu);
@@ -161,7 +196,7 @@ public abstract class ExternalAnnotationEditorBase
 
         aResponse.render(forReference(ExternalEditorJavascriptResourceReference.get()));
 
-        if (getModelObject().getDocument() != null && getProperties() != null) {
+        if (getModelObject().getDocument() != null) {
             aResponse.render(forScript(wrapInTryCatch(initScript())));
         }
     }
@@ -216,11 +251,17 @@ public abstract class ExternalAnnotationEditorBase
         props.setDiamAjaxCallbackUrl(getDiamBehavior().getCallbackUrl().toString());
         props.setDiamWsUrl(constructWsEndpointUrl());
         props.setCsrfToken(getCsrfTokenFromSession());
+        props.setStylesheetSources(getStylesheetSources());
+        props.setScriptSources(getScriptSources());
 
         if (getFactory() instanceof ClientSideUserPreferencesProvider factory) {
             factory.getUserPreferencesKey()
                     .ifPresent(key -> props.setUserPreferencesKey(key.getClientSideKey()));
         }
+
+        documentImportExportService
+                .getFormatDocumentStructureFactory(getModelObject().getDocument())
+                .ifPresent(props::setDocumentStructureFactory);
 
         return props;
     }

--- a/inception/inception-html-apache-annotator-editor/src/main/java/de/tudarmstadt/ukp/inception/apacheannotatoreditor/ApacheAnnotatorHtmlAnnotationEditor.java
+++ b/inception/inception-html-apache-annotator-editor/src/main/java/de/tudarmstadt/ukp/inception/apacheannotatoreditor/ApacheAnnotatorHtmlAnnotationEditor.java
@@ -37,7 +37,6 @@ import de.tudarmstadt.ukp.inception.editor.action.AnnotationActionHandler;
 import de.tudarmstadt.ukp.inception.editor.view.DocumentViewFactory;
 import de.tudarmstadt.ukp.inception.externaleditor.ExternalAnnotationEditorBase;
 import de.tudarmstadt.ukp.inception.externaleditor.model.AnnotationEditorProperties;
-import de.tudarmstadt.ukp.inception.io.xml.css.StylesheetRegistry;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
 import jakarta.servlet.ServletContext;
 
@@ -51,7 +50,6 @@ public class ApacheAnnotatorHtmlAnnotationEditor
     private @SpringBean DocumentService documentService;
     private @SpringBean ServletContext servletContext;
     private @SpringBean DocumentImportExportService documentImportExportService;
-    private @SpringBean StylesheetRegistry stylesheetSources;
 
     public ApacheAnnotatorHtmlAnnotationEditor(String aId, IModel<AnnotatorState> aModel,
             AnnotationActionHandler aActionHandler, CasProvider aCasProvider,
@@ -76,49 +74,29 @@ public class ApacheAnnotatorHtmlAnnotationEditor
         // The factory is the JS call. Cf. the "globalName" in build.js and the factory method
         // defined in main.ts
         props.setEditorFactory("ApacheAnnotatorEditor.factory()");
-        props.setStylesheetSources(getStylesheetSources());
-        props.setScriptSources(getScriptSources());
         props.setSectionElements(
                 documentImportExportService.getSectionElements(getModelObject().getDocument()));
         props.setProtectedElements(
                 documentImportExportService.getProtectedElements(getModelObject().getDocument()));
-        documentImportExportService
-                .getFormatDocumentStructureFactory(getModelObject().getDocument())
-                .ifPresent(props::setDocumentStructureFactory);
         return props;
     }
 
-    private List<String> getStylesheetSources()
+    @Override
+    protected List<String> getStylesheetSources()
     {
         var sources = new ArrayList<String>();
-
         sources.add(referenceToUrl(servletContext, ApacheAnnotatorJsCssResourceReference.get()));
-
-        for (var reference : stylesheetSources.listStylesheetReferences()) {
-            sources.add(referenceToUrl(servletContext, reference));
-        }
-
+        sources.addAll(super.getStylesheetSources());
         return sources;
     }
 
-    /**
-     * Build the script source list. Format-specific adapters come first, editor JS last; the
-     * external-editor loader honours that order by inserting the scripts with
-     * {@code script.async = false}, so the format adapter is guaranteed to have run by the time the
-     * editor bundle initializes and reads {@code props.documentStructureFactory}.
-     */
-    private List<String> getScriptSources()
+    @Override
+    protected List<String> getScriptSources()
     {
         var sources = new ArrayList<String>();
-
-        for (var reference : documentImportExportService
-                .getFormatJavaScripts(getModelObject().getDocument())) {
-            sources.add(referenceToUrl(servletContext, reference));
-        }
-
+        sources.addAll(super.getScriptSources());
         sources.add(
                 referenceToUrl(servletContext, ApacheAnnotatorJsJavascriptResourceReference.get()));
-
         return sources;
     }
 }

--- a/inception/inception-html-recogito-editor/src/main/java/de/tudarmstadt/ukp/inception/recogitojseditor/RecogitoHtmlAnnotationEditor.java
+++ b/inception/inception-html-recogito-editor/src/main/java/de/tudarmstadt/ukp/inception/recogitojseditor/RecogitoHtmlAnnotationEditor.java
@@ -18,7 +18,9 @@
 package de.tudarmstadt.ukp.inception.recogitojseditor;
 
 import static de.tudarmstadt.ukp.inception.support.wicket.ServletContextUtils.referenceToUrl;
-import static java.util.Arrays.asList;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.wicket.Component;
 import org.apache.wicket.model.IModel;
@@ -70,10 +72,24 @@ public class RecogitoHtmlAnnotationEditor
         // The factory is the JS call. Cf. the "globalName" in build.js and the factory method
         // defined in main.ts
         props.setEditorFactory("RecogitoEditor.factory()");
-        props.setStylesheetSources(
-                asList(referenceToUrl(servletContext, RecogitoJsCssResourceReference.get())));
-        props.setScriptSources(asList(
-                referenceToUrl(servletContext, RecogitoJsJavascriptResourceReference.get())));
         return props;
+    }
+
+    @Override
+    protected List<String> getStylesheetSources()
+    {
+        var sources = new ArrayList<String>();
+        sources.add(referenceToUrl(servletContext, RecogitoJsCssResourceReference.get()));
+        sources.addAll(super.getStylesheetSources());
+        return sources;
+    }
+
+    @Override
+    protected List<String> getScriptSources()
+    {
+        var sources = new ArrayList<String>();
+        sources.addAll(super.getScriptSources());
+        sources.add(referenceToUrl(servletContext, RecogitoJsJavascriptResourceReference.get()));
+        return sources;
     }
 }

--- a/inception/inception-pdf-editor2/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor2/PdfAnnotationEditor.java
+++ b/inception/inception-pdf-editor2/src/main/java/de/tudarmstadt/ukp/inception/pdfeditor2/PdfAnnotationEditor.java
@@ -20,6 +20,8 @@ package de.tudarmstadt.ukp.inception.pdfeditor2;
 import static de.tudarmstadt.ukp.inception.support.wicket.ServletContextUtils.referenceToUrl;
 import static java.util.Arrays.asList;
 
+import java.util.List;
+
 import org.apache.wicket.Component;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
@@ -67,8 +69,8 @@ public class PdfAnnotationEditor
     @Override
     protected Component makeView()
     {
-        AnnotatorState state = getModelObject();
-        String format = state.getDocument().getFormat();
+        var state = getModelObject();
+        var format = state.getDocument().getFormat();
         if (!format.equals(PdfFormatSupport.ID)) {
             return new WrongFileFormatPanel(VIS, format);
         }
@@ -85,11 +87,24 @@ public class PdfAnnotationEditor
         // The factory is the JS call. Cf. the "globalName" in build.js and the factory method
         // defined in main.ts
         props.setEditorFactory("PdfAnnotationEditor.factory()");
-        props.setStylesheetSources(asList(
-                referenceToUrl(servletContext, PdfAnnotationEditorCssResourceReference.get())));
-        props.setScriptSources(asList(referenceToUrl(servletContext,
-                PdfAnnotationEditorJavascriptResourceReference.get())));
         props.setLoadingIndicatorDisabled(true);
         return props;
+    }
+
+    @Override
+    protected List<String> getStylesheetSources()
+    {
+        // super.getStylesheetSources() intentionally not called here - this editor is not
+        // customizable
+        return asList(
+                referenceToUrl(servletContext, PdfAnnotationEditorCssResourceReference.get()));
+    }
+
+    @Override
+    protected List<String> getScriptSources()
+    {
+        // super.getScriptSources() intentionally not called here - this editor is not customizable
+        return asList(referenceToUrl(servletContext,
+                PdfAnnotationEditorJavascriptResourceReference.get()));
     }
 }


### PR DESCRIPTION
**What's in the PR**
- Introduce template methods `getStylesheetSources()` and `getScriptSources()` in `ExternalAnnotationEditorBase`
- Move `StylesheetRegistry` and `DocumentImportExportService` SpringBeans to `ExternalAnnotationEditorBase`
- Centralize format-provided CSS/JS and document-structure-factory wiring in `ExternalAnnotationEditorBase.getProperties()`
- Override stylesheet and script template methods in relevant editors

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
