### PR TITLE
#6126 - Concept lookup may find nothing on Virtuoso-backed knowledge bases

### DIFF
--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/IriConstants.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/IriConstants.java
@@ -42,7 +42,7 @@ public class IriConstants
     public static final String PREFIX_WIKIDATA_ENTITY = "http://www.wikidata.org/entity/";
     public static final String PREFIX_WIKIDATA_DIRECT = "http://www.wikidata.org/prop/direct/";
     public static final String PREFIX_SCHEMA = "http://schema.org/";
-    public static final String PREFIX_VIRTUOSO = "http://www.openlinksw.com/schemas/bif#";
+    public static final String PREFIX_VIRTUOSO = "bif:";
     public static final String PREFIX_RDF4J_LUCENE_SEARCH = "http://www.openrdf.org/contrib/lucenesail#";
     public static final String PREFIX_ALLEGRO_GRAPH_FTI = "http://franz.com/ns/allegrograph/2.2/textindex/";
     public static final String PREFIX_MWAPI = "https://www.mediawiki.org/ontology#API/";

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterVirtuoso.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterVirtuoso.java
@@ -40,7 +40,7 @@ public class FtsAdapterVirtuoso
     @Override
     public void withLabelMatchingExactlyAnyOf(String... aValues)
     {
-        // addPrefix(PREFIX_VIRTUOSO_SEARCH);
+        builder.addPrefix(PREFIX_VIRTUOSO_SEARCH);
 
         var valuePatterns = new ArrayList<GraphPattern>();
         for (var value : aValues) {
@@ -68,7 +68,7 @@ public class FtsAdapterVirtuoso
     @Override
     public void withLabelContainingAnyOf(String... aValues)
     {
-        // addPrefix(PREFIX_VIRTUOSO_SEARCH);
+        builder.addPrefix(PREFIX_VIRTUOSO_SEARCH);
 
         var valuePatterns = new ArrayList<GraphPattern>();
         for (var value : aValues) {
@@ -96,7 +96,7 @@ public class FtsAdapterVirtuoso
     @Override
     public void withLabelStartingWith(String aPrefixQuery)
     {
-        // addPrefix(PREFIX_VIRTUOSO_SEARCH);
+        builder.addPrefix(PREFIX_VIRTUOSO_SEARCH);
 
         // Strip single quotes and asterisks because they have special semantics
         var queryString = builder.sanitizeQueryString_FTS(aPrefixQuery);
@@ -156,7 +156,7 @@ public class FtsAdapterVirtuoso
     @Override
     public void withLabelMatchingAnyOf(String... aValues)
     {
-        // addPrefix(PREFIX_VIRTUOSO_SEARCH);
+        builder.addPrefix(PREFIX_VIRTUOSO_SEARCH);
 
         var valuePatterns = new ArrayList<GraphPattern>();
         for (var value : aValues) {

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLVariables.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLVariables.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.inception.kb.querybuilder;
 
 import static de.tudarmstadt.ukp.inception.kb.IriConstants.PREFIX_VIRTUOSO;
+import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.prefix;
 import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.var;
 import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
 
@@ -25,6 +26,7 @@ import org.eclipse.rdf4j.model.vocabulary.OWL;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.sparqlbuilder.constraint.propertypath.PropertyPath;
 import org.eclipse.rdf4j.sparqlbuilder.constraint.propertypath.builder.PropertyPathBuilder;
+import org.eclipse.rdf4j.sparqlbuilder.core.Prefix;
 import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
 import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
 
@@ -58,10 +60,11 @@ public interface SPARQLVariables
     Variable VAR_DESC_CANDIDATE = var(VAR_DESCRIPTION_CANDIDATE_NAME);
     Variable VAR_DEPRECATION = var(VAR_DEPRECATION_NAME);
 
-    // Some versions of Virtuoso do not like it when we declare the bif prefix.
-    // Prefix PREFIX_VIRTUOSO_SEARCH = prefix("bif", iri(PREFIX_VIRTUOSO));
-    // Iri VIRTUOSO_QUERY = PREFIX_VIRTUOSO_SEARCH.iri("contains");
-    Iri VIRTUOSO_QUERY = iri(PREFIX_VIRTUOSO, "contains");
+    // The Virtuoso FTS predicate must be rendered as the magic "bif:contains" prefixed name with
+    // the "bif" prefix declared (expanding to the engine-internal "bif:" namespace). The full-IRI
+    // form silently returns no results on stricter Virtuoso instances. See issue #6125.
+    Prefix PREFIX_VIRTUOSO_SEARCH = prefix("bif", iri(PREFIX_VIRTUOSO));
+    Iri VIRTUOSO_QUERY = PREFIX_VIRTUOSO_SEARCH.iri("contains");
 
     Iri OWL_INTERSECTIONOF = iri(OWL.INTERSECTIONOF.stringValue());
     Iri RDF_REST = iri(RDF.REST.stringValue());


### PR DESCRIPTION
**What's in the PR**
- Change Virtuoso FTS namespace to use magic `bif:` prefix instead of schema URL to fix concept lookup on stricter Virtuoso endpoints (e.g. NLM MeSH)
- Declare `PREFIX bif: <bif:>` in SPARQL queries using Virtuoso full-text search
- Activate `PREFIX_VIRTUOSO_SEARCH` prefix declaration in all Virtuoso FTS adapter methods

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
