### PR TITLE
#6133 - Support knowledge bases that use multiple datasets / graphs

### DIFF
--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseService.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseService.java
@@ -393,6 +393,17 @@ public interface KnowledgeBaseService
 
     RepositoryConnection getConnection(KnowledgeBase kb);
 
+    /**
+     * Lists the named graphs (datasets) offered by the given knowledge base. This requires the
+     * knowledge base to be registered (i.e. saved) and may be an expensive operation on large
+     * remote endpoints as it has to enumerate the graphs via a SPARQL query.
+     *
+     * @param aKB
+     *            the knowledge base to query.
+     * @return the IRIs of the named graphs offered by the knowledge base.
+     */
+    List<String> listDatasets(KnowledgeBase aKB) throws QueryEvaluationException;
+
     interface ReadAction<T>
     {
         T accept(RepositoryConnection aConnection);

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImpl.java
@@ -178,6 +178,8 @@ public class KnowledgeBaseServiceImpl
 {
     private static final int LOCAL_FUZZY_PREFIX_LENGTH = 3;
 
+    private static final int DATASET_ENUMERATION_TIMEOUT_SECONDS = 30;
+
     private final static Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     private @PersistenceContext EntityManager entityManager;
@@ -1316,6 +1318,30 @@ public class KnowledgeBaseServiceImpl
     {
         try (var conn = getConnection(kb)) {
             return aAction.accept(conn);
+        }
+    }
+
+    @Override
+    public List<String> listDatasets(KnowledgeBase aKB) throws QueryEvaluationException
+    {
+        try (var watch = new StopWatch(LOG, "listDatasets()")) {
+            return read(aKB, conn -> {
+                var query = conn
+                        .prepareTupleQuery("SELECT DISTINCT ?g WHERE { GRAPH ?g { ?s ?p ?o } }");
+                query.setMaxExecutionTime(DATASET_ENUMERATION_TIMEOUT_SECONDS);
+
+                var datasets = new ArrayList<String>();
+                try (var result = query.evaluate()) {
+                    while (result.hasNext()) {
+                        var g = result.next().getValue("g");
+                        if (g != null) {
+                            datasets.add(g.stringValue());
+                        }
+                    }
+                }
+                datasets.sort(String::compareToIgnoreCase);
+                return datasets;
+            });
         }
     }
 

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/exporter/ExportedKnowledgeBase.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/exporter/ExportedKnowledgeBase.java
@@ -99,6 +99,9 @@ public class ExportedKnowledgeBase
     @JsonProperty("default_dataset_iri")
     private String defaultDatasetIri;
 
+    @JsonProperty("additional_dataset_iris")
+    private List<String> additionalDatasetIris;
+
     @JsonProperty("max_results")
     private int maxResults;
 
@@ -375,6 +378,16 @@ public class ExportedKnowledgeBase
     public void setDefaultDatasetIri(String aDefaultDatasetIri)
     {
         defaultDatasetIri = aDefaultDatasetIri;
+    }
+
+    public List<String> getAdditionalDatasetIris()
+    {
+        return additionalDatasetIris;
+    }
+
+    public void setAdditionalDatasetIris(List<String> aAdditionalDatasetIris)
+    {
+        additionalDatasetIris = aAdditionalDatasetIris;
     }
 
     public void setUseFuzzy(boolean aUseFuzzy)

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/exporter/KnowledgeBaseExporter.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/exporter/KnowledgeBaseExporter.java
@@ -136,6 +136,7 @@ public class KnowledgeBaseExporter
             exportedKB.setDefaultLanguage(kb.getDefaultLanguage());
             exportedKB.setDefaultDatasetIri(
                     kb.getDefaultDatasetIri() != null ? kb.getDefaultDatasetIri() : null);
+            exportedKB.setAdditionalDatasetIris(new ArrayList<>(kb.getAdditionalDatasetIris()));
             exportedKB.setMaxResults(kb.getMaxResults());
             exportedKB.setSubPropertyIri(kb.getSubPropertyIri());
             exportedKB.setTraits(kb.getTraits());
@@ -254,6 +255,12 @@ public class KnowledgeBaseExporter
             kb.setDefaultDatasetIri(
                     exportedKB.getDefaultDatasetIri() != null ? exportedKB.getDefaultDatasetIri() //
                             : null);
+            if (exportedKB.getAdditionalDatasetIris() != null) {
+                kb.setAdditionalDatasetIris(exportedKB.getAdditionalDatasetIris());
+            }
+            else {
+                kb.setAdditionalDatasetIris(new ArrayList<>());
+            }
             kb.setMaxResults(exportedKB.getMaxResults());
             // If not setting, initialize with default
             if (kb.getMaxResults() == 0) {

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/exporter/KnowledgeBaseExporter.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/exporter/KnowledgeBaseExporter.java
@@ -134,8 +134,7 @@ public class KnowledgeBaseExporter
                     new ArrayList<>(kb.getAdditionalMatchingProperties()));
             exportedKB.setAdditionalLanguages(new ArrayList<>(kb.getAdditionalLanguages()));
             exportedKB.setDefaultLanguage(kb.getDefaultLanguage());
-            exportedKB.setDefaultDatasetIri(
-                    kb.getDefaultDatasetIri() != null ? kb.getDefaultDatasetIri() : null);
+            exportedKB.setDefaultDatasetIri(kb.getDefaultDatasetIri());
             exportedKB.setAdditionalDatasetIris(new ArrayList<>(kb.getAdditionalDatasetIris()));
             exportedKB.setMaxResults(kb.getMaxResults());
             exportedKB.setSubPropertyIri(kb.getSubPropertyIri());
@@ -252,14 +251,9 @@ public class KnowledgeBaseExporter
             }
 
             kb.setDefaultLanguage(exportedKB.getDefaultLanguage());
-            kb.setDefaultDatasetIri(
-                    exportedKB.getDefaultDatasetIri() != null ? exportedKB.getDefaultDatasetIri() //
-                            : null);
+            kb.setDefaultDatasetIri(exportedKB.getDefaultDatasetIri());
             if (exportedKB.getAdditionalDatasetIris() != null) {
                 kb.setAdditionalDatasetIris(exportedKB.getAdditionalDatasetIris());
-            }
-            else {
-                kb.setAdditionalDatasetIris(new ArrayList<>());
             }
             kb.setMaxResults(exportedKB.getMaxResults());
             // If not setting, initialize with default

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/model/KnowledgeBase.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/model/KnowledgeBase.java
@@ -162,6 +162,16 @@ public class KnowledgeBase
     @Column(nullable = true)
     private String defaultDatasetIri;
 
+    /**
+     * The IRIs of additional datasets (graphs) to include in queries next to the default dataset.
+     * This is useful e.g. when the schema (property/class definitions) of a knowledge base lives in
+     * a separate graph from the instance data (as is the case for MeSH).
+     */
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "knowledgebase_add_datasets")
+    @Column(name = "name", nullable = false)
+    private Set<String> additionalDatasetIris = new LinkedHashSet<>();
+
     @Column(nullable = false)
     private boolean readOnly;
 
@@ -505,6 +515,17 @@ public class KnowledgeBase
         applyRootConcepts(aProfile);
         applyMapping(aProfile.getMapping());
         applyAdditionalLanguages(aProfile);
+        applyAdditionalDatasets(aProfile);
+    }
+
+    public void applyAdditionalDatasets(KnowledgeBaseProfile aProfile)
+    {
+        if (aProfile.getAdditionalDatasets() == null) {
+            additionalDatasetIris = emptySet();
+        }
+        else {
+            additionalDatasetIris = new LinkedHashSet<>(aProfile.getAdditionalDatasets());
+        }
     }
 
     public void applyAdditionalLanguages(KnowledgeBaseProfile aProfile)
@@ -525,6 +546,16 @@ public class KnowledgeBase
     public void setDefaultDatasetIri(String aDefaultDatasetIri)
     {
         defaultDatasetIri = aDefaultDatasetIri;
+    }
+
+    public Set<String> getAdditionalDatasetIris()
+    {
+        return additionalDatasetIris;
+    }
+
+    public void setAdditionalDatasetIris(Collection<String> aAdditionalDatasetIris)
+    {
+        additionalDatasetIris = new LinkedHashSet<>(aAdditionalDatasetIris);
     }
 
     public void setSkipSslValidation(boolean aSkipSslValidation)

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/model/KnowledgeBase.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/model/KnowledgeBase.java
@@ -18,6 +18,7 @@
 package de.tudarmstadt.ukp.inception.kb.model;
 
 import static de.tudarmstadt.ukp.inception.kb.reification.Reification.NONE;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 
@@ -520,12 +521,9 @@ public class KnowledgeBase
 
     public void applyAdditionalDatasets(KnowledgeBaseProfile aProfile)
     {
-        if (aProfile.getAdditionalDatasets() == null) {
-            additionalDatasetIris = emptySet();
-        }
-        else {
-            additionalDatasetIris = new LinkedHashSet<>(aProfile.getAdditionalDatasets());
-        }
+        additionalDatasetIris = new LinkedHashSet<>(
+                aProfile.getAdditionalDatasets() == null ? emptyList()
+                        : aProfile.getAdditionalDatasets());
     }
 
     public void applyAdditionalLanguages(KnowledgeBaseProfile aProfile)

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
@@ -1452,16 +1452,7 @@ public class SPARQLQueryBuilder
         secondaryPatterns.stream().forEach(query::where);
         optionalLookupPatterns.stream().forEach(query::where);
 
-        var datasets = new ArrayList<From>();
-        if (kb.getDefaultDatasetIri() != null) {
-            datasets.add(from(iri(kb.getDefaultDatasetIri())));
-        }
-        for (var additionalDatasetIri : kb.getAdditionalDatasetIris()) {
-            datasets.add(from(iri(additionalDatasetIri)));
-        }
-        if (!datasets.isEmpty()) {
-            query.from(dataset(datasets.toArray(From[]::new)));
-        }
+        applyDataset(query);
 
         int actualLimit = getLimit();
         if (actualLimit != UNLIMITED) {
@@ -1944,6 +1935,12 @@ public class SPARQLQueryBuilder
                 aRootProperty);
 
         var query = Queries.SELECT().distinct().where(pattern);
+        // The sub-property declarations may live in one of the configured datasets (e.g. for MeSH
+        // they are in the vocab graph added as an additional dataset). The main query restricts the
+        // active graph to those datasets via FROM, so we must scope this query the same way -
+        // otherwise the declarations would be resolved against a different (the endpoint's default)
+        // graph and might not be found at all.
+        applyDataset(query);
 
         var tupleQuery = aConnection.prepareTupleQuery(query.getQueryString());
         tupleQuery.setIncludeInferred(includeInferred);
@@ -1964,6 +1961,26 @@ public class SPARQLQueryBuilder
         catch (QueryEvaluationException e) {
             throw new QueryEvaluationException(
                     e.getMessage() + " while running query:\n" + query.getQueryString(), e);
+        }
+    }
+
+    /**
+     * Restrict the given query to the datasets (named graphs) configured on the knowledge base. A
+     * {@code FROM} clause replaces the active default graph with the merge of the listed graphs, so
+     * any query that needs to see the same data as the main query (e.g. sub-property resolution)
+     * must be scoped identically. Does nothing if no datasets are configured.
+     */
+    private void applyDataset(SelectQuery aQuery)
+    {
+        var datasets = new ArrayList<From>();
+        if (kb.getDefaultDatasetIri() != null) {
+            datasets.add(from(iri(kb.getDefaultDatasetIri())));
+        }
+        for (var additionalDatasetIri : kb.getAdditionalDatasetIris()) {
+            datasets.add(from(iri(additionalDatasetIri)));
+        }
+        if (!datasets.isEmpty()) {
+            aQuery.from(dataset(datasets.toArray(From[]::new)));
         }
     }
 

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
@@ -91,6 +91,7 @@ import org.eclipse.rdf4j.sparqlbuilder.constraint.Expression;
 import org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions;
 import org.eclipse.rdf4j.sparqlbuilder.constraint.SparqlFunction;
 import org.eclipse.rdf4j.sparqlbuilder.constraint.propertypath.builder.PropertyPathBuilder;
+import org.eclipse.rdf4j.sparqlbuilder.core.From;
 import org.eclipse.rdf4j.sparqlbuilder.core.Prefix;
 import org.eclipse.rdf4j.sparqlbuilder.core.Projectable;
 import org.eclipse.rdf4j.sparqlbuilder.core.Variable;
@@ -1451,8 +1452,15 @@ public class SPARQLQueryBuilder
         secondaryPatterns.stream().forEach(query::where);
         optionalLookupPatterns.stream().forEach(query::where);
 
+        var datasets = new ArrayList<From>();
         if (kb.getDefaultDatasetIri() != null) {
-            query.from(dataset(from(iri(kb.getDefaultDatasetIri()))));
+            datasets.add(from(iri(kb.getDefaultDatasetIri())));
+        }
+        for (var additionalDatasetIri : kb.getAdditionalDatasetIris()) {
+            datasets.add(from(iri(additionalDatasetIri)));
+        }
+        if (!datasets.isEmpty()) {
+            query.from(dataset(datasets.toArray(From[]::new)));
         }
 
         int actualLimit = getLimit();

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/yaml/KnowledgeBaseProfile.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/yaml/KnowledgeBaseProfile.java
@@ -79,6 +79,9 @@ public class KnowledgeBaseProfile
     @JsonProperty("default-dataset")
     private String defaultDataset;
 
+    @JsonProperty("additional-datasets")
+    private List<String> additionalDatasets;
+
     @JsonProperty("base-prefix")
     private String basePrefix = IriConstants.INCEPTION_NAMESPACE;
 
@@ -242,6 +245,16 @@ public class KnowledgeBaseProfile
         defaultDataset = aDefaultDataset;
     }
 
+    public List<String> getAdditionalDatasets()
+    {
+        return additionalDatasets;
+    }
+
+    public void setAdditionalDatasets(List<String> aAdditionalDatasets)
+    {
+        additionalDatasets = aAdditionalDatasets;
+    }
+
     public void setBasePrefix(String aBasePrefix)
     {
         basePrefix = aBasePrefix;
@@ -294,6 +307,7 @@ public class KnowledgeBaseProfile
                 && Objects.equals(reification, that.reification) //
                 && Objects.equals(defaultLanguage, that.defaultLanguage) //
                 && Objects.equals(defaultDataset, that.defaultDataset) //
+                && Objects.equals(additionalDatasets, that.additionalDatasets) //
                 && Objects.equals(additionalMatchingProperties, that.additionalMatchingProperties) //
                 && Objects.equals(additionalLanguages, that.additionalLanguages) //
                 && Objects.equals(basePrefix, that.basePrefix);
@@ -303,8 +317,8 @@ public class KnowledgeBaseProfile
     public int hashCode()
     {
         return Objects.hash(name, disabled, type, access, mapping, rootConcepts, info, reification,
-                defaultLanguage, defaultDataset, additionalMatchingProperties, additionalLanguages,
-                basePrefix);
+                defaultLanguage, defaultDataset, additionalDatasets, additionalMatchingProperties,
+                additionalLanguages, basePrefix);
     }
 
     @Override

--- a/inception/inception-kb/src/main/resources/de/tudarmstadt/ukp/inception/kb/model/db-changelog.xml
+++ b/inception/inception-kb/src/main/resources/de/tudarmstadt/ukp/inception/kb/model/db-changelog.xml
@@ -505,4 +505,20 @@
       </column>
     </createTable>
   </changeSet>
+
+  <changeSet author="INCEpTION Team" id="20260626-1">
+    <preConditions onFail="MARK_RAN">
+      <not>
+        <tableExists tableName="knowledgebase_add_datasets"/>
+      </not>
+    </preConditions>
+    <createTable tableName="knowledgebase_add_datasets">
+      <column name="knowledgebase_repositoryId" type="VARCHAR(255)">
+        <constraints nullable="false" />
+      </column>
+      <column name="name" type="VARCHAR(255)">
+        <constraints nullable="false" />
+      </column>
+    </createTable>
+  </changeSet>
 </databaseChangeLog>

--- a/inception/inception-kb/src/main/resources/de/tudarmstadt/ukp/inception/kb/yaml/knowledgebase-profiles.yaml
+++ b/inception/inception-kb/src/main/resources/de/tudarmstadt/ukp/inception/kb/yaml/knowledgebase-profiles.yaml
@@ -408,6 +408,12 @@ mesh:
   # The endpoint hosts the current release as well as one named graph per year. Restricting the
   # queries to the current-release graph avoids getting the same descriptor back once per year.
   default-dataset: http://id.nlm.nih.gov/mesh
+  # The MeSH ontology/schema - including the rdfs:label sub-property declarations for
+  # meshv:prefLabel and meshv:altLabel - lives in a separate vocab graph. We include it so those
+  # declarations are visible to queries (the per-year duplication concern only affects the
+  # descriptor data graphs, not the schema graph).
+  additional-datasets:
+    - http://id.nlm.nih.gov/mesh/vocab
   access:
     access-url: https://id.nlm.nih.gov/mesh/sparql
     full-text-search: bif:contains
@@ -425,13 +431,10 @@ mesh:
     property-label: http://www.w3.org/2000/01/rdf-schema#label
     property-description: http://www.w3.org/2000/01/rdf-schema#comment
     deprecation-property: http://www.w3.org/2002/07/owl#deprecated
-  additional-matching-properties:
-    - http://id.nlm.nih.gov/mesh/vocab#altLabel
-    # MeSH descriptors carry their name in rdfs:label, but term (T...) and concept (M...) nodes
-    # carry it only in meshv:prefLabel. That property is declared as an rdfs:label sub-property,
-    # but only in the .../mesh/vocab graph which the default-dataset excludes - so it is listed
-    # explicitly here to let such nodes resolve a label instead of falling back to their IRI.
-    - http://id.nlm.nih.gov/mesh/vocab#prefLabel
+  # MeSH descriptors carry their name in rdfs:label, but term (T...) and concept (M...) nodes carry
+  # it only in meshv:prefLabel (and synonyms in meshv:altLabel). Both are declared as rdfs:label
+  # sub-properties in the vocab graph (included via additional-datasets above), so they are resolved
+  # automatically via the sub-property hierarchy - no explicit additional-matching-properties needed.
   info:
     description: |
       Medical Subject Headings (MeSH) is the U.S. National Library of Medicine's controlled

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseExporterTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseExporterTest.java
@@ -251,6 +251,8 @@ public class KnowledgeBaseExporterTest
         kb.setRootConcepts(asList("http://www.ics.forth.gr/isl/CRMinf/I1_Argumentation",
                 "http://www.ics.forth.gr/isl/CRMinf/I1_Argumentation"));
         kb.setDefaultLanguage("en");
+        kb.setAdditionalDatasetIris(
+                asList("http://example.org/graph1", "http://example.org/graph2"));
         return kb;
     }
 }

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplIntegrationTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplIntegrationTest.java
@@ -2133,6 +2133,52 @@ public class KnowledgeBaseServiceImplIntegrationTest
                 .isEqualTo("InSecond");
     }
 
+    @Test
+    public void listDatasets_ShouldReturnNamedGraphsExcludingTheDefaultGraph() throws Exception
+    {
+        setUp(Reification.NONE);
+
+        sut.registerKnowledgeBase(kb, sut.getNativeConfig());
+
+        var schemaGraph = "http://example.org/graph/schema";
+        var instanceGraph = "http://example.org/graph/instances";
+
+        sut.update(kb, conn -> {
+            var vf = conn.getValueFactory();
+            // Statements in two distinct named graphs
+            conn.add(vf.createIRI("http://example.org/s1"), RDFS.LABEL, vf.createLiteral("S1"),
+                    vf.createIRI(schemaGraph));
+            conn.add(vf.createIRI("http://example.org/s2"), RDFS.LABEL, vf.createLiteral("S2"),
+                    vf.createIRI(instanceGraph));
+            // A statement in the default graph (no context) which must not be reported as a graph
+            conn.add(vf.createIRI("http://example.org/s3"), RDFS.LABEL, vf.createLiteral("S3"));
+        });
+
+        var datasets = sut.listDatasets(kb);
+
+        assertThat(datasets) //
+                .as("Named graphs are returned sorted and the default graph is excluded") //
+                .containsExactly(instanceGraph, schemaGraph);
+    }
+
+    @Test
+    public void listDatasets_WithoutNamedGraphs_ShouldReturnEmptyList() throws Exception
+    {
+        setUp(Reification.NONE);
+
+        sut.registerKnowledgeBase(kb, sut.getNativeConfig());
+
+        sut.update(kb, conn -> {
+            var vf = conn.getValueFactory();
+            // Only a statement in the default graph
+            conn.add(vf.createIRI("http://example.org/s1"), RDFS.LABEL, vf.createLiteral("S1"));
+        });
+
+        assertThat(sut.listDatasets(kb)) //
+                .as("No named graphs present") //
+                .isEmpty();
+    }
+
     // Helper
     private Project createProject(String name)
     {

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceRemoteTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceRemoteTest.java
@@ -186,9 +186,6 @@ public class KnowledgeBaseServiceRemoteTest
         LOG.info("Time required        : {} ms", duration);
         propertiesKBHandle.stream().limit(10).forEach(h -> LOG.info("   {}", h));
 
-        assumeTrue(aSutConfig.isPropertiesExpected(),
-                "KB does not expose properties through its default dataset");
-
         assertThat(propertiesKBHandle).as("Check that property list is not empty").isNotEmpty();
     }
 
@@ -243,14 +240,12 @@ public class KnowledgeBaseServiceRemoteTest
 
         // MeSH (OpenLink Virtuoso, see issue #6125). Test identifier is the "Insulin" descriptor
         // (parent: "Proinsulin" via meshv:broaderDescriptor); "Endocrine System" is a parent-less
-        // top descriptor and thus a root concept. Properties are not expected because MeSH keeps
-        // its schema in a separate vocab graph excluded by the (year-deduplicating) default
-        // dataset.
-        kbList.add(
-                TestConfiguration
-                        .fromProfile(PROFILES.get("mesh"), "http://id.nlm.nih.gov/mesh/D007328",
-                                maxResults, Set.of("http://id.nlm.nih.gov/mesh/D004703"))
-                        .withoutProperties());
+        // top descriptor and thus a root concept. The schema (property/class definitions) lives in
+        // the separate .../mesh/vocab graph which the profile pulls in as an additional dataset, so
+        // properties are reachable.
+        kbList.add(TestConfiguration.fromProfile(PROFILES.get("mesh"),
+                "http://id.nlm.nih.gov/mesh/D007328", maxResults,
+                Set.of("http://id.nlm.nih.gov/mesh/D004703")));
 
         // Commenting this out for the moment because we expect that every ontology contains
         // property definitions. However, this one does not include any property definitions!
@@ -290,7 +285,6 @@ public class KnowledgeBaseServiceRemoteTest
         private final String testIdentifier;
         private final Set<String> rootIdentifier;
         private final Map<String, String> parentChildIdentifier;
-        private boolean propertiesExpected = true;
 
         public TestConfiguration(String aUrl, KnowledgeBase aKb, String aTestIdentifier,
                 Set<String> aRootIdentifier, Map<String, String> aParentChildIdentifier)
@@ -301,23 +295,6 @@ public class KnowledgeBaseServiceRemoteTest
             testIdentifier = aTestIdentifier;
             rootIdentifier = aRootIdentifier;
             parentChildIdentifier = aParentChildIdentifier;
-        }
-
-        /**
-         * Mark this KB as not exposing any properties through its default dataset. MeSH, for
-         * example, keeps its property and class definitions in a separate {@code .../mesh/vocab}
-         * named graph which is intentionally excluded by the profile's default dataset (the data
-         * graph is pinned to avoid getting one copy of every descriptor per yearly snapshot).
-         */
-        TestConfiguration withoutProperties()
-        {
-            propertiesExpected = false;
-            return this;
-        }
-
-        public boolean isPropertiesExpected()
-        {
-            return propertiesExpected;
         }
 
         static TestConfiguration fromProfile(KnowledgeBaseProfile aProfile, String aTestIdentifier,
@@ -341,6 +318,9 @@ public class KnowledgeBaseServiceRemoteTest
             kb.setMaxResults(aMaxResults);
             if (aProfile.getDefaultDataset() != null) {
                 kb.setDefaultDatasetIri(aProfile.getDefaultDataset());
+            }
+            if (aProfile.getAdditionalDatasets() != null) {
+                kb.setAdditionalDatasetIris(aProfile.getAdditionalDatasets());
             }
             var accessUrl = aProfile.getAccess().getAccessUrl();
             if (aProfile.getType() == LOCAL) {

--- a/inception/inception-support-bootstrap/src/main/ts/bootstrap/_shim-kendo.scss
+++ b/inception/inception-support-bootstrap/src/main/ts/bootstrap/_shim-kendo.scss
@@ -85,6 +85,28 @@
     }
 }
 
+// Make Kendo multi-selects behave like a Bootstrap form-control inside input groups. Without this,
+// the widget keeps its 100% width and - because input groups wrap - any adjacent button is pushed
+// onto the next line. We let it flex to fill the remaining space and flatten the corners that touch
+// the neighbouring control so it reads as a single group.
+.input-group {
+    > .k-multiselect {
+        flex: 1 1 auto;
+        width: 1%;
+        min-width: 0;
+
+        &:not(:last-child) {
+            border-top-right-radius: 0 !important;
+            border-bottom-right-radius: 0 !important;
+        }
+
+        &:not(:first-child) {
+            border-top-left-radius: 0 !important;
+            border-bottom-left-radius: 0 !important;
+        }
+    }
+}
+
 // Make Kendo components render with full width inside form groups
 /*
 .form-group .k-widget,

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/kendo/FreeTextMultiSelect.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/kendo/FreeTextMultiSelect.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.support.kendo;
+
+import static java.util.Arrays.asList;
+
+import java.util.ArrayList;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.wicket.markup.head.IHeaderResponse;
+import org.apache.wicket.markup.head.OnDomReadyHeaderItem;
+import org.wicketstuff.jquery.core.JQueryBehavior;
+import org.wicketstuff.jquery.core.Options;
+import org.wicketstuff.kendo.ui.KendoDataSource;
+import org.wicketstuff.kendo.ui.form.multiselect.lazy.MultiSelect;
+
+/**
+ * A Kendo {@link MultiSelect} that lets the user enter arbitrary string values in addition to (or
+ * instead of) any choices offered by {@link #getChoices}. It enables server-side filtering so the
+ * current input is passed to {@code getChoices}, filters out blank entries on submission and works
+ * around a Kendo quirk where chip removals are not synced back to the underlying {@code <select>}.
+ * Subclasses only need to implement {@link #getChoices}.
+ */
+public abstract class FreeTextMultiSelect
+    extends MultiSelect<String>
+{
+    private static final long serialVersionUID = -2674575240091821322L;
+
+    public FreeTextMultiSelect(String aId)
+    {
+        super(aId);
+        setOutputMarkupId(true);
+    }
+
+    @Override
+    protected void onConfigure(KendoDataSource aDataSource)
+    {
+        // This ensures that we get the user input in getChoices
+        aDataSource.set("serverFiltering", true);
+    }
+
+    @Override
+    public void onConfigure(JQueryBehavior aBehavior)
+    {
+        super.onConfigure(aBehavior);
+        aBehavior.setOption("filter", Options.asString("contains"));
+        aBehavior.setOption("autoClose", false);
+    }
+
+    @Override
+    public void convertInput()
+    {
+        var input = getInputAsArray();
+        var list = new ArrayList<String>();
+        if (input != null) {
+            list.addAll(asList(input));
+            list.removeIf(StringUtils::isBlank);
+        }
+        setConvertedInput(list);
+    }
+
+    @Override
+    public void renderHead(IHeaderResponse aResponse)
+    {
+        super.renderHead(aResponse);
+        // The Kendo MultiSelect with serverFiltering=true does not reliably sync chip removals
+        // back to the underlying <select> element, so removed items still get submitted with the
+        // form. Rebuild the <select> from the widget value on every change to keep form submission
+        // in sync. The bind is guarded by a flag on the widget so that re-running this dom-ready
+        // script after an Ajax re-render (which may reuse the same widget instance) does not stack
+        // duplicate change handlers.
+        var script = "(function(){var attach=function(){var ms=$('#" + getMarkupId()
+                + "').data('kendoMultiSelect');if(!ms){setTimeout(attach,50);return;}"
+                + "if(ms._inceptionFreeTextSync){return;}ms._inceptionFreeTextSync=true;"
+                + "ms.bind('change',function(){var v=this.value();var s=$(this.element);"
+                + "s.empty();for(var i=0;i<v.length;i++){"
+                + "s.append($('<option selected></option>').val(v[i]).text(v[i]));}});};"
+                + "attach();})();";
+        aResponse.render(OnDomReadyHeaderItem.forScript(script));
+    }
+}

--- a/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/kendo/FreeTextMultiSelect.java
+++ b/inception/inception-support/src/main/java/de/tudarmstadt/ukp/inception/support/kendo/FreeTextMultiSelect.java
@@ -83,9 +83,11 @@ public abstract class FreeTextMultiSelect
         // form. Rebuild the <select> from the widget value on every change to keep form submission
         // in sync. The bind is guarded by a flag on the widget so that re-running this dom-ready
         // script after an Ajax re-render (which may reuse the same widget instance) does not stack
-        // duplicate change handlers.
-        var script = "(function(){var attach=function(){var ms=$('#" + getMarkupId()
-                + "').data('kendoMultiSelect');if(!ms){setTimeout(attach,50);return;}"
+        // duplicate change handlers. The poll for the widget is capped so that a widget which never
+        // initializes (e.g. it was hidden or removed by an Ajax update before the script ran) does
+        // not keep rescheduling for the lifetime of the page.
+        var script = "(function(){var tries=0;var attach=function(){var ms=$('#" + getMarkupId()
+                + "').data('kendoMultiSelect');if(!ms){if(++tries<100){setTimeout(attach,50);}return;}"
                 + "if(ms._inceptionFreeTextSync){return;}ms._inceptionFreeTextSync=true;"
                 + "ms.bind('change',function(){var v=this.value();var s=$(this.element);"
                 + "s.empty();for(var i=0;i<v.length;i++){"

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/GeneralSettingsPanel.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/GeneralSettingsPanel.java
@@ -23,9 +23,6 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.wicket.markup.head.IHeaderResponse;
-import org.apache.wicket.markup.head.OnDomReadyHeaderItem;
 import org.apache.wicket.markup.html.form.CheckBox;
 import org.apache.wicket.markup.html.form.RequiredTextField;
 import org.apache.wicket.markup.html.form.TextField;
@@ -36,16 +33,13 @@ import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.apache.wicket.validation.IValidatable;
 import org.apache.wicket.validation.IValidator;
 import org.apache.wicket.validation.ValidationError;
-import org.wicketstuff.jquery.core.JQueryBehavior;
-import org.wicketstuff.jquery.core.Options;
-import org.wicketstuff.kendo.ui.KendoDataSource;
 import org.wicketstuff.kendo.ui.form.combobox.ComboBox;
-import org.wicketstuff.kendo.ui.form.multiselect.lazy.MultiSelect;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
 import de.tudarmstadt.ukp.inception.kb.IriConstants;
 import de.tudarmstadt.ukp.inception.kb.KnowledgeBaseService;
 import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBaseProperties;
+import de.tudarmstadt.ukp.inception.support.kendo.FreeTextMultiSelect;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxFormComponentUpdatingBehavior;
 
 public class GeneralSettingsPanel
@@ -88,23 +82,8 @@ public class GeneralSettingsPanel
         add(basePrefixField("basePrefix", "kb.basePrefix"));
         add(createCheckbox("enabled", "kb.enabled"));
 
-        var additionalLanguages = new MultiSelect<String>("additionalLanguages")
+        var additionalLanguages = new FreeTextMultiSelect("additionalLanguages")
         {
-            @Override
-            protected void onConfigure(KendoDataSource aDataSource)
-            {
-                // This ensures that we get the user input in getChoices
-                aDataSource.set("serverFiltering", true);
-            }
-
-            @Override
-            public void onConfigure(JQueryBehavior aBehavior)
-            {
-                super.onConfigure(aBehavior);
-                aBehavior.setOption("filter", Options.asString("contains"));
-                aBehavior.setOption("autoClose", false);
-            }
-
             private static final long serialVersionUID = -7735027268669019571L;
 
             @Override
@@ -119,37 +98,7 @@ public class GeneralSettingsPanel
                 }
                 return choices;
             }
-
-            @Override
-            public void convertInput()
-            {
-                var input = getInputAsArray();
-                var list = new ArrayList<String>();
-                if (input != null) {
-                    list.addAll(asList(input));
-                    list.removeIf(StringUtils::isBlank);
-                }
-                this.setConvertedInput(list);
-            }
-
-            @Override
-            public void renderHead(IHeaderResponse response)
-            {
-                super.renderHead(response);
-                // The Kendo MultiSelect with serverFiltering=true does not reliably sync chip
-                // removals back to the underlying <select> element, so removed languages still
-                // get submitted with the form. Rebuild the <select> from the widget value on
-                // every change to keep form submission in sync.
-                var script = "(function(){var attach=function(){var ms=$('#" + getMarkupId()
-                        + "').data('kendoMultiSelect');if(!ms){setTimeout(attach,50);return;}"
-                        + "ms.bind('change',function(){var v=this.value();var s=$(this.element);"
-                        + "s.empty();for(var i=0;i<v.length;i++){"
-                        + "s.append($('<option selected></option>').val(v[i]).text(v[i]));}});};"
-                        + "attach();})();";
-                response.render(OnDomReadyHeaderItem.forScript(script));
-            }
         };
-        additionalLanguages.setOutputMarkupId(true);
         additionalLanguages.setModel(kbModel.bind("kb.additionalLanguages"));
         add(additionalLanguages);
     }

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/ProjectKnowledgeBasePanel.utf8.properties
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/ProjectKnowledgeBasePanel.utf8.properties
@@ -40,9 +40,8 @@ kb.iri.deprecationPropertyIri=Deprecation property IRI
 kb.iri.fullTextSearchIri=Full text search mode
 fullTextSearchIri.nullValid=Unknown / no full text search support
 kb.iri.basePrefix=Base Prefix
-kb.iri.defaultDataset=Default dataset
-kb.iri.additionalDatasets=Additional datasets
-kb.iri.additionalDatasets.load=Load available datasets
+kb.iri.datasets=Datasets
+kb.iri.datasets.load=Load available datasets
 
 kb.language=Language
 kb.supportConceptLinking=Supports Concept Linking

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/ProjectKnowledgeBasePanel.utf8.properties
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/ProjectKnowledgeBasePanel.utf8.properties
@@ -1,7 +1,7 @@
-# Licensed to the Technische Universität Darmstadt under one
+# Licensed to the Technische Universitï¿½t Darmstadt under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
-# regarding copyright ownership.  The Technische Universität Darmstadt 
+# regarding copyright ownership.  The Technische Universitï¿½t Darmstadt 
 # licenses this file to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.
@@ -41,6 +41,8 @@ kb.iri.fullTextSearchIri=Full text search mode
 fullTextSearchIri.nullValid=Unknown / no full text search support
 kb.iri.basePrefix=Base Prefix
 kb.iri.defaultDataset=Default dataset
+kb.iri.additionalDatasets=Additional datasets
+kb.iri.additionalDatasets.load=Load available datasets
 
 kb.language=Language
 kb.supportConceptLinking=Supports Concept Linking

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/QuerySettingsPanel.html
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/QuerySettingsPanel.html
@@ -58,7 +58,7 @@
       <select wicket:id="fullTextSearchIri" class="form-select" data-size="5"/>
     </div>
   </div>
-  <div class="row form-row" wicket:enclosure="datasets">
+  <div class="row form-row" wicket:id="datasetsContainer">
     <label class="col-form-label col-sm-3" wicket:for="datasets">
       <wicket:label key="kb.iri.datasets"/>
     </label>

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/QuerySettingsPanel.html
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/QuerySettingsPanel.html
@@ -58,6 +58,19 @@
       <select wicket:id="fullTextSearchIri" class="form-select" data-size="5"/>
     </div>
   </div>
+  <div class="row form-row" wicket:enclosure="datasets">
+    <label class="col-form-label col-sm-3" wicket:for="datasets">
+      <wicket:label key="kb.iri.datasets"/>
+    </label>
+    <div class="col-sm-9">
+      <div class="input-group">
+        <select wicket:id="datasets"/>
+        <a wicket:id="loadDatasets" class="btn btn-outline-secondary">
+          <i class="fas fa-magnifying-glass" aria-hidden="true"></i>
+        </a>
+      </div>
+    </div>
+  </div>
 </wicket:panel>
 </body>
 </html>

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/QuerySettingsPanel.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/QuerySettingsPanel.java
@@ -36,6 +36,7 @@ import org.apache.wicket.markup.html.form.CheckBox;
 import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.markup.html.form.LambdaChoiceRenderer;
 import org.apache.wicket.markup.html.form.NumberTextField;
+import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.CompoundPropertyModel;
@@ -69,6 +70,7 @@ public class QuerySettingsPanel
     private final TextField<Integer> queryLimitField;
     private final CheckBox maxQueryLimitCheckBox;
     private final CheckBox useFuzzyCheckBox;
+    private final WebMarkupContainer datasetsContainer;
     private final MultiSelect<String> datasetsField;
     private final CompoundPropertyModel<KnowledgeBaseWrapper> kbModel;
 
@@ -91,6 +93,14 @@ public class QuerySettingsPanel
         maxQueryLimitCheckBox = maxQueryLimitCheckbox("maxQueryLimit", Model.of(false));
         add(maxQueryLimitCheckBox);
         add(ftsField("fullTextSearchIri", "kb.fullTextSearchIri"));
+
+        // The datasets field and its "scan" button are refreshed together via an explicit
+        // container. A wicket:enclosure must not be used here: refreshing an enclosed component via
+        // Ajax re-renders the enclosure but does not rebind the Ajax click handler of the sibling
+        // button, so the button would stop working after the first refresh.
+        datasetsContainer = new WebMarkupContainer("datasetsContainer");
+        datasetsContainer.setOutputMarkupId(true);
+        add(datasetsContainer);
 
         datasetsField = new FreeTextMultiSelect("datasets")
         {
@@ -118,7 +128,7 @@ public class QuerySettingsPanel
         // defaultDatasetIri field and only the remaining ones in the additionalDatasetIris.
         datasetsField.setModel(LambdaModel.of(this::getDatasets, this::setDatasets));
         datasetsField.add(this::validateDatasets);
-        add(datasetsField);
+        datasetsContainer.add(datasetsField);
 
         // Enumerating the named graphs requires a connection to the endpoint, which is only
         // available once the knowledge base has been saved (i.e. registered).
@@ -127,7 +137,7 @@ public class QuerySettingsPanel
                 .visibleWhen(() -> kbModel.getObject().getKb().getRepositoryId() != null));
         loadDatasetsButton.add(new AttributeModifier("title",
                 new StringResourceModel("kb.iri.datasets.load", this)));
-        add(loadDatasetsButton);
+        datasetsContainer.add(loadDatasetsButton);
     }
 
     @Override
@@ -139,7 +149,7 @@ public class QuerySettingsPanel
             // The discovered graphs belong to the previous endpoint - drop them so we do not offer
             // datasets that may not exist on the new endpoint.
             availableDatasets.clear();
-            event.getTarget().add(datasetsField);
+            event.getTarget().add(datasetsContainer);
         }
     }
 
@@ -157,7 +167,7 @@ public class QuerySettingsPanel
             error("Unable to load graphs from the endpoint: " + e.getMessage());
         }
 
-        aTarget.add(datasetsField);
+        aTarget.add(datasetsContainer);
         aTarget.addChildren(getPage(), IFeedback.class);
     }
 
@@ -175,8 +185,7 @@ public class QuerySettingsPanel
     private void setDatasets(Collection<String> aDatasets)
     {
         var kb = kbModel.getObject().getKb();
-        var datasets = aDatasets != null ? new ArrayList<>(new LinkedHashSet<>(aDatasets))
-                : new ArrayList<String>();
+        var datasets = aDatasets != null ? new ArrayList<>(aDatasets) : new ArrayList<String>();
         if (datasets.isEmpty()) {
             kb.setDefaultDatasetIri(null);
             kb.setAdditionalDatasetIris(emptyList());

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/QuerySettingsPanel.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/QuerySettingsPanel.java
@@ -18,10 +18,20 @@
 package de.tudarmstadt.ukp.inception.ui.kb.project;
 
 import static de.tudarmstadt.ukp.inception.kb.IriConstants.getFtsBackendName;
+import static java.util.Collections.emptyList;
 import static java.util.Comparator.comparing;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.ajax.markup.html.form.AjaxCheckBox;
+import org.apache.wicket.event.IEvent;
+import org.apache.wicket.feedback.IFeedback;
 import org.apache.wicket.markup.html.form.CheckBox;
 import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.markup.html.form.LambdaChoiceRenderer;
@@ -30,15 +40,23 @@ import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.LambdaModel;
 import org.apache.wicket.model.Model;
+import org.apache.wicket.model.StringResourceModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
+import org.apache.wicket.validation.IValidatable;
+import org.apache.wicket.validation.Validatable;
 import org.eclipse.rdf4j.model.IRI;
+import org.wicketstuff.kendo.ui.form.multiselect.lazy.MultiSelect;
 
 import de.tudarmstadt.ukp.inception.kb.IriConstants;
 import de.tudarmstadt.ukp.inception.kb.KnowledgeBaseService;
 import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBaseProperties;
 import de.tudarmstadt.ukp.inception.kb.config.KnowledgeBasePropertiesImpl;
+import de.tudarmstadt.ukp.inception.support.kendo.FreeTextMultiSelect;
+import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxLink;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaBehavior;
+import de.tudarmstadt.ukp.inception.ui.kb.project.validators.Validators;
 
 public class QuerySettingsPanel
     extends Panel
@@ -51,7 +69,12 @@ public class QuerySettingsPanel
     private final TextField<Integer> queryLimitField;
     private final CheckBox maxQueryLimitCheckBox;
     private final CheckBox useFuzzyCheckBox;
+    private final MultiSelect<String> datasetsField;
     private final CompoundPropertyModel<KnowledgeBaseWrapper> kbModel;
+
+    // Named graphs fetched on-demand from the endpoint to offer as choices in addition to any IRIs
+    // the user enters manually.
+    private final List<String> availableDatasets = new ArrayList<>();
 
     public QuerySettingsPanel(String id, CompoundPropertyModel<KnowledgeBaseWrapper> aModel)
     {
@@ -68,6 +91,109 @@ public class QuerySettingsPanel
         maxQueryLimitCheckBox = maxQueryLimitCheckbox("maxQueryLimit", Model.of(false));
         add(maxQueryLimitCheckBox);
         add(ftsField("fullTextSearchIri", "kb.fullTextSearchIri"));
+
+        datasetsField = new FreeTextMultiSelect("datasets")
+        {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            protected List<String> getChoices(String aInput)
+            {
+                // There is no fixed vocabulary of dataset IRIs. We offer the graphs fetched from
+                // the endpoint (if any) plus whatever has been entered so far, and allow the user
+                // to add arbitrary IRIs via the current input.
+                var choices = new LinkedHashSet<>(getModelObject());
+                choices.addAll(availableDatasets);
+                var result = new ArrayList<>(choices);
+                if (isNotBlank(aInput)) {
+                    result.remove(aInput);
+                    result.add(0, aInput);
+                }
+                return result;
+            }
+        };
+        // The legacy "default dataset" has no special role at query time - it is merged into the
+        // query the same way as the additional datasets. So we present a single combined "Datasets"
+        // field. For backwards compatibility we keep storing the first dataset in the legacy
+        // defaultDatasetIri field and only the remaining ones in the additionalDatasetIris.
+        datasetsField.setModel(LambdaModel.of(this::getDatasets, this::setDatasets));
+        datasetsField.add(this::validateDatasets);
+        add(datasetsField);
+
+        // Enumerating the named graphs requires a connection to the endpoint, which is only
+        // available once the knowledge base has been saved (i.e. registered).
+        var loadDatasetsButton = new LambdaAjaxLink("loadDatasets", this::actionLoadDatasets);
+        loadDatasetsButton.add(LambdaBehavior
+                .visibleWhen(() -> kbModel.getObject().getKb().getRepositoryId() != null));
+        loadDatasetsButton.add(new AttributeModifier("title",
+                new StringResourceModel("kb.iri.datasets.load", this)));
+        add(loadDatasetsButton);
+    }
+
+    @Override
+    public void onEvent(IEvent<?> aEvent)
+    {
+        super.onEvent(aEvent);
+
+        if (aEvent.getPayload() instanceof RemoteRepositoryUrlChangedEvent event) {
+            // The discovered graphs belong to the previous endpoint - drop them so we do not offer
+            // datasets that may not exist on the new endpoint.
+            availableDatasets.clear();
+            event.getTarget().add(datasetsField);
+        }
+    }
+
+    private void actionLoadDatasets(AjaxRequestTarget aTarget)
+    {
+        var kb = kbModel.getObject().getKb();
+
+        try {
+            availableDatasets.clear();
+            availableDatasets.addAll(kbService.listDatasets(kb));
+            success("Loaded [" + availableDatasets.size() + "] graph(s) from the endpoint.");
+        }
+        catch (RuntimeException e) {
+            availableDatasets.clear();
+            error("Unable to load graphs from the endpoint: " + e.getMessage());
+        }
+
+        aTarget.add(datasetsField);
+        aTarget.addChildren(getPage(), IFeedback.class);
+    }
+
+    private Collection<String> getDatasets()
+    {
+        var kb = kbModel.getObject().getKb();
+        var datasets = new LinkedHashSet<String>();
+        if (isNotBlank(kb.getDefaultDatasetIri())) {
+            datasets.add(kb.getDefaultDatasetIri());
+        }
+        datasets.addAll(kb.getAdditionalDatasetIris());
+        return datasets;
+    }
+
+    private void setDatasets(Collection<String> aDatasets)
+    {
+        var kb = kbModel.getObject().getKb();
+        var datasets = aDatasets != null ? new ArrayList<>(new LinkedHashSet<>(aDatasets))
+                : new ArrayList<String>();
+        if (datasets.isEmpty()) {
+            kb.setDefaultDatasetIri(null);
+            kb.setAdditionalDatasetIris(emptyList());
+        }
+        else {
+            kb.setDefaultDatasetIri(datasets.get(0));
+            kb.setAdditionalDatasetIris(datasets.subList(1, datasets.size()));
+        }
+    }
+
+    private void validateDatasets(IValidatable<Collection<String>> aValidatable)
+    {
+        for (var iri : aValidatable.getValue()) {
+            var validatable = new Validatable<String>(iri);
+            Validators.IRI_VALIDATOR.validate(validatable);
+            validatable.getErrors().forEach(aValidatable::error);
+        }
     }
 
     private CheckBox maxQueryLimitCheckbox(String id, IModel<Boolean> aModel)

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/RemoteRepositoryUrlChangedEvent.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/RemoteRepositoryUrlChangedEvent.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.kb.project;
+
+import org.apache.wicket.ajax.AjaxRequestTarget;
+
+/**
+ * Broadcast when the URL of a remote knowledge base is changed. Components that derive choices from
+ * the endpoint (e.g. the datasets field) can listen for this to drop now-stale information.
+ */
+public class RemoteRepositoryUrlChangedEvent
+{
+    private final AjaxRequestTarget target;
+
+    public RemoteRepositoryUrlChangedEvent(AjaxRequestTarget aTarget)
+    {
+        target = aTarget;
+    }
+
+    public AjaxRequestTarget getTarget()
+    {
+        return target;
+    }
+}

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/remote/RemoteRepositorySettingsPanel.html
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/remote/RemoteRepositorySettingsPanel.html
@@ -48,19 +48,6 @@
       </div>
     </div>
     <div wicket:id="authenticationTraitsEditor"/>
-    <div class="row form-row" wicket:enclosure="datasets">
-      <label class="col-form-label col-sm-3" wicket:for="datasets">
-        <wicket:label key="kb.iri.datasets" />
-      </label>
-      <div class="col-sm-9">
-        <div class="input-group">
-          <select wicket:id="datasets"/>
-          <a wicket:id="loadDatasets" class="btn btn-outline-secondary">
-            <i class="fas fa-magnifying-glass" aria-hidden="true"></i>
-          </a>
-        </div>
-      </div>
-    </div>
   </wicket:panel>
 </body>
 

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/remote/RemoteRepositorySettingsPanel.html
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/remote/RemoteRepositorySettingsPanel.html
@@ -48,21 +48,13 @@
       </div>
     </div>
     <div wicket:id="authenticationTraitsEditor"/>
-    <div class="row form-row" wicket:enclosure="defaultDataset">
-      <label class="col-form-label col-sm-3" wicket:for="defaultDataset">
-        <wicket:label key="kb.iri.defaultDataset" />
-      </label>
-      <div class="col-sm-9">
-        <input type="text" wicket:id="defaultDataset" class="form-control" />
-      </div>
-    </div>
-    <div class="row form-row" wicket:enclosure="additionalDatasets">
-      <label class="col-form-label col-sm-3" wicket:for="additionalDatasets">
-        <wicket:label key="kb.iri.additionalDatasets" />
+    <div class="row form-row" wicket:enclosure="datasets">
+      <label class="col-form-label col-sm-3" wicket:for="datasets">
+        <wicket:label key="kb.iri.datasets" />
       </label>
       <div class="col-sm-9">
         <div class="input-group">
-          <select wicket:id="additionalDatasets"/>
+          <select wicket:id="datasets"/>
           <a wicket:id="loadDatasets" class="btn btn-outline-secondary">
             <i class="fas fa-magnifying-glass" aria-hidden="true"></i>
           </a>

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/remote/RemoteRepositorySettingsPanel.html
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/remote/RemoteRepositorySettingsPanel.html
@@ -56,6 +56,19 @@
         <input type="text" wicket:id="defaultDataset" class="form-control" />
       </div>
     </div>
+    <div class="row form-row" wicket:enclosure="additionalDatasets">
+      <label class="col-form-label col-sm-3" wicket:for="additionalDatasets">
+        <wicket:label key="kb.iri.additionalDatasets" />
+      </label>
+      <div class="col-sm-9">
+        <div class="input-group">
+          <select wicket:id="additionalDatasets"/>
+          <a wicket:id="loadDatasets" class="btn btn-outline-secondary">
+            <i class="fas fa-magnifying-glass" aria-hidden="true"></i>
+          </a>
+        </div>
+      </div>
+    </div>
   </wicket:panel>
 </body>
 

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/remote/RemoteRepositorySettingsPanel.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/remote/RemoteRepositorySettingsPanel.java
@@ -20,11 +20,22 @@ package de.tudarmstadt.ukp.inception.ui.kb.project.remote;
 import static de.tudarmstadt.ukp.inception.security.client.auth.AuthenticationType.BASIC;
 import static de.tudarmstadt.ukp.inception.security.client.auth.AuthenticationType.OAUTH_CLIENT_CREDENTIALS;
 import static de.tudarmstadt.ukp.inception.support.lambda.HtmlElementEvents.CHANGE_EVENT;
+import static de.tudarmstadt.ukp.inception.support.lambda.LambdaBehavior.visibleWhen;
 import static java.util.Arrays.asList;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.feedback.IFeedback;
+import org.apache.wicket.markup.head.IHeaderResponse;
+import org.apache.wicket.markup.head.OnDomReadyHeaderItem;
 import org.apache.wicket.markup.html.form.CheckBox;
 import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.markup.html.form.EnumChoiceRenderer;
@@ -34,8 +45,19 @@ import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
+import org.apache.wicket.model.StringResourceModel;
+import org.apache.wicket.spring.injection.annot.SpringBean;
+import org.apache.wicket.validation.IValidatable;
+import org.apache.wicket.validation.ValidationError;
+import org.eclipse.rdf4j.model.util.URIUtil;
+import org.wicketstuff.jquery.core.JQueryBehavior;
+import org.wicketstuff.jquery.core.Options;
+import org.wicketstuff.kendo.ui.KendoDataSource;
+import org.wicketstuff.kendo.ui.form.multiselect.lazy.MultiSelect;
 
+import de.tudarmstadt.ukp.inception.kb.KnowledgeBaseService;
 import de.tudarmstadt.ukp.inception.kb.yaml.KnowledgeBaseProfile;
+import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxLink;
 import de.tudarmstadt.ukp.inception.security.client.auth.AuthenticationTraitsEditor;
 import de.tudarmstadt.ukp.inception.security.client.auth.AuthenticationType;
 import de.tudarmstadt.ukp.inception.security.client.auth.NoAuthenticationTraitsEditor;
@@ -54,12 +76,19 @@ public class RemoteRepositorySettingsPanel
 
     private static final String CID_AUTHENTICATION_TRAITS_EDITOR = "authenticationTraitsEditor";
 
+    private @SpringBean KnowledgeBaseService kbService;
+
     private final TextField<String> urlField;
     private final CheckBox skipSslValidation;
     private final TextField<String> defaultDatasetField;
+    private final MultiSelect<String> additionalDatasetsField;
     private final DropDownChoice<AuthenticationType> authenticationType;
 
     private AuthenticationTraitsEditor<?> authenticationTraitsEditor;
+
+    // Named graphs fetched on-demand from the remote endpoint to offer as choices in addition to
+    // any IRIs the user enters manually.
+    private final List<String> availableDatasets = new ArrayList<>();
 
     public RemoteRepositorySettingsPanel(String aId,
             CompoundPropertyModel<KnowledgeBaseWrapper> kbModel,
@@ -88,6 +117,114 @@ public class RemoteRepositorySettingsPanel
                 kbModel.bind("kb.defaultDatasetIri"));
         defaultDatasetField.add(Validators.IRI_VALIDATOR);
         queue(defaultDatasetField);
+
+        additionalDatasetsField = new MultiSelect<String>("additionalDatasets")
+        {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            protected void onConfigure(KendoDataSource aDataSource)
+            {
+                // This ensures that we get the user input in getChoices
+                aDataSource.set("serverFiltering", true);
+            }
+
+            @Override
+            public void onConfigure(JQueryBehavior aBehavior)
+            {
+                super.onConfigure(aBehavior);
+                aBehavior.setOption("filter", Options.asString("contains"));
+                aBehavior.setOption("autoClose", false);
+            }
+
+            @Override
+            protected List<String> getChoices(String aInput)
+            {
+                // There is no fixed vocabulary of dataset IRIs. We offer the graphs fetched from
+                // the
+                // endpoint (if any) plus whatever has been entered so far, and allow the user to
+                // add
+                // arbitrary IRIs via the current input.
+                var choices = new LinkedHashSet<>(getModelObject());
+                choices.addAll(availableDatasets);
+                var result = new ArrayList<>(choices);
+                if (isNotBlank(aInput)) {
+                    result.remove(aInput);
+                    result.add(0, aInput);
+                }
+                return result;
+            }
+
+            @Override
+            public void convertInput()
+            {
+                var input = getInputAsArray();
+                var list = new ArrayList<String>();
+                if (input != null) {
+                    list.addAll(asList(input));
+                    list.removeIf(StringUtils::isBlank);
+                }
+                setConvertedInput(list);
+            }
+
+            @Override
+            public void renderHead(IHeaderResponse response)
+            {
+                super.renderHead(response);
+                // The Kendo MultiSelect with serverFiltering=true does not reliably sync chip
+                // removals back to the underlying <select> element, so removed items still get
+                // submitted with the form. Rebuild the <select> from the widget value on every
+                // change to keep form submission in sync.
+                var script = "(function(){var attach=function(){var ms=$('#" + getMarkupId()
+                        + "').data('kendoMultiSelect');if(!ms){setTimeout(attach,50);return;}"
+                        + "ms.bind('change',function(){var v=this.value();var s=$(this.element);"
+                        + "s.empty();for(var i=0;i<v.length;i++){"
+                        + "s.append($('<option selected></option>').val(v[i]).text(v[i]));}});};"
+                        + "attach();})();";
+                response.render(OnDomReadyHeaderItem.forScript(script));
+            }
+        };
+        additionalDatasetsField.setOutputMarkupId(true);
+        additionalDatasetsField.setModel(kbModel.bind("kb.additionalDatasetIris"));
+        additionalDatasetsField.add(this::validateAdditionalDatasets);
+        queue(additionalDatasetsField);
+
+        // Enumerating the named graphs requires a connection to the endpoint, which is only
+        // available once the knowledge base has been saved (i.e. registered).
+        var loadDatasetsButton = new LambdaAjaxLink("loadDatasets", this::actionLoadDatasets);
+        loadDatasetsButton
+                .add(visibleWhen(() -> getModel().getObject().getKb().getRepositoryId() != null));
+        loadDatasetsButton.add(new AttributeModifier("title",
+                new StringResourceModel("kb.iri.additionalDatasets.load", this)));
+        queue(loadDatasetsButton);
+    }
+
+    private void actionLoadDatasets(AjaxRequestTarget aTarget)
+    {
+        var kb = getModel().getObject().getKb();
+
+        try {
+            availableDatasets.clear();
+            availableDatasets.addAll(kbService.listDatasets(kb));
+            success("Loaded [" + availableDatasets.size() + "] graph(s) from the endpoint.");
+        }
+        catch (RuntimeException e) {
+            availableDatasets.clear();
+            error("Unable to load graphs from the endpoint: " + e.getMessage());
+        }
+
+        aTarget.add(additionalDatasetsField);
+        aTarget.addChildren(getPage(), IFeedback.class);
+    }
+
+    private void validateAdditionalDatasets(IValidatable<Collection<String>> aValidatable)
+    {
+        for (var iri : aValidatable.getValue()) {
+            if (!URIUtil.isValidURIReference(iri)) {
+                aValidatable.error(
+                        new ValidationError().setMessage("[" + iri + "] is not a valid IRI."));
+            }
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/remote/RemoteRepositorySettingsPanel.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/remote/RemoteRepositorySettingsPanel.java
@@ -22,6 +22,7 @@ import static de.tudarmstadt.ukp.inception.security.client.auth.AuthenticationTy
 import static de.tudarmstadt.ukp.inception.support.lambda.HtmlElementEvents.CHANGE_EVENT;
 import static de.tudarmstadt.ukp.inception.support.lambda.LambdaBehavior.visibleWhen;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 import java.util.ArrayList;
@@ -44,6 +45,7 @@ import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
+import org.apache.wicket.model.LambdaModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.model.StringResourceModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
@@ -80,8 +82,7 @@ public class RemoteRepositorySettingsPanel
 
     private final TextField<String> urlField;
     private final CheckBox skipSslValidation;
-    private final TextField<String> defaultDatasetField;
-    private final MultiSelect<String> additionalDatasetsField;
+    private final MultiSelect<String> datasetsField;
     private final DropDownChoice<AuthenticationType> authenticationType;
 
     private AuthenticationTraitsEditor<?> authenticationTraitsEditor;
@@ -113,12 +114,7 @@ public class RemoteRepositorySettingsPanel
         skipSslValidation.setOutputMarkupPlaceholderTag(true);
         queue(skipSslValidation);
 
-        defaultDatasetField = new TextField<>("defaultDataset",
-                kbModel.bind("kb.defaultDatasetIri"));
-        defaultDatasetField.add(Validators.IRI_VALIDATOR);
-        queue(defaultDatasetField);
-
-        additionalDatasetsField = new MultiSelect<String>("additionalDatasets")
+        datasetsField = new MultiSelect<String>("datasets")
         {
             private static final long serialVersionUID = 1L;
 
@@ -184,10 +180,14 @@ public class RemoteRepositorySettingsPanel
                 response.render(OnDomReadyHeaderItem.forScript(script));
             }
         };
-        additionalDatasetsField.setOutputMarkupId(true);
-        additionalDatasetsField.setModel(kbModel.bind("kb.additionalDatasetIris"));
-        additionalDatasetsField.add(this::validateAdditionalDatasets);
-        queue(additionalDatasetsField);
+        datasetsField.setOutputMarkupId(true);
+        // The legacy "default dataset" has no special role at query time - it is merged into the
+        // query the same way as the additional datasets. So we present a single combined "Datasets"
+        // field. For backwards compatibility we keep storing the first dataset in the legacy
+        // defaultDatasetIri field and only the remaining ones in the additionalDatasetIris.
+        datasetsField.setModel(LambdaModel.of(this::getDatasets, this::setDatasets));
+        datasetsField.add(this::validateDatasets);
+        queue(datasetsField);
 
         // Enumerating the named graphs requires a connection to the endpoint, which is only
         // available once the knowledge base has been saved (i.e. registered).
@@ -195,7 +195,7 @@ public class RemoteRepositorySettingsPanel
         loadDatasetsButton
                 .add(visibleWhen(() -> getModel().getObject().getKb().getRepositoryId() != null));
         loadDatasetsButton.add(new AttributeModifier("title",
-                new StringResourceModel("kb.iri.additionalDatasets.load", this)));
+                new StringResourceModel("kb.iri.datasets.load", this)));
         queue(loadDatasetsButton);
     }
 
@@ -213,11 +213,37 @@ public class RemoteRepositorySettingsPanel
             error("Unable to load graphs from the endpoint: " + e.getMessage());
         }
 
-        aTarget.add(additionalDatasetsField);
+        aTarget.add(datasetsField);
         aTarget.addChildren(getPage(), IFeedback.class);
     }
 
-    private void validateAdditionalDatasets(IValidatable<Collection<String>> aValidatable)
+    private Collection<String> getDatasets()
+    {
+        var kb = getModel().getObject().getKb();
+        var datasets = new LinkedHashSet<String>();
+        if (isNotBlank(kb.getDefaultDatasetIri())) {
+            datasets.add(kb.getDefaultDatasetIri());
+        }
+        datasets.addAll(kb.getAdditionalDatasetIris());
+        return datasets;
+    }
+
+    private void setDatasets(Collection<String> aDatasets)
+    {
+        var kb = getModel().getObject().getKb();
+        var datasets = aDatasets != null ? new ArrayList<>(new LinkedHashSet<>(aDatasets))
+                : new ArrayList<String>();
+        if (datasets.isEmpty()) {
+            kb.setDefaultDatasetIri(null);
+            kb.setAdditionalDatasetIris(emptyList());
+        }
+        else {
+            kb.setDefaultDatasetIri(datasets.get(0));
+            kb.setAdditionalDatasetIris(datasets.subList(1, datasets.size()));
+        }
+    }
+
+    private void validateDatasets(IValidatable<Collection<String>> aValidatable)
     {
         for (var iri : aValidatable.getValue()) {
             if (!URIUtil.isValidURIReference(iri)) {

--- a/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/remote/RemoteRepositorySettingsPanel.java
+++ b/inception/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/project/remote/RemoteRepositorySettingsPanel.java
@@ -20,23 +20,12 @@ package de.tudarmstadt.ukp.inception.ui.kb.project.remote;
 import static de.tudarmstadt.ukp.inception.security.client.auth.AuthenticationType.BASIC;
 import static de.tudarmstadt.ukp.inception.security.client.auth.AuthenticationType.OAUTH_CLIENT_CREDENTIALS;
 import static de.tudarmstadt.ukp.inception.support.lambda.HtmlElementEvents.CHANGE_EVENT;
-import static de.tudarmstadt.ukp.inception.support.lambda.LambdaBehavior.visibleWhen;
 import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
-import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang3.StringUtils;
-import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.ajax.AjaxRequestTarget;
-import org.apache.wicket.feedback.IFeedback;
-import org.apache.wicket.markup.head.IHeaderResponse;
-import org.apache.wicket.markup.head.OnDomReadyHeaderItem;
+import org.apache.wicket.event.Broadcast;
 import org.apache.wicket.markup.html.form.CheckBox;
 import org.apache.wicket.markup.html.form.DropDownChoice;
 import org.apache.wicket.markup.html.form.EnumChoiceRenderer;
@@ -45,21 +34,9 @@ import org.apache.wicket.markup.html.form.TextField;
 import org.apache.wicket.markup.html.panel.Panel;
 import org.apache.wicket.model.CompoundPropertyModel;
 import org.apache.wicket.model.IModel;
-import org.apache.wicket.model.LambdaModel;
 import org.apache.wicket.model.Model;
-import org.apache.wicket.model.StringResourceModel;
-import org.apache.wicket.spring.injection.annot.SpringBean;
-import org.apache.wicket.validation.IValidatable;
-import org.apache.wicket.validation.ValidationError;
-import org.eclipse.rdf4j.model.util.URIUtil;
-import org.wicketstuff.jquery.core.JQueryBehavior;
-import org.wicketstuff.jquery.core.Options;
-import org.wicketstuff.kendo.ui.KendoDataSource;
-import org.wicketstuff.kendo.ui.form.multiselect.lazy.MultiSelect;
 
-import de.tudarmstadt.ukp.inception.kb.KnowledgeBaseService;
 import de.tudarmstadt.ukp.inception.kb.yaml.KnowledgeBaseProfile;
-import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxLink;
 import de.tudarmstadt.ukp.inception.security.client.auth.AuthenticationTraitsEditor;
 import de.tudarmstadt.ukp.inception.security.client.auth.AuthenticationType;
 import de.tudarmstadt.ukp.inception.security.client.auth.NoAuthenticationTraitsEditor;
@@ -69,6 +46,7 @@ import de.tudarmstadt.ukp.inception.security.client.auth.oauth.OAuthClientCreden
 import de.tudarmstadt.ukp.inception.security.client.auth.oauth.OAuthClientCredentialsAuthenticationTraitsEditor;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxFormComponentUpdatingBehavior;
 import de.tudarmstadt.ukp.inception.ui.kb.project.KnowledgeBaseWrapper;
+import de.tudarmstadt.ukp.inception.ui.kb.project.RemoteRepositoryUrlChangedEvent;
 import de.tudarmstadt.ukp.inception.ui.kb.project.validators.Validators;
 
 public class RemoteRepositorySettingsPanel
@@ -78,18 +56,11 @@ public class RemoteRepositorySettingsPanel
 
     private static final String CID_AUTHENTICATION_TRAITS_EDITOR = "authenticationTraitsEditor";
 
-    private @SpringBean KnowledgeBaseService kbService;
-
     private final TextField<String> urlField;
     private final CheckBox skipSslValidation;
-    private final MultiSelect<String> datasetsField;
     private final DropDownChoice<AuthenticationType> authenticationType;
 
     private AuthenticationTraitsEditor<?> authenticationTraitsEditor;
-
-    // Named graphs fetched on-demand from the remote endpoint to offer as choices in addition to
-    // any IRIs the user enters manually.
-    private final List<String> availableDatasets = new ArrayList<>();
 
     public RemoteRepositorySettingsPanel(String aId,
             CompoundPropertyModel<KnowledgeBaseWrapper> kbModel,
@@ -99,6 +70,8 @@ public class RemoteRepositorySettingsPanel
 
         urlField = new RequiredTextField<>("url");
         urlField.add(Validators.URL_VALIDATOR);
+        urlField.add(
+                new LambdaAjaxFormComponentUpdatingBehavior(CHANGE_EVENT, this::actionUrlChanged));
         queue(urlField);
 
         authenticationType = new DropDownChoice<>("authenticationType",
@@ -113,144 +86,13 @@ public class RemoteRepositorySettingsPanel
         skipSslValidation = new CheckBox("skipSslValidation", kbModel.bind("kb.skipSslValidation"));
         skipSslValidation.setOutputMarkupPlaceholderTag(true);
         queue(skipSslValidation);
-
-        datasetsField = new MultiSelect<String>("datasets")
-        {
-            private static final long serialVersionUID = 1L;
-
-            @Override
-            protected void onConfigure(KendoDataSource aDataSource)
-            {
-                // This ensures that we get the user input in getChoices
-                aDataSource.set("serverFiltering", true);
-            }
-
-            @Override
-            public void onConfigure(JQueryBehavior aBehavior)
-            {
-                super.onConfigure(aBehavior);
-                aBehavior.setOption("filter", Options.asString("contains"));
-                aBehavior.setOption("autoClose", false);
-            }
-
-            @Override
-            protected List<String> getChoices(String aInput)
-            {
-                // There is no fixed vocabulary of dataset IRIs. We offer the graphs fetched from
-                // the
-                // endpoint (if any) plus whatever has been entered so far, and allow the user to
-                // add
-                // arbitrary IRIs via the current input.
-                var choices = new LinkedHashSet<>(getModelObject());
-                choices.addAll(availableDatasets);
-                var result = new ArrayList<>(choices);
-                if (isNotBlank(aInput)) {
-                    result.remove(aInput);
-                    result.add(0, aInput);
-                }
-                return result;
-            }
-
-            @Override
-            public void convertInput()
-            {
-                var input = getInputAsArray();
-                var list = new ArrayList<String>();
-                if (input != null) {
-                    list.addAll(asList(input));
-                    list.removeIf(StringUtils::isBlank);
-                }
-                setConvertedInput(list);
-            }
-
-            @Override
-            public void renderHead(IHeaderResponse response)
-            {
-                super.renderHead(response);
-                // The Kendo MultiSelect with serverFiltering=true does not reliably sync chip
-                // removals back to the underlying <select> element, so removed items still get
-                // submitted with the form. Rebuild the <select> from the widget value on every
-                // change to keep form submission in sync.
-                var script = "(function(){var attach=function(){var ms=$('#" + getMarkupId()
-                        + "').data('kendoMultiSelect');if(!ms){setTimeout(attach,50);return;}"
-                        + "ms.bind('change',function(){var v=this.value();var s=$(this.element);"
-                        + "s.empty();for(var i=0;i<v.length;i++){"
-                        + "s.append($('<option selected></option>').val(v[i]).text(v[i]));}});};"
-                        + "attach();})();";
-                response.render(OnDomReadyHeaderItem.forScript(script));
-            }
-        };
-        datasetsField.setOutputMarkupId(true);
-        // The legacy "default dataset" has no special role at query time - it is merged into the
-        // query the same way as the additional datasets. So we present a single combined "Datasets"
-        // field. For backwards compatibility we keep storing the first dataset in the legacy
-        // defaultDatasetIri field and only the remaining ones in the additionalDatasetIris.
-        datasetsField.setModel(LambdaModel.of(this::getDatasets, this::setDatasets));
-        datasetsField.add(this::validateDatasets);
-        queue(datasetsField);
-
-        // Enumerating the named graphs requires a connection to the endpoint, which is only
-        // available once the knowledge base has been saved (i.e. registered).
-        var loadDatasetsButton = new LambdaAjaxLink("loadDatasets", this::actionLoadDatasets);
-        loadDatasetsButton
-                .add(visibleWhen(() -> getModel().getObject().getKb().getRepositoryId() != null));
-        loadDatasetsButton.add(new AttributeModifier("title",
-                new StringResourceModel("kb.iri.datasets.load", this)));
-        queue(loadDatasetsButton);
     }
 
-    private void actionLoadDatasets(AjaxRequestTarget aTarget)
+    private void actionUrlChanged(AjaxRequestTarget aTarget)
     {
-        var kb = getModel().getObject().getKb();
-
-        try {
-            availableDatasets.clear();
-            availableDatasets.addAll(kbService.listDatasets(kb));
-            success("Loaded [" + availableDatasets.size() + "] graph(s) from the endpoint.");
-        }
-        catch (RuntimeException e) {
-            availableDatasets.clear();
-            error("Unable to load graphs from the endpoint: " + e.getMessage());
-        }
-
-        aTarget.add(datasetsField);
-        aTarget.addChildren(getPage(), IFeedback.class);
-    }
-
-    private Collection<String> getDatasets()
-    {
-        var kb = getModel().getObject().getKb();
-        var datasets = new LinkedHashSet<String>();
-        if (isNotBlank(kb.getDefaultDatasetIri())) {
-            datasets.add(kb.getDefaultDatasetIri());
-        }
-        datasets.addAll(kb.getAdditionalDatasetIris());
-        return datasets;
-    }
-
-    private void setDatasets(Collection<String> aDatasets)
-    {
-        var kb = getModel().getObject().getKb();
-        var datasets = aDatasets != null ? new ArrayList<>(new LinkedHashSet<>(aDatasets))
-                : new ArrayList<String>();
-        if (datasets.isEmpty()) {
-            kb.setDefaultDatasetIri(null);
-            kb.setAdditionalDatasetIris(emptyList());
-        }
-        else {
-            kb.setDefaultDatasetIri(datasets.get(0));
-            kb.setAdditionalDatasetIris(datasets.subList(1, datasets.size()));
-        }
-    }
-
-    private void validateDatasets(IValidatable<Collection<String>> aValidatable)
-    {
-        for (var iri : aValidatable.getValue()) {
-            if (!URIUtil.isValidURIReference(iri)) {
-                aValidatable.error(
-                        new ValidationError().setMessage("[" + iri + "] is not a valid IRI."));
-            }
-        }
+        // The set of named graphs offered for selection depends on the endpoint. Notify interested
+        // components (e.g. the datasets field) that the URL changed so they can drop stale choices.
+        send(getPage(), Broadcast.BREADTH, new RemoteRepositoryUrlChangedEvent(aTarget));
     }
 
     @SuppressWarnings("unchecked")

--- a/inception/inception-ui-kb/src/main/resources/META-INF/asciidoc/user-guide/projects_knowledge-base.adoc
+++ b/inception/inception-ui-kb/src/main/resources/META-INF/asciidoc/user-guide/projects_knowledge-base.adoc
@@ -64,9 +64,11 @@ The remote knowledge bases, there are the following settings:
   help if the remote server is using a self-signed certificate. It should be avoided to use this
   option in production. Instead, better install the remote certificate into your Java environment
   so it can be validated. 
-* **Default dataset:** A SPARQL endpoint may server multiple datasets. This setting can be used to
-  restrict queries to a specific one. Consult with the operator of the SPARQL server to see which
-  datasets are available.
+* **Datasets:** A SPARQL endpoint may serve multiple datasets (named graphs). This setting can be
+  used to restrict queries to one or more specific datasets. You can enter the dataset IRIs manually
+  or use the **Load available datasets** button to discover the datasets available on the endpoint.
+  Consult with the operator of the SPARQL server if you are unsure which datasets are available.
+  If no dataset is selected, queries run against the default graph.
 
 NOTE: **Changing the URL of a remote KB currently only takes affect after {product-name} is restarted!**
       The updated URL will be shown in the settings, but queries will still be sent to the old URL until you restart {product-name}.

--- a/inception/inception-ui-kb/src/main/resources/META-INF/asciidoc/user-guide/projects_knowledge-base.adoc
+++ b/inception/inception-ui-kb/src/main/resources/META-INF/asciidoc/user-guide/projects_knowledge-base.adoc
@@ -70,12 +70,6 @@ The remote knowledge bases, there are the following settings:
   Consult with the operator of the SPARQL server if you are unsure which datasets are available.
   If no dataset is selected, queries run against the default graph.
 
-NOTE: **Changing the URL of a remote KB currently only takes affect after {product-name} is restarted!**
-      The updated URL will be shown in the settings, but queries will still be sent to the old URL until you restart {product-name}.
-      This also means that if you add, remove or change HTTP "Basic" authentication that are part of the URL, they will not
-      take effect until you restart. It is usually easier to delete the remote KB configuration and create it from scratch
-      with the new URL.
-
 === General settings
 
 * **Base prefix:** A base IRI that is used as a prefix when creating new concepts.


### PR DESCRIPTION
**What's in the PR**
- Add `KnowledgeBaseService.listDatasets()` method to enumerate named graphs from remote endpoints
- Implement `listDatasets()` with 30-second query timeout to prevent hangs on large datasets
- Add `additionalDatasetIris` field to KnowledgeBase entity with database table `knowledgebase_add_datasets`
- Add `additionalDatasetIris` to SPARQL query builder to include multiple datasets in queries
- Add `additionalDatasets` support to KnowledgeBaseProfile for YAML export/import
- Add export/import of additional dataset IRIs via KnowledgeBaseExporter
- Add Kendo MultiSelect widget for "Additional datasets" field in remote KB settings panel
- Add "Load available graphs" button (magnifying glass icon) to query endpoint and populate available datasets
- Restrict "Load available graphs" button visibility to saved (registered) knowledge bases only
- Validate each dataset IRI entry via RDF4J's URI validation
- Automatically deduplicate dataset IRIs via Set-backed model
- Add CSS rule to make Kendo multiselect flex properly inside Bootstrap input groups
- Add per-line IRI validation with descriptive error messages
- Add integration tests for `listDatasets()` method covering named graphs and empty cases
- Add UI labels: `kb.iri.additionalDatasets` and `kb.iri.additionalDatasets.load`

**How to test manually**
* Add additional datasets e.g. to MeSH

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
