### PR TITLE
#6135 - Searching a remote knowledge base for short terms shows an error instead of suggestions on Virtuoso

### DIFF
--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterVirtuoso.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterVirtuoso.java
@@ -108,10 +108,7 @@ public class FtsAdapterVirtuoso
             queryString = virtuosoStartsWithQuery(queryString);
         }
 
-        // If the query string was reduced to nothing, then the query should always return an
-        // empty
-        // result.
-        if (queryString.length() == 2) {
+        if (queryString.isBlank()) {
             builder.noResult();
         }
 
@@ -171,6 +168,10 @@ public class FtsAdapterVirtuoso
             // wildcard
             if (!value.endsWith(" ")) {
                 sanitizedValue = FtsAdapterVirtuoso.virtuosoStartsWithQuery(sanitizedValue);
+            }
+
+            if (isBlank(sanitizedValue)) {
+                continue;
             }
 
             valuePatterns.add(VAR_SUBJECT.has(VAR_MATCH_TERM_PROPERTY, VAR_MATCH_TERM).and(

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterWikidata.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterWikidata.java
@@ -111,11 +111,11 @@ public class FtsAdapterWikidata
         var language = kb.getDefaultLanguage() != null ? kb.getDefaultLanguage()
                 : FALLBACK_LANGUAGE;
 
-        if (aPrefixQuery.isEmpty()) {
+        var sanitizedValue = builder.sanitizeQueryString_FTS(aPrefixQuery);
+
+        if (isBlank(sanitizedValue)) {
             builder.noResult();
         }
-
-        var sanitizedValue = builder.sanitizeQueryString_FTS(aPrefixQuery);
 
         builder.addPattern(PRIMARY, and( //
                 builder.bindMatchTermProperties(VAR_MATCH_TERM_PROPERTY),


### PR DESCRIPTION
**What's in the PR**
- Fix Virtuoso FTS adapter to properly detect and skip empty queries that result from token reduction when the minimum 4-character wildcard requirement drops short input terms
- Add post-reduction guard in Virtuoso withLabelMatchingAnyOf to skip empty values after wildcard reduction, consistent with other FTS adapters
- Fix Wikidata FTS adapter to check if the sanitized value is blank before passing it to the entity search service, preventing queries with only special-character input

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
