### PR TITLE
#6137 - Drop BabelNet KB profile

### DIFF
--- a/inception/inception-kb/src/main/resources/de/tudarmstadt/ukp/inception/kb/yaml/knowledgebase-profiles.yaml
+++ b/inception/inception-kb/src/main/resources/de/tudarmstadt/ukp/inception/kb/yaml/knowledgebase-profiles.yaml
@@ -60,33 +60,6 @@ agrovoc:
     author-name: Food and Agriculture Organization (FAO) of the United Nations
     website-url: http://www.fao.org/agrovoc/
 
-babel_net:
-  name: BabelNet
-  type: REMOTE
-  default-language: en
-  default-dataset: http://babelnet.org/rdf/
-  access:
-    access-url: http://babelnet.org/sparql/
-    full-text-search: bif:contains
-  mapping:
-    class: http://www.w3.org/2000/01/rdf-schema#Class
-    subclass-of: http://www.w3.org/2000/01/rdf-schema#subClassOf
-    instance-of: http://www.w3.org/1999/02/22-rdf-syntax-ns#type
-    label: http://www.w3.org/2000/01/rdf-schema#label
-    property-type: http://www.w3.org/1999/02/22-rdf-syntax-ns#Property
-    description: http://www.w3.org/2000/01/rdf-schema#comment
-    property-label: http://www.w3.org/2000/01/rdf-schema#label
-    property-description: http://www.w3.org/2000/01/rdf-schema#comment
-    subproperty-of: http://www.w3.org/2000/01/rdf-schema#subPropertyOf
-    deprecation-property: http://www.w3.org/2002/07/owl#deprecated
-  info:
-    description: |
-      BabelNet is a multilingual lexicalized semantic network and ontology that was automatically 
-      created by linking Wikipedia to WordNet.
-    host-institution-name: Linguistic Computing Laboratory at Sapienza University of Rome
-    author-name: Linguistic Computing Laboratory at Sapienza University of Rome
-    website-url: https://babelnet.org/
-
 db_pedia:
   name: DBpedia (German)
   type: REMOTE
@@ -180,7 +153,11 @@ yago:
   default-language: de
   access:
     access-url: https://yago-knowledge.org/sparql/query
-    # YAGO runs BlazeGraph these days and they seem not to have set up a full text index
+    # YAGO has migrated to a QLever endpoint at https://yago-knowledge.org/sparql/qlever - the old
+    # /sparql/query URL above now only serves the project website and no longer answers SPARQL.
+    # The QLever instance has no full text index built for YAGO (ql:contains-word returns nothing),
+    # so full text search remains disabled. Note also that the class mapping below uses owl:Class,
+    # whereas current YAGO models classes as rdfs:Class.
     # full-text-search: bif:contains
   mapping:
     class: http://www.w3.org/2002/07/owl#Class

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplImportExportIntegrationTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/KnowledgeBaseServiceImplImportExportIntegrationTest.java
@@ -221,7 +221,7 @@ public class KnowledgeBaseServiceImplImportExportIntegrationTest
         var outputFile = temporaryFolder.toPath().resolve("outputfile").toFile();
         kb.setType(RepositoryType.REMOTE);
         sut.registerKnowledgeBase(kb, sut.getRemoteConfig(KnowledgeBaseProfile
-                .readKnowledgeBaseProfiles().get("babel_net").getAccess().getAccessUrl()));
+                .readKnowledgeBaseProfiles().get("db_pedia").getAccess().getAccessUrl()));
 
         try (var os = new FileOutputStream(outputFile)) {
             sut.exportData(kb, RDFFormat.TURTLE, os);

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderGenericTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderGenericTest.java
@@ -52,8 +52,7 @@ public class SPARQLQueryBuilderGenericTest
     private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
     // YAGO seems to have problem atm 29-04-2023
-    private static final List<String> SKIPPED_PROFILES = asList("babel_net", "yago", "hpo",
-            "snomed-ct");
+    private static final List<String> SKIPPED_PROFILES = asList("yago", "hpo", "snomed-ct");
 
     public static List<KnowledgeBaseProfile> data() throws Exception
     {

--- a/inception/inception-project-initializers-wikidatalinking/src/main/java/de/tudarmstadt/ukp/inception/project/initializers/wikidatalinking/config/WikiDataLinkingProjectInitializersAutoConfiguration.java
+++ b/inception/inception-project-initializers-wikidatalinking/src/main/java/de/tudarmstadt/ukp/inception/project/initializers/wikidatalinking/config/WikiDataLinkingProjectInitializersAutoConfiguration.java
@@ -155,19 +155,6 @@ public class WikiDataLinkingProjectInitializersAutoConfiguration
 
     @ConditionalOnBean(KnowledgeBaseService.class)
     @Bean
-    public ProfileBasedKnowledgeBaseInitializer babelNetKnowledgeBaseInitializer(
-            KnowledgeBaseService aKbService)
-    {
-        var thumbnail = new PackageResourceReference(WikiDataKnowledgeBaseInitializer.class,
-                "Dictionary.svg");
-        return new ProfileBasedKnowledgeBaseInitializer(aKbService, PROFILES.get("babel_net"),
-                thumbnail)
-        {
-        };
-    }
-
-    @ConditionalOnBean(KnowledgeBaseService.class)
-    @Bean
     public ProfileBasedKnowledgeBaseInitializer dbPediaNetKnowledgeBaseInitializer(
             KnowledgeBaseService aKbService)
     {

--- a/inception/inception-ui-kb/src/main/resources/META-INF/asciidoc/user-guide/projects_knowledge-base.adoc
+++ b/inception/inception-ui-kb/src/main/resources/META-INF/asciidoc/user-guide/projects_knowledge-base.adoc
@@ -37,7 +37,7 @@ Alternatively, you can skip the step to create an empty KB to create a knowledge
 It is also always possible to import data from an RDF file after the creation of a KB. 
 It is also possible to multiple RDF files into the same KB, one after another.
 
-For remote KBs, INCEpTION provides the user with some pre-configured knowledge base such as WikiData, British Museum, BabelNet, DBPediaa or Yago.
+For remote KBs, INCEpTION provides the user with some pre-configured knowledge base such as WikiData, British Museum, DBPediaa or Yago.
 You can also set up a custom remote KB, in which case the user needs to provide the SPARQL endpoint URL for the knowledge base as in the figure below.
 
 [.thumb]


### PR DESCRIPTION
**What's in the PR**
- Remove BabelNet KB profile from knowledgebase-profiles.yaml
- Remove babelNetKnowledgeBaseInitializer bean from WikiDataLinkingProjectInitializersAutoConfiguration.java
- Update KnowledgeBaseServiceImplImportExportIntegrationTest to use db_pedia profile instead of babel_net
- Remove babel_net from skipped profiles list in SPARQLQueryBuilderGenericTest.java
- Remove BabelNet reference from user-guide documentation

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
