### PR TITLE
#6143 - Add ready-to-use EuroVoc and EU Corporate Bodies knowledge bases (EU Vocabularies / CELLAR)

### DIFF
--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/model/KnowledgeBase.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/model/KnowledgeBase.java
@@ -515,6 +515,7 @@ public class KnowledgeBase
 
         applyRootConcepts(aProfile);
         applyMapping(aProfile.getMapping());
+        applyAdditionalMatchingProperties(aProfile);
         applyAdditionalLanguages(aProfile);
         applyAdditionalDatasets(aProfile);
     }

--- a/inception/inception-kb/src/main/resources/de/tudarmstadt/ukp/inception/kb/yaml/knowledgebase-profiles.yaml
+++ b/inception/inception-kb/src/main/resources/de/tudarmstadt/ukp/inception/kb/yaml/knowledgebase-profiles.yaml
@@ -158,6 +158,86 @@ db_pedia:
   root-concepts:
     - http://www.w3.org/2002/07/owl#Thing
 
+eurovoc:
+  name: EuroVoc (EU Vocabularies / CELLAR)
+  type: REMOTE
+  default-language: en
+  access:
+    access-url: https://publications.europa.eu/webapi/rdf/sparql
+    full-text-search: bif:contains
+  mapping:
+    class: http://www.w3.org/2004/02/skos/core#Concept
+    subclass-of: http://www.w3.org/2004/02/skos/core#broader
+    instance-of: http://www.w3.org/1999/02/22-rdf-syntax-ns#type
+    label: http://www.w3.org/2004/02/skos/core#prefLabel
+    description: http://www.w3.org/2004/02/skos/core#definition
+    property-type: http://www.w3.org/1999/02/22-rdf-syntax-ns#Property
+    subproperty-of: http://www.w3.org/2000/01/rdf-schema#subPropertyOf
+    property-label: http://www.w3.org/2004/02/skos/core#prefLabel
+    property-description: http://www.w3.org/2004/02/skos/core#definition
+    deprecation-property: http://www.w3.org/2002/07/owl#deprecated
+  additional-matching-properties:
+    - http://www.w3.org/2004/02/skos/core#altLabel
+  info:
+    description: |
+      EuroVoc is the European Union's multilingual, multidisciplinary thesaurus covering the
+      activities of the EU, with particular emphasis on parliamentary and legal subject areas.
+      It contains roughly 7,000 concepts organised into 21 domains and 127 micro-thesauri, and
+      is available in all official EU languages. EuroVoc is maintained and published by the
+      Publications Office of the European Union and is used to index documents in EUR-Lex and
+      across other EU services.
+
+      This profile queries EuroVoc through CELLAR, the central content and metadata repository of
+      the Publications Office, via its public SPARQL endpoint. Concepts are exposed as SKOS
+      (skos:Concept / skos:broader / skos:prefLabel / skos:altLabel), making EuroVoc a natural
+      target for linking subject matter in legal documents (e.g. Akoma Ntoso / LegalDocML) to
+      canonical EU concept IRIs.
+
+      For more information, please consult <https://op.europa.eu/en/web/eu-vocabularies>.
+    host-institution-name: Publications Office of the European Union
+    author-name: Publications Office of the European Union
+    website-url: https://op.europa.eu/en/web/eu-vocabularies/eurovoc
+
+eu-corporate-bodies:
+  name: EU Corporate Bodies (EU Vocabularies / CELLAR)
+  type: REMOTE
+  default-language: en
+  access:
+    access-url: https://publications.europa.eu/webapi/rdf/sparql
+    full-text-search: bif:contains
+  mapping:
+    class: http://publications.europa.eu/ontology/euvoc#Corporate
+    subclass-of: http://www.w3.org/2004/02/skos/core#broader
+    instance-of: http://www.w3.org/1999/02/22-rdf-syntax-ns#type
+    label: http://www.w3.org/2004/02/skos/core#prefLabel
+    description: http://www.w3.org/2004/02/skos/core#definition
+    property-type: http://www.w3.org/1999/02/22-rdf-syntax-ns#Property
+    subproperty-of: http://www.w3.org/2000/01/rdf-schema#subPropertyOf
+    property-label: http://www.w3.org/2004/02/skos/core#prefLabel
+    property-description: http://www.w3.org/2004/02/skos/core#definition
+    deprecation-property: http://www.w3.org/2002/07/owl#deprecated
+  additional-matching-properties:
+    - http://www.w3.org/2004/02/skos/core#altLabel
+  info:
+    description: |
+      The Corporate Bodies Named Authority List (NAL) of the EU Vocabularies, covering EU
+      institutions, bodies, offices and agencies (e.g. the European Commission, the Council, the
+      European Parliament, EFSA, the European Central Bank) as well as historical and associated
+      bodies. It contains roughly 2,000 corporate bodies, each with a preferred label and
+      alternative labels (including acronyms such as "STECF" or "ECB") in the official EU
+      languages, organised into a broader/narrower hierarchy.
+
+      This profile queries the list through CELLAR, the central content and metadata repository of
+      the Publications Office, via its public SPARQL endpoint. Concepts are typed
+      euvoc:Corporate and carry SKOS labels (skos:prefLabel / skos:altLabel), making this a
+      natural target for linking institutional actors named in legal documents (e.g. Akoma Ntoso
+      / LegalDocML) to canonical EU corporate-body IRIs.
+
+      For more information, please consult <https://op.europa.eu/en/web/eu-vocabularies>.
+    host-institution-name: Publications Office of the European Union
+    author-name: Publications Office of the European Union
+    website-url: https://op.europa.eu/en/web/eu-vocabularies/concept-scheme/-/resource?uri=http://publications.europa.eu/resource/authority/corporate-body
+
 wikidata:
   name: Wikidata (direct mapping)
   type: REMOTE

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderGenericTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderGenericTest.java
@@ -58,9 +58,21 @@ public class SPARQLQueryBuilderGenericTest
     {
         var profiles = KnowledgeBaseProfile.readKnowledgeBaseProfiles();
 
+        // Optional focus filter: set INCEPTION_KB_TEST_PROFILES (env) or
+        // -Dinception.kb.test.profiles (system property) to a comma-separated list of profile ids
+        // to run the generic suite against only those profiles. Empty/unset = all profiles.
+        var focusEnv = System.getenv("INCEPTION_KB_TEST_PROFILES");
+        var focus = (focusEnv != null ? focusEnv
+                : System.getProperty("inception.kb.test.profiles", "")).trim();
+        var focusProfiles = focus.isEmpty() ? List.<String> of() : asList(focus.split("\\s*,\\s*"));
+
         var dataList = new ArrayList<KnowledgeBaseProfile>();
         for (var entry : profiles.entrySet()) {
-            if (SKIPPED_PROFILES.contains(entry.getKey())) {
+            if (!focusProfiles.isEmpty() && !focusProfiles.contains(entry.getKey())) {
+                continue;
+            }
+
+            if (focusProfiles.isEmpty() && SKIPPED_PROFILES.contains(entry.getKey())) {
                 continue;
             }
 

--- a/inception/inception-project-initializers-wikidatalinking/src/main/java/de/tudarmstadt/ukp/inception/project/initializers/wikidatalinking/config/WikiDataLinkingProjectInitializersAutoConfiguration.java
+++ b/inception/inception-project-initializers-wikidatalinking/src/main/java/de/tudarmstadt/ukp/inception/project/initializers/wikidatalinking/config/WikiDataLinkingProjectInitializersAutoConfiguration.java
@@ -180,6 +180,32 @@ public class WikiDataLinkingProjectInitializersAutoConfiguration
 
     @ConditionalOnBean(KnowledgeBaseService.class)
     @Bean
+    public ProfileBasedKnowledgeBaseInitializer euCorporateBodiesKnowledgeBaseInitializer(
+            KnowledgeBaseService aKbService)
+    {
+        var thumbnail = new PackageResourceReference(WikiDataKnowledgeBaseInitializer.class,
+                "GenericKnowledgeBase.svg");
+        return new ProfileBasedKnowledgeBaseInitializer(aKbService,
+                PROFILES.get("eu-corporate-bodies"), thumbnail)
+        {
+        };
+    }
+
+    @ConditionalOnBean(KnowledgeBaseService.class)
+    @Bean
+    public ProfileBasedKnowledgeBaseInitializer euroVocKnowledgeBaseInitializer(
+            KnowledgeBaseService aKbService)
+    {
+        var thumbnail = new PackageResourceReference(WikiDataKnowledgeBaseInitializer.class,
+                "GenericKnowledgeBase.svg");
+        return new ProfileBasedKnowledgeBaseInitializer(aKbService, PROFILES.get("eurovoc"),
+                thumbnail)
+        {
+        };
+    }
+
+    @ConditionalOnBean(KnowledgeBaseService.class)
+    @Bean
     public ProfileBasedKnowledgeBaseInitializer geneOntologyKnowledgeBaseInitializer(
             KnowledgeBaseService aKbService)
     {


### PR DESCRIPTION
**What's in the PR**
- Add EuroVoc remote knowledge base profile (EU Vocabularies / CELLAR SPARQL endpoint), mapped as SKOS with Virtuoso full-text search
- Add EU Corporate Bodies remote knowledge base profile (CELLAR), scoped via the euvoc:Corporate class
- Register project initializers for the EuroVoc and EU Corporate Bodies knowledge bases so they appear as ready-to-use options
- Fix KnowledgeBase.applyProfile to apply the profile's additional-matching-properties (e.g. skos:altLabel), which were previously dropped for profile-created knowledge bases
- Add an optional profile-focus filter to SPARQLQueryBuilderGenericTest (via INCEPTION_KB_TEST_PROFILES env var or inception.kb.test.profiles system property) to run the generic suite against selected profiles only

**How to test manually**
* Try the new profiles

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
