### PR TITLE
#6147 - Support FTS of Marklogic triple store

### DIFF
--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/IriConstants.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/IriConstants.java
@@ -50,6 +50,7 @@ public class IriConstants
     public static final String PREFIX_BLAZEGRAPH = "http://www.bigdata.com/rdf/search#";
     public static final String PREFIX_GRAPHDB = "http://www.ontotext.com/";
     public static final String PREFIX_QLEVER = "http://qlever.cs.uni-freiburg.de/builtin-functions/";
+    public static final String PREFIX_MARKLOGIC = "http://marklogic.com/cts#";
 
     public static final String UKP_WIKIDATA_SPARQL_ENDPOINT = "http://knowledgebase.ukp.informatik.tu-darmstadt.de:8890/sparql";
     public static final Set<String> IMPLICIT_NAMESPACES = Set.of(RDF.NAMESPACE, RDFS.NAMESPACE,
@@ -94,6 +95,7 @@ public class IriConstants
     public static final IRI FTS_BLAZEGRAPH;
     public static final IRI FTS_GRAPHDB;
     public static final IRI FTS_QLEVER;
+    public static final IRI FTS_MARKLOGIC;
     public static final IRI FTS_NONE;
 
     public static final List<IRI> CLASS_IRIS;
@@ -127,6 +129,7 @@ public class IriConstants
         FTS_BLAZEGRAPH = vf.createIRI(PREFIX_BLAZEGRAPH, "search");
         FTS_GRAPHDB = vf.createIRI(PREFIX_GRAPHDB, "fts");
         FTS_QLEVER = vf.createIRI(PREFIX_QLEVER, "contains-word");
+        FTS_MARKLOGIC = vf.createIRI(PREFIX_MARKLOGIC, "contains");
         FTS_NONE = vf.createIRI("FTS:NONE");
 
         CLASS_IRIS = asList(RDFS.CLASS, OWL.CLASS, WIKIDATA_CLASS, SKOS.CONCEPT);
@@ -140,7 +143,7 @@ public class IriConstants
         PROPERTY_DESCRIPTION_IRIS = asList(RDFS.COMMENT, SCHEMA_DESCRIPTION);
         DEPRECATION_PROPERTY_IRIS = asList(OWL.DEPRECATED);
         FTS_IRIS = asList(FTS_FUSEKI, FTS_BLAZEGRAPH, FTS_GRAPHDB, FTS_VIRTUOSO, FTS_WIKIDATA,
-                FTS_RDF4J_LUCENE, FTS_STARDOG, FTS_ALLEGRO_GRAPH, FTS_QLEVER);
+                FTS_RDF4J_LUCENE, FTS_STARDOG, FTS_ALLEGRO_GRAPH, FTS_QLEVER, FTS_MARKLOGIC);
     }
 
     public static String getFtsBackendName(String aFTS)
@@ -179,6 +182,10 @@ public class IriConstants
 
         if (FTS_QLEVER.stringValue().equals(aFTS)) {
             return "QLever (SPARQL+Text)";
+        }
+
+        if (FTS_MARKLOGIC.stringValue().equals(aFTS)) {
+            return "MarkLogic";
         }
 
         return aFTS;

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterMarkLogic.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/FtsAdapterMarkLogic.java
@@ -1,0 +1,280 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.kb.querybuilder;
+
+import static de.tudarmstadt.ukp.inception.kb.IriConstants.PREFIX_MARKLOGIC;
+import static de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilder.Priority.PRIMARY;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions.and;
+import static org.eclipse.rdf4j.sparqlbuilder.constraint.Expressions.custom;
+import static org.eclipse.rdf4j.sparqlbuilder.core.SparqlBuilder.prefix;
+import static org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns.union;
+import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.iri;
+import static org.eclipse.rdf4j.sparqlbuilder.rdf.Rdf.literalOf;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.rdf4j.sparqlbuilder.constraint.Expression;
+import org.eclipse.rdf4j.sparqlbuilder.core.Prefix;
+import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPattern;
+import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPatterns;
+import org.eclipse.rdf4j.sparqlbuilder.rdf.Iri;
+
+/**
+ * Full-text search adapter for <a href="https://www.marklogic.com">MarkLogic Server</a>. MarkLogic
+ * exposes its text search inside SPARQL through the {@code cts:contains} extension function which
+ * can be used in a {@code FILTER} together with a {@code cts:query} - here a {@code cts:word-query}
+ * built from the search terms:
+ *
+ * <pre>
+ *   ?subj ?pMatch ?m .
+ *   FILTER( cts:contains(?m, cts:word-query("albert")) )
+ *   FILTER( cts:contains(?m, cts:word-query("ein*", "wildcarded")) )
+ *   FILTER( ... exactness check on ?m ... )
+ * </pre>
+ *
+ * Each search token becomes its own {@code cts:contains(...)} filter, so all tokens have to occur
+ * in the matched literal (in any order), mirroring the "contains all tokens" semantics of the other
+ * adapters. A trailing {@code *} turns the last token into a prefix match (used for the
+ * auto-completion / starts-with lookups) via the {@code wildcarded} option. As with the other
+ * adapters, the {@code cts:contains} filters only pre-select candidates through the text index; the
+ * final {@code FILTER} enforces the actual starts-with / contains / exact-match semantics on the
+ * matched literal.
+ * <p>
+ * This requires the target MarkLogic database to have the triple index enabled (otherwise SPARQL
+ * queries fail with {@code XDMP-TRPLIDXNOTFOUND}) and, for the wildcard lookups to be effective,
+ * wildcard searches enabled.
+ */
+public class FtsAdapterMarkLogic
+    implements FtsAdapter
+{
+    private static final Prefix PREFIX_MARKLOGIC_CTS = prefix("cts", iri(PREFIX_MARKLOGIC));
+    private static final Iri CTS_CONTAINS = PREFIX_MARKLOGIC_CTS.iri("contains");
+    private static final Iri CTS_WORD_QUERY = PREFIX_MARKLOGIC_CTS.iri("word-query");
+
+    private static final String WILDCARDED = "wildcarded";
+
+    /**
+     * How the search tokens are turned into {@code cts:word-query} terms. MarkLogic word queries
+     * match whole words, so substring / prefix lookups have to be expressed with wildcards (which
+     * require the {@code wildcarded} option). The trailing exactness {@code FILTER} added by the
+     * caller still enforces the precise semantics; these terms only pre-select candidates.
+     */
+    private enum MatchMode
+    {
+        /** Every token must occur as a whole word (e.g. for exact-match pre-filtering). */
+        WHOLE_WORD,
+        /** Every token must occur as a substring - {@code *token*}. */
+        SUBSTRING,
+        /** The last token is a prefix - {@code token*} - all preceding tokens are whole words. */
+        PREFIX_LAST
+    }
+
+    private final SPARQLQueryBuilder builder;
+
+    public FtsAdapterMarkLogic(SPARQLQueryBuilder aBuilder)
+    {
+        builder = aBuilder;
+    }
+
+    @Override
+    public void withLabelMatchingExactlyAnyOf(String... aValues)
+    {
+        builder.addPrefix(PREFIX_MARKLOGIC_CTS);
+
+        var valuePatterns = new ArrayList<GraphPattern>();
+        for (var value : aValues) {
+            var sanitizedValue = builder.sanitizeQueryString_FTS(value);
+
+            if (isBlank(sanitizedValue)) {
+                continue;
+            }
+
+            var textFilters = toContainsFilters(sanitizedValue, MatchMode.WHOLE_WORD);
+
+            if (textFilters.isEmpty()) {
+                continue;
+            }
+
+            valuePatterns.add(textMatch(textFilters) //
+                    .filter(builder.equalsPattern(VAR_MATCH_TERM, value)));
+        }
+
+        if (valuePatterns.isEmpty()) {
+            builder.noResult();
+        }
+
+        builder.addPattern(PRIMARY, GraphPatterns.and( //
+                builder.bindMatchTermProperties(VAR_MATCH_TERM_PROPERTY), //
+                union(valuePatterns.toArray(GraphPattern[]::new))));
+    }
+
+    @Override
+    public void withLabelContainingAnyOf(String... aValues)
+    {
+        builder.addPrefix(PREFIX_MARKLOGIC_CTS);
+
+        var valuePatterns = new ArrayList<GraphPattern>();
+        for (var value : aValues) {
+            var sanitizedValue = builder.sanitizeQueryString_FTS(value);
+
+            if (isBlank(sanitizedValue)) {
+                continue;
+            }
+
+            var textFilters = toContainsFilters(sanitizedValue, MatchMode.SUBSTRING);
+
+            if (textFilters.isEmpty()) {
+                continue;
+            }
+
+            valuePatterns.add(textMatch(textFilters) //
+                    .filter(builder.containsPattern(VAR_MATCH_TERM, value)));
+        }
+
+        if (valuePatterns.isEmpty()) {
+            builder.noResult();
+        }
+
+        builder.addPattern(PRIMARY, GraphPatterns.and( //
+                builder.bindMatchTermProperties(VAR_MATCH_TERM_PROPERTY), //
+                union(valuePatterns.toArray(GraphPattern[]::new))));
+    }
+
+    @Override
+    public void withLabelStartingWith(String aPrefixQuery)
+    {
+        builder.addPrefix(PREFIX_MARKLOGIC_CTS);
+
+        var sanitizedValue = builder.sanitizeQueryString_FTS(aPrefixQuery);
+
+        if (isBlank(sanitizedValue)) {
+            builder.noResult();
+            return;
+        }
+
+        // If the query string entered by the user does not end with a space character, then we
+        // assume that the user may not yet have finished writing the word and turn the last token
+        // into a prefix match.
+        var mode = aPrefixQuery.endsWith(" ") ? MatchMode.WHOLE_WORD : MatchMode.PREFIX_LAST;
+        var textFilters = toContainsFilters(sanitizedValue, mode);
+
+        if (textFilters.isEmpty()) {
+            builder.noResult();
+            return;
+        }
+
+        // Locate all entries where the label contains the prefix (using the FTS) and then filter
+        // them by those which actually start with the prefix.
+        builder.addPattern(PRIMARY, GraphPatterns.and( //
+                builder.bindMatchTermProperties(VAR_MATCH_TERM_PROPERTY), //
+                textMatch(textFilters)
+                        .filter(builder.startsWithPattern(VAR_MATCH_TERM, aPrefixQuery))));
+    }
+
+    @Override
+    public void withLabelMatchingAnyOf(String... aValues)
+    {
+        builder.addPrefix(PREFIX_MARKLOGIC_CTS);
+
+        var valuePatterns = new ArrayList<GraphPattern>();
+        for (var value : aValues) {
+            var sanitizedValue = builder.sanitizeQueryString_FTS(value);
+
+            if (isBlank(sanitizedValue)) {
+                continue;
+            }
+
+            // If the query string entered by the user does not end with a space character, then we
+            // assume that the user may not yet have finished writing the word and turn the last
+            // token into a prefix match.
+            var mode = value.endsWith(" ") ? MatchMode.WHOLE_WORD : MatchMode.PREFIX_LAST;
+            var textFilters = toContainsFilters(sanitizedValue, mode);
+
+            if (textFilters.isEmpty()) {
+                continue;
+            }
+
+            valuePatterns.add(textMatch(textFilters));
+        }
+
+        if (valuePatterns.isEmpty()) {
+            builder.noResult();
+        }
+
+        builder.addPattern(PRIMARY, GraphPatterns.and( //
+                builder.bindMatchTermProperties(VAR_MATCH_TERM_PROPERTY), //
+                union(valuePatterns.toArray(GraphPattern[]::new))));
+    }
+
+    /**
+     * Builds the {@code ?subj ?pMatch ?m . FILTER(cts:contains(...))...} core that binds the
+     * subject via the MarkLogic text index. One {@code cts:contains} filter is emitted per search
+     * token, so all of them have to match the same literal.
+     */
+    private GraphPattern textMatch(List<Expression<?>> aTextFilters)
+    {
+        return VAR_SUBJECT.has(VAR_MATCH_TERM_PROPERTY, VAR_MATCH_TERM) //
+                .filter(and(aTextFilters.toArray(Expression[]::new)));
+    }
+
+    /**
+     * Turns a sanitized query string into one {@code cts:contains(?m, cts:word-query(...))} filter
+     * per token, with wildcards applied according to {@code aMode}.
+     */
+    private List<Expression<?>> toContainsFilters(String aSanitizedQuery, MatchMode aMode)
+    {
+        var tokens = aSanitizedQuery.split(" ");
+        var filters = new ArrayList<Expression<?>>();
+        for (var i = 0; i < tokens.length; i++) {
+            var token = tokens[i];
+
+            if (isBlank(token)) {
+                continue;
+            }
+
+            switch (aMode) {
+            case WHOLE_WORD:
+                filters.add(containsWord(token, false));
+                break;
+            case SUBSTRING:
+                filters.add(containsWord("*" + token + "*", true));
+                break;
+            case PREFIX_LAST:
+                if (i == tokens.length - 1) {
+                    filters.add(containsWord(token + "*", true));
+                }
+                else {
+                    filters.add(containsWord(token, false));
+                }
+                break;
+            }
+        }
+
+        return filters;
+    }
+
+    private static Expression<?> containsWord(String aWord, boolean aWildcarded)
+    {
+        var wordQuery = aWildcarded //
+                ? custom(CTS_WORD_QUERY, literalOf(aWord), literalOf(WILDCARDED)) //
+                : custom(CTS_WORD_QUERY, literalOf(aWord));
+        return custom(CTS_CONTAINS, VAR_MATCH_TERM, wordQuery);
+    }
+}

--- a/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
+++ b/inception/inception-kb/src/main/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilder.java
@@ -21,6 +21,7 @@ import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_ALLEGRO_GRAPH;
 import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_BLAZEGRAPH;
 import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_FUSEKI;
 import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_GRAPHDB;
+import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_MARKLOGIC;
 import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_NONE;
 import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_QLEVER;
 import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_RDF4J_LUCENE;
@@ -963,6 +964,10 @@ public class SPARQLQueryBuilder
 
         if (FTS_QLEVER.equals(ftsMode)) {
             return new FtsAdapterQLever(this);
+        }
+
+        if (FTS_MARKLOGIC.equals(ftsMode)) {
+            return new FtsAdapterMarkLogic(this);
         }
 
         if (FTS_NONE.equals(ftsMode) || ftsMode == null) {

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/MarkLogicRepositoryTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/MarkLogicRepositoryTest.java
@@ -1,0 +1,349 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.kb.querybuilder;
+
+import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_MARKLOGIC;
+import static de.tudarmstadt.ukp.inception.kb.http.PerThreadSslCheckingHttpClientUtils.restoreSslVerification;
+import static de.tudarmstadt.ukp.inception.kb.http.PerThreadSslCheckingHttpClientUtils.suspendSslVerification;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.time.Duration.ofMinutes;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.time.Duration;
+import java.util.List;
+
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+import org.eclipse.rdf4j.repository.Repository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import de.tudarmstadt.ukp.inception.kb.RepositoryType;
+import de.tudarmstadt.ukp.inception.kb.model.KnowledgeBase;
+import de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilderLocalTestScenarios.Scenario;
+
+/**
+ * Integration test running the shared FTS scenarios against a dockerized MarkLogic Server.
+ * <p>
+ * Running this test requires accepting the (free) MarkLogic developer license - see
+ * <a href="https://developer.marklogic.com/free-developer/">developer.marklogic.com</a>. The image
+ * itself is publicly available on Docker Hub at {@code progressofficial/marklogic-db}.
+ * <p>
+ * The test brings up a single MarkLogic node and then, via the Management REST API:
+ * <ol>
+ * <li>enables the triple index (required for SPARQL - otherwise queries fail with
+ * {@code XDMP-TRPLIDXNOTFOUND}) and wildcard searches (so {@code cts:word-query} prefix lookups
+ * resolve from the index) on the {@code Documents} database, and</li>
+ * <li>switches the App-Services HTTP server (port 8000, which serves the {@code /v1/graphs/sparql}
+ * endpoint) from the default digest authentication to basic authentication, so the RDF4J
+ * {@link org.eclipse.rdf4j.repository.sparql.SPARQLRepository SPARQLRepository} can authenticate
+ * using the credentials embedded in the endpoint URL.</li>
+ * </ol>
+ */
+@Testcontainers(disabledWithoutDocker = true)
+public class MarkLogicRepositoryTest
+{
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    private static final String MARKLOGIC_IMAGE = "progressofficial/marklogic-db:11.3.5-ubi9-2.2.5";
+
+    private static final String ADMIN_USER = "admin";
+    private static final String ADMIN_PASSWORD = "admin";
+
+    private static final String GRAPH_IRI = "http://testgraph";
+
+    /** App-Services HTTP server - serves the REST API including {@code /v1/graphs/sparql}. */
+    private static final int APP_SERVICES_PORT = 8000;
+    /** Management HTTP server - serves the {@code /manage/v2} configuration API. */
+    private static final int MANAGE_PORT = 8002;
+
+    /** The database backing the App-Services server, where the triples are stored and indexed. */
+    private static final String CONTENT_DATABASE = "Documents";
+
+    @Container
+    private static final GenericContainer<?> MARKLOGIC = new GenericContainer<>(MARKLOGIC_IMAGE) //
+            .withExposedPorts(APP_SERVICES_PORT, 8001, MANAGE_PORT) //
+            .withLogConsumer(new Slf4jLogConsumer(LOG)) //
+            .withEnv("MARKLOGIC_INIT", "true") //
+            .withEnv("MARKLOGIC_ADMIN_USERNAME", ADMIN_USER) //
+            .withEnv("MARKLOGIC_ADMIN_PASSWORD", ADMIN_PASSWORD) //
+            .waitingFor(Wait.forHttp("/adminUI").forPort(8001)
+                    .forStatusCodeMatching(code -> code == 200 || code == 401 || code == 403)
+                    .withStartupTimeout(ofMinutes(5)));
+
+    private Repository repository;
+    private KnowledgeBase kb;
+
+    @BeforeAll
+    static void setUpClass() throws Exception
+    {
+        assertThat(MARKLOGIC.isRunning()).isTrue();
+
+        // The container is "up" (HTTP servers respond) well before MarkLogic has finished
+        // initializing the admin user, so the Management API initially answers with 401/403/503.
+        // Wait until it actually accepts authenticated requests before configuring anything.
+        LOG.info("Waiting for the MarkLogic Management API to become usable ...");
+        awaitOk(manageUrl("/manage/v2/hosts"), ofMinutes(3));
+
+        LOG.info("Enabling triple and wildcard indexes on database [{}] ...", CONTENT_DATABASE);
+        managePut("/manage/v2/databases/" + CONTENT_DATABASE + "/properties", //
+                """
+                        { \
+                          "triple-index": true, \
+                          "three-character-searches": true, \
+                          "trailing-wildcard-searches": true, \
+                          "trailing-wildcard-word-positions": true \
+                        }""");
+
+        LOG.info("Switching App-Services server to basic authentication ...");
+        managePut("/manage/v2/servers/App-Services/properties?group-id=Default",
+                "{ \"authentication\": \"basic\" }");
+
+        // Changing the authentication scheme restarts the App-Services server, so wait until the
+        // SPARQL endpoint is reachable again before letting any tests run against it.
+        LOG.info("Waiting for the SPARQL endpoint to come back up ...");
+        awaitOk(sparqlEndpointUrl() + "?query=" + URLEncoder.encode("ASK {}", UTF_8), ofMinutes(2));
+
+        // Enabling the wildcard / 3-character indexes triggers a background reindex of the
+        // database. Until that settles, cts:word-query lookups can return incomplete results, so
+        // wait until a probe wildcard query actually finds a freshly inserted triple.
+        LOG.info("Waiting for the full-text indexes to become queryable ...");
+        awaitFtsReady(ofMinutes(2));
+
+        LOG.info("MarkLogic setup complete");
+    }
+
+    private static final String PROBE_GRAPH = "http://inception/marklogic-fts-probe";
+
+    private static void awaitFtsReady(Duration aTimeout) throws Exception
+    {
+        sparqlUpdate("INSERT DATA { GRAPH <" + PROBE_GRAPH + "> { <" + PROBE_GRAPH
+                + "#s> <http://www.w3.org/2000/01/rdf-schema#label> \"marklogicftsprobe\" } }");
+        try {
+            var query = "PREFIX cts: <http://marklogic.com/cts#> ASK { GRAPH <" + PROBE_GRAPH
+                    + "> { ?s ?p ?o FILTER(cts:contains(?o, "
+                    + "cts:word-query(\"marklogicftspro*\", \"wildcarded\"))) } }";
+            awaitBodyContains(sparqlEndpointUrl() + "?query=" + URLEncoder.encode(query, UTF_8),
+                    "true", aTimeout);
+        }
+        finally {
+            sparqlUpdate("DROP SILENT GRAPH <" + PROBE_GRAPH + ">");
+        }
+    }
+
+    @BeforeEach
+    public void setUp(TestInfo aTestInfo) throws Exception
+    {
+        var methodName = aTestInfo.getTestMethod().map(Method::getName).orElse("<unknown>");
+        LOG.info("=== {} === {} =====================", methodName, aTestInfo.getDisplayName());
+
+        suspendSslVerification();
+
+        kb = new KnowledgeBase();
+        kb.setDefaultLanguage("en");
+        kb.setDefaultDatasetIri(GRAPH_IRI);
+        kb.setType(RepositoryType.REMOTE);
+        kb.setFullTextSearchIri(FTS_MARKLOGIC.stringValue());
+        kb.setMaxResults(100);
+
+        SPARQLQueryBuilderLocalTestScenarios.initRdfsMapping(kb);
+
+        var sparqlEndpoint = "http://" + ADMIN_USER + ":" + ADMIN_PASSWORD + "@"
+                + MARKLOGIC.getHost() + ":" + MARKLOGIC.getMappedPort(APP_SERVICES_PORT)
+                + "/v1/graphs/sparql";
+        repository = SPARQLQueryBuilderLocalTestScenarios.buildSparqlRepository(sparqlEndpoint,
+                sparqlEndpoint);
+
+        try (var conn = repository.getConnection()) {
+            // MarkLogic rejects CLEAR/DROP of a non-existing graph with XDMP-SPQLNOSUCHGRAPH (other
+            // stores no-op), so use the SILENT variant which is idempotent on the first run.
+            conn.prepareUpdate("CLEAR SILENT GRAPH <" + GRAPH_IRI + ">").execute();
+        }
+    }
+
+    @AfterEach
+    public void tearDown()
+    {
+        restoreSslVerification();
+    }
+
+    private static List<Arguments> tests() throws Exception
+    {
+        var exclusions = asList( //
+                // Like AllegroGraph: the scenario assumes the FTS also returns candidates that do
+                // not contain all search terms (searching "hand structure*" should also surface the
+                // "Hand" additional-search-property value), but MarkLogic's cts:word-query requires
+                // every term to be present, so "Hand" is not among the reported match terms.
+                "thatMatchingAgainstAdditionalSearchPropertiesWorks2");
+
+        return SPARQLQueryBuilderLocalTestScenarios.tests().stream() //
+                .filter(scenario -> !exclusions.contains(scenario.name)) //
+                .map(scenario -> Arguments.of(scenario.name, scenario)) //
+                .toList();
+    }
+
+    @ParameterizedTest(name = "{index}: test {0}")
+    @MethodSource("tests")
+    public void runTests(String aScenarioName, Scenario aScenario) throws Exception
+    {
+        aScenario.implementation.accept(repository, kb);
+    }
+
+    private static String manageUrl(String aPath)
+    {
+        return "http://" + MARKLOGIC.getHost() + ":" + MARKLOGIC.getMappedPort(MANAGE_PORT) + aPath;
+    }
+
+    private static String sparqlEndpointUrl()
+    {
+        return "http://" + MARKLOGIC.getHost() + ":" + MARKLOGIC.getMappedPort(APP_SERVICES_PORT)
+                + "/v1/graphs/sparql";
+    }
+
+    private static CloseableHttpClient newAuthenticatedClient()
+    {
+        var credentials = new BasicCredentialsProvider();
+        credentials.setCredentials(AuthScope.ANY,
+                new UsernamePasswordCredentials(ADMIN_USER, ADMIN_PASSWORD));
+        return HttpClientBuilder.create().setDefaultCredentialsProvider(credentials).build();
+    }
+
+    /**
+     * Polls the given URL with admin credentials until it answers with HTTP 200 or the timeout
+     * elapses. Connection failures and non-200 responses (e.g. 401/403/503 while MarkLogic is still
+     * initializing or while a server is restarting) are retried.
+     */
+    private static void awaitOk(String aUrl, Duration aTimeout) throws Exception
+    {
+        var deadline = System.currentTimeMillis() + aTimeout.toMillis();
+        var lastStatus = "no response";
+        while (System.currentTimeMillis() < deadline) {
+            try (var client = newAuthenticatedClient();
+                    var response = client.execute(RequestBuilder.get(new URI(aUrl)).build())) {
+                var statusCode = response.getStatusLine().getStatusCode();
+                if (statusCode == 200) {
+                    return;
+                }
+                lastStatus = "HTTP " + statusCode;
+            }
+            catch (Exception e) {
+                lastStatus = e.getClass().getSimpleName() + ": " + e.getMessage();
+            }
+            Thread.sleep(3000);
+        }
+        throw new IllegalStateException("Timed out waiting for [" + aUrl
+                + "] to become available (last: " + lastStatus + ")");
+    }
+
+    private static void awaitBodyContains(String aUrl, String aExpected, Duration aTimeout)
+        throws Exception
+    {
+        var deadline = System.currentTimeMillis() + aTimeout.toMillis();
+        var lastStatus = "no response";
+        while (System.currentTimeMillis() < deadline) {
+            try (var client = newAuthenticatedClient();
+                    var response = client.execute(RequestBuilder.get(new URI(aUrl)).build())) {
+                var statusCode = response.getStatusLine().getStatusCode();
+                var body = response.getEntity() != null ? EntityUtils.toString(response.getEntity())
+                        : "";
+                if (statusCode == 200 && body.contains(aExpected)) {
+                    return;
+                }
+                lastStatus = "HTTP " + statusCode + " body=" + body;
+            }
+            catch (Exception e) {
+                lastStatus = e.getClass().getSimpleName() + ": " + e.getMessage();
+            }
+            Thread.sleep(3000);
+        }
+        throw new IllegalStateException("Timed out waiting for [" + aUrl + "] to return ["
+                + aExpected + "] (last: " + lastStatus + ")");
+    }
+
+    private static void sparqlUpdate(String aUpdate) throws Exception
+    {
+        var request = RequestBuilder.post(new URI(sparqlEndpointUrl())) //
+                .setEntity(new StringEntity(aUpdate,
+                        ContentType.create("application/sparql-update", UTF_8))) //
+                .build();
+
+        try (var client = newAuthenticatedClient(); var response = client.execute(request)) {
+            var statusCode = response.getStatusLine().getStatusCode();
+            if (statusCode < 200 || statusCode >= 300) {
+                throw new RuntimeException("SPARQL update failed: HTTP " + statusCode);
+            }
+        }
+    }
+
+    private static void managePut(String aPath, String aJsonBody) throws Exception
+    {
+        // Applying a configuration change can briefly take the Management/App servers offline, so
+        // the immediately following request may see a dropped connection or a 5xx. Retry until it
+        // succeeds or the timeout elapses.
+        var deadline = System.currentTimeMillis() + ofMinutes(2).toMillis();
+        var lastStatus = "no response";
+        while (System.currentTimeMillis() < deadline) {
+            var request = RequestBuilder.put(new URI(manageUrl(aPath))) //
+                    .setEntity(new StringEntity(aJsonBody, ContentType.APPLICATION_JSON)) //
+                    .build();
+            try (var client = newAuthenticatedClient(); var response = client.execute(request)) {
+                var statusCode = response.getStatusLine().getStatusCode();
+                // 200/204 = applied; 202 = accepted but a server restart is in progress
+                if (statusCode >= 200 && statusCode < 300) {
+                    return;
+                }
+                lastStatus = "HTTP " + statusCode;
+                // 4xx (other than auth) won't fix itself by retrying - fail fast.
+                if (statusCode >= 400 && statusCode < 500 && statusCode != 401
+                        && statusCode != 403) {
+                    break;
+                }
+            }
+            catch (Exception e) {
+                lastStatus = e.getClass().getSimpleName() + ": " + e.getMessage();
+            }
+            Thread.sleep(3000);
+        }
+        throw new RuntimeException("Unable to apply MarkLogic configuration [" + aPath + "] (last: "
+                + lastStatus + ")");
+    }
+}

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/RepositoryTestSuite.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/RepositoryTestSuite.java
@@ -25,6 +25,7 @@ import org.junit.platform.suite.api.Suite;
         AllegroGraphRepositoryTest.class, //
         BlazegraphRepositoryTest.class, //
         FusekiRepositoryTest.class, //
+        MarkLogicRepositoryTest.class, //
         Rdf4JRepositoryTest.class, //
         StardogRepositoryTest.class, //
         VirtuosoRepositoryTest.class })

--- a/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderTest.java
+++ b/inception/inception-kb/src/test/java/de/tudarmstadt/ukp/inception/kb/querybuilder/SPARQLQueryBuilderTest.java
@@ -17,6 +17,7 @@
  */
 package de.tudarmstadt.ukp.inception.kb.querybuilder;
 
+import static de.tudarmstadt.ukp.inception.kb.IriConstants.FTS_MARKLOGIC;
 import static de.tudarmstadt.ukp.inception.kb.querybuilder.SPARQLQueryBuilderLocalTestScenarios.initRdfsMapping;
 import static java.util.List.of;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -71,5 +72,46 @@ public class SPARQLQueryBuilderTest
         assertThat(query) //
                 .as("no language filter is emitted when no language is configured") //
                 .doesNotContain("LANGMATCHES").doesNotContain("LANG(");
+    }
+
+    private SPARQLQueryBuilder markLogicBuilder()
+    {
+        var kb = new KnowledgeBase();
+        initRdfsMapping(kb);
+        kb.setDefaultLanguage("en");
+        kb.setMaxResults(100);
+        kb.setFullTextSearchIri(FTS_MARKLOGIC.stringValue());
+        var sut = new SPARQLQueryBuilder(kb, Mode.ITEM);
+        sut.withPrefLabelProperties(of("http://www.w3.org/2000/01/rdf-schema#label"));
+        return sut;
+    }
+
+    @Test
+    public void thatMarkLogicContainingEmitsCtsContainsPerToken() throws Exception
+    {
+        var query = markLogicBuilder() //
+                .withLabelContainingAnyOf("Green Goblin") //
+                .selectQuery().getQueryString();
+
+        assertThat(query) //
+                .as("the MarkLogic cts namespace is declared") //
+                .contains("PREFIX cts: <http://marklogic.com/cts#>");
+        assertThat(query) //
+                .as("a substring cts:contains / cts:word-query filter is emitted per token") //
+                .contains("cts:contains( ?m, cts:word-query( \"*green*\", \"wildcarded\" ) )") //
+                .contains("cts:contains( ?m, cts:word-query( \"*goblin*\", \"wildcarded\" ) )");
+    }
+
+    @Test
+    public void thatMarkLogicStartingWithWildcardsTheLastToken() throws Exception
+    {
+        var query = markLogicBuilder() //
+                .withLabelStartingWith("Green Gob") //
+                .selectQuery().getQueryString();
+
+        assertThat(query) //
+                .as("the unfinished last token becomes a wildcarded prefix query") //
+                .contains("cts:contains( ?m, cts:word-query( \"green\" ) )") //
+                .contains("cts:word-query( \"gob*\", \"wildcarded\" )");
     }
 }


### PR DESCRIPTION
**What's in the PR**
- Add FtsAdapterMarkLogic to support full-text search on MarkLogic Server SPARQL endpoints
- Add MarkLogicRepositoryTest for FTS adapter testing
- Add MarkLogic IRI constants to IriConstants.java (PREFIX_MARKLOGIC, FTS_MARKLOGIC, registration in FTS_IRIS list)
- Add getFtsBackendName case for MarkLogic in IriConstants.java
- Add FTS_MARKLOGIC import and factory instantiation in SPARQLQueryBuilder.java
- Added tests

**How to test manually**
* No specific test procedure

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
