### PR TITLE
#6159 - Assigning or revoking project permissions via the remote API fails when no role is given

### DIFF
--- a/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/inception/remoteapi/next/PermissionController.java
+++ b/inception/inception-remote/src/main/java/de/tudarmstadt/ukp/inception/remoteapi/next/PermissionController.java
@@ -146,11 +146,11 @@ public class PermissionController
                     User to assign the permissions to.
                     """) //
             String aSubjectUser, //
-            @RequestParam(PARAM_ROLES) //
+            @RequestParam(name = PARAM_ROLES, required = false) //
             @Schema(description = """
                     Project roles to assign.
                     """, //
-                    allowableValues = { "USER", "CURATOR", "ADMIN" }) //
+                    allowableValues = { "ANNOTATOR", "CURATOR", "MANAGER" }) //
             List<String> aRoles)
         throws Exception
     {
@@ -168,9 +168,12 @@ public class PermissionController
 
         var subjectUser = getUser(aSubjectUser);
 
-        var roles = aRoles.stream().map(PermissionLevel::valueOf).toArray(PermissionLevel[]::new);
-
-        projectService.assignRole(project, subjectUser, roles);
+        // An empty/absent role list is a no-op - we simply return the current permissions.
+        if (aRoles != null && !aRoles.isEmpty()) {
+            var roles = aRoles.stream().map(PermissionLevel::valueOf)
+                    .toArray(PermissionLevel[]::new);
+            projectService.assignRole(project, subjectUser, roles);
+        }
 
         var permissions = projectService.listProjectPermissionLevel(subjectUser, project).stream()
                 .map(RPermission::new) //
@@ -195,11 +198,11 @@ public class PermissionController
                     User to assign the permissions to.
                     """) //
             String aSubjectUser, //
-            @RequestParam(PARAM_ROLES) //
+            @RequestParam(name = PARAM_ROLES, required = false) //
             @Schema(description = """
                     Project roles to revoke.
                     """, //
-                    allowableValues = { "USER", "CURATOR", "ADMIN" }) //
+                    allowableValues = { "ANNOTATOR", "CURATOR", "MANAGER" }) //
             List<String> aRoles)
         throws Exception
     {
@@ -217,11 +220,13 @@ public class PermissionController
 
         var subjectUser = getUser(aSubjectUser);
 
-        var roles = aRoles.stream() //
-                .map(PermissionLevel::valueOf) //
-                .toArray(PermissionLevel[]::new);
-
-        projectService.revokeRole(project, subjectUser, roles);
+        // An empty/absent role list is a no-op - we simply return the current permissions.
+        if (aRoles != null && !aRoles.isEmpty()) {
+            var roles = aRoles.stream() //
+                    .map(PermissionLevel::valueOf) //
+                    .toArray(PermissionLevel[]::new);
+            projectService.revokeRole(project, subjectUser, roles);
+        }
 
         var permissions = projectService.listProjectPermissionLevel(subjectUser, project).stream()
                 .map(RPermission::new) //

--- a/inception/inception-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroPermissionControllerTest.java
+++ b/inception/inception-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/AeroPermissionControllerTest.java
@@ -158,6 +158,27 @@ public class AeroPermissionControllerTest
     }
 
     @Test
+    public void thatEmptyRolesIsNoOp() throws Exception
+    {
+        adminActor.grantProjectRole(1, "user", "ANNOTATOR", "CURATOR") //
+                .andExpect(status().isOk());
+
+        // Assigning with no roles must not fail and must leave the permissions unchanged.
+        adminActor.grantProjectRoleWithoutRoles(1, "user") //
+                .andExpect(status().isOk()) //
+                .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+                .andExpect(jsonPath("$.body[0].role").value("CURATOR"))
+                .andExpect(jsonPath("$.body[1].role").value("ANNOTATOR"));
+
+        // Revoking with no roles must not fail and must leave the permissions unchanged.
+        adminActor.revokeProjectRoleWithoutRoles(1, "user") //
+                .andExpect(status().isOk()) //
+                .andExpect(content().contentType(APPLICATION_JSON_VALUE))
+                .andExpect(jsonPath("$.body[0].role").value("CURATOR"))
+                .andExpect(jsonPath("$.body[1].role").value("ANNOTATOR"));
+    }
+
+    @Test
     public void thatNonAdminCannotChangePermissions() throws Exception
     {
         userActor.grantProjectRole(1, "user", "MANAGER") //

--- a/inception/inception-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/MockAeroClient.java
+++ b/inception/inception-remote/src/test/java/de/tudarmstadt/ukp/clarin/webanno/webapp/remoteapi/aero/MockAeroClient.java
@@ -208,6 +208,13 @@ class MockAeroClient
                 .param("roles", aRoles));
     }
 
+    ResultActions grantProjectRoleWithoutRoles(long aProjectId, String aUser) throws Exception
+    {
+        return mvc.perform(post(API_BASE + "/projects/" + aProjectId + "/permissions/" + aUser) //
+                .with(csrf().asHeader()) //
+                .with(user(username).roles(roles)));
+    }
+
     ResultActions listPermissionsForUser(long aProjectId, String aUser) throws Exception
     {
         return mvc.perform(get(API_BASE + "/projects/" + aProjectId + "/permissions/" + aUser) //
@@ -229,6 +236,13 @@ class MockAeroClient
                 .with(csrf().asHeader()) //
                 .with(user(username).roles(roles)) //
                 .param("roles", aRoles));
+    }
+
+    ResultActions revokeProjectRoleWithoutRoles(long aProjectId, String aUser) throws Exception
+    {
+        return mvc.perform(delete(API_BASE + "/projects/" + aProjectId + "/permissions/" + aUser) //
+                .with(csrf().asHeader()) //
+                .with(user(username).roles(roles)));
     }
 
     ResultActions listTasks(long aProjectId) throws Exception


### PR DESCRIPTION
**What's in the PR**
- Make role parameter optional in permission assignment/revocation endpoints with no-op behavior for empty role lists
- Update permission role names from USER/CURATOR/ADMIN to ANNOTATOR/CURATOR/MANAGER
- Add test cases and mock client helpers for permission endpoints invoked without roles

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
