### PR TITLE
#6161 - Curation auto-scrolls to end of document and has no default annotators selected

### DIFF
--- a/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/merge/CasMerge.java
+++ b/inception/inception-curation/src/main/java/de/tudarmstadt/ukp/inception/curation/merge/CasMerge.java
@@ -52,6 +52,7 @@ import de.tudarmstadt.ukp.dkpro.core.api.metadata.type.DocumentMetaData;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
 import de.tudarmstadt.ukp.inception.annotation.events.BulkAnnotationEvent;
+import de.tudarmstadt.ukp.inception.annotation.layer.TypeAdapter_ImplBase;
 import de.tudarmstadt.ukp.inception.annotation.layer.document.api.DocumentPosition;
 import de.tudarmstadt.ukp.inception.annotation.layer.relation.api.RelationPosition;
 import de.tudarmstadt.ukp.inception.annotation.layer.span.api.SpanPosition;
@@ -235,6 +236,16 @@ public class CasMerge
             eventPublisher
                     .publishEvent(new BulkAnnotationEvent(this, aTargetDocument, aTargetUsername));
         }
+
+        // Merging re-creates/updates the agreed annotations through the layer adapters, and every
+        // adapter create/edit call updates the resumption location to the begin offset of the
+        // annotation it just touched. Since annotations are merged in document order, the
+        // resumption
+        // location would end up pointing near the end of the document, causing the curation editor
+        // to open scrolled to the bottom. Reset the resumption location to the start of the
+        // document
+        // so the editor opens at the top.
+        TypeAdapter_ImplBase.setResumptionLocation(aTargetCas, 0);
 
         return localContext;
     }

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/page/CurationPage.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/page/CurationPage.java
@@ -32,7 +32,6 @@ import org.wicketstuff.annotation.mount.MountPath;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.AnnotationPageBase2;
-import de.tudarmstadt.ukp.inception.curation.api.CurationSessionService;
 import de.tudarmstadt.ukp.inception.curation.service.CurationDocumentService;
 import de.tudarmstadt.ukp.inception.ui.curation.sidebar.CurationEditorExtension;
 import de.tudarmstadt.ukp.inception.ui.curation.sidebar.CurationSidebarBehavior;
@@ -44,7 +43,6 @@ public class CurationPage
 {
     private static final long serialVersionUID = 8665608337791132617L;
 
-    private @SpringBean CurationSessionService curationSessionService;
     private @SpringBean UserDao userRepository;
     private @SpringBean WorkloadManagementService workloadManagementService;
     private @SpringBean CurationDocumentService curationDocumentService;
@@ -55,11 +53,8 @@ public class CurationPage
 
         add(new CurationSidebarBehavior());
 
-        var sessionOwner = userRepository.getCurrentUsername();
         var state = getModelObject();
         state.enableExtension(CurationEditorExtension.EXTENSION_ID);
-
-        curationSessionService.startSession(sessionOwner, state.getProject(), false);
     }
 
     @Override

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebarBehavior.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebarBehavior.java
@@ -105,7 +105,7 @@ public class CurationSidebarBehavior
         var sessionOwner = userService.getCurrentUsername();
         var doc = aEvent.getDocument();
         var project = doc.getProject();
-        var isCurationSessionActive = isSessionActive(project);
+        var sessionActiveBefore = isSessionActive(project);
 
         var params = page.getPageParameters();
         var dataOwner = aEvent.getDocumentOwner();
@@ -122,10 +122,17 @@ public class CurationSidebarBehavior
 
         handleSessionActivationPageParameters(page, params, doc, sessionOwner);
 
+        // On the dedicated curation page, a curation session is always active. We start it here
+        // rather than in the CurationPage constructor so that the sessionActiveBefore check above
+        // can tell a freshly started session apart from an ongoing one.
+        if (page instanceof CurationPage && !isSessionActive(project)) {
+            curationSessionService.startSession(sessionOwner, project, false);
+        }
+
         ensureDataOwnerMatchesCurationTarget(page, project, sessionOwner, dataOwner);
-        if (!isCurationSessionActive) {
-            curationSessionService.setDefaultSelectedUsersForDocument(aEvent.getSessionOwner(),
-                    aEvent.getDocument());
+
+        if (!sessionActiveBefore) {
+            curationSessionService.setDefaultSelectedUsersForDocument(sessionOwner, doc);
         }
 
         var prefs = preferencesService


### PR DESCRIPTION
**What's in the PR**
- Fix curation auto-scroll to end of document by resetting resumption location to 0 after merge
- Move curation session initialization from CurationPage constructor to CurationSidebarBehavior
- Fix default annotator selection by passing correct document and session owner parameters

**How to test manually**
* See issue description

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
