### PR TITLE
#6146 - Enhance editor infrastructure for displaying multiple documents simultaneously

### DIFF
--- a/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.java
+++ b/inception/inception-active-learning/src/main/java/de/tudarmstadt/ukp/inception/active/learning/sidebar/ActiveLearningSidebar.java
@@ -111,6 +111,7 @@ import de.tudarmstadt.ukp.inception.recommendation.api.model.SuggestionGroup.Del
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.FeatureState;
 import de.tudarmstadt.ukp.inception.rendering.pipeline.RenderAnnotationsEvent;
+import de.tudarmstadt.ukp.inception.rendering.selection.Selection;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VAnnotationMarker;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VDocument;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
@@ -892,7 +893,7 @@ public class ActiveLearningSidebar
             // Clear the annotation detail editor and the selection to avoid confusions with the
             // highlight because the selection highlight from the right sidebar and the one from
             // the AL sidebar have the same color!
-            state.getSelection().clear();
+            state.clearSelection();
             aTarget.add((Component) getActionHandler());
 
             getAnnotationPage().actionShowSelectedDocument(aTarget, sourceDocument,
@@ -1163,8 +1164,8 @@ public class ActiveLearningSidebar
         CAS cas = this.getCasProvider().get();
         Optional<AnnotationFS> anno = getMatchingAnnotation(cas, aRecord);
         if (anno.isPresent()) {
-            state.getSelection().selectSpan(VID.of(anno.get()), cas, aRecord.getOffsetBegin(),
-                    aRecord.getOffsetEnd());
+            state.setSelection(Selection.span(VID.of(anno.get()), cas, aRecord.getOffsetBegin(),
+                    aRecord.getOffsetEnd()));
             getActionHandler().actionDelete(aTarget);
         }
     }
@@ -1403,6 +1404,12 @@ public class ActiveLearningSidebar
     @OnEvent
     public void onRenderAnnotations(RenderAnnotationsEvent aEvent)
     {
+        // Only render our markers into our own editor, not into other editors on the page (e.g. the
+        // reference-document viewer or curation panes) even if they show the same document (#6146).
+        if (aEvent.getRequest().getState() != getModelObject()) {
+            return;
+        }
+
         renderHighlights(aEvent.getVDocument());
     }
 

--- a/inception/inception-api-annotation/pom.xml
+++ b/inception/inception-api-annotation/pom.xml
@@ -61,12 +61,22 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-annotation-storage-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-api-editor</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-api-render</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-api-diam</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/action/ReadOnlyActionHandler.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/action/ReadOnlyActionHandler.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.api.annotation.action;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+import org.apache.uima.cas.CAS;
+import org.apache.uima.cas.text.AnnotationFS;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.NotEditableException;
+import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasProvider;
+import de.tudarmstadt.ukp.inception.editor.action.AnnotationActionHandler;
+import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
+import de.tudarmstadt.ukp.inception.schema.api.adapter.AnnotationException;
+
+/**
+ * A read-only {@link AnnotationActionHandler} for editors that only display a document (e.g. a
+ * curation view or a reference-document sidebar).
+ * <p>
+ * Provides the CAS to the editor via the given {@link CasProvider}, ignores all
+ * selection/navigation callbacks (the viewer is fully passive) and rejects any mutating action.
+ */
+public class ReadOnlyActionHandler
+    implements AnnotationActionHandler, Serializable
+{
+    private static final long serialVersionUID = 1L;
+
+    private final CasProvider casProvider;
+
+    public ReadOnlyActionHandler(CasProvider aCasProvider)
+    {
+        casProvider = aCasProvider;
+    }
+
+    @Override
+    public CAS getEditorCas() throws IOException
+    {
+        return casProvider.get();
+    }
+
+    @Override
+    public void ensureIsEditable() throws AnnotationException
+    {
+        throw new NotEditableException("This editor is read-only.");
+    }
+
+    // --- Passive: clicks in the read-only editor do nothing -----------------------------------
+
+    @Override
+    public void actionSelect(AjaxRequestTarget aTarget)
+    {
+        // Passive viewer - ignore
+    }
+
+    @Override
+    public void actionSelect(AjaxRequestTarget aTarget, AnnotationFS aAnnoFs)
+    {
+        // Passive viewer - ignore
+    }
+
+    @Override
+    public void actionSelect(AjaxRequestTarget aTarget, VID aVid)
+    {
+        // Passive viewer - ignore
+    }
+
+    @Override
+    public void actionSelectAndJump(AjaxRequestTarget aTarget, VID aVid)
+    {
+        // Passive viewer - ignore
+    }
+
+    @Override
+    public void actionSelectAndJump(AjaxRequestTarget aTarget, AnnotationFS aFS)
+    {
+        // Passive viewer - ignore
+    }
+
+    @Override
+    public void actionJump(AjaxRequestTarget aTarget, VID aVid)
+    {
+        // Passive viewer - ignore
+    }
+
+    @Override
+    public void actionJump(AjaxRequestTarget aTarget, AnnotationFS aFS)
+    {
+        // Passive viewer - ignore
+    }
+
+    @Override
+    public void actionJump(AjaxRequestTarget aTarget, int aBegin, int aEnd)
+    {
+        // Passive viewer - ignore
+    }
+
+    @Override
+    public void actionClear(AjaxRequestTarget aTarget)
+    {
+        // Passive viewer - ignore
+    }
+
+    // --- Mutating actions are not permitted ---------------------------------------------------
+
+    @Override
+    public void actionCreateOrUpdate(AjaxRequestTarget aTarget, CAS aCas) throws AnnotationException
+    {
+        throw new NotEditableException("This editor is read-only.");
+    }
+
+    @Override
+    public void actionDelete(AjaxRequestTarget aTarget) throws AnnotationException
+    {
+        throw new NotEditableException("This editor is read-only.");
+    }
+
+    @Override
+    public void actionReverse(AjaxRequestTarget aTarget) throws AnnotationException
+    {
+        throw new NotEditableException("This editor is read-only.");
+    }
+
+    @Override
+    public void actionFillSlot(AjaxRequestTarget aTarget, CAS aCas, int aSlotFillerBegin,
+            int aSlotFillerEnd)
+        throws AnnotationException
+    {
+        throw new NotEditableException("This editor is read-only.");
+    }
+
+    @Override
+    public void actionFillSlot(AjaxRequestTarget aTarget, CAS aCas, VID aExistingSlotFillerId)
+        throws AnnotationException
+    {
+        throw new NotEditableException("This editor is read-only.");
+    }
+
+    @Override
+    public void writeEditorCas() throws AnnotationException
+    {
+        throw new NotEditableException("This editor is read-only.");
+    }
+}

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/page/AnnotationPageBase.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/page/AnnotationPageBase.java
@@ -61,6 +61,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.security.model.User;
 import de.tudarmstadt.ukp.clarin.webanno.ui.core.page.ProjectPageBase;
+import de.tudarmstadt.ukp.inception.diam.model.DiamContext;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentAccess;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.editor.ContextMenuLookup;
@@ -78,6 +79,7 @@ import jakarta.persistence.NoResultException;
 
 public abstract class AnnotationPageBase
     extends ProjectPageBase
+    implements DiamContext
 {
     private static final long serialVersionUID = -1133219266479577443L;
 
@@ -156,6 +158,18 @@ public abstract class AnnotationPageBase
     public AnnotatorState getModelObject()
     {
         return (AnnotatorState) getDefaultModelObject();
+    }
+
+    @Override
+    public AnnotatorState getAnnotatorState()
+    {
+        return getModelObject();
+    }
+
+    @Override
+    public AnnotationActionHandler getActionHandler()
+    {
+        return getAnnotationActionHandler();
     }
 
     protected SourceDocument getDocumentFromParameters(Project aProject,

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/paging/DefaultPagingNavigator.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/paging/DefaultPagingNavigator.java
@@ -33,7 +33,7 @@ import org.wicketstuff.event.annotation.OnEvent;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.config.KeyBindingsProperties;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.config.KeyBindingsUtil;
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
+import de.tudarmstadt.ukp.inception.diam.model.DiamContext;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
 import de.tudarmstadt.ukp.inception.rendering.selection.AnnotatorViewportChangedEvent;
 import de.tudarmstadt.ukp.inception.rendering.selection.FocusPosition;
@@ -48,24 +48,24 @@ public class DefaultPagingNavigator
 
     private @SpringBean KeyBindingsProperties keyBindings;
 
-    private AnnotationPageBase page;
+    private DiamContext context;
     private NumberTextField<Integer> gotoPageTextField;
     private FocusPosition defaultFocusPosition = FocusPosition.TOP;
 
-    public DefaultPagingNavigator(String aId, AnnotationPageBase aPage)
+    public DefaultPagingNavigator(String aId, DiamContext aContext)
     {
         super(aId);
 
         setOutputMarkupPlaceholderTag(true);
 
-        page = aPage;
+        context = aContext;
 
         Form<Void> form = new Form<>("form");
         gotoPageTextField = new NumberTextField<>("gotoPageText", Model.of(1), Integer.class);
-        // Using a LambdaModel here because the model object in the page may change and we want to
-        // always get the right one
-        gotoPageTextField.setModel(PropertyModel
-                .of(LoadableDetachableModel.of(() -> aPage.getModel()), "firstVisibleUnitIndex"));
+        // Using a LambdaModel here because the annotator state may change and we want to always get
+        // the right one
+        gotoPageTextField.setModel(PropertyModel.of(
+                LoadableDetachableModel.of(aContext::getAnnotatorState), "firstVisibleUnitIndex"));
         // FIXME minimum and maximum should be obtained from the annotator state
         gotoPageTextField.setMinimum(1);
         // gotoPageTextField.setMaximum(LambdaModel.of(() ->
@@ -112,48 +112,48 @@ public class DefaultPagingNavigator
 
     private boolean contentFitsFullyIntoVisibleWindow()
     {
-        AnnotatorState state = page.getModelObject();
+        AnnotatorState state = context.getAnnotatorState();
         return state.getUnitCount() <= state.getPreferences().getWindowSize();
     }
 
     public AnnotatorState getModelObject()
     {
-        return page.getModelObject();
+        return context.getAnnotatorState();
     }
 
     protected void actionShowPreviousPage(AjaxRequestTarget aTarget) throws Exception
     {
-        CAS cas = page.getEditorCas();
+        CAS cas = context.getEditorCas();
         getModelObject().moveToPreviousPage(cas, defaultFocusPosition);
-        page.actionRefreshDocument(aTarget);
+        context.actionRefreshDocument(aTarget);
     }
 
     protected void actionShowNextPage(AjaxRequestTarget aTarget) throws Exception
     {
-        CAS cas = page.getEditorCas();
+        CAS cas = context.getEditorCas();
         getModelObject().moveToNextPage(cas, defaultFocusPosition);
-        page.actionRefreshDocument(aTarget);
+        context.actionRefreshDocument(aTarget);
     }
 
     protected void actionShowFirstPage(AjaxRequestTarget aTarget) throws Exception
     {
-        CAS cas = page.getEditorCas();
+        CAS cas = context.getEditorCas();
         getModelObject().moveToFirstPage(cas, defaultFocusPosition);
-        page.actionRefreshDocument(aTarget);
+        context.actionRefreshDocument(aTarget);
     }
 
     protected void actionShowLastPage(AjaxRequestTarget aTarget) throws Exception
     {
-        CAS cas = page.getEditorCas();
+        CAS cas = context.getEditorCas();
         getModelObject().moveToLastPage(cas, defaultFocusPosition);
-        page.actionRefreshDocument(aTarget);
+        context.actionRefreshDocument(aTarget);
     }
 
     private void actionGotoPage(AjaxRequestTarget aTarget, Form<?> aForm) throws Exception
     {
-        CAS cas = page.getEditorCas();
+        CAS cas = context.getEditorCas();
         getModelObject().moveToUnit(cas, gotoPageTextField.getModelObject(), defaultFocusPosition);
-        page.actionRefreshDocument(aTarget);
+        context.actionRefreshDocument(aTarget);
     }
 
     public void setDefaultFocusPosition(FocusPosition aPos)
@@ -172,6 +172,11 @@ public class DefaultPagingNavigator
     @OnEvent
     public void onAnnotatorViewStateChangedEvent(AnnotatorViewportChangedEvent aEvent)
     {
+        // Only react to viewport changes in the editor this navigator belongs to (#6146).
+        if (!aEvent.isFor(getModelObject())) {
+            return;
+        }
+
         aEvent.getRequestHandler().add(gotoPageTextField);
     }
 }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/paging/LineOrientedPagingStrategy.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/paging/LineOrientedPagingStrategy.java
@@ -32,7 +32,7 @@ import org.apache.wicket.Page;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.model.IModel;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
+import de.tudarmstadt.ukp.inception.diam.model.DiamContext;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
 import de.tudarmstadt.ukp.inception.rendering.paging.Unit;
 
@@ -101,6 +101,6 @@ public class LineOrientedPagingStrategy
     @Override
     public DefaultPagingNavigator createPageNavigator(String aId, Page aPage)
     {
-        return new DefaultPagingNavigator(aId, (AnnotationPageBase) aPage);
+        return new DefaultPagingNavigator(aId, (DiamContext) aPage);
     }
 }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/paging/NoPagingStrategy.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/paging/NoPagingStrategy.java
@@ -27,7 +27,7 @@ import org.apache.wicket.Page;
 import org.apache.wicket.markup.html.panel.EmptyPanel;
 import org.apache.wicket.model.IModel;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
+import de.tudarmstadt.ukp.inception.diam.model.DiamContext;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
 import de.tudarmstadt.ukp.inception.rendering.paging.Unit;
 
@@ -54,7 +54,7 @@ public class NoPagingStrategy
     @Override
     public DefaultPagingNavigator createPageNavigator(String aId, Page aPage)
     {
-        var navi = new DefaultPagingNavigator(aId, (AnnotationPageBase) aPage);
+        var navi = new DefaultPagingNavigator(aId, (DiamContext) aPage);
         navi.setOutputMarkupPlaceholderTag(true);
         navi.setVisible(false);
         return navi;

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/paging/PagingStrategy_ImplBase.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/paging/PagingStrategy_ImplBase.java
@@ -68,7 +68,7 @@ public abstract class PagingStrategy_ImplBase
         switch (aPos) {
         case TOP: {
             aState.setPageBegin(aCas, unit.getBegin());
-            fireScrollToEvent(aOffset, aPingRanges, aPos);
+            fireScrollToEvent(aState, aOffset, aPingRanges, aPos);
             break;
         }
         case CENTERED: {
@@ -79,7 +79,7 @@ public abstract class PagingStrategy_ImplBase
 
             aState.setPageBegin(aCas, firstUnit.getBegin());
             aState.setFocusUnitIndex(unit.getIndex());
-            fireScrollToEvent(aOffset, aPingRanges, aPos);
+            fireScrollToEvent(aState, aOffset, aPingRanges, aPos);
             break;
         }
         default:
@@ -94,7 +94,8 @@ public abstract class PagingStrategy_ImplBase
         moveToOffset(aState, aCas, aOffset, aPingRange != null ? asList(aPingRange) : null, aPos);
     }
 
-    private void fireScrollToEvent(int aOffset, List<VRange> aPingRanges, FocusPosition aPos)
+    private void fireScrollToEvent(AnnotatorViewState aSource, int aOffset,
+            List<VRange> aPingRanges, FocusPosition aPos)
     {
         var requestCycle = RequestCycle.get();
 
@@ -106,7 +107,8 @@ public abstract class PagingStrategy_ImplBase
         if (handler.isPresent() && handler.get().isPageInstanceCreated()) {
             var page = (Page) handler.get().getPage();
             var target = requestCycle.find(AjaxRequestTarget.class).orElse(null);
-            page.send(page, BREADTH, new ScrollToEvent(target, aOffset, aPingRanges, aPos));
+            page.send(page, BREADTH,
+                    new ScrollToEvent(aSource, target, aOffset, aPingRanges, aPos));
         }
     }
 }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/paging/SentenceOrientedPagingStrategy.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/paging/SentenceOrientedPagingStrategy.java
@@ -31,7 +31,7 @@ import org.apache.wicket.Page;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.model.IModel;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
+import de.tudarmstadt.ukp.inception.diam.model.DiamContext;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
 import de.tudarmstadt.ukp.inception.rendering.paging.Unit;
@@ -100,6 +100,6 @@ public class SentenceOrientedPagingStrategy
     @Override
     public DefaultPagingNavigator createPageNavigator(String aId, Page aPage)
     {
-        return new DefaultPagingNavigator(aId, (AnnotationPageBase) aPage);
+        return new DefaultPagingNavigator(aId, (DiamContext) aPage);
     }
 }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/paging/TokenWrappingPagingStrategy.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/paging/TokenWrappingPagingStrategy.java
@@ -29,7 +29,7 @@ import org.apache.wicket.Page;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.model.IModel;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
+import de.tudarmstadt.ukp.inception.diam.model.DiamContext;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
 import de.tudarmstadt.ukp.inception.rendering.paging.Unit;
@@ -133,6 +133,6 @@ public class TokenWrappingPagingStrategy
     @Override
     public DefaultPagingNavigator createPageNavigator(String aId, Page aPage)
     {
-        return new DefaultPagingNavigator(aId, (AnnotationPageBase) aPage);
+        return new DefaultPagingNavigator(aId, (DiamContext) aPage);
     }
 }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/menu/ContextMenuItemContext.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/menu/ContextMenuItemContext.java
@@ -17,9 +17,20 @@
  */
 package de.tudarmstadt.ukp.inception.annotation.menu;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
+import de.tudarmstadt.ukp.inception.diam.model.DiamContext;
+import de.tudarmstadt.ukp.inception.editor.ContextMenuLookup;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
 
-public record ContextMenuItemContext(VID vid, AnnotationPageBase page) {
+/**
+ * Identifies the annotation ({@link #vid}) that a context menu was opened on, together with the
+ * {@link #context editor} it was opened in. Both the {@code context} and the
+ * {@code contextMenuLookup} belong to the editor whose {@code DiamAjaxBehavior} received the
+ * request, so context-menu items act on <i>that</i> editor rather than unconditionally on the main
+ * editor (cf. #6146). For the main editor the {@code context} is simply its
+ * {@code AnnotationPageBase}, reproducing the historic behavior.
+ */
+public record ContextMenuItemContext(VID vid, DiamContext context,
+        ContextMenuLookup contextMenuLookup)
+{
 
 }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/menu/ContextMenuItemExtension.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/annotation/menu/ContextMenuItemExtension.java
@@ -19,7 +19,6 @@ package de.tudarmstadt.ukp.inception.annotation.menu;
 
 import org.wicketstuff.jquery.ui.widget.menu.IMenuItem;
 
-import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
 import de.tudarmstadt.ukp.inception.support.extensionpoint.Extension;
 
 public interface ContextMenuItemExtension
@@ -37,5 +36,5 @@ public interface ContextMenuItemExtension
         return true;
     }
 
-    IMenuItem createMenuItem(VID aVid, int aClientX, int aClientY);
+    IMenuItem createMenuItem(ContextMenuItemContext aCtx, int aClientX, int aClientY);
 }

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/editor/state/AnnotatorStateImpl.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/inception/editor/state/AnnotatorStateImpl.java
@@ -68,6 +68,7 @@ import de.tudarmstadt.ukp.inception.rendering.paging.Unit;
 import de.tudarmstadt.ukp.inception.rendering.pipeline.RenderSlotsEvent;
 import de.tudarmstadt.ukp.inception.rendering.selection.AnnotatorViewportChangedEvent;
 import de.tudarmstadt.ukp.inception.rendering.selection.Selection;
+import de.tudarmstadt.ukp.inception.rendering.selection.SelectionChangedEvent;
 import de.tudarmstadt.ukp.inception.schema.api.layer.LayerTypes;
 
 /**
@@ -239,12 +240,40 @@ public class AnnotatorStateImpl
         constraints = aConstraints;
     }
 
-    private final Selection selection = new Selection();
+    private Selection selection = Selection.unselected();
 
     @Override
     public Selection getSelection()
     {
         return selection;
+    }
+
+    @Override
+    public void setSelection(Selection aSelection)
+    {
+        if (Objects.equals(selection, aSelection)) {
+            return;
+        }
+
+        selection = aSelection;
+
+        fireSelectionChanged();
+    }
+
+    private void fireSelectionChanged()
+    {
+        RequestCycle requestCycle = RequestCycle.get();
+
+        if (requestCycle == null) {
+            return;
+        }
+
+        Optional<IPageRequestHandler> handler = requestCycle.find(IPageRequestHandler.class);
+        if (handler.isPresent() && handler.get().isPageInstanceCreated()) {
+            Page page = (Page) handler.get().getPage();
+            page.send(page, BREADTH, new SelectionChangedEvent(this,
+                    requestCycle.find(AjaxRequestTarget.class).orElse(null)));
+        }
     }
 
     @Override
@@ -682,7 +711,7 @@ public class AnnotatorStateImpl
     @Override
     public void reset()
     {
-        getSelection().clear();
+        clearSelection();
         clearArmedSlot();
         clearRememberedFeatures();
         focusUnitIndex = 0;
@@ -735,7 +764,7 @@ public class AnnotatorStateImpl
         Optional<IPageRequestHandler> handler = requestCycle.find(IPageRequestHandler.class);
         if (handler.isPresent() && handler.get().isPageInstanceCreated()) {
             Page page = (Page) handler.get().getPage();
-            page.send(page, BREADTH, new RenderSlotsEvent(
+            page.send(page, BREADTH, new RenderSlotsEvent(this,
                     requestCycle.find(IPartialPageRequestHandler.class).orElse(null)));
         }
     }
@@ -855,7 +884,7 @@ public class AnnotatorStateImpl
         Optional<IPageRequestHandler> handler = requestCycle.find(IPageRequestHandler.class);
         if (handler.isPresent() && handler.get().isPageInstanceCreated()) {
             Page page = (Page) handler.get().getPage();
-            page.send(page, BREADTH, new AnnotatorViewportChangedEvent(
+            page.send(page, BREADTH, new AnnotatorViewportChangedEvent(this,
                     requestCycle.find(AjaxRequestTarget.class).orElse(null)));
         }
     }

--- a/inception/inception-api-editor/src/main/java/de/tudarmstadt/ukp/inception/editor/AnnotationEditorBase.java
+++ b/inception/inception-api-editor/src/main/java/de/tudarmstadt/ukp/inception/editor/AnnotationEditorBase.java
@@ -171,7 +171,7 @@ public abstract class AnnotationEditorBase
                 // Fire render event into UI
                 extensionRegistry.fireRenderRequested(aTarget, getModelObject());
                 aTarget.getPage().send(aTarget.getPage(), Broadcast.BREADTH,
-                        new RenderRequestedEvent(aTarget));
+                        new RenderRequestedEvent(getModelObject(), aTarget));
             }
         }
         catch (IllegalStateException e) {

--- a/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/editorstate/AnnotationSelectionState.java
+++ b/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/editorstate/AnnotationSelectionState.java
@@ -25,6 +25,24 @@ public interface AnnotationSelectionState
     Selection getSelection();
 
     /**
+     * Replace the current selection. This is the single choke point through which the selection of
+     * an editor changes; it broadcasts a {@code SelectionChangedEvent} carrying this state as the
+     * source (cf. #6146) when the selection actually changes.
+     *
+     * @param aSelection
+     *            the new selection (use {@link #clearSelection()} to clear).
+     */
+    void setSelection(Selection aSelection);
+
+    /**
+     * Clear the current selection. Convenience for {@code setSelection(Selection.unselected())}.
+     */
+    default void clearSelection()
+    {
+        setSelection(Selection.unselected());
+    }
+
+    /**
      * Mark a slot in the given feature state as armed. Note that this feature state does not
      * necessarily belong to the feature states for the annotation detail panel (cf.
      * {@link AnnotatorState#getFeatureStates()}) but may belong to some other feature editor

--- a/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/editorstate/EditorBoundEvent.java
+++ b/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/editorstate/EditorBoundEvent.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.rendering.editorstate;
+
+/**
+ * An event that carries the {@link AnnotatorViewState editor state} it originated from.
+ * <p>
+ * A page may host more than one editor over the same document (e.g. the main editor plus a
+ * read-only reference-document viewer, #6146). Consumers that are bound to a particular editor must
+ * therefore ignore events originating from another editor's state. Use {@link #isFor} at the top of
+ * an {@code @OnEvent} handler to fail fast on foreign events rather than hand-comparing
+ * {@link #getSource()}.
+ */
+public interface EditorBoundEvent
+{
+    /**
+     * @return the editor state this event originated from, or {@code null} if unknown.
+     */
+    AnnotatorViewState getSource();
+
+    /**
+     * @param aState
+     *            the editor state to test against.
+     * @return whether this event originated from the given editor state.
+     */
+    default boolean isFor(AnnotatorViewState aState)
+    {
+        return getSource() == aState;
+    }
+}

--- a/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/pipeline/RenderSlotsEvent.java
+++ b/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/pipeline/RenderSlotsEvent.java
@@ -19,14 +19,28 @@ package de.tudarmstadt.ukp.inception.rendering.pipeline;
 
 import org.apache.wicket.core.request.handler.IPartialPageRequestHandler;
 
+import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorViewState;
+import de.tudarmstadt.ukp.inception.rendering.editorstate.EditorBoundEvent;
+
 public class RenderSlotsEvent
+    implements EditorBoundEvent
 {
+    private final AnnotatorViewState source;
 
     private final IPartialPageRequestHandler requestHandler;
 
-    public RenderSlotsEvent(IPartialPageRequestHandler aRequestHandler)
+    public RenderSlotsEvent(AnnotatorViewState aSource, IPartialPageRequestHandler aRequestHandler)
     {
+        source = aSource;
         requestHandler = aRequestHandler;
+    }
+
+    /**
+     * @return the editor state whose slots are being (re-)rendered, or {@code null} if unknown.
+     */
+    public AnnotatorViewState getSource()
+    {
+        return source;
     }
 
     public IPartialPageRequestHandler getRequestHandler()

--- a/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/request/RenderRequestedEvent.java
+++ b/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/request/RenderRequestedEvent.java
@@ -19,13 +19,29 @@ package de.tudarmstadt.ukp.inception.rendering.request;
 
 import org.apache.wicket.core.request.handler.IPartialPageRequestHandler;
 
+import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorViewState;
+import de.tudarmstadt.ukp.inception.rendering.editorstate.EditorBoundEvent;
+
 public class RenderRequestedEvent
+    implements EditorBoundEvent
 {
+    private final AnnotatorViewState source;
+
     private final IPartialPageRequestHandler requestHandler;
 
-    public RenderRequestedEvent(IPartialPageRequestHandler aRequestHandler)
+    public RenderRequestedEvent(AnnotatorViewState aSource,
+            IPartialPageRequestHandler aRequestHandler)
     {
+        source = aSource;
         requestHandler = aRequestHandler;
+    }
+
+    /**
+     * @return the editor state that requested the render, or {@code null} if unknown.
+     */
+    public AnnotatorViewState getSource()
+    {
+        return source;
     }
 
     public IPartialPageRequestHandler getRequestHandler()

--- a/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/selection/AnnotatorViewportChangedEvent.java
+++ b/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/selection/AnnotatorViewportChangedEvent.java
@@ -20,6 +20,8 @@ package de.tudarmstadt.ukp.inception.rendering.selection;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
+import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorViewState;
+import de.tudarmstadt.ukp.inception.rendering.editorstate.EditorBoundEvent;
 
 /**
  * Fired by {@link AnnotatorState} if the parameters controlling the viewport have changed.
@@ -38,13 +40,25 @@ import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
  * @see AnnotatorState#getWindowEndOffset()
  */
 public class AnnotatorViewportChangedEvent
+    implements EditorBoundEvent
 {
+    private final AnnotatorViewState source;
 
     private final AjaxRequestTarget requestHandler;
 
-    public AnnotatorViewportChangedEvent(AjaxRequestTarget aRequestHandler)
+    public AnnotatorViewportChangedEvent(AnnotatorViewState aSource,
+            AjaxRequestTarget aRequestHandler)
     {
+        source = aSource;
         requestHandler = aRequestHandler;
+    }
+
+    /**
+     * @return the editor state whose viewport changed, or {@code null} if unknown.
+     */
+    public AnnotatorViewState getSource()
+    {
+        return source;
     }
 
     public AjaxRequestTarget getRequestHandler()

--- a/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/selection/ScrollToEvent.java
+++ b/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/selection/ScrollToEvent.java
@@ -23,28 +23,44 @@ import java.util.List;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
 
+import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorViewState;
+import de.tudarmstadt.ukp.inception.rendering.editorstate.EditorBoundEvent;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VRange;
 
 public class ScrollToEvent
+    implements EditorBoundEvent
 {
+    private final AnnotatorViewState source;
     private final AjaxRequestTarget requestHandler;
     private final int offset;
     private final List<VRange> pingRanges;
     private final FocusPosition position;
 
-    public ScrollToEvent(AjaxRequestTarget aRequestHandler, int aOffset, VRange aPingRange,
-            FocusPosition aPos)
+    public ScrollToEvent(AnnotatorViewState aSource, AjaxRequestTarget aRequestHandler, int aOffset,
+            VRange aPingRange, FocusPosition aPos)
     {
-        this(aRequestHandler, aOffset, aPingRange != null ? asList(aPingRange) : null, aPos);
+        this(aSource, aRequestHandler, aOffset, aPingRange != null ? asList(aPingRange) : null,
+                aPos);
     }
 
-    public ScrollToEvent(AjaxRequestTarget aRequestHandler, int aOffset, List<VRange> aPingRanges,
-            FocusPosition aPos)
+    public ScrollToEvent(AnnotatorViewState aSource, AjaxRequestTarget aRequestHandler, int aOffset,
+            List<VRange> aPingRanges, FocusPosition aPos)
     {
+        source = aSource;
         requestHandler = aRequestHandler;
         offset = aOffset;
         position = aPos;
         pingRanges = aPingRanges;
+    }
+
+    /**
+     * @return the annotator state that originated this scroll request. An editor should only react
+     *         to events originating from its own state so that paging one editor does not scroll
+     *         other editors sharing the same page (e.g. a reference-document sidebar viewer).
+     */
+    public AnnotatorViewState getSource()
+    {
+        return source;
     }
 
     public AjaxRequestTarget getRequestHandler()

--- a/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/selection/Selection.java
+++ b/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/selection/Selection.java
@@ -21,17 +21,12 @@ import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.FEAT_REL_SOURCE;
 import static de.tudarmstadt.ukp.inception.support.WebAnnoConst.FEAT_REL_TARGET;
 import static de.tudarmstadt.ukp.inception.support.uima.ICasUtil.getAddr;
 import static de.tudarmstadt.ukp.inception.support.uima.Range.rangeClippedToDocument;
-import static org.apache.wicket.event.Broadcast.BREADTH;
 
 import java.io.Serializable;
-import java.util.Optional;
+import java.util.Objects;
 
 import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.text.AnnotationFS;
-import org.apache.wicket.Page;
-import org.apache.wicket.ajax.AjaxRequestTarget;
-import org.apache.wicket.core.request.handler.IPageRequestHandler;
-import org.apache.wicket.request.cycle.RequestCycle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,6 +34,12 @@ import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
 import de.tudarmstadt.ukp.inception.support.uima.ICasUtil;
 import de.tudarmstadt.ukp.inception.support.uima.Range;
 
+/**
+ * An immutable snapshot of what an editor has selected. Instances are created through the static
+ * factory methods ({@link #unselected()}, {@link #span}, {@link #arc}); the current selection of an
+ * editor is replaced wholesale via {@code AnnotatorState.setSelection(Selection)}, which is the
+ * single place that broadcasts a {@link SelectionChangedEvent}.
+ */
 public class Selection
     implements Serializable
 {
@@ -46,48 +47,67 @@ public class Selection
 
     private static final long serialVersionUID = 2257223261821341371L;
 
+    private static final Selection UNSELECTED = new Selection(VID.NONE_ID, -1, -1, "", -1, -1, null,
+            null);
+
     // the span id of the dependent in arc annotation
-    private int originSpanId;
+    private final int originSpanId;
 
     // The span id of the governor in arc annotation
-    private int targetSpanId;
+    private final int targetSpanId;
 
     // the begin offset of a span annotation
-    private int beginOffset;
+    private final int beginOffset;
 
     // the end offset of a span annotation
-    private int endOffset;
+    private final int endOffset;
 
     // id of the select annotation layer
-    private VID selectedAnnotationId = VID.NONE_ID;
+    private final VID selectedAnnotationId;
 
     // selected span text
-    private String text;
+    private final String text;
 
-    private String originText;
-    private String targetText;
+    private final String originText;
+    private final String targetText;
 
-    public Selection()
+    private Selection(VID aSelectedAnnotationId, int aBeginOffset, int aEndOffset, String aText,
+            int aOriginSpanId, int aTargetSpanId, String aOriginText, String aTargetText)
     {
-        // Nothing to do
+        selectedAnnotationId = aSelectedAnnotationId;
+        beginOffset = aBeginOffset;
+        endOffset = aEndOffset;
+        text = aText;
+        originSpanId = aOriginSpanId;
+        targetSpanId = aTargetSpanId;
+        originText = aOriginText;
+        targetText = aTargetText;
     }
 
-    public void selectArc(AnnotationFS aFS)
+    /**
+     * @return the empty selection (nothing selected).
+     */
+    public static Selection unselected()
+    {
+        return UNSELECTED;
+    }
+
+    public static Selection arc(AnnotationFS aFS)
     {
         var depType = aFS.getType();
         var originFeat = depType.getFeatureByBaseName(FEAT_REL_SOURCE);
         var targetFeat = depType.getFeatureByBaseName(FEAT_REL_TARGET);
         var originFS = (AnnotationFS) aFS.getFeatureValue(originFeat);
         var targetFS = (AnnotationFS) aFS.getFeatureValue(targetFeat);
-        selectArc(VID.builder().forAnnotation(aFS).build(), originFS, targetFS);
+        return arc(VID.of(aFS), originFS, targetFS);
     }
 
-    public void selectArc(AnnotationFS aOriginFs, AnnotationFS aTargetFs)
+    public static Selection arc(AnnotationFS aOriginFs, AnnotationFS aTargetFs)
     {
-        selectArc(VID.NONE_ID, aOriginFs, aTargetFs);
+        return arc(VID.NONE_ID, aOriginFs, aTargetFs);
     }
 
-    public void selectArc(VID aVid, AnnotationFS aOriginFs, AnnotationFS aTargetFs)
+    public static Selection arc(VID aVid, AnnotationFS aOriginFs, AnnotationFS aTargetFs)
     {
         if (aVid.isSet()) {
             try {
@@ -95,39 +115,35 @@ public class Selection
             }
             catch (Exception e) {
                 LOG.error("While selecting an arc the VID does not point to a valid annotation", e);
-                clear();
-                return;
+                return unselected();
             }
         }
-
-        selectedAnnotationId = aVid;
-        text = "[" + aOriginFs.getCoveredText() + "] - [" + aTargetFs.getCoveredText() + "]";
-        originText = aOriginFs.getCoveredText();
-        targetText = aTargetFs.getCoveredText();
 
         var clippedRange = rangeClippedToDocument(aOriginFs.getCAS(),
                 Math.min(aOriginFs.getBegin(), aTargetFs.getBegin()),
                 Math.max(aOriginFs.getEnd(), aTargetFs.getEnd()));
 
-        beginOffset = clippedRange.getBegin();
-        endOffset = clippedRange.getEnd();
+        var selection = new Selection(aVid, clippedRange.getBegin(), clippedRange.getEnd(),
+                "[" + aOriginFs.getCoveredText() + "] - [" + aTargetFs.getCoveredText() + "]",
+                getAddr(aOriginFs), getAddr(aTargetFs), aOriginFs.getCoveredText(),
+                aTargetFs.getCoveredText());
 
-        // Properties used when an arc is selected
-        originSpanId = getAddr(aOriginFs);
-        targetSpanId = getAddr(aTargetFs);
+        LOG.trace("Arc selected: {}", selection);
 
-        LOG.trace("Arc selected: {}", this);
-
-        fireSelectionChanged();
+        return selection;
     }
 
-    public void selectSpan(AnnotationFS aFS)
+    public static Selection span(AnnotationFS aFS)
     {
-        selectSpan(VID.builder().forAnnotation(aFS).build(), aFS.getCAS(), aFS.getBegin(),
-                aFS.getEnd());
+        return span(VID.of(aFS), aFS.getCAS(), aFS.getBegin(), aFS.getEnd());
     }
 
-    public void selectSpan(VID aVid, CAS aCAS, int aBegin, int aEnd)
+    public static Selection span(CAS aCas, int aBegin, int aEnd)
+    {
+        return span(VID.NONE_ID, aCas, aBegin, aEnd);
+    }
+
+    public static Selection span(VID aVid, CAS aCAS, int aBegin, int aEnd)
     {
         if (aVid.isSet()) {
             try {
@@ -135,48 +151,19 @@ public class Selection
             }
             catch (Exception e) {
                 LOG.error("While selecting a span the VID does not point to a valid annotation", e);
-                clear();
-                return;
+                return unselected();
             }
         }
 
         var clippedRange = Range.rangeClippedToDocument(aCAS, aBegin, aEnd);
 
-        selectedAnnotationId = aVid;
-        text = aCAS.getDocumentText().substring(aBegin, aEnd);
-        beginOffset = clippedRange.getBegin();
-        endOffset = clippedRange.getEnd();
+        // Properties used when an arc is selected (origin/target) are cleared for a span
+        var selection = new Selection(aVid, clippedRange.getBegin(), clippedRange.getEnd(),
+                aCAS.getDocumentText().substring(aBegin, aEnd), -1, -1, null, null);
 
-        // Properties used when an arc is selected
-        originSpanId = -1;
-        targetSpanId = -1;
-        originText = null;
-        targetText = null;
+        LOG.trace("Span selected: {}", selection);
 
-        LOG.trace("Span selected: {}", this);
-
-        fireSelectionChanged();
-    }
-
-    public void selectSpan(CAS aCas, int aBegin, int aEnd)
-    {
-        selectSpan(VID.NONE_ID, aCas, aBegin, aEnd);
-    }
-
-    public void clear()
-    {
-        selectedAnnotationId = VID.NONE_ID;
-        beginOffset = -1;
-        endOffset = -1;
-        text = "";
-
-        // Properties used when an arc is selected
-        originSpanId = -1;
-        targetSpanId = -1;
-
-        LOG.trace("Selection cleared: {}", this);
-
-        fireSelectionChanged();
+        return selection;
     }
 
     public boolean isSet()
@@ -238,22 +225,11 @@ public class Selection
     }
 
     /**
-     * @deprecated Should no longer be used. Instead, text is set implicitly through
-     *             {@link #selectSpan} and {@code #selectArc}.
-     */
-    @SuppressWarnings("javadoc")
-    @Deprecated
-    public void setText(String aText)
-    {
-        text = aText;
-    }
-
-    /**
      * If an existing annotation is selected, it is returned here. Mind that a selection does not
      * have to point at an existing annotation. It can also point just at a span of text or at the
      * endpoints of a relation. In this case, the endpoints or begin/end offsets are set, but not
      * the annotation ID.
-     * 
+     *
      * @return the VID;
      */
     public VID getAnnotation()
@@ -261,27 +237,28 @@ public class Selection
         return selectedAnnotationId;
     }
 
-    public void reverseArc()
+    @Override
+    public boolean equals(Object aObj)
     {
-        int tempSpanId = originSpanId;
-        originSpanId = targetSpanId;
-        targetSpanId = tempSpanId;
-
-        String tempText = originText;
-        originText = targetText;
-        targetText = tempText;
-
-        fireSelectionChanged();
+        if (this == aObj) {
+            return true;
+        }
+        if (!(aObj instanceof Selection)) {
+            return false;
+        }
+        var other = (Selection) aObj;
+        return originSpanId == other.originSpanId && targetSpanId == other.targetSpanId
+                && beginOffset == other.beginOffset && endOffset == other.endOffset
+                && Objects.equals(selectedAnnotationId, other.selectedAnnotationId)
+                && Objects.equals(text, other.text) && Objects.equals(originText, other.originText)
+                && Objects.equals(targetText, other.targetText);
     }
 
-    private void fireSelectionChanged()
+    @Override
+    public int hashCode()
     {
-        Optional<IPageRequestHandler> handler = RequestCycle.get().find(IPageRequestHandler.class);
-        if (handler.isPresent() && handler.get().isPageInstanceCreated()) {
-            Page page = (Page) handler.get().getPage();
-            page.send(page, BREADTH, new SelectionChangedEvent(
-                    RequestCycle.get().find(AjaxRequestTarget.class).orElse(null)));
-        }
+        return Objects.hash(originSpanId, targetSpanId, beginOffset, endOffset,
+                selectedAnnotationId, text, originText, targetText);
     }
 
     @Override
@@ -312,31 +289,5 @@ public class Selection
         builder.append(text);
         builder.append("]]");
         return builder.toString();
-    }
-
-    public Selection copy()
-    {
-        Selection sel = new Selection();
-        sel.originSpanId = originSpanId;
-        sel.targetSpanId = targetSpanId;
-        sel.beginOffset = beginOffset;
-        sel.endOffset = endOffset;
-        sel.selectedAnnotationId = selectedAnnotationId;
-        sel.text = text;
-        sel.originText = originText;
-        sel.targetText = targetText;
-        return sel;
-    }
-
-    public void set(Selection aSelection)
-    {
-        originSpanId = aSelection.originSpanId;
-        targetSpanId = aSelection.targetSpanId;
-        beginOffset = aSelection.beginOffset;
-        endOffset = aSelection.endOffset;
-        selectedAnnotationId = aSelection.selectedAnnotationId;
-        text = aSelection.text;
-        originText = aSelection.originText;
-        targetText = aSelection.targetText;
     }
 }

--- a/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/selection/SelectionChangedEvent.java
+++ b/inception/inception-api-render/src/main/java/de/tudarmstadt/ukp/inception/rendering/selection/SelectionChangedEvent.java
@@ -19,17 +19,32 @@ package de.tudarmstadt.ukp.inception.rendering.selection;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
 
+import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorViewState;
+import de.tudarmstadt.ukp.inception.rendering.editorstate.EditorBoundEvent;
+
 /**
- * Fired by {@link Selection} when the selection changes.
+ * Fired when the selection of an editor changes. Carries the originating editor state as
+ * {@link #getSource() source} so consumers can react only to their own editor (cf. #6146).
  */
 public class SelectionChangedEvent
+    implements EditorBoundEvent
 {
+    private final AnnotatorViewState source;
 
     private final AjaxRequestTarget requestHandler;
 
-    public SelectionChangedEvent(AjaxRequestTarget aRequestHandler)
+    public SelectionChangedEvent(AnnotatorViewState aSource, AjaxRequestTarget aRequestHandler)
     {
+        source = aSource;
         requestHandler = aRequestHandler;
+    }
+
+    /**
+     * @return the editor state whose selection changed, or {@code null} if unknown.
+     */
+    public AnnotatorViewState getSource()
+    {
+        return source;
     }
 
     public AjaxRequestTarget getRequestHandler()

--- a/inception/inception-assistant-ui/pom.xml
+++ b/inception/inception-assistant-ui/pom.xml
@@ -82,6 +82,11 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-api-diam</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-ui-annotation</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -108,11 +113,6 @@
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-model-vdoc</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
-      <artifactId>inception-api-editor</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/inception/inception-assistant-ui/src/main/java/de/tudarmstadt/ukp/inception/assistant/contextmenu/CheckAnnotationContextMenuItem.java
+++ b/inception/inception-assistant-ui/src/main/java/de/tudarmstadt/ukp/inception/assistant/contextmenu/CheckAnnotationContextMenuItem.java
@@ -32,7 +32,6 @@ import de.tudarmstadt.ukp.inception.annotation.layer.span.api.SpanLayerSupport;
 import de.tudarmstadt.ukp.inception.annotation.menu.ContextMenuItemContext;
 import de.tudarmstadt.ukp.inception.annotation.menu.ContextMenuItemExtension;
 import de.tudarmstadt.ukp.inception.assistant.sidebar.AssistantSidebarFactory;
-import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
 import de.tudarmstadt.ukp.inception.scheduling.SchedulingService;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaMenuItem;
@@ -58,10 +57,10 @@ public class CheckAnnotationContextMenuItem
     @Override
     public boolean accepts(ContextMenuItemContext aCtx)
     {
-        var state = aCtx.page().getModelObject();
+        var state = aCtx.context().getAnnotatorState();
 
         try {
-            var cas = aCtx.page().getEditorCas();
+            var cas = aCtx.context().getEditorCas();
             var ann = selectAnnotationByAddr(cas, aCtx.vid().getId());
             if (ann == null) {
                 return false;
@@ -76,7 +75,7 @@ public class CheckAnnotationContextMenuItem
     }
 
     @Override
-    public IMenuItem createMenuItem(VID aVid, int aClientX, int aClientY)
+    public IMenuItem createMenuItem(ContextMenuItemContext aCtx, int aClientX, int aClientY)
     {
         return new LambdaMenuItem("Check ...", "fa-regular fa-comments", $ -> {
             // Need to fetch the item from the application context statically to make the
@@ -84,32 +83,30 @@ public class CheckAnnotationContextMenuItem
             // serializable
             getApplicationContext() //
                     .getBean(CheckAnnotationContextMenuItem.class) //
-                    .actionCheck($, aVid, aClientX, aClientY);
+                    .actionCheck($, aCtx, aClientX, aClientY);
         });
     }
 
-    private void actionCheck(AjaxRequestTarget aTarget, VID paramId, int aClientX, int aClientY)
+    private void actionCheck(AjaxRequestTarget aTarget, ContextMenuItemContext aCtx, int aClientX,
+            int aClientY)
         throws IOException
     {
+        // Revealing the assistant sidebar is a page-level action; the page hosts the sidebar
+        // regardless of which editor the context menu was opened in.
         var page = (AnnotationPageBase) aTarget.getPage();
-
-        var maybeContextMenuLookup = page.getContextMenuLookup();
-        if (!maybeContextMenuLookup.isPresent()) {
-            return;
-        }
-
         page.visitChildren(SidebarPanel.class,
                 (c, v) -> ((SidebarPanel) c).showTab(aTarget, assistantSidebarFactory.getId()));
 
+        // The annotation being checked belongs to the editor the menu was opened in.
         var sessionOwner = userService.getCurrentUser();
-        var state = page.getModelObject();
+        var state = aCtx.context().getAnnotatorState();
         schedulingService.enqueue(CheckAnnotationTask.builder() //
                 .withTrigger("Context menu") //
                 .withSessionOwner(sessionOwner) //
                 .withProject(state.getProject()) //
                 .withDocument(state.getDocument()) //
                 .withDataOwner(state.getUser().getUsername()) //
-                .withAnnotation(paramId) //
+                .withAnnotation(aCtx.vid()) //
                 .build());
     }
 }

--- a/inception/inception-assistant-ui/src/main/java/de/tudarmstadt/ukp/inception/assistant/sidebar/AssistantPanel.java
+++ b/inception/inception-assistant-ui/src/main/java/de/tudarmstadt/ukp/inception/assistant/sidebar/AssistantPanel.java
@@ -66,7 +66,7 @@ public class AssistantPanel
 
         add(new SvelteBehavior());
 
-        add(diamBehavior = new DiamAjaxBehavior(null));
+        add(diamBehavior = new DiamAjaxBehavior(findParent(AnnotationPageBase.class)));
     }
 
     @Override

--- a/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/annotation/BratAnnotationEditor.java
+++ b/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/annotation/BratAnnotationEditor.java
@@ -139,7 +139,7 @@ public class BratAnnotationEditor
     @Override
     public void renderHead(IHeaderResponse aResponse)
     {
-        var cmdQueue = QueuedEditorCommandsMetaDataKey.get();
+        var cmdQueue = QueuedEditorCommandsMetaDataKey.get(this);
         var collInfo = collectionInformationHandler.getCollectionInformation(getModelObject());
         cmdQueue.add(new LoadCollectionCommand(collInfo));
         cmdQueue.add(new LoadAnnotationsCommand());

--- a/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/annotation/GetCollectionInformationHandler.java
+++ b/inception/inception-brat-editor/src/main/java/de/tudarmstadt/ukp/clarin/webanno/brat/annotation/GetCollectionInformationHandler.java
@@ -58,7 +58,7 @@ class GetCollectionInformationHandler
             Request aRequest)
     {
         try {
-            var result = getCollectionInformation(getAnnotatorState());
+            var result = getCollectionInformation(aBehavior.getContext().getAnnotatorState());
             BratRequestUtils.attachResponse(aTarget, vis, result);
             return new DefaultAjaxResponse(getAction(aRequest));
         }

--- a/inception/inception-diam-api/pom.xml
+++ b/inception/inception-diam-api/pom.xml
@@ -26,8 +26,32 @@
   <artifactId>inception-api-diam</artifactId>
   <name>INCEpTION - DIAM - API</name>
   <dependencies>
-   <dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-    </dependency>  </dependencies>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.uima</groupId>
+      <artifactId>uimaj-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-api-render</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-schema-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-model</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.wicket</groupId>
+      <artifactId>wicket-core</artifactId>
+    </dependency>
+  </dependencies>
 </project>

--- a/inception/inception-diam-api/src/main/java/de/tudarmstadt/ukp/inception/diam/model/DiamContext.java
+++ b/inception/inception-diam-api/src/main/java/de/tudarmstadt/ukp/inception/diam/model/DiamContext.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.diam.model;
+
+import java.io.IOException;
+
+import org.apache.uima.cas.CAS;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.inception.editor.action.AnnotationActionHandler;
+import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
+import de.tudarmstadt.ukp.inception.schema.api.adapter.AnnotationException;
+
+/**
+ * Editor-scoped context through which DIAM AJAX request handlers resolve the annotator state, the
+ * editor CAS and the action handler of the editor they are serving.
+ * <p>
+ * Handlers used to resolve all of these via {@code getPage()}, which always returned the
+ * <i>main</i> editor's page regardless of which editor's {@code DiamAjaxBehavior} received the
+ * request. By going through a context held on the behavior instead, handlers can serve alternative
+ * editors (e.g. a read-only editor embedded in a sidebar) without leaking actions into the main
+ * editor.
+ * <p>
+ * Editability is <i>not</i> part of this context: it is a property of the
+ * {@link AnnotationActionHandler} (which performs the writes), so mutating handlers fail closed via
+ * {@code getActionHandler().ensureIsEditable()}.
+ * <p>
+ * A context is mandatory: every {@code DiamAjaxBehavior} is constructed with one and handlers
+ * dereference it unconditionally. {@code AnnotationPageBase} implements this interface, so the main
+ * editor simply supplies its page as the context, reproducing the historic {@code getPage()}
+ * behavior.
+ */
+public interface DiamContext
+{
+    AnnotatorState getAnnotatorState();
+
+    CAS getEditorCas() throws IOException;
+
+    AnnotationActionHandler getActionHandler();
+
+    /**
+     * Navigate the editor served by this context to show the given document at the given offsets.
+     * <p>
+     * A page-hosted editor may switch the document currently displayed on the page; a
+     * self-contained editor (e.g. a read-only reference document in a sidebar) scrolls within its
+     * own document and does not switch documents. Navigation therefore stays with the editor that
+     * received the request instead of always driving the main editor's page.
+     *
+     * @param aTarget
+     *            the AJAX target
+     * @param aDocument
+     *            the document to show
+     * @param aBegin
+     *            the offset to scroll to
+     * @param aEnd
+     *            the corresponding end offset
+     * @throws IOException
+     *             if there was an I/O-level problem
+     * @throws AnnotationException
+     *             if there was an annotation-level problem
+     */
+    void actionShowSelectedDocument(AjaxRequestTarget aTarget, SourceDocument aDocument, int aBegin,
+            int aEnd)
+        throws IOException, AnnotationException;
+
+    /**
+     * Re-render the editor served by this context, e.g. after the annotator state's visible window
+     * changed (paging). A page-hosted editor refreshes the editor on its page; a self-contained
+     * editor (e.g. a read-only reference document in a sidebar) re-renders itself. This keeps
+     * paging with the editor that received the request instead of always refreshing the main
+     * editor's page.
+     *
+     * @param aTarget
+     *            the AJAX target
+     */
+    void actionRefreshDocument(AjaxRequestTarget aTarget);
+}

--- a/inception/inception-diam-editor/pom.xml
+++ b/inception/inception-diam-editor/pom.xml
@@ -50,6 +50,11 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-api-diam</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-annotation-storage-api</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/inception/inception-diam-editor/src/main/java/de/tudarmstadt/ukp/inception/diam/sidebar/DiamAnnotationBrowser.java
+++ b/inception/inception-diam-editor/src/main/java/de/tudarmstadt/ukp/inception/diam/sidebar/DiamAnnotationBrowser.java
@@ -117,7 +117,7 @@ public class DiamAnnotationBrowser
 
     protected DiamAjaxBehavior createDiamBehavior()
     {
-        return new DiamAjaxBehavior(contextMenu);
+        return new DiamAjaxBehavior(findParent(AnnotationPageBase.class), contextMenu);
     }
 
     @Override

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/DiamAjaxBehavior.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/DiamAjaxBehavior.java
@@ -21,6 +21,7 @@ import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.lang3.Validate;
 import org.apache.wicket.ajax.AbstractDefaultAjaxBehavior;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.request.cycle.RequestCycle;
@@ -30,6 +31,7 @@ import org.slf4j.LoggerFactory;
 
 import de.tudarmstadt.ukp.inception.diam.editor.actions.EditorAjaxRequestHandler;
 import de.tudarmstadt.ukp.inception.diam.editor.actions.EditorAjaxRequestHandlerExtensionPoint;
+import de.tudarmstadt.ukp.inception.diam.model.DiamContext;
 import de.tudarmstadt.ukp.inception.editor.ContextMenuLookup;
 import de.tudarmstadt.ukp.inception.support.http.ServerTimingWatch;
 import de.tudarmstadt.ukp.inception.support.wicket.ContextMenu;
@@ -48,16 +50,21 @@ public class DiamAjaxBehavior
 
     private boolean globalHandlersEnabled = true;
 
+    private DiamContext context;
+
     private final ContextMenu contextMenu;
 
-    public DiamAjaxBehavior()
+    public DiamAjaxBehavior(DiamContext aContext)
     {
-        this(null);
+        this(aContext, null);
     }
 
-    public DiamAjaxBehavior(ContextMenu aContextMenu)
+    public DiamAjaxBehavior(DiamContext aContext, ContextMenu aContextMenu)
     {
+        Validate.notNull(aContext, "DiamContext must be set");
+
         contextMenu = aContextMenu;
+        context = aContext;
     }
 
     public DiamAjaxBehavior addPriorityHandler(EditorAjaxRequestHandler aHandler)
@@ -72,6 +79,15 @@ public class DiamAjaxBehavior
         return this;
     }
 
+    /**
+     * @return the editor-scoped context through which handlers resolve state, CAS, action handler
+     *         and editability. Never {@code null} — it is mandatory and set at construction.
+     */
+    public DiamContext getContext()
+    {
+        return context;
+    }
+
     @Override
     protected void onBind()
     {
@@ -81,10 +97,10 @@ public class DiamAjaxBehavior
     @Override
     protected void respond(AjaxRequestTarget aTarget)
     {
-        var request = RequestCycle.get().getRequest();
+        var diamRequest = new DiamRequest(context, RequestCycle.get().getRequest());
 
         var priorityHandler = priorityHandlers.stream() //
-                .filter(handler -> handler.accepts(request)) //
+                .filter(handler -> handler.accepts(diamRequest)) //
                 .findFirst();
 
         if (priorityHandler.isPresent()) {
@@ -93,7 +109,7 @@ public class DiamAjaxBehavior
         }
 
         if (globalHandlersEnabled) {
-            handlers.getHandler(request) //
+            handlers.getHandler(diamRequest) //
                     .ifPresent(h -> call(aTarget, h));
         }
     }

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/DiamRequest.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/DiamRequest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.diam.editor;
+
+import org.apache.wicket.request.Request;
+
+import de.tudarmstadt.ukp.inception.diam.model.DiamContext;
+
+/**
+ * The dispatch context for a DIAM AJAX request: the {@link Request} together with the
+ * {@link DiamContext} of the editor that received it.
+ * <p>
+ * This is the {@code C} of the {@code Extension<C>} framework for
+ * {@link de.tudarmstadt.ukp.inception.diam.editor.actions.EditorAjaxRequestHandler}. Bundling both
+ * into a single value keeps the framework's single-context {@code accepts(C)} shape while still
+ * giving acceptance checks access to the requesting editor's state (so they no longer fall back to
+ * the main page).
+ */
+public class DiamRequest
+{
+    private final DiamContext context;
+    private final Request request;
+
+    public DiamRequest(DiamContext aContext, Request aRequest)
+    {
+        context = aContext;
+        request = aRequest;
+    }
+
+    public DiamContext getContext()
+    {
+        return context;
+    }
+
+    public Request getRequest()
+    {
+        return request;
+    }
+}

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/CreateRelationAnnotationHandler.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/CreateRelationAnnotationHandler.java
@@ -31,7 +31,6 @@ import org.springframework.core.annotation.Order;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.IllegalPlacementException;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.exception.NotEditableException;
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationLayer;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Sentence;
 import de.tudarmstadt.ukp.dkpro.core.api.segmentation.type.Token;
@@ -40,10 +39,9 @@ import de.tudarmstadt.ukp.inception.annotation.layer.relation.api.CreateRelation
 import de.tudarmstadt.ukp.inception.annotation.layer.relation.api.RelationAdapter;
 import de.tudarmstadt.ukp.inception.diam.editor.DiamAjaxBehavior;
 import de.tudarmstadt.ukp.inception.diam.editor.config.DiamAutoConfig;
+import de.tudarmstadt.ukp.inception.diam.model.DiamContext;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.DefaultAjaxResponse;
 import de.tudarmstadt.ukp.inception.editor.ContextMenuLookup;
-import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
-import de.tudarmstadt.ukp.inception.rendering.selection.Selection;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.AnnotationException;
@@ -107,43 +105,43 @@ public class CreateRelationAnnotationHandler
         var clientX = cm.getClientX().getAsInt();
         var clientY = cm.getClientY().getAsInt();
 
-        actionArc(aBehavior, aTarget, originSpan, targetSpan, clientX, clientY);
+        actionArc(aBehavior.getContext(), aBehavior, aTarget, originSpan, targetSpan, clientX,
+                clientY);
     }
 
-    public void actionArc(ContextMenuLookup aBehavior, AjaxRequestTarget aTarget, VID originSpan,
-            VID targetSpan, int aClientX, int aClientY)
+    public void actionArc(DiamContext aContext, ContextMenuLookup aBehavior,
+            AjaxRequestTarget aTarget, VID originSpan, VID targetSpan, int aClientX, int aClientY)
         throws NotEditableException, IOException, AnnotationException, IllegalPlacementException
     {
-        var page = getPage();
-        page.ensureIsEditable();
+        aContext.getActionHandler().ensureIsEditable();
 
         if (originSpan.isSynthetic() || targetSpan.isSynthetic()) {
+            var page = getPage();
             page.error("Relations cannot be created from/to synthetic annotations");
             aTarget.addChildren(page, IFeedback.class);
             return;
         }
 
-        var cas = page.getEditorCas();
-        var state = getAnnotatorState();
+        var cas = aContext.getEditorCas();
+        var state = aContext.getAnnotatorState();
         var originFs = selectAnnotationByAddr(cas, originSpan.getId());
         var originLayer = schemaService.findLayer(state.getProject(), originFs);
         var originAdapter = schemaService.getAdapter(originLayer);
 
         if (originAdapter instanceof ChainAdapter chainAdapter) {
-            createChainLink(chainAdapter, aTarget, originSpan, targetSpan);
+            createChainLink(aContext, chainAdapter, aTarget, originSpan, targetSpan);
         }
         else {
-            createRelationAnnotation(aBehavior, aTarget, originLayer, originSpan, targetSpan,
-                    aClientX, aClientY);
+            createRelationAnnotation(aContext, aBehavior, aTarget, originLayer, originSpan,
+                    targetSpan, aClientX, aClientY);
         }
     }
 
-    private void createChainLink(ChainAdapter chainAdapter, AjaxRequestTarget aTarget,
-            VID aOriginSpan, VID aTargetSpan)
+    private void createChainLink(DiamContext aContext, ChainAdapter chainAdapter,
+            AjaxRequestTarget aTarget, VID aOriginSpan, VID aTargetSpan)
         throws IOException, AnnotationException
     {
-        var page = getPage();
-        var cas = page.getEditorCas();
+        var cas = aContext.getEditorCas();
         var originFs = selectAnnotationByAddr(cas, aOriginSpan.getId());
         var targetFs = selectAnnotationByAddr(cas, aTargetSpan.getId());
 
@@ -152,7 +150,7 @@ public class CreateRelationAnnotationHandler
                     "Cannot create links between chain elements on different layers");
         }
 
-        var state = getAnnotatorState();
+        var state = aContext.getAnnotatorState();
         var request = new CreateRelationAnnotationRequest(state.getDocument(),
                 state.getUser().getUsername(), cas, originFs, targetFs);
 
@@ -169,13 +167,13 @@ public class CreateRelationAnnotationHandler
             }
         }
 
-        commitAnnotation(aTarget, page, state, selection);
+        commitAnnotation(aTarget, aContext, state, selection);
 
     }
 
-    private void createRelationAnnotation(ContextMenuLookup aBehavior, AjaxRequestTarget aTarget,
-            AnnotationLayer originLayer, VID aOriginSpan, VID aTargetSpan, int aClientX,
-            int aClientY)
+    private void createRelationAnnotation(DiamContext aContext, ContextMenuLookup aBehavior,
+            AjaxRequestTarget aTarget, AnnotationLayer originLayer, VID aOriginSpan,
+            VID aTargetSpan, int aClientX, int aClientY)
         throws AnnotationException, IllegalPlacementException, IOException
     {
         var candidateLayers = schemaService.getRelationLayersFor(originLayer);
@@ -186,7 +184,7 @@ public class CreateRelationAnnotationHandler
 
         if (candidateLayers.size() == 1) {
             var relationLayer = candidateLayers.get(0);
-            createRelationAnnotation(aTarget, relationLayer, aOriginSpan, aTargetSpan);
+            createRelationAnnotation(aContext, aTarget, relationLayer, aOriginSpan, aTargetSpan);
             return;
         }
 
@@ -197,25 +195,28 @@ public class CreateRelationAnnotationHandler
         items.add(new MenuCategoryHeader("Select layer..."));
         for (var layer : candidateLayers) {
             items.add(new LambdaMenuItem(layer.getUiName(), $ -> {
-                // We need to fetch the bean here again because it is not serializable and
-                // the AJAX callback here needs to be serializable
+                // The handler is a Spring bean and thus not serializable, so we re-resolve it
+                // here where the AJAX callback needs to be serializable. The context, on the
+                // other hand, is held by the (serializable) DiamAjaxBehavior and can be carried
+                // across the serialization boundary, so we keep serving the editor that opened
+                // the menu instead of re-deriving the main editor's page.
                 var handler = ApplicationContextProvider.getApplicationContext()
                         .getBean(CreateRelationAnnotationHandler.class);
-                handler.createRelationAnnotation($, layer, aOriginSpan, aTargetSpan);
+                aContext.getActionHandler().ensureIsEditable();
+                handler.createRelationAnnotation(aContext, $, layer, aOriginSpan, aTargetSpan);
             }));
         }
 
         cm.onOpen(aTarget, aClientX, aClientY);
     }
 
-    private void createRelationAnnotation(AjaxRequestTarget aTarget, AnnotationLayer relationLayer,
-            VID origin, VID target)
+    private void createRelationAnnotation(DiamContext aContext, AjaxRequestTarget aTarget,
+            AnnotationLayer relationLayer, VID origin, VID target)
         throws AnnotationException, IOException
     {
-        var state = getAnnotatorState();
+        var state = aContext.getAnnotatorState();
 
-        var page = getPage();
-        var cas = page.getEditorCas();
+        var cas = aContext.getEditorCas();
         var originFs = selectAnnotationByAddr(cas, origin.getId());
         var targetFs = selectAnnotationByAddr(cas, target.getId());
 
@@ -246,15 +247,6 @@ public class CreateRelationAnnotationHandler
             }
         }
 
-        commitAnnotation(aTarget, page, state, selection);
-    }
-
-    private void commitAnnotation(AjaxRequestTarget aTarget, AnnotationPageBase page,
-            AnnotatorState state, Selection selection)
-        throws IOException, AnnotationException
-    {
-        state.getSelection().set(selection);
-        page.getAnnotationActionHandler().actionSelect(aTarget);
-        page.getAnnotationActionHandler().writeEditorCas();
+        commitAnnotation(aTarget, aContext, state, selection);
     }
 }

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/CreateSpanAnnotationHandler.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/CreateSpanAnnotationHandler.java
@@ -29,7 +29,6 @@ import org.apache.wicket.request.IRequestParameters;
 import org.apache.wicket.request.Request;
 import org.springframework.core.annotation.Order;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
 import de.tudarmstadt.ukp.inception.annotation.layer.chain.api.ChainAdapter;
 import de.tudarmstadt.ukp.inception.annotation.layer.span.api.CreateSpanAnnotationRequest;
 import de.tudarmstadt.ukp.inception.annotation.layer.span.api.SpanAdapter;
@@ -75,19 +74,20 @@ public class CreateSpanAnnotationHandler
             Request aRequest)
     {
         try {
-            var page = getPage();
-            page.ensureIsEditable();
+            var context = aBehavior.getContext();
+            context.getActionHandler().ensureIsEditable();
 
-            var state = getAnnotatorState();
+            var state = context.getAnnotatorState();
             var layer = state.getDefaultAnnotationLayer();
             if (layer == null) {
+                var page = getPage();
                 page.info(
                         "Cannot create annotation: this project does not define any span annotation layers.");
                 aTarget.addChildren(page, IFeedback.class);
                 return new DefaultAjaxResponse(getAction(aRequest));
             }
 
-            var cas = page.getEditorCas();
+            var cas = context.getEditorCas();
             var range = getRangeFromRequest(state, aRequest.getRequestParameters(), cas);
 
             var adapter = schemaService.getAdapter(layer);
@@ -124,7 +124,7 @@ public class CreateSpanAnnotationHandler
                 }
             }
 
-            commitAnnotation(aTarget, page, state, selection);
+            commitAnnotation(aTarget, context, state, selection);
 
             return new DefaultAjaxResponse(getAction(aRequest));
         }
@@ -149,14 +149,5 @@ public class CreateSpanAnnotationHandler
         var end = aState.getWindowBeginOffset() + offsetLists.get(offsetLists.size() - 1).getEnd();
 
         return rangeClippedToDocument(aCas, begin, end);
-    }
-
-    private void commitAnnotation(AjaxRequestTarget aTarget, AnnotationPageBase page,
-            AnnotatorState state, Selection selection)
-        throws IOException, AnnotationException
-    {
-        state.getSelection().set(selection);
-        page.getAnnotationActionHandler().actionSelect(aTarget);
-        page.getAnnotationActionHandler().writeEditorCas();
     }
 }

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/DeleteAnnotationHandler.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/DeleteAnnotationHandler.java
@@ -22,6 +22,7 @@ import org.apache.wicket.request.Request;
 import org.springframework.core.annotation.Order;
 
 import de.tudarmstadt.ukp.inception.diam.editor.DiamAjaxBehavior;
+import de.tudarmstadt.ukp.inception.diam.editor.DiamRequest;
 import de.tudarmstadt.ukp.inception.diam.editor.config.DiamAutoConfig;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.DefaultAjaxResponse;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
@@ -53,9 +54,9 @@ public class DeleteAnnotationHandler
     }
 
     @Override
-    public boolean accepts(Request aRequest)
+    public boolean accepts(DiamRequest aRequest)
     {
-        return super.accepts(aRequest) && !getAnnotatorState().isSlotArmed();
+        return super.accepts(aRequest) && !aRequest.getContext().getAnnotatorState().isSlotArmed();
     }
 
     @Override
@@ -63,9 +64,9 @@ public class DeleteAnnotationHandler
             Request aRequest)
     {
         try {
-            var page = getPage();
+            var context = aBehavior.getContext();
 
-            page.ensureIsEditable();
+            context.getActionHandler().ensureIsEditable();
 
             var vid = VID.parseOptional(
                     aRequest.getRequestParameters().getParameterValue(PARAM_ID).toOptionalString());
@@ -74,16 +75,16 @@ public class DeleteAnnotationHandler
                 return new DefaultAjaxResponse(getAction(aRequest));
             }
 
-            var cas = page.getEditorCas();
-            var state = page.getModelObject();
+            var cas = context.getEditorCas();
+            var state = context.getAnnotatorState();
 
             var fs = ICasUtil.selectAnnotationByAddr(cas, vid.getId());
 
             var adapter = schemaService.findAdapter(state.getProject(), fs);
-            state.getSelection().set(adapter.select(vid, fs));
+            state.setSelection(adapter.select(vid, fs));
 
-            page.getAnnotationActionHandler().actionSelect(aTarget);
-            page.getAnnotationActionHandler().actionDelete(aTarget);
+            context.getActionHandler().actionSelect(aTarget);
+            context.getActionHandler().actionDelete(aTarget);
 
             return new DefaultAjaxResponse(getAction(aRequest));
         }

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/EditorAjaxRequestHandler.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/EditorAjaxRequestHandler.java
@@ -21,12 +21,13 @@ import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.request.Request;
 
 import de.tudarmstadt.ukp.inception.diam.editor.DiamAjaxBehavior;
+import de.tudarmstadt.ukp.inception.diam.editor.DiamRequest;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.AjaxResponse;
 import de.tudarmstadt.ukp.inception.support.extensionpoint.Extension;
 import jakarta.servlet.http.HttpServletRequest;
 
 public interface EditorAjaxRequestHandler
-    extends Extension<Request>
+    extends Extension<DiamRequest>
 {
     int PRIO_CONTEXT_MENU = -10;
     int PRIO_RENDER_HANDLER = 0;
@@ -62,10 +63,10 @@ public interface EditorAjaxRequestHandler
     String getCommand();
 
     @Override
-    default boolean accepts(Request aRequest)
+    default boolean accepts(DiamRequest aRequest)
     {
-        return getCommand().equals(
-                aRequest.getRequestParameters().getParameterValue(PARAM_ACTION).toOptionalString());
+        return getCommand().equals(aRequest.getRequest().getRequestParameters()
+                .getParameterValue(PARAM_ACTION).toOptionalString());
     }
 
     AjaxResponse handle(DiamAjaxBehavior aBehavior, AjaxRequestTarget aTarget, Request aRequest);

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/EditorAjaxRequestHandlerBase.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/EditorAjaxRequestHandlerBase.java
@@ -19,6 +19,7 @@ package de.tudarmstadt.ukp.inception.diam.editor.actions;
 
 import static java.util.Arrays.asList;
 
+import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 
 import org.apache.wicket.ajax.AjaxRequestTarget;
@@ -29,8 +30,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
+import de.tudarmstadt.ukp.inception.diam.model.DiamContext;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.DefaultAjaxResponse;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
+import de.tudarmstadt.ukp.inception.rendering.selection.Selection;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.AnnotationException;
 
@@ -59,11 +62,6 @@ public abstract class EditorAjaxRequestHandlerBase
         return (AnnotationPageBase) getAjaxRequestTarget().getPage();
     }
 
-    protected AnnotatorState getAnnotatorState()
-    {
-        return getPage().getModelObject();
-    }
-
     protected String getAction(Request aRequest)
     {
         return aRequest.getRequestParameters().getParameterValue(PARAM_ACTION).toString();
@@ -81,6 +79,19 @@ public abstract class EditorAjaxRequestHandlerBase
         var token = aRequest.getRequestParameters().getParameterValue(PARAM_TOKEN).toString();
         aTarget.prependJavaScript(
                 "document['DIAM_TRANSPORT_BUFFER']['" + token + "'] = " + json + ";");
+    }
+
+    /**
+     * Set the given selection as the current selection and commit it to the editor CAS through the
+     * context's action handler.
+     */
+    protected void commitAnnotation(AjaxRequestTarget aTarget, DiamContext aContext,
+            AnnotatorState aState, Selection aSelection)
+        throws IOException, AnnotationException
+    {
+        aState.setSelection(aSelection);
+        aContext.getActionHandler().actionSelect(aTarget);
+        aContext.getActionHandler().writeEditorCas();
     }
 
     protected DefaultAjaxResponse handleError(String aMessage, Exception e)

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/EditorAjaxRequestHandlerExtensionPoint.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/EditorAjaxRequestHandlerExtensionPoint.java
@@ -19,12 +19,11 @@ package de.tudarmstadt.ukp.inception.diam.editor.actions;
 
 import java.util.Optional;
 
-import org.apache.wicket.request.Request;
-
+import de.tudarmstadt.ukp.inception.diam.editor.DiamRequest;
 import de.tudarmstadt.ukp.inception.support.extensionpoint.ExtensionPoint;
 
 public interface EditorAjaxRequestHandlerExtensionPoint
-    extends ExtensionPoint<Request, EditorAjaxRequestHandler>
+    extends ExtensionPoint<DiamRequest, EditorAjaxRequestHandler>
 {
-    Optional<EditorAjaxRequestHandler> getHandler(Request aRequest);
+    Optional<EditorAjaxRequestHandler> getHandler(DiamRequest aRequest);
 }

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/EditorAjaxRequestHandlerExtensionPointImpl.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/EditorAjaxRequestHandlerExtensionPointImpl.java
@@ -20,10 +20,10 @@ package de.tudarmstadt.ukp.inception.diam.editor.actions;
 import java.util.List;
 import java.util.Optional;
 
-import org.apache.wicket.request.Request;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 
+import de.tudarmstadt.ukp.inception.diam.editor.DiamRequest;
 import de.tudarmstadt.ukp.inception.diam.editor.config.DiamAutoConfig;
 import de.tudarmstadt.ukp.inception.support.extensionpoint.ExtensionPoint_ImplBase;
 
@@ -34,7 +34,7 @@ import de.tudarmstadt.ukp.inception.support.extensionpoint.ExtensionPoint_ImplBa
  * </p>
  */
 public class EditorAjaxRequestHandlerExtensionPointImpl
-    extends ExtensionPoint_ImplBase<Request, EditorAjaxRequestHandler>
+    extends ExtensionPoint_ImplBase<DiamRequest, EditorAjaxRequestHandler>
     implements EditorAjaxRequestHandlerExtensionPoint
 {
     public EditorAjaxRequestHandlerExtensionPointImpl(
@@ -44,7 +44,7 @@ public class EditorAjaxRequestHandlerExtensionPointImpl
     }
 
     @Override
-    public Optional<EditorAjaxRequestHandler> getHandler(Request aRequest)
+    public Optional<EditorAjaxRequestHandler> getHandler(DiamRequest aRequest)
     {
         return getExtensions().stream() //
                 .filter(handler -> handler.accepts(aRequest)) //
@@ -61,7 +61,7 @@ public class EditorAjaxRequestHandlerExtensionPointImpl
     }
 
     @Override
-    public List<EditorAjaxRequestHandler> getExtensions(Request aContext)
+    public List<EditorAjaxRequestHandler> getExtensions(DiamRequest aContext)
     {
         // EditorAjaxRequestHandler::accept may have side-effects! In particular the
         // ImplicitUnarmSlotHandler. You do not want this side effect to unarm a slot while

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/ExtensionActionHandler.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/ExtensionActionHandler.java
@@ -22,6 +22,7 @@ import org.apache.wicket.request.Request;
 import org.springframework.core.annotation.Order;
 
 import de.tudarmstadt.ukp.inception.diam.editor.DiamAjaxBehavior;
+import de.tudarmstadt.ukp.inception.diam.editor.DiamRequest;
 import de.tudarmstadt.ukp.inception.diam.editor.config.DiamAutoConfig;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.DefaultAjaxResponse;
 import de.tudarmstadt.ukp.inception.editor.AnnotationEditorExtensionRegistry;
@@ -51,9 +52,9 @@ public class ExtensionActionHandler
     }
 
     @Override
-    public boolean accepts(Request aRequest)
+    public boolean accepts(DiamRequest aRequest)
     {
-        return getVid(aRequest).isSynthetic();
+        return getVid(aRequest.getRequest()).isSynthetic();
     }
 
     @Override
@@ -61,14 +62,14 @@ public class ExtensionActionHandler
             Request aRequest)
     {
         try {
-            var page = getPage();
-            page.ensureIsEditable();
+            var context = aBehavior.getContext();
+            context.getActionHandler().ensureIsEditable();
 
             var action = getAction(aRequest);
             var paramId = getVid(aRequest);
-            var cas = page.getEditorCas();
+            var cas = context.getEditorCas();
 
-            extensionRegistry.fireAction(page.getAnnotationActionHandler(), page.getModelObject(),
+            extensionRegistry.fireAction(context.getActionHandler(), context.getAnnotatorState(),
                     aTarget, cas, paramId, action);
 
             return new DefaultAjaxResponse(action);

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/FillSlotWithExistingAnnotationHandler.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/FillSlotWithExistingAnnotationHandler.java
@@ -22,6 +22,7 @@ import org.apache.wicket.request.Request;
 import org.springframework.core.annotation.Order;
 
 import de.tudarmstadt.ukp.inception.diam.editor.DiamAjaxBehavior;
+import de.tudarmstadt.ukp.inception.diam.editor.DiamRequest;
 import de.tudarmstadt.ukp.inception.diam.editor.config.DiamAutoConfig;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.DefaultAjaxResponse;
 
@@ -48,14 +49,14 @@ public class FillSlotWithExistingAnnotationHandler
             Request aRequest)
     {
         try {
-            var page = getPage();
-            page.ensureIsEditable();
+            var context = aBehavior.getContext();
+            context.getActionHandler().ensureIsEditable();
 
-            var cas = page.getEditorCas();
+            var cas = context.getEditorCas();
             var slotFillerId = getVid(aRequest);
             // When filling a slot, the current selection is *NOT* changed. The Span annotation
             // which owns the slot that is being filled remains selected!
-            page.getAnnotationActionHandler().actionFillSlot(aTarget, cas, slotFillerId);
+            context.getActionHandler().actionFillSlot(aTarget, cas, slotFillerId);
 
             return new DefaultAjaxResponse(getAction(aRequest));
         }
@@ -65,9 +66,9 @@ public class FillSlotWithExistingAnnotationHandler
     }
 
     @Override
-    public boolean accepts(Request aRequest)
+    public boolean accepts(DiamRequest aRequest)
     {
-        return super.accepts(aRequest) && getAnnotatorState().isSlotArmed()
-                && getVid(aRequest).isSet();
+        return super.accepts(aRequest) && aRequest.getContext().getAnnotatorState().isSlotArmed()
+                && getVid(aRequest.getRequest()).isSet();
     }
 }

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/FillSlotWithNewAnnotationHandler.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/FillSlotWithNewAnnotationHandler.java
@@ -26,7 +26,9 @@ import org.apache.wicket.request.Request;
 import org.springframework.core.annotation.Order;
 
 import de.tudarmstadt.ukp.inception.diam.editor.DiamAjaxBehavior;
+import de.tudarmstadt.ukp.inception.diam.editor.DiamRequest;
 import de.tudarmstadt.ukp.inception.diam.editor.config.DiamAutoConfig;
+import de.tudarmstadt.ukp.inception.diam.model.DiamContext;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.DefaultAjaxResponse;
 import de.tudarmstadt.ukp.inception.diam.model.compact.CompactRange;
 import de.tudarmstadt.ukp.inception.diam.model.compact.CompactRangeList;
@@ -56,11 +58,11 @@ public class FillSlotWithNewAnnotationHandler
             Request aRequest)
     {
         try {
-            var page = getPage();
-            page.ensureIsEditable();
+            var context = aBehavior.getContext();
+            context.getActionHandler().ensureIsEditable();
 
-            var cas = page.getEditorCas();
-            actionSpan(aTarget, aRequest.getRequestParameters(), cas);
+            var cas = context.getEditorCas();
+            actionSpan(context, aTarget, aRequest.getRequestParameters(), cas);
             return new DefaultAjaxResponse(getAction(aRequest));
         }
         catch (Exception e) {
@@ -69,23 +71,22 @@ public class FillSlotWithNewAnnotationHandler
     }
 
     @Override
-    public boolean accepts(Request aRequest)
+    public boolean accepts(DiamRequest aRequest)
     {
-        return super.accepts(aRequest) && getAnnotatorState().isSlotArmed();
+        return super.accepts(aRequest) && aRequest.getContext().getAnnotatorState().isSlotArmed();
     }
 
-    private void actionSpan(AjaxRequestTarget aTarget, IRequestParameters aRequestParameters,
-            CAS aCas)
+    private void actionSpan(DiamContext aContext, AjaxRequestTarget aTarget,
+            IRequestParameters aRequestParameters, CAS aCas)
         throws IOException, AnnotationException
     {
         // This is the span the user has marked in the browser in order to create a new slot-filler
         // annotation OR the span of an existing annotation which the user has selected.
-        var range = getRangeFromRequest(aTarget, aRequestParameters, aCas);
+        var range = getRangeFromRequest(aContext, aRequestParameters, aCas);
 
         // When filling a slot, the current selection is *NOT* changed. The Span annotation which
         // owns the slot that is being filled remains selected!
-        getPage().getAnnotationActionHandler().actionFillSlot(aTarget, aCas, range.getBegin(),
-                range.getEnd());
+        aContext.getActionHandler().actionFillSlot(aTarget, aCas, range.getBegin(), range.getEnd());
     }
 
     /**
@@ -93,7 +94,7 @@ public class FillSlotWithNewAnnotationHandler
      * selected annotations or offsets contained in the request for the creation of a new
      * annotation.
      */
-    private CompactRange getRangeFromRequest(AjaxRequestTarget aTarget, IRequestParameters request,
+    private CompactRange getRangeFromRequest(DiamContext aContext, IRequestParameters request,
             CAS aCas)
         throws IOException
     {
@@ -103,7 +104,7 @@ public class FillSlotWithNewAnnotationHandler
 
         var offsetLists = JSONUtil.getObjectMapper().readValue(offsets, CompactRangeList.class);
 
-        var state = getAnnotatorState();
+        var state = aContext.getAnnotatorState();
         int annotationBegin = state.getWindowBeginOffset() + offsetLists.get(0).getBegin();
         int annotationEnd = state.getWindowBeginOffset()
                 + offsetLists.get(offsetLists.size() - 1).getEnd();

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/ImplicitUnarmSlotHandler.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/ImplicitUnarmSlotHandler.java
@@ -22,9 +22,9 @@ import org.apache.wicket.request.Request;
 import org.springframework.core.annotation.Order;
 
 import de.tudarmstadt.ukp.inception.diam.editor.DiamAjaxBehavior;
+import de.tudarmstadt.ukp.inception.diam.editor.DiamRequest;
 import de.tudarmstadt.ukp.inception.diam.editor.config.DiamAutoConfig;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.AjaxResponse;
-import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
 
 /**
  * Any handlers with a later priority that this one should be called only after a potentially armed
@@ -46,9 +46,9 @@ public class ImplicitUnarmSlotHandler
     }
 
     @Override
-    public boolean accepts(Request aRequest)
+    public boolean accepts(DiamRequest aRequest)
     {
-        AnnotatorState state = getAnnotatorState();
+        var state = aRequest.getContext().getAnnotatorState();
         if (state.isSlotArmed()) {
             state.clearArmedSlot();
         }

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/LazyDetailsHandler.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/LazyDetailsHandler.java
@@ -28,7 +28,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.annotation.Order;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasProvider;
 import de.tudarmstadt.ukp.inception.diam.editor.DiamAjaxBehavior;
 import de.tudarmstadt.ukp.inception.diam.editor.config.DiamAutoConfig;
@@ -67,13 +66,13 @@ public class LazyDetailsHandler
             Request aRequest)
     {
         try {
-            var page = (AnnotationPageBase) aTarget.getPage();
+            var context = aBehavior.getContext();
 
-            CasProvider casProvider = () -> page.getEditorCas();
+            CasProvider casProvider = () -> context.getEditorCas();
 
             // Parse annotation ID if present in request
             var paramId = getVid(aRequest);
-            var state = page.getModelObject();
+            var state = context.getAnnotatorState();
             var details = lazyDetailsLookupService.lookupLazyDetails(
                     aRequest.getRequestParameters(), paramId, casProvider, state.getDocument(),
                     state.getUser(), state.getWindowBeginOffset(), state.getWindowEndOffset());

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/LinkToContextMenuItem.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/LinkToContextMenuItem.java
@@ -26,12 +26,10 @@ import java.io.IOException;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.wicketstuff.jquery.ui.widget.menu.IMenuItem;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
 import de.tudarmstadt.ukp.inception.annotation.layer.chain.api.ChainLayerSupport;
 import de.tudarmstadt.ukp.inception.annotation.layer.span.api.SpanLayerSupport;
 import de.tudarmstadt.ukp.inception.annotation.menu.ContextMenuItemContext;
 import de.tudarmstadt.ukp.inception.annotation.menu.ContextMenuItemExtension;
-import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.AnnotationException;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaMenuItem;
@@ -52,7 +50,7 @@ public class LinkToContextMenuItem
     @Override
     public boolean accepts(ContextMenuItemContext aCtx)
     {
-        var state = aCtx.page().getModelObject();
+        var state = aCtx.context().getAnnotatorState();
 
         // Origin of the relation needs to be a span
         if (!state.getSelection().isSpan()) {
@@ -61,7 +59,7 @@ public class LinkToContextMenuItem
 
         // Target also needs to be a span
         try {
-            var cas = aCtx.page().getEditorCas();
+            var cas = aCtx.context().getEditorCas();
             var ann = selectAnnotationByAddr(cas, aCtx.vid().getId());
             if (ann == null) {
                 return false;
@@ -80,35 +78,32 @@ public class LinkToContextMenuItem
     }
 
     @Override
-    public IMenuItem createMenuItem(VID aVid, int aClientX, int aClientY)
+    public IMenuItem createMenuItem(ContextMenuItemContext aCtx, int aClientX, int aClientY)
     {
         return new LambdaMenuItem("Link to ...", $ -> {
             // Ensure that lambda is serializable
             getApplicationContext() //
                     .getBean(LinkToContextMenuItem.class) //
-                    .actionLinkTo($, aVid, aClientX, aClientY);
+                    .actionLinkTo($, aCtx, aClientX, aClientY);
         });
     }
 
-    private void actionLinkTo(AjaxRequestTarget aTarget, VID paramId, int aClientX, int aClientY)
+    private void actionLinkTo(AjaxRequestTarget aTarget, ContextMenuItemContext aCtx, int aClientX,
+            int aClientY)
         throws IOException, AnnotationException
     {
-        var page = (AnnotationPageBase) aTarget.getPage();
+        // Act on the editor the context menu was opened in, not on the main editor's page.
+        var context = aCtx.context();
 
-        var maybeContextMenuLookup = page.getContextMenuLookup();
-        if (!maybeContextMenuLookup.isPresent()) {
-            return;
-        }
+        context.getActionHandler().ensureIsEditable();
 
-        page.ensureIsEditable();
-
-        var state = page.getModelObject();
+        var state = context.getAnnotatorState();
 
         if (!state.getSelection().isSpan()) {
             return;
         }
 
-        createRelationAnnotationHandler.actionArc(maybeContextMenuLookup.get(), aTarget,
-                state.getSelection().getAnnotation(), paramId, aClientX, aClientY);
+        createRelationAnnotationHandler.actionArc(context, aCtx.contextMenuLookup(), aTarget,
+                state.getSelection().getAnnotation(), aCtx.vid(), aClientX, aClientY);
     }
 }

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/LoadAnnotationsHandler.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/LoadAnnotationsHandler.java
@@ -28,6 +28,7 @@ import org.springframework.core.annotation.Order;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.inception.diam.editor.DiamAjaxBehavior;
 import de.tudarmstadt.ukp.inception.diam.editor.config.DiamAutoConfig;
+import de.tudarmstadt.ukp.inception.diam.model.DiamContext;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.AjaxResponse;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.DefaultAjaxResponse;
 import de.tudarmstadt.ukp.inception.diam.model.compact.CompactSerializerImpl;
@@ -80,7 +81,7 @@ public class LoadAnnotationsHandler
             Request aRequest)
     {
         try {
-            var request = prepareRenderRequest(aRequest);
+            var request = prepareRenderRequest(aBehavior.getContext(), aRequest);
             var vdoc = renderingPipeline.render(request);
             var json = serializeToWireFormat(aRequest, request, vdoc);
             attachResponse(aTarget, aRequest, json);
@@ -91,10 +92,10 @@ public class LoadAnnotationsHandler
         }
     }
 
-    private RenderRequest prepareRenderRequest(Request aRequest) throws IOException
+    private RenderRequest prepareRenderRequest(DiamContext aContext, Request aRequest)
+        throws IOException
     {
-        var page = getPage();
-        var state = getAnnotatorState();
+        var state = aContext.getAnnotatorState();
 
         var begin = aRequest.getRequestParameters().getParameterValue(PARAM_BEGIN)
                 .toInt(state.getWindowBeginOffset());
@@ -112,7 +113,7 @@ public class LoadAnnotationsHandler
         return RenderRequest.builder() //
                 .withState(state) //
                 .withSessionOwner(userService.getCurrentUser()) //
-                .withCas(page.getEditorCas()) //
+                .withCas(aContext.getEditorCas()) //
                 .withWindow(begin, end) //
                 .withText(includeText) //
                 .withClipSpans(clipSpans) //

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/LoadPreferences.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/LoadPreferences.java
@@ -67,7 +67,7 @@ public class LoadPreferences
             var key = new ClientSidePreferenceKey<ClientSidePreferenceMapValue>(
                     ClientSidePreferenceMapValue.class,
                     aRequest.getRequestParameters().getParameterValue(PARAM_KEY).toString());
-            var project = getAnnotatorState().getProject();
+            var project = aBehavior.getContext().getAnnotatorState().getProject();
             var sessionOwner = userService.getCurrentUser();
             var prefs = preferencesService.loadTraitsForUserAndProject(key, sessionOwner, project);
             var json = JSONUtil.toInterpretableJsonString(prefs);

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/MoveSpanAnnotationHandler.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/MoveSpanAnnotationHandler.java
@@ -30,7 +30,9 @@ import de.tudarmstadt.ukp.inception.annotation.layer.span.api.MoveSpanAnnotation
 import de.tudarmstadt.ukp.inception.annotation.layer.span.api.SpanAdapter;
 import de.tudarmstadt.ukp.inception.diam.editor.DiamAjaxBehavior;
 import de.tudarmstadt.ukp.inception.diam.editor.config.DiamAutoConfig;
+import de.tudarmstadt.ukp.inception.diam.model.DiamContext;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.DefaultAjaxResponse;
+import de.tudarmstadt.ukp.inception.rendering.selection.Selection;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.AnnotationException;
@@ -66,16 +68,16 @@ public class MoveSpanAnnotationHandler
             Request aRequest)
     {
         try {
-            var page = getPage();
+            var context = aBehavior.getContext();
 
-            page.ensureIsEditable();
+            context.getActionHandler().ensureIsEditable();
 
-            var cas = page.getEditorCas();
+            var cas = context.getEditorCas();
             var vid = getVid(aRequest);
-            var state = getAnnotatorState();
+            var state = context.getAnnotatorState();
             var range = getRangeFromRequest(state, aRequest.getRequestParameters(), cas);
-            moveSpan(aTarget, cas, vid, range);
-            page.writeEditorCas(cas);
+            moveSpan(context, aTarget, cas, vid, range);
+            context.getActionHandler().writeEditorCas();
             return new DefaultAjaxResponse(getAction(aRequest));
         }
         catch (Exception e) {
@@ -83,10 +85,11 @@ public class MoveSpanAnnotationHandler
         }
     }
 
-    private void moveSpan(AjaxRequestTarget aTarget, CAS aCas, VID aVid, Range aRange)
+    private void moveSpan(DiamContext aContext, AjaxRequestTarget aTarget, CAS aCas, VID aVid,
+            Range aRange)
         throws IOException, AnnotationException
     {
-        var state = getAnnotatorState();
+        var state = aContext.getAnnotatorState();
 
         var annoFs = ICasUtil.selectAnnotationByAddr(aCas, aVid.getId());
 
@@ -100,7 +103,7 @@ public class MoveSpanAnnotationHandler
 
         var sel = state.getSelection();
         if (sel.isSet() && sel.getAnnotation().getId() == aVid.getId()) {
-            state.getSelection().selectSpan(annoFs);
+            state.setSelection(Selection.span(annoFs));
         }
     }
 }

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/RefreshHandler.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/RefreshHandler.java
@@ -48,7 +48,9 @@ public class RefreshHandler
             Request aRequest)
     {
         try {
-            getPage().actionRefreshDocument(aTarget);
+            // Refresh acts on the editor that received the request (via its context), not
+            // unconditionally on the main editor's page.
+            aBehavior.getContext().actionRefreshDocument(aTarget);
             return new DefaultAjaxResponse();
         }
         catch (Exception e) {

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/SavePreferences.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/SavePreferences.java
@@ -92,7 +92,7 @@ public class SavePreferences
                         "Client-side user preferences not allowed for given key");
             }
 
-            var project = getAnnotatorState().getProject();
+            var project = aBehavior.getContext().getAnnotatorState().getProject();
             var sessionOwner = userService.getCurrentUser();
             var dataString = aRequest.getRequestParameters().getParameterValue(PARAM_DATA);
             var data = fromValidatedJsonString(ClientSidePreferenceMapValue.class,

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/ScrollToHandler.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/ScrollToHandler.java
@@ -21,15 +21,14 @@ import static de.tudarmstadt.ukp.inception.support.uima.ICasUtil.selectAnnotatio
 
 import java.io.IOException;
 
-import org.apache.uima.cas.CAS;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.request.IRequestParameters;
 import org.apache.wicket.request.Request;
 import org.springframework.core.annotation.Order;
 
-import de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationPageBase;
 import de.tudarmstadt.ukp.inception.diam.editor.DiamAjaxBehavior;
 import de.tudarmstadt.ukp.inception.diam.editor.config.DiamAutoConfig;
+import de.tudarmstadt.ukp.inception.diam.model.DiamContext;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.DefaultAjaxResponse;
 import de.tudarmstadt.ukp.inception.diam.model.compact.CompactRangeList;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
@@ -67,12 +66,11 @@ public class ScrollToHandler
             Request aRequest)
     {
         try {
-            var page = getPage();
-            var cas = page.getEditorCas();
+            var context = aBehavior.getContext();
 
             var requestParameters = aRequest.getRequestParameters();
 
-            scrollTo(aTarget, page, cas, requestParameters);
+            scrollTo(aTarget, context, requestParameters);
 
             return new DefaultAjaxResponse(getAction(aRequest));
         }
@@ -81,15 +79,16 @@ public class ScrollToHandler
         }
     }
 
-    private void scrollTo(AjaxRequestTarget aTarget, AnnotationPageBase page, CAS cas,
+    private void scrollTo(AjaxRequestTarget aTarget, DiamContext aContext,
             IRequestParameters requestParameters)
         throws IOException, AnnotationException
     {
         var vid = VID
                 .parseOptional(requestParameters.getParameterValue(PARAM_ID).toOptionalString());
 
-        var project = page.getModelObject().getProject();
-        var doc = page.getModelObject().getDocument();
+        var state = aContext.getAnnotatorState();
+        var project = state.getProject();
+        var doc = state.getDocument();
         var docId = requestParameters.getParameterValue(PARAM_DOCUMENT_ID).toLong(-1);
         if (docId != -1) {
             doc = documentService.getSourceDocument(project.getId(), docId);
@@ -98,15 +97,17 @@ public class ScrollToHandler
             }
         }
 
+        // Navigation acts on the editor that received the request (via its context), not
+        // unconditionally on the main editor's page.
         if (vid.isSet() && !vid.isSynthetic()) {
-            var fs = selectAnnotationByAddr(page.getEditorCas(), vid.getId());
-            page.actionShowSelectedDocument(aTarget, doc, fs.getBegin(), fs.getEnd());
+            var fs = selectAnnotationByAddr(aContext.getEditorCas(), vid.getId());
+            aContext.actionShowSelectedDocument(aTarget, doc, fs.getBegin(), fs.getEnd());
             return;
         }
 
         if (!requestParameters.getParameterValue(PARAM_OFFSETS).isEmpty()) {
-            var offsets = getRangeFromRequest(requestParameters, cas);
-            page.actionShowSelectedDocument(aTarget, doc, offsets.getBegin(), offsets.getEnd());
+            var offsets = getRangeFromRequest(requestParameters);
+            aContext.actionShowSelectedDocument(aTarget, doc, offsets.getBegin(), offsets.getEnd());
             return;
         }
     }
@@ -116,7 +117,7 @@ public class ScrollToHandler
      * selected annotations or offsets contained in the request for the creation of a new
      * annotation.
      */
-    private Range getRangeFromRequest(IRequestParameters request, CAS aCas) throws IOException
+    private Range getRangeFromRequest(IRequestParameters request) throws IOException
     {
         var offsets = request.getParameterValue(PARAM_OFFSETS).toString();
 

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/SelectAnnotationHandler.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/SelectAnnotationHandler.java
@@ -22,6 +22,7 @@ import org.apache.wicket.request.Request;
 import org.springframework.core.annotation.Order;
 
 import de.tudarmstadt.ukp.inception.diam.editor.DiamAjaxBehavior;
+import de.tudarmstadt.ukp.inception.diam.editor.DiamRequest;
 import de.tudarmstadt.ukp.inception.diam.editor.config.DiamAutoConfig;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.DefaultAjaxResponse;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
@@ -53,9 +54,9 @@ public class SelectAnnotationHandler
     }
 
     @Override
-    public boolean accepts(Request aRequest)
+    public boolean accepts(DiamRequest aRequest)
     {
-        return super.accepts(aRequest) && !getAnnotatorState().isSlotArmed();
+        return super.accepts(aRequest) && !aRequest.getContext().getAnnotatorState().isSlotArmed();
     }
 
     @Override
@@ -63,7 +64,7 @@ public class SelectAnnotationHandler
             Request aRequest)
     {
         try {
-            var page = getPage();
+            var context = aBehavior.getContext();
 
             var requestParameters = aRequest.getRequestParameters();
 
@@ -74,20 +75,20 @@ public class SelectAnnotationHandler
                 return new DefaultAjaxResponse(getAction(aRequest));
             }
 
-            var cas = page.getEditorCas();
-            var state = page.getModelObject();
+            var cas = context.getEditorCas();
+            var state = context.getAnnotatorState();
 
             var fs = ICasUtil.selectAnnotationByAddr(cas, vid.getId());
 
             var adapter = schemaService.findAdapter(state.getProject(), fs);
-            state.getSelection().set(adapter.select(vid, fs));
+            state.setSelection(adapter.select(vid, fs));
 
             if (requestParameters.getParameterValue(PARAM_SCROLL_TO).toBoolean(false)) {
-                page.getAnnotationActionHandler().actionSelectAndJump(aTarget,
+                context.getActionHandler().actionSelectAndJump(aTarget,
                         state.getSelection().getAnnotation());
             }
             else {
-                page.getAnnotationActionHandler().actionSelect(aTarget);
+                context.getActionHandler().actionSelect(aTarget);
             }
 
             return new DefaultAjaxResponse(getAction(aRequest));

--- a/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/ShowContextMenuHandler.java
+++ b/inception/inception-diam/src/main/java/de/tudarmstadt/ukp/inception/diam/editor/actions/ShowContextMenuHandler.java
@@ -26,6 +26,7 @@ import org.springframework.core.annotation.Order;
 import de.tudarmstadt.ukp.inception.annotation.menu.ContextMenuItemContext;
 import de.tudarmstadt.ukp.inception.annotation.menu.ContextMenuItemRegistry;
 import de.tudarmstadt.ukp.inception.diam.editor.DiamAjaxBehavior;
+import de.tudarmstadt.ukp.inception.diam.editor.DiamRequest;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.AjaxResponse;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.DefaultAjaxResponse;
 
@@ -50,9 +51,9 @@ public class ShowContextMenuHandler
     }
 
     @Override
-    public boolean accepts(Request aRequest)
+    public boolean accepts(DiamRequest aRequest)
     {
-        var paramId = getVid(aRequest);
+        var paramId = getVid(aRequest.getRequest());
         return super.accepts(aRequest) && paramId.isSet() && !paramId.isSynthetic()
                 && !paramId.isSlotSet();
     }
@@ -75,9 +76,12 @@ public class ShowContextMenuHandler
 
             var vid = getVid(aRequest);
 
-            for (var ext : contextMenuItemRegistry
-                    .getExtensions(new ContextMenuItemContext(vid, getPage()))) {
-                items.add(ext.createMenuItem(vid, clientX, clientY));
+            // Bind the menu to the editor that received the request (its context / behavior),
+            // not to the main editor's page, so its items act on that editor (cf. #6146).
+            var ctx = new ContextMenuItemContext(vid, aBehavior.getContext(), aBehavior);
+
+            for (var ext : contextMenuItemRegistry.getExtensions(ctx)) {
+                items.add(ext.createMenuItem(ctx, clientX, clientY));
             }
 
             if (!items.isEmpty()) {

--- a/inception/inception-external-editor/pom.xml
+++ b/inception/inception-external-editor/pom.xml
@@ -55,6 +55,11 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-api-diam</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-api-render</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/ExternalAnnotationEditorBase.java
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/ExternalAnnotationEditorBase.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.uima.cas.CAS;
 import org.apache.wicket.Component;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.core.request.handler.IPartialPageRequestHandler;
@@ -47,9 +48,11 @@ import org.slf4j.Logger;
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.icon.FontAwesome7CssReference;
 import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasProvider;
 import de.tudarmstadt.ukp.clarin.webanno.api.export.DocumentImportExportService;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.inception.diam.editor.DiamAjaxBehavior;
 import de.tudarmstadt.ukp.inception.diam.editor.DiamJavaScriptReference;
+import de.tudarmstadt.ukp.inception.diam.model.DiamContext;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.editor.AnnotationEditorBase;
 import de.tudarmstadt.ukp.inception.editor.AnnotationEditorExtensionRegistry;
@@ -58,6 +61,7 @@ import de.tudarmstadt.ukp.inception.editor.AnnotationEditorRegistry;
 import de.tudarmstadt.ukp.inception.editor.ContextMenuLookup;
 import de.tudarmstadt.ukp.inception.editor.action.AnnotationActionHandler;
 import de.tudarmstadt.ukp.inception.editor.view.DocumentViewExtensionPoint;
+import de.tudarmstadt.ukp.inception.schema.api.adapter.AnnotationException;
 import de.tudarmstadt.ukp.inception.externaleditor.command.CommandQueue;
 import de.tudarmstadt.ukp.inception.externaleditor.command.EditorCommand;
 import de.tudarmstadt.ukp.inception.externaleditor.command.LoadAnnotationsCommand;
@@ -76,6 +80,7 @@ import jakarta.servlet.ServletContext;
 
 public abstract class ExternalAnnotationEditorBase
     extends AnnotationEditorBase
+    implements DiamContext
 {
     private static final long serialVersionUID = -196999336741495239L;
 
@@ -166,7 +171,42 @@ public abstract class ExternalAnnotationEditorBase
 
     protected DiamAjaxBehavior createDiamBehavior()
     {
-        return new DiamAjaxBehavior(contextMenu);
+        // The editor serves as its own DIAM context so that its handlers resolve this editor's
+        // state, CAS and action handler - not the hosting page's. This lets an embedded editor
+        // (e.g. a read-only reference document in a sidebar) operate on its own document.
+        return new DiamAjaxBehavior(this, contextMenu);
+    }
+
+    @Override
+    public AnnotatorState getAnnotatorState()
+    {
+        return getModelObject();
+    }
+
+    @Override
+    public CAS getEditorCas() throws IOException
+    {
+        return getCasProvider().get();
+    }
+
+    @Override
+    public void actionShowSelectedDocument(AjaxRequestTarget aTarget, SourceDocument aDocument,
+            int aBegin, int aEnd)
+        throws IOException, AnnotationException
+    {
+        // Forward the target document to the action handler, which is the host-scoped seam:
+        // switching to a different document is the concern of whatever hosts the editor. The main
+        // editor's detail panel switches the page to that document (so a cross-document scroll-to
+        // opens it before centering); a read-only reference-document viewer's handler ignores
+        // navigation (passive), so navigation stays local instead of driving the main editor's
+        // page.
+        getActionHandler().actionShowSelectedDocument(aTarget, aDocument, aBegin, aEnd);
+    }
+
+    @Override
+    public void actionRefreshDocument(AjaxRequestTarget aTarget)
+    {
+        requestRender(aTarget);
     }
 
     protected Component getViewComponent()
@@ -216,12 +256,16 @@ public abstract class ExternalAnnotationEditorBase
         // We cannot use a @OnEvent annotation for this because it will not handle
         // events for non-visible components - and the editor may not be visible in the
         // hierarchy a this time
-        if (aEvent.getPayload() instanceof ScrollToEvent event) {
+        // Only react to scroll requests originating from our own state. The event is broadcast to
+        // the whole page, so without this filter paging one editor would also scroll every other
+        // editor on the page (e.g. a read-only reference-document sidebar viewer).
+        if (aEvent.getPayload() instanceof ScrollToEvent event
+                && event.getSource() == getModelObject()) {
             var command = new ScrollToCommand(event.getOffset(), event.getPosition());
             if (event.getPingRanges() != null && !event.getPingRanges().isEmpty()) {
                 command.setPingRanges(event.getPingRanges());
             }
-            QueuedEditorCommandsMetaDataKey.get().add(command);
+            QueuedEditorCommandsMetaDataKey.get(this).add(command);
 
             // Do not call our requestRender because we do not want to unnecessarily add the
             // LoadAnnotationsCommand
@@ -234,7 +278,7 @@ public abstract class ExternalAnnotationEditorBase
     @Override
     public void requestRender(AjaxRequestTarget aTarget)
     {
-        QueuedEditorCommandsMetaDataKey.get().add(renderCommand());
+        QueuedEditorCommandsMetaDataKey.get(this).add(renderCommand());
 
         super.requestRender(aTarget);
     }
@@ -318,7 +362,7 @@ public abstract class ExternalAnnotationEditorBase
 
     private String initScript()
     {
-        var commandQueue = QueuedEditorCommandsMetaDataKey.get();
+        var commandQueue = QueuedEditorCommandsMetaDataKey.get(this);
         // // If we initialize the editor, it should auto-load the annotations - we do nothing
         // commandQueue.removeIf(cmd -> cmd instanceof LoadAnnotationsCommand);
         return assembleScript(commandQueue);
@@ -326,7 +370,7 @@ public abstract class ExternalAnnotationEditorBase
 
     private String renderScript()
     {
-        return assembleScript(QueuedEditorCommandsMetaDataKey.get());
+        return assembleScript(QueuedEditorCommandsMetaDataKey.get(this));
     }
 
     private String assembleScript(CommandQueue aCommandQueue)

--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/command/QueuedEditorCommandsMetaDataKey.java
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/command/QueuedEditorCommandsMetaDataKey.java
@@ -17,24 +17,38 @@
  */
 package de.tudarmstadt.ukp.inception.externaleditor.command;
 
+import java.util.HashMap;
+
+import org.apache.wicket.Component;
 import org.apache.wicket.MetaDataKey;
 import org.apache.wicket.request.cycle.RequestCycle;
 
 public class QueuedEditorCommandsMetaDataKey
-    extends MetaDataKey<CommandQueue>
+    extends MetaDataKey<HashMap<String, CommandQueue>>
 {
     private static final long serialVersionUID = 102615176759478581L;
 
     public final static QueuedEditorCommandsMetaDataKey INSTANCE = new QueuedEditorCommandsMetaDataKey();
 
-    public static CommandQueue get()
+    /**
+     * Get the per-request command queue for the given editor. The queue is keyed by the editor's
+     * markup ID so that each editor accumulates and drains only its own commands. Multiple editors
+     * may share a page (e.g. the main editor plus a read-only reference-document sidebar viewer);
+     * without per-editor scoping, rendering one editor would replay another editor's queued
+     * commands - so paging one editor could scroll the other.
+     *
+     * @param aEditor
+     *            the editor whose command queue is requested
+     * @return the command queue for that editor in the current request cycle
+     */
+    public static CommandQueue get(Component aEditor)
     {
-        RequestCycle requestCycle = RequestCycle.get();
-        CommandQueue commandQueue = requestCycle.getMetaData(INSTANCE);
-        if (commandQueue == null) {
-            commandQueue = new CommandQueue();
-            requestCycle.setMetaData(INSTANCE, commandQueue);
+        var requestCycle = RequestCycle.get();
+        var queues = requestCycle.getMetaData(INSTANCE);
+        if (queues == null) {
+            queues = new HashMap<>();
+            requestCycle.setMetaData(INSTANCE, queues);
         }
-        return commandQueue;
+        return queues.computeIfAbsent(aEditor.getMarkupId(), $ -> new CommandQueue());
     }
 }

--- a/inception/inception-feature-link/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/link/LinkFeatureEditor.java
+++ b/inception/inception-feature-link/src/main/java/de/tudarmstadt/ukp/inception/annotation/feature/link/LinkFeatureEditor.java
@@ -702,6 +702,12 @@ public class LinkFeatureEditor
     @OnEvent
     public void onRenderSlotsEvent(RenderSlotsEvent aEvent)
     {
+        // Only react to slot arming in the editor this feature editor belongs to, not in other
+        // editors on the page even if they show the same document (#6146).
+        if (!aEvent.isFor(stateModel.getObject())) {
+            return;
+        }
+
         // Redraw because it could happen that another slot is armed, replacing this.
         aEvent.getRequestHandler().add(this);
     }

--- a/inception/inception-image/src/main/java/de/tudarmstadt/ukp/inception/image/sidebar/ImageSidebar.java
+++ b/inception/inception-image/src/main/java/de/tudarmstadt/ukp/inception/image/sidebar/ImageSidebar.java
@@ -55,6 +55,7 @@ import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.editor.action.AnnotationActionHandler;
 import de.tudarmstadt.ukp.inception.image.feature.ImageFeatureSupport;
 import de.tudarmstadt.ukp.inception.rendering.request.RenderRequestedEvent;
+import de.tudarmstadt.ukp.inception.rendering.selection.Selection;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxLink;
@@ -160,6 +161,12 @@ public class ImageSidebar
     @OnEvent
     public void onRenderRequested(RenderRequestedEvent aEvent)
     {
+        // Only react to renders of the editor this sidebar belongs to, not to renders of other
+        // editors on the page even if they show the same document (#6146).
+        if (!aEvent.isFor(getModelObject())) {
+            return;
+        }
+
         aEvent.getRequestHandler().add(mainContainer);
     }
 
@@ -175,8 +182,8 @@ public class ImageSidebar
 
             var layer = annotationService.findLayer(state.getProject(), fs);
             if (SpanLayerSupport.TYPE.equals(layer.getType())) {
-                state.getSelection().selectSpan(aHandle.getVid(), cas, aHandle.getBegin(),
-                        aHandle.getEnd());
+                state.setSelection(Selection.span(aHandle.getVid(), cas, aHandle.getBegin(),
+                        aHandle.getEnd()));
             }
             else if (RelationLayerSupport.TYPE.equals(layer.getType())) {
                 var adapter = (RelationAdapter) annotationService.getAdapter(layer);
@@ -184,7 +191,7 @@ public class ImageSidebar
                         AnnotationFS.class);
                 var targetFS = FSUtil.getFeature(fs, adapter.getTargetFeatureName(),
                         AnnotationFS.class);
-                state.getSelection().selectArc(aHandle.getVid(), originFS, targetFS);
+                state.setSelection(Selection.arc(aHandle.getVid(), originFS, targetFS));
             }
             else {
                 return;

--- a/inception/inception-layer-chain/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/chain/ChainAdapterImpl.java
+++ b/inception/inception-layer-chain/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/chain/ChainAdapterImpl.java
@@ -541,45 +541,34 @@ public class ChainAdapterImpl
     @Override
     public Selection select(VID aVid, AnnotationFS aAnno)
     {
-        var selection = new Selection();
-
         if (aVid.getSubId() == 1) {
-            selection.selectArc(aVid, aAnno, getNextLink(aAnno));
-        }
-        else {
-            selection.selectSpan(aAnno);
+            return Selection.arc(aVid, aAnno, getNextLink(aAnno));
         }
 
-        return selection;
+        return Selection.span(aAnno);
     }
 
     @Override
     public Selection selectSpan(AnnotationFS aAnno)
     {
-        var selection = new Selection();
-        selection.selectSpan(aAnno);
-        return selection;
+        return Selection.span(aAnno);
     }
 
     @Override
     public Selection selectLink(AnnotationFS aAnno)
     {
-        var selection = new Selection();
-
         var nextLink = getNextLink(aAnno);
         if (nextLink != null) {
-            selection.selectArc(new VID(aAnno, 1, VID.NONE, VID.NONE), aAnno, nextLink);
-            return selection;
+            return Selection.arc(new VID(aAnno, 1, VID.NONE, VID.NONE), aAnno, nextLink);
         }
 
         var chain = getChainForLink(aAnno.getCAS(), aAnno);
         var prevLink = getPrevLink(chain, aAnno);
         if (prevLink != null) {
-            selection.selectArc(new VID(aAnno, 1, VID.NONE, VID.NONE), prevLink, aAnno);
-            return selection;
+            return Selection.arc(new VID(aAnno, 1, VID.NONE, VID.NONE), prevLink, aAnno);
         }
 
-        return selection;
+        return Selection.unselected();
     }
 
     @Override

--- a/inception/inception-layer-docmetadata/pom.xml
+++ b/inception/inception-layer-docmetadata/pom.xml
@@ -69,6 +69,11 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-api-diam</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-schema-api</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/document/DocumentMetadataLayerAdapterImpl.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/document/DocumentMetadataLayerAdapterImpl.java
@@ -160,9 +160,7 @@ public class DocumentMetadataLayerAdapterImpl
     @Override
     public Selection select(VID aVid, AnnotationFS aAnno)
     {
-        var selection = new Selection();
-        selection.selectSpan(aAnno);
-        return selection;
+        return Selection.span(aAnno);
     }
 
     @Override

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/document/sidebar/DocumentMetadataAnnotationDetailPanel.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/document/sidebar/DocumentMetadataAnnotationDetailPanel.java
@@ -55,6 +55,7 @@ import de.tudarmstadt.ukp.inception.annotation.feature.link.LinkFeatureEditor;
 import de.tudarmstadt.ukp.inception.editor.action.AnnotationActionHandler;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.FeatureState;
+import de.tudarmstadt.ukp.inception.rendering.selection.Selection;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
 import de.tudarmstadt.ukp.inception.schema.api.AnnotationSchemaService;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.AnnotationException;
@@ -351,7 +352,7 @@ public class DocumentMetadataAnnotationDetailPanel
         try {
             var cas = jcasProvider.get();
             var fs = ICasUtil.selectAnnotationByAddr(cas, aEvent.getLinkWithRoleModel().targetAddr);
-            state.getObject().getSelection().selectSpan(fs);
+            state.getObject().setSelection(Selection.span(fs));
             if (state.getObject().getSelection().getAnnotation().isSet()) {
                 actionHandler.actionDelete(target);
 

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/document/sidebar/DocumentMetadataAnnotationSelectionPanel.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/document/sidebar/DocumentMetadataAnnotationSelectionPanel.java
@@ -85,6 +85,7 @@ import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
 import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
 import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.AnnotationPageBase2;
+import de.tudarmstadt.ukp.inception.annotation.events.AnnotationEvent;
 import de.tudarmstadt.ukp.inception.annotation.events.FeatureValueUpdatedEvent;
 import de.tudarmstadt.ukp.inception.annotation.layer.document.api.CreateDocumentAnnotationRequest;
 import de.tudarmstadt.ukp.inception.annotation.layer.document.api.DocumentMetadataLayerAdapter;
@@ -944,6 +945,10 @@ public class DocumentMetadataAnnotationSelectionPanel
     @OnEvent
     public void onDocumentMetadataEvent(DocumentMetadataEvent aEvent)
     {
+        if (!appliesToThisEditor(aEvent)) {
+            return;
+        }
+
         aEvent.getRequestTarget().ifPresent(target -> target.add(layersContainer));
         annotationPage.actionRefreshDocument(aEvent.getRequestTarget().orElse(null));
     }
@@ -951,8 +956,26 @@ public class DocumentMetadataAnnotationSelectionPanel
     @OnEvent
     public void onFeatureValueUpdated(FeatureValueUpdatedEvent aEvent)
     {
+        if (!appliesToThisEditor(aEvent)) {
+            return;
+        }
+
         aEvent.getRequestTarget().ifPresent(target -> target.add(layersContainer));
         annotationPage.actionRefreshDocument((aEvent.getRequestTarget().orElse(null)));
+    }
+
+    /**
+     * These are backend (hybrid) events broadcast page-wide, so - now that a page may host more
+     * than one editor - we must check that the change actually concerns the document/owner shown in
+     * this editor before reacting. Mirrors the content-tuple guard in
+     * {@code AnnotationPageBase2.onFeatureValueUpdatedEvent}.
+     */
+    private boolean appliesToThisEditor(AnnotationEvent aEvent)
+    {
+        var state = getModelObject();
+        return Objects.equals(state.getProject(), aEvent.getProject())
+                && Objects.equals(state.getDocument(), aEvent.getDocument())
+                && Objects.equals(state.getUser().getUsername(), aEvent.getDocumentOwner());
     }
 
     protected static void handleException(Component aComponent, AjaxRequestTarget aTarget,

--- a/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/document/sidebar/DocumentMetadataSidebar.java
+++ b/inception/inception-layer-docmetadata/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/document/sidebar/DocumentMetadataSidebar.java
@@ -51,7 +51,7 @@ public class DocumentMetadataSidebar
     {
         super.onInitialize();
 
-        add(diamBehavior = new DiamAjaxBehavior());
+        add(diamBehavior = new DiamAjaxBehavior(findParent(AnnotationPageBase2.class)));
         add(new SvelteBehavior());
     }
 

--- a/inception/inception-layer-relation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/RelationAdapterImpl.java
+++ b/inception/inception-layer-relation/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/relation/RelationAdapterImpl.java
@@ -251,7 +251,6 @@ public class RelationAdapterImpl
     @Override
     public Selection select(VID aVid, AnnotationFS aAnno)
     {
-        var selection = new Selection();
         var src = getSourceAnnotation(aAnno);
         var tgt = getTargetAnnotation(aAnno);
 
@@ -262,8 +261,7 @@ public class RelationAdapterImpl
                     AnnotationFS.class);
         }
 
-        selection.selectArc(VID.of(aAnno), src, tgt);
-        return selection;
+        return Selection.arc(VID.of(aAnno), src, tgt);
     }
 
     @Override

--- a/inception/inception-layer-span/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanAdapterImpl.java
+++ b/inception/inception-layer-span/src/main/java/de/tudarmstadt/ukp/inception/annotation/layer/span/SpanAdapterImpl.java
@@ -315,9 +315,7 @@ public class SpanAdapterImpl
     @Override
     public Selection select(VID aVid, AnnotationFS aAnno)
     {
-        var selection = new Selection();
-        selection.selectSpan(aAnno);
-        return selection;
+        return Selection.span(aAnno);
     }
 
     @Override

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/RecommendationEditorExtension.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/RecommendationEditorExtension.java
@@ -204,7 +204,7 @@ public class RecommendationEditorExtension
         page.writeEditorCas(aCas);
 
         // Set selection to the accepted annotation and select it and load it into the detail editor
-        aState.getSelection().set(adapter.select(VID.of(annotation), annotation));
+        aState.setSelection(adapter.select(VID.of(annotation), annotation));
         page.getAnnotationActionHandler().actionSelect(aTarget);
 
         // Send a UI event that the suggestion has been accepted
@@ -247,7 +247,7 @@ public class RecommendationEditorExtension
 
         // Trigger a re-rendering of the document
         var page = aTarget.getPage();
-        page.send(page, BREADTH, new SelectionChangedEvent(aTarget));
+        page.send(page, BREADTH, new SelectionChangedEvent(aState, aTarget));
     }
 
     @Override

--- a/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommendationSidebar.java
+++ b/inception/inception-recommendation/src/main/java/de/tudarmstadt/ukp/inception/recommendation/sidebar/RecommendationSidebar.java
@@ -220,6 +220,12 @@ public class RecommendationSidebar
     @OnEvent
     public void onRenderRequested(RenderRequestedEvent aEvent)
     {
+        // Only react to renders of the editor this sidebar belongs to, not to renders of other
+        // editors on the page even if they show the same document (#6146).
+        if (!aEvent.isFor(getModelObject())) {
+            return;
+        }
+
         aEvent.getRequestHandler().add(warning);
     }
 

--- a/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/editor/action/AnnotationActionHandler.java
+++ b/inception/inception-schema-api/src/main/java/de/tudarmstadt/ukp/inception/editor/action/AnnotationActionHandler.java
@@ -23,6 +23,7 @@ import org.apache.uima.cas.CAS;
 import org.apache.uima.cas.text.AnnotationFS;
 import org.apache.wicket.ajax.AjaxRequestTarget;
 
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.AnnotationException;
@@ -86,6 +87,37 @@ public interface AnnotationActionHandler
 
     void actionJump(AjaxRequestTarget aTarget, int aBegin, int aEnd)
         throws IOException, AnnotationException;
+
+    /**
+     * Navigate to the given document at the given offsets.
+     * <p>
+     * The default stays within the editor's current document, scrolling to the offsets via
+     * {@link #actionJump(AjaxRequestTarget, int, int)} - appropriate for a self-contained editor
+     * (e.g. a read-only reference-document viewer). A handler that hosts a document-switchable
+     * editor (the main editor's detail panel) overrides this to switch the displayed document to
+     * {@code aDocument} first. This is the seam through which a cross-document scroll-to (search
+     * hit / cross-document link) opens the target document instead of jumping to raw offsets in the
+     * currently displayed one.
+     *
+     * @param aTarget
+     *            the AJAX target
+     * @param aDocument
+     *            the document to show
+     * @param aBegin
+     *            the offset to scroll to
+     * @param aEnd
+     *            the corresponding end offset
+     * @throws IOException
+     *             if there was an I/O-level problem
+     * @throws AnnotationException
+     *             if there was an annotation-level problem
+     */
+    default void actionShowSelectedDocument(AjaxRequestTarget aTarget, SourceDocument aDocument,
+            int aBegin, int aEnd)
+        throws IOException, AnnotationException
+    {
+        actionJump(aTarget, aBegin, aEnd);
+    }
 
     /**
      * Delete currently selected annotation.
@@ -179,4 +211,32 @@ public interface AnnotationActionHandler
     CAS getEditorCas() throws IOException;
 
     void writeEditorCas() throws IOException, AnnotationException;
+
+    /**
+     * @return whether the editor served by this handler accepts mutations.
+     */
+    default boolean isEditable()
+    {
+        try {
+            ensureIsEditable();
+            return true;
+        }
+        catch (AnnotationException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Fail closed if the editor served by this handler does not accept mutations. Mutating callers
+     * invoke this before touching the CAS.
+     * <p>
+     * Editability is an authorization decision with no safe default - a permissive default would
+     * fail open (silently allowing mutations on read-only/finished documents), a restrictive one
+     * would silently disable legitimately editable handlers. Every implementor must therefore make
+     * this decision explicitly.
+     *
+     * @throws AnnotationException
+     *             if the editor is not editable.
+     */
+    void ensureIsEditable() throws AnnotationException;
 }

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPageBase2.html
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPageBase2.html
@@ -38,7 +38,7 @@
           <div class="card-header d-flex justify-content-between border-bottom-0">
             <div wicket:id="documentNamePanel"/>
             <div class="d-flex">
-              <div wicket:id="numberOfPages" class="small text-muted"/>
+              <div wicket:id="numberOfPages" class="small text-muted align-self-center"/>
               <button wicket:id="toggleActionBar" class="btn btn-sm btn-outline-secondary border-0">
                 <i wicket:id="toggleActionBarIcon"/>
               </button>

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPageBase2.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPageBase2.java
@@ -394,6 +394,12 @@ public abstract class AnnotationPageBase2
     @OnEvent
     public void onSelectionChangedEvent(SelectionChangedEvent aEvent)
     {
+        // Only react to selection changes in our own editor, not in other editors on the page
+        // (e.g. the reference-document viewer) even if they show the same document (#6146).
+        if (!aEvent.isFor(getModelObject())) {
+            return;
+        }
+
         actionRefreshDocument(aEvent.getRequestHandler());
     }
 
@@ -450,6 +456,12 @@ public abstract class AnnotationPageBase2
     @OnEvent
     public void onViewStateChanged(AnnotatorViewportChangedEvent aEvent)
     {
+        // Only react to viewport changes in our own editor, not in other editors on the page
+        // (e.g. the reference-document viewer) even if they show the same document (#6146).
+        if (!aEvent.isFor(getModelObject())) {
+            return;
+        }
+
         // Partial page updates only need to be triggered if we are in a partial page update request
         if (aEvent.getRequestHandler() == null) {
             return;

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/docnav/DocumentNavigator.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/docnav/DocumentNavigator.java
@@ -193,7 +193,7 @@ public class DocumentNavigator
 
     public void actionShowOpenDocumentDialog(AjaxRequestTarget aTarget)
     {
-        page.getModelObject().getSelection().clear();
+        page.getModelObject().clearSelection();
         page.getFooterItems().getObject().stream()
                 .filter(component -> component instanceof OpenDocumentDialog)
                 .map(component -> (OpenDocumentDialog) component).findFirst()

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/open/OpenDocumentDialog.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/open/OpenDocumentDialog.java
@@ -23,6 +23,7 @@ import org.apache.wicket.ajax.AjaxRequestTarget;
 import org.apache.wicket.extensions.ajax.markup.html.modal.ModalDialog;
 import org.apache.wicket.model.IModel;
 import org.danekja.java.util.function.serializable.SerializableBiFunction;
+import org.danekja.java.util.function.serializable.SerializableConsumer;
 
 import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
 import de.tudarmstadt.ukp.clarin.webanno.model.Project;
@@ -37,9 +38,24 @@ public class OpenDocumentDialog
 
     private final SerializableBiFunction<Project, User, List<AnnotationDocument>> docListProvider;
     private final IModel<AnnotatorState> state;
+    private final SerializableConsumer<AjaxRequestTarget> onDocumentSelected;
 
     public OpenDocumentDialog(String aId, IModel<AnnotatorState> aModel,
             SerializableBiFunction<Project, User, List<AnnotationDocument>> aDocListProvider)
+    {
+        this(aId, aModel, aDocListProvider, null);
+    }
+
+    /**
+     * @param aOnDocumentSelected
+     *            invoked after the chosen document has been set on the state model, to load it into
+     *            the host. If {@code null}, the enclosing annotation page is loaded (historic
+     *            behavior). A sidebar-hosted viewer passes its own load action here so the
+     *            selection does not leak into the main editor.
+     */
+    public OpenDocumentDialog(String aId, IModel<AnnotatorState> aModel,
+            SerializableBiFunction<Project, User, List<AnnotationDocument>> aDocListProvider,
+            SerializableConsumer<AjaxRequestTarget> aOnDocumentSelected)
     {
         super(aId);
         setOutputMarkupId(true);
@@ -47,11 +63,13 @@ public class OpenDocumentDialog
 
         docListProvider = aDocListProvider;
         state = aModel;
+        onDocumentSelected = aOnDocumentSelected;
     }
 
     public void show(AjaxRequestTarget aTarget)
     {
-        var content = new OpenDocumentDialogPanel(ModalDialog.CONTENT_ID, state, docListProvider);
+        var content = new OpenDocumentDialogPanel(ModalDialog.CONTENT_ID, state, docListProvider,
+                onDocumentSelected);
         super.open(content, aTarget);
     }
 }

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/open/OpenDocumentDialogPanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/actionbar/open/OpenDocumentDialogPanel.java
@@ -68,6 +68,8 @@ import de.tudarmstadt.ukp.inception.project.api.ProjectService;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
 import de.tudarmstadt.ukp.inception.search.DocumentStatistics;
 import de.tudarmstadt.ukp.inception.search.SearchService;
+import org.danekja.java.util.function.serializable.SerializableConsumer;
+
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxFormComponentUpdatingBehavior;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxLink;
 import de.tudarmstadt.ukp.inception.support.wicket.DecoratedObject;
@@ -99,13 +101,28 @@ public class OpenDocumentDialogPanel
     private final IModel<Boolean> finishedDocumentsSkippedByNavigation;
 
     private final SerializableBiFunction<Project, User, List<AnnotationDocument>> docListProvider;
+    private final SerializableConsumer<AjaxRequestTarget> onDocumentSelected;
 
     public OpenDocumentDialogPanel(String aId, IModel<AnnotatorState> aState,
             SerializableBiFunction<Project, User, List<AnnotationDocument>> aDocListProvider)
     {
+        this(aId, aState, aDocListProvider, null);
+    }
+
+    /**
+     * @param aOnDocumentSelected
+     *            invoked after the chosen document has been set on the state model, to actually
+     *            load it into the host (page or sidebar). If {@code null}, the enclosing
+     *            {@link AnnotationPageBase} is loaded, reproducing the historic behavior.
+     */
+    public OpenDocumentDialogPanel(String aId, IModel<AnnotatorState> aState,
+            SerializableBiFunction<Project, User, List<AnnotationDocument>> aDocListProvider,
+            SerializableConsumer<AjaxRequestTarget> aOnDocumentSelected)
+    {
         super(aId, aState);
 
         docListProvider = aDocListProvider;
+        onDocumentSelected = aOnDocumentSelected;
 
         queue(userListChoice = createUserListChoice(CID_USER));
 
@@ -298,7 +315,12 @@ public class OpenDocumentDialogPanel
             getModelObject().setUser(userListChoice.getModelObject().get());
         }
 
-        ((AnnotationPageBase) getPage()).actionLoadDocument(aEvent.getTarget());
+        if (onDocumentSelected != null) {
+            onDocumentSelected.accept(aEvent.getTarget());
+        }
+        else {
+            ((AnnotationPageBase) getPage()).actionLoadDocument(aEvent.getTarget());
+        }
 
         findParent(ModalDialog.class).close(aEvent.getTarget());
     }

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/component/DocumentNamePanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/component/DocumentNamePanel.java
@@ -49,20 +49,41 @@ public class DocumentNamePanel
 
     public DocumentNamePanel(String id, final IModel<AnnotatorState> aModel)
     {
+        this(id, aModel, null);
+    }
+
+    /**
+     * @param aEditable
+     *            whether the described editor is editable; controls the read-only badge. When
+     *            {@code null}, editability is derived from the enclosing {@link AnnotationPageBase}
+     *            (legacy behavior). Pass an explicit model when the panel is not hosted directly by
+     *            the page it describes - e.g. an editor embedded in a sidebar, whose editability
+     *            differs from the surrounding page.
+     */
+    public DocumentNamePanel(String id, final IModel<AnnotatorState> aModel,
+            IModel<Boolean> aEditable)
+    {
         super(id, aModel);
         setOutputMarkupId(true);
-        queue(new WebMarkupContainer("read-only").add(visibleWhen(() -> {
+
+        var editable = aEditable != null ? aEditable : (IModel<Boolean>) () -> {
             var page = findParent(AnnotationPageBase.class);
-            return page != null ? !page.isEditable() : false;
-        })));
+            return page != null ? page.isEditable() : true;
+        };
+        queue(new WebMarkupContainer("read-only").add(visibleWhen(() -> !editable.getObject())));
         queue(new Label("user", aModel.map(AnnotatorState::getUser).map(User::getUiName))
                 .add(visibleWhenNot(aModel.map(AnnotatorState::getUser)
                         .map(u -> u.getUsername().equals(userService.getCurrentUsername())))));
         queue(new Label("project", aModel.map(AnnotatorState::getProject).map(Project::getName)));
         queue(new Label("projectId", aModel.map(AnnotatorState::getProject).map(Project::getId))
                 .add(visibleWhen(() -> DEVELOPMENT == getApplication().getConfigurationType())));
+        // The document badge (controlled via wicket:enclosure) must hide when no document is
+        // selected - otherwise it renders as an empty name with an empty "()" id (e.g. in the
+        // reference-document sidebar before a document has been loaded). A Label with a null model
+        // still counts as visible, so guard visibility explicitly on the document being present.
         queue(new Label("document",
-                aModel.map(AnnotatorState::getDocument).map(SourceDocument::getName)));
+                aModel.map(AnnotatorState::getDocument).map(SourceDocument::getName))
+                        .add(visibleWhen(aModel.map(AnnotatorState::getDocument).isPresent())));
         queue(new Label("documentId",
                 aModel.map(AnnotatorState::getDocument).map(SourceDocument::getId)).add(
                         visibleWhen(() -> DEVELOPMENT == getApplication().getConfigurationType())));

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/detail/AnnotationDetailEditorPanel.java
@@ -387,11 +387,17 @@ public abstract class AnnotationDetailEditorPanel
         // ... if the SLOT HOST annotation is NOT open in the detail panel on the right, then
         // select SLOT FILLER an open it there
         else {
-            state.getSelection().selectSpan(selectAnnotationByAddr(aCas, slotFillerAddr));
+            state.setSelection(Selection.span(selectAnnotationByAddr(aCas, slotFillerAddr)));
             actionSelect(aTarget);
         }
 
         state.clearArmedSlot();
+    }
+
+    @Override
+    public void ensureIsEditable() throws AnnotationException
+    {
+        editorPage.ensureIsEditable();
     }
 
     @Override
@@ -422,7 +428,7 @@ public abstract class AnnotationDetailEditorPanel
         var adapter = annotationService
                 .getAdapter(annotationService.findLayer(state.getProject(), annoFs));
 
-        state.getSelection().set(adapter.select(aVid, annoFs));
+        state.setSelection(adapter.select(aVid, annoFs));
         actionSelect(aTarget);
     }
 
@@ -448,6 +454,17 @@ public abstract class AnnotationDetailEditorPanel
     {
         editorPage.actionShowSelectedDocument(aTarget, getModelObject().getDocument(), aBegin,
                 aEnd);
+    }
+
+    @Override
+    public void actionShowSelectedDocument(AjaxRequestTarget aTarget, SourceDocument aDocument,
+            int aBegin, int aEnd)
+        throws IOException, AnnotationException
+    {
+        // The main editor is hosted by a page that can switch documents. Unlike actionJump (which
+        // stays in the current document), honor the requested target document so a cross-document
+        // scroll-to (search hit / cross-document link) opens that document before centering.
+        editorPage.actionShowSelectedDocument(aTarget, aDocument, aBegin, aEnd);
     }
 
     @Deprecated
@@ -665,7 +682,7 @@ public abstract class AnnotationDetailEditorPanel
             // Load the feature editors with the remembered values (if any)
             loadFeatureEditorModels(aTarget);
             var selection = createNewAnnotation(aTarget, adapter, aCas);
-            state.getSelection().set(selection);
+            state.setSelection(selection);
             loadFeatureEditorModels(aTarget);
         }
 
@@ -954,7 +971,7 @@ public abstract class AnnotationDetailEditorPanel
 
         internalCompleteAnnotation(aTarget, cas);
 
-        selection.selectArc(newRelation);
+        state.setSelection(Selection.arc(newRelation));
     }
 
     @Override
@@ -1142,6 +1159,12 @@ public abstract class AnnotationDetailEditorPanel
     @OnEvent
     public void onSelectionChangedEvent(SelectionChangedEvent aEvent)
     {
+        // The detail panel is bound to the main editor and must not rebuild itself from a selection
+        // change originating in another editor on the page (D1/D2, #6146).
+        if (!aEvent.isFor(getModelObject())) {
+            return;
+        }
+
         if (aEvent.getRequestHandler() != null) {
             try {
                 refresh(aEvent.getRequestHandler());
@@ -1182,7 +1205,7 @@ public abstract class AnnotationDetailEditorPanel
                     .anyMatch(ann -> ann._id() == id);
 
             if (!annotationStillExists) {
-                selection.clear();
+                getModelObject().clearSelection();
                 aEvent.getRequestTarget().ifPresent(this::refresh);
             }
         }
@@ -1312,7 +1335,7 @@ public abstract class AnnotationDetailEditorPanel
 
         // Clear selection and feature states
         state.getFeatureStates().clear();
-        state.getSelection().clear();
+        state.clearSelection();
 
         // Refresh the selectable layers dropdown
         state.refreshSelectableLayers(schemaProperties::isLayerBlocked);

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/actionbar/CurationDocumentNavigator.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/actionbar/CurationDocumentNavigator.java
@@ -182,7 +182,7 @@ public class CurationDocumentNavigator
 
     public void actionShowOpenDocumentDialog(AjaxRequestTarget aTarget)
     {
-        getModelObject().getSelection().clear();
+        getModelObject().clearSelection();
         page.getFooterItems().getObject().stream()
                 .filter(component -> component instanceof CurationOpenDocumentDialog)
                 .map(component -> (CurationOpenDocumentDialog) component) //

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/BratSuggestionVisualizer.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/component/BratSuggestionVisualizer.java
@@ -29,6 +29,7 @@ import java.io.Serializable;
 import java.lang.invoke.MethodHandles;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.uima.cas.CAS;
 import org.apache.wicket.ajax.AbstractDefaultAjaxBehavior;
 import org.apache.wicket.ajax.AjaxEventBehavior;
 import org.apache.wicket.ajax.AjaxRequestTarget;
@@ -53,8 +54,8 @@ import org.wicketstuff.jquery.ui.settings.JQueryUILibrarySettings;
 
 import de.agilecoders.wicket.core.markup.html.bootstrap.image.Icon;
 import de.agilecoders.wicket.extensions.markup.html.bootstrap.icon.FontAwesome5IconType;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.action.ReadOnlyActionHandler;
 import de.tudarmstadt.ukp.clarin.webanno.api.annotation.comment.AnnotatorCommentDialogPanel;
-import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasProvider;
 import de.tudarmstadt.ukp.clarin.webanno.brat.annotation.BratRequestUtils;
 import de.tudarmstadt.ukp.clarin.webanno.brat.message.GetCollectionInformationResponse;
 import de.tudarmstadt.ukp.clarin.webanno.brat.render.BratSerializer;
@@ -69,13 +70,18 @@ import de.tudarmstadt.ukp.clarin.webanno.ui.curation.component.render.CurationRe
 import de.tudarmstadt.ukp.clarin.webanno.ui.curation.page.LegacyCurationPage;
 import de.tudarmstadt.ukp.inception.bootstrap.BootstrapModalDialog;
 import de.tudarmstadt.ukp.inception.diam.editor.DiamAjaxBehavior;
+import de.tudarmstadt.ukp.inception.diam.editor.DiamRequest;
 import de.tudarmstadt.ukp.inception.diam.editor.actions.EditorAjaxRequestHandlerBase;
 import de.tudarmstadt.ukp.inception.diam.editor.actions.LazyDetailsHandler;
 import de.tudarmstadt.ukp.inception.diam.editor.lazydetails.LazyDetailsLookupService;
+import de.tudarmstadt.ukp.inception.diam.model.DiamContext;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.AjaxResponse;
 import de.tudarmstadt.ukp.inception.diam.model.ajax.DefaultAjaxResponse;
 import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
+import de.tudarmstadt.ukp.inception.editor.action.AnnotationActionHandler;
 import de.tudarmstadt.ukp.inception.project.api.ProjectService;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
 import de.tudarmstadt.ukp.inception.rendering.request.RenderRequest;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.AnnotationException;
 import de.tudarmstadt.ukp.inception.support.json.JSONUtil;
@@ -85,6 +91,7 @@ import de.tudarmstadt.ukp.inception.support.wicket.WicketUtil;
 
 public abstract class BratSuggestionVisualizer
     extends Panel
+    implements DiamContext
 {
     private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
@@ -173,7 +180,7 @@ public abstract class BratSuggestionVisualizer
                 AjaxEventBehavior.onEvent("click", _t -> actionShowAnnotatorComment(_t, annDoc)));
         queue(commentSymbol);
 
-        controller = new DiamAjaxBehavior() //
+        controller = new DiamAjaxBehavior(this) //
                 .setGlobalHandlersEnabled(false) //
                 .addPriorityHandler(new CurationLazyDetailsHandler()) //
                 .addPriorityHandler(new CurationActionAjaxRequestHandler());
@@ -247,6 +254,49 @@ public abstract class BratSuggestionVisualizer
     public AnnotatorSegmentState getModelObject()
     {
         return (AnnotatorSegmentState) getDefaultModelObject();
+    }
+
+    // The visualizer acts as the read-only DIAM context for its priority handlers: state and CAS
+    // are resolved per-segment (the annotator's own document), and its action handler rejects any
+    // mutation (editability is a property of the action handler).
+
+    private final AnnotationActionHandler actionHandler = new ReadOnlyActionHandler(
+            this::getEditorCas);
+
+    @Override
+    public AnnotatorState getAnnotatorState()
+    {
+        return getModelObject().getAnnotatorState();
+    }
+
+    @Override
+    public CAS getEditorCas() throws IOException
+    {
+        var segment = getModelObject();
+        return documentService.readAnnotationCas(segment.getAnnotatorState().getDocument(),
+                AnnotationSet.forUser(segment.getUser().getUsername()));
+    }
+
+    @Override
+    public AnnotationActionHandler getActionHandler()
+    {
+        return actionHandler;
+    }
+
+    @Override
+    public void actionShowSelectedDocument(AjaxRequestTarget aTarget, SourceDocument aDocument,
+            int aBegin, int aEnd)
+        throws IOException, AnnotationException
+    {
+        // Passive read-only view: the action handler ignores navigation, so this does not scroll
+        // and never drives the main editor.
+        getActionHandler().actionJump(aTarget, aBegin, aEnd);
+    }
+
+    @Override
+    public void actionRefreshDocument(AjaxRequestTarget aTarget)
+    {
+        render(aTarget);
     }
 
     @Override
@@ -381,13 +431,10 @@ public abstract class BratSuggestionVisualizer
                 final var request = getRequest().getPostParameters();
                 final var paramId = BratRequestUtils.getVidFromRequest(request);
 
-                var segment = getModelObject();
-                var state = segment.getAnnotatorState();
-                CasProvider casProvider = () -> documentService.readAnnotationCas(
-                        segment.getAnnotatorState().getDocument(),
-                        AnnotationSet.forUser(segment.getUser().getUsername()));
+                var context = aBehavior.getContext();
+                var state = context.getAnnotatorState();
                 var result = lazyDetailsLookupService.lookupLazyDetails(request, paramId,
-                        casProvider, state.getDocument(), segment.getUser(),
+                        context::getEditorCas, state.getDocument(), getModelObject().getUser(),
                         state.getWindowBeginOffset(), state.getWindowEndOffset());
                 attachResponse(aTarget, aRequest, toInterpretableJsonString(result));
 
@@ -425,7 +472,7 @@ public abstract class BratSuggestionVisualizer
         }
 
         @Override
-        public boolean accepts(Request aRequest)
+        public boolean accepts(DiamRequest aRequest)
         {
             return true;
         }

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/LegacyCurationPage.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/curation/page/LegacyCurationPage.java
@@ -351,6 +351,12 @@ public class LegacyCurationPage
     @OnEvent
     public void onSelectionChangedEvent(SelectionChangedEvent aEvent)
     {
+        // Only react to selection changes in this page's own editor state, not in other editors /
+        // panes hosted on the page (#6146).
+        if (!aEvent.isFor(getModelObject())) {
+            return;
+        }
+
         actionRefreshDocument(aEvent.getRequestHandler());
     }
 

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationEditorExtension.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationEditorExtension.java
@@ -64,6 +64,7 @@ import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
 import de.tudarmstadt.ukp.inception.editor.AnnotationEditorExtensionImplBase;
 import de.tudarmstadt.ukp.inception.editor.action.AnnotationActionHandler;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
+import de.tudarmstadt.ukp.inception.rendering.selection.Selection;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VID;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VLazyDetail;
 import de.tudarmstadt.ukp.inception.rendering.vmodel.VLazyDetailGroup;
@@ -260,7 +261,7 @@ public class CurationEditorExtension
 
         // open created/updates FS in annotation detail editor panel
         var mergedAnno = selectAnnotationByAddr(aTargetCas, mergeResult.targetAddress());
-        aState.getSelection().selectSpan(mergedAnno);
+        aState.setSelection(Selection.span(mergedAnno));
     }
 
     private void mergeRelation(AnnotatorState aState, CAS aTargetCas, VID aVid, String aSrcUser,
@@ -274,7 +275,7 @@ public class CurationEditorExtension
 
         // open created/updates FS in annotation detail editor panel
         var mergedAnno = selectAnnotationByAddr(aTargetCas, mergeResult.targetAddress());
-        aState.getSelection().selectArc(mergedAnno);
+        aState.setSelection(Selection.arc(mergedAnno));
     }
 
     private void mergeSpan(AnnotatorState aState, CAS aTargetCas, VID aVid, String aSrcUser,
@@ -288,7 +289,7 @@ public class CurationEditorExtension
 
         // open created/updates FS in annotation detail editor panel
         var mergedAnno = selectAnnotationByAddr(aTargetCas, mergeResult.targetAddress());
-        aState.getSelection().selectSpan(mergedAnno);
+        aState.setSelection(Selection.span(mergedAnno));
     }
 
     @Override

--- a/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebar.java
+++ b/inception/inception-ui-curation/src/main/java/de/tudarmstadt/ukp/inception/ui/curation/sidebar/CurationSidebar.java
@@ -278,7 +278,7 @@ public class CurationSidebar
         showMerged.setModelObject(curationSidebarService.isShowAll(sessionOwner, project));
 
         state.setUser(curationSessionService.getCurationTargetUser(sessionOwner, project));
-        state.getSelection().clear();
+        state.clearSelection();
 
         getAnnotationPage().actionLoadDocument(aTarget);
     }
@@ -296,7 +296,7 @@ public class CurationSidebar
         var sessionOwner = userRepository.getCurrentUser();
 
         state.setUser(userRepository.getCurrentUser());
-        state.getSelection().clear();
+        state.clearSelection();
 
         curationSessionService.closeSession(sessionOwner.getUsername(), state.getProject().getId());
 

--- a/inception/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/sidebar/ExternalSearchAnnotationSidebar.java
+++ b/inception/inception-ui-external-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/externalsearch/sidebar/ExternalSearchAnnotationSidebar.java
@@ -208,6 +208,13 @@ public class ExternalSearchAnnotationSidebar
     @OnEvent
     public void onRenderAnnotations(RenderAnnotationsEvent aEvent)
     {
+        // Only render our highlights into our own editor, not into other editors on the page (e.g.
+        // the reference-document viewer or curation panes) even if they show the same document
+        // (#6146).
+        if (aEvent.getRequest().getState() != getAnnotationPage().getModelObject()) {
+            return;
+        }
+
         ExternalSearchUserState searchState = searchStateModel.getObject();
 
         // highlight keywords if a document is selected from result list

--- a/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchSidebarIcon.java
+++ b/inception/inception-ui-search/src/main/java/de/tudarmstadt/ukp/inception/app/ui/search/sidebar/SearchSidebarIcon.java
@@ -82,6 +82,12 @@ public class SearchSidebarIcon
     @OnEvent
     public void onRenderAnnotations(RenderAnnotationsEvent aEvent)
     {
+        // Only render our markers into our own editor, not into other editors on the page (e.g. the
+        // reference-document viewer or curation panes) even if they show the same document (#6146).
+        if (aEvent.getRequest().getState() != getModelObject()) {
+            return;
+        }
+
         var searchOptions = SearchOptionsMetaDataKey.get(getPage());
 
         var query = searchOptions.map(SearchOptions::getQuery);


### PR DESCRIPTION
**What's in the PR**
- Tag render/selection/viewport events with the originating editor state as a source (SelectionChangedEvent, RenderRequestedEvent, RenderSlotsEvent, ScrollToEvent, AnnotatorViewportChangedEvent) so editors react only to their own events
- Filter events by source in DefaultPagingNavigator so paging one editor no longer scrolls or refreshes sibling editors on the same page
- Introduce DiamContext, an editor-scoped interface through which DIAM AJAX handlers resolve the annotator state, editor CAS, action handler, document navigation and refresh instead of always driving the main editor's page
- Let AnnotationPageBase implement DiamContext so the main editor supplies its page as the context, reproducing the historic getPage()-based behavior
- Make DiamAjaxBehavior require a mandatory DiamContext at construction and expose it to handlers
- Add DiamRequest (Request + DiamContext) and switch the EditorAjaxRequestHandler extension framework from Extension<Request> to Extension<DiamRequest> so acceptance checks and dispatch see the requesting editor
- Route all DIAM action handlers to resolve state, CAS and navigation through the request's DiamContext rather than getPage()
- Add commitAnnotation helper on EditorAjaxRequestHandlerBase to set the selection and commit via the context's action handler
- Make Selection an immutable value type with static factories unselected(), span() and arc(), final fields, equals()/hashCode() and a copy-returning reverseArc()
- Remove Selection.clear(), set(), copy(), setText() and the internal SelectionChangedEvent broadcast
- Move selection-change broadcasting to a single choke point, AnnotatorState.setSelection()/clearSelection(), which fires SelectionChangedEvent (tagged with its own state as source) only when the selection actually changes
- Add isEditable()/ensureIsEditable() to AnnotationActionHandler so editability is enforced fail-closed at the handler performing the writes, allowing read-only embedded editors
- Convert DefaultPagingNavigator to hold a DiamContext instead of AnnotationPageBase
- Thread the annotator state as source through PagingStrategy scroll-to events
- Extend BratSuggestionVisualizer, ExternalAnnotationEditorBase and curation/detail panels to participate in the context-scoped, source-tagged editor infrastructure
- Add inception-api-diam module dependencies to the poms wiring the new editor infrastructure

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
