### PR TITLE
#6170 - Add a reference document sidebar panel

### DIFF
--- a/inception/inception-api-editor/src/main/java/de/tudarmstadt/ukp/inception/editor/AnnotationEditorBase.java
+++ b/inception/inception-api-editor/src/main/java/de/tudarmstadt/ukp/inception/editor/AnnotationEditorBase.java
@@ -120,6 +120,16 @@ public abstract class AnnotationEditorBase
     }
 
     /**
+     * @return the markup id under which this editor's client-side counterpart registers with the
+     *         host page's viewport-sync hub, if the editor participates in cross-editor scroll
+     *         synchronization. Editors that do not support it return an empty optional.
+     */
+    public Optional<String> getViewportSyncClientId()
+    {
+        return Optional.empty();
+    }
+
+    /**
      * Schedules a rendering call via at the end of the given AJAX cycle. This method can be called
      * multiple times, even for the same annotation editor, but only resulting in a single rendering
      * call.

--- a/inception/inception-app-webapp/pom.xml
+++ b/inception/inception-app-webapp/pom.xml
@@ -128,6 +128,11 @@
     </dependency>
     <dependency>
       <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-ui-refdoc</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
       <artifactId>inception-curation</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -1190,6 +1195,7 @@
               <usedDependency>de.tudarmstadt.ukp.inception.app:inception-ui-kb</usedDependency>
               <usedDependency>de.tudarmstadt.ukp.inception.app:inception-ui-tagsets</usedDependency>
               <usedDependency>de.tudarmstadt.ukp.inception.app:inception-ui-curation</usedDependency>
+              <usedDependency>de.tudarmstadt.ukp.inception.app:inception-ui-refdoc</usedDependency>
               <usedDependency>de.tudarmstadt.ukp.inception.app:inception-ui-agreement</usedDependency>
               <usedDependency>de.tudarmstadt.ukp.inception.app:inception-ui-annotation</usedDependency>
               <usedDependency>de.tudarmstadt.ukp.inception.app:inception-ui-dashboard-activity</usedDependency>

--- a/inception/inception-brat-editor/src/main/ts/src/BratEditor.ts
+++ b/inception/inception-brat-editor/src/main/ts/src/BratEditor.ts
@@ -20,6 +20,8 @@ import type {
     AnnotationEditorProperties,
     DiamAjax,
     Offsets,
+    ViewportScrollPosition,
+    ViewportScrollTarget,
 } from '@inception-project/inception-js-api';
 import AnnotationDetailPopOver from '@inception-project/inception-js-api/src/widget/AnnotationDetailPopOver.svelte';
 import { Ajax } from './ajax/Ajax';
@@ -111,6 +113,14 @@ export class BratEditor implements AnnotationEditor {
 
     scrollTo(args: { offset: number; position?: string; pingRanges?: Offsets[] }): void {
         this.visualizer.scrollTo(args);
+    }
+
+    getViewportScrollPosition(): ViewportScrollPosition | null {
+        return this.visualizer.getViewportScrollPosition();
+    }
+
+    scrollToViewportPosition(pos: ViewportScrollTarget): void {
+        this.visualizer.scrollToViewportPosition(pos);
     }
 
     destroy(): void {

--- a/inception/inception-brat-editor/src/main/ts/src/BratEditor.ts
+++ b/inception/inception-brat-editor/src/main/ts/src/BratEditor.ts
@@ -22,6 +22,7 @@ import type {
     Offsets,
     ViewportScrollPosition,
     ViewportScrollTarget,
+    ViewportSyncPeer,
 } from '@inception-project/inception-js-api';
 import AnnotationDetailPopOver from '@inception-project/inception-js-api/src/widget/AnnotationDetailPopOver.svelte';
 import { Ajax } from './ajax/Ajax';
@@ -41,6 +42,8 @@ export class BratEditor implements AnnotationEditor {
     resizer: ResizeManager;
     resizeObserver: ResizeObserver;
     popover: AnnotationDetailPopOver;
+    private viewportSyncHub?: ViewportSyncPeer;
+    private viewportSyncId?: string;
 
     public constructor(element: Element, ajax: DiamAjax, props: AnnotationEditorProperties) {
         const markupId = element.getAttribute('id');
@@ -123,8 +126,25 @@ export class BratEditor implements AnnotationEditor {
         this.visualizer.scrollToViewportPosition(pos);
     }
 
+    connectViewportSync(aHub: ViewportSyncPeer, aId: string): void {
+        this.viewportSyncHub = aHub;
+        this.viewportSyncId = aId;
+        // Brat builds its `.scrolling` wrapper synchronously with the visualizer, so the container
+        // is available immediately - register right away with it as the scope.
+        aHub.register(aId, this, this.visualizer.getScrollContainer() ?? undefined);
+    }
+
+    disconnectViewportSync(): void {
+        if (this.viewportSyncHub && this.viewportSyncId) {
+            this.viewportSyncHub.unregister(this.viewportSyncId);
+        }
+        this.viewportSyncHub = undefined;
+        this.viewportSyncId = undefined;
+    }
+
     destroy(): void {
         console.log('Destroying BratEditor');
+        this.disconnectViewportSync();
         if (this.popover) {
             unmount(this.popover);
         }

--- a/inception/inception-brat-editor/src/main/ts/src/annotator_ui/AnnotatorUI.ts
+++ b/inception/inception-brat-editor/src/main/ts/src/annotator_ui/AnnotatorUI.ts
@@ -340,12 +340,10 @@ export class AnnotatorUI {
         const noNumArcType = this.arcOptions && this.arcOptions.type;
 
         spanDesc.arcs.map((possibleArc) => {
-            if (
-                !(
-                    (this.arcOptions && possibleArc.type === noNumArcType) ||
-                    !(this.arcOptions && this.arcOptions.old_target)
-                )
-            ) {
+            if (!(
+                (this.arcOptions && possibleArc.type === noNumArcType) ||
+                !(this.arcOptions && this.arcOptions.old_target)
+            )) {
                 return undefined;
             }
 

--- a/inception/inception-brat-editor/src/main/ts/src/visualizer/BratSyncController.test.ts
+++ b/inception/inception-brat-editor/src/main/ts/src/visualizer/BratSyncController.test.ts
@@ -1,0 +1,233 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+
+import {
+    anchorRowForViewport,
+    viewportScrollPositionFromRows,
+    targetScrollTopForPosition,
+} from './BratSyncController';
+import { type RowGeometry } from './ScrollSyncRowCache';
+
+// Three tiled rows of height 20, offsets contiguous. `top` is viewport-relative; the caller sets it
+// per scenario to place the viewport top within / above / below a given row.
+function rows(...tops: number[]): RowGeometry[] {
+    return tops.map((top, i) => ({
+        top,
+        height: 20,
+        begin: i * 100,
+        end: i * 100 + 100,
+    }));
+}
+
+describe('anchorRowForViewport', () => {
+    it('returns null for no rows', () => {
+        expect(anchorRowForViewport([])).toBeNull();
+    });
+
+    it('anchors on the last row whose top is at or above the viewport top', () => {
+        // rows at -30, -10, 10: the viewport top (0) sits within the second row (top -10)
+        const anchor = anchorRowForViewport(rows(-30, -10, 10));
+        expect(anchor?.begin).toBe(100);
+    });
+
+    it('anchors on a row whose top is exactly at the viewport top', () => {
+        const anchor = anchorRowForViewport(rows(-20, 0, 20));
+        expect(anchor?.begin).toBe(100);
+    });
+
+    it('anchors on the first row when all rows are below the viewport top', () => {
+        // Scrolled into the padding above the first row: every top > 0.
+        const anchor = anchorRowForViewport(rows(5, 25, 45));
+        expect(anchor?.begin).toBe(0);
+    });
+
+    it('anchors on the last row when all rows are above the viewport top', () => {
+        const anchor = anchorRowForViewport(rows(-60, -40, -20));
+        expect(anchor?.begin).toBe(200);
+    });
+});
+
+describe('viewportScrollPositionFromRows', () => {
+    it('returns null for no rows', () => {
+        expect(viewportScrollPositionFromRows([], 0, 100)).toBeNull();
+    });
+
+    it('reports the anchor offsets and the intra-row fraction', () => {
+        // Anchor is the second row (top -10, height 20): fraction = -(-10)/20 = 0.5
+        const pos = viewportScrollPositionFromRows(rows(-30, -10, 10), 200, 1000);
+        expect(pos).not.toBeNull();
+        expect(pos!.begin).toBe(100);
+        expect(pos!.end).toBe(200);
+        expect(pos!.fraction).toBeCloseTo(0.5);
+    });
+
+    it('yields a negative fraction when scrolled above the first row', () => {
+        // First row anchors with a positive top (10) -> fraction = -10/20 = -0.5
+        const pos = viewportScrollPositionFromRows(rows(10, 30, 50), 0, 1000);
+        expect(pos!.begin).toBe(0);
+        expect(pos!.fraction).toBeCloseTo(-0.5);
+    });
+
+    it('clamps the fraction to at most 1', () => {
+        // Only the first row is at/above the viewport top, so it anchors with top -40 (the later
+        // rows are below the seam). raw fraction = -(-40)/20 = 2, clamped to 1.
+        const pos = viewportScrollPositionFromRows(rows(-40, 10, 30), 500, 1000);
+        expect(pos!.begin).toBe(0);
+        expect(pos!.fraction).toBe(1);
+    });
+
+    it('computes scrollProgress as scrollTop / maxScroll', () => {
+        const pos = viewportScrollPositionFromRows(rows(0, 20, 40), 250, 1000);
+        expect(pos!.scrollProgress).toBeCloseTo(0.25);
+    });
+
+    it('reports zero progress when there is no scrollable range', () => {
+        const pos = viewportScrollPositionFromRows(rows(0, 20, 40), 0, 0);
+        expect(pos!.scrollProgress).toBe(0);
+    });
+
+    it('uses a zero fraction for a degenerate zero-height anchor', () => {
+        const zeroHeight: RowGeometry[] = [{ top: -5, height: 0, begin: 0, end: 10 }];
+        const pos = viewportScrollPositionFromRows(zeroHeight, 0, 100);
+        expect(pos!.fraction).toBe(0);
+    });
+});
+
+describe('targetScrollTopForPosition', () => {
+    it('returns null for no rows', () => {
+        expect(targetScrollTopForPosition([], { begin: 0, fraction: 0 }, 0, 100)).toBeNull();
+    });
+
+    it('anchors the target offset within the containing row', () => {
+        // rows tiled at top 0/20/40 with scrollTop 1000. Target offset 150 lands in row 1
+        // (begin 100, end 200): rowFraction = (150-100)/100 = 0.5.
+        // anchoredTop = 1000 + row.top(20) + 0.5*height(20) = 1030.
+        const target = targetScrollTopForPosition(
+            rows(0, 20, 40),
+            { begin: 100, end: 200, fraction: 0.5 },
+            1000,
+            10000
+        );
+        expect(target).toBeCloseTo(1030);
+    });
+
+    it('interpolates the incoming anchor in character space before locating the row', () => {
+        // begin 100, end 200, fraction 0.5 -> targetOffset 150, same as above.
+        const target = targetScrollTopForPosition(
+            rows(0, 20, 40),
+            { begin: 100, end: 200, fraction: 0.5 },
+            0,
+            10000
+        );
+        // row 1 top 20, rowFraction 0.5 -> 20 + 10 = 30
+        expect(target).toBeCloseTo(30);
+    });
+
+    it('defaults end to begin when omitted (targetOffset == begin)', () => {
+        const target = targetScrollTopForPosition(
+            rows(0, 20, 40),
+            { begin: 100, fraction: 0.5 },
+            0,
+            10000
+        );
+        // targetOffset = 100 -> row 1 begin, rowFraction 0 -> top 20
+        expect(target).toBeCloseTo(20);
+    });
+
+    it('clamps to the first row when the offset is before the window', () => {
+        const target = targetScrollTopForPosition(
+            rows(0, 20, 40),
+            { begin: -50, fraction: 0 },
+            0,
+            10000
+        );
+        // clamped to row 0 (top 0); offset below its begin -> rowFraction clamped to 0
+        expect(target).toBeCloseTo(0);
+    });
+
+    it('clamps to the last row when the offset is after the window', () => {
+        const target = targetScrollTopForPosition(
+            rows(0, 20, 40),
+            { begin: 5000, fraction: 0 },
+            0,
+            10000
+        );
+        // clamped to row 2 (top 40); offset above its end -> rowFraction clamped to 1 -> 40 + 20
+        expect(target).toBeCloseTo(60);
+    });
+
+    it('picks the nearest row by offset when the target lands in an inter-row gap', () => {
+        // Rows with a gap in offset space: [0,100] and [200,300]. Target 190 is nearest row 1's end.
+        const gapped: RowGeometry[] = [
+            { top: 0, height: 20, begin: 0, end: 100 },
+            { top: 20, height: 20, begin: 200, end: 300 },
+        ];
+        const target = targetScrollTopForPosition(gapped, { begin: 190, fraction: 0 }, 0, 10000);
+        // nearest is row 1 (|200-190|=10 < |100-190|=90); offset below its begin -> rowFraction 0 -> top 20
+        expect(target).toBeCloseTo(20);
+    });
+
+    it('ignores the progress blend in the document interior', () => {
+        // scrollProgress 0.5 is well outside the 0.15 band from either extreme -> nearness 0,
+        // so the anchored target is returned unchanged.
+        const target = targetScrollTopForPosition(
+            rows(0, 20, 40),
+            { begin: 100, end: 200, fraction: 0, scrollProgress: 0.5 },
+            0,
+            10000
+        );
+        expect(target).toBeCloseTo(20); // pure anchored value, no blend
+    });
+
+    it('lands exactly on the progress-mapped top at an extreme', () => {
+        // scrollProgress 0 -> nearness 1 -> target = progressTop = 0 * maxScroll = 0,
+        // regardless of the anchored value.
+        const target = targetScrollTopForPosition(
+            rows(0, 20, 40),
+            { begin: 200, end: 300, fraction: 1, scrollProgress: 0 },
+            0,
+            10000
+        );
+        expect(target).toBeCloseTo(0);
+    });
+
+    it('blends partially within the transition band', () => {
+        // scrollProgress 0.075 = half the 0.15 band -> nearness 0.5.
+        // progressTop = 0.075 * 10000 = 750. anchored: begin 100 fraction 0 -> row1 top 20.
+        // blended = 0.5*750 + 0.5*20 = 385.
+        const target = targetScrollTopForPosition(
+            rows(0, 20, 40),
+            { begin: 100, end: 200, fraction: 0, scrollProgress: 0.075 },
+            0,
+            10000
+        );
+        expect(target).toBeCloseTo(385);
+    });
+
+    it('skips the blend when there is no scrollable range', () => {
+        // maxScroll 0 -> blend guarded off, anchored value returned even though scrollProgress is set.
+        const target = targetScrollTopForPosition(
+            rows(0, 20, 40),
+            { begin: 100, end: 200, fraction: 0, scrollProgress: 0 },
+            0,
+            0
+        );
+        expect(target).toBeCloseTo(20);
+    });
+});

--- a/inception/inception-brat-editor/src/main/ts/src/visualizer/BratSyncController.ts
+++ b/inception/inception-brat-editor/src/main/ts/src/visualizer/BratSyncController.ts
@@ -1,0 +1,248 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    type ViewportScrollPosition,
+    type ViewportScrollTarget,
+} from '@inception-project/inception-js-api';
+import { ScrollSyncRowCache, type RowGeometry, type RowGeometrySource } from './ScrollSyncRowCache';
+
+/** Fraction of the scroll range over which to blend toward whole-container progress at each end. */
+const EXTREME_BLEND_BAND = 0.15;
+
+/**
+ * The row anchoring the viewport top: the last row whose top is at or above the viewport top
+ * (top <= 0). When the viewport is scrolled into the padding above the first row (every row has a
+ * positive top), the first row anchors it - the caller then derives a negative fraction from it.
+ * Rows are assumed sorted top-ascending. Returns null for an empty list.
+ */
+export function anchorRowForViewport(rows: readonly RowGeometry[]): RowGeometry | null {
+    if (rows.length === 0) return null;
+    let anchor = rows[0];
+    for (const row of rows) {
+        if (row.top <= 0) {
+            anchor = row;
+        } else {
+            break;
+        }
+    }
+    return anchor;
+}
+
+/**
+ * Build the {@link ViewportScrollPosition} the editor reports, from its current rows and scroll
+ * metrics. Pure counterpart of {@link BratSyncController.getViewportScrollPosition} - the DOM-free
+ * math, so it can be unit-tested with synthetic rows. Returns null when there are no rows.
+ *
+ * The fraction is intentionally NOT clamped below zero: when the viewport top sits in the padding
+ * above the first row, a negative fraction lets the receiver align there too instead of stopping a
+ * line short of the top. It IS clamped to at most 1.
+ */
+export function viewportScrollPositionFromRows(
+    rows: readonly RowGeometry[],
+    scrollTop: number,
+    maxScroll: number
+): ViewportScrollPosition | null {
+    const anchor = anchorRowForViewport(rows);
+    if (!anchor) return null;
+
+    // Overall scroll progress lets the receiver blend toward its own extreme near the top/bottom
+    // (see ViewportScrollPosition.scrollProgress), so scrolling just off an extreme no longer snaps.
+    const scrollProgress = maxScroll > 0 ? scrollTop / maxScroll : 0;
+
+    const fraction = anchor.height > 0 ? -anchor.top / anchor.height : 0;
+    return {
+        begin: anchor.begin,
+        end: anchor.end,
+        fraction: Math.min(1, fraction),
+        scrollProgress,
+    };
+}
+
+/**
+ * Given the receiver's current rows and a requested {@link ViewportScrollTarget}, compute the
+ * absolute scrollTop that places the target offset+fraction at the viewport top. Pure counterpart
+ * of {@link BratSyncController.scrollToViewportPosition} - the DOM-free math, so it can be
+ * unit-tested with synthetic rows. Returns null when there are no rows to anchor against.
+ *
+ * When the offset falls outside the current window (the two editors paged to different parts of the
+ * same document), the target is clamped to the nearest rendered row so the view aligns to the top
+ * or bottom of what is in the DOM instead of doing nothing.
+ */
+export function targetScrollTopForPosition(
+    rows: readonly RowGeometry[],
+    pos: ViewportScrollTarget,
+    currentScrollTop: number,
+    maxScroll: number
+): number | null {
+    if (rows.length === 0) return null;
+
+    // --- Offset-anchored target (accurate in the document interior) ---
+    // Convert the incoming anchor to a fractional CHARACTER offset - the layout-independent quantity
+    // the two editors agree on. Interpolating here in pixels off the source's row height would
+    // jitter, because the same sentence wraps to a different height on each side; in character space
+    // that difference washes out (each side re-derives pixels from its own rows below).
+    const end = pos.end ?? pos.begin;
+    const targetOffset = pos.begin + pos.fraction * (end - pos.begin);
+
+    // Find the row whose offset span contains targetOffset (nearest by span if it lands in an
+    // inter-row gap; clamp to the ends only if truly outside the window).
+    let anchor = rows.find((r) => targetOffset >= r.begin && targetOffset <= r.end);
+    if (!anchor) {
+        if (targetOffset < rows[0].begin) {
+            anchor = rows[0];
+        } else if (targetOffset > rows[rows.length - 1].end) {
+            anchor = rows[rows.length - 1];
+        } else {
+            anchor = rows.reduce((best, r) => {
+                const d = Math.min(
+                    Math.abs(r.begin - targetOffset),
+                    Math.abs(r.end - targetOffset)
+                );
+                const bestD = Math.min(
+                    Math.abs(best.begin - targetOffset),
+                    Math.abs(best.end - targetOffset)
+                );
+                return d < bestD ? r : best;
+            }, rows[0]);
+        }
+    }
+
+    // Interpolate the target offset's position WITHIN the receiver's own row, so the fraction is
+    // re-expressed against this editor's row height, not the source's. rows[i].top is
+    // viewport-relative, so this is the ABSOLUTE scrollTop that puts the target at the top.
+    const span = anchor.end - anchor.begin;
+    const rowFraction =
+        span > 0 ? Math.min(1, Math.max(0, (targetOffset - anchor.begin) / span)) : 0;
+    const anchoredTop = currentScrollTop + anchor.top + rowFraction * anchor.height;
+
+    // --- Blend toward whole-container scroll-progress near the extremes ---
+    // Offset-anchoring aligns viewport TOPS, so near a scroll extreme it lands short of this editor's
+    // own extreme (the two editors have different amounts of content below the shared top row). A
+    // pure progress mapping (progress * maxScroll) hits the extremes exactly but drifts in the
+    // interior. Blend: weight toward progress only within a transition band next to each extreme, so
+    // the extremes are exact AND the interior stays offset-accurate, with no discontinuity (snap) at
+    // the boundary between the two regimes.
+    if (pos.scrollProgress !== undefined && maxScroll > 0) {
+        const progressTop = pos.scrollProgress * maxScroll;
+        const p = pos.scrollProgress;
+        // 1 at an extreme -> 0 by EXTREME_BLEND_BAND in from it.
+        const nearness = Math.max(0, 1 - Math.min(p, 1 - p) / EXTREME_BLEND_BAND);
+        return nearness * progressTop + (1 - nearness) * anchoredTop;
+    }
+
+    return anchoredTop;
+}
+
+/**
+ * Editor-to-editor viewport synchronization for the brat visualizer. Implements the
+ * {@code AnnotationEditor} viewport-sync protocol: {@link getViewportScrollPosition} reports the
+ * visual row currently at the viewport top (plus how far the top has advanced through it), and
+ * {@link scrollToViewportPosition} places a given offset+fraction back at the viewport top.
+ * Anchoring is done in document-character space rather than pixels so two editors stay in sync even
+ * when they wrap the same text to different heights.
+ *
+ * The controller is decoupled from the visualizer: it depends only on a lazily-read scroll
+ * container and a lazily-assembled {@link RowGeometrySource} (both supplied as getters, since they
+ * are only meaningful after a render). It owns the {@link ScrollSyncRowCache} so the expensive
+ * per-layout DOM measurement lives with the code that consumes it; the visualizer calls
+ * {@link invalidate} from its render funnel.
+ */
+export class BratSyncController {
+    private readonly getScrollContainer: () => HTMLElement | null;
+    private readonly getRowGeometrySource: () => RowGeometrySource | null;
+
+    private rowGeometryCache = new ScrollSyncRowCache();
+
+    /**
+     * @param getScrollContainer resolves the current scroll container (null before it exists).
+     * @param getRowGeometrySource assembles the current inputs for row measurement (null when there
+     * is no rendered document to measure).
+     */
+    constructor(
+        getScrollContainer: () => HTMLElement | null,
+        getRowGeometrySource: () => RowGeometrySource | null
+    ) {
+        this.getScrollContainer = getScrollContainer;
+        this.getRowGeometrySource = getRowGeometrySource;
+    }
+
+    /** Discard the cached row geometry so the next sync read re-measures. Call on every render. */
+    invalidate(): void {
+        this.rowGeometryCache.invalidate();
+    }
+
+    /**
+     * The visual rows of the current window, each as its viewport-relative top edge, its height
+     * (the gap to the next row, so it spans the full inter-line distance), and the document offset
+     * span it covers. The heavy DOM measurement is cached per layout by {@link ScrollSyncRowCache};
+     * this only supplies the current inputs and projects into the live viewport.
+     *
+     * Anchoring viewport-sync on rows rather than individual chunks (tokens) is what keeps the
+     * follower smooth: a row changes far less often than a token as one scrolls, and the fraction
+     * moves continuously across the whole inter-row distance instead of resetting at every token.
+     */
+    private computeRowGeometry(): RowGeometry[] | null {
+        const container = this.getScrollContainer();
+        const source = this.getRowGeometrySource();
+        if (!container || !source) return null;
+
+        return this.rowGeometryCache.getRows(container, source);
+    }
+
+    /**
+     * Report the visual row currently at the top of the scroll viewport as document offsets plus
+     * the fraction of that row the viewport top has advanced through. Resolves the live scroll
+     * container and rows, then defers to the pure {@link viewportScrollPositionFromRows}.
+     *
+     * Offsets are document-absolute (the window offset is added back by the row cache), so a
+     * receiver on a different editor can map them into its own layout. brat is server-paged: only
+     * the current window is in the DOM, so the reported anchor is necessarily within it.
+     */
+    getViewportScrollPosition(): ViewportScrollPosition | null {
+        const container = this.getScrollContainer();
+        if (!container) return null;
+
+        const rows = this.computeRowGeometry();
+        if (!rows) return null;
+
+        const maxScroll = container.scrollHeight - container.clientHeight;
+        return viewportScrollPositionFromRows(rows, container.scrollTop, maxScroll);
+    }
+
+    /**
+     * Continuous top-alignment for scroll synchronization: resolve the live scroll container and
+     * rows, compute the target scrollTop via the pure {@link targetScrollTopForPosition}, and apply
+     * it. Deliberately not sharing {@code scrollTo}'s machinery - no pings, no smooth animation, no
+     * centering - so a stream of these (one per animation frame while the other editor scrolls)
+     * stays jank-free. Assigning scrollTop clamps to the scroll bounds, so an out-of-range target
+     * simply scrolls as far as the container allows.
+     */
+    scrollToViewportPosition(pos: ViewportScrollTarget): void {
+        const container = this.getScrollContainer();
+        if (!container) return;
+
+        const rows = this.computeRowGeometry();
+        if (!rows || rows.length === 0) return;
+
+        const maxScroll = container.scrollHeight - container.clientHeight;
+        const target = targetScrollTopForPosition(rows, pos, container.scrollTop, maxScroll);
+        if (target === null) return;
+
+        container.scrollTop = target;
+    }
+}

--- a/inception/inception-brat-editor/src/main/ts/src/visualizer/DocumentData.ts
+++ b/inception/inception-brat-editor/src/main/ts/src/visualizer/DocumentData.ts
@@ -54,23 +54,69 @@ import { VID } from '../protocol/Protocol';
  * which doesn't yet create the actual SVG representation.
  */
 export class DocumentData {
+    /** The full document text this data was built for. */
     text: string;
+
+    /** The text split into chunks (roughly, tokens/whitespace-delimited pieces) used for layout. */
     chunks: Array<Chunk> = [];
+
+    /** Span annotations (entities) indexed by their {@link VID}. */
     spans: Record<VID, Entity> = {};
+
+    /** Arcs indexed by the id of the {@link EventDesc} they were derived from. */
     arcById: Record<VID, Arc> = {};
+
+    /** All arcs (relations/event roles) to be rendered. */
     arcs: Array<Arc> = [];
+
+    /**
+     * Event descriptors indexed by event number. These are built both from actual events and
+     * synthesized from relations (see {@code buildEventDescsFromRelations}) and carry the arc
+     * label/color information.
+     */
     eventDescs: Record<VID, EventDesc> = {};
+
+    /** Comments attached to a whole sentence/row, indexed by sentence (row) number. */
     sentComment: Record<number, Comment> = {};
+
+    /** Sentences/rows flagged for highlighting, indexed by sentence (row) number. */
     markedSent: Record<number, boolean> = {};
+
     /**
      * Template SVG text elements. Clone these and fill in any missing information (translate, fill)
      * before adding them to the SVG.
      */
     spanAnnTexts: Record<string, SVGText> = {};
+
+    /**
+     * Span fragments grouped into vertical stacks ("towers") by their {@code towerId}, so that
+     * fragments sharing a tower are laid out at a consistent height.
+     */
     towers: Record<string, Fragment[]> = {};
+
+    /**
+     * The order in which spans are drawn/stacked, as a permutation of span {@link VID}s produced by
+     * {@code determineDrawOrder}.
+     */
     spanDrawOrderPermutation: Array<VID> = [];
+
+    /** Precomputed layout sizes (font metrics, box dimensions) used during rendering. */
     sizes: Sizes;
+
+    /**
+     * Set when the server response represents an error rather than renderable data; the UI checks
+     * this and skips rendering when true.
+     */
     exception = false;
+
+    /**
+     * The trailing y after the last row was placed by {@code renderRows}, i.e. the bottom edge of
+     * the laid-out content in SVG user units. The brat SVG is rendered with {@code viewBox} height
+     * equal to its pixel height (see {@code Visualizer.renderData}), so the vertical user->pixel
+     * scale is 1 and this value is directly comparable to viewport pixel measurements. Undefined
+     * until the first render completes.
+     */
+    contentHeight?: number;
 
     constructor(text: string) {
         this.text = text;

--- a/inception/inception-brat-editor/src/main/ts/src/visualizer/ScrollSyncRowCache.ts
+++ b/inception/inception-brat-editor/src/main/ts/src/visualizer/ScrollSyncRowCache.ts
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Chunk } from './Chunk';
+
+/** A visual row of the current window, projected into the viewport (top is scroll-relative). */
+export interface RowGeometry {
+    /** The row's top edge relative to the scroll viewport top (0 = at the viewport top). */
+    top: number;
+    /** The full inter-line advance to the next row (so rows tile the vertical space). */
+    height: number;
+    /** Document-absolute begin offset of the text on this row. */
+    begin: number;
+    /** Document-absolute end offset of the text on this row. */
+    end: number;
+}
+
+/** The inputs the cache needs to (re)measure the DOM. Supplied by the visualizer on rebuild. */
+export interface RowGeometrySource {
+    /** The rendered SVG root whose chunk-text elements are measured. */
+    svgNode: SVGSVGElement;
+    /** The current window's chunks, indexed by {@code Chunk.index} (== array position). */
+    chunks: ReadonlyArray<Chunk>;
+    /** Offset of the current window's start within the document, added back so offsets are absolute. */
+    windowBegin: number;
+    /** Fallback line height used when a single-row window has no inter-row gap to measure. */
+    defaultLineHeight: number;
+    /**
+     * Document-relative bottom edge of the laid-out content (the trailing y after the render loop
+     * placed the last row), in the same units as the measured row tops (the brat SVG renders at a
+     * vertical user->pixel scale of 1; see {@link DocumentData.contentHeight}). Used to give the
+     * LAST row its true height - it has no successor row whose top would otherwise reveal it.
+     * Undefined before the first render completes; falls back to the previous gap when absent.
+     */
+    contentBottom?: number;
+}
+
+/**
+ * Caches the visual-row geometry the brat editor reports for viewport synchronization.
+ *
+ * Measuring rows from the DOM (grouping chunk-text client rects by their top coordinate) is the
+ * expensive part, but it only depends on the LAYOUT, not the scroll position: a row's height and
+ * its document-offset span do not change as one scrolls, and its top merely translates by the
+ * scrollTop. So the measurement is done once per layout (storing each top DOCUMENT-relative, i.e.
+ * from the top of the scrollable content) and cached; each per-frame read just subtracts the live
+ * scrollTop to project the tops back into the viewport - no DOM measurement per frame.
+ *
+ * The visualizer calls {@link invalidate} at the start of every render (the single funnel through
+ * which render, patch, repage, resize and density/width tweaks all pass); the table is rebuilt
+ * lazily on the next {@link getRows}, so the measurement never runs at all unless viewport-sync
+ * actually asks for the geometry.
+ *
+ * Note the {@code g.row} groups report a zero-height client rect and so cannot be measured
+ * directly; the per-chunk grouping is the way to recover row tops from the DOM.
+ */
+export class ScrollSyncRowCache {
+    /** Cached rows with DOCUMENT-relative tops (scroll-invariant). Null means "rebuild on next use". */
+    private cache: Array<{
+        topAbs: number;
+        height: number;
+        begin: number;
+        end: number;
+    }> | null = null;
+
+    /** Discard the cached geometry so the next {@link getRows} re-measures. */
+    invalidate(): void {
+        this.cache = null;
+    }
+
+    /**
+     * The current window's rows projected into the given scroll container's viewport, rebuilding the
+     * cached layout measurement from {@code source} on first use after an {@link invalidate}. Returns
+     * null when there is nothing to measure (no container-independent geometry yet).
+     */
+    getRows(container: HTMLElement, source: RowGeometrySource): RowGeometry[] | null {
+        if (!this.cache) {
+            this.cache = this.build(container, source);
+        }
+        if (!this.cache) return null;
+
+        // Project the cached document-relative tops into the current viewport. This is the only
+        // scroll-dependent part; heights and offset spans are layout properties and stay as cached.
+        const scrollTop = container.scrollTop;
+        return this.cache.map((row) => ({
+            top: row.topAbs - scrollTop,
+            height: row.height,
+            begin: row.begin,
+            end: row.end,
+        }));
+    }
+
+    private build(
+        container: HTMLElement,
+        source: RowGeometrySource
+    ): Array<{ topAbs: number; height: number; begin: number; end: number }> | null {
+        const chunkElements = source.svgNode.querySelectorAll('text:not(.spacing)[data-chunk-id]');
+        if (!chunkElements || chunkElements.length === 0) return null;
+
+        // Document-relative reference: adding scrollTop to the viewport-relative rect turns a
+        // scroll-dependent top into a scroll-invariant one that the cache can reuse across frames.
+        const containerTop = container.getBoundingClientRect().top - container.scrollTop;
+        const windowBegin = source.windowBegin;
+
+        // Group chunk texts by their (rounded) top coordinate = one visual row.
+        const rowsByTop = new Map<number, { topAbs: number; begin: number; end: number }>();
+        for (const el of chunkElements) {
+            const chunkId = el.getAttribute('data-chunk-id');
+            if (chunkId == null) continue;
+            const index = parseInt(chunkId, 10);
+            // chunks are built in index order (see buildChunksFromTokenOffsets), so the array
+            // position equals chunk.index - a direct lookup instead of an O(n) find. Guard against
+            // the invariant ever breaking so we never pair an element with the wrong chunk.
+            const chunk = source.chunks[index];
+            if (!chunk || chunk.index !== index) continue;
+
+            const rect = el.getBoundingClientRect();
+            const key = Math.round(rect.top);
+            const row = rowsByTop.get(key);
+            if (row) {
+                row.begin = Math.min(row.begin, chunk.from + windowBegin);
+                row.end = Math.max(row.end, chunk.to + windowBegin);
+            } else {
+                rowsByTop.set(key, {
+                    topAbs: rect.top - containerTop,
+                    begin: chunk.from + windowBegin,
+                    end: chunk.to + windowBegin,
+                });
+            }
+        }
+
+        if (rowsByTop.size === 0) return null;
+
+        const rows = [...rowsByTop.values()].sort((a, b) => a.topAbs - b.topAbs);
+
+        // Bottom edge of the laid-out content in the same document-relative frame as the row tops.
+        // contentBottom comes from the render loop in SVG user space (origin = the SVG's own top,
+        // vertical scale 1); rebasing by the SVG's top - measured the same way the row tops are -
+        // lands it in the containerTop frame, correct even with padding/header above the SVG.
+        const contentBottomAbs =
+            source.contentBottom != null
+                ? source.svgNode.getBoundingClientRect().top - containerTop + source.contentBottom
+                : null;
+
+        // A row's height is the distance to the next row (the full inter-line advance). The last
+        // row has no successor row to reveal its height, so measure it against the content bottom
+        // (its true height, tower included); fall back to the previous gap, then a nominal line
+        // height. Guard against a bad measurement (non-positive) by not trusting contentBottom then.
+        return rows.map((row, i) => {
+            let height: number;
+            if (i + 1 < rows.length) {
+                height = rows[i + 1].topAbs - row.topAbs;
+            } else if (contentBottomAbs != null && contentBottomAbs - row.topAbs > 0) {
+                height = contentBottomAbs - row.topAbs;
+            } else if (rows.length >= 2) {
+                height = row.topAbs - rows[i - 1].topAbs;
+            } else {
+                height = source.defaultLineHeight;
+            }
+            return { topAbs: row.topAbs, height, begin: row.begin, end: row.end };
+        });
+    }
+}

--- a/inception/inception-brat-editor/src/main/ts/src/visualizer/Visualizer.ts
+++ b/inception/inception-brat-editor/src/main/ts/src/visualizer/Visualizer.ts
@@ -439,7 +439,7 @@ export class Visualizer {
      * {@link findClosestVerticalScrollable} would not catch it); we resolve that wrapper directly
      * and only fall back to the generic walk-up for non-standard hosts.
      */
-    private getScrollContainer(): HTMLElement | null {
+    getScrollContainer(): HTMLElement | null {
         const byClass = this.svgContainer?.closest('.scrolling');
         if (byClass instanceof HTMLElement) {
             return byClass;

--- a/inception/inception-brat-editor/src/main/ts/src/visualizer/Visualizer.ts
+++ b/inception/inception-brat-editor/src/main/ts/src/visualizer/Visualizer.ts
@@ -48,6 +48,8 @@ import { DocumentData } from './DocumentData';
 import { ENTITY, Entity, TRIGGER } from './Entity';
 import { EQUIV, EventDesc, RELATION } from './EventDesc';
 import { Chunk } from './Chunk';
+import { BratSyncController } from './BratSyncController';
+import { type RowGeometrySource } from './ScrollSyncRowCache';
 import { Fragment } from './Fragment';
 import type { SegmenterAdapter } from './SegmenterAnalysis';
 import { Arc } from './Arc';
@@ -97,6 +99,8 @@ import {
     AnnotationOutEvent,
     AnnotationOverEvent,
     type Offsets,
+    type ViewportScrollPosition,
+    type ViewportScrollTarget,
     Relation,
     Span,
     bgToFgColor,
@@ -221,6 +225,16 @@ export class Visualizer {
     private isRenderRequested = false;
     private drawing = false;
     private redraw = false;
+
+    /**
+     * Editor-to-editor viewport synchronization (offset+fraction reporting and scrolling). Owns the
+     * per-layout row-geometry cache; {@link BratSyncController.invalidate} is called from the render
+     * funnel. Reads the scroll container and row-geometry inputs lazily from this visualizer.
+     */
+    private syncController = new BratSyncController(
+        () => this.getScrollContainer(),
+        () => this.getRowGeometrySource()
+    );
 
     private entityTypes: Record<string, EntityTypeDto> = {};
     private relationTypes: Record<string, RelationTypeDto> = {};
@@ -418,6 +432,46 @@ export class Visualizer {
                 .after(() => ping.remove());
         }
     }
+
+    /**
+     * The vertically scrolling ancestor of the SVG. The brat markup wraps the visualizer in a
+     * `div.scrolling` (overflow: auto via CSS class, so the inline-style-only
+     * {@link findClosestVerticalScrollable} would not catch it); we resolve that wrapper directly
+     * and only fall back to the generic walk-up for non-standard hosts.
+     */
+    private getScrollContainer(): HTMLElement | null {
+        const byClass = this.svgContainer?.closest('.scrolling');
+        if (byClass instanceof HTMLElement) {
+            return byClass;
+        }
+        return findClosestVerticalScrollable(this.svg.node);
+    }
+
+    /**
+     * Assemble the current inputs the {@link BratSyncController} needs to (re)measure row geometry,
+     * or null when there is no rendered document to measure. Kept here because it reads this
+     * visualizer's live render state (SVG node, chunks, window offset, sizes).
+     */
+    private getRowGeometrySource(): RowGeometrySource | null {
+        if (!this.data) return null;
+
+        return {
+            svgNode: this.svg.node,
+            chunks: this.data.chunks,
+            windowBegin: this.sourceData?.windowBegin || 0,
+            defaultLineHeight: this.data.sizes.texts.height || 20,
+            contentBottom: this.data.contentHeight,
+        };
+    }
+
+    getViewportScrollPosition(): ViewportScrollPosition | null {
+        return this.syncController.getViewportScrollPosition();
+    }
+
+    scrollToViewportPosition(pos: ViewportScrollTarget): void {
+        this.syncController.scrollToViewportPosition(pos);
+    }
+
     /**
      * Get the priority of the given comment class.
      *
@@ -3774,6 +3828,11 @@ export class Visualizer {
             Util.profileStart('render');
             this.dispatcher.post('startedRendering', [this.args]);
 
+            // The layout is about to change, so any cached row geometry for viewport-sync is stale.
+            // Drop it here (the single funnel for every render/patch/repage/resize) and let it be
+            // rebuilt lazily on the next sync frame.
+            this.syncController.invalidate();
+
             if (!sourceData && !this.data) {
                 this.dispatcher.post('doneRendering', [this.args]);
                 return;
@@ -3881,6 +3940,7 @@ export class Visualizer {
 
             Util.profileStart('rows');
             const y = this.renderRows(this.data, rows, sentNumGroup, backgroundGroup);
+            this.data.contentHeight = y;
             Util.profileEnd('rows');
 
             Util.profileStart('chunkFinish');

--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/ExternalAnnotationEditorBase.java
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/ExternalAnnotationEditorBase.java
@@ -214,6 +214,12 @@ public abstract class ExternalAnnotationEditorBase
         return vis;
     }
 
+    @Override
+    public Optional<String> getViewportSyncClientId()
+    {
+        return Optional.ofNullable(vis).map(Component::getMarkupId);
+    }
+
     public DiamAjaxBehavior getDiamBehavior()
     {
         return diamBehavior;

--- a/inception/inception-external-editor/src/main/ts/src/ExternalEditorFactory.ts
+++ b/inception/inception-external-editor/src/main/ts/src/ExternalEditorFactory.ts
@@ -114,10 +114,8 @@ export class ExternalEditorFactory implements AnnotationEditorFactory {
             delete element[PROP_INITIALIZING];
             console.debug('[getOrInitialize] Promise chain completed');
 
-            // Scroll events do not cross the iframe boundary; observe them on the iframe
-            // document (capture phase) and hand them to the host-level viewport-sync hub
             if (iframe.id && iframe.contentDocument) {
-                this.viewportSync.register(iframe.id, element[PROP_EDITOR], iframe.contentDocument);
+                element[PROP_EDITOR].connectViewportSync?.(this.viewportSync, iframe.id);
             }
 
             // Restoring visibility
@@ -134,19 +132,7 @@ export class ExternalEditorFactory implements AnnotationEditorFactory {
         });
 
         if (element instanceof HTMLElement && element.id) {
-            // The scroll container is typically an *ancestor* of the editor element (e.g. the brat
-            // editor scrolls a `.scrolling` wrapper above its `vis` div), so we neither listen nor
-            // scope on the editor element itself. Scroll does not bubble, but a capture-phase
-            // listener on the owner document sees any descendant's scrolls (mirroring the iframe
-            // path, which observes the iframe's contentDocument). We scope by the container so its
-            // own scrolls are accepted; disjoint containers keep several editors' scrolls apart.
-            const scope = this.resolveScrollContainer(element);
-            this.viewportSync.register(
-                element.id,
-                element[PROP_EDITOR],
-                element.ownerDocument,
-                scope
-            );
+            element[PROP_EDITOR].connectViewportSync?.(this.viewportSync, element.id);
         }
 
         return element[PROP_EDITOR];
@@ -348,18 +334,6 @@ export class ExternalEditorFactory implements AnnotationEditorFactory {
                 resolve();
             }
         });
-    }
-
-    private resolveScrollContainer(element: HTMLElement): Element {
-        let node: HTMLElement | null = element;
-        while (node && node !== node.ownerDocument.body) {
-            const overflowY = node.ownerDocument.defaultView?.getComputedStyle(node).overflowY;
-            if (overflowY === 'auto' || overflowY === 'scroll' || overflowY === 'overlay') {
-                return node;
-            }
-            node = node.parentElement;
-        }
-        return element;
     }
 
     destroy(element: Node): void {

--- a/inception/inception-external-editor/src/main/ts/src/ExternalEditorFactory.ts
+++ b/inception/inception-external-editor/src/main/ts/src/ExternalEditorFactory.ts
@@ -21,11 +21,14 @@ import {
     type AnnotationEditorProperties,
     type DiamClientFactory,
 } from '@inception-project/inception-js-api';
+import { ViewportSyncHub } from './ViewportSyncHub';
 
 const PROP_EDITOR = '__editor__';
 const PROP_INITIALIZING = '__initializing__';
 
 export class ExternalEditorFactory implements AnnotationEditorFactory {
+    readonly viewportSync = new ViewportSyncHub();
+
     async getOrInitialize(
         element: Node,
         diam: DiamClientFactory,
@@ -111,6 +114,12 @@ export class ExternalEditorFactory implements AnnotationEditorFactory {
             delete element[PROP_INITIALIZING];
             console.debug('[getOrInitialize] Promise chain completed');
 
+            // Scroll events do not cross the iframe boundary; observe them on the iframe
+            // document (capture phase) and hand them to the host-level viewport-sync hub
+            if (iframe.id && iframe.contentDocument) {
+                this.viewportSync.register(iframe.id, element[PROP_EDITOR], iframe.contentDocument);
+            }
+
             // Restoring visibility
             if (!props.loadingIndicatorDisabled) {
                 loadingIndicator?.remove();
@@ -123,6 +132,22 @@ export class ExternalEditorFactory implements AnnotationEditorFactory {
         element[PROP_EDITOR] = await this.loadEditorResources(window, props).then((win) => {
             return this.initEditor(win, element as HTMLElement, diam, props);
         });
+
+        if (element instanceof HTMLElement && element.id) {
+            // The scroll container is typically an *ancestor* of the editor element (e.g. the brat
+            // editor scrolls a `.scrolling` wrapper above its `vis` div), so we neither listen nor
+            // scope on the editor element itself. Scroll does not bubble, but a capture-phase
+            // listener on the owner document sees any descendant's scrolls (mirroring the iframe
+            // path, which observes the iframe's contentDocument). We scope by the container so its
+            // own scrolls are accepted; disjoint containers keep several editors' scrolls apart.
+            const scope = this.resolveScrollContainer(element);
+            this.viewportSync.register(
+                element.id,
+                element[PROP_EDITOR],
+                element.ownerDocument,
+                scope
+            );
+        }
 
         return element[PROP_EDITOR];
     }
@@ -325,7 +350,23 @@ export class ExternalEditorFactory implements AnnotationEditorFactory {
         });
     }
 
+    private resolveScrollContainer(element: HTMLElement): Element {
+        let node: HTMLElement | null = element;
+        while (node && node !== node.ownerDocument.body) {
+            const overflowY = node.ownerDocument.defaultView?.getComputedStyle(node).overflowY;
+            if (overflowY === 'auto' || overflowY === 'scroll' || overflowY === 'overlay') {
+                return node;
+            }
+            node = node.parentElement;
+        }
+        return element;
+    }
+
     destroy(element: Node): void {
+        if (element instanceof HTMLElement && element.id) {
+            this.viewportSync.unregister(element.id);
+        }
+
         if (element[PROP_EDITOR] != null) {
             element[PROP_EDITOR].destroy();
             console.info('Destroyed editor');

--- a/inception/inception-external-editor/src/main/ts/src/ViewportSyncHub.ts
+++ b/inception/inception-external-editor/src/main/ts/src/ViewportSyncHub.ts
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { type AnnotationEditor } from '@inception-project/inception-js-api';
+
+/**
+ * Suppress scroll echoing of recieving peers for this many milliseconds after a scroll event is received to avoid
+ * events echoing back and forth between two editors.
+ */
+const SUPPRESS_ECHO_MS = 250;
+
+/**
+ * A registered editor participating in scroll synchronization.
+ */
+type PeerEditor = {
+    id: string;
+    editor: AnnotationEditor;
+    scrollTarget: EventTarget;
+    listener: (event: Event) => void;
+    scope?: Element;
+    rafHandle?: number;
+    suppressUntil: number;
+};
+
+/**
+ * Host-page hub that mirrors scroll positions between the annotation editors on a page.
+ *
+ * Editors are registered under the markup id of their host element as they initialize.
+ */
+export class ViewportSyncHub {
+    private peers = new Map<string, PeerEditor>();
+    private links = new Map<string, string>();
+
+    register(
+        aId: string,
+        aEditor: AnnotationEditor,
+        aScrollTarget: EventTarget,
+        aScope?: Element
+    ): void {
+        if (!aId) return;
+
+        this.unregister(aId);
+
+        const peer: PeerEditor = {
+            id: aId,
+            editor: aEditor,
+            scrollTarget: aScrollTarget,
+            scope: aScope,
+            listener: (event: Event) => this.onScroll(peer, event),
+            suppressUntil: 0,
+        };
+        aScrollTarget.addEventListener('scroll', peer.listener, {
+            capture: true,
+            passive: true,
+        });
+        this.peers.set(aId, peer);
+        console.debug(`[ViewportSyncHub] Registered editor [${aId}]`);
+    }
+
+    unregister(aId: string): void {
+        const peer = this.peers.get(aId);
+        if (!peer) return;
+
+        peer.scrollTarget.removeEventListener('scroll', peer.listener, { capture: true });
+        if (peer.rafHandle !== undefined) cancelAnimationFrame(peer.rafHandle);
+        this.peers.delete(aId);
+        console.debug(`[ViewportSyncHub] Unregistered editor [${aId}]`);
+    }
+
+    /** Make the two editors track each other's scrolling. Replaces any existing links of either. */
+    link(aId: string, aOtherId: string): void {
+        if (!aId || !aOtherId || aId === aOtherId) return;
+
+        this.unlink(aId);
+        this.unlink(aOtherId);
+        this.links.set(aId, aOtherId);
+        this.links.set(aOtherId, aId);
+        console.debug(`[ViewportSyncHub] Linked editors [${aId}] and [${aOtherId}]`);
+    }
+
+    unlink(aId: string): void {
+        const partner = this.links.get(aId);
+        if (partner === undefined) return;
+
+        this.links.delete(aId);
+        if (this.links.get(partner) === aId) {
+            this.links.delete(partner);
+        }
+        console.debug(`[ViewportSyncHub] Unlinked editor [${aId}]`);
+    }
+
+    private onScroll(aPeer: PeerEditor, aEvent: Event): void {
+        // Ignore scrolls of other editors sharing the same (captured) document - only scrolls of
+        // this peer's own scroll container (or a scroller nested inside it) count. The scope is
+        // that container, so the container's own scroll event has target === scope, which
+        // `contains` accepts (an element contains itself). scroll targets a Document when the whole
+        // page/iframe scrolls, in which case there is no scoping to do.
+        if (aPeer.scope) {
+            const target = aEvent.target;
+            if (target instanceof Node && !aPeer.scope.contains(target)) return;
+        } else {
+            // Scope-less (iframe) peers: the capture-phase listener on the iframe document also
+            // sees scrolls of scrollers nested inside it (a scrollable table, <pre>, resize box).
+            // Those don't move the editor's viewport, so mirroring them is at best wasted work and
+            // at worst a spurious position. Only the document's own scroll - target is the Document
+            // or its root scrolling element - counts as this editor's viewport scroll.
+            const target = aEvent.target;
+            const doc = aPeer.scrollTarget as Document;
+            const root = doc.scrollingElement ?? doc.documentElement;
+            if (target !== doc && target !== root) return;
+        }
+
+        // Coalesce the high-frequency scroll events into one emission per animation frame
+        if (aPeer.rafHandle !== undefined) return;
+
+        aPeer.rafHandle = requestAnimationFrame(() => {
+            aPeer.rafHandle = undefined;
+
+            if (performance.now() < aPeer.suppressUntil) return;
+
+            const partnerId = this.links.get(aPeer.id);
+            if (partnerId === undefined) return;
+
+            const partner = this.peers.get(partnerId);
+            if (!partner || !partner.editor.scrollToViewportPosition) return;
+
+            const pos = aPeer.editor.getViewportScrollPosition?.();
+            if (!pos) return;
+
+            partner.suppressUntil = performance.now() + SUPPRESS_ECHO_MS;
+            partner.editor.scrollToViewportPosition({
+                begin: pos.begin,
+                end: pos.end,
+                fraction: pos.fraction,
+                scrollProgress: pos.scrollProgress,
+            });
+        });
+    }
+}

--- a/inception/inception-external-editor/src/main/ts/src/ViewportSyncHub.ts
+++ b/inception/inception-external-editor/src/main/ts/src/ViewportSyncHub.ts
@@ -31,6 +31,10 @@ type PeerEditor = {
     editor: AnnotationEditor;
     scrollTarget: EventTarget;
     listener: (event: Event) => void;
+    /**
+     * The element whose scrolling moves this editor's viewport, or undefined if the editor scrolls
+     * its whole document.
+     */
     scope?: Element;
     rafHandle?: number;
     suppressUntil: number;
@@ -45,25 +49,25 @@ export class ViewportSyncHub {
     private peers = new Map<string, PeerEditor>();
     private links = new Map<string, string>();
 
-    register(
-        aId: string,
-        aEditor: AnnotationEditor,
-        aScrollTarget: EventTarget,
-        aScope?: Element
-    ): void {
+    /**
+     * Register an editor as a scroll-sync peer under the given (host-page markup) id. When {@code aScope}
+     * is omitted the editor's whole document is treated as the viewport.
+     */
+    register(aId: string, aEditor: AnnotationEditor, aScope?: Element): void {
         if (!aId) return;
 
         this.unregister(aId);
 
+        const scrollTarget: EventTarget = aScope?.ownerDocument ?? aScope ?? document;
         const peer: PeerEditor = {
             id: aId,
             editor: aEditor,
-            scrollTarget: aScrollTarget,
+            scrollTarget,
             scope: aScope,
             listener: (event: Event) => this.onScroll(peer, event),
             suppressUntil: 0,
         };
-        aScrollTarget.addEventListener('scroll', peer.listener, {
+        scrollTarget.addEventListener('scroll', peer.listener, {
             capture: true,
             passive: true,
         });
@@ -113,11 +117,14 @@ export class ViewportSyncHub {
             const target = aEvent.target;
             if (target instanceof Node && !aPeer.scope.contains(target)) return;
         } else {
-            // Scope-less (iframe) peers: the capture-phase listener on the iframe document also
-            // sees scrolls of scrollers nested inside it (a scrollable table, <pre>, resize box).
-            // Those don't move the editor's viewport, so mirroring them is at best wasted work and
-            // at worst a spurious position. Only the document's own scroll - target is the Document
-            // or its root scrolling element - counts as this editor's viewport scroll.
+            // Scope-less peers - the editor did not declare a scroll container, so its viewport is
+            // the document itself (e.g. an XML document scrolling as a whole inside its iframe). The
+            // capture-phase listener also sees scrolls of scrollers nested inside the document (a
+            // scrollable table, <pre>, resize box); those don't move the editor's viewport, so
+            // mirroring them is at best wasted work and at worst a spurious position. Only the
+            // document's own scroll - target is the Document or its root scrolling element - counts.
+            // Editors whose viewport is an inner wrapper (brat, Apache Annotator) declare that
+            // wrapper via getScrollContainer() and take the scoped branch above instead.
             const target = aEvent.target;
             const doc = aPeer.scrollTarget as Document;
             const root = doc.scrollingElement ?? doc.documentElement;

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorEditor.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorEditor.ts
@@ -20,6 +20,8 @@ import {
     type DiamAjax,
     type DocumentStructureStrategy,
     type Offsets,
+    type ViewportScrollPosition,
+    type ViewportScrollTarget,
     calculateStartOffset,
 } from '@inception-project/inception-js-api';
 import DocumentStructureNavigator from '@inception-project/inception-js-api/src/documentStructure/DocumentStructureNavigator.svelte';
@@ -475,6 +477,16 @@ export class ApacheAnnotatorEditor implements AnnotationEditor {
 
         this.vis?.scrollTo(args);
         this.keyboardMode?.moveCaretToOffset(args.offset);
+    }
+
+    getViewportScrollPosition(): ViewportScrollPosition | null {
+        if (!this.initializationComplete) return null;
+        return this.vis?.getViewportScrollPosition() ?? null;
+    }
+
+    scrollToViewportPosition(pos: ViewportScrollTarget): void {
+        if (!this.initializationComplete) return;
+        this.vis?.scrollToViewportPosition(pos);
     }
 
     destroy(): void {

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorEditor.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorEditor.ts
@@ -22,6 +22,7 @@ import {
     type Offsets,
     type ViewportScrollPosition,
     type ViewportScrollTarget,
+    type ViewportSyncPeer,
     calculateStartOffset,
 } from '@inception-project/inception-js-api';
 import DocumentStructureNavigator from '@inception-project/inception-js-api/src/documentStructure/DocumentStructureNavigator.svelte';
@@ -60,6 +61,8 @@ export class ApacheAnnotatorEditor implements AnnotationEditor {
     private navigatorContainer: HTMLElement;
     private deferredInitializationSteps: (() => void)[] = [];
     private initializationComplete = false;
+    private viewportSyncHub?: ViewportSyncPeer;
+    private viewportSyncId?: string;
     private protectedElements: Set<string>;
     private protectedElementsMatcher?: (el: Element) => boolean;
     private activeResizeCleanup: (() => void) | undefined = undefined;
@@ -205,7 +208,20 @@ export class ApacheAnnotatorEditor implements AnnotationEditor {
             })
             .then(() => {
                 this.initializationComplete = true;
+                this.registerViewportSync();
             });
+    }
+
+    /**
+     * Connect to the scroll-sync hub if a connection has been requested and the visualizer is ready.
+     * The visualizer's sync controller owns the actual registration (it knows the scroll container);
+     * the editor only gates on lifecycle - registration must wait until the viewport wrapper exists.
+     */
+    private registerViewportSync(): void {
+        if (!this.viewportSyncHub || !this.viewportSyncId || !this.initializationComplete) {
+            return;
+        }
+        this.vis?.connectToHub(this.viewportSyncHub, this.viewportSyncId, this);
     }
 
     /**
@@ -489,7 +505,23 @@ export class ApacheAnnotatorEditor implements AnnotationEditor {
         this.vis?.scrollToViewportPosition(pos);
     }
 
+    connectViewportSync(aHub: ViewportSyncPeer, aId: string): void {
+        this.viewportSyncHub = aHub;
+        this.viewportSyncId = aId;
+        // Connects now if the visualizer is ready; otherwise the init chain connects once the
+        // viewport wrapper exists (see registerViewportSync).
+        this.registerViewportSync();
+    }
+
+    disconnectViewportSync(): void {
+        this.vis?.disconnectFromHub();
+        this.viewportSyncHub = undefined;
+        this.viewportSyncId = undefined;
+    }
+
     destroy(): void {
+        this.disconnectViewportSync();
+
         // Clean up any active resize operation
         if (this.activeResizeCleanup) {
             this.activeResizeCleanup();

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorSyncController.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorSyncController.ts
@@ -1,0 +1,278 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+    type ViewportScrollPosition,
+    type ViewportScrollTarget,
+    offsetToRange,
+    calculateStartOffset,
+    calculateEndOffset,
+} from '@inception-project/inception-js-api';
+import { removeClassFromAncestors } from './Utilities';
+
+// CSS `display` values whose boxes are block-level; an element with one of these owns a
+// distinct block in the flow and so can anchor a text offset (a box whose height is a
+// meaningful denominator for the intra-anchor scroll fraction).
+const ANCHOR_DISPLAY_CATEGORIES = new Set([
+    'block',
+    'flex',
+    'grid',
+    'table',
+    'table-row',
+    'list-item',
+]);
+
+// Our own overlay elements: they sit above the content at the viewport top but carry no document
+// offsets, so scroll-sync anchoring must skip them and look at the content behind them instead.
+const OVERLAY_SELECTOR =
+    '.iaa-section-control, .iaa-vertical-marker-focus, .iaa-ping-marker,' +
+    ' iaa-visible-annotations-panel, iaa-visible-annotations-panel-spacer';
+
+/**
+ * Editor-to-editor viewport synchronization for the Apache Annotator visualizer. Implements the
+ * {@code AnnotationEditor} viewport-sync protocol: {@link getViewportScrollPosition} reports the
+ * document offset currently at the viewport top (plus how far the top has scrolled into it), and
+ * {@link scrollToViewportPosition} places a given offset+fraction back at the viewport top.
+ * Interpolating in character space rather than pixels keeps two editors in sync even when they wrap
+ * the same text to different heights.
+ *
+ * The controller is deliberately decoupled from the visualizer: it depends only on the editor root
+ * element and a lazily-read scroll container (the container is assigned after the visualizer is
+ * constructed, so it is passed as a getter). It touches DOM/geometry only — no tracker, rendering,
+ * or paging state — which keeps this measurement-heavy anchor-finding logic isolated and testable.
+ */
+export class ApacheAnnotatorSyncController {
+    private readonly root: Element;
+    private readonly getScrollContainer: () => Element | undefined;
+
+    /** Last viewport position applied by {@link scrollToViewportPosition}, for per-frame dedup. */
+    private lastAppliedViewportScrollPosition: { begin: number; fraction: number } | undefined =
+        undefined;
+
+    constructor(root: Element, getScrollContainer: () => Element | undefined) {
+        this.root = root;
+        this.getScrollContainer = getScrollContainer;
+    }
+
+    /**
+     * @return the scroll position of the block element currently at the top of the scroll viewport as document offsets
+     * plus the fraction of it that has already been scrolled past.
+     * @see {@link scrollToViewportPosition}.
+     */
+    getViewportScrollPosition(): ViewportScrollPosition | null {
+        const container = this.getScrollContainer();
+        if (!container) return null;
+
+        const containerRect = container.getBoundingClientRect();
+        const anchor = this.findViewportTopAnchor(containerRect);
+        if (!anchor) return null;
+
+        const anchorRect = anchor.getBoundingClientRect();
+        const begin = calculateStartOffset(this.root, anchor);
+        const end = calculateEndOffset(this.root, anchor);
+        const fraction =
+            anchorRect.height > 0
+                ? Math.min(1, Math.max(0, (containerRect.top - anchorRect.top) / anchorRect.height))
+                : 0;
+        return { begin, end, fraction };
+    }
+
+    scrollToViewportPosition(pos: ViewportScrollTarget): void {
+        const container = this.getScrollContainer();
+        if (!container) return;
+
+        const range = offsetToRange(this.root, pos.begin, pos.begin);
+        if (!range) return;
+
+        const start = range.startContainer;
+        const startElement = start instanceof Element ? start : start.parentElement;
+        const block = this.closestAnchorElement(startElement);
+        if (!block) return;
+
+        // Skip if the scroll request would not actually move the scroll position
+        const fraction = Math.min(1, Math.max(0, pos.fraction));
+        const last = this.lastAppliedViewportScrollPosition;
+        if (last && last.begin === pos.begin && Math.abs(last.fraction - fraction) < 0.01) {
+            return;
+        }
+        this.lastAppliedViewportScrollPosition = { begin: pos.begin, fraction };
+
+        // If necessary unhide the target block before measuring. We unhide only if hidden because a write (even a noop one) to the DOM can invalidate the layout
+        if (block.closest('.iaa-secluded')) {
+            removeClassFromAncestors(block, 'iaa-secluded', this.root);
+        }
+
+        const containerRect = container.getBoundingClientRect();
+        const blockRect = block.getBoundingClientRect();
+        container.scrollTop =
+            container.scrollTop + (blockRect.top - containerRect.top) + fraction * blockRect.height;
+    }
+
+    /**
+     * Reset the per-frame dedup memory. Call when a (programmatic) scroll completes so the next sync
+     * position is applied even if it coincides with the last one applied during the scroll.
+     */
+    reset(): void {
+        this.lastAppliedViewportScrollPosition = undefined;
+    }
+
+    /**
+     * Try locating the block-level element that straddles the top of the scroll viewport.
+     */
+    private findViewportTopAnchor(containerRect: DOMRect): Element | null {
+        const doc = this.root.ownerDocument;
+        const rootRect = this.root.getBoundingClientRect();
+        const left = Math.max(containerRect.left, rootRect.left);
+        const right = Math.min(containerRect.right, rootRect.right);
+        if (right <= left) return null;
+
+        const seamY = containerRect.top;
+        const width = right - left;
+        // x offsets guard against a probe column falling in a gutter/float; y offsets step past the
+        // seam's top-margin gap (see method doc). Neither needs to land on the target block - any
+        // in-root node lets blockAtSeam() resolve the anchor by structure.
+        const entryX = [left + width * 0.5, left + width * 0.25, left + width * 0.75];
+        const entryY = [seamY + 8, seamY + 24, seamY + 48, seamY + 96];
+
+        for (const y of entryY) {
+            for (const x of entryX) {
+                for (const el of doc.elementsFromPoint(x, y)) {
+                    if (el === this.root || !this.root.contains(el)) continue;
+                    // Skip our own overlays - they sit above the content but carry no offsets
+                    if (el.closest('svg')) continue;
+                    if (el.closest(OVERLAY_SELECTOR)) continue;
+
+                    const anchor = this.blockAtSeam(el, seamY);
+                    if (anchor) return anchor;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * From an entry node near the viewport top, return the block-level element with text that
+     * straddles {@code seamY} (its box spans the seam line), searching in document order. If the
+     * entry node's own block sits entirely above the seam (its content has scrolled past), we
+     * advance to the following blocks; if it sits entirely below, we accept it as the first block
+     * at or after the seam. Straddling is preferred because {@link getViewportScrollPosition}
+     * measures how far the viewport top has scrolled <em>into</em> the anchor, which is only
+     * meaningful for a block the seam actually crosses.
+     * <p>
+     * When straddling blocks nest (e.g. a section and a paragraph inside it both cross the seam) we
+     * return the <em>innermost</em> one: the deepest block gives the finest-grained height for the
+     * scroll fraction, matching the granularity the previous ancestor-only anchor produced.
+     */
+    private blockAtSeam(entry: Element, seamY: number): Element | null {
+        let start = this.closestBlockWithText(entry);
+        if (!start) return null;
+
+        const straddles = (el: Element) => {
+            const rect = el.getBoundingClientRect();
+            return rect.top <= seamY && rect.bottom > seamY;
+        };
+
+        // The entry probe can land on a block just below the seam (e.g. the table row under the one
+        // that crosses it). The straddling block is then earlier in document order, which the
+        // forward walk below never revisits - so back up while the start block sits entirely below
+        // the seam and the previous block reaches up to or across it.
+        while (start.getBoundingClientRect().top > seamY) {
+            const prev = this.prevBlockWithText(start);
+            if (!prev || prev.getBoundingClientRect().top > seamY) break;
+            start = prev;
+        }
+
+        let firstBelow: Element | null = null;
+        let innermostStraddler: Element | null = null;
+        let current: Element | null = start;
+        while (current && current !== this.root) {
+            if (straddles(current)) {
+                // Descend into nested straddlers, but stop once the walk leaves this subtree - a
+                // later straddling sibling is a different, lower block, not a finer anchor.
+                if (!innermostStraddler || innermostStraddler.contains(current)) {
+                    innermostStraddler = current;
+                } else {
+                    break;
+                }
+            } else if (innermostStraddler) {
+                break; // left the straddling run; keep the innermost we found
+            } else if (!firstBelow) {
+                const rect = current.getBoundingClientRect();
+                if (rect.top > seamY) {
+                    firstBelow = current; // first fully-below block, a fallback if nothing straddles
+                }
+            }
+            current = this.nextBlockWithText(current);
+        }
+
+        return innermostStraddler ?? firstBelow ?? start;
+    }
+
+    private closestBlockWithText(element: Element | null): Element | null {
+        let current = element;
+        while (current && current !== this.root) {
+            if (this.isBlockWithText(current)) return current;
+            current = current.parentElement;
+        }
+        return null;
+    }
+
+    private nextBlockWithText(element: Element): Element | null {
+        const walker = this.blockWalker();
+        walker.currentNode = element;
+        return walker.nextNode() as Element | null;
+    }
+
+    private prevBlockWithText(element: Element): Element | null {
+        const walker = this.blockWalker();
+        walker.currentNode = element;
+        return walker.previousNode() as Element | null;
+    }
+
+    private blockWalker(): TreeWalker {
+        return this.root.ownerDocument.createTreeWalker(this.root, NodeFilter.SHOW_ELEMENT, {
+            acceptNode: (node) =>
+                this.isBlockWithText(node as Element)
+                    ? NodeFilter.FILTER_ACCEPT
+                    : NodeFilter.FILTER_SKIP,
+        });
+    }
+
+    private isBlockWithText(element: Element): boolean {
+        // The editor root/scroll container itself is never a content anchor: it spans the whole
+        // viewport, so accepting it would yield a meaningless full-height fraction denominator. It
+        // can otherwise slip through here as block-with-text, e.g. when the document's first block
+        // is at the seam and the back-up walk steps past it to the container.
+        if (element === this.root) return false;
+        if (!element.textContent) return false;
+        if (element.closest('svg')) return false;
+        if (element.closest(OVERLAY_SELECTOR)) return false;
+        return ANCHOR_DISPLAY_CATEGORIES.has(window.getComputedStyle(element).display);
+    }
+
+    private closestAnchorElement(element: Element | null): Element | null {
+        let current = element;
+        while (current && current !== this.root) {
+            if (ANCHOR_DISPLAY_CATEGORIES.has(window.getComputedStyle(current).display)) {
+                return current;
+            }
+            current = current.parentElement;
+        }
+        return current;
+    }
+}

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorSyncController.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorSyncController.ts
@@ -16,8 +16,10 @@
  * limitations under the License.
  */
 import {
+    type AnnotationEditor,
     type ViewportScrollPosition,
     type ViewportScrollTarget,
+    type ViewportSyncPeer,
     offsetToRange,
     calculateStartOffset,
     calculateEndOffset,
@@ -63,9 +65,35 @@ export class ApacheAnnotatorSyncController {
     private lastAppliedViewportScrollPosition: { begin: number; fraction: number } | undefined =
         undefined;
 
+    /** The hub this controller has registered its editor with, and the id it used. */
+    private hub?: ViewportSyncPeer;
+    private hubPeerId?: string;
+
     constructor(root: Element, getScrollContainer: () => Element | undefined) {
         this.root = root;
         this.getScrollContainer = getScrollContainer;
+    }
+
+    /**
+     * Register {@code aEditor} with the scroll-sync {@code aHub} under {@code aId}, scoped to the
+     * editor's current scroll container. This controller owns viewport-sync for the editor, so it is
+     * the natural place to hand the container to the hub - the container getter it already holds is
+     * exactly the scope the hub needs. The caller (the editor) is responsible for calling this only
+     * once its viewport exists. Re-registers if called again (e.g. after the container is rebuilt).
+     */
+    connectToHub(aHub: ViewportSyncPeer, aId: string, aEditor: AnnotationEditor): void {
+        this.hub = aHub;
+        this.hubPeerId = aId;
+        aHub.register(aId, aEditor, this.getScrollContainer() ?? undefined);
+    }
+
+    /** Remove the editor from the hub it was registered with via {@link connectToHub}. */
+    disconnectFromHub(): void {
+        if (this.hub && this.hubPeerId) {
+            this.hub.unregister(this.hubPeerId);
+        }
+        this.hub = undefined;
+        this.hubPeerId = undefined;
     }
 
     /**

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorVisualizer.svelte.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorVisualizer.svelte.ts
@@ -22,6 +22,8 @@ import {
     type DiamAjax,
     type DiamLoadAnnotationsOptions,
     type VID,
+    type ViewportScrollPosition,
+    type ViewportScrollTarget,
     offsetToRange,
     AnnotatedText,
     Span,
@@ -39,6 +41,7 @@ import { SectionAnnotationCreator } from './SectionAnnotationCreator';
 import { RelationVisualizer } from './RelationVisualizer';
 import { RelationGripLayer, GRIP_CLASS } from './RelationGripLayer';
 import { RelationDragController, type PickRelationTarget } from './RelationDragController';
+import { ApacheAnnotatorSyncController } from './ApacheAnnotatorSyncController';
 import {
     groupHighlightsByVid,
     removeClassFromAncestors,
@@ -81,6 +84,7 @@ export class ApacheAnnotatorVisualizer {
     private relationVisualizer: RelationVisualizer;
     private relationGripLayer: RelationGripLayer;
     private relationDragController: RelationDragController;
+    private syncController: ApacheAnnotatorSyncController;
 
     private data?: AnnotatedText;
 
@@ -205,6 +209,13 @@ export class ApacheAnnotatorVisualizer {
         // Re-band relations on manual scroll, independent of the ViewportTracker (see onContentScroll).
         this.scrollContainer = this.root.closest('.i7n-wrapper') || this.root;
         this.scrollContainer.addEventListener('scroll', this.onContentScroll, { passive: true });
+
+        // Editor-to-editor viewport synchronization. The scroll container is read lazily so the
+        // controller always sees the current one.
+        this.syncController = new ApacheAnnotatorSyncController(
+            this.root,
+            () => this.scrollContainer
+        );
     }
 
     /**
@@ -1071,6 +1082,14 @@ export class ApacheAnnotatorVisualizer {
         }
     }
 
+    getViewportScrollPosition(): ViewportScrollPosition | null {
+        return this.syncController.getViewportScrollPosition();
+    }
+
+    scrollToViewportPosition(pos: ViewportScrollTarget): void {
+        this.syncController.scrollToViewportPosition(pos);
+    }
+
     private schedule(timeout: number, callback: () => void): number {
         if (typeof window.requestIdleCallback == 'undefined') {
             return window.setTimeout(callback, timeout);
@@ -1100,6 +1119,7 @@ export class ApacheAnnotatorVisualizer {
         this.relationVisualizer.resume();
         this.lastScrollTop = undefined;
         this.lastMarkerTop = undefined;
+        this.syncController.reset();
     }
 
     private clearHighlights(): void {

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorVisualizer.svelte.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorVisualizer.svelte.ts
@@ -19,11 +19,13 @@ import './ApacheAnnotatorEditor.scss';
 import {
     ViewportTracker,
     unpackCompactAnnotatedTextV2,
+    type AnnotationEditor,
     type DiamAjax,
     type DiamLoadAnnotationsOptions,
     type VID,
     type ViewportScrollPosition,
     type ViewportScrollTarget,
+    type ViewportSyncPeer,
     offsetToRange,
     AnnotatedText,
     Span,
@@ -1088,6 +1090,14 @@ export class ApacheAnnotatorVisualizer {
 
     scrollToViewportPosition(pos: ViewportScrollTarget): void {
         this.syncController.scrollToViewportPosition(pos);
+    }
+
+    connectToHub(aHub: ViewportSyncPeer, aId: string, aEditor: AnnotationEditor): void {
+        this.syncController.connectToHub(aHub, aId, aEditor);
+    }
+
+    disconnectFromHub(): void {
+        this.syncController.disconnectFromHub();
     }
 
     private schedule(timeout: number, callback: () => void): number {

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/Utilities.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/Utilities.ts
@@ -486,8 +486,7 @@ export function compileNsSelector(selector?: string | null): ((el: Element) => b
 
     if (selector === '') return null;
     type Token =
-        | { type: 'css'; sel: string }
-        | { type: 'ns'; namespace: string | '*'; localName: string };
+        { type: 'css'; sel: string } | { type: 'ns'; namespace: string | '*'; localName: string };
 
     const parts: string[] = [];
     let buf = '';

--- a/inception/inception-js-api/src/main/ts/src/editor/AnnotationEditor.ts
+++ b/inception/inception-js-api/src/main/ts/src/editor/AnnotationEditor.ts
@@ -60,6 +60,25 @@ export type ViewportScrollTarget = {
     scrollProgress?: number;
 };
 
+/**
+ * The peer-facing view of the host-page scroll-sync hub: the subset an editor uses to add and
+ * remove itself as a sync peer. Kept minimal (and defined here rather than importing the concrete
+ * hub) so an editor can register without depending on the external-editor module that owns the hub.
+ */
+export interface ViewportSyncPeer {
+    /**
+     * Register {@code aEditor} as a scroll-sync peer under {@code aId}. The editor passes the element
+     * whose scrolling moves its viewport as {@code aScope} - the hub listens on that element's owner
+     * document and uses it to tell the editor's own scroll apart from unrelated scrolls of nested
+     * scrollers sharing the same document. Omit {@code aScope} when the editor scrolls its whole
+     * document.
+     */
+    register(aId: string, aEditor: AnnotationEditor, aScope?: Element): void;
+
+    /** Remove the peer previously registered under {@code aId}, detaching its scroll listener. */
+    unregister(aId: string): void;
+}
+
 export interface AnnotationEditor {
     loadAnnotations(): void;
 
@@ -86,6 +105,20 @@ export interface AnnotationEditor {
      * to a pixel position with its own layout. {@code end} defaults to {@code begin} if omitted.
      */
     scrollToViewportPosition?(pos: ViewportScrollTarget): void;
+
+    /**
+     * Add this editor to the scroll-sync {@code aHub} under {@code aId} (a host-page markup id chosen
+     * by the backend, which drives linking). The editor registers itself - rather than the hub or
+     * the factory reaching in - because it owns its layout and so knows which of the elements it owns
+     * actually scrolls; it passes that element to {@link ViewportSyncPeer.register} as the scope.
+     * The editor should call this once its viewport is built (so the scroll container exists), and
+     * re-run it if the container is rebuilt. Implementations remember {@code aHub}/{@code aId} so
+     * {@link disconnectViewportSync} can undo it.
+     */
+    connectViewportSync?(aHub: ViewportSyncPeer, aId: string): void;
+
+    /** Remove this editor from the hub it was connected to via {@link connectViewportSync}. */
+    disconnectViewportSync?(): void;
 
     destroy(): void;
 }

--- a/inception/inception-js-api/src/main/ts/src/editor/AnnotationEditor.ts
+++ b/inception/inception-js-api/src/main/ts/src/editor/AnnotationEditor.ts
@@ -17,6 +17,49 @@
  */
 import type { Offsets } from '../model/Offsets';
 
+/**
+ * Vertical scroll position: where the top edge of an editor's viewport currently falls in the
+ * document, expressed layout-independently along the one-dimensional character-offset axis (there
+ * is no x/y here - only vertical scroll). The position is an anchor element the viewport top cuts
+ * through, given as the character-offset interval {@code begin..end}, plus {@code fraction}: how
+ * far the viewport top has progressed through that interval. Together they denote a fractional
+ * character offset {@code begin + fraction*(end-begin)}.
+ */
+export type ViewportScrollPosition = {
+    /** Document character offset at which the topmost visible anchor element begins. */
+    begin: number;
+    /** End offset of the anchor element, so a receiver can size the anchor. */
+    end: number;
+    /** Progress (0..1) of the viewport top through the anchor element. */
+    fraction: number;
+    /**
+     * The source's overall scroll progress: scrollTop / maxScroll, in [0,1] (0 = at the very top,
+     * 1 = at the very bottom).
+     */
+    scrollProgress?: number;
+};
+
+/**
+ * Input accepted by {@link AnnotationEditor.scrollToViewportPosition}. A relaxation of
+ * {@link ViewportScrollPosition} in which {@code end} is optional: the receiver only needs
+ * {@code begin} + {@code fraction} to align its viewport and defaults {@code end} to {@code begin}
+ * when absent. A {@link ViewportScrollPosition} is assignable here, so producers can forward one
+ * directly.
+ */
+export type ViewportScrollTarget = {
+    /** Document character offset at which the anchor element begins. */
+    begin: number;
+    /** End offset of the anchor element. Defaults to {@code begin} when omitted. */
+    end?: number;
+    /** Progress (0..1) of the viewport top through the anchor element. */
+    fraction: number;
+    /**
+     * The source's overall scroll progress: scrollTop / maxScroll, in [0,1] (0 = at the very top,
+     * 1 = at the very bottom).
+     */
+    scrollProgress?: number;
+};
+
 export interface AnnotationEditor {
     loadAnnotations(): void;
 
@@ -26,6 +69,23 @@ export interface AnnotationEditor {
      * its viewport, the offset should be adjusted accordingly.
      */
     scrollTo(args: { offset: number; position?: string; pingRanges?: Offsets[] }): void;
+
+    /**
+     * Report the vertical scroll position currently at the top of the viewport. May return null when the
+     * position cannot be determined (e.g. before initialization has completed).
+     */
+    getViewportScrollPosition?(): ViewportScrollPosition | null;
+
+    /**
+     * Place the viewport top at the given anchor offset plus intra-anchor fraction. The
+     * editor resolves the offset in its own layout and clamps to its own scroll bounds.
+     * <p>
+     * The anchor + fraction denote a fractional character offset (begin + fraction*(end-begin)) at
+     * the viewport top. Interpolating in character space rather than pixels keeps the sync stable
+     * when the two editors wrap the same text to different heights - each side converts that offset
+     * to a pixel position with its own layout. {@code end} defaults to {@code begin} if omitted.
+     */
+    scrollToViewportPosition?(pos: ViewportScrollTarget): void;
 
     destroy(): void;
 }

--- a/inception/inception-js-api/src/main/ts/src/editor/index.ts
+++ b/inception/inception-js-api/src/main/ts/src/editor/index.ts
@@ -17,6 +17,7 @@
  */
 export {
     AnnotationEditor,
+    type ViewportSyncPeer,
     type ViewportScrollPosition,
     type ViewportScrollTarget,
 } from './AnnotationEditor';

--- a/inception/inception-pdf-editor2/src/main/ts/src/PdfAnnotationEditor.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/PdfAnnotationEditor.ts
@@ -16,12 +16,20 @@
  * limitations under the License.
  */
 import AbstractAnnotation from './pdfanno/core/src/model/AbstractAnnotation';
-import type { AnnotationEditor, DiamAjax, Offsets } from '@inception-project/inception-js-api';
+import type {
+    AnnotationEditor,
+    DiamAjax,
+    Offsets,
+    ViewportScrollPosition,
+    ViewportScrollTarget,
+} from '@inception-project/inception-js-api';
 import './PdfAnnotationEditor.scss';
 import {
     initPdfAnno,
     getAnnotations as doLoadAnnotations,
     scrollTo,
+    getViewportScrollPosition,
+    scrollToViewportPosition,
     destroy as destroyPdfAnno,
 } from './pdfanno/pdfanno';
 
@@ -64,6 +72,14 @@ export class PdfAnnotationEditor implements AnnotationEditor {
     scrollTo(args: { offset: number; position?: string; pingRanges?: Offsets[] }): void {
         // console.log(`SCROLLING! ${args.offset} ${args.position}`)
         scrollTo(args);
+    }
+
+    getViewportScrollPosition(): ViewportScrollPosition | null {
+        return getViewportScrollPosition();
+    }
+
+    scrollToViewportPosition(pos: ViewportScrollTarget): void {
+        scrollToViewportPosition(pos);
     }
 
     private cancelRightClick(e: Event): void {

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/page/textLayer.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/page/textLayer.ts
@@ -64,6 +64,28 @@ export function findPageForTextOffset(offset: number): VPage | undefined {
 }
 
 /**
+ * Like {@link findPageForTextOffset}, but clamps to the first/last page when the offset falls
+ * outside the document instead of returning {@code undefined}. An offset at or past the last page's
+ * end (offset >= lastPage.range[1]) or before the first page's start resolves to the nearest page,
+ * so callers that only need to locate a page for scrolling stay well-defined at the boundaries.
+ */
+export function findPageForTextOffsetClamped(offset: number): VPage | undefined {
+    if (!pages || pages.length === 0) {
+        console.error(`No pages available. Cannot find page for offset [${offset}]`);
+        return undefined;
+    }
+
+    const page = pages.find((p) => p.range[0] <= offset && offset < p.range[1]);
+    if (page) {
+        return page;
+    }
+
+    const firstPage = pages[0];
+    const lastPage = pages[pages.length - 1];
+    return offset < firstPage.range[0] ? firstPage : lastPage;
+}
+
+/**
  * Find the glyph at the given position in the PDF document. This operation uses the glyph
  * position data that is provided by the server.
  *

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/pdfanno.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/pdfanno.ts
@@ -12,6 +12,8 @@ import {
     unpackCompactAnnotatedTextV2,
     type DiamAjax,
     type Offsets,
+    type ViewportScrollPosition,
+    type ViewportScrollTarget,
     AnnotatedText,
     Span,
     Relation,
@@ -341,6 +343,105 @@ export function scrollTo(args: {
     markerLayer.appendChild(ping);
     ping.firstElementChild?.scrollIntoView({ behavior: 'auto', block: 'center', inline: 'center' });
     setTimeout(() => ping.remove(), 2000); // Need to defer so scrolling can complete
+}
+
+/**
+ * @return the scrollable viewport container of the PDF.js viewer.
+ */
+function getScrollContainer(): HTMLElement | null {
+    return document.getElementById('viewer')?.parentElement ?? null;
+}
+
+/** @return the `.page` element for a 1-based page number, or null if it is not in the DOM. */
+function getPageElement(pageNumber: number): HTMLElement | null {
+    return document.querySelector<HTMLElement>(`.page[data-page-number="${pageNumber}"]`);
+}
+
+/**
+ * @return the scroll distance a page occupies, i.e. the gap between this page's top and the next page's top, for the
+ * last page the page's own box height.
+ */
+function getPageScrollDistance(pageNumber: number, aRect: DOMRect): number {
+    const next = getPageElement(pageNumber + 1);
+    if (next) {
+        const distance = next.getBoundingClientRect().top - aRect.top;
+        // Guard against a degenerate/zero reading (e.g. next page not yet laid out).
+        if (distance > 0) return distance;
+    }
+    return aRect.height;
+}
+
+/**
+ * @return the position of the the PDF page straddling the viewport top, and the fraction is the viewport
+ * top's progress through that page's height.
+ */
+export function getViewportScrollPosition(): ViewportScrollPosition | null {
+    const container = getScrollContainer();
+    if (!container) return null;
+
+    const containerTop = container.getBoundingClientRect().top;
+
+    // The anchor page is the first `.page` whose bottom is below the viewport top - i.e. the page
+    // the viewport top currently sits within. Pages render top-to-bottom in document order.
+    const pageElements = Array.from(
+        document.querySelectorAll<HTMLElement>('.page[data-page-number]')
+    );
+    let anchorElement: HTMLElement | undefined;
+    for (const pageElement of pageElements) {
+        if (pageElement.getBoundingClientRect().bottom > containerTop) {
+            anchorElement = pageElement;
+            break;
+        }
+    }
+    if (!anchorElement) return null;
+
+    const page = textLayer.getPage(Number(anchorElement.dataset.pageNumber));
+    if (!page) return null;
+
+    const rect = anchorElement.getBoundingClientRect();
+    const distance = getPageScrollDistance(page.index, rect);
+    const fraction =
+        distance > 0 ? Math.min(1, Math.max(0, (containerTop - rect.top) / distance)) : 0;
+
+    // Overall scroll progress lets the receiver blend toward its own extreme near the top/bottom
+    // (see ViewportScrollPosition.scrollProgress), so scrolling just off an extreme no longer snaps.
+    const maxScroll = container.scrollHeight - container.clientHeight;
+    const scrollProgress = maxScroll > 0 ? container.scrollTop / maxScroll : 0;
+
+    return { begin: page.range[0], end: page.range[1], fraction, scrollProgress };
+}
+
+export function scrollToViewportPosition(pos: ViewportScrollTarget): void {
+    const container = getScrollContainer();
+    if (!container) return;
+
+    const page = textLayer.findPageForTextOffsetClamped(pos.begin);
+    if (!page) return;
+
+    const pageElement = getPageElement(page.index);
+    if (!pageElement) return;
+
+    const containerTop = container.getBoundingClientRect().top;
+    const rect = pageElement.getBoundingClientRect();
+    const fraction = Math.min(1, Math.max(0, pos.fraction));
+    const distance = getPageScrollDistance(page.index, rect);
+
+    // Interpolate position within the page's scroll distance
+    const anchoredTop = container.scrollTop + (rect.top - containerTop) + fraction * distance;
+
+    const maxScroll = container.scrollHeight - container.clientHeight;
+
+    // Ensure smooth scrolling near the start and end of the document
+    let target = anchoredTop;
+    if (pos.scrollProgress !== undefined && maxScroll > 0) {
+        const progressTop = pos.scrollProgress * maxScroll;
+        const BAND = 0.15; // fraction of the scroll range over which to blend at each end
+        const p = pos.scrollProgress;
+        const nearness = Math.max(0, 1 - Math.min(p, 1 - p) / BAND); // 1 at extreme → 0 by BAND
+        target = nearness * progressTop + (1 - nearness) * anchoredTop;
+    }
+
+    container.scrollTop = target;
 }
 
 export function getAnnotations() {

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPageBase2.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPageBase2.java
@@ -528,6 +528,16 @@ public abstract class AnnotationPageBase2
                         .add(visibleWhen(() -> getModelObject().getDocument() != null)));
     }
 
+    /**
+     * @return the main annotation editor component, or {@code null} if none has been created yet.
+     *         Allows page components hosting a second editor (e.g. the reference-document sidebar)
+     *         to coordinate with the main editor, e.g. for viewport synchronization.
+     */
+    public AnnotationEditorBase getAnnotationEditor()
+    {
+        return annotationEditor;
+    }
+
     private SidebarPanel createLeftSidebar(String aId)
     {
         return new SidebarPanel(aId, detailEditor, () -> getEditorCas(), AnnotationPageBase2.this);

--- a/inception/inception-ui-refdoc/pom.xml
+++ b/inception/inception-ui-refdoc/pom.xml
@@ -1,0 +1,147 @@
+<!--
+  Licensed to the Technische Universität Darmstadt under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The Technische Universität Darmstadt
+  licenses this file to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+    <artifactId>inception-app</artifactId>
+    <version>42.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>inception-ui-refdoc</artifactId>
+  <name>INCEpTION - UI - Reference Document Sidebar</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-ui-annotation</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-api-annotation</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-api-editor</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-api-diam</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-api-render</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-schema-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-documents-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-annotation-storage-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-model</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-preferences</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-security</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>de.tudarmstadt.ukp.inception.app</groupId>
+      <artifactId>inception-support</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.uima</groupId>
+      <artifactId>uimaj-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.persistence</groupId>
+      <artifactId>jakarta.persistence-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.wicket</groupId>
+      <artifactId>wicket-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.wicket</groupId>
+      <artifactId>wicket-spring</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.wicketstuff</groupId>
+      <artifactId>wicketstuff-annotationeventdispatcher</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.agilecoders.wicket</groupId>
+      <artifactId>wicket-bootstrap-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>de.agilecoders.wicket</groupId>
+      <artifactId>wicket-bootstrap-extensions</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.danekja</groupId>
+      <artifactId>jdk-serializable-functional</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/inception/inception-ui-refdoc/src/main/java/de/tudarmstadt/ukp/inception/ui/refdoc/ReferenceDocumentSidebar.html
+++ b/inception/inception-ui-refdoc/src/main/java/de/tudarmstadt/ukp/inception/ui/refdoc/ReferenceDocumentSidebar.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<!--
+  Licensed to the Technische Universität Darmstadt under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The Technische Universität Darmstadt
+  licenses this file to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<html xmlns:wicket="http://wicket.apache.org">
+<wicket:panel>
+  <div class="flex-content flex-v-container flex-gutter flex-only-internal-gutter">
+    <div class="flex-content flex-v-container card overflow-hidden">
+      <div class="card-header d-flex justify-content-between border-bottom-0">
+        <div wicket:id="documentNamePanel"></div>
+        <div class="d-flex">
+          <div wicket:id="numberOfPages" class="small text-muted align-self-center"></div>
+          <button wicket:id="toggleActionBar" class="btn btn-sm btn-outline-secondary border-0">
+            <i wicket:id="toggleActionBarIcon"/>
+          </button>
+        </div>
+      </div>
+      <div class="card-body flex-v-container" style="padding: 0px;">
+        <nav wicket:id="actionBar" class="action-bar">
+          <div class="action-bar-group">
+            <div class="btn-group">
+              <button wicket:id="showOpenDocumentDialog" class="btn btn-action-bar" type="button"
+                      title="Open document">
+                <i class="far fa-folder-open"></i>
+              </button>
+            </div>
+            <div wicket:id="documentNavigation" class="btn-group">
+              <button wicket:id="showPreviousDocument" class="btn btn-action-bar" type="button"
+                      title="Previous document">
+                <i class="far fa-caret-square-left"></i>
+              </button>
+              <button wicket:id="showNextDocument" class="btn btn-action-bar" type="button"
+                      title="Next document">
+                <i class="far fa-caret-square-right"></i>
+              </button>
+            </div>
+            <div class="btn-group">
+              <button wicket:id="toggleScrollSync" class="btn btn-action-bar" type="button"
+                      title="Synchronize scrolling with the main editor (takes effect while showing the same document)">
+                <i wicket:id="toggleScrollSyncIcon"/>
+              </button>
+            </div>
+          </div>
+          <div wicket:id="pagingNavigator"></div>
+        </nav>
+        <div wicket:id="editorContainer" class="flex-content flex-v-container" style="padding: 0px;">
+          <div wicket:id="editor" class="flex-content flex-v-container" style="padding: 0px;"></div>
+        </div>
+      </div>
+      <div wicket:id="openDialog"></div>
+    </div>
+  </div>
+</wicket:panel>
+</html>

--- a/inception/inception-ui-refdoc/src/main/java/de/tudarmstadt/ukp/inception/ui/refdoc/ReferenceDocumentSidebar.java
+++ b/inception/inception-ui-refdoc/src/main/java/de/tudarmstadt/ukp/inception/ui/refdoc/ReferenceDocumentSidebar.java
@@ -1,0 +1,595 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.refdoc;
+
+import static de.agilecoders.wicket.extensions.markup.html.bootstrap.icon.FontAwesome7IconType.chevron_down_s;
+import static de.agilecoders.wicket.extensions.markup.html.bootstrap.icon.FontAwesome7IconType.chevron_up_s;
+import static de.agilecoders.wicket.extensions.markup.html.bootstrap.icon.FontAwesome7IconType.link_s;
+import static de.agilecoders.wicket.extensions.markup.html.bootstrap.icon.FontAwesome7IconType.link_slash_s;
+import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationNavigationUserPrefs.KEY_ANNOTATION_NAVIGATION_USER_PREFS;
+import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode.SHARED_READ_ONLY_ACCESS;
+import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasUpgradeMode.AUTO_CAS_UPGRADE;
+import static de.tudarmstadt.ukp.inception.support.lambda.LambdaBehavior.visibleWhen;
+import static de.tudarmstadt.ukp.inception.ui.refdoc.ReferenceDocumentSidebarState.KEY_REFERENCE_DOCUMENT_SIDEBAR_STATE;
+import static java.lang.String.format;
+import static java.util.stream.Collectors.toList;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.apache.uima.cas.CAS;
+import org.apache.wicket.AttributeModifier;
+import org.apache.wicket.Component;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.wicket.feedback.IFeedback;
+import org.apache.wicket.markup.head.IHeaderResponse;
+import org.apache.wicket.markup.head.OnDomReadyHeaderItem;
+import org.apache.wicket.markup.html.WebMarkupContainer;
+import org.apache.wicket.markup.html.panel.EmptyPanel;
+import org.apache.wicket.model.LambdaModel;
+import org.apache.wicket.model.Model;
+import org.apache.wicket.spring.injection.annot.SpringBean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wicketstuff.event.annotation.OnEvent;
+
+import de.agilecoders.wicket.core.markup.html.bootstrap.image.Icon;
+
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.action.ReadOnlyActionHandler;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.paging.DefaultPagingNavigator;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.paging.NoPagingStrategy;
+import de.tudarmstadt.ukp.clarin.webanno.api.annotation.preferences.UserPreferencesService;
+import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasProvider;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocument;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationDocumentState;
+import de.tudarmstadt.ukp.clarin.webanno.model.AnnotationSet;
+import de.tudarmstadt.ukp.clarin.webanno.model.SourceDocument;
+import de.tudarmstadt.ukp.clarin.webanno.security.UserDao;
+import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.AnnotationPageBase2;
+import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.actionbar.open.OpenDocumentDialog;
+import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.component.DocumentNamePanel;
+import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar.AnnotationSidebar_ImplBase;
+import de.tudarmstadt.ukp.inception.diam.model.DiamContext;
+import de.tudarmstadt.ukp.inception.documents.api.DocumentService;
+import de.tudarmstadt.ukp.inception.editor.AnnotationEditorBase;
+import de.tudarmstadt.ukp.inception.editor.AnnotationEditorRegistry;
+import de.tudarmstadt.ukp.inception.editor.action.AnnotationActionHandler;
+import de.tudarmstadt.ukp.inception.editor.state.AnnotatorStateImpl;
+import de.tudarmstadt.ukp.inception.preferences.PreferencesService;
+import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
+import de.tudarmstadt.ukp.inception.rendering.selection.AnnotatorViewportChangedEvent;
+import de.tudarmstadt.ukp.inception.rendering.selection.FocusPosition;
+import de.tudarmstadt.ukp.inception.schema.api.adapter.AnnotationException;
+import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxLink;
+import jakarta.persistence.NoResultException;
+
+/**
+ * A sidebar that opens an arbitrary document from the current project in a read-only annotation
+ * editor. The editor is auto-selected based on the document's format ("AUTO" mode).
+ * <p>
+ * The viewer is fully passive - it uses its own {@link AnnotatorState} so that paging/selection in
+ * the sidebar never affects the main editor, and a {@link ReadOnlyActionHandler} so that clicks and
+ * mutating actions are absorbed.
+ * <p>
+ * The sidebar acts as the {@link DiamContext} for its own toolbar: the reused
+ * {@link OpenDocumentDialog} and {@link DefaultPagingNavigator} resolve the annotator state, editor
+ * CAS and refresh action through this sidebar instead of the main editor's page, so opening or
+ * paging a reference document stays local to the sidebar.
+ */
+public class ReferenceDocumentSidebar
+    extends AnnotationSidebar_ImplBase
+    implements DiamContext
+{
+    private static final long serialVersionUID = 1L;
+
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    private static final String MID_EDITOR = "editor";
+    private static final String MID_NUMBER_OF_PAGES = "numberOfPages";
+
+    private @SpringBean DocumentService documentService;
+    private @SpringBean UserDao userRepository;
+    private @SpringBean AnnotationEditorRegistry editorRegistry;
+    private @SpringBean UserPreferencesService userPreferencesService;
+    private @SpringBean PreferencesService preferencesService;
+
+    private final AnnotatorStateImpl state;
+    private final ReadOnlyActionHandler actionHandler;
+    private final WebMarkupContainer editorContainer;
+    private final DocumentNamePanel documentNamePanel;
+    private final WebMarkupContainer actionBar;
+    private final LambdaAjaxLink actionBarToggle;
+    private final WebMarkupContainer documentNavigation;
+    private final DefaultPagingNavigator pagingNavigator;
+    private final OpenDocumentDialog openDialog;
+
+    // Whether the sidebar's own action bar (open/navigate/paging controls) is hidden. Mirrors the
+    // show/hide toggle the main editor offers, and is persisted per user/project via
+    // ReferenceDocumentSidebarState so it survives page reloads and sessions.
+    private boolean actionBarCollapsed = false;
+
+    private boolean scrollSyncEnabled = false;
+    private transient boolean syncingViewport = false;
+
+    private final LambdaAjaxLink scrollSyncToggle;
+
+    // The editor and CAS provider for the reference document currently shown (null while none).
+    private AnnotationEditorBase editor;
+    private CasProvider casProvider;
+
+    public ReferenceDocumentSidebar(String aId, AnnotationActionHandler aActionHandler,
+            CasProvider aCasProvider, AnnotationPageBase2 aAnnotationPage)
+    {
+        super(aId, aActionHandler, aCasProvider, aAnnotationPage);
+
+        var sessionOwner = userRepository.getCurrentUser();
+        var project = getModelObject().getProject();
+
+        // Independent state so paging/selection in the sidebar never affects the main editor.
+        state = new AnnotatorStateImpl();
+        state.setUser(sessionOwner);
+        // No document is shown yet - use the no-op paging strategy so the position label renders
+        // empty until a reference document is loaded (mirrors AnnotationPageBase2).
+        state.setPagingStrategy(new NoPagingStrategy());
+        if (project != null) {
+            state.setProject(project);
+            // Populates visible/selectable layers and the annotation preferences (window size etc.)
+            try {
+                userPreferencesService.loadPreferences(state, sessionOwner.getUsername());
+            }
+            catch (IOException e) {
+                throw new RuntimeException("Unable to load annotation preferences", e);
+            }
+
+            // Restore the persisted sidebar layout (e.g. whether the action bar is collapsed) so it
+            // survives page reloads and sessions.
+            var sidebarState = preferencesService.loadTraitsForUserAndProject(
+                    KEY_REFERENCE_DOCUMENT_SIDEBAR_STATE, sessionOwner, project);
+            actionBarCollapsed = sidebarState.isActionBarCollapsed();
+            scrollSyncEnabled = sidebarState.isScrollSyncEnabled();
+        }
+
+        actionHandler = new ReadOnlyActionHandler(this::getEditorCas);
+
+        // Document name/project info line, same component the main editor uses in its header. The
+        // sidebar is read-only, so editability comes from our own action handler rather than the
+        // (editable) enclosing page.
+        documentNamePanel = new DocumentNamePanel("documentNamePanel",
+                Model.of((AnnotatorState) state), actionHandler::isEditable);
+        add(documentNamePanel);
+
+        // Position info line ("N-M / K sentences [doc x / y]"); the concrete label is produced by
+        // the current paging strategy, so it is recreated whenever a document is (re)loaded.
+        add(state.getPagingStrategy().createPositionLabel(MID_NUMBER_OF_PAGES,
+                Model.of((AnnotatorState) state)));
+
+        // The action bar (open/navigate/paging controls) can be collapsed via the toggle in the
+        // card header, mirroring the main editor. Its children live inside this container so a
+        // single class swap hides them all at once.
+        actionBar = new WebMarkupContainer("actionBar");
+        actionBar.setOutputMarkupId(true);
+        actionBar.add(AttributeModifier.append("class",
+                LambdaModel.of(() -> actionBarCollapsed ? " visually-hidden" : "")));
+        add(actionBar);
+
+        actionBarToggle = new LambdaAjaxLink("toggleActionBar", this::actionToggleActionBar);
+        actionBarToggle.add(new Icon("toggleActionBarIcon",
+                LambdaModel.of(() -> actionBarCollapsed ? chevron_down_s : chevron_up_s)));
+        actionBarToggle.setOutputMarkupId(true);
+        add(actionBarToggle);
+
+        actionBar.add(
+                new LambdaAjaxLink("showOpenDocumentDialog", this::actionShowOpenDocumentDialog));
+
+        // Previous/next document buttons stepping through the same accessible-documents list the
+        // open dialog offers. Only meaningful once a reference document is loaded.
+        documentNavigation = new WebMarkupContainer("documentNavigation");
+        documentNavigation.setOutputMarkupPlaceholderTag(true);
+        documentNavigation.add(visibleWhen(() -> state.getDocument() != null));
+        documentNavigation
+                .add(new LambdaAjaxLink("showPreviousDocument", this::actionShowPreviousDocument));
+        documentNavigation
+                .add(new LambdaAjaxLink("showNextDocument", this::actionShowNextDocument));
+        actionBar.add(documentNavigation);
+
+        // Two-way scroll synchronization with the main editor. Only meaningful while a document is
+        // shown; whether it actually engages is gated in scrollSyncScript().
+        scrollSyncToggle = new LambdaAjaxLink("toggleScrollSync", this::actionToggleScrollSync);
+        scrollSyncToggle.add(new Icon("toggleScrollSyncIcon",
+                LambdaModel.of(() -> scrollSyncEnabled ? link_s : link_slash_s)));
+        scrollSyncToggle.setOutputMarkupPlaceholderTag(true);
+        scrollSyncToggle.add(visibleWhen(() -> state.getDocument() != null));
+        actionBar.add(scrollSyncToggle);
+
+        openDialog = new OpenDocumentDialog("openDialog", Model.of((AnnotatorState) state),
+                getAnnotationPage()::listAccessibleDocuments, this::actionLoadDocument);
+        add(openDialog);
+
+        pagingNavigator = new DefaultPagingNavigator("pagingNavigator", this);
+        pagingNavigator.add(visibleWhen(() -> state.getDocument() != null));
+        actionBar.add(pagingNavigator);
+
+        editorContainer = new WebMarkupContainer("editorContainer");
+        editorContainer.setOutputMarkupId(true);
+        editorContainer.add(new EmptyPanel(MID_EDITOR).setOutputMarkupId(true));
+        add(editorContainer);
+    }
+
+    @Override
+    protected void onInitialize()
+    {
+        super.onInitialize();
+
+        // Default to the document currently open in the main editor so the sidebar shows useful
+        // content immediately instead of an empty viewer. The user can still switch to any other
+        // accessible document via the open dialog or the previous/next buttons.
+        var mainDocument = getModelObject().getDocument();
+        if (mainDocument != null && state.getProject() != null) {
+            // Keep the full accessible-documents list on the state so the position label reads
+            // "[doc i / n]" and previous/next navigation works from the default document onwards.
+            state.setDocument(mainDocument, listReferenceDocuments());
+            try {
+                loadDocumentIntoEditor();
+            }
+            catch (IOException e) {
+                // Fall back to the empty viewer - the user can pick a document manually.
+                state.setDocument(null, Collections.emptyList());
+                LOG.error("Unable to load default reference document [{}]", mainDocument, e);
+            }
+        }
+    }
+
+    private void actionToggleActionBar(AjaxRequestTarget aTarget)
+    {
+        actionBarCollapsed = !actionBarCollapsed;
+
+        var project = state.getProject();
+        if (project != null) {
+            var sessionOwner = userRepository.getCurrentUser();
+            var sidebarState = preferencesService.loadTraitsForUserAndProject(
+                    KEY_REFERENCE_DOCUMENT_SIDEBAR_STATE, sessionOwner, project);
+            sidebarState.setActionBarCollapsed(actionBarCollapsed);
+            preferencesService.saveTraitsForUserAndProject(KEY_REFERENCE_DOCUMENT_SIDEBAR_STATE,
+                    sessionOwner, project, sidebarState);
+        }
+
+        aTarget.add(actionBar, actionBarToggle);
+    }
+
+    private void actionToggleScrollSync(AjaxRequestTarget aTarget)
+    {
+        scrollSyncEnabled = !scrollSyncEnabled;
+
+        var project = state.getProject();
+        if (project != null) {
+            var sessionOwner = userRepository.getCurrentUser();
+            var sidebarState = preferencesService.loadTraitsForUserAndProject(
+                    KEY_REFERENCE_DOCUMENT_SIDEBAR_STATE, sessionOwner, project);
+            sidebarState.setScrollSyncEnabled(scrollSyncEnabled);
+            preferencesService.saveTraitsForUserAndProject(KEY_REFERENCE_DOCUMENT_SIDEBAR_STATE,
+                    sessionOwner, project, sidebarState);
+        }
+
+        aTarget.add(scrollSyncToggle);
+        scrollSyncScript().ifPresent(aTarget::appendJavaScript);
+    }
+
+    private Optional<String> scrollSyncScript()
+    {
+        var sidebarEditorId = editor != null ? editor.getViewportSyncClientId().orElse(null) : null;
+        if (sidebarEditorId == null) {
+            return Optional.empty();
+        }
+
+        var mainEditor = getAnnotationPage().getAnnotationEditor();
+        var mainEditorId = mainEditor != null ? mainEditor.getViewportSyncClientId().orElse(null)
+                : null;
+
+        String script;
+        if (isScrollSyncActive() && mainEditorId != null) {
+            script = format("ExternalEditor.viewportSync.link('%s', '%s');", sidebarEditorId,
+                    mainEditorId);
+        }
+        else {
+            script = format("ExternalEditor.viewportSync.unlink('%s');", sidebarEditorId);
+        }
+
+        // The hub ships with the external-editor bundle; a page whose editors are all
+        // non-external may not have it - then there is nothing to (un-)link anyway
+        return Optional
+                .of("if (window.ExternalEditor && ExternalEditor.viewportSync) { " + script + " }");
+    }
+
+    private boolean isScrollSyncActive()
+    {
+        return scrollSyncEnabled
+                && Objects.equals(getModelObject().getDocument(), state.getDocument());
+    }
+
+    @Override
+    public void renderHead(IHeaderResponse aResponse)
+    {
+        super.renderHead(aResponse);
+
+        scrollSyncScript()
+                .ifPresent(script -> aResponse.render(OnDomReadyHeaderItem.forScript(script)));
+    }
+
+    private void actionShowOpenDocumentDialog(AjaxRequestTarget aTarget)
+    {
+        openDialog.show(aTarget);
+    }
+
+    private void actionShowPreviousDocument(AjaxRequestTarget aTarget)
+    {
+        actionShowAdjacentDocument(aTarget, -1, "previous");
+    }
+
+    private void actionShowNextDocument(AjaxRequestTarget aTarget)
+    {
+        actionShowAdjacentDocument(aTarget, 1, "next");
+    }
+
+    /**
+     * Step to the {@code aDirection}-adjacent accessible document, honoring the same "skip finished
+     * documents" navigation preference the main editor's {@code DocumentNavigator} respects, so the
+     * buttons behave identically in both places.
+     */
+    private void actionShowAdjacentDocument(AjaxRequestTarget aTarget, int aDirection,
+            String aWhich)
+    {
+        var documents = listReferenceDocuments();
+        var prefs = preferencesService.loadTraitsForUserAndProject(
+                KEY_ANNOTATION_NAVIGATION_USER_PREFS, userRepository.getCurrentUser(),
+                state.getProject());
+        var skipFinished = prefs.isFinishedDocumentsSkippedByNavigation();
+
+        var index = documents.indexOf(state.getDocument());
+        while (true) {
+            index += aDirection;
+
+            if (index < 0 || index >= documents.size()) {
+                if (skipFinished) {
+                    info("There is no " + aWhich + " unfinished document. Use the Open Document"
+                            + " dialog to select finished documents.");
+                }
+                else {
+                    info("There is no " + aWhich + " document.");
+                }
+                aTarget.addChildren(getPage(), IFeedback.class);
+                return;
+            }
+
+            var candidate = documents.get(index);
+            if (!skipFinished || !isTerminal(candidate)) {
+                // Keep the full list on the state so the position label stays
+                // "[doc i / n]"-consistent.
+                state.setDocument(candidate, documents);
+                actionLoadDocument(aTarget);
+                return;
+            }
+        }
+    }
+
+    private boolean isTerminal(SourceDocument aDocument)
+    {
+        var dataOwner = state.getUser();
+        try {
+            return documentService.getAnnotationDocument(aDocument, dataOwner).getState()
+                    .isTerminal();
+        }
+        catch (NoResultException e) {
+            return AnnotationDocumentState.NEW.isTerminal();
+        }
+    }
+
+    /**
+     * The accessible documents to step through - the same list, in the same order, that the open
+     * dialog offers (both go through {@link AnnotationPageBase2#listAccessibleDocuments}).
+     */
+    private List<SourceDocument> listReferenceDocuments()
+    {
+        var project = state.getProject();
+        var user = state.getUser();
+        if (project == null || user == null) {
+            return Collections.emptyList();
+        }
+
+        return getAnnotationPage().listAccessibleDocuments(project, user).stream()
+                .map(AnnotationDocument::getDocument) //
+                .collect(toList());
+    }
+
+    /**
+     * Load the document currently set on our {@link #state} into a fresh read-only editor. Invoked
+     * by the open dialog once the user has picked a document (the dialog has already set it on our
+     * state model). The editor type is resolved automatically from the document format.
+     */
+    private void actionLoadDocument(AjaxRequestTarget aTarget)
+    {
+        try {
+            loadDocumentIntoEditor();
+
+            aTarget.add(editorContainer);
+            aTarget.add(documentNamePanel);
+            aTarget.add(documentNavigation);
+            aTarget.add(pagingNavigator);
+            aTarget.add(scrollSyncToggle);
+            aTarget.add(get(MID_NUMBER_OF_PAGES));
+
+            scrollSyncScript().ifPresent(aTarget::appendJavaScript);
+        }
+        catch (IOException e) {
+            error("Unable to load reference document: " + e.getMessage());
+            aTarget.addChildren(getPage(), IFeedback.class);
+        }
+    }
+
+    /**
+     * Build a fresh read-only editor for the document currently set on our {@link #state} and swap
+     * it into the sidebar (along with a matching position label). Does not touch any
+     * {@link AjaxRequestTarget}, so it can be used both during initial rendering (see
+     * {@link #onInitialize()}) and from AJAX actions such as {@link #actionLoadDocument}. The
+     * editor type is resolved automatically from the document format.
+     */
+    private void loadDocumentIntoEditor() throws IOException
+    {
+        var document = state.getDocument();
+
+        Component newEditor;
+        if (document == null) {
+            editor = null;
+            casProvider = null;
+            state.setPagingStrategy(new NoPagingStrategy());
+            newEditor = new EmptyPanel(MID_EDITOR);
+        }
+        else {
+            // AUTO editor mode: pick the editor based on the document format
+            var factory = editorRegistry.getPreferredEditorFactory(document.getProject(),
+                    document.getFormat());
+            state.setEditorFactoryId(factory.getBeanName());
+
+            casProvider = () -> readReferenceCas(document);
+
+            editor = factory.create(MID_EDITOR, Model.of((AnnotatorState) state), actionHandler,
+                    casProvider);
+
+            // Let the editor configure the paging strategy, then page the document
+            factory.initState(state);
+            var cas = casProvider.get();
+            state.reset();
+            state.getPagingStrategy().recalculatePage(state, cas);
+            state.moveToUnit(cas, 0, FocusPosition.TOP);
+
+            newEditor = editor;
+        }
+
+        newEditor.setOutputMarkupId(true);
+        editorContainer.addOrReplace(newEditor);
+
+        // The position label is bound to the (possibly new) paging strategy, so recreate it.
+        var positionLabel = state.getPagingStrategy().createPositionLabel(MID_NUMBER_OF_PAGES,
+                Model.of((AnnotatorState) state));
+        addOrReplace(positionLabel);
+    }
+
+    private CAS readReferenceCas(SourceDocument aDocument) throws IOException
+    {
+        // Read-only: SHARED_READ_ONLY_ACCESS never writes the CAS file (so it does not bump the
+        // optimistic-locking timestamp), does not take the exclusive pool lock used by the main
+        // editor, and for documents the user has never annotated it returns a transient CAS that is
+        // never persisted. This mode requires AUTO_CAS_UPGRADE (upgrade happens in-memory only).
+        return documentService.readAnnotationCas(aDocument,
+                AnnotationSet.forUser(userRepository.getCurrentUser()), AUTO_CAS_UPGRADE,
+                SHARED_READ_ONLY_ACCESS);
+    }
+
+    // --- DiamContext: the sidebar hosts its own editor/toolbar --------------------------------
+
+    @Override
+    public AnnotatorState getAnnotatorState()
+    {
+        return state;
+    }
+
+    @Override
+    public CAS getEditorCas() throws IOException
+    {
+        if (casProvider == null) {
+            throw new IllegalStateException("No reference document is currently loaded");
+        }
+        return casProvider.get();
+    }
+
+    @Override
+    public AnnotationActionHandler getActionHandler()
+    {
+        return actionHandler;
+    }
+
+    @Override
+    public void actionShowSelectedDocument(AjaxRequestTarget aTarget, SourceDocument aDocument,
+            int aBegin, int aEnd)
+        throws IOException, AnnotationException
+    {
+        // A self-contained viewer scrolls within its own document and does not switch documents;
+        // the
+        // read-only action handler ignores navigation, so this stays local.
+        getActionHandler().actionJump(aTarget, aBegin, aEnd);
+    }
+
+    @Override
+    public void actionRefreshDocument(AjaxRequestTarget aTarget)
+    {
+        if (editor != null) {
+            editor.requestRender(aTarget);
+        }
+    }
+
+    @OnEvent
+    public void onAnnotatorViewportChanged(AnnotatorViewportChangedEvent aEvent)
+    {
+        if (syncingViewport || !isScrollSyncActive()) {
+            return;
+        }
+
+        var target = aEvent.getRequestHandler();
+        if (target == null) {
+            return;
+        }
+
+        var mainState = getModelObject();
+
+        try {
+            syncingViewport = true;
+
+            if (aEvent.isFor(mainState)) {
+                // Main editor paged - follow it in the sidebar.
+                var mainEditor = getAnnotationPage().getAnnotationEditor();
+                if (editor == null || mainEditor == null) {
+                    return;
+                }
+                state.moveToOffset(getEditorCas(), mainState.getWindowBeginOffset(),
+                        FocusPosition.TOP);
+                editor.requestRender(target);
+                target.add(pagingNavigator);
+                target.add(get(MID_NUMBER_OF_PAGES));
+            }
+            else if (aEvent.isFor(state)) {
+                // Sidebar paged - follow it in the main editor.
+                var mainEditor = getAnnotationPage().getAnnotationEditor();
+                if (mainEditor == null) {
+                    return;
+                }
+                mainState.moveToOffset(getCasProvider().get(), state.getWindowBeginOffset(),
+                        FocusPosition.TOP);
+                mainEditor.requestRender(target);
+            }
+        }
+        catch (IOException e) {
+            LOG.error("Unable to synchronize reference document viewport", e);
+        }
+        finally {
+            syncingViewport = false;
+        }
+    }
+}

--- a/inception/inception-ui-refdoc/src/main/java/de/tudarmstadt/ukp/inception/ui/refdoc/ReferenceDocumentSidebarFactory.java
+++ b/inception/inception-ui-refdoc/src/main/java/de/tudarmstadt/ukp/inception/ui/refdoc/ReferenceDocumentSidebarFactory.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.refdoc;
+
+import org.apache.wicket.Component;
+import org.apache.wicket.model.IModel;
+import org.springframework.core.annotation.Order;
+
+import de.agilecoders.wicket.core.markup.html.bootstrap.image.Icon;
+import de.agilecoders.wicket.extensions.markup.html.bootstrap.icon.FontAwesome5IconType;
+import de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasProvider;
+import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.AnnotationPageBase2;
+import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar.AnnotationSidebarFactory_ImplBase;
+import de.tudarmstadt.ukp.clarin.webanno.ui.annotation.sidebar.AnnotationSidebar_ImplBase;
+import de.tudarmstadt.ukp.inception.editor.action.AnnotationActionHandler;
+import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
+
+@Order(4500)
+public class ReferenceDocumentSidebarFactory
+    extends AnnotationSidebarFactory_ImplBase
+{
+    @Override
+    public String getDisplayName()
+    {
+        return "Reference document";
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Opens another document from the project in a read-only editor for reference.";
+    }
+
+    @Override
+    public Component createIcon(String aId, IModel<AnnotatorState> aState)
+    {
+        return new Icon(aId, FontAwesome5IconType.book_s);
+    }
+
+    @Override
+    public AnnotationSidebar_ImplBase create(String aId, AnnotationActionHandler aActionHandler,
+            CasProvider aCasProvider, AnnotationPageBase2 aAnnotationPage)
+    {
+        return new ReferenceDocumentSidebar(aId, aActionHandler, aCasProvider, aAnnotationPage);
+    }
+}

--- a/inception/inception-ui-refdoc/src/main/java/de/tudarmstadt/ukp/inception/ui/refdoc/ReferenceDocumentSidebarState.java
+++ b/inception/inception-ui-refdoc/src/main/java/de/tudarmstadt/ukp/inception/ui/refdoc/ReferenceDocumentSidebarState.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.inception.ui.refdoc;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import de.tudarmstadt.ukp.inception.preferences.PreferenceKey;
+import de.tudarmstadt.ukp.inception.preferences.PreferenceValue;
+
+/**
+ * Per-user/project layout preferences for the {@link ReferenceDocumentSidebar}. Persisted via the
+ * {@link de.tudarmstadt.ukp.inception.preferences.PreferencesService} so the sidebar keeps its
+ * state across page reloads and sessions - the counterpart of the main editor's
+ * {@code AnnotationPageLayoutState}.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ReferenceDocumentSidebarState
+    implements PreferenceValue
+{
+    public static final PreferenceKey<ReferenceDocumentSidebarState> KEY_REFERENCE_DOCUMENT_SIDEBAR_STATE = //
+            new PreferenceKey<>(ReferenceDocumentSidebarState.class,
+                    "annotation/editor/reference-document-sidebar");
+
+    private static final long serialVersionUID = -6155195746441156846L;
+
+    private boolean actionBarCollapsed;
+
+    private boolean scrollSyncEnabled;
+
+    public boolean isActionBarCollapsed()
+    {
+        return actionBarCollapsed;
+    }
+
+    public void setActionBarCollapsed(boolean aActionBarCollapsed)
+    {
+        actionBarCollapsed = aActionBarCollapsed;
+    }
+
+    public boolean isScrollSyncEnabled()
+    {
+        return scrollSyncEnabled;
+    }
+
+    public void setScrollSyncEnabled(boolean aScrollSyncEnabled)
+    {
+        scrollSyncEnabled = aScrollSyncEnabled;
+    }
+}

--- a/inception/inception-ui-refdoc/src/main/java/de/tudarmstadt/ukp/inception/ui/refdoc/config/ReferenceDocumentSidebarAutoConfiguration.java
+++ b/inception/inception-ui-refdoc/src/main/java/de/tudarmstadt/ukp/inception/ui/refdoc/config/ReferenceDocumentSidebarAutoConfiguration.java
@@ -15,10 +15,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export {
-    AnnotationEditor,
-    type ViewportScrollPosition,
-    type ViewportScrollTarget,
-} from './AnnotationEditor';
-export { AnnotationEditorFactory } from './AnnotationEditorFactory';
-export { AnnotationEditorProperties } from './AnnotationEditorProperties';
+package de.tudarmstadt.ukp.inception.ui.refdoc.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import de.tudarmstadt.ukp.inception.ui.refdoc.ReferenceDocumentSidebarFactory;
+
+@ConditionalOnWebApplication
+@Configuration
+public class ReferenceDocumentSidebarAutoConfiguration
+{
+    @Bean
+    public ReferenceDocumentSidebarFactory referenceDocumentSidebarFactory()
+    {
+        return new ReferenceDocumentSidebarFactory();
+    }
+}

--- a/inception/inception-ui-refdoc/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/inception/inception-ui-refdoc/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+de.tudarmstadt.ukp.inception.ui.refdoc.config.ReferenceDocumentSidebarAutoConfiguration

--- a/inception/pom.xml
+++ b/inception/pom.xml
@@ -198,6 +198,7 @@
     <module>inception-ui-dashboard-api</module>
     <module>inception-ui-project</module>
     <module>inception-ui-annotation</module>
+    <module>inception-ui-refdoc</module>
     <module>inception-ui-scheduling</module>
     <module>inception-ui-tagsets</module>
     <module>inception-sharing</module>


### PR DESCRIPTION
**What's in the PR**
- Added reference document sidebar with basic synchronized scrolling provisions when viewing the same document (e.g. on two different users as a curator/manager)

**How to test manually**
* Try using the reference document sidebar

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
