### PR TITLE
#6170 - Add a reference document sidebar panel

### DIFF
--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/paging/LineOrientedPagingStrategy.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/paging/LineOrientedPagingStrategy.java
@@ -29,7 +29,6 @@ import java.util.regex.Pattern;
 import org.apache.uima.cas.CAS;
 import org.apache.wicket.Component;
 import org.apache.wicket.Page;
-import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.model.IModel;
 
 import de.tudarmstadt.ukp.inception.diam.model.DiamContext;
@@ -88,14 +87,7 @@ public class LineOrientedPagingStrategy
     @Override
     public Component createPositionLabel(String aId, IModel<AnnotatorState> aModel)
     {
-        var label = new Label(aId, () -> {
-            var state = aModel.getObject();
-            return String.format("%d-%d / %d lines [doc %d / %d]", state.getFirstVisibleUnitIndex(),
-                    state.getLastVisibleUnitIndex(), state.getUnitCount(),
-                    state.getDocumentIndex() + 1, state.getNumberOfDocuments());
-        });
-        label.setOutputMarkupPlaceholderTag(true);
-        return label;
+        return new PositionInfoPanel(aId, aModel, "lines");
     }
 
     @Override

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/paging/PositionInfoPanel.html
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/paging/PositionInfoPanel.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<!--
+  Licensed to the Technische Universität Darmstadt under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The Technische Universität Darmstadt
+  licenses this file to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<html xmlns:wicket="http://wicket.apache.org">
+<body>
+  <wicket:panel>
+    <!--
+      The unit position ("N-M / K sentences") and the document position ("[doc i / n]") live in
+      separate spans so that hosts can control their layout independently - e.g. keep each on its
+      own line, or let them wrap independently in a narrow container such as the reference-document
+      sidebar. Kept inline with a whitespace-preserving separator so the default rendering still
+      reads as a single "N-M / K sentences [doc i / n]" line.
+    -->
+    <span wicket:id="unitPosition" class="position-info-unit"></span>
+    <wicket:enclosure child="documentPosition">
+      <span class="position-info-separator"> </span>
+      <span wicket:id="documentPosition" class="position-info-document"></span>
+    </wicket:enclosure>
+  </wicket:panel>
+</body>
+</html>

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/paging/PositionInfoPanel.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/paging/PositionInfoPanel.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.tudarmstadt.ukp.clarin.webanno.api.annotation.paging;
+
+import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.markup.html.panel.Panel;
+import org.apache.wicket.model.IModel;
+
+import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
+
+public class PositionInfoPanel
+    extends Panel
+{
+    private static final long serialVersionUID = 4131266760920882496L;
+
+    private static final String MID_UNIT_POSITION = "unitPosition";
+    private static final String MID_DOCUMENT_POSITION = "documentPosition";
+
+    /**
+     * @param aId
+     *            component id
+     * @param aModel
+     *            the annotator state supplying the current position
+     * @param aUnitName
+     *            plural noun for the paging unit, e.g. {@code "sentences"}, {@code "lines"} or
+     *            {@code "blocks"}
+     */
+    public PositionInfoPanel(String aId, IModel<AnnotatorState> aModel, String aUnitName)
+    {
+        super(aId, aModel);
+
+        // Mirrors the AJAX re-rendering contract the previous position Label had: callers re-add
+        // this component to the AjaxRequestTarget by id when paging changes.
+        setOutputMarkupPlaceholderTag(true);
+
+        add(new Label(MID_UNIT_POSITION,
+                aModel.map(state -> String.format("%d-%d / %d %s", state.getFirstVisibleUnitIndex(),
+                        state.getLastVisibleUnitIndex(), state.getUnitCount(), aUnitName))));
+
+        add(new Label(MID_DOCUMENT_POSITION, aModel.map(state -> String.format("[doc %d / %d]",
+                state.getDocumentIndex() + 1, state.getNumberOfDocuments()))));
+    }
+}

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/paging/SentenceOrientedPagingStrategy.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/paging/SentenceOrientedPagingStrategy.java
@@ -28,7 +28,6 @@ import org.apache.uima.fit.util.CasUtil;
 import org.apache.uima.fit.util.FSUtil;
 import org.apache.wicket.Component;
 import org.apache.wicket.Page;
-import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.model.IModel;
 
 import de.tudarmstadt.ukp.inception.diam.model.DiamContext;
@@ -86,15 +85,7 @@ public class SentenceOrientedPagingStrategy
     @Override
     public Component createPositionLabel(String aId, IModel<AnnotatorState> aModel)
     {
-        var label = new Label(aId, () -> {
-            var state = aModel.getObject();
-            return String.format("%d-%d / %d sentences [doc %d / %d]",
-                    state.getFirstVisibleUnitIndex(), state.getLastVisibleUnitIndex(),
-                    state.getUnitCount(), state.getDocumentIndex() + 1,
-                    state.getNumberOfDocuments());
-        });
-        label.setOutputMarkupPlaceholderTag(true);
-        return label;
+        return new PositionInfoPanel(aId, aModel, "sentences");
     }
 
     @Override

--- a/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/paging/TokenWrappingPagingStrategy.java
+++ b/inception/inception-api-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/api/annotation/paging/TokenWrappingPagingStrategy.java
@@ -26,7 +26,6 @@ import java.util.List;
 import org.apache.uima.cas.CAS;
 import org.apache.wicket.Component;
 import org.apache.wicket.Page;
-import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.model.IModel;
 
 import de.tudarmstadt.ukp.inception.diam.model.DiamContext;
@@ -119,15 +118,7 @@ public class TokenWrappingPagingStrategy
     @Override
     public Component createPositionLabel(String aId, IModel<AnnotatorState> aModel)
     {
-        Label label = new Label(aId, () -> {
-            AnnotatorState state = aModel.getObject();
-            return String.format("%d-%d / %d blocks [doc %d / %d]",
-                    state.getFirstVisibleUnitIndex(), state.getLastVisibleUnitIndex(),
-                    state.getUnitCount(), state.getDocumentIndex() + 1,
-                    state.getNumberOfDocuments());
-        });
-        label.setOutputMarkupPlaceholderTag(true);
-        return label;
+        return new PositionInfoPanel(aId, aModel, "blocks");
     }
 
     @Override

--- a/inception/inception-brat-editor/src/main/ts/src/annotator_ui/AnnotatorUI.ts
+++ b/inception/inception-brat-editor/src/main/ts/src/annotator_ui/AnnotatorUI.ts
@@ -340,10 +340,12 @@ export class AnnotatorUI {
         const noNumArcType = this.arcOptions && this.arcOptions.type;
 
         spanDesc.arcs.map((possibleArc) => {
-            if (!(
-                (this.arcOptions && possibleArc.type === noNumArcType) ||
-                !(this.arcOptions && this.arcOptions.old_target)
-            )) {
+            if (
+                !(
+                    (this.arcOptions && possibleArc.type === noNumArcType) ||
+                    !(this.arcOptions && this.arcOptions.old_target)
+                )
+            ) {
                 return undefined;
             }
 

--- a/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/policy/DefaultHtmlDocumentPolicy.yaml
+++ b/inception/inception-external-editor/src/main/java/de/tudarmstadt/ukp/inception/externaleditor/policy/DefaultHtmlDocumentPolicy.yaml
@@ -72,6 +72,9 @@ policies:
   - action: PASS
     attributes: ["class"]
     matching: "[a-zA-Z0-9\\s,\\-_]+"
+  - action: PASS
+    attributes: ["id"]
+    matching: "[a-zA-Z0-9\\-_:.]+"
   # Data attributes
   - action: PASS
     attribute_patterns: ["data-.*"]

--- a/inception/inception-external-editor/src/main/ts/src/ViewportSyncHub.ts
+++ b/inception/inception-external-editor/src/main/ts/src/ViewportSyncHub.ts
@@ -154,6 +154,9 @@ export class ViewportSyncHub {
                 end: pos.end,
                 fraction: pos.fraction,
                 scrollProgress: pos.scrollProgress,
+                sectionKey: pos.sectionKey,
+                sectionFraction: pos.sectionFraction,
+                sectionKeySequence: pos.sectionKeySequence,
             });
         });
     }

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorEditor.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorEditor.ts
@@ -20,9 +20,11 @@ import {
     type DiamAjax,
     type DocumentStructureStrategy,
     type Offsets,
+    type TocLevel,
     type ViewportScrollPosition,
     type ViewportScrollTarget,
     type ViewportSyncPeer,
+    buildDocumentStructure,
     calculateStartOffset,
 } from '@inception-project/inception-js-api';
 import DocumentStructureNavigator from '@inception-project/inception-js-api/src/documentStructure/DocumentStructureNavigator.svelte';
@@ -68,6 +70,7 @@ export class ApacheAnnotatorEditor implements AnnotationEditor {
     private activeResizeCleanup: (() => void) | undefined = undefined;
     private documentStructure: DocumentStructureStrategy;
     private documentContainer: HTMLElement | undefined = undefined;
+    private tocRoot: TocLevel | undefined = undefined;
     private keyboardMode: KeyboardEditorMode | undefined = undefined;
 
     public constructor(
@@ -136,8 +139,8 @@ export class ApacheAnnotatorEditor implements AnnotationEditor {
                 );
                 this.ensureSectionElementsHaveAnId();
 
-                // Build the outline for the navigator, operating on the post-pinning DOM.
                 this.documentStructure.preprocess(documentContainer);
+                this.tocRoot = buildDocumentStructure(documentContainer, this.documentStructure);
 
                 this.navigatorContainer = this.root.ownerDocument.createElement('div');
                 this.navigatorContainer.classList.add('iaa-document-navigator');
@@ -161,12 +164,19 @@ export class ApacheAnnotatorEditor implements AnnotationEditor {
                 );
                 this.vis.protectedElementSelector = [...protectedElements].join(',');
 
+                this.vis.setSyncDocumentStructure({
+                    sectionSelector: () => this.documentStructure.sectionSelector,
+                    extractKey: (section) => this.documentStructure.extractKey(section),
+                    tocRoot: () => this.tocRoot,
+                });
+
                 this.documentContainer = documentContainer;
 
                 this.documentStructureNavigator = this.createDocumentNavigator(
                     this.navigatorContainer,
                     documentContainer,
-                    this.documentStructure
+                    this.documentStructure,
+                    this.tocRoot
                 );
                 this.toolbar = this.createToolbar();
 
@@ -404,13 +414,15 @@ export class ApacheAnnotatorEditor implements AnnotationEditor {
     private createDocumentNavigator(
         target: HTMLElement,
         documentContainer: HTMLElement,
-        structure: DocumentStructureStrategy
+        structure: DocumentStructureStrategy,
+        tocRoot: TocLevel
     ) {
         return mount(DocumentStructureNavigator, {
             target,
             props: {
                 documentContainer,
                 structure,
+                tocRoot,
             },
         });
     }

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorSyncController.test.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorSyncController.test.ts
@@ -1,0 +1,543 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { buildDocumentStructure, type TocLevel } from '@inception-project/inception-js-api';
+
+import {
+    blendTowardScrollProgress,
+    buildSyncRegions,
+    LEADING_REGION_KEY,
+    resolveRegionTarget,
+    sameScrollProgress,
+    shouldBlendTowardScrollProgress,
+    type SyncRegion,
+} from './ApacheAnnotatorSyncController';
+import { calculateEndOffset } from '@inception-project/inception-js-api';
+
+// The band over which the blend ramps, mirrored from the implementation. Kept as a literal rather
+// than imported so a change to the constant makes these expectations fail loudly instead of
+// silently re-deriving themselves.
+const BAND = 0.15;
+const MAX_SCROLL = 1000;
+
+describe('blendTowardScrollProgress', () => {
+    describe('pass-through cases', () => {
+        it('returns the anchored top unchanged when the source sent no progress', () => {
+            // The pre-extension wire format: peers that never send progress must keep the old
+            // pure offset-anchored behaviour.
+            expect(blendTowardScrollProgress(400, undefined, MAX_SCROLL)).toBe(400);
+        });
+
+        it('returns the anchored top unchanged when the container cannot scroll', () => {
+            expect(blendTowardScrollProgress(400, 0.5, 0)).toBe(400);
+        });
+
+        it('returns the anchored top unchanged for a negative scroll range', () => {
+            // scrollHeight < clientHeight can yield a negative maxScroll; treat as unscrollable
+            // rather than blending toward a nonsensical negative progressTop.
+            expect(blendTowardScrollProgress(400, 0.5, -50)).toBe(400);
+        });
+    });
+
+    describe('at the extremes, progress wins exactly', () => {
+        // The whole point of the blend: an offset anchor lands short of the extreme because the two
+        // editors hold different amounts of content below the shared top block. At p=0/p=1 the
+        // anchored value must be overridden completely, or scrolling to an end never quite arrives.
+        it('snaps to the very top at progress 0, ignoring a short anchored top', () => {
+            expect(blendTowardScrollProgress(120, 0, MAX_SCROLL)).toBe(0);
+        });
+
+        it('snaps to the very bottom at progress 1, ignoring a short anchored top', () => {
+            expect(blendTowardScrollProgress(880, 1, MAX_SCROLL)).toBe(MAX_SCROLL);
+        });
+    });
+
+    describe('in the interior, the offset anchor wins', () => {
+        it('leaves the anchored top untouched at the exact band edge', () => {
+            // nearness hits 0 precisely at BAND in from an extreme.
+            expect(blendTowardScrollProgress(400, BAND, MAX_SCROLL)).toBeCloseTo(400);
+            expect(blendTowardScrollProgress(400, 1 - BAND, MAX_SCROLL)).toBeCloseTo(400);
+        });
+
+        it('leaves the anchored top untouched in mid-document', () => {
+            expect(blendTowardScrollProgress(400, 0.5, MAX_SCROLL)).toBeCloseTo(400);
+        });
+
+        it('leaves the anchored top untouched well outside the band', () => {
+            expect(blendTowardScrollProgress(250, 0.25, MAX_SCROLL)).toBeCloseTo(250);
+            expect(blendTowardScrollProgress(750, 0.75, MAX_SCROLL)).toBeCloseTo(750);
+        });
+    });
+
+    describe('within the band, the two regimes mix', () => {
+        it('weights progress and anchor evenly at half the band from the top', () => {
+            // p = BAND/2 -> nearness = 0.5, so the result is the midpoint of the two candidates.
+            const p = BAND / 2;
+            const progressTop = p * MAX_SCROLL; // 75
+            const anchoredTop = 200;
+            expect(blendTowardScrollProgress(anchoredTop, p, MAX_SCROLL)).toBeCloseTo(
+                0.5 * progressTop + 0.5 * anchoredTop
+            );
+        });
+
+        it('weights progress and anchor evenly at half the band from the bottom', () => {
+            const p = 1 - BAND / 2;
+            const progressTop = p * MAX_SCROLL; // 925
+            const anchoredTop = 800;
+            expect(blendTowardScrollProgress(anchoredTop, p, MAX_SCROLL)).toBeCloseTo(
+                0.5 * progressTop + 0.5 * anchoredTop
+            );
+        });
+
+        it('moves monotonically from the anchor toward progress as an extreme nears', () => {
+            // Approaching the top with an anchor that overshoots it: each step must pull further
+            // toward progressTop, never bounce back. A non-monotonic ramp would read as jitter.
+            const anchoredTop = 300;
+            const results = [BAND, BAND * 0.75, BAND * 0.5, BAND * 0.25, 0].map((p) =>
+                blendTowardScrollProgress(anchoredTop, p, MAX_SCROLL)
+            );
+            for (let i = 1; i < results.length; i++) {
+                expect(results[i]).toBeLessThan(results[i - 1]);
+            }
+        });
+
+        it('is continuous across the band edge, so there is no snap', () => {
+            // Just inside vs. just outside the band must differ only marginally - the property that
+            // makes blending preferable to switching regimes at a threshold.
+            const anchoredTop = 300;
+            const outside = blendTowardScrollProgress(anchoredTop, BAND + 0.001, MAX_SCROLL);
+            const inside = blendTowardScrollProgress(anchoredTop, BAND - 0.001, MAX_SCROLL);
+            expect(Math.abs(outside - inside)).toBeLessThan(2);
+        });
+    });
+});
+
+describe('sameScrollProgress', () => {
+    // This guards the dedup key in ApacheAnnotatorSyncController: near an extreme, two positions
+    // agreeing on begin/fraction can still blend to different pixels, so progress must take part in
+    // the comparison or those scrolls get dropped as duplicates.
+    it('treats values within the dedup tolerance as the same', () => {
+        expect(sameScrollProgress(0.5, 0.5)).toBe(true);
+        expect(sameScrollProgress(0.5, 0.505)).toBe(true);
+    });
+
+    it('treats values beyond the dedup tolerance as different', () => {
+        expect(sameScrollProgress(0.5, 0.52)).toBe(false);
+        expect(sameScrollProgress(0, 1)).toBe(false);
+    });
+
+    it('treats two absent values as the same', () => {
+        expect(sameScrollProgress(undefined, undefined)).toBe(true);
+    });
+
+    it('never matches a present value against an absent one', () => {
+        // Losing progress switches the receiver from the blended target back to the bare offset
+        // anchor - a real move, not a no-op.
+        expect(sameScrollProgress(0.5, undefined)).toBe(false);
+        expect(sameScrollProgress(undefined, 0.5)).toBe(false);
+        // Zero is a present value, not an absence - the top extreme must not read as "no progress".
+        expect(sameScrollProgress(0, undefined)).toBe(false);
+    });
+});
+
+describe('buildSyncRegions', () => {
+    // Regions partition the document by keyed-section START offsets into a flat, non-overlapping
+    // list. calculateStartOffset is character-based (not layout), so this is exercisable in jsdom.
+    let container: HTMLElement;
+
+    beforeEach(() => {
+        container = document.createElement('div');
+        document.body.appendChild(container);
+    });
+
+    afterEach(() => {
+        while (document.body.firstChild) {
+            document.body.removeChild(document.body.firstChild);
+        }
+    });
+
+    // A minimal structure strategy: sections are <sec> elements; the key is their data-key attr.
+    const strategy = {
+        sectionSelector: 'sec',
+        preprocess: () => {},
+        extractTitle: (s: Element) => s.getAttribute('data-title') ?? undefined,
+        extractKey: (s: Element) => s.getAttribute('data-key') ?? undefined,
+    };
+
+    function sec(text: string, key: string | undefined, ...children: Node[]): HTMLElement {
+        const e = document.createElement('sec');
+        e.setAttribute('data-title', text);
+        if (key !== undefined) e.setAttribute('data-key', key);
+        e.appendChild(document.createTextNode(text));
+        for (const c of children) e.appendChild(c);
+        return e;
+    }
+
+    function regions() {
+        const toc: TocLevel = buildDocumentStructure(container, strategy);
+        return buildSyncRegions(container, toc, calculateEndOffset(container, container));
+    }
+
+    it('partitions the document into non-overlapping regions in document order', () => {
+        // A leading paragraph (no section), then two sibling keyed sections.
+        container.appendChild(document.createTextNode('intro'));
+        container.appendChild(sec('AAAA', 'k-a'));
+        container.appendChild(sec('BB', 'k-b'));
+
+        const rs = regions();
+        // leading [0,5) then k-a [5,9) then k-b [9,11)
+        expect(rs.map((r) => r.key)).toEqual([LEADING_REGION_KEY, 'k-a', 'k-b']);
+        expect(rs.map((r) => [r.start, r.end])).toEqual([
+            [0, 5],
+            [5, 9],
+            [9, 11],
+        ]);
+        // No overlap: each region's end is the next region's start.
+        for (let i = 1; i < rs.length; i++) expect(rs[i].start).toBe(rs[i - 1].end);
+    });
+
+    it('uses a nested section START as a boundary, running the parent region only up to it', () => {
+        // Chapter "CH" contains child "SUB"; the chapter region must END where SUB begins, not
+        // continue underneath it -- that non-overlap is the whole point.
+        const sub = sec('SUB', 'k-sub');
+        const chapter = sec('CH', 'k-ch', sub);
+        container.appendChild(chapter);
+
+        const rs = regions();
+        // "CH" text is offset 0..2, then SUB starts at 2.
+        expect(rs.map((r) => r.key)).toEqual(['k-ch', 'k-sub']);
+        expect(rs[0].start).toBe(0);
+        expect(rs[0].end).toBe(2); // chapter region stops at SUB start
+        expect(rs[1].start).toBe(2); // sub region starts there, no overlap
+    });
+
+    it('ignores keyless sections (their content belongs to the enclosing region)', () => {
+        container.appendChild(sec('AAAA', 'k-a', sec('xx', undefined)));
+
+        const rs = regions();
+        expect(rs.map((r) => r.key)).toEqual(['k-a']);
+    });
+
+    it('keeps the first key when two sections share a start offset / key', () => {
+        // Two sections at the same offset can't both open a region; first in doc order wins.
+        const first = sec('First', 'dup');
+        container.appendChild(first);
+        // second section immediately after, distinct offset, same key -> deduped by key
+        container.appendChild(sec('Second', 'dup'));
+
+        const rs = regions();
+        // leading region is empty (first section at 0), so only the 'dup' region(s) — deduped to one
+        expect(rs.filter((r) => r.key === 'dup').length).toBe(1);
+    });
+
+    it('produces a single leading region spanning the whole document when there are no sections', () => {
+        container.appendChild(document.createTextNode('just text'));
+        const rs = regions();
+        expect(rs.length).toBe(1);
+        expect(rs[0].key).toBe(LEADING_REGION_KEY);
+        expect(rs[0].start).toBe(0);
+        expect(rs[0].end).toBe('just text'.length);
+    });
+});
+
+describe('resolveRegionTarget', () => {
+    // Pure key-order reasoning, no geometry -- regions only need a `key` for these tests, so offsets
+    // are irrelevant filler.
+    function region(key: string): SyncRegion {
+        return { key, start: 0, end: 0 };
+    }
+
+    it('matches directly when the receiver has a region for the key (interior, not at either extreme)', () => {
+        const regions = [region('a'), region('b'), region('c')];
+        expect(resolveRegionTarget(regions, 'b', ['a', 'b', 'c'])).toEqual({
+            kind: 'exact',
+            regionIndex: 1,
+            atDocumentStart: false,
+            atDocumentEnd: false,
+        });
+    });
+
+    it('matches directly even with no sender sequence supplied, defaulting both extreme flags true (nothing to disprove correspondence)', () => {
+        const regions = [region('a'), region('b')];
+        expect(resolveRegionTarget(regions, 'b', undefined)).toEqual({
+            kind: 'exact',
+            regionIndex: 1,
+            atDocumentStart: false,
+            atDocumentEnd: true,
+        });
+    });
+
+    it('reports no bracket when the key is absent from the sender sequence entirely', () => {
+        const regions = [region('a'), region('b')];
+        // 'z' isn't in the sender's own sequence -- can't bracket at all.
+        expect(resolveRegionTarget(regions, 'z', ['a', 'b'])).toEqual({ kind: 'none' });
+        expect(resolveRegionTarget(regions, 'z', undefined)).toEqual({ kind: 'none' });
+    });
+
+    it('reports no bracket when neither neighbour of the missing key exists locally', () => {
+        const regions = [region('a')];
+        // 'z' sits between two other keys the receiver also lacks.
+        expect(resolveRegionTarget(regions, 'z', ['y', 'z', 'x'])).toEqual({ kind: 'none' });
+    });
+
+    it('interpolates between the nearest shared keys when the sender key is an interior gap (the "Characters" case)', () => {
+        // Sender: Chapter 1, Characters (unmatched), Chapter 2. Receiver only has Chapter 1 / Chapter 2.
+        const regions = [region('chapter-1'), region('chapter-2')];
+        const senderSeq = ['chapter-1', 'characters', 'chapter-2'];
+
+        const plan = resolveRegionTarget(regions, 'characters', senderSeq, 0.5);
+        expect(plan).toEqual({
+            kind: 'interpolate',
+            beforeRegionIndex: 0,
+            afterRegionIndex: 1,
+            progress: 0.75, // 1 key-step past chapter-1, plus 0.5 through "characters", out of 2 steps
+        });
+    });
+
+    it('interpolates smoothly across the gap as the sender scrolls through the unmatched region', () => {
+        const regions = [region('chapter-1'), region('chapter-2')];
+        const senderSeq = ['chapter-1', 'characters', 'chapter-2'];
+
+        const start = resolveRegionTarget(regions, 'characters', senderSeq, 0);
+        const mid = resolveRegionTarget(regions, 'characters', senderSeq, 0.5);
+        const end = resolveRegionTarget(regions, 'characters', senderSeq, 1);
+        expect(start.kind).toBe('interpolate');
+        expect(mid.kind).toBe('interpolate');
+        expect(end.kind).toBe('interpolate');
+        if (start.kind === 'interpolate' && mid.kind === 'interpolate' && end.kind === 'interpolate') {
+            expect(start.progress).toBeLessThan(mid.progress);
+            expect(mid.progress).toBeLessThan(end.progress);
+        }
+    });
+
+    it('spans multiple unmatched keys between the same bracket', () => {
+        const regions = [region('a'), region('e')];
+        const senderSeq = ['a', 'b', 'c', 'd', 'e'];
+        // 'c' is the middle of 3 unmatched keys between 'a' and 'e' -> halfway across.
+        expect(resolveRegionTarget(regions, 'c', senderSeq)).toEqual({
+            kind: 'interpolate',
+            beforeRegionIndex: 0,
+            afterRegionIndex: 1,
+            progress: 0.5,
+        });
+    });
+
+    it('freezes at the last shared region when the sender is past every key this document has (trailing gap)', () => {
+        const regions = [region('chapter-1'), region('chapter-2')];
+        const senderSeq = ['chapter-1', 'chapter-2', 'appendix'];
+
+        expect(resolveRegionTarget(regions, 'appendix', senderSeq)).toEqual({
+            kind: 'freeze-after',
+            regionIndex: 1,
+        });
+    });
+
+    it('freezes at the first shared region when the sender is before every key this document has (leading gap)', () => {
+        const regions = [region('chapter-1'), region('chapter-2')];
+        const senderSeq = ['preface', 'chapter-1', 'chapter-2'];
+
+        expect(resolveRegionTarget(regions, 'preface', senderSeq)).toEqual({
+            kind: 'freeze-before',
+            regionIndex: 0,
+        });
+    });
+
+    it('clamps progress into [0,1] even if sectionFraction is out of range', () => {
+        const regions = [region('a'), region('c')];
+        const senderSeq = ['a', 'b', 'c'];
+        expect(resolveRegionTarget(regions, 'b', senderSeq, 5).kind).toBe('interpolate');
+        const plan = resolveRegionTarget(regions, 'b', senderSeq, 5);
+        if (plan.kind === 'interpolate') expect(plan.progress).toBe(1);
+    });
+
+    it('does not treat the shared LEADING_REGION_KEY sentinel as a real bracket (regression)', () => {
+        // Both documents trivially have a leading region (every region list starts with one), but
+        // their actual leading content is unrelated (e.g. a different title page/TOC). The sender is
+        // still inside ITS leading region -- key equals LEADING_REGION_KEY exactly, which IS an exact
+        // match here (both docs are "in their own leading region"), so this must resolve 'exact', not
+        // interpolate toward chapter-1. Both sides' leading region is at index 0 of its own sequence,
+        // so atDocumentStart is true here.
+        const regions = [region(LEADING_REGION_KEY), region('chapter-1'), region('chapter-2')];
+        const senderSeq = [LEADING_REGION_KEY, 'chapter-1', 'chapter-2'];
+
+        expect(resolveRegionTarget(regions, LEADING_REGION_KEY, senderSeq, 0.5)).toEqual({
+            kind: 'exact',
+            regionIndex: 0,
+            atDocumentStart: true,
+            atDocumentEnd: false,
+        });
+    });
+
+    it('reports atDocumentStart=false for an exact match at THIS document\'s first region when the SENDER\'s matching key is not at the start of ITS sequence (the "Chapter 1" asymmetric-extreme regression)', () => {
+        // Live bug (2026-07-17): main doc starts directly at "1" (Chapter 1, index 0 of its own
+        // sequence). The reference doc (tei-book1-outline.xml) shares that same key "1", but only
+        // after 12 unmatched front-matter regions, so key "1" sits at regionIndex 13 there, NOT 0.
+        // Scrolling the main doc from its very top (sender sectionKey "1", scrollProgress near 0)
+        // must NOT snap the reference doc toward ITS OWN top (which would land it back on
+        // "Characters") -- atDocumentStart must be false so the blend is skipped.
+        const regions = [
+            region('front-1'),
+            region('front-2'),
+            region('1'), // "Chapter 1" -- the shared key, NOT this document's first region
+            region('2'),
+        ];
+        const senderSeq = ['1', '2']; // sender's OWN sequence: "1" opens it, at index 0
+
+        const plan = resolveRegionTarget(regions, '1', senderSeq);
+        expect(plan).toEqual({
+            kind: 'exact',
+            regionIndex: 2,
+            atDocumentStart: false, // regionIndex 2 !== 0 locally, regardless of the sender's index 0
+            atDocumentEnd: false,
+        });
+    });
+
+    it('reports atDocumentStart=true when the exact match is at index 0 on BOTH sides (symmetric documents, the ordinary case)', () => {
+        const regions = [region('1'), region('2'), region('3')];
+        const senderSeq = ['1', '2', '3', '4'];
+
+        expect(resolveRegionTarget(regions, '1', senderSeq)).toEqual({
+            kind: 'exact',
+            regionIndex: 0,
+            atDocumentStart: true,
+            atDocumentEnd: false,
+        });
+    });
+
+    it('reports atDocumentEnd=true only when the match is at the last region on BOTH sides', () => {
+        const regions = [region('1'), region('2')];
+        // Sender's sequence has more content after '2' -> sender is not at ITS OWN end there.
+        const senderSeqNotAtEnd = ['1', '2', '3'];
+        expect(resolveRegionTarget(regions, '2', senderSeqNotAtEnd)).toEqual({
+            kind: 'exact',
+            regionIndex: 1,
+            atDocumentStart: false,
+            atDocumentEnd: false,
+        });
+
+        const senderSeqAtEnd = ['0', '1', '2'];
+        expect(resolveRegionTarget(regions, '2', senderSeqAtEnd)).toEqual({
+            kind: 'exact',
+            regionIndex: 1,
+            atDocumentStart: false,
+            atDocumentEnd: true,
+        });
+    });
+
+    it('freezes before chapter-1 while the sender is in an unmatched intro section, not interpolating via the leading sentinel (regression)', () => {
+        // Refdoc structure: leading sentinel region, then an unmatched "toc" section (e.g. a table of
+        // contents heading that has no counterpart in the main doc), then "chapter-1" which IS shared.
+        // Before the LEADING_REGION_KEY exclusion, 'toc' would have found LEADING_REGION_KEY as its
+        // "before" bracket (trivially present in both region lists) and interpolated the receiver
+        // forward from its own leading region toward chapter-1 -- then snapped back once the sender
+        // actually reached chapter-1's exact match. That produced the reported
+        // scroll-down-then-back-up jump. The correct behaviour is freeze-before at chapter-1's start:
+        // there is no genuinely shared anchor before it.
+        const regions = [region(LEADING_REGION_KEY), region('chapter-1'), region('chapter-2')];
+        const senderSeq = [LEADING_REGION_KEY, 'toc', 'chapter-1', 'chapter-2'];
+
+        expect(resolveRegionTarget(regions, 'toc', senderSeq, 0.5)).toEqual({
+            kind: 'freeze-before',
+            regionIndex: 1, // chapter-1
+        });
+    });
+});
+
+describe('shouldBlendTowardScrollProgress', () => {
+    // Regression #1 (found live 2026-07-17): resolveRegionTarget correctly returned 'freeze-before'
+    // for every scroll step while the sender was in tei-book1-outline.xml's unmatched leading
+    // sections, but the main doc still visibly scrolled down and back up before settling. Root cause
+    // was NOT in resolveRegionTarget -- it was that scrollToRegion blended every resolved target
+    // toward the SENDER's overall scrollProgress via blendTowardScrollProgress, unconditionally. That
+    // blend is only meaningful for an 'exact' match (both docs at an equivalent point in shared
+    // structure); for freeze/interpolate outcomes the sender's overall progress has no correspondence
+    // to the receiver's frozen/bracketed position, so blending toward it dragged the "frozen" receiver
+    // up and back down as the sender's progress crossed the extreme-blend band near the document top.
+    //
+    // Regression #2 (found live 2026-07-17, same day): even after fixing #1, scrolling the MAIN doc
+    // (which opens directly on "Chapter 1") still snapped the reference doc to (approximately) its own
+    // document start instead of to its "Chapter 1" region -- 13 regions in. The match WAS 'exact'
+    // (both docs share the "Chapter 1" key), but the sender's overall scrollProgress-near-0 was blended
+    // in anyway, because 'exact' alone was treated as sufficient. It is not: the reference doc's
+    // "Chapter 1" is not at ITS OWN document start, so the sender being at ITS OWN start has no
+    // correspondence to the receiver's position. Fix: 'exact' only blends when the match is ALSO at a
+    // corresponding extreme on both sides (RegionTargetPlan.atDocumentStart / atDocumentEnd).
+    it('blends only for an exact match at a corresponding document start', () => {
+        expect(
+            shouldBlendTowardScrollProgress({
+                kind: 'exact',
+                regionIndex: 0,
+                atDocumentStart: true,
+                atDocumentEnd: false,
+            })
+        ).toBe(true);
+    });
+
+    it('blends only for an exact match at a corresponding document end', () => {
+        expect(
+            shouldBlendTowardScrollProgress({
+                kind: 'exact',
+                regionIndex: 5,
+                atDocumentStart: false,
+                atDocumentEnd: true,
+            })
+        ).toBe(true);
+    });
+
+    it('does NOT blend for an exact match that is at neither extreme (interior match)', () => {
+        expect(
+            shouldBlendTowardScrollProgress({
+                kind: 'exact',
+                regionIndex: 2,
+                atDocumentStart: false,
+                atDocumentEnd: false,
+            })
+        ).toBe(false);
+    });
+
+    it('does NOT blend for an exact match at THIS document\'s extreme when the sender is not correspondingly at its own extreme (the asymmetric "Chapter 1" case)', () => {
+        // This is the exact shape resolveRegionTarget would never actually produce (atDocumentStart
+        // requires BOTH sides), included here to pin the predicate's own logic independent of how the
+        // plan was built.
+        expect(
+            shouldBlendTowardScrollProgress({
+                kind: 'exact',
+                regionIndex: 0,
+                atDocumentStart: false,
+                atDocumentEnd: false,
+            })
+        ).toBe(false);
+    });
+
+    it('does not blend for freeze-before, freeze-after, or interpolate', () => {
+        expect(shouldBlendTowardScrollProgress({ kind: 'freeze-before', regionIndex: 0 })).toBe(false);
+        expect(shouldBlendTowardScrollProgress({ kind: 'freeze-after', regionIndex: 0 })).toBe(false);
+        expect(
+            shouldBlendTowardScrollProgress({
+                kind: 'interpolate',
+                beforeRegionIndex: 0,
+                afterRegionIndex: 1,
+                progress: 0.5,
+            })
+        ).toBe(false);
+    });
+
+    it('never blends for none (though none never reaches this call in practice)', () => {
+        expect(shouldBlendTowardScrollProgress({ kind: 'none' })).toBe(false);
+    });
+});

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorSyncController.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorSyncController.ts
@@ -17,14 +17,268 @@
  */
 import {
     type AnnotationEditor,
+    type TocLevel,
     type ViewportScrollPosition,
     type ViewportScrollTarget,
     type ViewportSyncPeer,
+    generateTOCKeyIndex,
     offsetToRange,
     calculateStartOffset,
     calculateEndOffset,
 } from '@inception-project/inception-js-api';
 import { removeClassFromAncestors } from './Utilities';
+
+/**
+ * Optional document-structure inputs the controller uses for by-key scroll sync (Rule 2)   . All are
+ * read lazily so the controller sees the current document's structure without being reconstructed.
+ * When absent (or when they yield no key), the controller uses only offset/fraction anchoring, so
+ * behaviour is identical to an editor with no structure.
+ */
+export interface SyncStructureAccessors {
+    /** Selector matching section elements (empty string when the document has no structure). */
+    sectionSelector: () => string;
+    /** The structural key for a section element, or undefined when it has none. */
+    extractKey: (section: Element) => string | undefined;
+    /** The current document's TOC tree, or undefined before a document is loaded. */
+    tocRoot: () => TocLevel | undefined;
+}
+
+/**
+ * The document as a flat list of non-overlapping "scroll-sync regions" for by-key sync (Rule 2).
+ *
+ * The document is partitioned by the START offsets of its keyed sections: a region runs from one
+ * section start to the NEXT section start (never back up to an enclosing section), so regions never
+ * nest or overlap and every position belongs to exactly one region -- the non-overlap is what keeps
+ * the intra-region fraction continuous across section boundaries.
+ *
+ * Each region is identified by the key of the section that opens it, so two documents sharing a
+ * structure produce the same ordered region keys and align region-by-region. The leading region
+ * (document start up to the first keyed section) has no opening section and gets a fixed sentinel
+ * key so both documents still match it.
+ */
+export const LEADING_REGION_KEY = '@@sync-leading-region';
+
+export interface SyncRegion {
+    key: string;
+    /** Character-offset span of the region: [start, end). */
+    start: number;
+    end: number;
+    /**
+     * The section element that opens this region, or undefined for the leading region (which starts
+     * at the document top). Its pixel top defines the region boundary the fraction is measured
+     * against; the region ends where the next region's element begins.
+     */
+    startElement?: Element;
+}
+
+/**
+ * Build the sorted, non-overlapping regions from a TOC. Region boundaries are the keyed sections'
+ * start offsets (via {@code calculateStartOffset}); {@code docEnd} closes the last region. Sections
+ * without a key are ignored (they do not partition -- their content belongs to the enclosing
+ * region). Duplicate/shared keys keep their first occurrence in document order, matching
+ * {@link generateTOCKeyIndex}. Returns regions in ascending start order, always beginning with the
+ * leading region [0, firstSectionStart) keyed {@link LEADING_REGION_KEY}.
+ */
+export function buildSyncRegions(root: Element, tocRoot: TocLevel, docEnd: number): SyncRegion[] {
+    const byKey = generateTOCKeyIndex(tocRoot);
+
+    type Boundary = { key: string; start: number; element?: Element };
+    const starts: Boundary[] = [];
+    for (const key of Object.keys(byKey)) {
+        const el = byKey[key].element;
+        if (!el) continue;
+        const start = calculateStartOffset(root, el);
+        if (start < 0) continue;
+        starts.push({ key, start, element: el });
+    }
+
+    starts.sort((a, b) => a.start - b.start);
+
+    // Boundary list: leading sentinel at 0, then each section start (deduped by offset). Two sections
+    // sharing a start offset would make a zero-width region; keep the first key at that offset.
+    const boundaries: Boundary[] = [{ key: LEADING_REGION_KEY, start: 0 }];
+    for (const s of starts) {
+        if (s.start <= 0) continue; // a section at offset 0 replaces the leading region below
+        const prev = boundaries[boundaries.length - 1];
+        if (s.start === prev.start) continue; // same offset -> first key wins
+        boundaries.push(s);
+    }
+    // If a keyed section starts exactly at 0, it owns the leading region instead of the sentinel.
+    const zeroStart = starts.find((s) => s.start === 0);
+    if (zeroStart) boundaries[0] = zeroStart;
+
+    const regions: SyncRegion[] = [];
+    for (let i = 0; i < boundaries.length; i++) {
+        const start = boundaries[i].start;
+        const end = i + 1 < boundaries.length ? boundaries[i + 1].start : docEnd;
+        if (end <= start) continue; // drop empty/inverted regions (e.g. docEnd before last start)
+        regions.push({
+            key: boundaries[i].key,
+            start,
+            end,
+            startElement: boundaries[i].element,
+        });
+    }
+    return regions;
+}
+
+/**
+ * How to place the receiver's viewport for an incoming by-key sync position, once the receiver's
+ * own regions are compared against the sender's key sequence.
+ */
+export type RegionTargetPlan =
+    /**
+     * The receiver has a region for `pos.sectionKey` directly: place at that region's own fraction.
+     *
+     * `atDocumentStart`/`atDocumentEnd` say whether this match sits at THIS document's first/last
+     * region AND (when the sender's sequence is available) at the SENDER's first/last region too --
+     * i.e. whether the two documents' overall extremes genuinely correspond here. A matched key can
+     * be common to both documents while sitting at wildly different overall positions (e.g. a shared
+     * "Chapter 1" that opens the main document but is the 13th region of a reference document with 12
+     * unmatched front-matter sections first) -- there, the sender being at overall scrollProgress 0
+     * does NOT mean this document's matching region is anywhere near ITS OWN top. Both flags default
+     * true when the sender sent no sequence (nothing to disprove correspondence with).
+     */
+    | { kind: 'exact'; regionIndex: number; atDocumentStart: boolean; atDocumentEnd: boolean }
+    /**
+     * Neither `pos.sectionKey` nor any bracketing key before/after it (in the sender's sequence) has
+     * a region here: no shared structure to align on at all.
+     */
+    | { kind: 'none' }
+    /**
+     * The sender's current region has no local match, but a shared key exists on both sides of it in
+     * the sender's sequence. Interpolate the receiver's viewport between the two bracketing regions,
+     * scaled by how far the sender has progressed from the "before" key to the "after" key.
+     */
+    | { kind: 'interpolate'; beforeRegionIndex: number; afterRegionIndex: number; progress: number }
+    /**
+     * Only a "before" key matches (the sender is past the last key it shares with the receiver, e.g.
+     * a trailing document-only section): freeze at that region's end.
+     */
+    | { kind: 'freeze-after'; regionIndex: number }
+    /**
+     * Only an "after" key matches (the sender is before the first key it shares with the receiver):
+     * freeze at that region's start.
+     */
+    | { kind: 'freeze-before'; regionIndex: number };
+
+/**
+ * Decide how to place the receiver's viewport for a by-key sync position, given the receiver's own
+ * regions and the sender's full ordered key sequence.
+ *
+ * The sender's sequence is required to bracket a miss: the receiver alone has no notion of "where in
+ * the sender's document" an unmatched key sits, only the sender's own region order tells us that. See
+ * {@link RegionTargetPlan} for the five outcomes.
+ *
+ * {@link LEADING_REGION_KEY} is never accepted as a BRACKET (only ever as an exact match): it is a
+ * fixed sentinel every document's region list starts with, so it is trivially "shared" even when the
+ * two documents' actual leading content is unrelated (e.g. a title page here, a different preface
+ * there). Treating it as a real bracket anchor would interpolate the receiver toward its own leading
+ * region while the sender is still in an unmatched section before the first real heading, then snap
+ * back once the sender reaches a genuinely shared key -- a scroll-down-then-back-up jump.
+ */
+export function resolveRegionTarget(
+    regions: SyncRegion[],
+    sectionKey: string,
+    sectionKeySequence: string[] | undefined,
+    sectionFraction = 0
+): RegionTargetPlan {
+    const exactIdx = regions.findIndex((r) => r.key === sectionKey);
+    if (exactIdx >= 0) {
+        const senderIdx = sectionKeySequence?.indexOf(sectionKey) ?? -1;
+        const senderKnown = sectionKeySequence !== undefined && senderIdx >= 0;
+        return {
+            kind: 'exact',
+            regionIndex: exactIdx,
+            atDocumentStart: exactIdx === 0 && (!senderKnown || senderIdx === 0),
+            atDocumentEnd:
+                exactIdx === regions.length - 1 &&
+                (!senderKnown || senderIdx === (sectionKeySequence as string[]).length - 1),
+        };
+    }
+
+    if (!sectionKeySequence || sectionKeySequence.length === 0) return { kind: 'none' };
+
+    const senderIdx = sectionKeySequence.indexOf(sectionKey);
+    if (senderIdx < 0) return { kind: 'none' };
+
+    const localIndexOf = new Map(regions.map((r, i) => [r.key, i]));
+
+    let beforeSenderIdx = -1;
+    let beforeRegionIndex = -1;
+    for (let i = senderIdx - 1; i >= 0; i--) {
+        const key = sectionKeySequence[i];
+        if (key === LEADING_REGION_KEY) continue;
+        const idx = localIndexOf.get(key);
+        if (idx !== undefined) {
+            beforeSenderIdx = i;
+            beforeRegionIndex = idx;
+            break;
+        }
+    }
+
+    let afterSenderIdx = -1;
+    let afterRegionIndex = -1;
+    for (let i = senderIdx + 1; i < sectionKeySequence.length; i++) {
+        const key = sectionKeySequence[i];
+        if (key === LEADING_REGION_KEY) continue;
+        const idx = localIndexOf.get(key);
+        if (idx !== undefined) {
+            afterSenderIdx = i;
+            afterRegionIndex = idx;
+            break;
+        }
+    }
+
+    if (beforeRegionIndex < 0 && afterRegionIndex < 0) return { kind: 'none' };
+    if (beforeRegionIndex < 0) return { kind: 'freeze-before', regionIndex: afterRegionIndex };
+    if (afterRegionIndex < 0) return { kind: 'freeze-after', regionIndex: beforeRegionIndex };
+
+    // Both found: the sender's progress from the "before" key to the "after" key, in sender-key-index
+    // space, is the fraction to place the receiver between the two bracketing regions. The sender's
+    // current position is `senderIdx` keys past `beforeSenderIdx`, plus its fractional progress
+    // through its own current region (so movement is smooth within a single unmatched region rather
+    // than stepping only at key boundaries), out of the `afterSenderIdx - beforeSenderIdx` keys
+    // between the two bracketing keys.
+    const span = afterSenderIdx - beforeSenderIdx;
+    const progress = span > 0 ? (senderIdx - beforeSenderIdx + sectionFraction) / span : 0;
+    return {
+        kind: 'interpolate',
+        beforeRegionIndex,
+        afterRegionIndex,
+        progress: Math.min(1, Math.max(0, progress)),
+    };
+}
+
+/**
+ * @return whether a resolved {@link RegionTargetPlan} should be placed via
+ * {@link blendTowardScrollProgress} (blending the computed pixel target toward the sender's overall
+ * scroll progress near a document extreme) rather than applied as-is.
+ *
+ * Only `'exact'` can qualify, and even then only when the matched region sits at BOTH documents'
+ * corresponding overall extreme (`atDocumentStart`/`atDocumentEnd` -- see {@link RegionTargetPlan}).
+ * There, the sender's overall progress is a meaningful stand-in for "how close to MY OWN top/bottom
+ * should I be", which is exactly what the blend is for.
+ *
+ * For `'freeze-before'`/`'freeze-after'`/`'interpolate'` the sender is partly or wholly in content this
+ * document does not have, so its overall progress has no such correspondence: blending toward it pulls
+ * the receiver away from the resolved target as the sender's progress climbs, then back as the blend's
+ * near-extreme weighting fades -- a scroll-down-then-back-up wobble instead of a hold (found live
+ * 2026-07-17, reference doc `tei-book1-outline.xml` scrolling through its unmatched leading sections
+ * before "Chapter 1"). Applying `target` directly for those three kinds is what makes a freeze an
+ * actual freeze and an interpolation a straight line.
+ *
+ * The `atDocumentStart`/`atDocumentEnd` guard is what makes an `'exact'` match qualify only at
+ * genuinely corresponding extremes: a shared key can sit at very different overall positions in the
+ * two documents (the front-matter case in {@link RegionTargetPlan}), and without the guard blending
+ * snapped the receiver toward its own document start instead of the matched region -- found live
+ * 2026-07-17, scrolling the MAIN doc (which starts at "Chapter 1") while linked to a reference
+ * document that reaches "Chapter 1" only after 12 unmatched front-matter sections.
+ */
+export function shouldBlendTowardScrollProgress(plan: RegionTargetPlan): boolean {
+    if (plan.kind !== 'exact') return false;
+    return plan.atDocumentStart || plan.atDocumentEnd;
+}
 
 // CSS `display` values whose boxes are block-level; an element with one of these owns a
 // distinct block in the flow and so can anchor a text offset (a box whose height is a
@@ -45,6 +299,47 @@ const OVERLAY_SELECTOR =
     ' iaa-visible-annotations-panel, iaa-visible-annotations-panel-spacer';
 
 /**
+ * Fraction of the scroll range over which to blend toward whole-container progress at each end.
+ */
+const EXTREME_BLEND_BAND = 0.15;
+
+/**
+ * Blend an offset-anchored scrollTop toward whole-container scroll progress near the extremes.
+ *
+ * Offset-anchoring aligns viewport top positions, so near a scroll extreme it lands short of this editor's
+ * own extreme (the two editors have different amounts of content below the shared top block). A
+ * pure progress mapping hits the extremes exactly but drifts in the interior. Weighting toward
+ * progress only within a band next to each extreme makes the extremes exact AND keeps the interior
+ * offset-accurate, with no snap at the boundary between the two regimes.
+ */
+export function blendTowardScrollProgress(
+    anchoredTop: number,
+    scrollProgress: number | undefined,
+    maxScroll: number
+): number {
+    if (scrollProgress === undefined || maxScroll <= 0) return anchoredTop;
+
+    const progressTop = scrollProgress * maxScroll;
+    const p = scrollProgress;
+    // 1 at an extreme -> 0 by EXTREME_BLEND_BAND in from it.
+    const nearness = Math.max(0, 1 - Math.min(p, 1 - p) / EXTREME_BLEND_BAND);
+    return nearness * progressTop + (1 - nearness) * anchoredTop;
+}
+
+/**
+ * Whether two {@code scrollProgress} values would drive {@link blendTowardScrollProgress} to the
+ * same place, for the per-frame dedup in {@link ApacheAnnotatorSyncController}. Uses the same 0.01
+ * tolerance as the fraction comparison there.
+ *
+ * A present value never matches an absent one: dropping progress switches the receiver from the
+ * blended target back to the bare offset anchor, which is a real move, not a no-op.
+ */
+export function sameScrollProgress(a: number | undefined, b: number | undefined): boolean {
+    if (a === undefined || b === undefined) return a === b;
+    return Math.abs(a - b) < 0.01;
+}
+
+/**
  * Editor-to-editor viewport synchronization for the Apache Annotator visualizer. Implements the
  * {@code AnnotationEditor} viewport-sync protocol: {@link getViewportScrollPosition} reports the
  * document offset currently at the viewport top (plus how far the top has scrolled into it), and
@@ -61,17 +356,63 @@ export class ApacheAnnotatorSyncController {
     private readonly root: Element;
     private readonly getScrollContainer: () => Element | undefined;
 
-    /** Last viewport position applied by {@link scrollToViewportPosition}, for per-frame dedup. */
-    private lastAppliedViewportScrollPosition: { begin: number; fraction: number } | undefined =
-        undefined;
+    /**
+     * Last viewport position applied by {@link scrollToViewportPosition}, for per-frame dedup.
+     *
+     * {@code scrollProgress} is part of the key because it independently moves the applied
+     * scrollTop via the extreme blend: two positions agreeing on begin/fraction can still target
+     * different pixels near an extreme, and dropping progress from the key would dedup those away.
+     *
+     * Dedup is per-regime, never across the two: the by-key path ({@link scrollToRegion}) and the
+     * offset path ({@link scrollToOffset}) compute different pixel targets from the same
+     * begin/fraction (region-fractional vs. block-anchored), so a value applied by one regime must
+     * not suppress a re-apply by the other. Each guard therefore also checks {@code sectionKey}:
+     * {@link scrollToRegion} requires the last apply to have been by-key ({@code sectionFraction}
+     * present), {@link scrollToOffset} requires it to have been offset ({@code sectionKey} absent).
+     */
+    private lastAppliedViewportScrollPosition:
+        | {
+              begin: number;
+              fraction: number;
+              scrollProgress: number | undefined;
+              sectionKey?: string;
+              sectionFraction?: number;
+          }
+        | undefined = undefined;
 
     /** The hub this controller has registered its editor with, and the id it used. */
     private hub?: ViewportSyncPeer;
     private hubPeerId?: string;
 
+    /** Document-structure inputs for by-key sync; undefined until {@link setDocumentStructure}. */
+    private structure?: SyncStructureAccessors;
+
+    /**
+     * Memoized flat scroll-sync regions for the current tocRoot, so per-scroll region lookup does not
+     * re-walk the TOC. Rebuilt lazily when the tocRoot identity changes (e.g. a new document is
+     * loaded), which is why the tocRoot it was built from is remembered alongside it.
+     */
+    private regions?: SyncRegion[];
+    private regionsTocRoot?: TocLevel;
+    /** The keys of {@link regions} in order, memoized alongside it so the per-frame producer path
+     * (see {@link augmentWithSectionPosition}) reuses one array instead of remapping every frame. */
+    private regionKeys?: string[];
+
     constructor(root: Element, getScrollContainer: () => Element | undefined) {
         this.root = root;
         this.getScrollContainer = getScrollContainer;
+    }
+
+    /**
+     * Provide (or replace) the document-structure inputs used for by-key scroll sync. Called by the
+     * editor once the document outline exists. Without this, the controller uses offset anchoring
+     * only.
+     */
+    setDocumentStructure(structure: SyncStructureAccessors): void {
+        this.structure = structure;
+        // Drop any memoized regions; they will be rebuilt lazily from the new structure's tocRoot.
+        this.regions = undefined;
+        this.regionsTocRoot = undefined;
     }
 
     /**
@@ -116,13 +457,201 @@ export class ApacheAnnotatorSyncController {
             anchorRect.height > 0
                 ? Math.min(1, Math.max(0, (containerRect.top - anchorRect.top) / anchorRect.height))
                 : 0;
-        return { begin, end, fraction };
+
+        // Overall scroll progress lets the receiver blend toward its own extreme near the top/bottom
+        // (see ViewportScrollPosition.scrollProgress), so scrolling just off an extreme no longer snaps.
+        const maxScroll = container.scrollHeight - container.clientHeight;
+        const scrollProgress = maxScroll > 0 ? container.scrollTop / maxScroll : 0;
+
+        const pos: ViewportScrollPosition = { begin, end, fraction, scrollProgress };
+
+        // Additive by-key augmentation (Rule 2). Leaves the offset result above untouched; only
+        // attaches a region key + intra-region fraction when the viewport top falls in a keyed region.
+        // Any missing step (no structure, no region) leaves the fields unset, and the receiver falls
+        // back to offset anchoring.
+        this.augmentWithSectionPosition(pos, container);
+
+        return pos;
+    }
+
+    /**
+     * Attach {@code sectionKey} / {@code sectionFraction} to {@code pos} for by-key sync, using the
+     * flat scroll-sync region containing the viewport top. Pure follow-on: it never alters the offset
+     * fields, so a receiver without matching regions still has the offset path to fall back on.
+     *
+     * The fraction is in PIXEL space, not character space: characters are not evenly distributed down
+     * a region (a heading is few characters but many pixels tall), so a char fraction would advance
+     * unevenly against a smooth scroll. The viewport-top scroll position is monotonic with scrolling,
+     * and the receiver works in the same pixel space as its exact inverse.
+     */
+    private augmentWithSectionPosition(pos: ViewportScrollPosition, container: Element): void {
+        const regions = this.syncRegions();
+        if (!regions) return; // no structure/outline -> offset anchoring only
+
+        // The viewport top expressed as a scroll position (0 = document top). Region tops are in the
+        // same coordinate (see regionTopScrollPos), so bracketing is a direct comparison.
+        const viewportTop = container.scrollTop;
+        const containerTop = container.getBoundingClientRect().top;
+
+        for (let i = 0; i < regions.length; i++) {
+            const topPx = this.regionTopScrollPos(container, regions[i], containerTop);
+            const bottomPx =
+                i + 1 < regions.length
+                    ? this.regionTopScrollPos(container, regions[i + 1], containerTop)
+                    : container.scrollHeight;
+            // Bracket the viewport top; the last region also catches anything at/after its bottom.
+            const isLast = i === regions.length - 1;
+            if (viewportTop < topPx) break; // regions are sorted; nothing earlier can match
+            if (viewportTop < bottomPx || isLast) {
+                const height = bottomPx - topPx;
+                if (height <= 0) return;
+                pos.sectionKey = regions[i].key;
+                pos.sectionFraction = Math.min(1, Math.max(0, (viewportTop - topPx) / height));
+                pos.sectionKeySequence = this.regionKeys;
+                return;
+            }
+        }
+    }
+
+    /**
+     * The scroll position (0 = document top) at which a region's top reaches the viewport top. For
+     * the leading region (no start element) that is 0; otherwise it is the section element's top
+     * translated into scroll-position space. Shared by the producer's region lookup and the receiver's
+     * placement so both sides agree on region boundaries exactly.
+     */
+    private regionTopScrollPos(
+        container: Element,
+        region: SyncRegion,
+        containerTop = container.getBoundingClientRect().top
+    ): number {
+        if (!region.startElement) return 0;
+        return container.scrollTop + (this.elementTop(region.startElement) - containerTop);
     }
 
     scrollToViewportPosition(pos: ViewportScrollTarget): void {
         const container = this.getScrollContainer();
         if (!container) return;
 
+        // By-key sync (Rule 2): if the source tagged a region key this document also has, scroll
+        // region-fractionally (the inverse of the producer). Otherwise fall back to offset anchoring.
+        if (pos.sectionKey !== undefined && this.scrollToRegion(container, pos)) return;
+
+        this.scrollToOffset(container, pos);
+    }
+
+    /**
+     * Region-fractional scroll. Resolves `pos.sectionKey` against this document's own regions via
+     * {@link resolveRegionTarget}:
+     * - an exact region match scrolls to `region.start + fraction*(regionHeight)`, the inverse of the
+     *   producer (unchanged from before bracketing existed);
+     * - a miss that brackets between two shared keys interpolates the viewport between those regions'
+     *   boundaries;
+     * - a miss with only a "before" or only an "after" bracketing key freezes at that region's
+     *   boundary (the sender is past the last, or before the first, key shared with this document);
+     * - no bracket at all (`kind: 'none'`) returns false so the caller falls back to offset anchoring.
+     */
+    private scrollToRegion(container: Element, pos: ViewportScrollTarget): boolean {
+        const regions = this.syncRegions();
+        if (!regions || pos.sectionKey === undefined) return false;
+
+        const plan = resolveRegionTarget(
+            regions,
+            pos.sectionKey,
+            pos.sectionKeySequence,
+            pos.sectionFraction ?? 0
+        );
+        if (plan.kind === 'none') return false;
+
+        // Region top/bottom as scroll positions, via the SAME helper the producer uses so both sides
+        // agree on the boundary exactly. Bottom = the next region's top, or the document bottom for
+        // the last region.
+        const regionBoundary = (index: number): number => {
+            const next = regions[index + 1];
+            return next ? this.regionTopScrollPos(container, next) : container.scrollHeight;
+        };
+
+        let target: number;
+        switch (plan.kind) {
+            case 'exact': {
+                const topPx = this.regionTopScrollPos(container, regions[plan.regionIndex]);
+                const bottomPx = regionBoundary(plan.regionIndex);
+                const height = bottomPx - topPx;
+                if (height <= 0) return false;
+                const frac = Math.min(1, Math.max(0, pos.sectionFraction ?? 0));
+                target = topPx + frac * height;
+                break;
+            }
+            case 'freeze-after': {
+                // Past the last shared key: hold at that region's own end (its boundary with
+                // whatever unmatched content follows it here), rather than following the sender
+                // further into content this document doesn't have.
+                target = regionBoundary(plan.regionIndex);
+                break;
+            }
+            case 'freeze-before': {
+                // Before the first shared key: hold at that region's start.
+                target = this.regionTopScrollPos(container, regions[plan.regionIndex]);
+                break;
+            }
+            case 'interpolate': {
+                const topPx = this.regionTopScrollPos(container, regions[plan.beforeRegionIndex]);
+                const bottomPx = this.regionTopScrollPos(container, regions[plan.afterRegionIndex]);
+                target = topPx + plan.progress * (bottomPx - topPx);
+                break;
+            }
+        }
+
+        // Dedup identical re-applies (per-frame), same axis as the offset path. For 'freeze-before'/
+        // 'freeze-after' this under-dedups (the sender's sectionFraction keeps changing while frozen,
+        // so the comparison below never matches and scrollTop is reassigned every frame) -- harmless
+        // since the reassigned value is the same pixel target each time, just not free.
+        const frac = Math.min(1, Math.max(0, pos.sectionFraction ?? 0));
+        const last = this.lastAppliedViewportScrollPosition;
+        if (
+            last &&
+            last.sectionKey === pos.sectionKey &&
+            last.sectionFraction !== undefined &&
+            Math.abs(last.sectionFraction - frac) < 0.001 &&
+            sameScrollProgress(last.scrollProgress, pos.scrollProgress)
+        ) {
+            return true;
+        }
+        this.lastAppliedViewportScrollPosition = {
+            begin: pos.begin,
+            fraction: Math.min(1, Math.max(0, pos.fraction)),
+            scrollProgress: pos.scrollProgress,
+            sectionKey: pos.sectionKey,
+            sectionFraction: frac,
+        };
+
+        // See shouldBlendTowardScrollProgress for why only an 'exact' match AT A CORRESPONDING
+        // DOCUMENT EXTREME blends toward the sender's overall scrollProgress; everything else applies
+        // `target` as-is.
+        if (shouldBlendTowardScrollProgress(plan)) {
+            const maxScroll = container.scrollHeight - container.clientHeight;
+            container.scrollTop = blendTowardScrollProgress(target, pos.scrollProgress, maxScroll);
+        } else {
+            container.scrollTop = target;
+        }
+        return true;
+    }
+
+    /**
+     * Read a region start element's viewport-top. Pure measurement: this runs on the read/measure
+     * path ({@link getViewportScrollPosition} via {@link regionTopScrollPos}, every scroll frame),
+     * so it must never write to the DOM. Un-secluding here would strip {@code iaa-secluded} off
+     * sections merely being measured, permanently defeating the seclusion/windowing optimization for
+     * large documents. It is also unnecessary: a top-level secluded section is {@code visibility:
+     * hidden}, which keeps its layout box, so its top measures correctly while still hidden. (The
+     * offset scroll path in {@link scrollToOffset} legitimately unhides its target -- it is about to
+     * scroll to that block, not just measure it.)
+     */
+    private elementTop(element: Element): number {
+        return element.getBoundingClientRect().top;
+    }
+
+    /** Offset-anchored scroll, used when by-key sync does not apply. */
+    private scrollToOffset(container: Element, pos: ViewportScrollTarget): void {
         const range = offsetToRange(this.root, pos.begin, pos.begin);
         if (!range) return;
 
@@ -134,10 +663,20 @@ export class ApacheAnnotatorSyncController {
         // Skip if the scroll request would not actually move the scroll position
         const fraction = Math.min(1, Math.max(0, pos.fraction));
         const last = this.lastAppliedViewportScrollPosition;
-        if (last && last.begin === pos.begin && Math.abs(last.fraction - fraction) < 0.01) {
+        if (
+            last &&
+            last.sectionKey === undefined && // only dedup against a prior offset-path apply (see field doc)
+            last.begin === pos.begin &&
+            Math.abs(last.fraction - fraction) < 0.01 &&
+            sameScrollProgress(last.scrollProgress, pos.scrollProgress)
+        ) {
             return;
         }
-        this.lastAppliedViewportScrollPosition = { begin: pos.begin, fraction };
+        this.lastAppliedViewportScrollPosition = {
+            begin: pos.begin,
+            fraction,
+            scrollProgress: pos.scrollProgress,
+        };
 
         // If necessary unhide the target block before measuring. We unhide only if hidden because a write (even a noop one) to the DOM can invalidate the layout
         if (block.closest('.iaa-secluded')) {
@@ -146,8 +685,28 @@ export class ApacheAnnotatorSyncController {
 
         const containerRect = container.getBoundingClientRect();
         const blockRect = block.getBoundingClientRect();
-        container.scrollTop =
+        const anchoredTop =
             container.scrollTop + (blockRect.top - containerRect.top) + fraction * blockRect.height;
+
+        const maxScroll = container.scrollHeight - container.clientHeight;
+        container.scrollTop = blendTowardScrollProgress(anchoredTop, pos.scrollProgress, maxScroll);
+    }
+
+    /**
+     * The current document's flat scroll-sync regions, memoized and rebuilt when the tocRoot changes.
+     * Returns undefined when there is no structure/outline (then sync uses plain offset anchoring).
+     */
+    private syncRegions(): SyncRegion[] | undefined {
+        const tocRoot = this.structure?.tocRoot();
+        if (!tocRoot) return undefined;
+
+        if (this.regions === undefined || this.regionsTocRoot !== tocRoot) {
+            const docEnd = calculateEndOffset(this.root, this.root);
+            this.regions = buildSyncRegions(this.root, tocRoot, docEnd);
+            this.regionKeys = this.regions.map((r) => r.key);
+            this.regionsTocRoot = tocRoot;
+        }
+        return this.regions.length ? this.regions : undefined;
     }
 
     /**

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorVisualizer.svelte.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/ApacheAnnotatorVisualizer.svelte.ts
@@ -43,7 +43,10 @@ import { SectionAnnotationCreator } from './SectionAnnotationCreator';
 import { RelationVisualizer } from './RelationVisualizer';
 import { RelationGripLayer, GRIP_CLASS } from './RelationGripLayer';
 import { RelationDragController, type PickRelationTarget } from './RelationDragController';
-import { ApacheAnnotatorSyncController } from './ApacheAnnotatorSyncController';
+import {
+    ApacheAnnotatorSyncController,
+    type SyncStructureAccessors,
+} from './ApacheAnnotatorSyncController';
 import {
     groupHighlightsByVid,
     removeClassFromAncestors,
@@ -218,6 +221,14 @@ export class ApacheAnnotatorVisualizer {
             this.root,
             () => this.scrollContainer
         );
+    }
+
+    /**
+     * Provide the document-structure inputs used for by-key scroll sync. Forwarded to the sync
+     * controller; called by the editor once the document outline has been built.
+     */
+    public setSyncDocumentStructure(structure: SyncStructureAccessors): void {
+        this.syncController.setDocumentStructure(structure);
     }
 
     /**

--- a/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/Utilities.ts
+++ b/inception/inception-html-apache-annotator-editor/src/main/ts/src/apache-annotator/Utilities.ts
@@ -486,7 +486,8 @@ export function compileNsSelector(selector?: string | null): ((el: Element) => b
 
     if (selector === '') return null;
     type Token =
-        { type: 'css'; sel: string } | { type: 'ns'; namespace: string | '*'; localName: string };
+        | { type: 'css'; sel: string }
+        | { type: 'ns'; namespace: string | '*'; localName: string };
 
     const parts: string[] = [];
     let buf = '';

--- a/inception/inception-io-html/src/main/ts/src/HtmlDocumentStructure.test.ts
+++ b/inception/inception-io-html/src/main/ts/src/HtmlDocumentStructure.test.ts
@@ -262,6 +262,44 @@ describe('HtmlDocumentStructure', () => {
         });
     });
 
+    describe('extractKey', () => {
+        it('prefers a source id on the section heading', () => {
+            container.innerHTML =
+                '<sec-wrap id="sec-wrap-3"><h2 id="introduction">Intro</h2></sec-wrap>';
+            const section = container.querySelector('sec-wrap')!;
+            expect(new HtmlDocumentStructure().extractKey(section)).toBe('introduction');
+        });
+
+        it('falls back to the generated sec-wrap id when the heading has no id', () => {
+            container.innerHTML = '<sec-wrap id="sec-wrap-3"><h2>Intro</h2></sec-wrap>';
+            const section = container.querySelector('sec-wrap')!;
+            expect(new HtmlDocumentStructure().extractKey(section)).toBe('sec-wrap-3');
+        });
+
+        it('falls back to the section id when there is no heading at all', () => {
+            container.innerHTML = '<sec-wrap id="sec-wrap-3"><div>body</div></sec-wrap>';
+            const section = container.querySelector('sec-wrap')!;
+            expect(new HtmlDocumentStructure().extractKey(section)).toBe('sec-wrap-3');
+        });
+
+        it('returns undefined when neither the heading nor the section carries an id', () => {
+            container.innerHTML = '<sec-wrap><h2>Intro</h2></sec-wrap>';
+            const section = container.querySelector('sec-wrap')!;
+            expect(new HtmlDocumentStructure().extractKey(section)).toBeUndefined();
+        });
+
+        it('produces the generated id assigned by preprocess as the fallback key', () => {
+            container.innerHTML = '<h1>A</h1><h2>B</h2>';
+            const s = new HtmlDocumentStructure();
+            s.preprocess(container);
+            const wraps = container.querySelectorAll('sec-wrap');
+            // No source ids, so the key is the preprocess-assigned sec-wrap-N.
+            expect(s.extractKey(wraps[0])).toBe(wraps[0].id);
+            expect(s.extractKey(wraps[1])).toBe(wraps[1].id);
+            expect(wraps[0].id).not.toBe(wraps[1].id);
+        });
+    });
+
     describe('sectionSelector', () => {
         it('matches the synthetic wrapper element', () => {
             const s = new HtmlDocumentStructure();

--- a/inception/inception-io-html/src/main/ts/src/HtmlDocumentStructure.ts
+++ b/inception/inception-io-html/src/main/ts/src/HtmlDocumentStructure.ts
@@ -52,6 +52,11 @@ export class HtmlDocumentStructure implements DocumentStructureStrategy {
         return section.querySelector(DIRECT_HEADING_SELECTOR) ?? section;
     }
 
+    extractKey(section: Element): string | undefined {
+        const headingId = section.querySelector(DIRECT_HEADING_SELECTOR)?.id;
+        return headingId || section.id || undefined;
+    }
+
     private wrapHeadingSectionsIn(container: Element, counter: { n: number }) {
         const doc = container.ownerDocument;
         const isHeading = (node: Node): node is HTMLElement =>

--- a/inception/inception-io-tei/src/main/java/de/tudarmstadt/ukp/inception/io/tei/TeiXmlDocumentPolicy.yaml
+++ b/inception/inception-io-tei/src/main/java/de/tudarmstadt/ukp/inception/io/tei/TeiXmlDocumentPolicy.yaml
@@ -131,6 +131,7 @@ policies:
     action: PASS
   - { attributes: ["fform", "nform"],  on_elements: ["tok"], action: "PASS" }
   - { attributes: ["class", "type"], action: "PASS" }
+  - { attributes: ["{http://www.w3.org/XML/1998/namespace}id", "n"], on_elements: ["div"], action: "PASS" }
   - { attributes: ["place", "n"], on_elements: ["note"], action: "PASS" }
   - { attributes: ["n"], on_elements: ["pb"], action: "PASS" }
   - { attributes: ["type", "place"], on_elements: ["fw"], action: "PASS" }

--- a/inception/inception-io-tei/src/main/ts/src/TeiDocumentStructure.test.ts
+++ b/inception/inception-io-tei/src/main/ts/src/TeiDocumentStructure.test.ts
@@ -21,7 +21,12 @@ import { TeiDocumentStructure } from './TeiDocumentStructure';
 let container: HTMLElement;
 
 beforeEach(() => {
-    container = document.createElement('div');
+    // Use a non-<div> container so it stands in for the TEI <body>/<text>
+    // wrapper that structural <div>s actually live under. extractKey's
+    // @n-path walk stops at the first non-<div> ancestor, so the container's
+    // tag name defines where a path is rooted -- a <div> container would
+    // wrongly become part of every path.
+    container = document.createElement('section');
     document.body.appendChild(container);
 });
 
@@ -106,6 +111,102 @@ describe('TeiDocumentStructure', () => {
             const section = el('div', el('p', 'only body'));
             container.appendChild(section);
             expect(new TeiDocumentStructure().scrollTarget(section)).toBe(section);
+        });
+    });
+
+    describe('extractKey', () => {
+        it('returns xml:id when present', () => {
+            const section = el('div', el('head', 'A'));
+            section.setAttribute('xml:id', 'chapter-1');
+            container.appendChild(section);
+            expect(new TeiDocumentStructure().extractKey(section)).toBe('chapter-1');
+        });
+
+        it('prefers xml:id over the @n-path', () => {
+            const section = el('div', el('head', 'A'));
+            section.setAttribute('xml:id', 'chapter-1');
+            section.setAttribute('n', '1');
+            container.appendChild(section);
+            expect(new TeiDocumentStructure().extractKey(section)).toBe('chapter-1');
+        });
+
+        it('falls back to a single-segment @n-path for a top-level div', () => {
+            const section = el('div', el('head', 'A'));
+            section.setAttribute('n', '1');
+            container.appendChild(section);
+            expect(new TeiDocumentStructure().extractKey(section)).toBe('1');
+        });
+
+        it('builds a slash-separated @n-path from the chain of div ancestors', () => {
+            // A bare @n is only unique among siblings; the path 1/4/5 is what
+            // makes a level-3 section globally identifiable.
+            const inner = el('div', el('head', 'C'));
+            inner.setAttribute('n', '5');
+            const mid = el('div', el('head', 'B'), inner);
+            mid.setAttribute('n', '4');
+            const top = el('div', el('head', 'A'), mid);
+            top.setAttribute('n', '1');
+            container.appendChild(top);
+            expect(new TeiDocumentStructure().extractKey(inner)).toBe('1/4/5');
+        });
+
+        it('separates with / so full-path @n cannot collide with nested local @n', () => {
+            // Full-path @n="1.1" on a single div must not produce the same key as two nested
+            // divs with local @n="1". With '/' as the separator the two are distinct.
+            const fullPath = el('div', el('head', 'X'));
+            fullPath.setAttribute('n', '1.1');
+            container.appendChild(fullPath);
+
+            const outer = el('div', el('head', 'A'));
+            outer.setAttribute('n', '1');
+            const nested = el('div', el('head', 'B'));
+            nested.setAttribute('n', '1');
+            outer.appendChild(nested);
+            container.appendChild(outer);
+
+            const s = new TeiDocumentStructure();
+            expect(s.extractKey(fullPath)).toBe('1.1'); // single segment, kept verbatim
+            expect(s.extractKey(nested)).toBe('1/1'); // two segments
+            expect(s.extractKey(fullPath)).not.toBe(s.extractKey(nested));
+        });
+
+        it('stops the path at the first non-div ancestor', () => {
+            // A <body>/<text> wrapper terminates the chain, so the path is
+            // relative to the outermost div -- not affected by non-div parents.
+            const inner = el('div', el('head', 'B'));
+            inner.setAttribute('n', '2');
+            const top = el('div', el('head', 'A'), inner);
+            top.setAttribute('n', '1');
+            const body = el('body', top);
+            container.appendChild(body);
+            expect(new TeiDocumentStructure().extractKey(inner)).toBe('1/2');
+        });
+
+        it('returns undefined when a div ancestor in the chain lacks @n (gap)', () => {
+            // The path cannot be reconstructed identically on the peer if a
+            // link is missing, so no key is emitted.
+            const inner = el('div', el('head', 'C'));
+            inner.setAttribute('n', '5');
+            const mid = el('div', el('head', 'B'), inner); // no @n -- gap
+            const top = el('div', el('head', 'A'), mid);
+            top.setAttribute('n', '1');
+            container.appendChild(top);
+            expect(new TeiDocumentStructure().extractKey(inner)).toBeUndefined();
+        });
+
+        it('returns undefined when the section itself lacks @n and xml:id', () => {
+            const section = el('div', el('head', 'A'));
+            container.appendChild(section);
+            expect(new TeiDocumentStructure().extractKey(section)).toBeUndefined();
+        });
+
+        it('reads xml:id supplied as a namespaced attribute', () => {
+            // When the document is parsed as XML rather than HTML, xml:id lands
+            // as a namespaced attribute rather than one literally named "xml:id".
+            const section = el('div', el('head', 'A'));
+            section.setAttributeNS('http://www.w3.org/XML/1998/namespace', 'xml:id', 'chapter-ns');
+            container.appendChild(section);
+            expect(new TeiDocumentStructure().extractKey(section)).toBe('chapter-ns');
         });
     });
 

--- a/inception/inception-io-tei/src/main/ts/src/TeiDocumentStructure.ts
+++ b/inception/inception-io-tei/src/main/ts/src/TeiDocumentStructure.ts
@@ -45,4 +45,33 @@ export class TeiDocumentStructure implements DocumentStructureStrategy {
     scrollTarget(section: Element): Element {
         return section.querySelector(':scope > head') ?? section;
     }
+
+    extractKey(section: Element): string | undefined {
+        // If there is an xml:id, we use that.
+        const xmlId =
+            section.getAttributeNS('http://www.w3.org/XML/1998/namespace', 'id') ??
+            section.getAttribute('xml:id');
+        if (xmlId) {
+            return xmlId;
+        }
+
+        // Otherwise we try to derive a key from the @n attributes of this section and its ancestors.
+        return this.nPath(section);
+    }
+
+    private nPath(section: Element): string | undefined {
+        const segments: string[] = [];
+        // TEI uses <div> for sections; we walk the <div> chain to build a unique path of @n values.
+        // If any <div> lacks @n, the path is incomplete and we return undefined.
+        let current: Element | null = section;
+        while (current && current.localName === 'div') {
+            const n = current.getAttribute('n');
+            if (!n) {
+                return undefined;
+            }
+            segments.unshift(n);
+            current = current.parentElement;
+        }
+        return segments.length ? segments.join('/') : undefined;
+    }
 }

--- a/inception/inception-js-api/src/main/ts/src/documentStructure/DocumentStructureNavigator.svelte
+++ b/inception/inception-js-api/src/main/ts/src/documentStructure/DocumentStructureNavigator.svelte
@@ -17,20 +17,17 @@
 -->
 <script lang="ts">
     import { onMount, onDestroy } from 'svelte';
-    import { type TocLevel, generateTOC } from './DocumentStructureNavigatorUtils';
+    import { type TocLevel } from './DocumentStructureNavigatorUtils';
     import type { DocumentStructureStrategy } from './DocumentStructureStrategy';
     import DocumentStructureNode from './DocumentStructureNode.svelte';
 
     interface Props {
         documentContainer: HTMLElement;
         structure: DocumentStructureStrategy;
+        tocRoot: TocLevel;
     }
 
-    let { documentContainer, structure }: Props = $props();
-
-    let tocRoot: TocLevel = generateTOC(documentContainer, structure.sectionSelector, (s) =>
-        structure.extractTitle(s)
-    );
+    let { documentContainer, structure, tocRoot }: Props = $props();
     let observer: IntersectionObserver | undefined;
     let observeTargetToLevel = new Map<Element, TocLevel>();
 

--- a/inception/inception-js-api/src/main/ts/src/documentStructure/DocumentStructureNavigatorUtils.test.ts
+++ b/inception/inception-js-api/src/main/ts/src/documentStructure/DocumentStructureNavigatorUtils.test.ts
@@ -16,7 +16,12 @@
  * limitations under the License.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { type TocLevel, generateTOC, generateTOCIndex } from './DocumentStructureNavigatorUtils';
+import {
+    type TocLevel,
+    generateTOC,
+    generateTOCIndex,
+    generateTOCKeyIndex,
+} from './DocumentStructureNavigatorUtils';
 
 let container: HTMLElement;
 
@@ -46,6 +51,18 @@ function sec(title: string | undefined, ...children: Node[]): HTMLElement {
 /** Default extractor used by the suite. */
 function extractTitle(el: Element): string | undefined {
     return el.getAttribute('data-title') ?? undefined;
+}
+
+/** Structural-key extractor used by the key-related tests. */
+function extractKey(el: Element): string | undefined {
+    return el.getAttribute('data-key') ?? undefined;
+}
+
+/** Build a section carrying both a title and a structural key. */
+function keyedSec(title: string, key: string | undefined, ...children: Node[]): HTMLElement {
+    const e = sec(title, ...children);
+    if (key !== undefined) e.setAttribute('data-key', key);
+    return e;
 }
 
 /**
@@ -136,6 +153,28 @@ describe('generateTOC', () => {
         const toc = generateTOC(container, 'test-sec', extractTitle);
         expect(outline(toc)).toEqual(['match']);
     });
+
+    it('populates key from extractKey when supplied', () => {
+        container.appendChild(keyedSec('A', 'k-a', keyedSec('A.1', 'k-a-1')));
+        const toc = generateTOC(container, 'test-sec', extractTitle, extractKey);
+        const a = toc.children[0];
+        expect(a.key).toBe('k-a');
+        expect(a.children[0].key).toBe('k-a-1');
+    });
+
+    it('leaves key undefined when extractKey is omitted', () => {
+        container.appendChild(keyedSec('A', 'k-a'));
+        const toc = generateTOC(container, 'test-sec', extractTitle);
+        expect(toc.children[0].key).toBeUndefined();
+    });
+
+    it('leaves key undefined for a section extractKey returns undefined for', () => {
+        // Titled section, but no key -- must still appear in the outline.
+        container.appendChild(keyedSec('A', undefined));
+        const toc = generateTOC(container, 'test-sec', extractTitle, extractKey);
+        expect(toc.children[0].title).toBe('A');
+        expect(toc.children[0].key).toBeUndefined();
+    });
 });
 
 describe('generateTOCIndex', () => {
@@ -173,5 +212,50 @@ describe('generateTOCIndex', () => {
 
         const idx = generateTOCIndex(generateTOC(container, 'test-sec', extractTitle));
         expect(Object.keys(idx)).toEqual(['a-1']);
+    });
+});
+
+describe('generateTOCKeyIndex', () => {
+    it('returns an empty map for an empty TOC', () => {
+        const toc = generateTOC(container, 'test-sec', extractTitle, extractKey);
+        expect(generateTOCKeyIndex(toc)).toEqual({});
+    });
+
+    it('indexes every keyed section by its structural key', () => {
+        container.appendChild(keyedSec('A', 'k-a', keyedSec('A.1', 'k-a-1')));
+        container.appendChild(keyedSec('B', 'k-b'));
+
+        const idx = generateTOCKeyIndex(
+            generateTOC(container, 'test-sec', extractTitle, extractKey)
+        );
+
+        expect(Object.keys(idx).sort()).toEqual(['k-a', 'k-a-1', 'k-b']);
+        expect(idx['k-a'].title).toBe('A');
+        expect(idx['k-a-1'].title).toBe('A.1');
+        expect(idx['k-b'].title).toBe('B');
+    });
+
+    it('skips sections that have no key (so a lookup miss means "no matching key")', () => {
+        // A has a title but no key; A.1 is keyed. Only A.1 is indexed.
+        container.appendChild(keyedSec('A', undefined, keyedSec('A.1', 'k-a-1')));
+
+        const idx = generateTOCKeyIndex(
+            generateTOC(container, 'test-sec', extractTitle, extractKey)
+        );
+        expect(Object.keys(idx)).toEqual(['k-a-1']);
+    });
+
+    it('keeps the first section in document order when two share a key', () => {
+        // A weaker positional fallback key could collide; the first wins.
+        const first = keyedSec('First', 'dup');
+        const second = keyedSec('Second', 'dup');
+        container.appendChild(first);
+        container.appendChild(second);
+
+        const idx = generateTOCKeyIndex(
+            generateTOC(container, 'test-sec', extractTitle, extractKey)
+        );
+        expect(Object.keys(idx)).toEqual(['dup']);
+        expect(idx['dup'].title).toBe('First');
     });
 });

--- a/inception/inception-js-api/src/main/ts/src/documentStructure/DocumentStructureNavigatorUtils.ts
+++ b/inception/inception-js-api/src/main/ts/src/documentStructure/DocumentStructureNavigatorUtils.ts
@@ -15,10 +15,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import type { DocumentStructureStrategy } from './DocumentStructureStrategy';
+
 export interface TocLevel {
     parent?: TocLevel;
     label?: string;
     title?: string;
+    key?: string;
     element?: Element;
     tocElement?: Element;
     children: TocLevel[];
@@ -42,10 +45,40 @@ function _generateTOCIndex(root: TocLevel, result: Record<string, TocLevel>): vo
     }
 }
 
+/**
+ * Index the TOC by structural key (TocLevel.key) rather than by DOM id. Used
+ * by by-key scroll sync to look up the section in a peer document that matches
+ * a given key. Only sections with a defined key are indexed -- keyless
+ * sections are intentionally absent, so a lookup miss signals "no matching
+ * key" and the caller degrades to fractional sync.
+ *
+ * If two sections share a key (which explicit source keys should prevent, but
+ * a weaker positional fallback key may not), the first one encountered in
+ * document order wins.
+ */
+export function generateTOCKeyIndex(root: TocLevel): Record<string, TocLevel> {
+    const result: Record<string, TocLevel> = {};
+    _generateTOCKeyIndex(root, result);
+    return result;
+}
+
+function _generateTOCKeyIndex(root: TocLevel, result: Record<string, TocLevel>): void {
+    if (!root) return;
+    if (root.key !== undefined && !(root.key in result)) {
+        result[root.key] = root;
+    }
+    if (root.children?.length > 0) {
+        for (const child of root.children) {
+            _generateTOCKeyIndex(child, result);
+        }
+    }
+}
+
 export function generateTOC(
     rootElement: Element,
     selector: string,
-    extractTitle: (section: Element) => string | undefined
+    extractTitle: (section: Element) => string | undefined,
+    extractKey?: (section: Element) => string | undefined
 ): TocLevel {
     const tocRoot: TocLevel = { element: rootElement, children: [] };
     const walker = rootElement.ownerDocument.createTreeWalker(
@@ -67,6 +100,7 @@ export function generateTOC(
         const newLevel: TocLevel = {
             parent: currentLevel,
             title: extractTitle(currentNode),
+            key: extractKey?.(currentNode),
             element: currentNode,
             children: [],
         };
@@ -85,4 +119,24 @@ export function generateTOC(
         currentNode = walker.nextNode() as Element | null;
     }
     return tocRoot;
+}
+
+/**
+ * Build the TOC for a document from a {@link DocumentStructureStrategy},
+ * wiring the strategy's per-section accessors (title + key) into
+ * {@link generateTOC}. This is the single place that composes a strategy with
+ * the generic tree builder, so callers that own a strategy (the structure
+ * navigator, and editors that also need the tree for scroll sync) do not each
+ * repeat the callback wiring.
+ */
+export function buildDocumentStructure(
+    container: Element,
+    structure: DocumentStructureStrategy
+): TocLevel {
+    return generateTOC(
+        container,
+        structure.sectionSelector,
+        (s) => structure.extractTitle(s),
+        (s) => structure.extractKey(s)
+    );
 }

--- a/inception/inception-js-api/src/main/ts/src/documentStructure/DocumentStructureStrategy.ts
+++ b/inception/inception-js-api/src/main/ts/src/documentStructure/DocumentStructureStrategy.ts
@@ -46,6 +46,13 @@ export interface DocumentStructureStrategy {
     extractTitle(section: Element): string | undefined;
 
     /**
+     * A stable structural key identifying this section, used to align the
+     * scroll position of two documents that share a document structure (see
+     * the reference-document sidebar's by-key scroll sync).
+     */
+    extractKey(section: Element): string | undefined;
+
+    /**
      * The element to scroll into view when the user clicks a TOC entry.
      * Usually the heading/title inside the section. Falls back to the
      * section itself.

--- a/inception/inception-js-api/src/main/ts/src/documentStructure/NoopDocumentStructure.ts
+++ b/inception/inception-js-api/src/main/ts/src/documentStructure/NoopDocumentStructure.ts
@@ -33,6 +33,10 @@ export class NoopDocumentStructure implements DocumentStructureStrategy {
         return undefined;
     }
 
+    extractKey(): string | undefined {
+        return undefined;
+    }
+
     scrollTarget(section: Element): Element {
         return section;
     }

--- a/inception/inception-js-api/src/main/ts/src/editor/AnnotationEditor.ts
+++ b/inception/inception-js-api/src/main/ts/src/editor/AnnotationEditor.ts
@@ -37,6 +37,28 @@ export type ViewportScrollPosition = {
      * 1 = at the very bottom).
      */
     scrollProgress?: number;
+    /**
+     * Key of the scroll-sync region covering the viewport top, when the two documents share a
+     * structure (regions are derived from DocumentStructureStrategy section keys). Lets a receiver
+     * align by matching region rather than by absolute character offset -- correct even between two
+     * different documents. Absent when there is no structure or no covering region; the receiver then
+     * falls back to offset/fraction/scrollProgress anchoring.
+     */
+    sectionKey?: string;
+    /**
+     * The viewport top's position within the keyed region as a pixel fraction in [0,1] (paired with
+     * sectionKey). The receiver places its own viewport top at the same fraction of its matching
+     * region's pixel span.
+     */
+    sectionFraction?: number;
+    /**
+     * The source's full ordered list of scroll-sync region keys (document order). Lets a receiver
+     * that has no region for {@code sectionKey} still align sensibly: it looks for the nearest keys
+     * before/after {@code sectionKey} in this sequence that it DOES have a region for, and brackets
+     * between them (interpolating if both are found, freezing at the one found boundary if only one
+     * is, falling back to offset sync if neither is). Absent when the source has no structure.
+     */
+    sectionKeySequence?: string[];
 };
 
 /**
@@ -58,6 +80,25 @@ export type ViewportScrollTarget = {
      * 1 = at the very bottom).
      */
     scrollProgress?: number;
+    /**
+     * Key of the scroll-sync region to align to, when the source and this receiver share a document
+     * structure. When present and this receiver has a matching region, the receiver scrolls
+     * region-fractionally by {@code sectionFraction} instead of using {@code begin}. Ignored on a key
+     * miss, so a {@link ViewportScrollPosition} remains assignable here and the offset path stays the
+     * default.
+     */
+    sectionKey?: string;
+    /**
+     * The viewport top's pixel fraction in [0,1] within the keyed region (paired with sectionKey).
+     * The receiver places its viewport top at the same fraction of its matching region's pixel span.
+     */
+    sectionFraction?: number;
+    /**
+     * The source's full ordered list of scroll-sync region keys (document order), used to bracket a
+     * {@code sectionKey} the receiver has no region for. See
+     * {@link ViewportScrollPosition.sectionKeySequence}.
+     */
+    sectionKeySequence?: string[];
 };
 
 /**

--- a/inception/inception-pdf-editor2/src/main/ts/src/PdfAnnotationEditor.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/PdfAnnotationEditor.ts
@@ -22,6 +22,7 @@ import type {
     Offsets,
     ViewportScrollPosition,
     ViewportScrollTarget,
+    ViewportSyncPeer,
 } from '@inception-project/inception-js-api';
 import './PdfAnnotationEditor.scss';
 import {
@@ -30,12 +31,15 @@ import {
     scrollTo,
     getViewportScrollPosition,
     scrollToViewportPosition,
+    getScrollContainer,
     destroy as destroyPdfAnno,
 } from './pdfanno/pdfanno';
 
 export class PdfAnnotationEditor implements AnnotationEditor {
     private ajax: DiamAjax;
     private root: Element;
+    private viewportSyncHub?: ViewportSyncPeer;
+    private viewportSyncId?: string;
 
     public constructor(element: Element, ajax: DiamAjax) {
         this.ajax = ajax;
@@ -80,6 +84,22 @@ export class PdfAnnotationEditor implements AnnotationEditor {
 
     scrollToViewportPosition(pos: ViewportScrollTarget): void {
         scrollToViewportPosition(pos);
+    }
+
+    connectViewportSync(aHub: ViewportSyncPeer, aId: string): void {
+        this.viewportSyncHub = aHub;
+        this.viewportSyncId = aId;
+        // PDF.js has built its viewport container by now: the factory awaits init() before the
+        // editor is handed to ExternalEditorFactory, which only then calls this method.
+        aHub.register(aId, this, getScrollContainer() ?? undefined);
+    }
+
+    disconnectViewportSync(): void {
+        if (this.viewportSyncHub && this.viewportSyncId) {
+            this.viewportSyncHub.unregister(this.viewportSyncId);
+        }
+        this.viewportSyncHub = undefined;
+        this.viewportSyncId = undefined;
     }
 
     private cancelRightClick(e: Event): void {
@@ -136,6 +156,7 @@ export class PdfAnnotationEditor implements AnnotationEditor {
     }
 
     destroy(): void {
+        this.disconnectViewportSync();
         destroyPdfAnno();
     }
 }

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/ViewportSyncUtils.test.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/ViewportSyncUtils.test.ts
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { blendTowardScrollProgress } from './ViewportSyncUtils';
+
+// The band over which the blend ramps, mirrored from the implementation. Kept as a literal rather
+// than imported so a change to the constant makes these expectations fail loudly instead of
+// silently re-deriving themselves.
+const BAND = 0.15;
+const MAX_SCROLL = 1000;
+
+describe('blendTowardScrollProgress', () => {
+    describe('pass-through cases', () => {
+        it('returns the anchored top unchanged when the source sent no progress', () => {
+            expect(blendTowardScrollProgress(400, undefined, MAX_SCROLL)).toBe(400);
+        });
+
+        it('returns the anchored top unchanged when the container cannot scroll', () => {
+            expect(blendTowardScrollProgress(400, 0.5, 0)).toBe(400);
+        });
+
+        it('returns the anchored top unchanged for a negative scroll range', () => {
+            // scrollHeight < clientHeight can yield a negative maxScroll; treat as unscrollable
+            // rather than blending toward a nonsensical negative progressTop.
+            expect(blendTowardScrollProgress(400, 0.5, -50)).toBe(400);
+        });
+    });
+
+    describe('at the extremes, progress wins exactly', () => {
+        // The whole point of the blend: an offset anchor lands short of the extreme because the two
+        // editors hold different amounts of content below the shared top page. At p=0/p=1 the
+        // anchored value must be overridden completely, or scrolling to an end never quite arrives.
+        it('snaps to the very top at progress 0, ignoring a short anchored top', () => {
+            expect(blendTowardScrollProgress(120, 0, MAX_SCROLL)).toBe(0);
+        });
+
+        it('snaps to the very bottom at progress 1, ignoring a short anchored top', () => {
+            expect(blendTowardScrollProgress(880, 1, MAX_SCROLL)).toBe(MAX_SCROLL);
+        });
+    });
+
+    describe('in the interior, the offset anchor wins', () => {
+        it('leaves the anchored top untouched at the exact band edge', () => {
+            // nearness hits 0 precisely at BAND in from an extreme.
+            expect(blendTowardScrollProgress(400, BAND, MAX_SCROLL)).toBeCloseTo(400);
+            expect(blendTowardScrollProgress(400, 1 - BAND, MAX_SCROLL)).toBeCloseTo(400);
+        });
+
+        it('leaves the anchored top untouched in mid-document', () => {
+            expect(blendTowardScrollProgress(400, 0.5, MAX_SCROLL)).toBeCloseTo(400);
+        });
+
+        it('leaves the anchored top untouched well outside the band', () => {
+            expect(blendTowardScrollProgress(250, 0.25, MAX_SCROLL)).toBeCloseTo(250);
+            expect(blendTowardScrollProgress(750, 0.75, MAX_SCROLL)).toBeCloseTo(750);
+        });
+    });
+
+    describe('within the band, the two regimes mix', () => {
+        it('weights progress and anchor evenly at half the band from the top', () => {
+            // p = BAND/2 -> nearness = 0.5, so the result is the midpoint of the two candidates.
+            const p = BAND / 2;
+            const progressTop = p * MAX_SCROLL; // 75
+            const anchoredTop = 200;
+            expect(blendTowardScrollProgress(anchoredTop, p, MAX_SCROLL)).toBeCloseTo(
+                0.5 * progressTop + 0.5 * anchoredTop
+            );
+        });
+
+        it('weights progress and anchor evenly at half the band from the bottom', () => {
+            const p = 1 - BAND / 2;
+            const progressTop = p * MAX_SCROLL; // 925
+            const anchoredTop = 800;
+            expect(blendTowardScrollProgress(anchoredTop, p, MAX_SCROLL)).toBeCloseTo(
+                0.5 * progressTop + 0.5 * anchoredTop
+            );
+        });
+
+        it('moves monotonically from the anchor toward progress as an extreme nears', () => {
+            // Approaching the top with an anchor that overshoots it: each step must pull further
+            // toward progressTop, never bounce back. A non-monotonic ramp would read as jitter.
+            const anchoredTop = 300;
+            const results = [BAND, BAND * 0.75, BAND * 0.5, BAND * 0.25, 0].map((p) =>
+                blendTowardScrollProgress(anchoredTop, p, MAX_SCROLL)
+            );
+            for (let i = 1; i < results.length; i++) {
+                expect(results[i]).toBeLessThan(results[i - 1]);
+            }
+        });
+
+        it('is continuous across the band edge, so there is no snap', () => {
+            // Just inside vs. just outside the band must differ only marginally - the property that
+            // makes blending preferable to switching regimes at a threshold.
+            const anchoredTop = 300;
+            const outside = blendTowardScrollProgress(anchoredTop, BAND + 0.001, MAX_SCROLL);
+            const inside = blendTowardScrollProgress(anchoredTop, BAND - 0.001, MAX_SCROLL);
+            expect(Math.abs(outside - inside)).toBeLessThan(2);
+        });
+    });
+});

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/ViewportSyncUtils.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/ViewportSyncUtils.ts
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Fraction of the scroll range over which to blend toward whole-container progress at each end.
+ *
+ * Deliberately a per-editor constant: brat (`BratSyncController.ts`) and the Apache Annotator
+ * editor (`ApacheAnnotatorSyncController.ts`) each carry their own copy of this band and of
+ * {@link blendTowardScrollProgress}. The three editors anchor at different granularities - rows,
+ * pages (here), and block elements - so it is not established that one band suits all of them, and
+ * a shared helper in `inception-js-api` would freeze that assumption into the public API. Fork this
+ * value if PDF's page-anchoring turns out to want a different band.
+ *
+ * @see blendTowardScrollProgress
+ */
+const EXTREME_BLEND_BAND = 0.15;
+
+/**
+ * Blend an offset-anchored scrollTop toward whole-container scroll progress near the extremes.
+ *
+ * Offset-anchoring aligns viewport TOPS, so near a scroll extreme it lands short of this editor's
+ * own extreme (the two editors have different amounts of content below the shared top page). A pure
+ * progress mapping hits the extremes exactly but drifts in the interior. Weighting toward progress
+ * only within a band next to each extreme makes the extremes exact AND keeps the interior
+ * offset-accurate, with no snap at the boundary between the two regimes.
+ *
+ * Kept out of `pdfanno.ts` to stay clear of that module's global mutable state: the blend needs
+ * only resolved numbers, which makes it the one piece of PDF viewport-sync that separates cleanly
+ * and can be unit-tested on its own. A full sync-controller class like the other editors have
+ * (`BratSyncController`, `ApacheAnnotatorSyncController`) was considered and judged not worth the
+ * wider extraction here: the surrounding anchoring logic also needs `textLayer` for page/offset
+ * mapping plus the page-element helpers, and what it would buy back is mostly geometry that can
+ * only be tested against live layout anyway. Returns {@code anchoredTop} unchanged when the source
+ * sent no progress or this container cannot scroll.
+ */
+export function blendTowardScrollProgress(
+    anchoredTop: number,
+    scrollProgress: number | undefined,
+    maxScroll: number
+): number {
+    if (scrollProgress === undefined || maxScroll <= 0) return anchoredTop;
+
+    const progressTop = scrollProgress * maxScroll;
+    const p = scrollProgress;
+    // 1 at an extreme -> 0 by EXTREME_BLEND_BAND in from it.
+    const nearness = Math.max(0, 1 - Math.min(p, 1 - p) / EXTREME_BLEND_BAND);
+    return nearness * progressTop + (1 - nearness) * anchoredTop;
+}

--- a/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/pdfanno.ts
+++ b/inception/inception-pdf-editor2/src/main/ts/src/pdfanno/pdfanno.ts
@@ -29,6 +29,7 @@ import { Rectangle } from '../vmodel/Rectangle';
 import AnnotationDetailPopOver from '@inception-project/inception-js-api/src/widget/AnnotationDetailPopOver.svelte';
 import { mount, unmount } from 'svelte';
 import { transform } from './core/src/UI/utils';
+import { blendTowardScrollProgress } from './ViewportSyncUtils';
 
 // TODO make it a global const.
 // const svgLayerId = 'annoLayer'
@@ -348,7 +349,7 @@ export function scrollTo(args: {
 /**
  * @return the scrollable viewport container of the PDF.js viewer.
  */
-function getScrollContainer(): HTMLElement | null {
+export function getScrollContainer(): HTMLElement | null {
     return document.getElementById('viewer')?.parentElement ?? null;
 }
 
@@ -432,16 +433,7 @@ export function scrollToViewportPosition(pos: ViewportScrollTarget): void {
     const maxScroll = container.scrollHeight - container.clientHeight;
 
     // Ensure smooth scrolling near the start and end of the document
-    let target = anchoredTop;
-    if (pos.scrollProgress !== undefined && maxScroll > 0) {
-        const progressTop = pos.scrollProgress * maxScroll;
-        const BAND = 0.15; // fraction of the scroll range over which to blend at each end
-        const p = pos.scrollProgress;
-        const nearness = Math.max(0, 1 - Math.min(p, 1 - p) / BAND); // 1 at extreme → 0 by BAND
-        target = nearness * progressTop + (1 - nearness) * anchoredTop;
-    }
-
-    container.scrollTop = target;
+    container.scrollTop = blendTowardScrollProgress(anchoredTop, pos.scrollProgress, maxScroll);
 }
 
 export function getAnnotations() {

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPageBase2.html
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPageBase2.html
@@ -35,7 +35,7 @@
       <div wicket:id="centerArea" class="flex-content flex-v-container"
            style="padding-block: 0.75rem 1rem; box-sizing: border-box;">
         <div class="flex-content card overflow-hidden">
-          <div class="card-header d-flex justify-content-between border-bottom-0">
+          <div class="card-header d-flex justify-content-between border-bottom-0 pt-2">
             <div wicket:id="documentNamePanel"/>
             <div class="d-flex">
               <div wicket:id="numberOfPages" class="small text-muted align-self-center"/>

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPageBase2.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/AnnotationPageBase2.java
@@ -260,9 +260,12 @@ public abstract class AnnotationPageBase2
         if (project == null) {
             return;
         }
-        if (aSize < SIDEBAR_SIZE_MIN || aSize > SIDEBAR_SIZE_MAX) {
-            return;
-        }
+
+        // Do not reject sizes outside [MIN, MAX] here: dragging the splitter toward the middle
+        // produces a reported size at (or just above) SIDEBAR_SIZE_MAX due to splitbar-width
+        // rounding, and rejecting it would silently drop the user's drag so the pane snaps back to
+        // its previously stored size on the next page load. The trait setters below already clamp
+        // the value into range, so we simply let them store the clamped size.
 
         var sessionOwner = userRepository.getCurrentUser();
         var layoutState = preferencesService.loadTraitsForUserAndProject(KEY_LAYOUT_STATE,

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/component/DocumentNamePanel.html
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/component/DocumentNamePanel.html
@@ -21,6 +21,23 @@
 <html lang="en-US" xml:lang="en-US" xmlns="http://www.w3.org/1999/xhtml"
   xmlns:wicket="http://wicket.apache.org/dtds.data/wicket-xhtml1.4-strict.dtd">
 
+<wicket:head>
+  <style>
+    .project-name {
+      max-width: 30em;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .document-name {
+      max-width: 30em;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+  </style>
+</wicket:head>
 <body>
   <wicket:panel>
     <span wicket:id="read-only" class="badge text-bg-warning">
@@ -31,14 +48,16 @@
       <i class="fas fa-user"></i>
       <wicket:container wicket:id="user"/>
     </span>
-    <span wicket:enclosure="project" class="badge border border-secondary text-secondary">
+    <span wicket:id="projectBadge"
+          class="project-name badge border border-secondary text-secondary">
       <i class="fas fa-archive"></i>
       <wicket:container wicket:id="project"/>
       <wicket:enclosure child="projectId">
         (<wicket:container wicket:id="projectId"/>)
       </wicket:enclosure>
     </span>
-    <span wicket:enclosure="document" class="badge border border-secondary text-secondary">
+    <span wicket:id="documentBadge"
+          class="document-name badge border border-secondary text-secondary">
       <i class="fas fa-file"></i>
       <wicket:container wicket:id="document"/>
       <wicket:enclosure child="documentId">

--- a/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/component/DocumentNamePanel.java
+++ b/inception/inception-ui-annotation/src/main/java/de/tudarmstadt/ukp/clarin/webanno/ui/annotation/component/DocumentNamePanel.java
@@ -21,6 +21,7 @@ import static de.tudarmstadt.ukp.inception.support.lambda.LambdaBehavior.visible
 import static de.tudarmstadt.ukp.inception.support.lambda.LambdaBehavior.visibleWhenNot;
 import static org.apache.wicket.RuntimeConfigurationType.DEVELOPMENT;
 
+import org.apache.wicket.AttributeModifier;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.panel.Panel;
@@ -74,16 +75,18 @@ public class DocumentNamePanel
         queue(new Label("user", aModel.map(AnnotatorState::getUser).map(User::getUiName))
                 .add(visibleWhenNot(aModel.map(AnnotatorState::getUser)
                         .map(u -> u.getUsername().equals(userService.getCurrentUsername())))));
-        queue(new Label("project", aModel.map(AnnotatorState::getProject).map(Project::getName)));
+        var projectName = aModel.map(AnnotatorState::getProject).map(Project::getName);
+        queue(new WebMarkupContainer("projectBadge")
+                .add(AttributeModifier.replace("title", projectName)));
+        queue(new Label("project", projectName));
         queue(new Label("projectId", aModel.map(AnnotatorState::getProject).map(Project::getId))
                 .add(visibleWhen(() -> DEVELOPMENT == getApplication().getConfigurationType())));
-        // The document badge (controlled via wicket:enclosure) must hide when no document is
-        // selected - otherwise it renders as an empty name with an empty "()" id (e.g. in the
-        // reference-document sidebar before a document has been loaded). A Label with a null model
-        // still counts as visible, so guard visibility explicitly on the document being present.
-        queue(new Label("document",
-                aModel.map(AnnotatorState::getDocument).map(SourceDocument::getName))
-                        .add(visibleWhen(aModel.map(AnnotatorState::getDocument).isPresent())));
+
+        var documentName = aModel.map(AnnotatorState::getDocument).map(SourceDocument::getName);
+        queue(new WebMarkupContainer("documentBadge") //
+                .add(AttributeModifier.replace("title", documentName)) //
+                .add(visibleWhen(aModel.map(AnnotatorState::getDocument).isPresent())));
+        queue(new Label("document", documentName));
         queue(new Label("documentId",
                 aModel.map(AnnotatorState::getDocument).map(SourceDocument::getId)).add(
                         visibleWhen(() -> DEVELOPMENT == getApplication().getConfigurationType())));

--- a/inception/inception-ui-refdoc/src/main/java/de/tudarmstadt/ukp/inception/ui/refdoc/ReferenceDocumentSidebar.html
+++ b/inception/inception-ui-refdoc/src/main/java/de/tudarmstadt/ukp/inception/ui/refdoc/ReferenceDocumentSidebar.html
@@ -17,12 +17,38 @@
   limitations under the License.
 -->
 <html xmlns:wicket="http://wicket.apache.org">
+<wicket:head>
+  <!--
+    Header layout tweaks scoped to the (narrow) reference-document sidebar; the main editor's much
+    wider header is unaffected.
+
+    The header keeps the main editor's horizontal "name | position+toggle" row so the position
+    label stays inline to the right of the name instead of consuming an extra line. The name block
+    is allowed to shrink (min-width:0) and its badges truncate with an ellipsis (via .project-name
+    / .document-name in DocumentNamePanel), so a long document name no longer squashes the position
+    label - the name yields space to it instead.
+
+    The position label is a PositionInfoPanel: the unit position ("N-M / K sentences") and the
+    document position ("[doc i / n]") are separate spans. We keep each part intact (no mid-phrase
+    break) but allow a break *between* them, so in a narrow sidebar the "[doc i / n]" part drops to
+    a second line only when it genuinely does not fit rather than the whole label wrapping mid-word.
+  -->
+  <style>
+    .refdoc-sidebar-document-name {
+      min-width: 0;
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 0.25rem;
+    }
+  </style>
+</wicket:head>
 <wicket:panel>
   <div class="flex-content flex-v-container flex-gutter flex-only-internal-gutter">
     <div class="flex-content flex-v-container card overflow-hidden">
-      <div class="card-header d-flex justify-content-between border-bottom-0">
-        <div wicket:id="documentNamePanel"></div>
-        <div class="d-flex">
+      <div class="card-header d-flex justify-content-between border-bottom-0 pt-2">
+        <div wicket:id="documentNamePanel" class="refdoc-sidebar-document-name"></div>
+        <div class="d-flex refdoc-sidebar-header-meta">
           <div wicket:id="numberOfPages" class="small text-muted align-self-center"></div>
           <button wicket:id="toggleActionBar" class="btn btn-sm btn-outline-secondary border-0">
             <i wicket:id="toggleActionBarIcon"/>
@@ -48,9 +74,8 @@
                 <i class="far fa-caret-square-right"></i>
               </button>
             </div>
-            <div class="btn-group">
-              <button wicket:id="toggleScrollSync" class="btn btn-action-bar" type="button"
-                      title="Synchronize scrolling with the main editor (takes effect while showing the same document)">
+            <div wicket:id="scrollSyncGroup" class="btn-group">
+              <button wicket:id="toggleScrollSync" class="btn btn-action-bar" type="button">
                 <i wicket:id="toggleScrollSyncIcon"/>
               </button>
             </div>

--- a/inception/inception-ui-refdoc/src/main/java/de/tudarmstadt/ukp/inception/ui/refdoc/ReferenceDocumentSidebar.java
+++ b/inception/inception-ui-refdoc/src/main/java/de/tudarmstadt/ukp/inception/ui/refdoc/ReferenceDocumentSidebar.java
@@ -24,6 +24,8 @@ import static de.agilecoders.wicket.extensions.markup.html.bootstrap.icon.FontAw
 import static de.tudarmstadt.ukp.clarin.webanno.api.annotation.page.AnnotationNavigationUserPrefs.KEY_ANNOTATION_NAVIGATION_USER_PREFS;
 import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasAccessMode.SHARED_READ_ONLY_ACCESS;
 import static de.tudarmstadt.ukp.clarin.webanno.api.casstorage.CasUpgradeMode.AUTO_CAS_UPGRADE;
+import static de.tudarmstadt.ukp.inception.rendering.selection.FocusPosition.TOP;
+import static de.tudarmstadt.ukp.inception.support.lambda.LambdaBehavior.enabledWhen;
 import static de.tudarmstadt.ukp.inception.support.lambda.LambdaBehavior.visibleWhen;
 import static de.tudarmstadt.ukp.inception.ui.refdoc.ReferenceDocumentSidebarState.KEY_REFERENCE_DOCUMENT_SIDEBAR_STATE;
 import static java.lang.String.format;
@@ -77,7 +79,6 @@ import de.tudarmstadt.ukp.inception.editor.state.AnnotatorStateImpl;
 import de.tudarmstadt.ukp.inception.preferences.PreferencesService;
 import de.tudarmstadt.ukp.inception.rendering.editorstate.AnnotatorState;
 import de.tudarmstadt.ukp.inception.rendering.selection.AnnotatorViewportChangedEvent;
-import de.tudarmstadt.ukp.inception.rendering.selection.FocusPosition;
 import de.tudarmstadt.ukp.inception.schema.api.adapter.AnnotationException;
 import de.tudarmstadt.ukp.inception.support.lambda.LambdaAjaxLink;
 import jakarta.persistence.NoResultException;
@@ -130,7 +131,7 @@ public class ReferenceDocumentSidebar
     private boolean scrollSyncEnabled = false;
     private transient boolean syncingViewport = false;
 
-    private final LambdaAjaxLink scrollSyncToggle;
+    private final WebMarkupContainer scrollSyncGroup;
 
     // The editor and CAS provider for the reference document currently shown (null while none).
     private AnnotationEditorBase editor;
@@ -213,12 +214,24 @@ public class ReferenceDocumentSidebar
 
         // Two-way scroll synchronization with the main editor. Only meaningful while a document is
         // shown; whether it actually engages is gated in scrollSyncScript().
-        scrollSyncToggle = new LambdaAjaxLink("toggleScrollSync", this::actionToggleScrollSync);
+        // The tooltip sits on the group, not on the button: browsers deliver no pointer events to a
+        // disabled button, so a title on the button itself would stay invisible precisely when it
+        // explains why the toggle cannot be used.
+        scrollSyncGroup = new WebMarkupContainer("scrollSyncGroup");
+        scrollSyncGroup.setOutputMarkupPlaceholderTag(true);
+        scrollSyncGroup.add(visibleWhen(() -> state.getDocument() != null));
+        scrollSyncGroup.add(AttributeModifier.replace("title",
+                LambdaModel.of(() -> isScrollSyncPossible()
+                        ? "Synchronize scrolling with the main editor"
+                        : "Scroll synchronization is unavailable while a paged editor shows a "
+                                + "different document than the main editor")));
+        actionBar.add(scrollSyncGroup);
+
+        var scrollSyncToggle = new LambdaAjaxLink("toggleScrollSync", this::actionToggleScrollSync);
         scrollSyncToggle.add(new Icon("toggleScrollSyncIcon",
                 LambdaModel.of(() -> scrollSyncEnabled ? link_s : link_slash_s)));
-        scrollSyncToggle.setOutputMarkupPlaceholderTag(true);
-        scrollSyncToggle.add(visibleWhen(() -> state.getDocument() != null));
-        actionBar.add(scrollSyncToggle);
+        scrollSyncToggle.add(enabledWhen(this::isScrollSyncPossible));
+        scrollSyncGroup.add(scrollSyncToggle);
 
         openDialog = new OpenDocumentDialog("openDialog", Model.of((AnnotatorState) state),
                 getAnnotationPage()::listAccessibleDocuments, this::actionLoadDocument);
@@ -289,7 +302,7 @@ public class ReferenceDocumentSidebar
                     sessionOwner, project, sidebarState);
         }
 
-        aTarget.add(scrollSyncToggle);
+        aTarget.add(scrollSyncGroup);
         scrollSyncScript().ifPresent(aTarget::appendJavaScript);
     }
 
@@ -321,8 +334,29 @@ public class ReferenceDocumentSidebar
 
     private boolean isScrollSyncActive()
     {
-        return scrollSyncEnabled
-                && Objects.equals(getModelObject().getDocument(), state.getDocument());
+        return scrollSyncEnabled && isScrollSyncPossible();
+    }
+
+    private boolean isScrollSyncPossible()
+    {
+        if (state.getDocument() == null) {
+            return false;
+        }
+
+        var refDocPaged = !(state.getPagingStrategy() instanceof NoPagingStrategy);
+        var mainPaged = !(getModelObject().getPagingStrategy() instanceof NoPagingStrategy);
+        if ((mainPaged && !refDocPaged) || (!mainPaged && refDocPaged)) {
+            // Mixed mode cannot sync
+            return false;
+        }
+
+        if (mainPaged && refDocPaged && !Objects.equals(state.getPagingStrategy().getClass(),
+                getModelObject().getPagingStrategy().getClass())) {
+            // If both editors are paging, they must have the same paging regime
+            return false;
+        }
+
+        return true;
     }
 
     @Override
@@ -433,7 +467,7 @@ public class ReferenceDocumentSidebar
             aTarget.add(documentNamePanel);
             aTarget.add(documentNavigation);
             aTarget.add(pagingNavigator);
-            aTarget.add(scrollSyncToggle);
+            aTarget.add(scrollSyncGroup);
             aTarget.add(get(MID_NUMBER_OF_PAGES));
 
             scrollSyncScript().ifPresent(aTarget::appendJavaScript);
@@ -478,7 +512,7 @@ public class ReferenceDocumentSidebar
             var cas = casProvider.get();
             state.reset();
             state.getPagingStrategy().recalculatePage(state, cas);
-            state.moveToUnit(cas, 0, FocusPosition.TOP);
+            state.moveToUnit(cas, 0, TOP);
 
             newEditor = editor;
         }
@@ -532,8 +566,7 @@ public class ReferenceDocumentSidebar
         throws IOException, AnnotationException
     {
         // A self-contained viewer scrolls within its own document and does not switch documents;
-        // the
-        // read-only action handler ignores navigation, so this stays local.
+        // the read-only action handler ignores navigation, so this stays local.
         getActionHandler().actionJump(aTarget, aBegin, aEnd);
     }
 
@@ -559,6 +592,12 @@ public class ReferenceDocumentSidebar
 
         var mainState = getModelObject();
 
+        // If not showing the same document, we cannot sync by character offset - bail out
+        if (!Objects.equals(mainState.getDocument(), state.getDocument())) {
+            return;
+        }
+
+        // ... otherwise we can sync by character offset.
         try {
             syncingViewport = true;
 
@@ -568,8 +607,7 @@ public class ReferenceDocumentSidebar
                 if (editor == null || mainEditor == null) {
                     return;
                 }
-                state.moveToOffset(getEditorCas(), mainState.getWindowBeginOffset(),
-                        FocusPosition.TOP);
+                state.moveToOffset(getEditorCas(), mainState.getWindowBeginOffset(), TOP);
                 editor.requestRender(target);
                 target.add(pagingNavigator);
                 target.add(get(MID_NUMBER_OF_PAGES));
@@ -580,8 +618,7 @@ public class ReferenceDocumentSidebar
                 if (mainEditor == null) {
                     return;
                 }
-                mainState.moveToOffset(getCasProvider().get(), state.getWindowBeginOffset(),
-                        FocusPosition.TOP);
+                mainState.moveToOffset(getCasProvider().get(), state.getWindowBeginOffset(), TOP);
                 mainEditor.requestRender(target);
             }
         }


### PR DESCRIPTION
**What's in the PR**
- Add scroll-sync support to the reference document sidebar panel
- Add new PositionInfoPanel component to display document position information in paging strategies
- Improve scroll container and editor registration across multiple editor implementations
- Enhance document structure navigation utilities and tests for TEI and HTML document structure handling
- Update paging strategies (line-oriented, sentence-oriented, token-wrapping) to support scroll-sync integration
- Refactor viewport-sync hub integration across brat, Apache Annotator, external, and PDF editors
- Add comprehensive tests for ApacheAnnotatorSyncController covering sync region calculation and viewport positioning
- Update document name panel styling and annotation page base components
- Add YAML policy updates for HTML and TEI document structure handling to support scroll-sync

**How to test manually**
* Check if per-section syncing in TEI / HTML works

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
